### PR TITLE
feat(ui): picker single-click selection and multi-select improvements

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -475,6 +475,16 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
       }
       handlePickerMultiSelect(index, code, { ctrlKey: !!event.ctrlKey, shiftKey: !!event.shiftKey }, pickerTabKeycodeNumbers)
+    } else if (handlePickerMultiSelect) {
+      // Normal click: select single key and set anchor for subsequent Shift/Ctrl clicks
+      const keys = pickerSource === 'file' && pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
+      let index = 0
+      for (const k of keys) {
+        if (k.row == null || k.col == null) continue
+        if (k.row === key.row && k.col === key.col) break
+        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
+      }
+      handlePickerMultiSelect(index, code, { ctrlKey: true, shiftKey: false }, pickerTabKeycodeNumbers)
     } else {
       handleKeycodeSelect(kc)
     }
@@ -664,7 +674,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           <div className="flex items-center gap-1">
             {Array.from({ length: pickerData.totalLayers }, (_, i) => (
               <button key={i} type="button" className={layerBtnClass(pickerLayer === i)}
-                onClick={() => setPickerLayer(i)}>
+                onClick={() => { setPickerLayer(i); multiSelect.clearPickerSelection() }}>
                 {pickerData.names?.[i] || i}
               </button>
             ))}
@@ -786,7 +796,10 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           <TabbedKeycodes
             keyboardPickerContent={layoutPickerContent}
             onKeycodeSelect={handleKeycodeSelect} onKeycodeMultiSelect={handlePickerMultiSelect}
-            pickerSelectedIndices={pickerSelectedIndices} onBackgroundClick={handleDeselect}
+            pickerSelectedIndices={pickerSelectedIndices}
+            pickerMultiSelectEnabled={!selectedKey && !selectedEncoder}
+            onBackgroundClick={handleDeselect}
+            onTabChange={() => { handleDeselect(); multiSelect.clearPickerSelection() }}
             highlightedKeycodes={configuredKeycodes} maskOnly={isMaskKey} lmMode={isLMMask} showHint={!isMaskKey}
             tabFooterContent={tabFooterContent} tabContentOverride={tabContentOverride}
             basicViewType={basicViewType} splitKeyMode={splitKeyMode} remapLabel={remapLabel}

--- a/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
@@ -275,7 +275,7 @@ describe('KeymapEditor — picker paste', () => {
     expect(selected.size).toBe(0)
   })
 
