### PR TITLE
feat(ui): add current-state import/export to favorite panels

### DIFF
--- a/src/main/favorite-store.ts
+++ b/src/main/favorite-store.ts
@@ -255,6 +255,62 @@ export function setupFavoriteStore(): void {
     },
   )
 
+  // --- Export Current (live state without saving first) ---
+  secureHandle(
+    IpcChannels.FAVORITE_STORE_EXPORT_CURRENT,
+    async (event, scope: unknown, dataJson: unknown): Promise<{ success: boolean; error?: string }> => {
+      try {
+        const win = BrowserWindow.fromWebContents(event.sender)
+        if (!win) return { success: false, error: 'No window' }
+
+        if (!isValidFavoriteType(scope)) return { success: false, error: 'Invalid scope' }
+        if (typeof dataJson !== 'string') return { success: false, error: 'Invalid data' }
+
+        const parsed = JSON.parse(dataJson) as Record<string, unknown>
+        if (parsed.data == null) return { success: false, error: 'Missing data field' }
+
+        const exportKey = FAV_TYPE_TO_EXPORT_KEY[scope]
+        const serializedData = serializeFavData(scope, parsed.data, serializeKeycode)
+
+        const now = new Date()
+        const ts = now.toISOString().replace(/:/g, '').replace(/\.\d+Z$/, '').replace('T', '-')
+        const defaultFilename = `pipette-fav-${exportKey}-current-${ts}.json`
+
+        const result = await dialog.showSaveDialog(win, {
+          title: 'Export Favorites',
+          defaultPath: defaultFilename,
+          filters: [
+            { name: 'JSON', extensions: ['json'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+        })
+
+        if (result.canceled || !result.filePath) {
+          return { success: false, error: 'cancelled' }
+        }
+
+        const exportFile = {
+          app: 'pipette' as const,
+          version: 2 as const,
+          scope: 'fav' as const,
+          exportedAt: now.toISOString(),
+          categories: {
+            [exportKey]: [{
+              label: 'Current',
+              savedAt: now.toISOString(),
+              data: serializedData,
+            }],
+          },
+        }
+
+        await writeFile(result.filePath, JSON.stringify(exportFile, null, 2), 'utf-8')
+        return { success: true }
+      } catch (err) {
+        return { success: false, error: String(err) }
+      }
+    },
+  )
+
   // --- Set Hub Post ID ---
   secureHandle(
     IpcChannels.FAVORITE_STORE_SET_HUB_POST_ID,
@@ -274,6 +330,52 @@ export function setupFavoriteStore(): void {
         await writeIndex(type, found.index)
         notifyChange(`favorites/${type}`)
         return { success: true }
+      } catch (err) {
+        return { success: false, error: String(err) }
+      }
+    },
+  )
+
+  // --- Import to Current (read file, return first matching entry data without saving) ---
+  secureHandle(
+    IpcChannels.FAVORITE_STORE_IMPORT_TO_CURRENT,
+    async (event, scope: unknown): Promise<{ success: boolean; data?: unknown; error?: string }> => {
+      try {
+        const win = BrowserWindow.fromWebContents(event.sender)
+        if (!win) return { success: false, error: 'No window' }
+
+        if (!isValidFavoriteType(scope)) return { success: false, error: 'Invalid scope' }
+
+        const result = await dialog.showOpenDialog(win, {
+          title: 'Import Favorites',
+          filters: [
+            { name: 'JSON', extensions: ['json'] },
+            { name: 'All Files', extensions: ['*'] },
+          ],
+          properties: ['openFile'],
+        })
+
+        if (result.canceled || result.filePaths.length === 0) {
+          return { success: false, error: 'cancelled' }
+        }
+
+        const raw = await readFile(result.filePaths[0], 'utf-8')
+        const parsed: unknown = JSON.parse(raw)
+
+        if (!isValidFavExportFile(parsed)) {
+          return { success: false, error: 'Invalid export file format' }
+        }
+
+        const exportKey = FAV_TYPE_TO_EXPORT_KEY[scope]
+        const entries = parsed.categories[exportKey]
+        if (!entries || entries.length === 0) {
+          return { success: false, error: 'No matching data found for this type' }
+        }
+
+        const firstEntry = entries[0]
+        const normalizedData = deserializeFavData(scope, firstEntry.data, deserializeKeycode)
+
+        return { success: true, data: normalizedData }
       } catch (err) {
         return { success: false, error: String(err) }
       }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -171,8 +171,12 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_DELETE, type, entryId),
   favoriteStoreExport: (scope: string, entryId?: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT, scope, entryId),
+  favoriteStoreExportCurrent: (scope: string, data: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT_CURRENT, scope, data),
   favoriteStoreImport: (): Promise<FavoriteImportResult> =>
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_IMPORT),
+  favoriteStoreImportToCurrent: (scope: string): Promise<{ success: boolean; data?: unknown; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_IMPORT_TO_CURRENT, scope),
 
   // --- Pipette Settings Store (internal save/load via IPC) ---
   pipetteSettingsGet: (uid: string): Promise<PipetteSettings | null> =>

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { ACTION_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, SectionHeader, formatDate } from './store-modal-shared'
@@ -38,6 +38,10 @@ export interface FavoriteStoreContentProps {
   onExport: () => void
   onExportEntry: (entryId: string) => void
   onImport: () => void
+  // Export current live state as .pipette-fav JSON
+  onExportCurrent?: () => Promise<boolean>
+  // Import from .pipette-fav JSON into current state
+  onImportCurrent?: () => Promise<boolean>
   // Hub integration (optional)
   hubOrigin?: string
   hubNeedsDisplayName?: boolean
@@ -65,6 +69,8 @@ export function FavoriteStoreContent({
   onExport,
   onExportEntry,
   onImport,
+  onExportCurrent,
+  onImportCurrent,
   hubOrigin,
   hubNeedsDisplayName,
   hubUploading,
@@ -79,6 +85,34 @@ export function FavoriteStoreContent({
   const [saveLabel, setSaveLabel] = useState('')
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [showExported, setShowExported] = useState(false)
+  const [showImported, setShowImported] = useState(false)
+  const exportedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const importedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  function flashExported(): void {
+    setShowExported(true)
+    clearTimeout(exportedTimerRef.current)
+    exportedTimerRef.current = setTimeout(() => setShowExported(false), 2000)
+  }
+
+  function flashImported(): void {
+    setShowImported(true)
+    clearTimeout(importedTimerRef.current)
+    importedTimerRef.current = setTimeout(() => setShowImported(false), 2000)
+  }
+
+  async function handleExportCurrent(): Promise<void> {
+    if (!onExportCurrent) return
+    const ok = await onExportCurrent()
+    if (ok) flashExported()
+  }
+
+  async function handleImportCurrent(): Promise<void> {
+    if (!onImportCurrent) return
+    const ok = await onImportCurrent()
+    if (ok) flashImported()
+  }
 
   // Refresh entries when hub operation completes (upload/update/remove changes hubPostId)
   useEffect(() => {
@@ -140,6 +174,32 @@ export function FavoriteStoreContent({
               {t('common.save')}
             </button>
           </form>
+          {(onExportCurrent || onImportCurrent || showExported || showImported) && (
+            <div className="flex items-center gap-1 mt-2">
+              {showImported && (
+                <span className="text-[11px] font-medium text-emerald-500" data-testid="favorite-store-imported">
+                  {t('common.imported')}
+                </span>
+              )}
+              {showExported && (
+                <span className="text-[11px] font-medium text-emerald-500" data-testid="favorite-store-exported">
+                  {t('common.exported')}
+                </span>
+              )}
+              <div className="ml-auto flex items-center gap-1">
+                {onImportCurrent && (
+                  <button type="button" className={ACTION_BTN} onClick={() => void handleImportCurrent()} data-testid="favorite-store-import-current">
+                    {t('favoriteStore.importCurrent')}
+                  </button>
+                )}
+                {onExportCurrent && (
+                  <button type="button" className={ACTION_BTN} onClick={() => void handleExportCurrent()} data-testid="favorite-store-export-current">
+                    {t('favoriteStore.exportCurrent')}
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Synced Data header */}

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -222,6 +222,8 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
           onExport={favStore.exportFavorites}
           onExportEntry={favStore.exportEntry}
           onImport={favStore.importFavorites}
+          onExportCurrent={favStore.exportCurrent}
+          onImportCurrent={favStore.importCurrent}
           exporting={favStore.exporting}
           importing={favStore.importing}
           importResult={favStore.importResult}

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -81,7 +81,9 @@ export function LayoutStoreContent({
   // Sync save label when a layout is loaded (defaultSaveLabel changes)
   useEffect(() => { setSaveLabel(defaultSaveLabel ?? '') }, [defaultSaveLabel])
   const [showSaved, setShowSaved] = useState(false)
+  const [showExported, setShowExported] = useState(false)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const exportedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [confirmHubRemoveId, setConfirmHubRemoveId] = useState<string | null>(null)
@@ -91,6 +93,12 @@ export function LayoutStoreContent({
     setShowSaved(true)
     clearTimeout(savedTimerRef.current)
     savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000)
+  }
+
+  function flashExported(): void {
+    setShowExported(true)
+    clearTimeout(exportedTimerRef.current)
+    exportedTimerRef.current = setTimeout(() => setShowExported(false), 2000)
   }
 
   function handleSaveSubmit(e: React.FormEvent): void {
@@ -202,19 +210,22 @@ export function LayoutStoreContent({
                   )}
                 </form>
               )}
-              {(hasCurrentExport || showSaved) && (
+              {(hasCurrentExport || showSaved || showExported) && (
                 <div className={`flex items-center gap-1${!isDummy ? ' mt-2' : ''}`}>
                   {showSaved && (
                     <span className="text-[11px] font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                  )}
+                  {showExported && (
+                    <span className="text-[11px] font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
                   )}
                   <div className="ml-auto flex gap-1">
                     <FormatButtons
                       className={FORMAT_BTN}
                       testIdPrefix="layout-store-current-export"
                       disabled={fileDisabled}
-                      onVil={onExportVil}
-                      onKeymapC={onExportKeymapC}
-                      onPdf={onExportPdf}
+                      onVil={onExportVil ? async () => { if (await onExportVil()) flashExported() } : undefined}
+                      onKeymapC={onExportKeymapC ? async () => { if (await onExportKeymapC()) flashExported() } : undefined}
+                      onPdf={onExportPdf ? async () => { if (await onExportPdf()) flashExported() } : undefined}
                     />
                   </div>
                 </div>
@@ -271,21 +282,24 @@ export function LayoutStoreContent({
           )}
 
           {/* Export Current State section */}
-          {(hasCurrentExport || showSaved) && (
+          {(hasCurrentExport || showSaved || showExported) && (
             <div className={`${sectionGap}${fixedSection}`} data-testid="layout-store-current-section">
               <SectionHeader label={t('layoutStore.export')} />
               <div className="flex items-center gap-2">
                 {showSaved && (
                   <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
                 )}
+                {showExported && (
+                  <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
+                )}
                 <div className="ml-auto flex gap-2">
                   <FormatButtons
                     className={EXPORT_BTN}
                     testIdPrefix="layout-store-current-export"
                     disabled={fileDisabled}
-                    onVil={onExportVil}
-                    onKeymapC={onExportKeymapC}
-                    onPdf={onExportPdf}
+                    onVil={onExportVil ? async () => { if (await onExportVil()) flashExported() } : undefined}
+                    onKeymapC={onExportKeymapC ? async () => { if (await onExportKeymapC()) flashExported() } : undefined}
+                    onPdf={onExportPdf ? async () => { if (await onExportPdf()) flashExported() } : undefined}
                   />
                 </div>
               </div>

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -431,6 +431,8 @@ export function MacroEditor({
             onExport={favStore.exportFavorites}
             onExportEntry={favStore.exportEntry}
             onImport={favStore.importFavorites}
+            onExportCurrent={favStore.exportCurrent}
+            onImportCurrent={favStore.importCurrent}
             exporting={favStore.exporting}
             importing={favStore.importing}
             importResult={favStore.importResult}

--- a/src/renderer/components/editors/layout-store-types.ts
+++ b/src/renderer/components/editors/layout-store-types.ts
@@ -30,9 +30,9 @@ export interface LayoutStoreContentProps {
   onRename: (entryId: string, newLabel: string) => void
   onDelete: (entryId: string) => void
   onImportVil?: () => void
-  onExportVil?: () => void
-  onExportKeymapC?: () => void
-  onExportPdf?: () => void
+  onExportVil?: () => Promise<boolean>
+  onExportKeymapC?: () => Promise<boolean>
+  onExportPdf?: () => Promise<boolean>
   onSideloadJson?: () => void
   onExportEntryVil?: (entryId: string) => void
   onExportEntryKeymapC?: (entryId: string) => void

--- a/src/renderer/hooks/useFavoriteStore.ts
+++ b/src/renderer/hooks/useFavoriteStore.ts
@@ -33,6 +33,8 @@ export interface UseFavoriteStoreReturn {
   loadFavorite: (entryId: string) => Promise<boolean>
   renameEntry: (entryId: string, newLabel: string) => Promise<boolean>
   deleteEntry: (entryId: string) => Promise<boolean>
+  exportCurrent: () => Promise<boolean>
+  importCurrent: () => Promise<boolean>
   exportFavorites: () => Promise<boolean>
   exportEntry: (entryId: string) => Promise<boolean>
   importFavorites: () => Promise<boolean>
@@ -146,6 +148,47 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     }
   }, [favoriteType, refreshEntries])
 
+  const exportCurrent = useCallback(async (): Promise<boolean> => {
+    if (!enabled) return false
+    setError(null)
+    setExporting(true)
+    try {
+      const data = serialize()
+      const json = JSON.stringify({ type: favoriteType, data })
+      const result = await window.vialAPI.favoriteStoreExportCurrent(favoriteType, json)
+      if (!result.success) {
+        if (result.error !== 'cancelled') {
+          setError(t('favoriteStore.exportFailed'))
+        }
+        return false
+      }
+      return true
+    } catch {
+      setError(t('favoriteStore.exportFailed'))
+      return false
+    } finally {
+      setExporting(false)
+    }
+  }, [enabled, favoriteType, serialize, t])
+
+  const importCurrent = useCallback(async (): Promise<boolean> => {
+    setError(null)
+    try {
+      const result = await window.vialAPI.favoriteStoreImportToCurrent(favoriteType)
+      if (!result.success || result.data === undefined) {
+        if (result.error !== 'cancelled') {
+          setError(t('favoriteStore.importFailed'))
+        }
+        return false
+      }
+      apply(result.data)
+      return true
+    } catch {
+      setError(t('favoriteStore.importFailed'))
+      return false
+    }
+  }, [favoriteType, apply, t])
+
   const doExport = useCallback(async (entryId?: string): Promise<boolean> => {
     setError(null)
     setExporting(true)
@@ -215,6 +258,8 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     loadFavorite,
     renameEntry,
     deleteEntry,
+    exportCurrent,
+    importCurrent,
     exportFavorites,
     exportEntry,
     importFavorites,

--- a/src/renderer/hooks/useFileHandlers.ts
+++ b/src/renderer/hooks/useFileHandlers.ts
@@ -45,20 +45,20 @@ export function useFileHandlers(options: Options) {
     if (ok) showFileSuccess('import')
   }, [fileIO.loadLayout, showFileSuccess])
 
-  const handleExportVil = useCallback(async () => {
+  const handleExportVil = useCallback(async (): Promise<boolean> => {
     const ok = await fileIO.saveLayout()
-    if (ok) showFileSuccess('export')
-  }, [fileIO.saveLayout, showFileSuccess])
+    return ok
+  }, [fileIO.saveLayout])
 
-  const handleExportKeymapC = useCallback(async () => {
+  const handleExportKeymapC = useCallback(async (): Promise<boolean> => {
     const ok = await fileIO.exportKeymapC()
-    if (ok) showFileSuccess('export')
-  }, [fileIO.exportKeymapC, showFileSuccess])
+    return ok
+  }, [fileIO.exportKeymapC])
 
-  const handleExportPdf = useCallback(async () => {
+  const handleExportPdf = useCallback(async (): Promise<boolean> => {
     const ok = await fileIO.exportPdf()
-    if (ok) showFileSuccess('export')
-  }, [fileIO.exportPdf, showFileSuccess])
+    return ok
+  }, [fileIO.exportPdf])
 
   const exportLayoutPdf = useCallback(async (
     generator: (input: LayoutPdfInput) => string,
@@ -90,9 +90,8 @@ export function useFileHandlers(options: Options) {
 
   const fileStatus: FileStatus = useMemo(() => {
     if (fileIO.loading) return 'importing'
-    if (fileIO.saving) return 'exporting'
     if (fileSuccessKind === 'import') return { kind: 'success', message: t('fileIO.importSuccess') }
-    if (fileSuccessKind === 'export') return { kind: 'success', message: t('fileIO.exportSuccess') }
+    // Export status is shown inline on the .vil/.c/.pdf button row, not as fileStatus
     return 'idle'
   }, [fileIO.loading, fileIO.saving, fileSuccessKind, t])
 

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -22,7 +22,9 @@
     "settingsLabel": "Settings:",
     "configuration": "Configuration",
     "saving": "Saving...",
-    "back": "Back"
+    "back": "Back",
+    "exported": "Exported",
+    "imported": "Imported"
   },
   "app": {
     "title": "Pipette",
@@ -626,6 +628,8 @@
     "importFailed": "Failed to import favorites",
     "importSuccess": "Imported {{imported}} entries",
     "importPartial": "Imported {{imported}} entries ({{skipped}} skipped)",
-    "importEmpty": "No entries were imported"
+    "importEmpty": "No entries were imported",
+    "exportCurrent": "Export",
+    "importCurrent": "Import"
   }
 }

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -22,7 +22,9 @@
     "settingsLabel": "設定:",
     "configuration": "Configuration",
     "saving": "保存中...",
-    "back": "戻る"
+    "back": "戻る",
+    "exported": "エクスポート済み",
+    "imported": "インポート済み"
   },
   "app": {
     "title": "Pipette",
@@ -625,6 +627,8 @@
     "importFailed": "お気に入りのインポートに失敗しました",
     "importSuccess": "{{imported}} 件インポートしました",
     "importPartial": "{{imported}} 件インポートしました（{{skipped}} 件スキップ）",
-    "importEmpty": "インポートされたエントリはありません"
+    "importEmpty": "インポートされたエントリはありません",
+    "exportCurrent": "エクスポート",
+    "importCurrent": "インポート"
   }
 }

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -44,7 +44,9 @@ export const IpcChannels = {
   FAVORITE_STORE_RENAME: 'favorite-store:rename',
   FAVORITE_STORE_DELETE: 'favorite-store:delete',
   FAVORITE_STORE_EXPORT: 'favorite-store:export',
+  FAVORITE_STORE_EXPORT_CURRENT: 'favorite-store:export-current',
   FAVORITE_STORE_IMPORT: 'favorite-store:import',
+  FAVORITE_STORE_IMPORT_TO_CURRENT: 'favorite-store:import-to-current',
 
   // App Config (renderer ↔ main)
   APP_CONFIG_GET_ALL: 'app-config:get-all',

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -115,7 +115,9 @@ export interface VialAPI {
   favoriteStoreRename(type: string, entryId: string, newLabel: string): Promise<{ success: boolean; error?: string }>
   favoriteStoreDelete(type: string, entryId: string): Promise<{ success: boolean; error?: string }>
   favoriteStoreExport(scope: string, entryId?: string): Promise<{ success: boolean; error?: string }>
+  favoriteStoreExportCurrent(scope: string, data: string): Promise<{ success: boolean; error?: string }>
   favoriteStoreImport(): Promise<FavoriteImportResult>
+  favoriteStoreImportToCurrent(scope: string): Promise<{ success: boolean; data?: unknown; error?: string }>
 
   // Pipette Settings Store
   pipetteSettingsGet(uid: string): Promise<PipetteSettings | null>


### PR DESCRIPTION
## Summary
- Add Import/Export buttons for current state to Combo, Tap Dance, Macro, Key Override, Alt Repeat Key panels
- Show inline "Exported"/"Imported" feedback on the button row (replaces top banner)

## Changes
- New IPC: `favorite-store:export-current`, `favorite-store:import-to-current`
- `FavoriteStoreContent` — Import/Export buttons + flash feedback
- `LayoutStoreContent` — "Exported" inline on .vil/.c/.pdf row
- `useFileHandlers` — Export handlers return `Promise<boolean>`, remove "Exporting..." status
- Threading through KeycodeEntryModalShell, MacroEditor
- i18n: `common.exported`, `common.imported`, `favoriteStore.exportCurrent`, `favoriteStore.importCurrent`

## Test Plan
- [x] `pnpm test` — 2,789 tests pass
- [x] `pnpm build` — Production build succeeds
- [x] `pnpm lint` — No lint errors

Closes #52