### PR TITLE
feat(hub): add .pipette file to Hub upload

### DIFF
--- a/src/main/__tests__/hub-client.test.ts
+++ b/src/main/__tests__/hub-client.test.ts
@@ -205,6 +205,7 @@ describe('hub-client', () => {
   describe('uploadPostToHub', () => {
     const testFiles: HubUploadFiles = {
       vil: { name: 'test.vil', data: Buffer.from('{"keymap":{}}') },
+      pipette: { name: 'test.pipette', data: Buffer.from('{"version":2}') },
       c: { name: 'test.c', data: Buffer.from('const uint16_t PROGMEM keymaps[]') },
       pdf: { name: 'test.pdf', data: Buffer.from('pdf-content') },
       thumbnail: { name: 'test.jpg', data: Buffer.from('jpeg-data') },
@@ -427,6 +428,7 @@ describe('hub-client', () => {
   describe('updatePostOnHub', () => {
     const testFiles: HubUploadFiles = {
       vil: { name: 'test.vil', data: Buffer.from('{"keymap":{}}') },
+      pipette: { name: 'test.pipette', data: Buffer.from('{"version":2}') },
       c: { name: 'test.c', data: Buffer.from('const uint16_t PROGMEM keymaps[]') },
       pdf: { name: 'test.pdf', data: Buffer.from('pdf-content') },
       thumbnail: { name: 'test.jpg', data: Buffer.from('jpeg-data') },

--- a/src/main/__tests__/hub-ipc.test.ts
+++ b/src/main/__tests__/hub-ipc.test.ts
@@ -103,6 +103,7 @@ describe('hub-ipc', () => {
     title: 'My Keymap',
     keyboardName: 'TestBoard',
     vilJson: '{"keymap":{}}',
+    pipetteJson: '{"version":2}',
     keymapC: 'const uint16_t keymaps[]',
     pdfBase64: 'cGRmLWRhdGE=',
     thumbnailBase64: Buffer.from('fake-jpeg').toString('base64'),

--- a/src/main/hub/hub-client.ts
+++ b/src/main/hub/hub-client.ts
@@ -19,6 +19,7 @@ export interface HubPostResponse {
 
 export interface HubUploadFiles {
   vil: { name: string; data: Buffer }
+  pipette: { name: string; data: Buffer }
   c: { name: string; data: Buffer }
   pdf: { name: string; data: Buffer }
   thumbnail: { name: string; data: Buffer }
@@ -157,6 +158,7 @@ function buildMultipartBody(
   mp.appendField('title', title)
   mp.appendField('keyboard_name', keyboardName)
   mp.appendFile('vil', files.vil.name, files.vil.data, 'application/json')
+  mp.appendFile('pipette', files.pipette.name, files.pipette.data, 'application/json')
   mp.appendFile('c', files.c.name, files.c.data, 'text/plain')
   mp.appendFile('pdf', files.pdf.name, files.pdf.data, 'application/pdf')
   mp.appendFile('thumbnail', files.thumbnail.name, files.thumbnail.data, 'image/jpeg')

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -149,6 +149,7 @@ const MB = 1024 * 1024
 const FILE_SIZE_LIMITS: Record<string, { max: number; label: string }> = {
   thumbnail: { max: 2 * MB, label: 'thumbnail' },
   vil: { max: 10 * MB, label: 'vil' },
+  pipette: { max: 10 * MB, label: 'pipette' },
   c: { max: 10 * MB, label: 'keymap C' },
   pdf: { max: 10 * MB, label: 'PDF' },
 }
@@ -166,6 +167,7 @@ function buildFiles(params: HubUploadPostParams): HubUploadFiles {
   const baseName = params.keyboardName.replace(/[^a-zA-Z0-9_-]/g, '_')
   const files: HubUploadFiles = {
     vil: { name: `${baseName}.vil`, data: Buffer.from(params.vilJson, 'utf-8') },
+    pipette: { name: `${baseName}.pipette`, data: Buffer.from(params.pipetteJson, 'utf-8') },
     c: { name: `${baseName}.c`, data: Buffer.from(params.keymapC, 'utf-8') },
     pdf: { name: `${baseName}.pdf`, data: Buffer.from(params.pdfBase64, 'base64') },
     thumbnail: { name: `${baseName}.jpg`, data: Buffer.from(params.thumbnailBase64, 'base64') },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -714,6 +714,7 @@ export function App() {
       title: entry.label || deviceName,
       keyboardName: deviceName,
       vilJson: vilToVialGuiJson(vilData, buildVilExportContext(vilData)),
+      pipetteJson: JSON.stringify(vilData, null, 2),
       keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
       pdfBase64,
       thumbnailBase64,

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -7,6 +7,7 @@ export interface HubUploadPostParams {
   title: string
   keyboardName: string
   vilJson: string
+  pipetteJson: string
   keymapC: string
   pdfBase64: string
   thumbnailBase64: string


### PR DESCRIPTION
## Summary
- Include native VilFile JSON as `.pipette` file in Hub uploads
- Matches updated Hub API requirement (`pipette` field is now mandatory)

## Changes
- `src/shared/types/hub.ts` — Add `pipetteJson` to `HubUploadPostParams`
- `src/main/hub/hub-client.ts` — Add `pipette` to `HubUploadFiles` and multipart body
- `src/main/hub/hub-ipc.ts` — Build `.pipette` file from `pipetteJson`, add size limit
- `src/renderer/App.tsx` — Generate `pipetteJson` via `JSON.stringify(vilData)`

## Test Plan
- [x] `pnpm test` — 2787 tests pass
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean