### PR TITLE
feat(config): preload QMK settings on connect and normalize HID data

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -562,6 +562,17 @@ export function App() {
     }
   }, [layoutStore, clearFileStatus])
 
+  // Back-fill QMK settings from live keyboard state when a snapshot was
+  // saved before Phase 8b introduced settings preloading.
+  const backfillQmkSettings = useCallback((vil: VilFile): boolean => {
+    if (Object.keys(vil.qmkSettings).length === 0 &&
+        Object.keys(keyboard.qmkSettingsValues).length > 0) {
+      vil.qmkSettings = { ...keyboard.qmkSettingsValues }
+      return true
+    }
+    return false
+  }, [keyboard.qmkSettingsValues])
+
   const loadEntryVilData = useCallback(async (entryId: string): Promise<VilFile | null> => {
     try {
       const result = await window.vialAPI.snapshotStoreLoad(keyboard.uid, entryId)
@@ -569,28 +580,37 @@ export function App() {
       const parsed: unknown = JSON.parse(result.data)
       if (!isVilFile(parsed)) return null
 
+      let vil = parsed
+      let dirty = false
+
       // Auto-migrate v1 → v2 on read
       if (isVilFileV1(parsed) && keyboard.definition) {
-        const migrated = migrateVilFileToV2(parsed, {
+        vil = migrateVilFileToV2(parsed, {
           definition: keyboard.definition,
           viaProtocol: keyboard.viaProtocol,
           vialProtocol: keyboard.vialProtocol,
           featureFlags: keyboard.dynamicCounts.featureFlags,
         })
+        dirty = true
+      }
+
+      // Back-fill empty QMK settings (v1 or v2 saved before Phase 8b)
+      if (backfillQmkSettings(vil)) dirty = true
+
+      if (dirty) {
         window.vialAPI.snapshotStoreUpdate(
           keyboard.uid,
           entryId,
-          JSON.stringify(migrated, null, 2),
-          migrated.version,
-        ).then((r) => { if (!r.success) console.warn('[Snapshot] v1→v2 migration failed:', r.error) })
-        return migrated
+          JSON.stringify(vil, null, 2),
+          vil.version ?? 1,
+        ).then((r) => { if (!r.success) console.warn('[Snapshot] update failed:', r.error) })
       }
 
-      return parsed
+      return vil
     } catch {
       return null
     }
-  }, [keyboard.uid, keyboard.definition])
+  }, [keyboard.uid, keyboard.definition, backfillQmkSettings])
 
   const entryExportName = useCallback((entryId: string): string => {
     const entry = layoutStore.entries.find((e) => e.id === entryId)
@@ -916,6 +936,7 @@ export function App() {
               vialProtocol: keyboard.vialProtocol,
               featureFlags: keyboard.dynamicCounts.featureFlags,
             })
+            backfillQmkSettings(upgraded)
             await window.vialAPI.snapshotStoreUpdate(
               uid, entry.id, JSON.stringify(upgraded, null, 2), upgraded.version,
             )

--- a/src/renderer/hooks/useKeyboard.ts
+++ b/src/renderer/hooks/useKeyboard.ts
@@ -31,6 +31,7 @@ import { splitMacroBuffer, deserializeMacro, macroActionsToJson, jsonToMacroActi
 import { parseKle } from '../../shared/kle/kle-parser'
 import type { KeyboardLayout } from '../../shared/kle/types'
 import { recreateKeyboardKeycodes } from '../../shared/keycodes/keycodes'
+import { normalizeQmkSettingData } from '../../shared/qmk-settings-normalize'
 
 export interface BulkKeyEntry {
   layer: number
@@ -388,7 +389,7 @@ export function useKeyboard() {
         supportedFeatures,
       })
 
-      // Phase 8: QMK Settings discovery (matches Python reload_settings)
+      // Phase 8a: QMK Settings discovery (matches Python reload_settings)
       // Wrapped in a timeout so a hung HID call cannot block reload forever.
       progress('loading.settings')
       if (newState.vialProtocol >= VIAL_PROTOCOL_QMK_SETTINGS) {
@@ -421,6 +422,53 @@ export function useKeyboard() {
           } else {
             console.error('[KB] QMK settings discovery failed:', err)
           }
+        }
+
+        // Phase 8b: Fetch current values for each supported QSID.
+        // Uses a separate timeout so a hung get call does not poison the
+        // entire reload.  Per-QSID failures are tolerated — partial data
+        // is better than none for Hub upload / .vil export.
+        // NOTE: Like Phase 8a, the fetch loop is sequential (not
+        // individually timed) because HID commands are serialised anyway.
+        // A cancelled flag prevents late completions from mutating the
+        // snapshot after a timeout.
+        if (newState.supportedQsids.size > 0) {
+          const values: Record<string, number[]> = {}
+          let cancelled = false
+          let timer: ReturnType<typeof setTimeout> | undefined
+          try {
+            await Promise.race([
+              (async () => {
+                for (const qsid of newState.supportedQsids) {
+                  if (cancelled) break
+                  try {
+                    const data = await api.qmkSettingsGet(qsid)
+                    if (!cancelled) {
+                      values[String(qsid)] = normalizeQmkSettingData(qsid, data)
+                    }
+                  } catch {
+                    console.warn(`[KB] Failed to read QMK setting ${qsid}, skipping`)
+                  }
+                }
+              })(),
+              new Promise<void>((_, reject) => {
+                timer = setTimeout(() => reject(new Error('QMK settings value fetch timeout')), 5000)
+              }),
+            ])
+          } catch {
+            cancelled = true
+            console.warn('[KB] QMK settings value fetch timed out, using partial data')
+          } finally {
+            clearTimeout(timer)
+          }
+          newState.qmkSettingsValues = values
+          qmkSettingsBaselineRef.current = Object.fromEntries(
+            Object.entries(values).map(([k, v]) => [k, [...v]]),
+          )
+        } else {
+          // No supported QSIDs — clear stale baseline from prior reload
+          newState.qmkSettingsValues = {}
+          qmkSettingsBaselineRef.current = {}
         }
       }
 
@@ -834,9 +882,10 @@ export function useKeyboard() {
   }, [bumpActivity])
 
   const updateQmkSettingsValue = useCallback((qsid: number, data: number[]) => {
+    const normalized = normalizeQmkSettingData(qsid, data)
     setState((s) => ({
       ...s,
-      qmkSettingsValues: { ...s.qmkSettingsValues, [String(qsid)]: data },
+      qmkSettingsValues: { ...s.qmkSettingsValues, [String(qsid)]: normalized },
     }))
     bumpActivity()
   }, [bumpActivity])

