### PR TITLE
fix(ui): rename File editing mode, preserve save label, add saved indicator

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1532,11 +1532,11 @@ export function App() {
       {!keyboard.loading && (
         <>
           {device.isDummy && (
-            <div className="border-b border-warning/30 bg-warning/10 px-4 py-2 text-sm text-warning">
-              {device.isPipetteFile ? t('error.pipetteFileMode') : t('error.dummyMode')}
+            <div className="flex items-center justify-between border-b border-warning/30 bg-warning/10 px-4 py-2 text-sm text-warning">
+              <span>{device.isPipetteFile ? t('error.pipetteFileMode') : t('error.dummyMode')}</span>
               {device.isPipetteFile && keyboard.activityCount > pipetteFileSavedActivityRef.current && (
-                <span className="ml-2 text-danger" data-testid="unsaved-indicator">
-                  — {t('error.unsavedChanges')}
+                <span className="text-danger" data-testid="unsaved-indicator">
+                  {t('error.unsavedChanges')}
                 </span>
               )}
             </div>

--- a/src/renderer/components/editors/LayoutStoreModal.tsx
+++ b/src/renderer/components/editors/LayoutStoreModal.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { ModalCloseButton } from './ModalCloseButton'
@@ -277,10 +277,18 @@ export function LayoutStoreContent({
   const [saveLabel, setSaveLabel] = useState(defaultSaveLabel ?? '')
   // Sync save label when a layout is loaded (defaultSaveLabel changes)
   useEffect(() => { setSaveLabel(defaultSaveLabel ?? '') }, [defaultSaveLabel])
+  const [showSaved, setShowSaved] = useState(false)
+  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [confirmHubRemoveId, setConfirmHubRemoveId] = useState<string | null>(null)
   const [confirmOverwriteId, setConfirmOverwriteId] = useState<string | null>(null)
+
+  function flashSaved(): void {
+    setShowSaved(true)
+    clearTimeout(savedTimerRef.current)
+    savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000)
+  }
 
   function handleSaveSubmit(e: React.FormEvent): void {
     e.preventDefault()
@@ -299,7 +307,7 @@ export function LayoutStoreContent({
       if (onOverwriteSave) {
         onOverwriteSave(confirmOverwriteId, trimmed)
         setConfirmOverwriteId(null)
-        setSaveLabel('')
+        flashSaved()
         return
       }
       onDelete(confirmOverwriteId)
@@ -307,7 +315,7 @@ export function LayoutStoreContent({
     }
 
     onSave(trimmed)
-    setSaveLabel('')
+    flashSaved()
   }
 
   function commitRename(entryId: string): void {
@@ -391,16 +399,21 @@ export function LayoutStoreContent({
                   )}
                 </form>
               )}
-              {hasCurrentExport && (
-                <div className={`flex justify-end gap-1${!isDummy ? ' mt-2' : ''}`}>
-                  <FormatButtons
-                    className={FORMAT_BTN}
-                    testIdPrefix="layout-store-current-export"
-                    disabled={fileDisabled}
-                    onVil={onExportVil}
-                    onKeymapC={onExportKeymapC}
-                    onPdf={onExportPdf}
-                  />
+              {(hasCurrentExport || showSaved) && (
+                <div className={`flex items-center gap-1${!isDummy ? ' mt-2' : ''}`}>
+                  {showSaved && (
+                    <span className="text-[11px] font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                  )}
+                  <div className="ml-auto flex gap-1">
+                    <FormatButtons
+                      className={FORMAT_BTN}
+                      testIdPrefix="layout-store-current-export"
+                      disabled={fileDisabled}
+                      onVil={onExportVil}
+                      onKeymapC={onExportKeymapC}
+                      onPdf={onExportPdf}
+                    />
+                  </div>
                 </div>
               )}
             </div>
@@ -455,18 +468,23 @@ export function LayoutStoreContent({
           )}
 
           {/* Export Current State section */}
-          {hasCurrentExport && (
+          {(hasCurrentExport || showSaved) && (
             <div className={`${sectionGap}${fixedSection}`} data-testid="layout-store-current-section">
               <SectionHeader label={t('layoutStore.export')} />
-              <div className="flex justify-end gap-2">
-                <FormatButtons
-                  className={EXPORT_BTN}
-                  testIdPrefix="layout-store-current-export"
-                  disabled={fileDisabled}
-                  onVil={onExportVil}
-                  onKeymapC={onExportKeymapC}
-                  onPdf={onExportPdf}
-                />
+              <div className="flex items-center gap-2">
+                {showSaved && (
+                  <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                )}
+                <div className="ml-auto flex gap-2">
+                  <FormatButtons
+                    className={EXPORT_BTN}
+                    testIdPrefix="layout-store-current-export"
+                    disabled={fileDisabled}
+                    onVil={onExportVil}
+                    onKeymapC={onExportKeymapC}
+                    onPdf={onExportPdf}
+                  />
+                </div>
               </div>
             </div>
           )}

--- a/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
@@ -365,7 +365,7 @@ describe('LayoutStoreModal', () => {
     expect(screen.getByTestId('layout-store-save-submit')).toBeDisabled()
   })
 
-  it('clears input after save submit', () => {
+  it('preserves input label after save submit and shows saved indicator', () => {
     render(
       <LayoutStoreModal
         entries={[]}
@@ -377,7 +377,8 @@ describe('LayoutStoreModal', () => {
     fireEvent.change(input, { target: { value: 'Test Label' } })
     fireEvent.submit(input.closest('form')!)
 
-    expect(input.value).toBe('')
+    expect(input.value).toBe('Test Label')
+    expect(screen.getByTestId('layout-store-saved')).toBeInTheDocument()
   })
 
   it('shows overwrite confirmation when saving with existing label', () => {
@@ -1573,7 +1574,7 @@ describe('LayoutStoreModal', () => {
       expect(onSave).toHaveBeenCalledWith('First Layout')
     })
 
-    it('clears save input and confirmation state after onOverwriteSave', () => {
+    it('preserves save input and clears confirmation state after onOverwriteSave', () => {
       const onOverwriteSave = vi.fn()
       render(
         <LayoutStoreModal
@@ -1588,11 +1589,13 @@ describe('LayoutStoreModal', () => {
       fireEvent.submit(input.closest('form')!)
       fireEvent.click(screen.getByTestId('layout-store-overwrite-confirm'))
 
-      // Input should be cleared
-      expect(input.value).toBe('')
+      // Input should preserve the label
+      expect(input.value).toBe('First Layout')
       // Confirmation state should be reset (save button visible again)
       expect(screen.getByTestId('layout-store-save-submit')).toBeInTheDocument()
       expect(screen.queryByTestId('layout-store-overwrite-confirm')).not.toBeInTheDocument()
+      // Saved indicator should be shown
+      expect(screen.getByTestId('layout-store-saved')).toBeInTheDocument()
     })
   })
 })

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "save": "Save",
+    "saved": "Saved",
     "select": "Select",
     "clickToSelect": "Click to select",
     "cancel": "Cancel",
@@ -261,7 +262,7 @@
     "saveFailed": "Failed to save layout file",
     "exampleUid": "Please configure a unique UID.",
     "dummyMode": "Dummy mode",
-    "pipetteFileMode": "File editing mode",
+    "pipetteFileMode": "File Mode",
     "unsavedChanges": "Unsaved changes",
     "noSavedFiles": "No saved files",
     "vilV1NotSupported": "Legacy data format. Connect the keyboard and open the keymap to migrate.",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "save": "保存",
+    "saved": "保存しました",
     "select": "選択",
     "clickToSelect": "クリックして選択",
     "cancel": "キャンセル",
@@ -260,7 +261,7 @@
     "saveFailed": "レイアウトファイルの保存に失敗しました",
     "exampleUid": "固有のUIDを設定してください。",
     "dummyMode": "ダミーモード",
-    "pipetteFileMode": "ファイル編集モード",
+    "pipetteFileMode": "ファイルモード",
     "unsavedChanges": "未保存の変更があります",
     "vilV1NotSupported": "古いデータフォーマットです。キーボードを接続し、キーマップを開くとマイグレーションされます。",
     "noSavedFiles": "保存済みファイルはありません",


### PR DESCRIPTION
## Summary
- Rename "File editing mode" to "File Mode" (en/ja)
- Right-align "Unsaved changes" indicator in the file mode banner
- Preserve save input label after saving instead of clearing it
- Show brief "Saved" indicator next to .vil/.c/.pdf export buttons after save

## Changes
- `src/renderer/App.tsx` — flex layout for unsaved changes banner
- `src/renderer/components/editors/LayoutStoreModal.tsx` — preserve label, add saved flash
- `src/renderer/i18n/locales/en.json` — rename to "File Mode", add `common.saved`
- `src/renderer/i18n/locales/ja.json` — rename to file-mode translation, add `common.saved`

## Test Plan
- [x] `pnpm test` — 2787 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean