### PR TITLE
fix(ui): add independent split key half selection in picker

### DIFF
--- a/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
@@ -174,7 +174,7 @@ describe('KeymapEditor — picker paste', () => {
     expect(selected.size).toBe(1)
   })
 
-  it('adds duplicate on second Ctrl+click of same keycode', () => {
+  it('toggles off on second Ctrl+click of same keycode (toggle)', () => {
     render(<KeymapEditor {...defaultProps} />)
     const multiSelect = getOnKeycodeMultiSelect()!
 
@@ -187,9 +187,9 @@ describe('KeymapEditor — picker paste', () => {
     })
 
     const selected = getPickerSelectedSet()!
-    // Set deduplicates by qmkId, but the underlying array has 2 entries
-    expect(selected.has(0)).toBe(true)
-    expect(selected.size).toBe(1)
+    // Second Ctrl+click of same keycode at same index removes it (toggle)
+    expect(selected.has(0)).toBe(false)
+    expect(selected.size).toBe(0)
   })
 
   it('selects range on Shift+click after Ctrl anchor', () => {

--- a/src/renderer/components/editors/useKeymapMultiSelect.ts
+++ b/src/renderer/components/editors/useKeymapMultiSelect.ts
@@ -9,7 +9,7 @@ export interface UseKeymapMultiSelectOptions {
   hasActiveSingleSelectionRef: React.RefObject<boolean>
 }
 
-/** A picker selection: index in the tab's ordered keycode list → keycode number. */
+/** A picker selection: expanded index -> keycode number. */
 export type PickerSelection = Map<number, number>
 
 export interface UseKeymapMultiSelectReturn {
@@ -21,7 +21,7 @@ export interface UseKeymapMultiSelectReturn {
   setSelectionSourcePane: React.Dispatch<React.SetStateAction<'primary' | 'secondary' | null>>
   selectionMode: 'ctrl' | 'shift'
   setSelectionMode: React.Dispatch<React.SetStateAction<'ctrl' | 'shift'>>
-  /** Map of selected indices → keycode numbers (ordered by index). */
+  /** Map of selected indices -> keycode numbers (ordered by index). */
   pickerSelected: PickerSelection
   /** Derived set of selected indices for fast .has() checks. */
   pickerSelectedIndices: Set<number>
@@ -29,12 +29,17 @@ export interface UseKeymapMultiSelectReturn {
   clearPickerSelection: () => void
   /**
    * Handle Ctrl+click / Shift+click on a picker keycode.
-   * @param index - position in the tab's ordered keycode list
+   * @param index - position in the tab's expanded keycode list
    * @param keycode - the keycode number at that position
    * @param event - modifier key state
-   * @param tabKeycodeNumbers - ordered keycode numbers for the current tab (for Shift range fill)
+   * @param tabKeycodeNumbers - ordered keycode numbers for the current tab (expanded, for Shift range fill)
    */
-  handlePickerMultiSelect: (index: number, keycode: number, event: { ctrlKey: boolean; shiftKey: boolean }, tabKeycodeNumbers: number[]) => void
+  handlePickerMultiSelect: (
+    index: number,
+    keycode: number,
+    event: { ctrlKey: boolean; shiftKey: boolean },
+    tabKeycodeNumbers: number[],
+  ) => void
 }
 
 const EMPTY_MAP: PickerSelection = new Map()
@@ -74,7 +79,12 @@ export function useKeymapMultiSelect({
   pickerAnchorRef.current = pickerAnchorIndex
 
   const handlePickerMultiSelect = useCallback(
-    (index: number, keycode: number, event: { ctrlKey: boolean; shiftKey: boolean }, tabKeycodeNumbers: number[]) => {
+    (
+      index: number,
+      keycode: number,
+      event: { ctrlKey: boolean; shiftKey: boolean },
+      tabKeycodeNumbers: number[],
+    ) => {
 
       setMultiSelectedKeys((prev) => prev.size === 0 ? prev : new Set())
       setSelectionAnchor(null)
@@ -87,7 +97,11 @@ export function useKeymapMultiSelect({
       } else if (event.ctrlKey) {
         setPickerSelected((prev) => {
           const next = new Map(prev)
-          next.set(index, keycode)
+          if (next.has(index)) {
+            next.delete(index)
+          } else {
+            next.set(index, keycode)
+          }
           return next
         })
         setPickerAnchorIndex(index)
@@ -101,11 +115,11 @@ export function useKeymapMultiSelect({
         }
         const start = Math.min(anchor, index)
         const end = Math.max(anchor, index)
+
         const range = new Map<number, number>()
         for (let i = start; i <= end; i++) {
-          if (i < tabKeycodeNumbers.length) {
-            range.set(i, tabKeycodeNumbers[i])
-          }
+          if (i >= tabKeycodeNumbers.length) continue
+          range.set(i, tabKeycodeNumbers[i])
         }
         setPickerSelected(range)
       }

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -253,7 +253,6 @@ export function useKeymapSelectionHandlers({
   const handlePickerPaste = useCallback(async (targetKey: KleKey) => {
     const targetIdx = selectableKeys.findIndex((k) => k.row === targetKey.row && k.col === targetKey.col)
     if (targetIdx < 0) return
-    // Get keycodes ordered by index (Map iteration order = insertion order, but sort to be safe)
     const sortedEntries = [...pickerSelected.entries()].sort((a, b) => a[0] - b[0])
     const targetPositions = selectableKeys.slice(targetIdx, targetIdx + sortedEntries.length)
     await runCopy(async () => {

--- a/src/renderer/components/keycodes/BasicKeyboardView.tsx
+++ b/src/renderer/components/keycodes/BasicKeyboardView.tsx
@@ -27,9 +27,10 @@ interface Props {
   onKeycodeHover?: (keycode: Keycode, rect: DOMRect) => void
   onKeycodeHoverEnd?: () => void
   highlightedKeycodes?: Set<string>
-  pickerSelectedIndices?: Set<string>
+  pickerSelectedIndices?: Set<number>
   isVisible?: (kc: Keycode) => boolean
   remapLabel?: (qmkId: string) => string
+  keycodeIndexMap?: Map<string, { baseIdx: number; shiftedIdx?: number }>
 }
 
 /** Collect all keycode names present in a KLE layout definition */
@@ -80,6 +81,7 @@ export function BasicKeyboardView({
   pickerSelectedIndices,
   isVisible,
   remapLabel,
+  keycodeIndexMap,
 }: Props) {
   const { t } = useTranslation()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -131,6 +133,7 @@ export function BasicKeyboardView({
         isVisible={visCheck}
         splitKeyMode={splitKeyMode}
         remapLabel={remapLabel}
+        keycodeIndexMap={keycodeIndexMap}
       />
     )
   }
@@ -150,6 +153,7 @@ export function BasicKeyboardView({
             splitKeyMode={splitKeyMode}
             remapLabel={remapLabel}
             isVisible={visCheck}
+            keycodeIndexMap={keycodeIndexMap}
           />
           {remainingRows.length > 0 && (
             <div className="mt-1">

--- a/src/renderer/components/keycodes/DisplayKeyboard.tsx
+++ b/src/renderer/components/keycodes/DisplayKeyboard.tsx
@@ -5,7 +5,7 @@ import { parseKle } from '../../../shared/kle/kle-parser'
 import { findKeycode, type Keycode } from '../../../shared/keycodes/keycodes'
 import type { SplitKeyMode } from '../../../shared/types/app-config'
 import { KeycodeButton } from './KeycodeButton'
-import { getRemapDisplayLabel, getSplitRemapProps } from './KeycodeGrid'
+import { getRemapDisplayLabel, getSplitRemapProps, computeSplitSelectedPart } from './KeycodeGrid'
 import { SplitKey, getShiftedKeycode } from './SplitKey'
 
 /** Grid multiplier: 1u = 4 grid cells (same as vial-gui QGridLayout) */
@@ -61,6 +61,7 @@ interface Props {
   splitKeyMode?: SplitKeyMode
   remapLabel?: (qmkId: string) => string
   isVisible?: (kc: Keycode) => boolean
+  keycodeIndexMap?: Map<string, { baseIdx: number; shiftedIdx?: number }>
 }
 
 interface GridKey {
@@ -68,8 +69,10 @@ interface GridKey {
   shiftedKeycode: Keycode | null
   gridRow: number
   gridCol: number
-  /** Original index in the flat keycode list (for selection tracking). */
+  /** Index of the base keycode in the expanded list. */
   originalIndex: number
+  /** Index of the shifted keycode in the expanded list (undefined if not a split key). */
+  shiftedOriginalIndex: number | undefined
   gridRowSpan: number
   gridColSpan: number
   clipPath?: string
@@ -86,13 +89,15 @@ export function DisplayKeyboard({
   splitKeyMode,
   remapLabel,
   isVisible,
+  keycodeIndexMap,
 }: Props) {
   const { gridKeys, totalCols, totalRows } = useMemo(() => {
     const layout = parseKle(kle)
+    const useSplit = splitKeyMode !== 'flat'
     const keys: GridKey[] = []
+    let fallbackIndex = 0
     let maxCol = 0
     let maxRow = 0
-    let flatIndex = 0
 
     for (const key of layout.keys) {
       const qmkId = key.labels[0]
@@ -103,8 +108,6 @@ export function DisplayKeyboard({
       const stepped = computeSteppedKeyInfo(
         key.width, key.height, key.x2, key.y2, key.width2, key.height2,
       )
-
-      // For stepped keys, use the bounding box; for normal keys, use key dimensions directly
       const originX = key.x + (stepped?.left ?? 0)
       const originY = key.y + (stepped?.top ?? 0)
       const spanW = stepped?.width ?? key.width
@@ -114,25 +117,23 @@ export function DisplayKeyboard({
       const colSpan = Math.round(spanW * GRID_SCALE)
       const rowSpan = Math.round(spanH * GRID_SCALE)
 
-      const shiftedKc = splitKeyMode !== 'flat' ? getShiftedKeycode(kc.qmkId) : null
+      const shiftedKc = useSplit ? getShiftedKeycode(kc.qmkId) : null
+      // Look up index from the global map; fall back to local counter
+      const entry = keycodeIndexMap?.get(kc.qmkId)
+      const originalIndex = entry?.baseIdx ?? fallbackIndex++
+      const shiftedOriginalIndex = shiftedKc ? entry?.shiftedIdx : undefined
 
       keys.push({
-        keycode: kc,
-        shiftedKeycode: shiftedKc,
-        gridRow: row + 1, // CSS grid is 1-indexed
-        gridCol: col + 1,
-        gridRowSpan: rowSpan,
-        gridColSpan: colSpan,
-        clipPath: stepped?.clipPath,
-        originalIndex: flatIndex++,
+        keycode: kc, shiftedKeycode: shiftedKc,
+        gridRow: row + 1, gridCol: col + 1, gridRowSpan: rowSpan, gridColSpan: colSpan,
+        clipPath: stepped?.clipPath, originalIndex, shiftedOriginalIndex,
       })
-
       maxCol = Math.max(maxCol, col + colSpan)
       maxRow = Math.max(maxRow, row + rowSpan)
     }
 
     return { gridKeys: keys, totalCols: maxCol, totalRows: maxRow }
-  }, [kle, splitKeyMode])
+  }, [kle, splitKeyMode, keycodeIndexMap])
 
   return (
     <div
@@ -149,7 +150,7 @@ export function DisplayKeyboard({
 
         const buttonContent = !keyVisible ? (
           <div className="w-full h-full rounded-md bg-surface-dim opacity-30" />
-        ) : gk.shiftedKeycode ? (
+        ) : gk.shiftedKeycode && gk.shiftedOriginalIndex != null ? (
           <SplitKey
             base={gk.keycode}
             shifted={gk.shiftedKeycode}
@@ -158,8 +159,9 @@ export function DisplayKeyboard({
             onHover={onKeycodeHover}
             onHoverEnd={onKeycodeHoverEnd}
             highlightedKeycodes={highlightedKeycodes}
-            selected={isSelected}
+            selectedPart={computeSplitSelectedPart(pickerSelectedIndices, gk.originalIndex, gk.shiftedOriginalIndex)}
             index={gk.originalIndex}
+            shiftedIndex={gk.shiftedOriginalIndex}
             {...getSplitRemapProps(gk.keycode.qmkId, remapLabel)}
           />
         ) : (

--- a/src/renderer/components/keycodes/KeycodeGrid.tsx
+++ b/src/renderer/components/keycodes/KeycodeGrid.tsx
@@ -3,7 +3,7 @@
 import type { Keycode } from '../../../shared/keycodes/keycodes'
 import type { SplitKeyMode } from '../../../shared/types/app-config'
 import { KeycodeButton } from './KeycodeButton'
-import { SplitKey, getShiftedKeycode } from './SplitKey'
+import { SplitKey, getShiftedKeycode, type SplitKeySelectedPart } from './SplitKey'
 
 interface Props {
   keycodes: Keycode[]
@@ -16,8 +16,8 @@ interface Props {
   isVisible?: (kc: Keycode) => boolean
   splitKeyMode?: SplitKeyMode
   remapLabel?: (qmkId: string) => string
-  /** Offset added to the index for each keycode (used when rendering a subset). */
-  indexOffset?: number
+  /** Global index map: base qmkId → { baseIdx, shiftedIdx } */
+  keycodeIndexMap?: Map<string, { baseIdx: number; shiftedIdx?: number }>
 }
 
 /** Return remapped display label for a keycode, or undefined if unchanged */
@@ -38,6 +38,21 @@ export function getSplitRemapProps(qmkId: string, remapLabel?: (qmkId: string) =
   return { baseDisplayLabel: remapped }
 }
 
+/** Compute the selectedPart for a split key by checking expanded indices */
+export function computeSplitSelectedPart(
+  pickerSelectedIndices: Set<number> | undefined,
+  baseIdx: number,
+  shiftedIdx: number,
+): SplitKeySelectedPart | undefined {
+  if (!pickerSelectedIndices) return undefined
+  const baseSel = pickerSelectedIndices.has(baseIdx)
+  const shiftSel = pickerSelectedIndices.has(shiftedIdx)
+  if (baseSel && shiftSel) return 'both'
+  if (baseSel) return 'base'
+  if (shiftSel) return 'shifted'
+  return undefined
+}
+
 export function KeycodeGrid({
   keycodes,
   onClick,
@@ -49,25 +64,23 @@ export function KeycodeGrid({
   isVisible,
   splitKeyMode,
   remapLabel,
-  indexOffset = 0,
+  keycodeIndexMap,
 }: Props): React.ReactNode {
   const visible = isVisible ? keycodes.filter(isVisible) : keycodes
   const useSplit = splitKeyMode !== 'flat'
 
-  // Build index map: when filtering, we need the original index
-  const indexMap = isVisible
-    ? keycodes.reduce<number[]>((acc, kc, i) => { if (isVisible(kc)) acc.push(i); return acc }, [])
-    : null
-
   return (
     <div className="flex flex-wrap gap-1">
       {visible.map((kc, visibleIdx) => {
-        const originalIdx = (indexMap ? indexMap[visibleIdx] : visibleIdx) + indexOffset
+        const entry = keycodeIndexMap?.get(kc.qmkId)
+        const baseIdx = entry?.baseIdx ?? visibleIdx
         const shifted = useSplit ? getShiftedKeycode(kc.qmkId) : null
-        if (shifted) {
+        const shiftedIdx = shifted ? entry?.shiftedIdx : undefined
+
+        if (shifted && shiftedIdx != null) {
           const splitRemap = getSplitRemapProps(kc.qmkId, remapLabel)
           return (
-            <div key={`${originalIdx}-${kc.qmkId}`} className="w-[44px] h-[44px]">
+            <div key={`${baseIdx}-${kc.qmkId}`} className="w-[44px] h-[44px]">
               <SplitKey
                 base={kc}
                 shifted={shifted}
@@ -76,8 +89,9 @@ export function KeycodeGrid({
                 onHover={onHover}
                 onHoverEnd={onHoverEnd}
                 highlightedKeycodes={highlightedKeycodes}
-                selected={pickerSelectedIndices?.has(originalIdx)}
-                index={originalIdx}
+                selectedPart={computeSplitSelectedPart(pickerSelectedIndices, baseIdx, shiftedIdx)}
+                index={baseIdx}
+                shiftedIndex={shiftedIdx}
                 {...splitRemap}
               />
             </div>
@@ -86,14 +100,14 @@ export function KeycodeGrid({
         const displayLabel = getRemapDisplayLabel(kc.qmkId, remapLabel)
         return (
           <KeycodeButton
-            key={`${originalIdx}-${kc.qmkId}`}
+            key={`${baseIdx}-${kc.qmkId}`}
             keycode={kc}
-            onClick={onClick ? (k, e) => onClick(k, e, originalIdx) : undefined}
+            onClick={onClick ? (k, e) => onClick(k, e, baseIdx) : undefined}
             onDoubleClick={onDoubleClick}
             onHover={onHover}
             onHoverEnd={onHoverEnd}
             highlighted={highlightedKeycodes?.has(kc.qmkId)}
-            selected={pickerSelectedIndices?.has(originalIdx)}
+            selected={pickerSelectedIndices?.has(baseIdx)}
             displayLabel={displayLabel}
           />
         )

--- a/src/renderer/components/keycodes/SplitKey.tsx
+++ b/src/renderer/components/keycodes/SplitKey.tsx
@@ -47,6 +47,8 @@ export function getShiftedKeycode(qmkId: string): Keycode | null {
   return shiftedId ? findKeycode(shiftedId) ?? null : null
 }
 
+export type SplitKeySelectedPart = 'base' | 'shifted' | 'both'
+
 export interface SplitKeyProps {
   base: Keycode
   shifted: Keycode
@@ -55,8 +57,12 @@ export interface SplitKeyProps {
   onHover?: (keycode: Keycode, rect: DOMRect) => void
   onHoverEnd?: () => void
   highlightedKeycodes?: Set<string>
-  selected?: boolean
+  /** Which half of the split key is selected */
+  selectedPart?: SplitKeySelectedPart
+  /** Index of the base (bottom half) keycode in the expanded list */
   index: number
+  /** Index of the shifted (top half) keycode in the expanded list */
+  shiftedIndex: number
   baseDisplayLabel?: string
   shiftedDisplayLabel?: string
 }
@@ -77,15 +83,16 @@ function SplitKeyInner({
   onHover,
   onHoverEnd,
   highlightedKeycodes,
-  selected: isSelected,
+  selectedPart,
   index,
+  shiftedIndex,
   baseDisplayLabel,
   shiftedDisplayLabel,
 }: SplitKeyProps) {
   const baseHighlighted = highlightedKeycodes?.has(base.qmkId)
-  const baseSelected = isSelected
+  const baseSelected = selectedPart === 'base' || selectedPart === 'both'
   const shiftHighlighted = highlightedKeycodes?.has(shifted.qmkId)
-  const shiftSelected = isSelected
+  const shiftSelected = selectedPart === 'shifted' || selectedPart === 'both'
 
   const anySelected = baseSelected || shiftSelected
   const anyHighlighted = baseHighlighted || shiftHighlighted
@@ -107,7 +114,7 @@ function SplitKeyInner({
       <button
         type="button"
         className={`${SPLIT_HALF_BASE} rounded-t ${splitHalfClass(shiftHighlighted, shiftSelected, shiftedDisplayLabel != null)}`}
-        onClick={(e) => onClick?.(shifted, e, index)}
+        onClick={(e) => onClick?.(shifted, e, shiftedIndex)}
         onDoubleClick={() => onDoubleClick?.(shifted)}
         onMouseEnter={(e) => onHover?.(hoverShifted, e.currentTarget.getBoundingClientRect())}
         onMouseLeave={onHoverEnd}

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -13,6 +13,78 @@ import { KeycodeGrid } from './KeycodeGrid'
 import { BasicKeyboardView } from './BasicKeyboardView'
 import { isShiftedKeycode, getShiftedKeycode } from './SplitKey'
 
+export interface KeycodeIndexEntry { baseIdx: number; shiftedIdx?: number }
+
+/** Expand a flat list of base keycodes: shifted first, then all in original order.
+ *  Also builds an index map keyed by base qmkId. */
+function expandGrouped(
+  keycodes: Keycode[],
+  startIdx: number,
+  indexMap: Map<string, KeycodeIndexEntry>,
+): Keycode[] {
+  let idx = startIdx
+  const shiftedPairs: { shifted: Keycode; baseQmkId: string; shiftedIdx: number }[] = []
+  for (const kc of keycodes) {
+    const s = getShiftedKeycode(kc.qmkId)
+    if (s) shiftedPairs.push({ shifted: s, baseQmkId: kc.qmkId, shiftedIdx: idx++ })
+  }
+  const expanded: Keycode[] = shiftedPairs.map((p) => p.shifted)
+  for (const kc of keycodes) {
+    const pair = shiftedPairs.find((p) => p.baseQmkId === kc.qmkId)
+    indexMap.set(kc.qmkId, { baseIdx: idx, shiftedIdx: pair?.shiftedIdx })
+    expanded.push(kc)
+    idx++
+  }
+  return expanded
+}
+
+/** Expand layout keycodes per physical row using KLE positions.
+ *  For each row: shifted in X order, then ALL keys in X order.
+ *  Also builds an index map keyed by base qmkId. */
+function expandPerRow(
+  keycodes: Keycode[],
+  kleData: unknown[][],
+  startIdx: number,
+  indexMap: Map<string, KeycodeIndexEntry>,
+): Keycode[] {
+  const kle = parseKle(kleData)
+  const kcSet = new Set(keycodes.map((k) => k.qmkId))
+  const rows = new Map<number, { kc: Keycode; x: number }[]>()
+  for (const key of kle.keys) {
+    const qmkId = key.labels[0]
+    if (!qmkId || !kcSet.has(qmkId)) continue
+    const kc = keycodes.find((k) => k.qmkId === qmkId)
+    if (!kc) continue
+    const y = Math.round(key.y * 2) / 2
+    if (!rows.has(y)) rows.set(y, [])
+    rows.get(y)!.push({ kc, x: key.x })
+  }
+
+  let idx = startIdx
+  const expanded: Keycode[] = []
+  const sortedRows = [...rows.entries()].sort((a, b) => a[0] - b[0])
+  for (const [, keys] of sortedRows) {
+    keys.sort((a, b) => a.x - b.x)
+    // Record shifted indices first
+    const shiftedMap = new Map<string, number>() // baseQmkId → shiftedIdx
+    for (const k of keys) {
+      const shifted = getShiftedKeycode(k.kc.qmkId)
+      if (shifted) {
+        shiftedMap.set(k.kc.qmkId, idx)
+        expanded.push(shifted)
+        idx++
+      }
+    }
+    // Base line: ALL keys in X order
+    for (const k of keys) {
+      indexMap.set(k.kc.qmkId, { baseIdx: idx, shiftedIdx: shiftedMap.get(k.kc.qmkId) })
+      expanded.push(k.kc)
+      idx++
+    }
+  }
+  return expanded
+}
+
 const LM_CATEGORY: KeycodeCategory = {
   id: 'lm-mods',
   labelKey: 'keycodes.modifiers',
@@ -146,16 +218,15 @@ export function TabbedKeycodes({
     [lmMode, isVisible, revision],
   )
 
-  const activeTabKeycodes = useMemo(() => {
+  const { activeTabKeycodes, keycodeIndexMap } = useMemo(() => {
     const cat = categories.find((c) => c.id === activeTab)
-    if (!cat) return []
+    if (!cat) return { activeTabKeycodes: [] as Keycode[], keycodeIndexMap: new Map<string, KeycodeIndexEntry>() }
 
-    let keycodes: Keycode[]
+    const indexMap = new Map<string, KeycodeIndexEntry>()
 
     // For keyboard views (ANSI/ISO/JIS), order by physical layout position
     if (cat.id === 'basic' && resolvedBasicViewType != null && resolvedBasicViewType !== 'list' && !lmMode) {
       const layouts = getLayoutsForViewType(resolvedBasicViewType)
-      // Largest layout has the most keys — extract keycode names in physical row-major order
       const kleLayout = parseKle(layouts[0].kle)
       const layoutKeycodes: Keycode[] = []
       const layoutIds = new Set<string>()
@@ -168,39 +239,57 @@ export function TabbedKeycodes({
           layoutIds.add(qmkId)
         }
       }
-      // Append remaining keycodes from view-specific groups (not on the keyboard)
       const groups = cat.getGroups?.(resolvedBasicViewType)?.filter((g) => g.keycodes.some(isVisible))
-      const remaining = groups
-        ? groups.flatMap((g) => g.keycodes.filter((kc) => !layoutIds.has(kc.qmkId) && isVisible(kc)))
+      const remainingGroups = groups
+        ? groups.map((g) => g.keycodes.filter((kc) => !layoutIds.has(kc.qmkId) && isVisible(kc))).filter((arr) => arr.length > 0)
         : []
-      keycodes = [...layoutKeycodes, ...remaining]
+      const remaining = remainingGroups.flat()
+
+      if (useSplit && !maskOnly) {
+        const expandedLayout = expandPerRow(layoutKeycodes, layouts[0].kle, 0, indexMap)
+        let offset = expandedLayout.length
+        const expandedRemaining = remainingGroups.flatMap((g) => {
+          const result = expandGrouped(g, offset, indexMap)
+          offset += result.length
+          return result
+        })
+        return { activeTabKeycodes: [...expandedLayout, ...expandedRemaining], keycodeIndexMap: indexMap }
+      }
+
+      const keycodes = [...layoutKeycodes, ...remaining]
+      keycodes.forEach((kc, i) => indexMap.set(kc.qmkId, { baseIdx: i }))
+      return { activeTabKeycodes: keycodes, keycodeIndexMap: indexMap }
+    }
+
+    // List/other tabs
+    const groups = cat.getGroups?.()?.filter((g) => g.keycodes.some(isVisible))
+    let keycodes: Keycode[]
+    if (!groups) {
+      keycodes = cat.getKeycodes().filter(isVisible)
     } else {
-      const groups = cat.getGroups?.()?.filter((g) => g.keycodes.some(isVisible))
-      if (!groups) keycodes = cat.getKeycodes().filter(isVisible)
-      else keycodes = groups.flatMap((g) =>
-        g.sections
-          ? g.sections.flatMap((s) => s.filter(isVisible))
-          : g.keycodes.filter(isVisible),
+      keycodes = groups.flatMap((g) =>
+        g.sections ? g.sections.flatMap((s) => s.filter(isVisible)) : g.keycodes.filter(isVisible),
       )
     }
 
-    // When split keys are active, expand each base keycode with its shifted
-    // counterpart so multi-select can address both halves independently.
     if (useSplit && !maskOnly) {
-      const expanded: Keycode[] = []
-      for (const kc of keycodes) {
-        const shifted = getShiftedKeycode(kc.qmkId)
-        if (shifted) {
-          expanded.push(shifted) // top half
-          expanded.push(kc)     // bottom half
-        } else {
-          expanded.push(kc)
-        }
+      let offset = 0
+      if (groups) {
+        const expanded = groups.flatMap((g) => {
+          const visible = g.sections
+            ? g.sections.flatMap((s) => s.filter(isVisible))
+            : g.keycodes.filter(isVisible)
+          const result = expandGrouped(visible, offset, indexMap)
+          offset += result.length
+          return result
+        })
+        return { activeTabKeycodes: expanded, keycodeIndexMap: indexMap }
       }
-      return expanded
+      return { activeTabKeycodes: expandGrouped(keycodes, 0, indexMap), keycodeIndexMap: indexMap }
     }
 
-    return keycodes
+    keycodes.forEach((kc, i) => indexMap.set(kc.qmkId, { baseIdx: i }))
+    return { activeTabKeycodes: keycodes, keycodeIndexMap: indexMap }
   }, [categories, activeTab, isVisible, revision, resolvedBasicViewType, maskOnly, lmMode, useSplit])
 
   // Reset active tab if it no longer exists in the filtered categories
@@ -250,7 +339,8 @@ export function TabbedKeycodes({
     [onKeycodeMultiSelect, onKeycodeSelect, activeTabKeycodeNumbers, pickerMultiSelectEnabled, onBackgroundClick],
   )
 
-  function renderKeycodeGrid(keycodes: Keycode[], tabId?: string, indexOffset = 0): React.ReactNode {
+  function renderKeycodeGrid(keycodes: Keycode[], tabId?: string): React.ReactNode {
+    const isActive = !tabId || tabId === activeTab
     return (
       <KeycodeGrid
         keycodes={keycodes}
@@ -259,17 +349,16 @@ export function TabbedKeycodes({
         onHover={handleKeycodeHover}
         onHoverEnd={handleKeycodeHoverEnd}
         highlightedKeycodes={highlightedKeycodes}
-        pickerSelectedIndices={(!tabId || tabId === activeTab) ? pickerSelectedIndices : undefined}
+        pickerSelectedIndices={isActive ? pickerSelectedIndices : undefined}
         isVisible={isVisible}
         splitKeyMode={maskOnly ? 'flat' : resolvedSplitKeyMode}
         remapLabel={remapLabel}
-        indexOffset={indexOffset}
+        keycodeIndexMap={keycodeIndexMap}
       />
     )
   }
 
-  function renderGroup(group: KeycodeGroup, tabId?: string, hint?: string, groupOffset = 0): React.ReactNode {
-    let sectionOffset = groupOffset
+  function renderGroup(group: KeycodeGroup, tabId?: string, hint?: string): React.ReactNode {
     return (
       <div key={group.labelKey}>
         <h4 className="text-xs font-normal text-content-muted px-1 pt-2 pb-1">
@@ -279,14 +368,12 @@ export function TabbedKeycodes({
           <div className="space-y-1">
             {group.sections
               .filter((s) => s.some(isVisible))
-              .map((section, i) => {
-                const offset = sectionOffset
-                sectionOffset += section.filter(isVisible).length
-                return <div key={i}>{renderKeycodeGrid(section, tabId, offset)}</div>
-              })}
+              .map((section, i) => (
+                <div key={i}>{renderKeycodeGrid(section, tabId)}</div>
+              ))}
           </div>
         ) : (
-          renderKeycodeGrid(group.keycodes, tabId, groupOffset)
+          renderKeycodeGrid(group.keycodes, tabId)
         )}
       </div>
     )
@@ -308,6 +395,7 @@ export function TabbedKeycodes({
           pickerSelectedIndices={isActive ? pickerSelectedIndices : undefined}
           isVisible={isVisible}
           remapLabel={remapLabel}
+          keycodeIndexMap={keycodeIndexMap}
         />
       )
     }
@@ -324,16 +412,10 @@ export function TabbedKeycodes({
     }
 
     const rows = groupByLayoutRow(groups ?? [])
-    let cumulativeOffset = 0
     const groupContent = rows.map((row) => (
       <div key={row[0].labelKey} className="flex gap-x-3">
         {row.map((group) => {
-          const offset = cumulativeOffset
-          const count = group.sections
-            ? group.sections.reduce((sum, s) => sum + s.filter(isVisible).length, 0)
-            : group.keycodes.filter(isVisible).length
-          cumulativeOffset += count
-          return renderGroup(group, category.id, undefined, offset)
+          return renderGroup(group, category.id)
         })}
       </div>
     ))

--- a/src/renderer/components/keycodes/__tests__/SplitKey.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/SplitKey.test.tsx
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SplitKey, type SplitKeyProps } from '../SplitKey'
+import { computeSplitSelectedPart } from '../KeycodeGrid'
+import type { Keycode } from '../../../../shared/keycodes/keycodes'
+
+const BASE: Keycode = { qmkId: 'KC_1', label: '1', keycode: 0x001e, hidden: false }
+const SHIFTED: Keycode = { qmkId: 'KC_EXLM', label: '!', keycode: 0x021e, hidden: false }
+
+function renderSplitKey(overrides: Partial<SplitKeyProps> = {}) {
+  const defaults: SplitKeyProps = {
+    base: BASE,
+    shifted: SHIFTED,
+    index: 3,
+    shiftedIndex: 2,
+    ...overrides,
+  }
+  return render(<SplitKey {...defaults} />)
+}
+
+describe('SplitKey', () => {
+  it('renders base and shifted labels', () => {
+    renderSplitKey()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    expect(screen.getByText('!')).toBeInTheDocument()
+  })
+
+  it('calls onClick with base keycode and base index on bottom click', () => {
+    const onClick = vi.fn()
+    renderSplitKey({ onClick })
+    fireEvent.click(screen.getByText('1'))
+    expect(onClick).toHaveBeenCalledWith(BASE, expect.any(Object), 3)
+  })
+
+  it('calls onClick with shifted keycode and shifted index on top click', () => {
+    const onClick = vi.fn()
+    renderSplitKey({ onClick })
+    fireEvent.click(screen.getByText('!'))
+    expect(onClick).toHaveBeenCalledWith(SHIFTED, expect.any(Object), 2)
+  })
+
+  it('highlights only base half when selectedPart is base', () => {
+    renderSplitKey({ selectedPart: 'base' })
+    const baseBtn = screen.getByText('1')
+    const shiftedBtn = screen.getByText('!')
+    expect(baseBtn.className).toContain('text-accent')
+    expect(shiftedBtn.className).not.toContain('text-accent')
+  })
+
+  it('highlights only shifted half when selectedPart is shifted', () => {
+    renderSplitKey({ selectedPart: 'shifted' })
+    const baseBtn = screen.getByText('1')
+    const shiftedBtn = screen.getByText('!')
+    expect(baseBtn.className).not.toContain('text-accent')
+    expect(shiftedBtn.className).toContain('text-accent')
+  })
+
+  it('highlights both halves when selectedPart is both', () => {
+    renderSplitKey({ selectedPart: 'both' })
+    const baseBtn = screen.getByText('1')
+    const shiftedBtn = screen.getByText('!')
+    expect(baseBtn.className).toContain('text-accent')
+    expect(shiftedBtn.className).toContain('text-accent')
+  })
+
+  it('highlights neither half when selectedPart is undefined', () => {
+    renderSplitKey({ selectedPart: undefined })
+    const baseBtn = screen.getByText('1')
+    const shiftedBtn = screen.getByText('!')
+    // Neither should have the selected accent (only check for bg-accent/20 which is selection-specific)
+    expect(baseBtn.className).not.toContain('bg-accent/20')
+    expect(shiftedBtn.className).not.toContain('bg-accent/20')
+  })
+})
+
+describe('computeSplitSelectedPart', () => {
+  it('returns undefined when pickerSelectedIndices is empty', () => {
+    expect(computeSplitSelectedPart(new Set(), 3, 2)).toBeUndefined()
+  })
+
+  it('returns undefined when pickerSelectedIndices is undefined', () => {
+    expect(computeSplitSelectedPart(undefined, 3, 2)).toBeUndefined()
+  })
+
+  it('returns base when only base index is selected', () => {
+    expect(computeSplitSelectedPart(new Set([3]), 3, 2)).toBe('base')
+  })
+
+  it('returns shifted when only shifted index is selected', () => {
+    expect(computeSplitSelectedPart(new Set([2]), 3, 2)).toBe('shifted')
+  })
+
+  it('returns both when both indices are selected', () => {
+    expect(computeSplitSelectedPart(new Set([2, 3]), 3, 2)).toBe('both')
+  })
+
+  it('returns undefined when neither index is selected', () => {
+    expect(computeSplitSelectedPart(new Set([5, 6]), 3, 2)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Allow the upper half (shifted) and lower half (base) of a split key to be selected independently in the picker.
- Each half gets its own index in the expanded list so Ctrl+click / Shift+range picks only the intended half.
- Indices are laid out row-by-row in shifted → base order (see KEY-INDEX.md).
- `keycodeIndexMap` keeps the index assignment consistent across every view (ANSI / ISO / JIS keyboard view and list view).

## Test plan
- [ ] ANSI keyboard view: clicking the shifted keycode (`~`) selects only the shifted half
- [ ] Clicking the base keycode (`` ` ``) selects only the base half
- [ ] Shift+range from `!` to `^` selects only the shifted keycodes
- [ ] Shift+range from `1` to `Bksp` selects only base / non-split keycodes
- [ ] Same behaviour verified on ISO / JIS keyboard views
- [ ] List view respects the shifted → base selection order within each group
- [ ] With Separate Shift OFF: behaviour is unchanged (no regression)
- [ ] All 2817 existing tests pass