### PR TITLE
feat(ui): add redo button to key popover

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -54,12 +54,14 @@ interface PopoverForStateProps {
   quickSelect?: boolean
   previousKeycode?: number
   onUndo?: () => void
+  nextKeycode?: number
+  onRedo?: () => void
 }
 
 function PopoverForState({
   popoverState, keymap, encoderLayout, currentLayer, layers,
   onKeycodeSelect, onRawKeycodeSelect, onModMaskChange, onClose,
-  quickSelect, previousKeycode, onUndo,
+  quickSelect, previousKeycode, onUndo, nextKeycode, onRedo,
 }: PopoverForStateProps) {
   const currentKeycode = popoverState.kind === 'key'
     ? keymap.get(`${currentLayer},${popoverState.row},${popoverState.col}`) ?? 0
@@ -70,6 +72,7 @@ function PopoverForState({
       anchorRect={popoverState.anchorRect} currentKeycode={currentKeycode} maskOnly={maskOnly} layers={layers}
       onKeycodeSelect={onKeycodeSelect} onRawKeycodeSelect={onRawKeycodeSelect} onModMaskChange={onModMaskChange}
       onClose={onClose} quickSelect={quickSelect} previousKeycode={previousKeycode} onUndo={onUndo}
+      nextKeycode={nextKeycode} onRedo={onRedo}
     />
   )
 }
@@ -187,6 +190,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     handleKeyClick, handleEncoderClick, handleKeyDoubleClick, handleEncoderDoubleClick,
     handleKeycodeSelect, handlePopoverKeycodeSelect, handlePopoverRawKeycodeSelect,
     handlePopoverModMaskChange, popoverUndoKeycode, handlePopoverUndo,
+    popoverRedoKeycode, handlePopoverRedo,
     handleUndo, handleRedo,
     handleDeselect, handleDeselectClick,
     isCopying, copyLayerPending, handleCopyLayerClick,
@@ -929,6 +933,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           onModMaskChange={handlePopoverModMaskChange}
           onClose={() => setPopoverState(null)} quickSelect={quickSelect}
           previousKeycode={popoverUndoKeycode} onUndo={handlePopoverUndo}
+          nextKeycode={popoverRedoKeycode} onRedo={handlePopoverRedo}
         />
       )}
 

--- a/src/renderer/components/editors/__tests__/KeymapEditor.undo.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor.undo.test.tsx
@@ -51,16 +51,20 @@ vi.mock('../../keycodes/TabbedKeycodes', () => ({
 }))
 
 let capturedPreviousKeycode: number | undefined