-  it('does not allow picker multi-select when a key is selected', () => {
+  it('allows picker multi-select even when a key is selected', () => {
     render(<KeymapEditor {...defaultProps} />)
 
     // Select a key first
@@ -284,14 +284,15 @@ describe('KeymapEditor — picker paste', () => {
       onKeyClick({ row: 0, col: 0 } as KleKey, false)
     })
 
-    // Try picker multi-select
+    // Ctrl+click picker multi-select — should work (deselects key first)
     const multiSelect = getOnKeycodeMultiSelect()!
     act(() => {
       multiSelect(0, TAB_KEYCODE_NUMBERS[0], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
     })
 
     const selected = getPickerSelectedSet()!
-    expect(selected.size).toBe(0)
+    expect(selected.size).toBe(1)
+    expect(selected.has(0)).toBe(true)
   })
 
   it('clears picker selection on normal keycode click', () => {

--- a/src/renderer/components/editors/useKeymapMultiSelect.ts
+++ b/src/renderer/components/editors/useKeymapMultiSelect.ts
@@ -75,7 +75,6 @@ export function useKeymapMultiSelect({
 
   const handlePickerMultiSelect = useCallback(
     (index: number, keycode: number, event: { ctrlKey: boolean; shiftKey: boolean }, tabKeycodeNumbers: number[]) => {
-      if (hasActiveSingleSelectionRef.current) return
 
       setMultiSelectedKeys((prev) => prev.size === 0 ? prev : new Set())
       setSelectionAnchor(null)

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -34,7 +34,9 @@ interface Props {
   onConfirm?: () => void // Confirm current selection (Enter key)
   onKeycodeMultiSelect?: (index: number, keycode: number, event: { ctrlKey: boolean; shiftKey: boolean }, tabKeycodeNumbers: number[]) => void
   pickerSelectedIndices?: Set<number>
+  pickerMultiSelectEnabled?: boolean
   onBackgroundClick?: () => void
+  onTabChange?: () => void
   onClose?: () => void
   highlightedKeycodes?: Set<string>
   maskOnly?: boolean // When true, only show keycodes with value < 0xFF (for mask inner byte editing)
@@ -56,7 +58,9 @@ export function TabbedKeycodes({
   onConfirm,
   onKeycodeMultiSelect,
   pickerSelectedIndices,
+  pickerMultiSelectEnabled = false,
   onBackgroundClick,
+  onTabChange,
   onClose,
   highlightedKeycodes,
   maskOnly = false,
@@ -234,15 +238,18 @@ export function TabbedKeycodes({
     (kc: Keycode, event: React.MouseEvent, index: number) => {
       const isModified = event.ctrlKey || event.metaKey || event.shiftKey
       if (isModified && onKeycodeMultiSelect) {
+        if (!pickerMultiSelectEnabled) onBackgroundClick?.()
         onKeycodeMultiSelect(index, deserialize(kc.qmkId), { ctrlKey: event.ctrlKey || event.metaKey, shiftKey: event.shiftKey }, activeTabKeycodeNumbers)
+      } else if (onKeycodeMultiSelect && pickerMultiSelectEnabled) {
+        onKeycodeMultiSelect(index, deserialize(kc.qmkId), { ctrlKey: true, shiftKey: false }, activeTabKeycodeNumbers)
       } else {
         onKeycodeSelect?.(kc)
       }
     },
-    [onKeycodeMultiSelect, onKeycodeSelect, activeTabKeycodeNumbers],
+    [onKeycodeMultiSelect, onKeycodeSelect, activeTabKeycodeNumbers, pickerMultiSelectEnabled, onBackgroundClick],
   )
 
-  function renderKeycodeGrid(keycodes: Keycode[]): React.ReactNode {
+  function renderKeycodeGrid(keycodes: Keycode[], tabId?: string): React.ReactNode {
     return (
       <KeycodeGrid
         keycodes={keycodes}
@@ -251,7 +258,7 @@ export function TabbedKeycodes({
         onHover={handleKeycodeHover}
         onHoverEnd={handleKeycodeHoverEnd}
         highlightedKeycodes={highlightedKeycodes}
-        pickerSelectedIndices={pickerSelectedIndices}
+        pickerSelectedIndices={(!tabId || tabId === activeTab) ? pickerSelectedIndices : undefined}
         isVisible={isVisible}
         splitKeyMode={maskOnly ? 'flat' : resolvedSplitKeyMode}
         remapLabel={remapLabel}
@@ -259,7 +266,7 @@ export function TabbedKeycodes({
     )
   }
 
-  function renderGroup(group: KeycodeGroup, hint?: string): React.ReactNode {
+  function renderGroup(group: KeycodeGroup, tabId?: string, hint?: string): React.ReactNode {
     return (
       <div key={group.labelKey}>
         <h4 className="text-xs font-normal text-content-muted px-1 pt-2 pb-1">
@@ -270,17 +277,18 @@ export function TabbedKeycodes({
             {group.sections
               .filter((s) => s.some(isVisible))
               .map((section, i) => (
-                <div key={i}>{renderKeycodeGrid(section)}</div>
+                <div key={i}>{renderKeycodeGrid(section, tabId)}</div>
               ))}
           </div>
         ) : (
-          renderKeycodeGrid(group.keycodes)
+          renderKeycodeGrid(group.keycodes, tabId)
         )}
       </div>
     )
   }
 
   function renderCategoryContent(category: KeycodeCategory): React.ReactNode {
+    const isActive = category.id === activeTab
     // Keyboard view for basic tab (ANSI, ISO, or JIS)
     if (category.id === 'basic' && resolvedBasicViewType !== 'list' && resolvedBasicViewType != null && !lmMode) {
       return (
@@ -292,7 +300,7 @@ export function TabbedKeycodes({
           onKeycodeHover={handleKeycodeHover}
           onKeycodeHoverEnd={handleKeycodeHoverEnd}
           highlightedKeycodes={highlightedKeycodes}
-          pickerSelectedIndices={pickerSelectedIndices}
+          pickerSelectedIndices={isActive ? pickerSelectedIndices : undefined}
           isVisible={isVisible}
           remapLabel={remapLabel}
         />
@@ -307,13 +315,13 @@ export function TabbedKeycodes({
 
     // No override, no groups — fall back to flat keycode grid
     if (!override && !groups?.length) {
-      return renderKeycodeGrid(category.getKeycodes().filter(isVisible))
+      return renderKeycodeGrid(category.getKeycodes().filter(isVisible), category.id)
     }
 
     const rows = groupByLayoutRow(groups ?? [])
     const groupContent = rows.map((row) => (
       <div key={row[0].labelKey} className="flex gap-x-3">
-        {row.map((group) => renderGroup(group))}
+        {row.map((group) => renderGroup(group, category.id))}
       </div>
     ))
 
@@ -342,7 +350,7 @@ export function TabbedKeycodes({
                   ? 'border-b-accent text-accent font-semibold'
                   : 'border-b-transparent text-content-secondary hover:text-content'
               }`}
-              onClick={() => { setActiveTab(cat.id); setTooltip(null) }}
+              onClick={() => { onTabChange?.(); setActiveTab(cat.id); setTooltip(null) }}
             >
               {t(cat.labelKey)}
             </button>
@@ -356,7 +364,7 @@ export function TabbedKeycodes({
                   ? 'border-b-accent text-accent font-semibold'
                   : 'border-b-transparent text-content-secondary hover:text-content'
               }`}
-              onClick={() => { setActiveTab('keyboard'); setTooltip(null) }}
+              onClick={() => { onTabChange?.(); setActiveTab('keyboard'); setTooltip(null) }}
             >
               {t('editor.keymap.keyboardTab')}
             </button>


### PR DESCRIPTION
## Summary
- Normal click selects keycode and sets anchor when no key is selected on keyboard
- Shift/Ctrl multi-select works even when a key is selected (deselects key first)
- Selection clears on tab switch and picker layer change
- Non-active tabs don't receive selection props (no flash on transitions)

## Test plan
- [ ] No key selected: click picker → selects, Shift+click → range
- [ ] Key selected: click → assigns, Shift/Ctrl → deselects key then multi-selects
- [ ] Tab switch / layer change → selection clears