### PR TITLE
fix(hub): use individual post URL for favorite hub Open button

### DIFF
--- a/src/renderer/components/DataModal.tsx
+++ b/src/renderer/components/DataModal.tsx
@@ -11,9 +11,7 @@ import { FavoriteHubActions } from './editors/FavoriteHubActions'
 import type { FavHubEntryResult } from './editors/FavoriteHubActions'
 import { HubPostRow, HubRefreshButton, DEFAULT_PER_PAGE, BTN_SECONDARY } from './hub-post-shared'
 import type { DataModalTabId, TabDef } from './editors/modal-tabs'
-import { FAV_TYPE_TO_EXPORT_KEY } from '../../shared/favorite-data'
 import type { FavoriteType } from '../../shared/types/favorite-store'
-import type { HubFeaturePostType } from '../../shared/types/hub'
 import type { FavoriteImportResultState } from '../hooks/useFavoriteStore'
 import type { HubMyPost, HubPaginationMeta, HubFetchMyPostsParams } from '../../shared/types/hub'
 
@@ -204,7 +202,6 @@ function FavoriteTabContent({
 
                 <FavoriteHubActions
                   entry={entry}
-                  postType={FAV_TYPE_TO_EXPORT_KEY[favoriteType] as HubFeaturePostType}
                   hubOrigin={hubOrigin}
                   hubNeedsDisplayName={hubNeedsDisplayName}
                   hubUploading={hubUploading}

--- a/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
+++ b/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
@@ -459,7 +459,6 @@ export function AltRepeatKeyPanelModal({
             exporting={favStore.exporting}
             importing={favStore.importing}
             importResult={favStore.importResult}
-            hubPostType="ark"
             hubOrigin={hubOrigin}
             hubNeedsDisplayName={hubNeedsDisplayName}
             hubUploading={hubUploading}

--- a/src/renderer/components/editors/ComboPanelModal.tsx
+++ b/src/renderer/components/editors/ComboPanelModal.tsx
@@ -458,7 +458,6 @@ export function ComboPanelModal({
             exporting={favStore.exporting}
             importing={favStore.importing}
             importResult={favStore.importResult}
-            hubPostType="combo"
             hubOrigin={hubOrigin}
             hubNeedsDisplayName={hubNeedsDisplayName}
             hubUploading={hubUploading}

--- a/src/renderer/components/editors/FavoriteHubActions.tsx
+++ b/src/renderer/components/editors/FavoriteHubActions.tsx
@@ -3,7 +3,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SavedFavoriteMeta } from '../../../shared/types/favorite-store'
-import type { HubFeaturePostType } from '../../../shared/types/hub'
 
 const HUB_BTN_BASE = 'text-[11px] font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50'
 const HUB_BTN = `${HUB_BTN_BASE} disabled:opacity-50`
@@ -16,7 +15,6 @@ export interface FavHubEntryResult {
 
 interface FavoriteHubActionsProps {
   entry: SavedFavoriteMeta
-  postType?: HubFeaturePostType
   hubOrigin?: string
   hubNeedsDisplayName?: boolean
   hubUploading?: string | null
@@ -28,7 +26,6 @@ interface FavoriteHubActionsProps {
 
 export function FavoriteHubActions({
   entry,
-  postType,
   hubOrigin,
   hubNeedsDisplayName,
   hubUploading,
@@ -48,7 +45,7 @@ export function FavoriteHubActions({
   const result = hubUploadResult?.entryId === entry.id ? hubUploadResult : null
 
   const hasHubPost = !!entry.hubPostId
-  const hubListUrl = hasHubPost && hubOrigin && postType ? `${hubOrigin}/?post_type=${postType}` : null
+  const hubPostUrl = hasHubPost && hubOrigin ? `${hubOrigin}/post/${encodeURIComponent(entry.hubPostId!)}` : null
 
   return (
     <div className="mt-1.5 border-t border-edge pt-1.5" data-testid="fav-hub-actions">
@@ -79,12 +76,12 @@ export function FavoriteHubActions({
                 </>
               ) : (
                 <>
-                  {hubListUrl && (
+                  {hubPostUrl && (
                     <a
-                      href={hubListUrl}
+                      href={hubPostUrl}
                       onClick={(e) => {
                         e.preventDefault()
-                        void window.vialAPI.openExternal(hubListUrl)
+                        void window.vialAPI.openExternal(hubPostUrl)
                       }}
                       className={HUB_BTN_BASE}
                       data-testid="fav-hub-share-link"

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -7,7 +7,6 @@ import { ACTION_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, SectionHeader, formatDate }
 import { FavoriteHubActions } from './FavoriteHubActions'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import type { FavoriteType, SavedFavoriteMeta } from '../../../shared/types/favorite-store'
-import type { HubFeaturePostType } from '../../../shared/types/hub'
 import type { FavoriteImportResultState } from '../../hooks/useFavoriteStore'
 
 export function formatImportMessage(t: (key: string, opts?: Record<string, unknown>) => string, result: FavoriteImportResultState): string {
@@ -40,7 +39,6 @@ export interface FavoriteStoreContentProps {
   onExportEntry: (entryId: string) => void
   onImport: () => void
   // Hub integration (optional)
-  hubPostType?: HubFeaturePostType
   hubOrigin?: string
   hubNeedsDisplayName?: boolean
   hubUploading?: string | null
@@ -67,7 +65,6 @@ export function FavoriteStoreContent({
   onExport,
   onExportEntry,
   onImport,
-  hubPostType,
   hubOrigin,
   hubNeedsDisplayName,
   hubUploading,
@@ -256,7 +253,6 @@ export function FavoriteStoreContent({
 
                 <FavoriteHubActions
                   entry={entry}
-                  postType={hubPostType}
                   hubOrigin={hubOrigin}
                   hubNeedsDisplayName={hubNeedsDisplayName}
                   hubUploading={hubUploading}

--- a/src/renderer/components/editors/KeyOverridePanelModal.tsx
+++ b/src/renderer/components/editors/KeyOverridePanelModal.tsx
@@ -487,7 +487,6 @@ export function KeyOverridePanelModal({
             exporting={favStore.exporting}
             importing={favStore.importing}
             importResult={favStore.importResult}
-            hubPostType="ko"
             hubOrigin={hubOrigin}
             hubNeedsDisplayName={hubNeedsDisplayName}
             hubUploading={hubUploading}

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -583,7 +583,6 @@ export function MacroEditor({
             exporting={favStore.exporting}
             importing={favStore.importing}
             importResult={favStore.importResult}
-            hubPostType="macro"
             hubOrigin={hubOrigin}
             hubNeedsDisplayName={hubNeedsDisplayName}
             hubUploading={hubUploading}

--- a/src/renderer/components/editors/TapDanceModal.tsx
+++ b/src/renderer/components/editors/TapDanceModal.tsx
@@ -307,7 +307,6 @@ export function TapDanceModal({
                 exporting={favStore.exporting}
                 importing={favStore.importing}
                 importResult={favStore.importResult}
-                hubPostType="td"
                 hubOrigin={hubOrigin}
                 hubNeedsDisplayName={hubNeedsDisplayName}
                 hubUploading={hubUploading}

--- a/src/renderer/components/editors/__tests__/FavoriteHubActions.test.tsx
+++ b/src/renderer/components/editors/__tests__/FavoriteHubActions.test.tsx
@@ -70,11 +70,10 @@ describe('FavoriteHubActions', () => {
     expect(screen.queryByTestId('fav-hub-upload-btn')).not.toBeInTheDocument()
   })
 
-  it('shows Open link when entry has hubPostId, hubOrigin, and postType', () => {
+  it('shows Open link when entry has hubPostId and hubOrigin', () => {
     render(
       <FavoriteHubActions
         entry={ENTRY_WITH_HUB}
-        postType="td"
         hubOrigin="https://hub.example.com"
         onUpdateOnHub={vi.fn()}
       />,
@@ -82,7 +81,7 @@ describe('FavoriteHubActions', () => {
 
     const link = screen.getByTestId('fav-hub-share-link')
     expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', 'https://hub.example.com/?post_type=td')
+    expect(link).toHaveAttribute('href', 'https://hub.example.com/post/hub-post-42')
     expect(screen.getByText('hub.openInBrowser')).toBeInTheDocument()
   })
 
@@ -90,7 +89,6 @@ describe('FavoriteHubActions', () => {
     render(
       <FavoriteHubActions
         entry={ENTRY_WITH_HUB}
-        postType="td"
         hubOrigin="https://hub.example.com"
         onUpdateOnHub={vi.fn()}
       />,
@@ -98,7 +96,7 @@ describe('FavoriteHubActions', () => {
 
     fireEvent.click(screen.getByTestId('fav-hub-share-link'))
     expect(window.vialAPI.openExternal).toHaveBeenCalledWith(
-      'https://hub.example.com/?post_type=td',
+      'https://hub.example.com/post/hub-post-42',
     )
   })
 
@@ -106,7 +104,6 @@ describe('FavoriteHubActions', () => {
     render(
       <FavoriteHubActions
         entry={ENTRY_WITH_HUB}
-        postType="td"
         onUpdateOnHub={vi.fn()}
       />,
     )
@@ -144,7 +141,6 @@ describe('FavoriteHubActions', () => {
     render(
       <FavoriteHubActions
         entry={ENTRY_WITH_HUB}
-        postType="td"
         hubNeedsDisplayName
         hubOrigin="https://hub.example.com"
         onUploadToHub={vi.fn()}

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -89,8 +89,6 @@ export interface HubUserResult {
   error?: string
 }
 
-export type HubFeaturePostType = 'td' | 'macro' | 'combo' | 'ko' | 'ark'
-
 export interface HubUploadFavoritePostParams {
   type: FavoriteType
   entryId: string


### PR DESCRIPTION
## Summary
- Change favorite hub Open button URL from `/?post_type={type}` (list filter) to `/post/{hubPostId}` (individual post page)
- Remove unused `postType`/`hubPostType` prop from the entire renderer component tree
- Remove dead `HubFeaturePostType` type export from shared types

## Changes
- `FavoriteHubActions.tsx`: URL changed to `/post/{hubPostId}`, removed `postType` prop
- `FavoriteStoreContent.tsx`: Removed `hubPostType` prop
- `DataModal.tsx`: Removed `postType`, `FAV_TYPE_TO_EXPORT_KEY`, `HubFeaturePostType` imports
- 5 editor modals: Removed `hubPostType` prop passthrough
- `hub.ts`: Removed dead `HubFeaturePostType` type
- `FavoriteHubActions.test.tsx`: Updated URL assertions

## Test Plan
- [x] `pnpm test` — 2699 tests passed
- [x] `pnpm build` — success
- [x] `pnpm lint` — clean