### PR TITLE
refactor(ui): replace "QMK ID" with "keycode name" in code comments

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1229,7 +1229,7 @@ export const KeymapEditor = forwardRef<KeymapEditorHandle, Props>(function Keyma
     hasMatrixTester,
   }), [handleMatrixToggle, handleTypingTestToggle, matrixMode, hasMatrixTester])
 
-  // Build keycodes map for a given layer: "row,col" -> serialized QMK ID
+  // Build keycodes map for a given layer: "row,col" -> serialized keycode name
   // Also build a set of position keys whose keycode is remapped in the current layout
   const buildKeycodesForLayer = useCallback((layer: number) => {
     const keycodes = new Map<string, string>()
@@ -1308,7 +1308,7 @@ export const KeymapEditor = forwardRef<KeymapEditorHandle, Props>(function Keyma
     [buildEncoderKeycodesForLayer, typingTest.effectiveLayer, typingTestMode],
   )
 
-  // Get selected key's current QMK ID string
+  // Get selected key's current keycode name string
   const selectedKeycode = useMemo(() => {
     if (selectedKey) {
       const code = keymap.get(`${currentLayer},${selectedKey.row},${selectedKey.col}`) ?? 0

--- a/src/renderer/components/keyboard/types.ts
+++ b/src/renderer/components/keyboard/types.ts
@@ -4,7 +4,7 @@ import type { KleKey } from '../../../shared/kle/types'
 
 export interface KeyWidgetProps {
   kleKey: KleKey
-  keycode: string // QMK ID for display label
+  keycode: string // keycode name for display label
   maskKeycode?: string // Inner keycode for masked keys
   selected?: boolean
   multiSelected?: boolean
@@ -27,8 +27,8 @@ export interface EncoderWidgetProps {
 
 export interface KeyboardWidgetProps {
   keys: KleKey[]
-  keycodes: Map<string, string> // "row,col" -> QMK ID
-  maskKeycodes?: Map<string, string> // "row,col" -> inner QMK ID (for masked keys)
+  keycodes: Map<string, string> // "row,col" -> keycode name
+  maskKeycodes?: Map<string, string> // "row,col" -> inner keycode name (for masked keys)
   encoderKeycodes?: Map<string, [string, string]> // "idx" -> [CW, CCW]
   selectedKey?: { row: number; col: number } | null
   selectedEncoder?: { idx: number; dir: number } | null

--- a/src/renderer/components/keycodes/BasicKeyboardView.tsx
+++ b/src/renderer/components/keycodes/BasicKeyboardView.tsx
@@ -32,7 +32,7 @@ interface Props {
   remapLabel?: (qmkId: string) => string
 }
 
-/** Collect all QMK IDs present in a KLE layout definition */
+/** Collect all keycode names present in a KLE layout definition */
 function collectLayoutQmkIds(kle: unknown[][]): Set<string> {
   const layout = parseKle(kle)
   const ids = new Set<string>()

--- a/src/renderer/components/keycodes/SplitKey.tsx
+++ b/src/renderer/components/keycodes/SplitKey.tsx
@@ -33,10 +33,10 @@ const SHIFTED_MAP: Record<string, string> = {
   KC_JYEN: 'KC_PIPE',
 }
 
-/** Set of all QMK IDs that appear as shifted counterparts */
+/** Set of all keycode names that appear as shifted counterparts */
 const SHIFTED_IDS: ReadonlySet<string> = new Set(Object.values(SHIFTED_MAP))
 
-/** Check if a QMK ID is a shifted keycode (e.g. KC_AT, KC_EXLM) */
+/** Check if a keycode name is a shifted keycode (e.g. KC_AT, KC_EXLM) */
 export function isShiftedKeycode(qmkId: string): boolean {
   return SHIFTED_IDS.has(qmkId)
 }

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -149,7 +149,7 @@ export function TabbedKeycodes({
     // For keyboard views (ANSI/ISO/JIS), order by physical layout position
     if (cat.id === 'basic' && resolvedBasicViewType != null && resolvedBasicViewType !== 'list' && !lmMode) {
       const layouts = getLayoutsForViewType(resolvedBasicViewType)
-      // Largest layout has the most keys — extract QMK IDs in physical row-major order
+      // Largest layout has the most keys — extract keycode names in physical row-major order
       const kleLayout = parseKle(layouts[0].kle)
       const layoutKeycodes: Keycode[] = []
       const layoutIds = new Set<string>()

--- a/src/shared/pdf-export.ts
+++ b/src/shared/pdf-export.ts
@@ -389,7 +389,7 @@ function pdfKeycodeLabel(code: number, input: PdfExportInput): string {
 }
 
 /**
- * QMK ID-based label for macro badges. Shows full QMK name (e.g. LCTL_T(KC_3))
+ * Keycode-name-based label for macro badges. Shows full QMK name (e.g. LCTL_T(KC_3))
  * instead of the visual key cap label, matching pipette-hub's macro card format.
  */
 function pdfMacroLabel(code: number, input: PdfExportInput): string {


### PR DESCRIPTION
## Summary
- Replace non-existent "QMK ID" term with "keycode name" in source code comments across 6 files
- Aligns code comments with the documentation terminology fix (a596e3c)

## Changes
- `src/shared/pdf-export.ts` — JSDoc comment
- `src/renderer/components/keycodes/SplitKey.tsx` — JSDoc comments (2 locations)
- `src/renderer/components/keyboard/types.ts` — inline comments (3 locations)
- `src/renderer/components/keycodes/TabbedKeycodes.tsx` — inline comment
- `src/renderer/components/keycodes/BasicKeyboardView.tsx` — JSDoc comment
- `src/renderer/components/editors/KeymapEditor.tsx` — inline comments (2 locations)

## Test Plan
- [x] `pnpm test` — 2728 tests passed (comment-only changes)
- [x] `pnpm build` — build successful
- [x] No remaining "QMK ID" references in .ts/.tsx source files (verified via ripgrep)