### PR TITLE
refactor(ui): split MacroEditor.tsx into 3 focused modules (610→451 lines)

### DIFF
--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef } from 'react'
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MacroActionItem, defaultAction, type ActionType } from './MacroActionItem'
 import { MacroRecorder } from './MacroRecorder'
@@ -9,24 +9,22 @@ import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
 import { KeyPopover } from '../keycodes/KeyPopover'
 import {
   type MacroAction,
-  deserializeAllMacros,
   serializeAllMacros,
   serializeMacro,
   macroActionsToJson,
   jsonToMacroActions,
   isValidMacroText,
 } from '../../../preload/macro'
-import { type Keycode, deserialize } from '../../../shared/keycodes/keycodes'
 import type { TapDanceEntry } from '../../../shared/types/protocol'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
-import { useMaskedKeycodeSelection } from '../../hooks/useMaskedKeycodeSelection'
 import { useFavoriteStore } from '../../hooks/useFavoriteStore'
-import { useTileContentOverride } from '../../hooks/useTileContentOverride'
+import { useMacroKeycodeSelection } from '../../hooks/useMacroKeycodeSelection'
 import { ConfirmButton } from './ConfirmButton'
 import { FavoriteStoreContent } from './FavoriteStoreContent'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
+import { parseMacroBuffer, isKeycodeAction } from './macro-editor-utils'
 
 interface Props {
   macroCount: number
@@ -55,27 +53,6 @@ interface Props {
   quickSelect?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
-}
-
-function parseMacroBuffer(
-  buffer: number[],
-  protocol: number,
-  count: number,
-): MacroAction[][] {
-  const parsed = deserializeAllMacros(buffer, protocol, count)
-  while (parsed.length < count) {
-    parsed.push([])
-  }
-  return parsed
-}
-
-const KC_TRNS = 1
-const KC_NO = 0
-
-type KeycodeAction = Extract<MacroAction, { type: 'tap' | 'down' | 'up' }>
-
-function isKeycodeAction(action: MacroAction): action is KeycodeAction {
-  return action.type === 'tap' || action.type === 'down' || action.type === 'up'
 }
 
 export function MacroEditor({
@@ -108,6 +85,17 @@ export function MacroEditor({
   const { t } = useTranslation()
   const { guardAll, clearPending } = useUnlockGate({ unlocked, onUnlock })
   const [activeMacro, setActiveMacro] = useState(initialMacro ?? 0)
+  const [dirty, setDirty] = useState(false)
+  const [showTextEditor, setShowTextEditor] = useState(false)
+
+  const [macros, setMacros] = useState<MacroAction[][]>(() =>
+    parsedMacrosProp ?? parseMacroBuffer(macroBuffer, vialProtocol, macroCount),
+  )
+  const macrosRef = useRef(macros)
+  macrosRef.current = macros
+
+  const currentActions = macros[activeMacro] ?? []
+
   const favStore = useFavoriteStore({
     favoriteType: 'macro',
     serialize: () => JSON.parse(macroActionsToJson(currentActions)),
@@ -124,33 +112,42 @@ export function MacroEditor({
     setActiveMacro(initialMacro ?? 0)
   }, [initialMacro])
 
-  const [dirty, setDirty] = useState(false)
-
   useEffect(() => {
     if (!isDummy) {
       favStore.refreshEntries()
     }
   }, [isDummy, favStore.refreshEntries])
 
-  const [macros, setMacros] = useState<MacroAction[][]>(() =>
-    parsedMacrosProp ?? parseMacroBuffer(macroBuffer, vialProtocol, macroCount),
-  )
-  const macrosRef = useRef(macros)
-  macrosRef.current = macros
-
-  const currentActions = macros[activeMacro] ?? []
-
-  // Selection state for keycode editing
-  const [selectedKey, setSelectedKey] = useState<{ actionIndex: number; keycodeIndex: number } | null>(null)
-  const [popoverState, setPopoverState] = useState<{ actionIndex: number; keycodeIndex: number; anchorRect: DOMRect } | null>(null)
-  const [showTextEditor, setShowTextEditor] = useState(false)
-  const preEditValueRef = useRef<number>(0)
-
-  const isEditing = selectedKey !== null
-
-  useLayoutEffect(() => {
-    onEditingChange?.(isEditing)
-  }, [isEditing, onEditingChange])
+  const {
+    selectedKey,
+    setSelectedKey,
+    setPopoverState,
+    preEditValueRef,
+    isEditing,
+    maskedSelection,
+    tabContentOverride,
+    pickerRef,
+    popoverState,
+    popoverKeycode,
+    handleKeycodeClick,
+    handleKeycodeDoubleClick,
+    handleKeycodeAdd,
+    handleMaskPartClick,
+    applyPopoverKeycode,
+    handlePopoverKeycodeSelect,
+    closePopover,
+    revertAndDeselect,
+  } = useMacroKeycodeSelection({
+    currentActions,
+    activeMacro,
+    setMacros,
+    setDirty,
+    clearPending,
+    onEditingChange,
+    tapDanceEntries,
+    deserializedMacros,
+    quickSelect,
+  })
 
   const updateActions = useCallback(
     (newActions: MacroAction[]) => {
@@ -164,7 +161,7 @@ export function MacroEditor({
       })
       setDirty(true)
     },
-    [activeMacro, clearPending],
+    [activeMacro, clearPending, setSelectedKey, setPopoverState],
   )
 
   const handleRecordComplete = useCallback(
@@ -247,7 +244,7 @@ export function MacroEditor({
     setPopoverState(null)
     setMacros(parseMacroBuffer(macroBuffer, vialProtocol, macroCount))
     setDirty(false)
-  }, [macroBuffer, vialProtocol, macroCount, clearPending]))
+  }, [macroBuffer, vialProtocol, macroCount, clearPending, setSelectedKey, setPopoverState]))
 
   // Clear selection state when switching macros to avoid stale indices
   useEffect(() => {
@@ -272,122 +269,6 @@ export function MacroEditor({
     [macros],
   )
 
-  // --- Keycode selection handlers ---
-
-  /** Update keycodes for a specific action without clearing selectedKey. */
-  const setKeycodeAt = useCallback(
-    (actionIndex: number, newKeycodes: number[]) => {
-      clearPending()
-      setMacros((prev) => {
-        const updated = [...prev]
-        const actions = [...(updated[activeMacro] ?? [])]
-        const action = actions[actionIndex]
-        if (isKeycodeAction(action)) {
-          actions[actionIndex] = { ...action, keycodes: newKeycodes }
-        }
-        updated[activeMacro] = actions
-        return updated
-      })
-      setDirty(true)
-    },
-    [activeMacro, clearPending],
-  )
-
-  const handleKeycodeClick = useCallback(
-    (actionIndex: number, keycodeIndex: number) => {
-      const action = currentActions[actionIndex]
-      if (isKeycodeAction(action)) {
-        preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
-      }
-      setSelectedKey({ actionIndex, keycodeIndex })
-    },
-    [currentActions],
-  )
-
-  const handleKeycodeDoubleClick = useCallback(
-    (actionIndex: number, keycodeIndex: number, rect: DOMRect) => {
-      setPopoverState({ actionIndex, keycodeIndex, anchorRect: rect })
-    },
-    [],
-  )
-
-  const handleKeycodeAdd = useCallback(
-    (actionIndex: number) => {
-      const action = currentActions[actionIndex]
-      if (isKeycodeAction(action)) {
-        setKeycodeAt(actionIndex, [...action.keycodes, KC_TRNS])
-      }
-    },
-    [currentActions, setKeycodeAt],
-  )
-
-  const macroInitialValue = (() => {
-    if (!selectedKey) return undefined
-    const action = currentActions[selectedKey.actionIndex]
-    return isKeycodeAction(action) ? action.keycodes[selectedKey.keycodeIndex] : undefined
-  })()
-
-  const maskedSelection = useMaskedKeycodeSelection({
-    onUpdate(code: number) {
-      if (!selectedKey) return false
-      const action = currentActions[selectedKey.actionIndex]
-      if (!isKeycodeAction(action)) return false
-
-      if (code === KC_NO) {
-        // Delete this keycode, but keep at least one
-        if (action.keycodes.length <= 1) return false
-        setKeycodeAt(selectedKey.actionIndex, action.keycodes.filter((_, i) => i !== selectedKey.keycodeIndex))
-      } else {
-        const newKeycodes = [...action.keycodes]
-        newKeycodes[selectedKey.keycodeIndex] = code
-        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
-      }
-    },
-    onCommit() {
-      setSelectedKey(null)
-    },
-    resetKey: selectedKey,
-    initialValue: macroInitialValue,
-    quickSelect,
-  })
-
-  const tabContentOverride = useTileContentOverride(tapDanceEntries, deserializedMacros, maskedSelection.handleKeycodeSelect)
-
-  const handleMaskPartClick = useCallback(
-    (actionIndex: number, keycodeIndex: number, part: 'outer' | 'inner') => {
-      const action = currentActions[actionIndex]
-      if (!isKeycodeAction(action)) return
-      const code = action.keycodes[keycodeIndex]
-      if (code == null) return
-      preEditValueRef.current = code
-      maskedSelection.enterMaskMode(code, part)
-      setSelectedKey({ actionIndex, keycodeIndex })
-    },
-    [currentActions, maskedSelection.enterMaskMode],
-  )
-
-  const applyPopoverKeycode = useCallback(
-    (code: number) => {
-      if (!popoverState) return
-      const action = currentActions[popoverState.actionIndex]
-      if (!isKeycodeAction(action)) return
-
-      const newKeycodes = [...action.keycodes]
-      newKeycodes[popoverState.keycodeIndex] = code
-      setKeycodeAt(popoverState.actionIndex, newKeycodes)
-    },
-    [popoverState, currentActions, setKeycodeAt],
-  )
-
-  const handlePopoverKeycodeSelect = useCallback(
-    (kc: Keycode) => applyPopoverKeycode(deserialize(kc.qmkId)),
-    [applyPopoverKeycode],
-  )
-
-  const closePopover = useCallback(() => {
-    setPopoverState(null)
-  }, [])
-
   const handleTextEditorApply = useCallback(
     (actions: MacroAction[]) => {
       updateActions(actions)
@@ -395,46 +276,6 @@ export function MacroEditor({
     },
     [updateActions],
   )
-
-  const pickerRef = useRef<HTMLDivElement>(null)
-
-  const revertAndDeselect = useCallback(() => {
-    if (selectedKey) {
-      const action = currentActions[selectedKey.actionIndex]
-      if (isKeycodeAction(action) && action.keycodes[selectedKey.keycodeIndex] !== preEditValueRef.current) {
-        const newKeycodes = [...action.keycodes]
-        newKeycodes[selectedKey.keycodeIndex] = preEditValueRef.current
-        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
-      }
-    }
-    maskedSelection.clearMask()
-    setSelectedKey(null)
-  }, [selectedKey, currentActions, setKeycodeAt, maskedSelection.clearMask])
-
-  // Close picker when clicking outside of it.
-  // Uses click (not mousedown) so the DOM hasn't re-rendered yet when the
-  // event processes — the modal's stopPropagation still covers the area and
-  // prevents the backdrop from receiving the event.
-  useEffect(() => {
-    if (!isEditing) return
-    function handler(e: MouseEvent): void {
-      const target = e.target as Node | null
-      if (!target) return
-      if (pickerRef.current?.contains(target)) return
-      // Resolve to Element for text node targets (e.g. spans inside buttons)
-      const el = target instanceof Element ? target : target.parentElement
-      if (el?.closest('[data-testid="keycode-field"]')) return
-      revertAndDeselect()
-    }
-    window.addEventListener('click', handler)
-    return () => window.removeEventListener('click', handler)
-  }, [isEditing, revertAndDeselect])
-
-  const popoverKeycode = (() => {
-    if (!popoverState) return 0
-    const action = currentActions[popoverState.actionIndex]
-    return isKeycodeAction(action) ? action.keycodes[popoverState.keycodeIndex] ?? 0 : 0
-  })()
 
   return (
     <>

--- a/src/renderer/components/editors/macro-editor-utils.ts
+++ b/src/renderer/components/editors/macro-editor-utils.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { type MacroAction, deserializeAllMacros } from '../../../preload/macro'
+
+export const KC_TRNS = 1
+export const KC_NO = 0
+
+export type KeycodeAction = Extract<MacroAction, { type: 'tap' | 'down' | 'up' }>
+
+export function isKeycodeAction(action: MacroAction): action is KeycodeAction {
+  return action.type === 'tap' || action.type === 'down' || action.type === 'up'
+}
+
+export function parseMacroBuffer(
+  buffer: number[],
+  protocol: number,
+  count: number,
+): MacroAction[][] {
+  const parsed = deserializeAllMacros(buffer, protocol, count)
+  while (parsed.length < count) {
+    parsed.push([])
+  }
+  return parsed
+}

--- a/src/renderer/hooks/useMacroKeycodeSelection.ts
+++ b/src/renderer/hooks/useMacroKeycodeSelection.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useCallback, useEffect, useLayoutEffect, useRef } from 'react'
+import { type MacroAction } from '../../preload/macro'
+import { type Keycode, deserialize } from '../../shared/keycodes/keycodes'
+import type { TapDanceEntry } from '../../shared/types/protocol'
+import { useMaskedKeycodeSelection } from './useMaskedKeycodeSelection'
+import { useTileContentOverride } from './useTileContentOverride'
+import { KC_TRNS, KC_NO, isKeycodeAction } from '../components/editors/macro-editor-utils'
+
+interface UseMacroKeycodeSelectionOptions {
+  currentActions: MacroAction[]
+  activeMacro: number
+  setMacros: React.Dispatch<React.SetStateAction<MacroAction[][]>>
+  setDirty: (dirty: boolean) => void
+  clearPending: () => void
+  onEditingChange?: (editing: boolean) => void
+  tapDanceEntries?: TapDanceEntry[]
+  deserializedMacros?: MacroAction[][]
+  quickSelect?: boolean
+}
+
+export function useMacroKeycodeSelection({
+  currentActions,
+  activeMacro,
+  setMacros,
+  setDirty,
+  clearPending,
+  onEditingChange,
+  tapDanceEntries,
+  deserializedMacros,
+  quickSelect,
+}: UseMacroKeycodeSelectionOptions) {
+  const [selectedKey, setSelectedKey] = useState<{
+    actionIndex: number
+    keycodeIndex: number
+  } | null>(null)
+  const [popoverState, setPopoverState] = useState<{
+    actionIndex: number
+    keycodeIndex: number
+    anchorRect: DOMRect
+  } | null>(null)
+  const preEditValueRef = useRef<number>(0)
+
+  const isEditing = selectedKey !== null
+
+  useLayoutEffect(() => {
+    onEditingChange?.(isEditing)
+  }, [isEditing, onEditingChange])
+
+  /** Update keycodes for a specific action without clearing selectedKey. */
+  const setKeycodeAt = useCallback(
+    (actionIndex: number, newKeycodes: number[]) => {
+      clearPending()
+      setMacros((prev) => {
+        const updated = [...prev]
+        const actions = [...(updated[activeMacro] ?? [])]
+        const action = actions[actionIndex]
+        if (isKeycodeAction(action)) {
+          actions[actionIndex] = { ...action, keycodes: newKeycodes }
+        }
+        updated[activeMacro] = actions
+        return updated
+      })
+      setDirty(true)
+    },
+    [activeMacro, clearPending, setMacros, setDirty],
+  )
+
+  const handleKeycodeClick = useCallback(
+    (actionIndex: number, keycodeIndex: number) => {
+      const action = currentActions[actionIndex]
+      if (isKeycodeAction(action)) {
+        preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
+      }
+      setSelectedKey({ actionIndex, keycodeIndex })
+    },
+    [currentActions],
+  )
+
+  const handleKeycodeDoubleClick = useCallback(
+    (actionIndex: number, keycodeIndex: number, rect: DOMRect) => {
+      setPopoverState({ actionIndex, keycodeIndex, anchorRect: rect })
+    },
+    [],
+  )
+
+  const handleKeycodeAdd = useCallback(
+    (actionIndex: number) => {
+      const action = currentActions[actionIndex]
+      if (isKeycodeAction(action)) {
+        setKeycodeAt(actionIndex, [...action.keycodes, KC_TRNS])
+      }
+    },
+    [currentActions, setKeycodeAt],
+  )
+
+  const macroInitialValue = (() => {
+    if (!selectedKey) return undefined
+    const action = currentActions[selectedKey.actionIndex]
+    return isKeycodeAction(action)
+      ? action.keycodes[selectedKey.keycodeIndex]
+      : undefined
+  })()
+
+  const maskedSelection = useMaskedKeycodeSelection({
+    onUpdate(code: number) {
+      if (!selectedKey) return false
+      const action = currentActions[selectedKey.actionIndex]
+      if (!isKeycodeAction(action)) return false
+
+      if (code === KC_NO) {
+        // Delete this keycode, but keep at least one
+        if (action.keycodes.length <= 1) return false
+        setKeycodeAt(
+          selectedKey.actionIndex,
+          action.keycodes.filter((_, i) => i !== selectedKey.keycodeIndex),
+        )
+      } else {
+        const newKeycodes = [...action.keycodes]
+        newKeycodes[selectedKey.keycodeIndex] = code
+        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
+      }
+    },
+    onCommit() {
+      setSelectedKey(null)
+    },
+    resetKey: selectedKey,
+    initialValue: macroInitialValue,
+    quickSelect,
+  })
+
+  const tabContentOverride = useTileContentOverride(
+    tapDanceEntries,
+    deserializedMacros,
+    maskedSelection.handleKeycodeSelect,
+  )
+
+  const handleMaskPartClick = useCallback(
+    (actionIndex: number, keycodeIndex: number, part: 'outer' | 'inner') => {
+      const action = currentActions[actionIndex]
+      if (!isKeycodeAction(action)) return
+      const code = action.keycodes[keycodeIndex]
+      if (code == null) return
+      preEditValueRef.current = code
+      maskedSelection.enterMaskMode(code, part)
+      setSelectedKey({ actionIndex, keycodeIndex })
+    },
+    [currentActions, maskedSelection.enterMaskMode],
+  )
+
+  const applyPopoverKeycode = useCallback(
+    (code: number) => {
+      if (!popoverState) return
+      const action = currentActions[popoverState.actionIndex]
+      if (!isKeycodeAction(action)) return
+
+      const newKeycodes = [...action.keycodes]
+      newKeycodes[popoverState.keycodeIndex] = code
+      setKeycodeAt(popoverState.actionIndex, newKeycodes)
+    },
+    [popoverState, currentActions, setKeycodeAt],
+  )
+
+  const handlePopoverKeycodeSelect = useCallback(
+    (kc: Keycode) => applyPopoverKeycode(deserialize(kc.qmkId)),
+    [applyPopoverKeycode],
+  )
+
+  const closePopover = useCallback(() => {
+    setPopoverState(null)
+  }, [])
+
+  const pickerRef = useRef<HTMLDivElement>(null)
+
+  const revertAndDeselect = useCallback(() => {
+    if (selectedKey) {
+      const action = currentActions[selectedKey.actionIndex]
+      if (
+        isKeycodeAction(action) &&
+        action.keycodes[selectedKey.keycodeIndex] !== preEditValueRef.current
+      ) {
+        const newKeycodes = [...action.keycodes]
+        newKeycodes[selectedKey.keycodeIndex] = preEditValueRef.current
+        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
+      }
+    }
+    maskedSelection.clearMask()
+    setSelectedKey(null)
+  }, [selectedKey, currentActions, setKeycodeAt, maskedSelection.clearMask])
+
+  // Close picker when clicking outside of it.
+  useEffect(() => {
+    if (!isEditing) return
+    function handler(e: MouseEvent): void {
+      const target = e.target as Node | null
+      if (!target) return
+      if (pickerRef.current?.contains(target)) return
+      // Resolve to Element for text node targets (e.g. spans inside buttons)
+      const el = target instanceof Element ? target : target.parentElement
+      if (el?.closest('[data-testid="keycode-field"]')) return
+      revertAndDeselect()
+    }
+    window.addEventListener('click', handler)
+    return () => window.removeEventListener('click', handler)
+  }, [isEditing, revertAndDeselect])
+
+  const popoverKeycode = (() => {
+    if (!popoverState) return 0
+    const action = currentActions[popoverState.actionIndex]
+    return isKeycodeAction(action)
+      ? action.keycodes[popoverState.keycodeIndex] ?? 0
+      : 0
+  })()
+
+  return {
+    selectedKey,
+    setSelectedKey,
+    popoverState,
+    setPopoverState,
+    preEditValueRef,
+    isEditing,
+    maskedSelection,
+    tabContentOverride,
+    pickerRef,
+    popoverKeycode,
+    handleKeycodeClick,
+    handleKeycodeDoubleClick,
+    handleKeycodeAdd,
+    handleMaskPartClick,
+    applyPopoverKeycode,
+    handlePopoverKeycodeSelect,
+    closePopover,
+    revertAndDeselect,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract keycode selection logic and utilities from MacroEditor.tsx
- MacroEditor.tsx reduced from 610 to 451 lines (within 500-line limit)

## Changes
- `macro-editor-utils.ts` (24 lines) — parseMacroBuffer, KeycodeAction type, isKeycodeAction guard
- `useMacroKeycodeSelection.ts` (236 lines) — Keycode selection state, masked editing, popover, click-outside
- `MacroEditor.tsx` (451 lines) — Core state, action CRUD, drag-and-drop, JSX

## Test Plan
- [x] `pnpm test` — 2,789 tests pass (110 files)
- [x] `pnpm build` — Production build succeeds
- [x] `pnpm lint` — No lint errors