+let capturedNextKeycode: number | undefined
 
 vi.mock('../../keycodes/KeyPopover', () => ({
   KeyPopover: (props: {
     previousKeycode?: number
     onUndo?: () => void
+    nextKeycode?: number
+    onRedo?: () => void
     onKeycodeSelect?: (kc: { qmkId: string }) => void
     onRawKeycodeSelect?: (code: number) => void
     onClose?: () => void
   }) => {
     capturedPreviousKeycode = props.previousKeycode
+    capturedNextKeycode = props.nextKeycode
     return (
       <div data-testid="key-popover">
         <button
@@ -72,6 +76,11 @@ vi.mock('../../keycodes/KeyPopover', () => ({
         {props.previousKeycode != null && props.onUndo && (
           <button data-testid="popover-undo" onClick={props.onUndo}>
             Undo
+          </button>
+        )}
+        {props.nextKeycode != null && props.onRedo && (
+          <button data-testid="popover-redo" onClick={props.onRedo}>
+            Redo
           </button>
         )}
       </div>
@@ -154,6 +163,7 @@ describe('KeymapEditor — undo after single-click selection', () => {
     capturedOnKeyClick = undefined
     capturedOnKeyDoubleClick = undefined
     capturedPreviousKeycode = undefined
+    capturedNextKeycode = undefined
   })
 
   it('records undo when assigning keycode via single-click picker flow', async () => {
@@ -260,6 +270,7 @@ describe('KeymapEditor — Ctrl+Z / Ctrl+Y keyboard shortcuts', () => {
     capturedOnKeyClick = undefined
     capturedOnKeyDoubleClick = undefined
     capturedPreviousKeycode = undefined
+    capturedNextKeycode = undefined
   })
 
   it('Ctrl+Z undoes the last keycode assignment', async () => {
@@ -375,5 +386,106 @@ describe('KeymapEditor — Ctrl+Z / Ctrl+Y keyboard shortcuts', () => {
 
     await act(async () => { fireEvent.keyDown(screen.getByTestId('text-input'), { key: 'z', ctrlKey: true }) })
     expect(onSetKey).not.toHaveBeenCalled()
+  })
+})
+
+describe('KeymapEditor — popover redo', () => {
+  const onSetKey = vi.fn().mockResolvedValue(undefined)
+
+  const mockRect = {
+    top: 100, left: 200, bottom: 140, right: 260,
+    width: 60, height: 40, x: 200, y: 100, toJSON: () => ({}),
+  } as DOMRect
+
+  const defaultProps = {
+    layout: makeLayout(),
+    layers: 2,
+    currentLayer: 0,
+    onLayerChange: vi.fn(),
+    keymap: new Map([
+      ['0,0,0', 5],
+      ['0,0,1', 6],
+    ]),
+    encoderLayout: new Map<string, number>(),
+    encoderCount: 0,
+    layoutOptions: new Map<number, number>(),
+    onSetKey,
+    onSetKeysBulk: vi.fn().mockResolvedValue(undefined),
+    onSetEncoder: vi.fn().mockResolvedValue(undefined),
+    autoAdvance: false,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedOnKeyClick = undefined
+    capturedOnKeyDoubleClick = undefined
+    capturedPreviousKeycode = undefined
+    capturedNextKeycode = undefined
+  })
+
+  it('shows redo in popover after undo when same key is opened', async () => {
+    render(<KeymapEditor {...defaultProps} />)
+
+    // Assign KC_A to [0,0]
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    await act(async () => { fireEvent.click(screen.getByTestId('kc-a')) })
+    expect(onSetKey).toHaveBeenCalledWith(0, 0, 0, 4)
+
+    // Undo via Ctrl+Z
+    await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+
+    // Open popover on same key — redo should be available (newKeycode = 4 = KC_A)
+    act(() => capturedOnKeyDoubleClick?.({ row: 0, col: 0 }, mockRect))
+    expect(screen.getByTestId('key-popover')).toBeInTheDocument()
+    expect(screen.getByTestId('popover-redo')).toBeInTheDocument()
+    expect(capturedNextKeycode).toBe(4)
+  })
+
+  it('does NOT show redo when redo stack top is for a different key', async () => {
+    render(<KeymapEditor {...defaultProps} />)
+
+    // Assign KC_A to [0,0]
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    await act(async () => { fireEvent.click(screen.getByTestId('kc-a')) })
+
+    // Undo
+    await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+
+    // Open popover on [0,1] — redo is for [0,0], not [0,1]
+    act(() => capturedOnKeyDoubleClick?.({ row: 0, col: 1 }, mockRect))
+    expect(screen.getByTestId('key-popover')).toBeInTheDocument()
+    expect(screen.queryByTestId('popover-redo')).not.toBeInTheDocument()
+    expect(capturedNextKeycode).toBeUndefined()
+  })
+
+  it('popover redo re-applies keycode via onSetKey', async () => {
+    render(<KeymapEditor {...defaultProps} />)
+
+    // Assign KC_A to [0,0]
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    await act(async () => { fireEvent.click(screen.getByTestId('kc-a')) })
+
+    // Undo
+    await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+    onSetKey.mockClear()
+
+    // Open popover and click redo
+    act(() => capturedOnKeyDoubleClick?.({ row: 0, col: 0 }, mockRect))
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('popover-redo'))
+    })
+
+    // Should re-apply KC_A (4)
+    expect(onSetKey).toHaveBeenCalledWith(0, 0, 0, 4)
+  })
+
+  it('does NOT show redo when redo stack is empty', () => {
+    render(<KeymapEditor {...defaultProps} />)
+
+    // No undo/redo history — directly open popover
+    act(() => capturedOnKeyDoubleClick?.({ row: 0, col: 0 }, mockRect))
+    expect(screen.getByTestId('key-popover')).toBeInTheDocument()
+    expect(screen.queryByTestId('popover-redo')).not.toBeInTheDocument()
+    expect(capturedNextKeycode).toBeUndefined()
   })
 })

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -12,6 +12,19 @@ import type { PopoverState } from './keymap-editor-types'
 import type { UseKeymapMultiSelectReturn } from './useKeymapMultiSelect'
 import type { UseKeymapHistoryReturn, SingleHistoryEntry, HistoryEntry } from './useKeymapHistory'
 
+/** Match a history entry against the current popover position, returning the keycode if matched. */
+function matchPopoverEntry(
+  popoverState: PopoverState | null,
+  entry: HistoryEntry | null,
+  currentLayer: number,
+  field: 'oldKeycode' | 'newKeycode',
+): number | undefined {
+  if (!popoverState || !entry || entry.kind === 'batch') return undefined
+  if (popoverState.kind === 'key' && entry.kind === 'key' && entry.layer === currentLayer && entry.row === popoverState.row && entry.col === popoverState.col) return entry[field]
+  if (popoverState.kind === 'encoder' && entry.kind === 'encoder' && entry.layer === currentLayer && entry.idx === popoverState.idx && entry.dir === popoverState.dir) return entry[field]
+  return undefined
+}
+
 export interface UseKeymapSelectionOptions {
   // Core data
   layout: { keys: KleKey[] } | null
@@ -398,14 +411,10 @@ export function useKeymapSelectionHandlers({
   }, [popoverState, currentLayer, keymap, encoderLayout, onSetKey, onSetEncoder, history])
 
   // --- History-derived popover undo ---
-  const popoverUndoKeycode = useMemo(() => {
-    if (!popoverState) return undefined
-    const entry = history.peekUndo
-    if (!entry || entry.kind === 'batch') return undefined
-    if (popoverState.kind === 'key' && entry.kind === 'key' && entry.layer === currentLayer && entry.row === popoverState.row && entry.col === popoverState.col) return entry.oldKeycode
-    if (popoverState.kind === 'encoder' && entry.kind === 'encoder' && entry.layer === currentLayer && entry.idx === popoverState.idx && entry.dir === popoverState.dir) return entry.oldKeycode
-    return undefined
-  }, [popoverState, currentLayer, history.peekUndo])
+  const popoverUndoKeycode = useMemo(
+    () => matchPopoverEntry(popoverState, history.peekUndo, currentLayer, 'oldKeycode'),
+    [popoverState, currentLayer, history.peekUndo],
+  )
 
   // --- Undo / redo ---
   const applyHistoryEntry = useCallback(async (entry: HistoryEntry, isUndo: boolean) => {
@@ -458,6 +467,17 @@ export function useKeymapSelectionHandlers({
     if (popoverUndoKeycode == null) return
     void handleUndo()
   }, [popoverUndoKeycode, handleUndo])
+
+  // --- History-derived popover redo (top-only) ---
+  const popoverRedoKeycode = useMemo(
+    () => matchPopoverEntry(popoverState, history.peekRedo, currentLayer, 'newKeycode'),
+    [popoverState, currentLayer, history.peekRedo],
+  )
+
+  const handlePopoverRedo = useCallback(() => {
+    if (popoverRedoKeycode == null) return
+    void handleRedo()
+  }, [popoverRedoKeycode, handleRedo])
 
   // --- Keyboard shortcuts for undo/redo ---
   useEffect(() => {
@@ -539,6 +559,8 @@ export function useKeymapSelectionHandlers({
     handlePopoverModMaskChange,
     popoverUndoKeycode,
     handlePopoverUndo,
+    popoverRedoKeycode,
+    handlePopoverRedo,
     handleUndo,
     handleRedo,
     // Deselect

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -45,6 +45,8 @@ interface KeyPopoverProps {
   quickSelect?: boolean  // true: click applies + closes; false: buffer until Enter
   previousKeycode?: number // Previous keycode for undo (undefined = no undo available)
   onUndo?: () => void      // Revert to previousKeycode and close
+  nextKeycode?: number     // Next keycode for redo (undefined = no redo available)
+  onRedo?: () => void      // Re-apply nextKeycode and close
 }
 
 const POPOVER_WIDTH = 320
@@ -63,6 +65,8 @@ export function KeyPopover({
   quickSelect,
   previousKeycode,
   onUndo,
+  nextKeycode,
+  onRedo,
 }: KeyPopoverProps) {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState<Tab>('key')
@@ -426,20 +430,36 @@ export function KeyPopover({
         )}
       </div>
 
-      {previousKeycode != null && onUndo && (
-        <div className="border-t border-edge-subtle px-3 py-1.5">
-          <button
-            type="button"
-            className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs text-content-secondary hover:bg-surface-dim hover:text-content"
-            onClick={onUndo}
-            data-testid="popover-undo"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5 shrink-0">
-              <path fillRule="evenodd" d="M7.793 2.232a.75.75 0 0 1-.025 1.06L3.622 7.25h10.003a5.375 5.375 0 0 1 0 10.75H10.75a.75.75 0 0 1 0-1.5h2.875a3.875 3.875 0 0 0 0-7.75H3.622l4.146 3.957a.75.75 0 0 1-1.036 1.085l-5.5-5.25a.75.75 0 0 1 0-1.085l5.5-5.25a.75.75 0 0 1 1.06.025Z" clipRule="evenodd" />
-            </svg>
-            <span>{t('editor.keymap.keyPopover.undo')}</span>
-            <span className="ml-auto font-mono text-content-muted">{serialize(previousKeycode)}</span>
-          </button>
+      {((previousKeycode != null && onUndo) || (nextKeycode != null && onRedo)) && (
+        <div className="border-t border-edge-subtle px-3 py-1.5 space-y-0.5">
+          {previousKeycode != null && onUndo && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs text-content-secondary hover:bg-surface-dim hover:text-content"
+              onClick={onUndo}
+              data-testid="popover-undo"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5 shrink-0">
+                <path fillRule="evenodd" d="M7.793 2.232a.75.75 0 0 1-.025 1.06L3.622 7.25h10.003a5.375 5.375 0 0 1 0 10.75H10.75a.75.75 0 0 1 0-1.5h2.875a3.875 3.875 0 0 0 0-7.75H3.622l4.146 3.957a.75.75 0 0 1-1.036 1.085l-5.5-5.25a.75.75 0 0 1 0-1.085l5.5-5.25a.75.75 0 0 1 1.06.025Z" clipRule="evenodd" />
+              </svg>
+              <span>{t('editor.keymap.keyPopover.undo')}</span>
+              <span className="ml-auto font-mono text-content-muted">{serialize(previousKeycode)}</span>
+            </button>
+          )}
+          {nextKeycode != null && onRedo && (
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded px-2 py-1 text-xs text-content-secondary hover:bg-surface-dim hover:text-content"
+              onClick={onRedo}
+              data-testid="popover-redo"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-3.5 w-3.5 shrink-0">
+                <path fillRule="evenodd" d="M12.207 2.232a.75.75 0 0 0 .025 1.06l4.146 3.958H6.375a5.375 5.375 0 0 0 0 10.75H9.25a.75.75 0 0 0 0-1.5H6.375a3.875 3.875 0 0 1 0-7.75h10.003l-4.146 3.957a.75.75 0 0 0 1.036 1.085l5.5-5.25a.75.75 0 0 0 0-1.085l-5.5-5.25a.75.75 0 0 0-1.06.025Z" clipRule="evenodd" />
+              </svg>
+              <span>{t('editor.keymap.keyPopover.redo')}</span>
+              <span className="ml-auto font-mono text-content-muted">{serialize(nextKeycode)}</span>
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -123,7 +123,8 @@
         "layerLabel": "Layer",
         "keySelected": "Selected: {{key}}",
         "clickToClose": "Click to apply and close, or press Enter",
-        "undo": "Undo"
+        "undo": "Undo",
+        "redo": "Redo"
       }
     },
     "layout": {

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -122,7 +122,8 @@
         "layerLabel": "レイヤー",
         "keySelected": "選択済み: {{key}}",
         "clickToClose": "クリックして適用して閉じる、またはEnterキーで確定",
-        "undo": "元に戻す"
+        "undo": "元に戻す",
+        "redo": "やり直し"
       }
     },
     "layout": {


### PR DESCRIPTION
## Summary
- Add a keycode redo button to `KeyPopover`. Like undo, it only appears when the top of the redo stack matches the hovered key.
- Share the undo/redo position-matching logic in a new `matchPopoverEntry` helper.
- Group undo and redo inside a single footer container so they don't render with a double border.

## Test plan
- [x] After an undo, opening the popover shows a redo button
- [x] Redo button is hidden when the top of the redo stack targets a different key
- [x] Clicking the redo button re-applies the keycode
- [x] Redo button is hidden when the redo stack is empty
- [x] The existing 11 undo tests still pass
- [x] tsc / eslint / vitest all clean