### PR TITLE
feat(keymap): use custom keycode names in keymap.c export

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -160,6 +160,7 @@ export function App() {
       encoderCount: keyboard.encoderCount,
       layoutOptions: decodedLayoutOptions,
       serializeKeycode: serializeForCExport,
+      customKeycodes: keyboard.definition?.customKeycodes,
     }),
     [
       keyboard.layers,
@@ -168,6 +169,7 @@ export function App() {
       keyboard.encoderLayout,
       keyboard.encoderCount,
       decodedLayoutOptions,
+      keyboard.definition?.customKeycodes,
     ],
   )
 
@@ -534,6 +536,7 @@ export function App() {
         ? decodeLayoutOptions(vilData.layoutOptions, labels)
         : new Map<number, number>(),
       serializeKeycode,
+      customKeycodes: keyboard.definition?.customKeycodes,
       tapDance: vilData.tapDance,
       combo: vilData.combo,
       keyOverride: vilData.keyOverride,

--- a/src/shared/__tests__/keymap-export.test.ts
+++ b/src/shared/__tests__/keymap-export.test.ts
@@ -315,4 +315,49 @@ describe('generateKeymapC', () => {
     const result = generateKeymapC(createBasicInput())
     expect(result.endsWith('\n')).toBe(true)
   })
+
+  it('generates enum for custom keycodes when provided', () => {
+    const result = generateKeymapC(createBasicInput({
+      customKeycodes: [
+        { name: 'CUSTOM_1', title: 'Custom One', shortName: 'C1' },
+        { name: 'CUSTOM_2', title: 'Custom Two', shortName: 'C2' },
+      ],
+    }))
+
+    expect(result).toContain('enum custom_keycodes {')
+    expect(result).toContain('CUSTOM_1 = QK_KB_0,')
+    expect(result).toContain('CUSTOM_2,')
+    expect(result).toContain('};')
+    // Enum should appear between #include and keymaps array
+    const includeIdx = result.indexOf('#include QMK_KEYBOARD_H')
+    const enumIdx = result.indexOf('enum custom_keycodes')
+    const keymapsIdx = result.indexOf('const uint16_t PROGMEM keymaps')
+    expect(enumIdx).toBeGreaterThan(includeIdx)
+    expect(enumIdx).toBeLessThan(keymapsIdx)
+  })
+
+  it('does not generate enum when customKeycodes is undefined', () => {
+    const result = generateKeymapC(createBasicInput())
+
+    expect(result).not.toContain('enum custom_keycodes')
+  })
+
+  it('does not generate enum when customKeycodes is empty', () => {
+    const result = generateKeymapC(createBasicInput({ customKeycodes: [] }))
+
+    expect(result).not.toContain('enum custom_keycodes')
+  })
+
+  it('handles custom keycodes with missing name field', () => {
+    const result = generateKeymapC(createBasicInput({
+      customKeycodes: [
+        { title: 'No Name', shortName: 'NN' },
+        { name: 'HAS_NAME', title: 'Has Name', shortName: 'HN' },
+      ],
+    }))
+
+    // Entry without name should use USER00 fallback
+    expect(result).toContain('USER00 = QK_KB_0,')
+    expect(result).toContain('HAS_NAME,')
+  })
 })

--- a/src/shared/keycodes/__tests__/keycodes.test.ts
+++ b/src/shared/keycodes/__tests__/keycodes.test.ts
@@ -1082,6 +1082,32 @@ describe('createCustomUserKeycodes()', () => {
     expect(kc1!.label).toBe('USER01')
     expect(kc1!.tooltip).toBe('USER01')
   })
+
+  it('sets cExportId to custom name for keymap.c export', () => {
+    const customs: CustomKeycodeDefinition[] = [
+      { name: 'MY_KEY', title: 'My Custom Key', shortName: 'MK' },
+      { name: 'OTHER_KEY', title: 'Other Key', shortName: 'OK' },
+    ]
+    createCustomUserKeycodes(customs)
+    const kc0 = findByQmkId('USER00')
+    expect(kc0).toBeDefined()
+    expect(kc0!.cExportId).toBe('MY_KEY')
+
+    const kc1 = findByQmkId('USER01')
+    expect(kc1).toBeDefined()
+    expect(kc1!.cExportId).toBe('OTHER_KEY')
+  })
+
+  it('falls back cExportId to USER## when name is missing', () => {
+    const customs: CustomKeycodeDefinition[] = [
+      {}, // no name
+    ]
+    createCustomUserKeycodes(customs)
+    const kc0 = findByQmkId('USER00')
+    expect(kc0).toBeDefined()
+    // When name is missing, cExportId should be undefined so it falls back to qmkId (USER00)
+    expect(kc0!.cExportId).toBeUndefined()
+  })
 })
 
 // --- New keycode categories ---

--- a/src/shared/keycodes/keycodes.ts
+++ b/src/shared/keycodes/keycodes.ts
@@ -1992,6 +1992,7 @@ export function createCustomUserKeycodes(
         label: c.shortName ?? `USER${String(x).padStart(2, '0')}`,
         tooltip: c.title ?? `USER${String(x).padStart(2, '0')}`,
         alias: [c.name ?? `USER${String(x).padStart(2, '0')}`],
+        cExportId: c.name,
       }),
     )
   }

--- a/src/shared/keymap-export.ts
+++ b/src/shared/keymap-export.ts
@@ -2,6 +2,7 @@
 // Generate QMK-compatible keymap.c from current keymap state
 
 import type { KleKey } from './kle/types'
+import type { CustomKeycodeDefinition } from './keycodes/keycodes'
 import { filterVisibleKeys } from './kle/filter-keys'
 
 export interface KeymapExportInput {
@@ -12,6 +13,7 @@ export interface KeymapExportInput {
   encoderCount: number
   layoutOptions: Map<number, number>
   serializeKeycode: (code: number) => string
+  customKeycodes?: CustomKeycodeDefinition[]
 }
 
 function groupKeysByRow(keys: KleKey[]): KleKey[][] {
@@ -73,6 +75,17 @@ function generateEncoderLayer(
   return `    [${layer}] = { ${entries.join(', ')} }`
 }
 
+function generateCustomKeycodeEnum(customKeycodes: CustomKeycodeDefinition[]): string | null {
+  if (customKeycodes.length === 0) return null
+
+  const entries = customKeycodes.map((c, i) => {
+    const name = c.name ?? `USER${String(i).padStart(2, '0')}`
+    return i === 0 ? `    ${name} = QK_KB_0,` : `    ${name},`
+  })
+
+  return [`enum custom_keycodes {`, ...entries, `};`].join('\n')
+}
+
 export function generateKeymapC(input: KeymapExportInput): string {
   const {
     layers,
@@ -82,6 +95,7 @@ export function generateKeymapC(input: KeymapExportInput): string {
     encoderCount,
     layoutOptions,
     serializeKeycode,
+    customKeycodes,
   } = input
 
   const visibleKeys = filterVisibleKeys(keys, layoutOptions)
@@ -95,10 +109,18 @@ export function generateKeymapC(input: KeymapExportInput): string {
     `/* SPDX-License-Identifier: GPL-2.0-or-later */`,
     `#include QMK_KEYBOARD_H`,
     '',
+  ]
+
+  const enumBlock = customKeycodes ? generateCustomKeycodeEnum(customKeycodes) : null
+  if (enumBlock) {
+    sections.push(enumBlock, '')
+  }
+
+  sections.push(
     `const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {`,
     `${layerBlocks.join(',\n')},`,
     `};`,
-  ]
+  )
 
   if (encoderCount > 0) {
     const encoderBlocks = Array.from({ length: layers }, (_, l) =>


### PR DESCRIPTION
## Summary
- Export custom keycode definitions as `enum custom_keycodes { NAME = QK_KB_0, ... }` in keymap.c
- Use configured custom keycode names (from `customKeycodes[].name`) instead of generic `USER##` identifiers in the keymaps array
- Reuse existing `CustomKeycodeDefinition` type from keycodes.ts

## Changes
- `src/shared/keycodes/keycodes.ts` — Add `cExportId: c.name` to `createCustomUserKeycodes()`
- `src/shared/keymap-export.ts` — Add `customKeycodes` to export input, generate enum block
- `src/renderer/App.tsx` — Pass `customKeycodes` at all three `generateKeymapC()` call sites

## Test Plan
- [x] Custom keycodes generate correct enum block
- [x] Empty/undefined customKeycodes produce no enum
- [x] Missing name falls back to USER## in enum
- [x] cExportId set correctly for serialization
- [x] cExportId undefined when name is missing
- [x] `pnpm test` passes (2728/2728)
- [x] `pnpm build` passes
- [x] `pnpm lint` passes