### PR TITLE
refactor(config): extract sync bundle logic from sync-service.ts (867→783 lines)

### DIFF
--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Bundle creation: reads local sync data into uploadable bundles
+
+import { app } from 'electron'
+import { join } from 'node:path'
+import { readFile, readdir, access } from 'node:fs/promises'
+import { gcTombstones } from './merge'
+import { FAVORITE_TYPES } from '../../shared/favorite-data'
+import type { FavoriteIndex } from '../../shared/types/favorite-store'
+import type { SnapshotIndex } from '../../shared/types/snapshot-store'
+import type { SyncBundle } from '../../shared/types/sync'
+
+export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | null> {
+  try {
+    const raw = await readFile(join(dir, 'index.json'), 'utf-8')
+    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex
+  } catch {
+    return null
+  }
+}
+
+export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | null> {
+  const parts = syncUnit.split('/')
+  const userData = app.getPath('userData')
+
+  // Handle "keyboards/{uid}/settings" — single-file bundle (no index)
+  if (parts.length === 3 && parts[0] === 'keyboards' && parts[2] === 'settings') {
+    const uid = parts[1]
+    const filePath = join(userData, 'sync', 'keyboards', uid, 'pipette_settings.json')
+    try {
+      const content = await readFile(filePath, 'utf-8')
+      return {
+        type: 'settings',
+        key: uid,
+        index: { uid, entries: [] } as SnapshotIndex,
+        files: { 'pipette_settings.json': content },
+      }
+    } catch {
+      return null
+    }
+  }
+
+  // Handle index-based sync units (favorites, keyboard snapshots)
+  const basePath = join(userData, 'sync', ...parts)
+  const index = await readIndexFile(basePath)
+  if (!index) return null
+
+  const gcEntries = gcTombstones(index.entries)
+  index.entries = gcEntries as typeof index.entries
+
+  const files: Record<string, string> = {}
+
+  for (const entry of gcEntries) {
+    try {
+      const content = await readFile(join(basePath, entry.filename), 'utf-8')
+      files[entry.filename] = content
+    } catch {
+      // File missing — skip
+    }
+  }
+
+  files['index.json'] = JSON.stringify(index, null, 2)
+
+  const type: SyncBundle['type'] = parts[0] === 'favorites' ? 'favorite' : 'layout'
+
+  return { type, key: parts[1], index, files }
+}
+
+export async function collectAllSyncUnits(): Promise<string[]> {
+  const userData = app.getPath('userData')
+  const units = FAVORITE_TYPES.map((type) => `favorites/${type}`)
+
+  // Scan sync/keyboards/{uid}/ for settings and snapshots
+  const keyboardsDir = join(userData, 'sync', 'keyboards')
+  try {
+    const entries = await readdir(keyboardsDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue
+      const uid = entry.name
+      // settings (single file)
+      try {
+        await access(join(keyboardsDir, uid, 'pipette_settings.json'))
+        units.push(`keyboards/${uid}/settings`)
+      } catch { /* no settings */ }
+      // snapshots (index-based)
+      try {
+        await access(join(keyboardsDir, uid, 'snapshots', 'index.json'))
+        units.push(`keyboards/${uid}/snapshots`)
+      } catch { /* no snapshots */ }
+    }
+  } catch { /* dir doesn't exist */ }
+
+  return units
+}

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -3,7 +3,7 @@
 
 import { app, BrowserWindow } from 'electron'
 import { join } from 'node:path'
-import { readFile, writeFile, readdir, mkdir, access } from 'node:fs/promises'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import { encrypt, decrypt, retrievePassword, storePassword, clearPassword } from './sync-crypto'
 import { loadAppConfig } from '../app-config'
 import { getAuthStatus } from './google-auth'
@@ -17,10 +17,8 @@ import {
 } from './google-drive'
 import { pLimit } from '../../shared/concurrency'
 import { IpcChannels } from '../../shared/ipc/channels'
-import { FAVORITE_TYPES } from '../../shared/favorite-data'
 import { mergeEntries, gcTombstones } from './merge'
