### PR TITLE
refactor(ui): remove Back button and tile grid from Combo/KO/AR modals

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1648,11 +1648,11 @@ export function App() {
             onMatrixModeChange={handleMatrixModeChange}
             onOpenLighting={lightingSupported ? () => setShowLightingModal(true) : undefined}
             comboEntries={comboSupported ? keyboard.comboEntries : undefined}
-            onOpenCombo={comboSupported ? (index?: number) => { setComboInitialIndex(index); setShowComboModal(true) } : undefined}
+            onOpenCombo={comboSupported ? (index: number) => { setComboInitialIndex(index); setShowComboModal(true) } : undefined}
             keyOverrideEntries={keyOverrideSupported ? keyboard.keyOverrideEntries : undefined}
-            onOpenKeyOverride={keyOverrideSupported ? (index?: number) => { setKeyOverrideInitialIndex(index); setShowKeyOverrideModal(true) } : undefined}
+            onOpenKeyOverride={keyOverrideSupported ? (index: number) => { setKeyOverrideInitialIndex(index); setShowKeyOverrideModal(true) } : undefined}
             altRepeatKeyEntries={altRepeatKeySupported ? keyboard.altRepeatKeyEntries : undefined}
-            onOpenAltRepeatKey={altRepeatKeySupported ? (index?: number) => { setAltRepeatKeyInitialIndex(index); setShowAltRepeatKeyModal(true) } : undefined}
+            onOpenAltRepeatKey={altRepeatKeySupported ? (index: number) => { setAltRepeatKeyInitialIndex(index); setShowAltRepeatKeyModal(true) } : undefined}
             layerNames={!effectiveIsDummy ? keyboard.layerNames : undefined}
             onSetLayerName={!effectiveIsDummy ? keyboard.setLayerName : undefined}
             toolsExtra={toolsExtra}
@@ -1779,7 +1779,7 @@ export function App() {
         </div>
       )}
 
