### PR TITLE
fix(hid): pause device polling during unlock to prevent counter reset

### DIFF
--- a/src/main/__tests__/hid-service.test.ts
+++ b/src/main/__tests__/hid-service.test.ts
@@ -315,42 +315,24 @@ describe('sendReceive', () => {
     expect(result.length).toBe(MSG_LEN)
   })
 
-  it('retries on transient device errors', async () => {
-    vi.useFakeTimers()
-    mockRead
-      .mockRejectedValueOnce(new Error('could not read data from device'))
-      .mockRejectedValueOnce(new Error('could not read data from device'))
-      .mockResolvedValueOnce(Buffer.alloc(MSG_LEN))
+  it('throws immediately on read errors (not transient)', async () => {
+    mockRead.mockRejectedValue(new Error('could not read data from device'))
 
-    const promise = sendReceive([0x01])
-    await vi.advanceTimersByTimeAsync(HID_RETRY_DELAY_MS)
-    await vi.advanceTimersByTimeAsync(HID_RETRY_DELAY_MS)
-    const result = await promise
-
-    expect(mockWrite).toHaveBeenCalledTimes(3)
-    expect(result.length).toBe(MSG_LEN)
+    await expect(sendReceive([0x01])).rejects.toThrow('could not read')
+    expect(mockWrite).toHaveBeenCalledTimes(1)
   })
 
-  it('retries on write errors', async () => {
-    vi.useFakeTimers()
-    mockWrite
-      .mockImplementationOnce(() => { throw new Error('Cannot write to hid device') })
-      .mockReturnValue(MSG_LEN + 1)
-    mockRead.mockResolvedValue(Buffer.alloc(MSG_LEN))
+  it('throws immediately on write errors (not transient)', async () => {
+    mockWrite.mockImplementation(() => { throw new Error('Cannot write to hid device') })
 
-    const promise = sendReceive([0x01])
-    await vi.advanceTimersByTimeAsync(HID_RETRY_DELAY_MS)
-    const result = await promise
-
-    expect(mockWrite).toHaveBeenCalledTimes(2)
-    expect(result.length).toBe(MSG_LEN)
+    await expect(sendReceive([0x01])).rejects.toThrow('Cannot write')
+    expect(mockWrite).toHaveBeenCalledTimes(1)
   })
 
   it('throws immediately on non-transient errors', async () => {
     mockRead.mockRejectedValue(new Error('Device disconnected'))
 
     await expect(sendReceive([0x01])).rejects.toThrow('Device disconnected')
-
     expect(mockWrite).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/hid-service.ts
+++ b/src/main/hid-service.ts
@@ -119,11 +119,9 @@ function delay(ms: number): Promise<void> {
 
 function isTransientError(err: Error): boolean {
   const msg = err.message.toLowerCase()
-  return (
-    msg.includes('timeout') ||
-    msg.includes('could not read') ||
-    msg.includes('cannot write')
-  )
+  // "cannot write" and "could not read" on a disconnected device are NOT transient —
+  // retrying just floods the mutex queue. Only timeout is worth retrying.
+  return msg.includes('timeout')
 }
 
 /**

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -635,12 +635,18 @@ export function App() {
           keys={keyboard.layout?.keys ?? []}
           unlockKeys={keyboard.unlockStatus.keys}
           layoutOptions={decodedLayoutOptions}
-          unlockStart={api.unlockStart}
+          unlockStart={() => { device.setPollSuspended(true); return api.unlockStart() }}
           unlockPoll={api.unlockPoll}
           onComplete={async () => {
+            device.setPollSuspended(false)
             editorUI.setShowUnlockDialog(false)
             editorUI.setUnlockMacroWarning(false)
             await keyboard.refreshUnlockStatus()
+          }}
+          onDisconnect={() => {
+            device.setPollSuspended(false)
+            editorUI.setShowUnlockDialog(false)
+            editorUI.setUnlockMacroWarning(false)
           }}
           macroWarning={editorUI.unlockMacroWarning}
         />

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -6,6 +6,7 @@ import type { KleKey } from '../../../shared/kle/types'
 import { KeyboardWidget } from '../keyboard'
 
 const UNLOCK_POLL_INTERVAL = 200 // ms
+const MAX_CONSECUTIVE_ERRORS = 5 // treat as disconnect after this many consecutive poll errors
 const EMPTY_KEYCODES = new Map<string, string>()
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
   unlockStart: () => Promise<void>
   unlockPoll: () => Promise<number[]>
   onComplete: () => void
+  onDisconnect?: () => void
   macroWarning?: boolean
 }
 
@@ -25,12 +27,14 @@ export function UnlockDialog({
   unlockStart,
   unlockPoll,
   onComplete,
+  onDisconnect,
   macroWarning,
 }: Props) {
   const { t } = useTranslation()
   const [counter, setCounter] = useState(0)
   const totalRef = useRef(0)
   const startedRef = useRef(false)
+  const consecutiveErrorsRef = useRef(0)
 
   // Highlight unlock keys in the keyboard widget
   const highlightedKeys = new Set<string>()
@@ -43,7 +47,9 @@ export function UnlockDialog({
   const unlockPollRef = useRef(unlockPoll)
   unlockPollRef.current = unlockPoll
   const onCompleteRef = useRef(onComplete)
+  const onDisconnectRef = useRef(onDisconnect)
   onCompleteRef.current = onComplete
+  onDisconnectRef.current = onDisconnect
   const busyRef = useRef(false)
 
   // Single useEffect: send unlockStart once, then poll via setInterval.
@@ -58,6 +64,7 @@ export function UnlockDialog({
       try {
         const data = await unlockPollRef.current()
         if (cancelled) return
+        consecutiveErrorsRef.current = 0
         if (data.length < 3) return
 
         const unlocked = data[0]
@@ -72,7 +79,13 @@ export function UnlockDialog({
           return
         }
       } catch {
-        // device error — next interval tick will retry
+        consecutiveErrorsRef.current++
+        if (consecutiveErrorsRef.current >= MAX_CONSECUTIVE_ERRORS) {
+          // Device likely disconnected — stop polling and notify parent
+          if (intervalId) clearInterval(intervalId)
+          onDisconnectRef.current?.()
+          return
+        }
       } finally {
         busyRef.current = false
       }

--- a/src/renderer/hooks/useDeviceConnection.ts
+++ b/src/renderer/hooks/useDeviceConnection.ts
@@ -40,6 +40,9 @@ export function useDeviceConnection() {
   const connectedDeviceRef = useRef<DeviceInfo | null>(null)
   const isDummyRef = useRef(false)
   const deviceListActiveRef = useRef(false)
+  // Skip all USB activity when suspended (e.g. during unlock dialog).
+  // USB device enumeration disrupts firmware operations like unlock counter.
+  const pollSuspendedRef = useRef(false)
 
   useEffect(() => {
     mountedRef.current = true
@@ -187,6 +190,12 @@ export function useDeviceConnection() {
     async function poll(): Promise<void> {
       if (!mountedRef.current || cancelled) return
 
+      // Skip all USB activity while suspended (e.g. during unlock dialog)
+      if (pollSuspendedRef.current) {
+        if (!cancelled) timerId = setTimeout(poll, POLL_INTERVAL_MS)
+        return
+      }
+
       // Refresh device list only when device picker is actively browsing
       if (deviceListActiveRef.current || !connectedDeviceRef.current) {
         try {
@@ -228,6 +237,7 @@ export function useDeviceConnection() {
   }, []) // stable — uses refs internally
 
   const setDeviceListActive = useCallback((active: boolean) => { deviceListActiveRef.current = active }, [])
+  const setPollSuspended = useCallback((suspended: boolean) => { pollSuspendedRef.current = suspended }, [])
 
   return {
     ...state,
@@ -237,5 +247,6 @@ export function useDeviceConnection() {
     connectPipetteFile,
     disconnectDevice,
     setDeviceListActive,
+    setPollSuspended,
   }
 }


### PR DESCRIPTION
## Summary
- Fix a bug where USB device enumeration (`listDevices` / `isDeviceOpen`) during unlock was resetting the firmware's unlock counter.
- `pollSuspendedRef` pauses all device polling while the unlock dialog is showing.
- Five consecutive poll errors now trigger disconnect detection — the dialog closes and polling resumes.
- `isTransientError` no longer classifies "cannot write" / "could not read" as transient; they throw immediately so the mutex queue isn't polluted.

## Test plan
- [ ] Unlock: counter decreases to 0 on key press and unlock completes
- [ ] Disconnecting the keyboard mid-unlock closes the dialog and returns to the connect screen
- [ ] Normal operation after unlock is unaffected
- [ ] The Keyboard tab device list renders correctly
- [ ] All 2817 existing tests pass