### PR TITLE
feat(ui): improve macro tile preview display

### DIFF
--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -6,7 +6,7 @@ import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } f
 import { codeToLabel, findKeycode, type Keycode } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 
-const MAX_VISIBLE_MACRO_ACTIONS = 7
+const MAX_VISIBLE_MACRO_ACTIONS = 8
 
 const TILE_ENABLED = 'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
 const TILE_DISABLED = 'justify-start border-accent/50 bg-accent/10 text-accent/70 font-semibold hover:bg-accent/15'
@@ -176,7 +176,7 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
           >
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
             {configured ? (
-              <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px overflow-hidden">
+              <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0 overflow-hidden">
                 {actions.slice(0, MAX_VISIBLE_MACRO_ACTIONS).map((action, j) => (
                   <Fragment key={j}>
                     <span className="text-left text-content-secondary/60">{MACRO_PREFIX[action.type]}</span>
@@ -184,10 +184,7 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
                   </Fragment>
                 ))}
                 {actions.length > MAX_VISIBLE_MACRO_ACTIONS && (
-                  <>
-                    <span />
-                    <span className="text-content-secondary/60">{t('keycodes.macroMoreActions', { count: actions.length - MAX_VISIBLE_MACRO_ACTIONS })}</span>
-                  </>
+                  <span className="col-span-2 text-center text-content-secondary/60">{t('keycodes.macroMoreActions', { count: actions.length - MAX_VISIBLE_MACRO_ACTIONS })}</span>
                 )}
               </span>
             ) : (

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -6,6 +6,8 @@ import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } f
 import { codeToLabel, findKeycode, type Keycode } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 
+const MAX_VISIBLE_MACRO_ACTIONS = 7
+
 const TILE_ENABLED = 'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
 const TILE_DISABLED = 'justify-start border-accent/50 bg-accent/10 text-accent/70 font-semibold hover:bg-accent/15'
 const TILE_EMPTY = 'justify-center border-accent/30 bg-accent/5 text-content-secondary hover:bg-accent/10'
@@ -175,16 +177,16 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
             {configured ? (
               <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px overflow-hidden">
-                {actions.slice(0, 4).map((action, j) => (
+                {actions.slice(0, MAX_VISIBLE_MACRO_ACTIONS).map((action, j) => (
                   <Fragment key={j}>
                     <span className="text-left text-content-secondary/60">{MACRO_PREFIX[action.type]}</span>
                     <span className="truncate text-left">{macroActionLabel(action)}</span>
                   </Fragment>
                 ))}
-                {actions.length > 4 && (
+                {actions.length > MAX_VISIBLE_MACRO_ACTIONS && (
                   <>
                     <span />
-                    <span className="text-content-secondary/60">+{actions.length - 4}</span>
+                    <span className="text-content-secondary/60">{t('keycodes.macroMoreActions', { count: actions.length - MAX_VISIBLE_MACRO_ACTIONS })}</span>
                   </>
                 )}
               </span>

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -1,12 +1,19 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { Fragment } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
 import { codeToLabel, findKeycode, type Keycode } from '../../../shared/keycodes/keycodes'
 import type { MacroAction } from '../../../preload/macro'
 
-const MAX_VISIBLE_MACRO_ACTIONS = 8
+const MIN_VISIBLE_MACRO_ACTIONS = 6
+const GRID_COLUMNS = 12
+const GRID_GAP_PX = 4
+const TILE_PADDING_TOP = 4
+const TILE_LABEL_HEIGHT = 12
+const TILE_CONTENT_MT = 8
+const MACRO_LINE_HEIGHT = 12
+const MACRO_MORE_ROW_HEIGHT = 12
 
 const TILE_ENABLED = 'justify-start border-accent bg-accent/20 text-accent font-semibold hover:bg-accent/30'
 const TILE_DISABLED = 'justify-start border-accent/50 bg-accent/10 text-accent/70 font-semibold hover:bg-accent/15'
@@ -160,10 +167,36 @@ interface MacroTileGridProps {
   onSelect: (keycode: Keycode) => void
 }
 
+function useMacroVisibleLines(gridRef: React.RefObject<HTMLDivElement | null>): number {
+  const [visibleLines, setVisibleLines] = useState(MIN_VISIBLE_MACRO_ACTIONS)
+
+  useEffect(() => {
+    const el = gridRef.current
+    if (!el) return
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const gridWidth = entry.contentRect.width
+        const tileWidth = (gridWidth - GRID_GAP_PX * (GRID_COLUMNS - 1)) / GRID_COLUMNS
+        const tileHeight = tileWidth
+        const contentHeight = tileHeight - TILE_PADDING_TOP - TILE_LABEL_HEIGHT - TILE_CONTENT_MT
+        const actionLines = Math.floor((contentHeight - MACRO_MORE_ROW_HEIGHT) / MACRO_LINE_HEIGHT)
+        const next = Math.max(MIN_VISIBLE_MACRO_ACTIONS, actionLines)
+        setVisibleLines((prev) => prev !== next ? next : prev)
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [gridRef])
+
+  return visibleLines
+}
+
 export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
   const { t } = useTranslation()
+  const gridRef = useRef<HTMLDivElement>(null)
+  const maxVisible = useMacroVisibleLines(gridRef)
   return (
-    <div className="grid grid-cols-12 auto-rows-fr gap-1">
+    <div ref={gridRef} className="grid grid-cols-12 auto-rows-fr gap-1">
       {macros.map((actions, i) => {
         const configured = actions.length > 0
         return (
@@ -177,14 +210,14 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
             {configured ? (
               <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0 overflow-hidden">
-                {actions.slice(0, MAX_VISIBLE_MACRO_ACTIONS).map((action, j) => (
+                {actions.slice(0, maxVisible).map((action, j) => (
                   <Fragment key={j}>
                     <span className="text-left text-content-secondary/60">{MACRO_PREFIX[action.type]}</span>
                     <span className="truncate text-left">{macroActionLabel(action)}</span>
                   </Fragment>
                 ))}
-                {actions.length > MAX_VISIBLE_MACRO_ACTIONS && (
-                  <span className="col-span-2 text-center text-content-secondary/60">{t('keycodes.macroMoreActions', { count: actions.length - MAX_VISIBLE_MACRO_ACTIONS })}</span>
+                {actions.length > maxVisible && (
+                  <span className="col-span-2 text-center text-content-secondary/60">{t('keycodes.macroMoreActions', { count: actions.length - maxVisible })}</span>
                 )}
               </span>
             ) : (

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -330,6 +330,7 @@
     "keyOverride": "Key Override",
     "altRepeatKey": "Alt Repeat Key",
     "settingsNote": "These features apply to the entire keyboard and cannot be assigned to individual keys.",
+    "macroMoreActions": "+{{count}} more",
     "user": "User",
     "midi": "MIDI",
     "group": {

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -329,6 +329,7 @@
     "keyOverride": "Key Override",
     "altRepeatKey": "Alt Repeat Key",
     "settingsNote": "この機能はキーボード全体に適用され、個別のキーに割り当てることはできません。",
+    "macroMoreActions": "残り {{count}} 行",
     "user": "User",
     "midi": "MIDI",
     "group": {


### PR DESCRIPTION
## Summary
- Increase macro tile preview from 4 to dynamically calculated lines based on window size (minimum 6 lines)
- Replace hardcoded `+N` overflow indicator with an i18n-supported label (en: `+N more`, ja: `+N more` equivalent)
- Center overflow label and reduce row gap for better space utilization
- Use `ResizeObserver` to adjust visible action count as tile size changes

Closes #95

## Test plan
- [ ] Verify macro tile preview shows more action lines than before
- [ ] Resize window and confirm line count adjusts dynamically
- [ ] Confirm overflow label appears when actions overflow
- [ ] Confirm overflow label is centered
- [ ] Switch language and verify i18n works for overflow label
- [ ] Verify minimum 6 lines are always shown