### PR TITLE
docs: Add aur package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Download the latest release for your platform:
 > chmod +x Pipette-linux-x86_64.AppImage
 > ```
 
-> Arch users: install with your favorite AUR helper
+> Arch users: install with your favorite AUR helper (here for example `yay`).
 > ```bash
 > yay -S pipette-desktop-bin
 > ```


### PR DESCRIPTION
I have created an AUR package for installing Pipette on Arch-based Linux distros more easily. The AUR page is https://aur.archlinux.org/packages/pipette-desktop-bin and I have edited README.MD to include install steps