--- a/src/shared/__tests__/qmk-settings-normalize.test.ts
+++ b/src/shared/__tests__/qmk-settings-normalize.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { normalizeQmkSettingData } from '../qmk-settings-normalize'
+
+describe('normalizeQmkSettingData', () => {
+  it('trims 31-byte HID response to declared width for a 2-byte setting (QSID 7 = Tapping Term)', () => {
+    // QSID 7 has width: 2
+    const hidResponse = new Array(31).fill(0)
+    hidResponse[0] = 0xc8 // 200 LE low byte
+    hidResponse[1] = 0x00 // 200 LE high byte
+    hidResponse[2] = 0xff // padding (should be trimmed)
+
+    const result = normalizeQmkSettingData(7, hidResponse)
+    expect(result).toEqual([0xc8, 0x00])
+  })
+
+  it('trims to width 4 for a 4-byte boolean setting (QSID 21 = Magic)', () => {
+    // QSID 21 has width: 4
+    const hidResponse = new Array(31).fill(0)
+    hidResponse[0] = 0x0f
+    hidResponse[3] = 0x01
+    hidResponse[4] = 0xff // padding
+
+    const result = normalizeQmkSettingData(21, hidResponse)
+    expect(result).toEqual([0x0f, 0x00, 0x00, 0x01])
+  })
+
+  it('trims to width 1 for a 1-byte setting (QSID 5 = One Shot Count)', () => {
+    // QSID 5 has width: 1
+    const hidResponse = new Array(31).fill(0xaa)
+    hidResponse[0] = 0x05
+
+    const result = normalizeQmkSettingData(5, hidResponse)
+    expect(result).toEqual([0x05])
+  })
+
+  it('defaults to 4 bytes max for unknown QSIDs', () => {
+    const hidResponse = new Array(31).fill(0xff)
+
+    const result = normalizeQmkSettingData(9999, hidResponse)
+    expect(result).toEqual([0xff, 0xff, 0xff, 0xff])
+  })
+
+  it('passes through already-trimmed data unchanged', () => {
+    const trimmed = [0x88, 0x13]
+    const result = normalizeQmkSettingData(7, trimmed)
+    expect(result).toEqual([0x88, 0x13])
+  })
+
+  it('handles empty array', () => {
+    const result = normalizeQmkSettingData(7, [])
+    expect(result).toEqual([])
+  })
+
+  it('handles shorter-than-width array', () => {
+    // QSID 7 has width 2, but only 1 byte provided
+    const result = normalizeQmkSettingData(7, [0x42])
+    expect(result).toEqual([0x42])
+  })
+})

