### PR TITLE
fix(ui): prevent unlock polling from stopping mid-sequence

### DIFF
--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { KleKey } from '../../../shared/kle/types'
 import { KeyboardWidget } from '../keyboard'
@@ -40,52 +40,68 @@ export function UnlockDialog({
     highlightedKeys.add(`${row},${col}`)
   }
 
-  const poll = useCallback(async () => {
-    if (!pollingRef.current) return
-    try {
-      const data = await unlockPoll()
-      if (!pollingRef.current) return
-      if (data.length < 3) return // unexpected data
+  // Store callbacks in refs so the interval handler always sees the
+  // latest versions without re-triggering the useEffect.
+  const unlockPollRef = useRef(unlockPoll)
+  unlockPollRef.current = unlockPoll
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+  const busyRef = useRef(false)
 
-      const unlocked = data[0]
-      const cnt = data[2]
+  // Single useEffect: send unlockStart once, then poll via setInterval.
+  // setInterval (like Python's QTimer) guarantees exactly one poll loop.
+  useEffect(() => {
+    let intervalId: ReturnType<typeof setInterval> | undefined
+    let cancelled = false
 
-      // Capture the max counter as total on first meaningful value
-      if (cnt > totalRef.current) totalRef.current = cnt
-      setCounter(cnt)
+    const pollOnce = async () => {
+      if (cancelled || busyRef.current) return
+      busyRef.current = true
+      try {
+        const data = await unlockPollRef.current()
+        if (cancelled) return
+        if (data.length < 3) return
 
-      if (unlocked === 1) {
-        pollingRef.current = false
-        onComplete()
+        const unlocked = data[0]
+        const cnt = data[2]
+
+        if (cnt > totalRef.current) totalRef.current = cnt
+        setCounter(cnt)
+
+        if (unlocked === 1) {
+          if (intervalId) clearInterval(intervalId)
+          onCompleteRef.current()
+          return
+        }
+      } catch {
+        // device error — next interval tick will retry
+      } finally {
+        busyRef.current = false
+      }
+    }
+
+    const start = async () => {
+      if (startedRef.current) {
+        intervalId = setInterval(() => void pollOnce(), UNLOCK_POLL_INTERVAL)
         return
       }
-    } catch {
-      // device error
-    }
-
-    if (pollingRef.current) {
-      timerRef.current = setTimeout(poll, UNLOCK_POLL_INTERVAL)
-    }
-  }, [unlockPoll, onComplete])
-
-  useEffect(() => {
-    pollingRef.current = true
-    const start = async () => {
-      if (startedRef.current) return
       startedRef.current = true
       try {
         await unlockStart()
-        poll()
+        if (cancelled) return
+        intervalId = setInterval(() => void pollOnce(), UNLOCK_POLL_INTERVAL)
       } catch {
-        // failed to start
+        // failed to start unlock
       }
     }
+
     start()
+
     return () => {
-      pollingRef.current = false
-      if (timerRef.current) clearTimeout(timerRef.current)
+      cancelled = true
+      if (intervalId) clearInterval(intervalId)
     }
-  }, [unlockStart, poll])
+  }, [unlockStart])
 
   // Derive progress from firmware counter
   const total = totalRef.current

--- a/src/renderer/components/editors/__tests__/UnlockDialog.test.tsx
+++ b/src/renderer/components/editors/__tests__/UnlockDialog.test.tsx
@@ -93,6 +93,9 @@ describe('UnlockDialog', () => {
     // First poll: counter=50 (total captured as 50)
     unlockPoll.mockResolvedValueOnce([0, 0, 50])
     await act(async () => { renderDialog() })
+    // setInterval fires first poll at t=200ms
+    await act(async () => { vi.advanceTimersByTime(200) })
+    await act(async () => {})
 
     // After first poll, total=50, counter=50, progress=0
     expect(screen.getByText('0/50')).toBeInTheDocument()
@@ -118,8 +121,11 @@ describe('UnlockDialog', () => {
       .mockResolvedValueOnce([1, 0, 0])
 
     await act(async () => { renderDialog() })
-    // First poll ran (counter=50)
+    // First poll at t=200ms (counter=50)
+    await act(async () => { vi.advanceTimersByTime(200) })
+    await act(async () => {})
 
+    // Second poll at t=400ms (unlocked=1)
     await act(async () => { vi.advanceTimersByTime(200) })
     await act(async () => {})
 


### PR DESCRIPTION
## Summary
- Fix UnlockDialog polling loop dying mid-sequence, preventing keyboard unlock from completing

## Root Cause
The `useEffect` dependency array included the `poll` callback, which depended on `onComplete` — an inline function in App.tsx whose reference changed on every re-render. This caused the effect to clean up (stopping the poll timer) and re-run, but `startedRef` prevented restarting, permanently killing the poll loop. Additionally, on re-mount both the pending `unlockStart` callback and the new mount started separate poll loops, causing double polling that confused the firmware (counter oscillating 49→50→49→50).

## Changes
- `UnlockDialog.tsx`: Replace recursive `setTimeout` with `setInterval` (matching Python vial-gui's QTimer pattern). Store callbacks in refs to decouple from React render cycle. Add `busyRef` guard and `cancelled` flag to prevent overlapping polls and stale async callbacks
- `UnlockDialog.test.tsx`: Adjust test timing for `setInterval`-based polling (first poll fires at t=200ms, not immediately)

## Test Plan
- [x] `pnpm test` all tests pass (2476/2476)
- [x] `pnpm build` succeeds
- [x] Device test: unlock countdown 50→0 completes successfully
- [x] Device test: release keys mid-unlock, resume, and complete successfully

Closes #4