### PR TITLE
fix(macro): merge consecutive same-type keycodes in v2 deserialization

### DIFF
--- a/src/shared/types/protocol.ts
+++ b/src/shared/types/protocol.ts
@@ -127,6 +127,7 @@ export interface VilFile {
   keymap: Record<string, number>
   encoderLayout: Record<string, number>
   macros: number[]
+  macroJson?: unknown[][]
   layoutOptions: number
   tapDance: TapDanceEntry[]
   combo: ComboEntry[]


### PR DESCRIPTION
## Summary
- Merge consecutive same-type keycodes during v2 macro deserialization, matching Python vial-gui behavior
- Preserve macro action grouping in app paths (vil export, keyboard save) by preferring `parsedMacros` over binary re-deserialization
- Persist macro grouping in `.vil` files via optional `macroJson` field in `VilFile`

## Root Cause
v2 macro deserializer (`deserializeV2`) created individual actions per keycode instead of merging consecutive same-type keycodes. This caused macro grouping to be lost on disconnect/reconnect or `.vil` export when going through binary re-deserialization.

## Changes
- `src/preload/macro.ts` — Added `pushOrMergeKeycode` helper; `deserializeV2` now merges consecutive same-type keycodes (1-byte and 2-byte) matching Python reference
- `src/preload/__tests__/macro.test.ts` — Added merge tests (same-type, different-type, mixed 1/2-byte, text/delay boundaries); updated round-trip tests; added JSON and binary round-trip identity tests
- `src/renderer/hooks/useKeyboard.ts` — `serialize()`, `serializeVialGui()`, and `applyVilFile()` now prefer `parsedMacros` over binary buffer re-deserialization
- `src/shared/types/protocol.ts` — Added optional `macroJson` field to `VilFile` interface

## Test Plan
- [x] `pnpm test` — 2511 tests pass
- [x] `pnpm build` — builds successfully
- [x] `pnpm lint` — no errors
- [x] Binary round-trip merges same-type keycodes (matches Python vial-gui)
- [x] JSON round-trip preserves exact grouping
- [ ] Manual: verify macro grouping preserved after disconnect/reconnect
- [ ] Manual: verify `.vil` export/import preserves macro grouping

Closes #10