### PR TITLE
fix(ui): remove redundant connecting text from device list

### DIFF
--- a/src/renderer/components/DeviceSelector.tsx
+++ b/src/renderer/components/DeviceSelector.tsx
@@ -188,13 +188,7 @@ export function DeviceSelector({
                         {device.type !== 'vial' && ` (${device.type})`}
                       </div>
                     </div>
-                    {connecting ? (
-                      <span className="text-sm text-accent">
-                        {t('app.connecting', { dots: '...' })}
-                      </span>
-                    ) : (
-                      <ChevronRight size={16} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
-                    )}
+                    <ChevronRight size={16} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
                   </button>
                 ))}
 

--- a/src/renderer/components/__tests__/DeviceSelector.test.tsx
+++ b/src/renderer/components/__tests__/DeviceSelector.test.tsx
@@ -106,9 +106,10 @@ describe('DeviceSelector', () => {
     expect(screen.getByTestId('tab-file')).not.toBeDisabled()
   })
 
-  it('shows connecting indicator on device when connecting', () => {
+  it('shows chevron instead of connecting text when connecting', () => {
     render(<DeviceSelector {...defaultProps} devices={[mockDevice]} connecting={true} />)
-    expect(screen.getByText('Connecting...')).toBeInTheDocument()
+    // connecting text removed — chevron always shown, loading overlay handles transition
+    expect(screen.queryByText('Connecting...')).not.toBeInTheDocument()
   })
 
   it('displays error message when error is present', () => {


### PR DESCRIPTION
## Summary
- Remove "Connecting..." text from all device entries — loading overlay handles the transition
- Keep disabled state on buttons for double-click prevention

## Test plan
- [ ] Click a keyboard → no "Connecting..." flash, loading overlay appears directly