### PR TITLE
fix(ui): preserve key selection on picker tab switch

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -913,7 +913,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
             pickerSelectedIndices={pickerSelectedIndices}
             pickerMultiSelectEnabled={!selectedKey && !selectedEncoder}
             onBackgroundClick={handleDeselect}
-            onTabChange={() => { handleDeselect(); multiSelect.clearPickerSelection() }}
+            onTabChange={() => { multiSelect.clearPickerSelection() }}
             highlightedKeycodes={configuredKeycodes} maskOnly={isMaskKey} lmMode={isLMMask} showHint={!isMaskKey}
             tabFooterContent={tabFooterContent} tabContentOverride={tabContentOverride}
             basicViewType={basicViewType} splitKeyMode={splitKeyMode} remapLabel={remapLabel}


### PR DESCRIPTION
## Summary
- Remove `handleDeselect()` from `onTabChange` in `KeymapEditor.tsx`
- Picker tab switch now only clears picker multi-select state, preserving keyboard key selection
- Fixes the issue where selecting a key then switching picker tabs (e.g. to Modifiers) would deselect the key

Closes #72

## Test plan
- [ ] Select a key on the keyboard layout
- [ ] Switch picker tabs (e.g. Basic → Modifiers) — key should remain selected
- [ ] Click a keycode in the new tab — it should assign to the selected key
- [ ] Verify picker multi-select is still cleared on tab switch
- [ ] Verify clicking empty space in picker still deselects everything (onBackgroundClick)