### PR TITLE
fix(hid): limit listDevices polling to device picker browsing only

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -599,6 +599,7 @@ export function App() {
             onFavRenameOnHub={hub.hubReady ? hub.handleFavRenameOnHub : undefined}
             devices={device.devices}
             connectedDevice={device.connectedDevice}
+            onDeviceListActiveChange={device.setDeviceListActive}
           />
         </div>
 
@@ -634,12 +635,10 @@ export function App() {
           unlockStart={api.unlockStart}
           unlockPoll={api.unlockPoll}
           onComplete={async () => {
-            device.resumePoll()
             editorUI.setShowUnlockDialog(false)
             editorUI.setUnlockMacroWarning(false)
             await keyboard.refreshUnlockStatus()
           }}
-          onOpen={device.pausePoll}
           macroWarning={editorUI.unlockMacroWarning}
         />
       )}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -101,7 +101,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   deviceName, isDummy, onExportLayoutPdfAll, onExportLayoutPdfCurrent,
   favHubOrigin, favHubNeedsDisplayName, favHubUploading, favHubUploadResult,
   onFavUploadToHub, onFavUpdateOnHub, onFavRemoveFromHub, onFavRenameOnHub,
-  devices, connectedDevice,
+  devices, connectedDevice, onDeviceListActiveChange,
 }, ref) {
   const { t } = useTranslation()
   const keyboardContentRef = useRef<HTMLDivElement>(null)
@@ -186,6 +186,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
   hasActiveSingleSelectionRef.current = !!(selectedKey || selectedEncoder)
   const { multiSelectedKeys, selectionSourcePane, pickerSelectedIndices, handlePickerMultiSelect } = multiSelect
+
+  // --- Notify parent when device list browsing state changes ---
+  useEffect(() => {
+    onDeviceListActiveChange?.(pickerSource === 'device' && deviceBrowsing)
+  }, [pickerSource, deviceBrowsing, onDeviceListActiveChange])
 
   // --- Escape clears picker selection ---
   useEffect(() => {

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -15,7 +15,6 @@ interface Props {
   unlockStart: () => Promise<void>
   unlockPoll: () => Promise<number[]>
   onComplete: () => void
-  onOpen?: () => void
   macroWarning?: boolean
 }
 
@@ -26,7 +25,6 @@ export function UnlockDialog({
   unlockStart,
   unlockPoll,
   onComplete,
-  onOpen,
   macroWarning,
 }: Props) {
   const { t } = useTranslation()
@@ -48,13 +46,9 @@ export function UnlockDialog({
   onCompleteRef.current = onComplete
   const busyRef = useRef(false)
 
-  const onOpenRef = useRef(onOpen)
-  onOpenRef.current = onOpen
-
   // Single useEffect: send unlockStart once, then poll via setInterval.
   // setInterval (like Python's QTimer) guarantees exactly one poll loop.
   useEffect(() => {
-    onOpenRef.current?.()
     let intervalId: ReturnType<typeof setInterval> | undefined
     let cancelled = false
 

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -143,4 +143,6 @@ export interface KeymapEditorProps {
   devices?: DeviceInfo[]
   /** Currently connected (primary) device info */
   connectedDevice?: DeviceInfo | null
+  /** Notify parent when device list browsing state changes (for polling control) */
+  onDeviceListActiveChange?: (active: boolean) => void
 }

--- a/src/renderer/hooks/__tests__/useDeviceConnection.test.ts
+++ b/src/renderer/hooks/__tests__/useDeviceConnection.test.ts
@@ -127,14 +127,16 @@ describe('useDeviceConnection', () => {
 
       mockListDevices.mockClear()
 
-      // Wait for the polling interval — both listDevices and isDeviceOpen are called
+      // Wait for the polling interval to call isDeviceOpen instead of listDevices
+      // (listDevices only runs when deviceListActive is true)
       await waitFor(
         () => {
           expect(mockIsDeviceOpen).toHaveBeenCalled()
-          expect(mockListDevices).toHaveBeenCalled()
         },
         { timeout: 5000, interval: 200 },
       )
+
+      expect(mockListDevices).not.toHaveBeenCalled()
     })
 
     it('detects disconnection via isDeviceOpen returning false', async () => {

--- a/src/renderer/hooks/useDeviceConnection.ts
+++ b/src/renderer/hooks/useDeviceConnection.ts
@@ -39,7 +39,7 @@ export function useDeviceConnection() {
   const mountedRef = useRef(true)
   const connectedDeviceRef = useRef<DeviceInfo | null>(null)
   const isDummyRef = useRef(false)
-  const pollPausedRef = useRef(false)
+  const deviceListActiveRef = useRef(false)
 
   useEffect(() => {
     mountedRef.current = true
@@ -187,23 +187,19 @@ export function useDeviceConnection() {
     async function poll(): Promise<void> {
       if (!mountedRef.current || cancelled) return
 
-      // Skip all USB activity while paused (e.g. during unlock dialog)
-      if (pollPausedRef.current) {
-        if (!cancelled) timerId = setTimeout(poll, POLL_INTERVAL_MS)
-        return
-      }
-
-      // Always refresh device list (for device picker to detect plug/unplug)
-      try {
-        const devices = await withTimeout(
-          window.vialAPI.listDevices(),
-          POLL_TIMEOUT_MS,
-        )
-        if (mountedRef.current) {
-          setState((s) => ({ ...s, devices, error: null }))
+      // Refresh device list only when device picker is actively browsing
+      if (deviceListActiveRef.current || !connectedDeviceRef.current) {
+        try {
+          const devices = await withTimeout(
+            window.vialAPI.listDevices(),
+            POLL_TIMEOUT_MS,
+          )
+          if (mountedRef.current) {
+            setState((s) => ({ ...s, devices, error: null }))
+          }
+        } catch {
+          // Ignore polling errors (including timeouts) to avoid flooding the UI
         }
-      } catch {
-        // Ignore polling errors (including timeouts) to avoid flooding the UI
       }
 
       if (connectedDeviceRef.current) {
@@ -231,8 +227,7 @@ export function useDeviceConnection() {
     }
   }, []) // stable — uses refs internally
 
-  const pausePoll = useCallback(() => { pollPausedRef.current = true }, [])
-  const resumePoll = useCallback(() => { pollPausedRef.current = false }, [])
+  const setDeviceListActive = useCallback((active: boolean) => { deviceListActiveRef.current = active }, [])
 
   return {
     ...state,
@@ -241,7 +236,6 @@ export function useDeviceConnection() {
     connectDummy,
     connectPipetteFile,
     disconnectDevice,
-    pausePoll,
-    resumePoll,
+    setDeviceListActive,
   }
 }


### PR DESCRIPTION
## Summary
- listDevices() now only polls when Keyboard tab device list is actively visible
- Removes pausePoll/resumePoll workaround from unlock dialog
- Unlock counter reset issue prevented at root cause (no USB enumeration during editing)

## Test plan
- [ ] Device list updates in real time when Keyboard tab is open
- [ ] No unnecessary USB polling during normal keymap editing
- [ ] Unlock progress advances smoothly without reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)