### PR TITLE
fix(hid): pause device polling during unlock to prevent counter reset

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -634,10 +634,12 @@ export function App() {
           unlockStart={api.unlockStart}
           unlockPoll={api.unlockPoll}
           onComplete={async () => {
+            device.resumePoll()
             editorUI.setShowUnlockDialog(false)
             editorUI.setUnlockMacroWarning(false)
             await keyboard.refreshUnlockStatus()
           }}
+          onOpen={device.pausePoll}
           macroWarning={editorUI.unlockMacroWarning}
         />
       )}

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -15,6 +15,7 @@ interface Props {
   unlockStart: () => Promise<void>
   unlockPoll: () => Promise<number[]>
   onComplete: () => void
+  onOpen?: () => void
   macroWarning?: boolean
 }
 
@@ -25,6 +26,7 @@ export function UnlockDialog({
   unlockStart,
   unlockPoll,
   onComplete,
+  onOpen,
   macroWarning,
 }: Props) {
   const { t } = useTranslation()
@@ -46,9 +48,13 @@ export function UnlockDialog({
   onCompleteRef.current = onComplete
   const busyRef = useRef(false)
 
+  const onOpenRef = useRef(onOpen)
+  onOpenRef.current = onOpen
+
   // Single useEffect: send unlockStart once, then poll via setInterval.
   // setInterval (like Python's QTimer) guarantees exactly one poll loop.
   useEffect(() => {
+    onOpenRef.current?.()
     let intervalId: ReturnType<typeof setInterval> | undefined
     let cancelled = false
 

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -305,7 +305,6 @@ export function useKeymapSelectionHandlers({
 
   // --- Deselect ---
   const handleDeselect = useCallback(() => {
-    console.log('[Deselect] called')
     clearSingleSelection(); clearMultiSelection(); clearPickerSelection(); setCopyLayerPending(false)
   }, [clearSingleSelection, clearMultiSelection, clearPickerSelection])
 

--- a/src/renderer/hooks/useDeviceConnection.ts
+++ b/src/renderer/hooks/useDeviceConnection.ts
@@ -39,6 +39,7 @@ export function useDeviceConnection() {
   const mountedRef = useRef(true)
   const connectedDeviceRef = useRef<DeviceInfo | null>(null)
   const isDummyRef = useRef(false)
+  const pollPausedRef = useRef(false)
 
   useEffect(() => {
     mountedRef.current = true
@@ -186,6 +187,12 @@ export function useDeviceConnection() {
     async function poll(): Promise<void> {
       if (!mountedRef.current || cancelled) return
 
+      // Skip all USB activity while paused (e.g. during unlock dialog)
+      if (pollPausedRef.current) {
+        if (!cancelled) timerId = setTimeout(poll, POLL_INTERVAL_MS)
+        return
+      }
+
       // Always refresh device list (for device picker to detect plug/unplug)
       try {
         const devices = await withTimeout(
@@ -224,6 +231,9 @@ export function useDeviceConnection() {
     }
   }, []) // stable — uses refs internally
 
+  const pausePoll = useCallback(() => { pollPausedRef.current = true }, [])
+  const resumePoll = useCallback(() => { pollPausedRef.current = false }, [])
+
   return {
     ...state,
     refreshDevices,
@@ -231,5 +241,7 @@ export function useDeviceConnection() {
     connectDummy,
     connectPipetteFile,
     disconnectDevice,
+    pausePoll,
+    resumePoll,
   }
 }


### PR DESCRIPTION
## Summary
- Pause listDevices() and isDeviceOpen() polling while unlock dialog is open
- USB device enumeration was disrupting firmware unlock counter, causing progress to reset every ~1 second
- Add pausePoll/resumePoll to useDeviceConnection, triggered by UnlockDialog onOpen/onComplete
- Remove debug console.log statements

## Test plan
- [ ] Open unlock dialog, hold unlock keys → progress advances smoothly to completion
- [ ] After unlock completes, device polling resumes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)