--- a/src/shared/qmk-settings-normalize.ts
+++ b/src/shared/qmk-settings-normalize.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { QmkSettingsTab } from './types/protocol'
+import settingsDefs from './qmk-settings-defs.json'
+
+const tabs = (settingsDefs as { tabs: QmkSettingsTab[] }).tabs
+
+/** Width (in bytes) for each known QSID, derived from qmk-settings-defs.json */
+const qsidWidthMap = new Map<number, number>()
+for (const tab of tabs) {
+  for (const field of tab.fields) {
+    // Multiple fields may share a QSID (e.g. boolean bit-fields).
+    // They all share the same width, so first-write wins.
+    if (!qsidWidthMap.has(field.qsid)) {
+      qsidWidthMap.set(field.qsid, field.width ?? 1)
+    }
+  }
+}
+
+/** Maximum byte width for any QMK setting (defensive upper bound) */
+export const MAX_SETTING_WIDTH = 4
+
+/**
+ * Trim a raw HID response (up to 31 bytes) to the declared width for the QSID.
+ *
+ * qmkSettingsGet() returns the full HID payload (31 bytes after status byte).
+ * Only the first `width` bytes carry the setting value; the rest are padding.
+ * The Python reference (vial-gui) performs the same trim via
+ * `data[0:fields[0]["width"]]` in QmkSettings.qsid_deserialize().
+ */
+export function normalizeQmkSettingData(qsid: number, data: number[]): number[] {
+  const width = qsidWidthMap.get(qsid) ?? MAX_SETTING_WIDTH
+  return data.slice(0, width)
+}

--- a/src/shared/vil-compat.ts
+++ b/src/shared/vil-compat.ts
@@ -8,6 +8,7 @@ import type {
   AltRepeatKeyEntry,
 } from './types/protocol'
 import { serialize as serializeKeycode, deserialize as deserializeKeycode } from './keycodes/keycodes'
+import { MAX_SETTING_WIDTH } from './qmk-settings-normalize'
 
 // --- Helpers ---
 
@@ -248,8 +249,13 @@ function vialGuiToAltRepeatKey(
 function qmkSettingsToVialGui(settings: Record<string, number[]>): Record<string, number> {
   const result: Record<string, number> = {}
   for (const [key, bytes] of Object.entries(settings)) {
+    // Defensive: clamp to MAX_SETTING_WIDTH to prevent overflow from raw
+    // HID data.  Normally data is already trimmed by
+    // normalizeQmkSettingData(), but legacy .vil files or imported data
+    // may contain untrimmed arrays.
+    const len = Math.min(bytes.length, MAX_SETTING_WIDTH)
     let value = 0
-    for (let i = 0; i < bytes.length; i++) {
+    for (let i = 0; i < len; i++) {
       value |= (bytes[i] & 0xff) << (i * 8)
     }
     result[key] = value


### PR DESCRIPTION
## Summary
- Preload QMK settings values during keyboard connection (Phase 8b) so .vil exports and Hub uploads always include settings
- Fix bug where `qmkSettingsGet()` returned full 31-byte HID response instead of meaningful bytes
- Add `normalizeQmkSettingData()` to trim raw HID data to declared width, matching Python vial-gui reference
- Back-fill empty QMK settings from live keyboard state when loading legacy snapshots

## Root Cause
`qmkSettingsGet()` in `protocol.ts` returns `Array.from(resp.subarray(1))` which is the full 31-byte HID payload minus status byte. The QmkSettings UI component worked because `deserializeValue(data, width)` only reads `width` bytes, but `qmkSettingsToVialGui()` tried to bit-shift all 31 bytes, overflowing JS 32-bit integer range and producing zero values in Hub uploads.

## Changes
- `src/shared/qmk-settings-normalize.ts` — New shared normalizer using `qmk-settings-defs.json` width
- `src/shared/__tests__/qmk-settings-normalize.test.ts` — 7 unit tests
- `src/renderer/hooks/useKeyboard.ts` — Phase 8b settings preload + normalize in `updateQmkSettingsValue`
- `src/renderer/App.tsx` — `backfillQmkSettings()` helper for v1/v2 legacy snapshots
- `src/shared/vil-compat.ts` — Defensive 4-byte clamp in `qmkSettingsToVialGui()`

## Test Plan
- [x] `pnpm test` — 2787 tests pass (108 files)
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [x] Manual: connect keyboard → save → Hub upload → verify settings present
- [x] Hub upload audit: all 6 upload paths verified for settings inclusion