### PR TITLE
fix(ui): clear key selection after picker multi-paste

### DIFF
--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -256,6 +256,7 @@ export function useKeymapSelectionHandlers({
       await onSetKeysBulk(entries)
     })
     clearPickerSelection()
+    setSelectedKey(null); setSelectedMaskPart(false); setSelectedEncoder(null)
   }, [pickerSelected, selectableKeys, currentLayer, onSetKeysBulk, runCopy, clearPickerSelection])
 
   // --- Click handlers ---


### PR DESCRIPTION
Clear selectedKey/selectedEncoder after pasting multi-selected keycodes from picker to prevent stale highlight on upper keymap.