### PR TITLE
feat(ui): add native context menu for editable text fields

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -92,6 +92,19 @@ function createWindow(): void {
 
   win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }))
 
+  // Native context menu for editable text fields (textarea, input)
+  win.webContents.on('context-menu', (_event, params) => {
+    if (!params.isEditable) return
+    const menu = Menu.buildFromTemplate([
+      { role: 'cut' },
+      { role: 'copy' },
+      { role: 'paste' },
+      { type: 'separator' },
+      { role: 'selectAll' },
+    ])
+    menu.popup()
+  })
+
   if (process.env.ELECTRON_RENDERER_URL) {
     win.loadURL(process.env.ELECTRON_RENDERER_URL)
   } else {


### PR DESCRIPTION
## Summary
- Add Cut, Copy, Paste, and Select All context menu to all editable text fields (textarea, input)
- Implemented via `webContents.on('context-menu')` in main process — no preload/renderer changes needed

## Changes
- `src/main/index.ts`: Add context-menu event handler that shows native menu when `params.isEditable` is true

## Test Plan
- [ ] Right-click in JSON editor textarea → context menu appears with Cut/Copy/Paste/Select All
- [ ] Right-click in macro text editor textarea → same menu
- [ ] Right-click in other input fields (save label, search) → same menu
- [ ] Right-click on non-editable areas → no menu
- [ ] Cut/Copy/Paste operations work correctly