### PR TITLE
refactor(ui): rename i18n key matrixTester to keyTester

### DIFF
--- a/src/renderer/components/editors/KeycodesOverlayPanel.tsx
+++ b/src/renderer/components/editors/KeycodesOverlayPanel.tsx
@@ -272,13 +272,13 @@ export function KeycodesOverlayPanel({
             {(hasMatrixTester || matrixMode) && onToggleMatrix && (
               <div className={ROW_CLASS} data-testid="overlay-matrix-row">
                 <span className="text-[13px] font-medium text-content">
-                  {t('editor.matrixTester.title')}
+                  {t('editor.keyTester.title')}
                 </span>
                 <button
                   type="button"
                   role="switch"
                   aria-checked={matrixMode}
-                  aria-label={t('editor.matrixTester.title')}
+                  aria-label={t('editor.keyTester.title')}
                   className={toggleTrackClass(matrixMode)}
                   onClick={onToggleMatrix}
                   data-testid="overlay-matrix-toggle"

--- a/src/renderer/components/editors/__tests__/KeycodesOverlayPanel.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeycodesOverlayPanel.test.tsx
@@ -14,7 +14,7 @@ vi.mock('react-i18next', () => ({
         'editorSettings.tabLayout': 'Layout',
         'layout.keyboardLayout': 'Layout',
         'editor.autoAdvance': 'Auto Move',
-        'editor.matrixTester.title': 'Key Tester',
+        'editor.keyTester.title': 'Key Tester',
         'settings.security': 'Security',
         'security.lock': 'Lock',
         'statusBar.locked': 'Locked',

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -183,7 +183,7 @@
       "settings": "Alt Repeat Key Settings",
       "selectEntry": "Select an entry to edit"
     },
-    "matrixTester": {
+    "keyTester": {
       "title": "Key Tester"
     },
     "typingTest": {

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -183,7 +183,7 @@
       "settings": "Alt Repeat Key Settings",
       "selectEntry": "編集するエントリを選択"
     },
-    "matrixTester": {
+    "keyTester": {
       "title": "キーテスター"
     },
     "typingTest": {


### PR DESCRIPTION
## Summary
- Rename i18n key namespace `editor.matrixTester` → `editor.keyTester` to align with display label "Key Tester"
- "matrix" is QMK internal terminology; user-facing label uses "Key Tester"

## Changes
- `src/renderer/i18n/locales/en.json`, `ja.json` — key `matrixTester` → `keyTester`
- `src/renderer/components/editors/KeycodesOverlayPanel.tsx` — `t()` calls updated (2 places)
- `src/renderer/components/editors/__tests__/KeycodesOverlayPanel.test.tsx` — mock key updated

## Test Plan
- [x] `pnpm test` — 2710/2710 tests pass
- [x] `pnpm build` — successful
- [x] `pnpm lint` — no errors
- [x] Internal names (hasMatrixTester, matrixMode, matrix-utils.ts) intentionally kept