-import type { FavoriteIndex } from '../../shared/types/favorite-store'
-import type { SnapshotIndex } from '../../shared/types/snapshot-store'
+import { readIndexFile, bundleSyncUnit, collectAllSyncUnits } from './sync-bundle'
 import type { SyncBundle, SyncProgress, SyncEnvelope, UndecryptableFile, SyncDataScanResult, SyncScope } from '../../shared/types/sync'
 
 const SYNC_CONCURRENCY = 10
@@ -231,63 +229,8 @@ export async function changePassword(newPassword: string): Promise<void> {
   }
 }
 
-// --- Bundle creation ---
-
-export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | null> {
-  try {
-    const raw = await readFile(join(dir, 'index.json'), 'utf-8')
-    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex
-  } catch {
-    return null
-  }
-}
-
-export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | null> {
-  const parts = syncUnit.split('/')
-  const userData = app.getPath('userData')
-
-  // Handle "keyboards/{uid}/settings" — single-file bundle (no index)
-  if (parts.length === 3 && parts[0] === 'keyboards' && parts[2] === 'settings') {
-    const uid = parts[1]
-    const filePath = join(userData, 'sync', 'keyboards', uid, 'pipette_settings.json')
-    try {
-      const content = await readFile(filePath, 'utf-8')
-      return {
-        type: 'settings',
-        key: uid,
-        index: { uid, entries: [] } as SnapshotIndex,
-        files: { 'pipette_settings.json': content },
-      }
-    } catch {
-      return null
-    }
-  }
-
-  // Handle index-based sync units (favorites, keyboard snapshots)
-  const basePath = join(userData, 'sync', ...parts)
-  const index = await readIndexFile(basePath)
-  if (!index) return null
-
-  const gcEntries = gcTombstones(index.entries)
-  index.entries = gcEntries as typeof index.entries
-
-  const files: Record<string, string> = {}
-
-  for (const entry of gcEntries) {
-    try {
-      const content = await readFile(join(basePath, entry.filename), 'utf-8')
-      files[entry.filename] = content
-    } catch {
-      // File missing — skip
-    }
-  }
-
-  files['index.json'] = JSON.stringify(index, null, 2)
-
-  const type: SyncBundle['type'] = parts[0] === 'favorites' ? 'favorite' : 'layout'
-
-  return { type, key: parts[1], index, files }
-}
+// Re-export bundle functions for backward compatibility
+export { readIndexFile, bundleSyncUnit, collectAllSyncUnits } from './sync-bundle'
 
 // --- Password check validation ---
 
@@ -618,33 +561,6 @@ async function executeUploadSync(
   updateRemoteState(updatedFiles)
 
   return failedUnits
-}
-
-export async function collectAllSyncUnits(): Promise<string[]> {
-  const userData = app.getPath('userData')
-  const units = FAVORITE_TYPES.map((type) => `favorites/${type}`)
-
-  // Scan sync/keyboards/{uid}/ for settings and snapshots
-  const keyboardsDir = join(userData, 'sync', 'keyboards')
-  try {
-    const entries = await readdir(keyboardsDir, { withFileTypes: true })
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue
-      const uid = entry.name
-      // settings (single file)
-      try {
-        await access(join(keyboardsDir, uid, 'pipette_settings.json'))
-        units.push(`keyboards/${uid}/settings`)
-      } catch { /* no settings */ }
-      // snapshots (index-based)
-      try {
-        await access(join(keyboardsDir, uid, 'snapshots', 'index.json'))
-        units.push(`keyboards/${uid}/snapshots`)
-      } catch { /* no snapshots */ }
-    }
-  } catch { /* dir doesn't exist */ }
-
-  return units
 }
 
 // --- Remote state tracking ---


### PR DESCRIPTION
## Summary
- Extract sync bundle creation logic from sync-service.ts (867→783 lines)

## Changes
- `sync-bundle.ts` (94 lines) — readIndexFile, bundleSyncUnit, collectAllSyncUnits
- `sync-service.ts` (783 lines) — Core sync orchestration + re-exports

## Test Plan
- [x] `pnpm test` — 2,789 tests pass
- [x] `pnpm build` — Production build succeeds
- [x] `pnpm lint` — No lint errors