-      {showComboModal && comboSupported && (
+      {showComboModal && comboSupported && comboInitialIndex !== undefined && (
         <ComboPanelModal
           entries={keyboard.comboEntries}
           onSetEntry={keyboard.setComboEntry}
@@ -1803,7 +1803,7 @@ export function App() {
         />
       )}
 
-      {showAltRepeatKeyModal && altRepeatKeySupported && (
+      {showAltRepeatKeyModal && altRepeatKeySupported && altRepeatKeyInitialIndex !== undefined && (
         <AltRepeatKeyPanelModal
           entries={keyboard.altRepeatKeyEntries}
           onSetEntry={keyboard.setAltRepeatKeyEntry}
@@ -1827,7 +1827,7 @@ export function App() {
         />
       )}
 
-      {showKeyOverrideModal && keyOverrideSupported && (
+      {showKeyOverrideModal && keyOverrideSupported && keyOverrideInitialIndex !== undefined && (
         <KeyOverridePanelModal
           entries={keyboard.keyOverrideEntries}
           onSetEntry={keyboard.setKeyOverrideEntry}

--- a/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
+++ b/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect, useCallback, useRef, Fragment } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { AltRepeatKeyEntry, TapDanceEntry } from '../../../shared/types/protocol'
 import { AltRepeatKeyOptions } from '../../../shared/types/protocol'
 import type { Keycode } from '../../../shared/keycodes/keycodes'
-import { deserialize, codeToLabel } from '../../../shared/keycodes/keycodes'
+import { deserialize } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
@@ -25,7 +25,7 @@ import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-conf
 interface Props {
   entries: AltRepeatKeyEntry[]
   onSetEntry: (index: number, entry: AltRepeatKeyEntry) => Promise<void>
-  initialIndex?: number
+  initialIndex: number
   unlocked?: boolean
   onUnlock?: () => void
   tapDanceEntries?: TapDanceEntry[]
@@ -58,26 +58,8 @@ const optionEntries = Object.entries(AltRepeatKeyOptions).filter(
 )
 
 
-const AR_FIELDS = [
-  { key: 'lastKey', prefix: 'LK' },
-  { key: 'altKey', prefix: 'AK' },
-] as const
-
 function isConfigured(entry: AltRepeatKeyEntry): boolean {
   return entry.lastKey !== 0
-}
-
-const TILE_STYLE_ACTIVE =
-  'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
-const TILE_STYLE_DISABLED =
-  'justify-start border-picker-item-border bg-picker-item-bg text-picker-item-text hover:bg-picker-item-hover'
-const TILE_STYLE_EMPTY =
-  'justify-center border-accent/30 bg-accent/5 text-content-secondary hover:bg-accent/10'
-
-function tileStyle(configured: boolean, enabled: boolean): string {
-  if (configured && enabled) return TILE_STYLE_ACTIVE
-  if (configured) return TILE_STYLE_DISABLED
-  return TILE_STYLE_EMPTY
 }
 
 export function AltRepeatKeyPanelModal({
@@ -103,7 +85,7 @@ export function AltRepeatKeyPanelModal({
 }: Props) {
   const { t } = useTranslation()
   const { guard, clearPending } = useUnlockGate({ unlocked, onUnlock })
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(initialIndex ?? null)
+  const selectedIndex = initialIndex
   const [editedEntry, setEditedEntry] = useState<AltRepeatKeyEntry | null>(null)
   const [selectedField, setSelectedField] = useState<KeycodeFieldName | null>(null)
   const [popoverState, setPopoverState] = useState<{ field: KeycodeFieldName; anchorRect: DOMRect } | null>(null)
@@ -124,7 +106,7 @@ export function AltRepeatKeyPanelModal({
   }, []))
 
   const revertAction = useConfirmAction(useCallback(() => {
-    if (selectedIndex === null || !entries[selectedIndex]) return
+    if (!entries[selectedIndex]) return
     clearPending()
     setEditedEntry(entries[selectedIndex])
     setSelectedField(null)
@@ -137,11 +119,10 @@ export function AltRepeatKeyPanelModal({
     setPopoverState(null)
     clearAction.reset()
     revertAction.reset()
-    if (selectedIndex !== null && entries[selectedIndex]) {
+    if (entries[selectedIndex]) {
       setEditedEntry(entries[selectedIndex])
     } else {
       setEditedEntry(null)
-      if (selectedIndex !== null) setSelectedIndex(null)
     }
   }, [selectedIndex, entries])
 
@@ -154,18 +135,15 @@ export function AltRepeatKeyPanelModal({
     onClose()
   }, [clearPending, onClose])
 
-  const handleBack = useCallback(() => {
-    setSelectedIndex(null)
-  }, [])
 
   const handleEntrySave = useCallback(async () => {
-    if (selectedIndex === null || !editedEntry) return
+    if (!editedEntry) return
     const codes = [editedEntry.lastKey, editedEntry.altKey]
     await guard(codes, async () => {
       await onSetEntry(selectedIndex, editedEntry)
-      setSelectedIndex(null)
+      handleClose()
     })
-  }, [selectedIndex, editedEntry, onSetEntry, guard])
+  }, [selectedIndex, editedEntry, onSetEntry, guard, handleClose])
 
   const updateEntry = useCallback((field: KeycodeFieldName, code: number) => {
     setEditedEntry((prev) => {
@@ -238,63 +216,12 @@ export function AltRepeatKeyPanelModal({
   const canEnable = editedEntry !== null && isConfigured(editedEntry)
 
   const hasChanges =
-    selectedIndex !== null &&
     editedEntry !== null &&
     JSON.stringify(entries[selectedIndex]) !== JSON.stringify(editedEntry)
 
-  const hasEntries = entries.length > 0
-  const isEditing = selectedIndex !== null
-
-  const headerTitle = isEditing
-    ? t('editor.altRepeatKey.editTitle', { index: selectedIndex })
-    : t('editor.altRepeatKey.title')
+  const headerTitle = t('editor.altRepeatKey.editTitle', { index: selectedIndex })
 
   function renderBody(): React.ReactNode {
-    if (!hasEntries) {
-      return (
-        <div className="text-sm text-content-muted" data-testid="editor-alt-repeat-key">
-          {t('common.noEntries')}
-        </div>
-      )
-    }
-
-    if (!isEditing) {
-      return (
-        <div className="flex-1 min-h-0 px-6 pb-6" data-testid="editor-alt-repeat-key">
-          <div className="mt-1 grid h-full grid-cols-6 auto-rows-fr gap-2">
-            {entries.map((entry, i) => {
-              const configured = isConfigured(entry)
-              return (
-                <button
-                  key={i}
-                  type="button"
-                  data-testid={`ar-tile-${i}`}
-                  className={`relative flex min-h-0 flex-col items-start rounded-md border p-1.5 pl-2 text-[11px] leading-tight transition-colors ${tileStyle(configured, entry.enabled)}`}
-                  onClick={() => setSelectedIndex(i)}
-                >
-                  <span className="absolute top-1 left-1.5 text-[10px] text-content-secondary/60">{i}</span>
-                  {configured ? (
-                    <span className="mt-3 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0.5 overflow-hidden">
-                      {AR_FIELDS.map(({ key, prefix }) => (
-                        <Fragment key={key}>
-                          <span className="text-left text-content-secondary/60">{prefix}</span>
-                          <span className="truncate text-left">{entry[key] !== 0 ? codeToLabel(entry[key]) : ''}</span>
-                        </Fragment>
-                      ))}
-                    </span>
-                  ) : (
-                    <span className="w-full text-center text-content-secondary/60">
-                      {t('common.notConfigured')}
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-      )
-    }
-
     return (
       <div className="flex min-h-0 flex-1 overflow-hidden" data-testid="editor-alt-repeat-key">
         {/* Left panel: detail editor */}
@@ -442,19 +369,6 @@ export function AltRepeatKeyPanelModal({
             )}
           </div>
 
-          {/* Fixed footer: Back */}
-          {!selectedField && editedEntry && (
-            <div className="shrink-0 px-6 py-3">
-              <button
-                type="button"
-                data-testid="ar-back-btn"
-                className="rounded-lg border border-edge bg-surface px-4 py-2 text-[13px] font-semibold text-content hover:bg-surface-alt"
-                onClick={handleBack}
-              >
-                {t('common.back')}
-              </button>
-            </div>
-          )}
         </div>
 
         {/* Right panel: favorites (hidden when picker is open) */}
@@ -499,11 +413,11 @@ export function AltRepeatKeyPanelModal({
       onClick={handleClose}
     >
       <div
-        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${hasEntries ? 'w-[1050px] max-w-[95vw] h-[80vh] flex flex-col' : 'p-6'}`}
+        className="overflow-hidden rounded-lg bg-surface-alt shadow-xl w-[1050px] max-w-[95vw] h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {!selectedField && (
-          <div className={`flex items-center justify-between shrink-0 ${hasEntries ? 'px-6 pt-6 pb-4' : 'mb-4'}`}>
+          <div className="flex items-center justify-between shrink-0 px-6 pt-6 pb-4">
             <h3 className="text-lg font-semibold">{headerTitle}</h3>
             <ModalCloseButton testid="ar-modal-close" onClick={handleClose} />
           </div>

--- a/src/renderer/components/editors/ComboPanelModal.tsx
+++ b/src/renderer/components/editors/ComboPanelModal.tsx
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect, useCallback, useRef, Fragment } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ComboEntry, TapDanceEntry } from '../../../shared/types/protocol'
 import type { Keycode } from '../../../shared/keycodes/keycodes'
-import { deserialize, codeToLabel } from '../../../shared/keycodes/keycodes'
+import { deserialize } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
@@ -27,7 +27,7 @@ interface Props {
   onUnlock?: () => void
   tapDanceEntries?: TapDanceEntry[]
   deserializedMacros?: MacroAction[][]
-  initialIndex?: number
+  initialIndex: number
   onClose: () => void
   // Hub integration (optional)
   hubOrigin?: string
@@ -64,18 +64,6 @@ function isConfigured(entry: ComboEntry): boolean {
   return entry.key1 !== 0 || entry.key2 !== 0
 }
 
-const COMBO_FIELDS = [
-  { key: 'key1', prefix: 'K1' },
-  { key: 'key2', prefix: 'K2' },
-  { key: 'key3', prefix: 'K3' },
-  { key: 'key4', prefix: 'K4' },
-  { key: 'output', prefix: 'O' },
-] as const
-
-const TILE_STYLE_CONFIGURED =
-  'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
-const TILE_STYLE_EMPTY =
-  'justify-center border-accent/30 bg-accent/5 text-content-secondary hover:bg-accent/10'
 
 export function ComboPanelModal({
   entries,
@@ -100,7 +88,7 @@ export function ComboPanelModal({
 }: Props) {
   const { t } = useTranslation()
   const { guard, clearPending } = useUnlockGate({ unlocked, onUnlock })
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(initialIndex ?? null)
+  const selectedIndex = initialIndex
   const [editedEntry, setEditedEntry] = useState<ComboEntry | null>(null)
   const [selectedField, setSelectedField] = useState<KeycodeFieldName | null>(null)
   const [popoverState, setPopoverState] = useState<{ field: KeycodeFieldName; anchorRect: DOMRect } | null>(null)
@@ -119,7 +107,7 @@ export function ComboPanelModal({
   }, []))
 
   const revertAction = useConfirmAction(useCallback(() => {
-    if (selectedIndex === null || !entries[selectedIndex]) return
+    if (!entries[selectedIndex]) return
     clearPending()
     setEditedEntry(entries[selectedIndex])
     setSelectedField(null)
@@ -132,11 +120,10 @@ export function ComboPanelModal({
     setPopoverState(null)
     clearAction.reset()
     revertAction.reset()
-    if (selectedIndex !== null && entries[selectedIndex]) {
+    if (entries[selectedIndex]) {
       setEditedEntry(entries[selectedIndex])
     } else {
       setEditedEntry(null)
-      if (selectedIndex !== null) setSelectedIndex(null)
     }
   }, [selectedIndex, entries])
 
@@ -149,18 +136,15 @@ export function ComboPanelModal({
     onClose()
   }, [clearPending, onClose])
 
-  const handleBack = useCallback(() => {
-    setSelectedIndex(null)
-  }, [])
 
   const handleEntrySave = useCallback(async () => {
-    if (selectedIndex === null || !editedEntry) return
+    if (!editedEntry) return
     const codes = [editedEntry.key1, editedEntry.key2, editedEntry.key3, editedEntry.key4, editedEntry.output]
     await guard(codes, async () => {
       await onSetEntry(selectedIndex, editedEntry)
-      setSelectedIndex(null)
+      handleClose()
     })
-  }, [selectedIndex, editedEntry, onSetEntry, guard])
+  }, [selectedIndex, editedEntry, onSetEntry, guard, handleClose])
 
   const updateField = useCallback((field: KeycodeFieldName, code: number) => {
     setEditedEntry((prev) => prev ? { ...prev, [field]: code } : prev)
@@ -214,63 +198,12 @@ export function ComboPanelModal({
   )
 
   const hasChanges =
-    selectedIndex !== null &&
     editedEntry !== null &&
     JSON.stringify(entries[selectedIndex]) !== JSON.stringify(editedEntry)
 
-  const hasEntries = entries.length > 0
-  const isEditing = selectedIndex !== null
-
-  const headerTitle = isEditing
-    ? t('editor.combo.editTitle', { index: selectedIndex })
-    : t('editor.combo.title')
+  const headerTitle = t('editor.combo.editTitle', { index: selectedIndex })
 
   function renderBody(): React.ReactNode {
-    if (!hasEntries) {
-      return (
-        <div className="text-sm text-content-muted" data-testid="editor-combo">
-          {t('common.noEntries')}
-        </div>
-      )
-    }
-
-    if (!isEditing) {
-      return (
-        <div className="flex-1 min-h-0 flex flex-col px-6 pb-6" data-testid="editor-combo">
-          <div className="mt-1 flex-1 min-h-0 grid grid-cols-6 auto-rows-fr gap-2">
-            {entries.map((entry, i) => {
-              const configured = isConfigured(entry)
-              return (
-                <button
-                  key={i}
-                  type="button"
-                  data-testid={`combo-tile-${i}`}
-                  className={`relative flex min-h-0 flex-col items-start rounded-md border p-1.5 pl-2 text-[11px] leading-tight transition-colors ${configured ? TILE_STYLE_CONFIGURED : TILE_STYLE_EMPTY}`}
-                  onClick={() => setSelectedIndex(i)}
-                >
-                  <span className="absolute top-1 left-1.5 text-[10px] text-content-secondary/60">{i}</span>
-                  {configured ? (
-                    <span className="mt-3 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0.5 overflow-hidden">
-                      {COMBO_FIELDS.map(({ key, prefix }) => (
-                        <Fragment key={key}>
-                          <span className="text-left text-content-secondary/60">{prefix}</span>
-                          <span className="truncate text-left">{entry[key] !== 0 ? codeToLabel(entry[key]) : ''}</span>
-                        </Fragment>
-                      ))}
-                    </span>
-                  ) : (
-                    <span className="w-full text-center text-content-secondary/60">
-                      {t('common.notConfigured')}
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-      )
-    }
-
     return (
       <div className="flex min-h-0 flex-1 overflow-hidden" data-testid="editor-combo">
         {/* Left panel: detail editor */}
@@ -374,19 +307,6 @@ export function ComboPanelModal({
             )}
           </div>
 
-          {/* Fixed footer: Back */}
-          {!selectedField && editedEntry && (
-            <div className="shrink-0 px-6 py-3">
-              <button
-                type="button"
-                data-testid="combo-back-btn"
-                className="rounded-lg border border-edge bg-surface px-4 py-2 text-[13px] font-semibold text-content hover:bg-surface-alt"
-                onClick={handleBack}
-              >
-                {t('common.back')}
-              </button>
-            </div>
-          )}
         </div>
 
         {/* Right panel: favorites (hidden when picker is open) */}
@@ -431,11 +351,11 @@ export function ComboPanelModal({
       onClick={handleClose}
     >
       <div
-        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${hasEntries ? 'w-[1050px] max-w-[95vw] h-[80vh] flex flex-col' : 'p-6'}`}
+        className="overflow-hidden rounded-lg bg-surface-alt shadow-xl w-[1050px] max-w-[95vw] h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {!selectedField && (
-          <div className={`flex items-center justify-between shrink-0 ${hasEntries ? 'px-6 pt-6 pb-4' : 'mb-4'}`}>
+          <div className="flex items-center justify-between shrink-0 px-6 pt-6 pb-4">
             <h3 className="text-lg font-semibold">{headerTitle}</h3>
             <ModalCloseButton testid="combo-modal-close" onClick={handleClose} />
           </div>

--- a/src/renderer/components/editors/KeyOverridePanelModal.tsx
+++ b/src/renderer/components/editors/KeyOverridePanelModal.tsx
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect, useCallback, useRef, Fragment } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { KeyOverrideEntry, TapDanceEntry } from '../../../shared/types/protocol'
 import { KeyOverrideOptions } from '../../../shared/types/protocol'
 import type { Keycode } from '../../../shared/keycodes/keycodes'
-import { deserialize, codeToLabel } from '../../../shared/keycodes/keycodes'
+import { deserialize } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
@@ -26,7 +26,7 @@ import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-conf
 interface Props {
   entries: KeyOverrideEntry[]
   onSetEntry: (index: number, entry: KeyOverrideEntry) => Promise<void>
-  initialIndex?: number
+  initialIndex: number
   unlocked?: boolean
   onUnlock?: () => void
   tapDanceEntries?: TapDanceEntry[]
@@ -67,26 +67,8 @@ const optionEntries = Object.entries(KeyOverrideOptions).filter(
 )
 
 
-const KO_FIELDS = [
-  { key: 'triggerKey', prefix: 'TK' },
-  { key: 'replacementKey', prefix: 'RK' },
-] as const
-
 function isConfigured(entry: KeyOverrideEntry): boolean {
   return entry.triggerKey !== 0 || entry.triggerMods !== 0
-}
-
-const TILE_STYLE_ACTIVE =
-  'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
-const TILE_STYLE_DISABLED =
-  'justify-start border-picker-item-border bg-picker-item-bg text-picker-item-text hover:bg-picker-item-hover'
-const TILE_STYLE_EMPTY =
-  'justify-center border-accent/30 bg-accent/5 text-content-secondary hover:bg-accent/10'
-
-function tileStyle(configured: boolean, enabled: boolean): string {
-  if (configured && enabled) return TILE_STYLE_ACTIVE
-  if (configured) return TILE_STYLE_DISABLED
-  return TILE_STYLE_EMPTY
 }
 
 export function KeyOverridePanelModal({
@@ -112,7 +94,7 @@ export function KeyOverridePanelModal({
 }: Props) {
   const { t } = useTranslation()
   const { guard, clearPending } = useUnlockGate({ unlocked, onUnlock })
-  const [selectedIndex, setSelectedIndex] = useState<number | null>(initialIndex ?? null)
+  const selectedIndex = initialIndex
   const [editedEntry, setEditedEntry] = useState<KeyOverrideEntry | null>(null)
   const [selectedField, setSelectedField] = useState<KeycodeFieldName | null>(null)
   const [popoverState, setPopoverState] = useState<{ field: KeycodeFieldName; anchorRect: DOMRect } | null>(null)
@@ -135,7 +117,7 @@ export function KeyOverridePanelModal({
   }, []))
 
   const revertAction = useConfirmAction(useCallback(() => {
-    if (selectedIndex === null || !entries[selectedIndex]) return
+    if (!entries[selectedIndex]) return
     clearPending()
     setEditedEntry(entries[selectedIndex])
     setSelectedField(null)
@@ -147,11 +129,10 @@ export function KeyOverridePanelModal({
     setPopoverState(null)
     clearAction.reset()
     revertAction.reset()
-    if (selectedIndex !== null && entries[selectedIndex]) {
+    if (entries[selectedIndex]) {
       setEditedEntry(entries[selectedIndex])
     } else {
       setEditedEntry(null)
-      if (selectedIndex !== null) setSelectedIndex(null)
     }
   }, [selectedIndex, entries])
 
@@ -164,18 +145,15 @@ export function KeyOverridePanelModal({
     onClose()
   }, [clearPending, onClose])
 
-  const handleBack = useCallback(() => {
-    setSelectedIndex(null)
-  }, [])
 
   const handleEntrySave = useCallback(async () => {
-    if (selectedIndex === null || !editedEntry) return
+    if (!editedEntry) return
     const codes = [editedEntry.triggerKey, editedEntry.replacementKey]
     await guard(codes, async () => {
       await onSetEntry(selectedIndex, editedEntry)
-      setSelectedIndex(null)
+      handleClose()
     })
-  }, [selectedIndex, editedEntry, onSetEntry, guard])
+  }, [selectedIndex, editedEntry, onSetEntry, guard, handleClose])
 
   const updateEntry = useCallback((field: keyof KeyOverrideEntry, value: number) => {
     setEditedEntry((prev) => {
@@ -248,71 +226,12 @@ export function KeyOverridePanelModal({
   const canEnable = editedEntry !== null && isConfigured(editedEntry)
 
   const hasChanges =
-    selectedIndex !== null &&
     editedEntry !== null &&
     JSON.stringify(entries[selectedIndex]) !== JSON.stringify(editedEntry)
 
-  const hasEntries = entries.length > 0
-  const isEditing = selectedIndex !== null
-
-  const headerTitle = isEditing
-    ? t('editor.keyOverride.editTitle', { index: selectedIndex })
-    : t('editor.keyOverride.title')
+  const headerTitle = t('editor.keyOverride.editTitle', { index: selectedIndex })
 
   function renderBody(): React.ReactNode {
-    if (!hasEntries) {
-      return (
-        <div className="text-sm text-content-muted" data-testid="editor-key-override">
-          {t('common.noEntries')}
-        </div>
-      )
-    }
-
-    if (!isEditing) {
-      return (
-        <div className="flex-1 min-h-0 px-6 pb-6" data-testid="editor-key-override">
-          <div className="mt-1 grid h-full grid-cols-6 auto-rows-fr gap-2">
-            {entries.map((entry, i) => {
-              const configured = isConfigured(entry)
-              return (
-                <button
-                  key={i}
-                  type="button"
-                  data-testid={`ko-tile-${i}`}
-                  className={`relative flex min-h-0 flex-col items-start rounded-md border p-1.5 pl-2 text-[11px] leading-tight transition-colors ${tileStyle(configured, entry.enabled)}`}
-                  onClick={() => setSelectedIndex(i)}
-                >
-                  <span className="absolute top-1 left-1.5 text-[10px] text-content-secondary/60">{i}</span>
-                  {configured ? (
-                    <span className="mt-3 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0.5 overflow-hidden">
-                      {KO_FIELDS.map(({ key, prefix }) => {
-                        let label = ''
-                        if (key === 'triggerKey' && entry.triggerKey === 0 && entry.triggerMods !== 0) {
-                          label = t('editor.keyOverride.modsOnly')
-                        } else if (entry[key] !== 0) {
-                          label = codeToLabel(entry[key])
-                        }
-                        return (
-                          <Fragment key={key}>
-                            <span className="text-left text-content-secondary/60">{prefix}</span>
-                            <span className="truncate text-left">{label}</span>
-                          </Fragment>
-                        )
-                      })}
-                    </span>
-                  ) : (
-                    <span className="w-full text-center text-content-secondary/60">
-                      {t('common.notConfigured')}
-                    </span>
-                  )}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-      )
-    }
-
     return (
       <div className="flex min-h-0 flex-1 overflow-hidden" data-testid="editor-key-override">
         {/* Left panel: detail editor */}
@@ -441,45 +360,35 @@ export function KeyOverridePanelModal({
             )}
           </div>
 
-          {/* Fixed footer: Back / Revert+Save — aligned with favorites Import/Export */}
+          {/* Fixed footer: Clear / Revert / Save — aligned with favorites Import/Export */}
           {!selectedField && editedEntry && (
             <div className="shrink-0 px-6 py-3">
-              <div className="flex justify-between">
+              <div className="flex justify-end gap-2">
+                <ConfirmButton
+                  testId="ko-modal-clear"
+                  confirming={clearAction.confirming}
+                  onClick={() => { revertAction.reset(); clearAction.trigger() }}
+                  labelKey="common.clear"
+                  confirmLabelKey="common.confirmClear"
+                  className="rounded-lg border px-4 py-2 text-[13px] font-semibold"
+                />
+                <ConfirmButton
+                  testId="ko-modal-revert"
+                  confirming={revertAction.confirming}
+                  onClick={() => { clearAction.reset(); revertAction.trigger() }}
+                  labelKey="common.revert"
+                  confirmLabelKey="common.confirmRevert"
+                  className="rounded-lg border px-4 py-2 text-[13px] font-semibold"
+                />
                 <button
                   type="button"
-                  data-testid="ko-back-btn"
-                  className="rounded-lg border border-edge bg-surface px-4 py-2 text-[13px] font-semibold text-content hover:bg-surface-alt"
-                  onClick={handleBack}
+                  data-testid="ko-modal-save"
+                  className="rounded-lg bg-accent px-4 py-2 text-[13px] font-semibold text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+                  disabled={!hasChanges}
+                  onClick={handleEntrySave}
                 >
-                  {t('common.back')}
+                  {t('common.save')}
                 </button>
-                <div className="flex gap-2">
-                  <ConfirmButton
-                    testId="ko-modal-clear"
-                    confirming={clearAction.confirming}
-                    onClick={() => { revertAction.reset(); clearAction.trigger() }}
-                    labelKey="common.clear"
-                    confirmLabelKey="common.confirmClear"
-                    className="rounded-lg border px-4 py-2 text-[13px] font-semibold"
-                  />
-                  <ConfirmButton
-                    testId="ko-modal-revert"
-                    confirming={revertAction.confirming}
-                    onClick={() => { clearAction.reset(); revertAction.trigger() }}
-                    labelKey="common.revert"
-                    confirmLabelKey="common.confirmRevert"
-                    className="rounded-lg border px-4 py-2 text-[13px] font-semibold"
-                  />
-                  <button
-                    type="button"
-                    data-testid="ko-modal-save"
-                    className="rounded-lg bg-accent px-4 py-2 text-[13px] font-semibold text-content-inverse hover:bg-accent-hover disabled:opacity-50"
-                    disabled={!hasChanges}
-                    onClick={handleEntrySave}
-                  >
-                    {t('common.save')}
-                  </button>
-                </div>
               </div>
             </div>
           )}
@@ -527,11 +436,11 @@ export function KeyOverridePanelModal({
       onClick={handleClose}
     >
       <div
-        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${hasEntries ? 'w-[1050px] max-w-[95vw] h-[80vh] flex flex-col' : 'p-6'}`}
+        className="overflow-hidden rounded-lg bg-surface-alt shadow-xl w-[1050px] max-w-[95vw] h-[80vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         {!selectedField && (
-          <div className={`flex items-center justify-between shrink-0 ${hasEntries ? 'px-6 pt-6 pb-4' : 'mb-4'}`}>
+          <div className="flex items-center justify-between shrink-0 px-6 pt-6 pb-4">
             <h3 className="text-lg font-semibold">{headerTitle}</h3>
             <ModalCloseButton testid="ko-modal-close" onClick={handleClose} />
           </div>

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -590,11 +590,11 @@ interface Props {
   onMatrixModeChange?: (matrixMode: boolean, hasMatrixTester: boolean) => void
   onOpenLighting?: () => void
   comboEntries?: import('../../../shared/types/protocol').ComboEntry[]
-  onOpenCombo?: (index?: number) => void
+  onOpenCombo?: (index: number) => void
   keyOverrideEntries?: import('../../../shared/types/protocol').KeyOverrideEntry[]
-  onOpenKeyOverride?: (index?: number) => void
+  onOpenKeyOverride?: (index: number) => void
   altRepeatKeyEntries?: import('../../../shared/types/protocol').AltRepeatKeyEntry[]
-  onOpenAltRepeatKey?: (index?: number) => void
+  onOpenAltRepeatKey?: (index: number) => void
   toolsExtra?: React.ReactNode
   dataPanel?: React.ReactNode
   onOverlayOpen?: () => void

--- a/src/renderer/components/editors/__tests__/AltRepeatKeyPanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/AltRepeatKeyPanelModal.test.tsx
@@ -16,12 +16,8 @@ vi.mock('react-i18next', () => ({
         'editor.altRepeatKey.allowedMods': 'Allowed Mods',
         'editor.altRepeatKey.options': 'Options',
         'editor.altRepeatKey.enabled': 'Enabled',
-        'editor.altRepeatKey.selectEntry': 'Select an entry to edit',
-        'common.noEntries': 'No entries',
-        'common.notConfigured': 'N/C',
         'common.save': 'Save',
         'common.close': 'Close',
-        'common.back': 'Back',
       }
       if (key === 'editor.altRepeatKey.editTitle') return `Alt Repeat Key - ${opts?.index}`
       return map[key] ?? key
@@ -86,105 +82,34 @@ describe('AltRepeatKeyPanelModal', () => {
     vi.useRealTimers()
   })
 
-  it('renders no entries message when empty', () => {
-    render(<AltRepeatKeyPanelModal entries={[]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.getByText('No entries')).toBeInTheDocument()
-  })
-
-  it('renders grid tiles for each entry', () => {
+  it('shows editor and favorites panel directly', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    expect(screen.getByTestId('ar-tile-0')).toHaveTextContent('0')
-    expect(screen.getByTestId('ar-tile-0')).toHaveTextContent('N/C')
-    expect(screen.getByTestId('ar-tile-1')).toHaveTextContent('1')
-  })
-
-  it('renders configured+enabled tile with active accent style', () => {
-    render(
-      <AltRepeatKeyPanelModal
-        entries={[makeEntry({ lastKey: 4, altKey: 5, enabled: true })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('ar-tile-0')
-    expect(tile.className).toContain('border-accent')
-    expect(tile.className).toContain('bg-accent/20')
-    expect(tile.className).toContain('font-semibold')
-  })
-
-  it('renders configured+disabled tile with disabled style', () => {
-    render(
-      <AltRepeatKeyPanelModal
-        entries={[makeEntry({ lastKey: 4, altKey: 5, enabled: false })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('ar-tile-0')
-    expect(tile.className).toContain('border-picker-item-border')
-  })
-
-  it('renders unconfigured tile with empty style', () => {
-    render(<AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    const tile = screen.getByTestId('ar-tile-0')
-    expect(tile.className).toContain('border-accent/30')
-    expect(tile.className).toContain('bg-accent/5')
-  })
-
-  it('shows tile screen initially with no editor visible', () => {
-    render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    expect(screen.getByTestId('ar-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Alt Repeat Key - 0')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('ar-favorites-panel')).not.toBeInTheDocument()
-  })
-
-  it('shows editor and favorites panel when tile is clicked', () => {
-    render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByText('Alt Repeat Key - 0')).toBeInTheDocument()
     expect(screen.getAllByTestId('keycode-field')).toHaveLength(2)
     expect(screen.getByTestId('ar-favorites-panel')).toBeInTheDocument()
     expect(screen.getByTestId('favorite-store-content')).toBeInTheDocument()
   })
 
-  it('navigates back to tile screen when Back button is clicked', () => {
-    render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
-    expect(screen.getByText('Alt Repeat Key - 0')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('ar-back-btn'))
-    expect(screen.queryByText('Alt Repeat Key - 0')).not.toBeInTheDocument()
-    expect(screen.getByTestId('ar-tile-0')).toBeInTheDocument()
-  })
-
   it('shows enabled checkbox disabled when lastKey is 0', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByTestId('ar-enabled')).toBeDisabled()
   })
 
   it('shows enabled checkbox enabled when lastKey is nonzero', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry({ lastKey: 4 })]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry({ lastKey: 4 })]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByTestId('ar-enabled')).not.toBeDisabled()
   })
 
   it('shows TabbedKeycodes when a keycode field is clicked', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.queryByTestId('tabbed-keycodes')).not.toBeInTheDocument()
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
@@ -193,9 +118,8 @@ describe('AltRepeatKeyPanelModal', () => {
 
   it('hides advanced fields when picker is open', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByTestId('ar-advanced-fields')).toBeInTheDocument()
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
@@ -204,17 +128,15 @@ describe('AltRepeatKeyPanelModal', () => {
 
   it('Save button is disabled when no changes', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByTestId('ar-modal-save')).toBeDisabled()
   })
 
   it('Save button enables after editing lastKey', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -222,11 +144,10 @@ describe('AltRepeatKeyPanelModal', () => {
     expect(screen.getByTestId('ar-modal-save')).toBeEnabled()
   })
 
-  it('calls onSetEntry and returns to tile screen on Save', async () => {
+  it('calls onSetEntry and closes modal on Save', async () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -236,14 +157,12 @@ describe('AltRepeatKeyPanelModal', () => {
     await waitFor(() => {
       expect(onSetEntry).toHaveBeenCalledWith(0, expect.objectContaining({ lastKey: 7 }))
     })
-    // After save, should return to tile screen
-    expect(screen.getByTestId('ar-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Alt Repeat Key - 0')).not.toBeInTheDocument()
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('calls onClose when close button is clicked', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('ar-modal-close'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -251,7 +170,7 @@ describe('AltRepeatKeyPanelModal', () => {
 
   it('calls onClose when backdrop is clicked', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('ar-modal-backdrop'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -259,39 +178,16 @@ describe('AltRepeatKeyPanelModal', () => {
 
   it('does not close modal on Escape key', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('returns to tile screen when entries shrink and selected index is out of bounds', () => {
-    const { rerender } = render(
-      <AltRepeatKeyPanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ar-tile-1'))
-    expect(screen.getByText('Alt Repeat Key - 1')).toBeInTheDocument()
-    // Rerender with fewer entries — selected index 1 no longer exists
-    rerender(<AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.queryByText('Alt Repeat Key - 1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('ar-tile-0')).toBeInTheDocument()
-  })
-
-  it('shows close button in editor view when picker is closed', () => {
-    render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
-    expect(screen.getByTestId('ar-modal-close')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('ar-modal-close'))
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
   it('hides favorites panel when picker is open', () => {
     render(
-      <AltRepeatKeyPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ar-tile-0'))
     expect(screen.getByTestId('ar-favorites-panel').className).not.toContain('hidden')
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })

--- a/src/renderer/components/editors/__tests__/ComboPanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/ComboPanelModal.test.tsx
@@ -12,12 +12,8 @@ vi.mock('react-i18next', () => ({
       const map: Record<string, string> = {
         'editor.combo.title': 'Combo',
         'editor.combo.output': 'Output',
-        'editor.combo.selectEntry': 'Select an entry to edit',
-        'common.noEntries': 'No entries',
-        'common.notConfigured': 'N/C',
         'common.save': 'Save',
         'common.close': 'Close',
-        'common.back': 'Back',
       }
       if (key === 'editor.combo.key') return `Key ${opts?.number}`
       if (key === 'editor.combo.editTitle') return `Combo - ${opts?.index}`
@@ -83,94 +79,20 @@ describe('ComboPanelModal', () => {
     vi.useRealTimers()
   })
 
-  it('renders no entries message when empty', () => {
-    render(<ComboPanelModal entries={[]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.getByText('No entries')).toBeInTheDocument()
-  })
-
-  it('renders grid tiles for each entry', () => {
+  it('shows editor and favorites panel directly', () => {
     render(
-      <ComboPanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    expect(screen.getByTestId('combo-tile-0')).toHaveTextContent('0')
-    expect(screen.getByTestId('combo-tile-0')).toHaveTextContent('N/C')
-    expect(screen.getByTestId('combo-tile-1')).toHaveTextContent('1')
-  })
-
-  it('renders configured tile with combo key labels', () => {
-    render(
-      <ComboPanelModal
-        entries={[makeEntry({ key1: 4, key2: 5, output: 6 })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('combo-tile-0')
-    expect(tile).toHaveTextContent('K1')
-    expect(tile).toHaveTextContent('KC_4')
-    expect(tile).toHaveTextContent('K2')
-    expect(tile).toHaveTextContent('KC_5')
-    expect(tile).toHaveTextContent('O')
-    expect(tile).toHaveTextContent('KC_6')
-  })
-
-  it('renders unconfigured tile with muted accent color', () => {
-    render(<ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    const tile = screen.getByTestId('combo-tile-0')
-    expect(tile.className).toContain('border-accent/30')
-    expect(tile.className).toContain('bg-accent/5')
-  })
-
-  it('renders configured tile with accent color', () => {
-    render(
-      <ComboPanelModal
-        entries={[makeEntry({ key1: 4 })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('combo-tile-0')
-    expect(tile.className).toContain('border-accent')
-    expect(tile.className).toContain('bg-accent/20')
-    expect(tile.className).toContain('font-semibold')
-  })
-
-  it('shows tile screen initially with no editor visible', () => {
-    render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    expect(screen.getByTestId('combo-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Combo - 0')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('combo-favorites-panel')).not.toBeInTheDocument()
-  })
-
-  it('shows editor and favorites panel when tile is clicked', () => {
-    render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     expect(screen.getByText('Combo - 0')).toBeInTheDocument()
     expect(screen.getAllByTestId('keycode-field')).toHaveLength(5)
     expect(screen.getByTestId('combo-favorites-panel')).toBeInTheDocument()
     expect(screen.getByTestId('favorite-store-content')).toBeInTheDocument()
   })
 
-  it('navigates back to tile screen when Back button is clicked', () => {
-    render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
-    expect(screen.getByText('Combo - 0')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('combo-back-btn'))
-    expect(screen.queryByText('Combo - 0')).not.toBeInTheDocument()
-    expect(screen.getByTestId('combo-tile-0')).toBeInTheDocument()
-  })
-
   it('shows TabbedKeycodes when a keycode field is clicked', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     expect(screen.queryByTestId('tabbed-keycodes')).not.toBeInTheDocument()
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
@@ -179,17 +101,15 @@ describe('ComboPanelModal', () => {
 
   it('Save button is disabled when no changes', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     expect(screen.getByTestId('combo-modal-save')).toBeDisabled()
   })
 
   it('Save button enables after editing key1', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -197,11 +117,10 @@ describe('ComboPanelModal', () => {
     expect(screen.getByTestId('combo-modal-save')).toBeEnabled()
   })
 
-  it('calls onSetEntry and returns to tile screen on Save', async () => {
+  it('calls onSetEntry and closes modal on Save', async () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -211,14 +130,13 @@ describe('ComboPanelModal', () => {
     await waitFor(() => {
       expect(onSetEntry).toHaveBeenCalledWith(0, expect.objectContaining({ key1: 7 }))
     })
-    // After save, should return to tile screen
-    expect(screen.getByTestId('combo-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Combo - 0')).not.toBeInTheDocument()
+    // After save, modal should close
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('calls onClose when close button is clicked', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('combo-modal-close'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -226,7 +144,7 @@ describe('ComboPanelModal', () => {
 
   it('calls onClose when backdrop is clicked', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('combo-modal-backdrop'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -234,39 +152,16 @@ describe('ComboPanelModal', () => {
 
   it('does not close modal on Escape key', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('returns to tile screen when entries shrink and selected index is out of bounds', () => {
-    const { rerender } = render(
-      <ComboPanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('combo-tile-1'))
-    expect(screen.getByText('Combo - 1')).toBeInTheDocument()
-    // Rerender with fewer entries — selected index 1 no longer exists
-    rerender(<ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.queryByText('Combo - 1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('combo-tile-0')).toBeInTheDocument()
-  })
-
-  it('shows close button in editor view when picker is closed', () => {
-    render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
-    expect(screen.getByTestId('combo-modal-close')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('combo-modal-close'))
-    expect(onClose).toHaveBeenCalledTimes(1)
-  })
-
   it('hides favorites panel when picker is open', () => {
     render(
-      <ComboPanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('combo-tile-0'))
     expect(screen.getByTestId('combo-favorites-panel').className).not.toContain('hidden')
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })

--- a/src/renderer/components/editors/__tests__/KeyOverridePanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeyOverridePanelModal.test.tsx
@@ -19,13 +19,8 @@ vi.mock('react-i18next', () => ({
         'editor.keyOverride.suppressedMods': 'Suppressed Mods',
         'editor.keyOverride.options': 'Options',
         'editor.keyOverride.enabled': 'Enabled',
-        'editor.keyOverride.modsOnly': 'Mods',
-        'editor.keyOverride.selectEntry': 'Select an entry to edit',
-        'common.noEntries': 'No entries',
-        'common.notConfigured': 'N/C',
         'common.save': 'Save',
         'common.close': 'Close',
-        'common.back': 'Back',
       }
       if (key === 'editor.keyOverride.editTitle') return `Key Override - ${opts?.index}`
       return map[key] ?? key
@@ -93,105 +88,34 @@ describe('KeyOverridePanelModal', () => {
     vi.useRealTimers()
   })
 
-  it('renders no entries message when empty', () => {
-    render(<KeyOverridePanelModal entries={[]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.getByText('No entries')).toBeInTheDocument()
-  })
-
-  it('renders grid tiles for each entry', () => {
+  it('shows editor and favorites panel directly', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    expect(screen.getByTestId('ko-tile-0')).toHaveTextContent('0')
-    expect(screen.getByTestId('ko-tile-0')).toHaveTextContent('N/C')
-    expect(screen.getByTestId('ko-tile-1')).toHaveTextContent('1')
-  })
-
-  it('renders configured+enabled tile with active accent style', () => {
-    render(
-      <KeyOverridePanelModal
-        entries={[makeEntry({ triggerKey: 4, replacementKey: 5, enabled: true })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('ko-tile-0')
-    expect(tile.className).toContain('border-accent')
-    expect(tile.className).toContain('bg-accent/20')
-    expect(tile.className).toContain('font-semibold')
-  })
-
-  it('renders configured+disabled tile with disabled style', () => {
-    render(
-      <KeyOverridePanelModal
-        entries={[makeEntry({ triggerKey: 4, replacementKey: 5, enabled: false })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('ko-tile-0')
-    expect(tile.className).toContain('border-picker-item-border')
-  })
-
-  it('renders unconfigured tile with empty style', () => {
-    render(<KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    const tile = screen.getByTestId('ko-tile-0')
-    expect(tile.className).toContain('border-accent/30')
-    expect(tile.className).toContain('bg-accent/5')
-  })
-
-  it('shows tile screen initially with no editor visible', () => {
-    render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    expect(screen.getByTestId('ko-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Key Override - 0')).not.toBeInTheDocument()
-    expect(screen.queryByTestId('ko-favorites-panel')).not.toBeInTheDocument()
-  })
-
-  it('shows editor and favorites panel when tile is clicked', () => {
-    render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByText('Key Override - 0')).toBeInTheDocument()
     expect(screen.getAllByTestId('keycode-field')).toHaveLength(2)
     expect(screen.getByTestId('ko-favorites-panel')).toBeInTheDocument()
     expect(screen.getByTestId('favorite-store-content')).toBeInTheDocument()
   })
 
-  it('navigates back to tile screen when Back button is clicked', () => {
-    render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
-    expect(screen.getByText('Key Override - 0')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('ko-back-btn'))
-    expect(screen.queryByText('Key Override - 0')).not.toBeInTheDocument()
-    expect(screen.getByTestId('ko-tile-0')).toBeInTheDocument()
-  })
-
   it('shows enabled checkbox disabled when triggerKey and triggerMods are 0', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByTestId('ko-enabled')).toBeDisabled()
   })
 
   it('shows enabled checkbox enabled when triggerKey is nonzero', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry({ triggerKey: 4 })]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry({ triggerKey: 4 })]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByTestId('ko-enabled')).not.toBeDisabled()
   })
 
   it('shows TabbedKeycodes when a keycode field is clicked', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.queryByTestId('tabbed-keycodes')).not.toBeInTheDocument()
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
@@ -200,9 +124,8 @@ describe('KeyOverridePanelModal', () => {
 
   it('hides advanced fields when picker is open', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByTestId('ko-advanced-fields')).toBeInTheDocument()
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
@@ -211,17 +134,15 @@ describe('KeyOverridePanelModal', () => {
 
   it('Save button is disabled when no changes', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByTestId('ko-modal-save')).toBeDisabled()
   })
 
   it('Save button enables after editing triggerKey', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -229,11 +150,10 @@ describe('KeyOverridePanelModal', () => {
     expect(screen.getByTestId('ko-modal-save')).toBeEnabled()
   })
 
-  it('calls onSetEntry and returns to tile screen on Save', async () => {
+  it('calls onSetEntry and closes modal on Save', async () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     fireEvent.click(screen.getByTestId('pick-kc-a'))
@@ -243,14 +163,12 @@ describe('KeyOverridePanelModal', () => {
     await waitFor(() => {
       expect(onSetEntry).toHaveBeenCalledWith(0, expect.objectContaining({ triggerKey: 7 }))
     })
-    // After save, should return to tile screen
-    expect(screen.getByTestId('ko-tile-0')).toBeInTheDocument()
-    expect(screen.queryByText('Key Override - 0')).not.toBeInTheDocument()
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('calls onClose when close button is clicked', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('ko-modal-close'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -258,7 +176,7 @@ describe('KeyOverridePanelModal', () => {
 
   it('calls onClose when backdrop is clicked', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.click(screen.getByTestId('ko-modal-backdrop'))
     expect(onClose).toHaveBeenCalledTimes(1)
@@ -266,54 +184,19 @@ describe('KeyOverridePanelModal', () => {
 
   it('does not close modal on Escape key', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
     fireEvent.keyDown(document, { key: 'Escape' })
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('shows mods-only label when triggerMods is set but triggerKey is 0', () => {
-    render(
-      <KeyOverridePanelModal
-        entries={[makeEntry({ triggerMods: 0x01, enabled: true })]}
-        onSetEntry={onSetEntry}
-        onClose={onClose}
-      />,
-    )
-    const tile = screen.getByTestId('ko-tile-0')
-    expect(tile).toHaveTextContent('Mods')
-  })
-
   it('hides favorites panel when picker is open', () => {
     render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
+      <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
     expect(screen.getByTestId('ko-favorites-panel').className).not.toContain('hidden')
     fireEvent.click(screen.getAllByTestId('keycode-field')[0])
     act(() => { vi.advanceTimersByTime(300) })
     expect(screen.getByTestId('ko-favorites-panel').className).toContain('hidden')
-  })
-
-  it('returns to tile screen when entries shrink and selected index is out of bounds', () => {
-    const { rerender } = render(
-      <KeyOverridePanelModal entries={[makeEntry(), makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ko-tile-1'))
-    expect(screen.getByText('Key Override - 1')).toBeInTheDocument()
-    // Rerender with fewer entries — selected index 1 no longer exists
-    rerender(<KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />)
-    expect(screen.queryByText('Key Override - 1')).not.toBeInTheDocument()
-    expect(screen.getByTestId('ko-tile-0')).toBeInTheDocument()
-  })
-
-  it('shows close button in editor view when picker is closed', () => {
-    render(
-      <KeyOverridePanelModal entries={[makeEntry()]} onSetEntry={onSetEntry} onClose={onClose} />,
-    )
-    fireEvent.click(screen.getByTestId('ko-tile-0'))
-    expect(screen.getByTestId('ko-modal-close')).toBeInTheDocument()
-    fireEvent.click(screen.getByTestId('ko-modal-close'))
-    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -18,7 +18,7 @@ interface SettingsTileGridProps<T extends Record<string, unknown>> {
   entries: T[]
   fields: ReadonlyArray<{ key: keyof T & string; prefix: string }>
   isConfigured: (entry: T) => boolean
-  onOpen: (index?: number) => void
+  onOpen: (index: number) => void
   testIdPrefix: string
 }
 
@@ -190,14 +190,14 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
   )
 }
 
-export function ComboTileGrid({ entries, onOpenCombo }: { entries: ComboEntry[]; onOpenCombo: (index?: number) => void }) {
+export function ComboTileGrid({ entries, onOpenCombo }: { entries: ComboEntry[]; onOpenCombo: (index: number) => void }) {
   return <SettingsTileGrid entries={entries} fields={COMBO_FIELDS} isConfigured={(e) => e.key1 !== 0 || e.key2 !== 0} onOpen={onOpenCombo} testIdPrefix="combo" />
 }
 
-export function KeyOverrideTileGrid({ entries, onOpen }: { entries: KeyOverrideEntry[]; onOpen: (index?: number) => void }) {
+export function KeyOverrideTileGrid({ entries, onOpen }: { entries: KeyOverrideEntry[]; onOpen: (index: number) => void }) {
   return <SettingsTileGrid entries={entries} fields={KEY_OVERRIDE_FIELDS} isConfigured={(e) => e.enabled || e.triggerKey !== 0 || e.replacementKey !== 0} onOpen={onOpen} testIdPrefix="ko" />
 }
 
-export function AltRepeatKeyTileGrid({ entries, onOpen }: { entries: AltRepeatKeyEntry[]; onOpen: (index?: number) => void }) {
+export function AltRepeatKeyTileGrid({ entries, onOpen }: { entries: AltRepeatKeyEntry[]; onOpen: (index: number) => void }) {
   return <SettingsTileGrid entries={entries} fields={ALT_REPEAT_KEY_FIELDS} isConfigured={(e) => e.enabled || e.lastKey !== 0 || e.altKey !== 0} onOpen={onOpen} testIdPrefix="arep" />
 }

--- a/src/renderer/hooks/useTileContentOverride.tsx
+++ b/src/renderer/hooks/useTileContentOverride.tsx
@@ -8,11 +8,11 @@ import { TdTileGrid, MacroTileGrid, ComboTileGrid, KeyOverrideTileGrid, AltRepea
 
 interface SettingsTabOptions {
   comboEntries?: ComboEntry[]
-  onOpenCombo?: (index?: number) => void
+  onOpenCombo?: (index: number) => void
   keyOverrideEntries?: KeyOverrideEntry[]
-  onOpenKeyOverride?: (index?: number) => void
+  onOpenKeyOverride?: (index: number) => void
   altRepeatKeyEntries?: AltRepeatKeyEntry[]
-  onOpenAltRepeatKey?: (index?: number) => void
+  onOpenAltRepeatKey?: (index: number) => void
 }
 
 /**


### PR DESCRIPTION
## Summary
- Remove redundant Back button and in-modal tile grid from Combo, Key Override, and Alt Repeat Key editor modals
- Modals now open directly into edit view via required `initialIndex` prop and close on save
- Remove ~580 lines of dead code (tile grid rendering, tile styles, unused imports)

## Changes
- `ComboPanelModal.tsx` — Remove tile grid view, Back button, make `initialIndex` required, close on save
- `KeyOverridePanelModal.tsx` — Same changes as Combo
- `AltRepeatKeyPanelModal.tsx` — Same changes as Combo
- `App.tsx` — Update render conditions to require `initialIndex`, update callback signatures
- `KeymapEditor.tsx` — Update `onOpenCombo`/`onOpenKeyOverride`/`onOpenAltRepeatKey` signatures from optional to required index
- `TileGrids.tsx` — Update `onOpen` callback signatures from optional to required index
- `useTileContentOverride.tsx` — Update callback type signatures
- Test files — Remove tile-related tests, add `initialIndex` prop, update save assertions

## Test Plan
- [x] `pnpm test` — 108 files, 2759 tests passed
- [x] `pnpm build` — Clean build
- [x] `pnpm lint` — No errors
- [ ] Manual: Open Combo/KO/AR from tab tiles, verify edit view opens directly
- [ ] Manual: Save entry, verify modal closes and returns to keymap