### PR TITLE
fix(config): add withWriteLock to snapshot-store updateEntry

### DIFF
--- a/src/main/snapshot-store.ts
+++ b/src/main/snapshot-store.ts
@@ -67,20 +67,22 @@ async function updateEntry(
   entryId: string,
   mutate: (entry: SnapshotMeta) => void,
 ): Promise<{ success: boolean; error?: string }> {
-  try {
-    validateUid(uid)
-    const index = await readIndex(uid)
-    const entry = index.entries.find((e) => e.id === entryId)
-    if (!entry) return { success: false, error: 'Entry not found' }
+  return withWriteLock(uid, async () => {
+    try {
+      validateUid(uid)
+      const index = await readIndex(uid)
+      const entry = index.entries.find((e) => e.id === entryId)
+      if (!entry) return { success: false, error: 'Entry not found' }
 
-    mutate(entry)
-    entry.updatedAt = new Date().toISOString()
-    await writeIndex(uid, index)
-    notifyChange(`keyboards/${uid}/snapshots`)
-    return { success: true }
-  } catch (err) {
-    return { success: false, error: String(err) }
-  }
+      mutate(entry)
+      entry.updatedAt = new Date().toISOString()
+      await writeIndex(uid, index)
+      notifyChange(`keyboards/${uid}/snapshots`)
+      return { success: true }
+    } catch (err) {
+      return { success: false, error: String(err) }
+    }
+  })
 }
 
 // Simple per-uid write serialization to prevent race conditions


### PR DESCRIPTION
## Summary
- Add missing `withWriteLock` to `updateEntry` in snapshot-store.ts

## Root Cause
`updateEntry` (used by rename, setHubPostId, setVilVersion) was not serialized
with `withWriteLock`, unlike save/delete/update operations. This could cause
race conditions when concurrent metadata updates overlap on the same keyboard UID.

## Changes
- `src/main/snapshot-store.ts` — Wrap `updateEntry` body in `withWriteLock(uid, ...)`

## Test Plan
- [x] `pnpm test` — 2,789 tests pass
- [x] `pnpm build` — Production build succeeds
- [x] `pnpm lint` — No lint errors