### PR TITLE
fix(ui): show warning when loading non-V2 file in key picker

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -119,6 +119,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   const [selectedFileUid, setSelectedFileUid] = useState<string | null>(null)
   const [storedEntries, setStoredEntries] = useState<SnapshotMeta[]>([])
   const [fileBrowseView, setFileBrowseView] = useState<'list' | 'entries'>('list')
+  const [pickerLoadError, setPickerLoadError] = useState<string | null>(null)
   const [probeStatus, setProbeStatus] = useState<'idle' | 'probing' | 'error'>('idle')
   const [deviceBrowsing, setDeviceBrowsing] = useState(true)
   const [pickerScale, setPickerScale] = useState<number | undefined>(undefined)
@@ -238,8 +239,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   const loadPickerFromJson = useCallback((jsonStr: string) => {
     try {
       const parsed = JSON.parse(jsonStr)
-      if (!isVilFile(parsed)) return false
-      if (isVilFileV1(parsed) || !parsed.definition) return false
+      if (!isVilFile(parsed)) {
+        setPickerLoadError(t('error.loadFailed'))
+        return false
+      }
+      if (isVilFileV1(parsed) || !parsed.definition) {
+        setPickerLoadError(t('error.vilV1NotSupported'))
+        return false
+      }
       const fileLayout = parseKle(parsed.definition.layouts.keymap)
       const fileKeymap = recordToMap(parsed.keymap)
       const fileLayers = deriveLayerCount(parsed.keymap)
@@ -273,20 +280,31 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
       setPickerLayer(0)
       setFileBrowseView('list')
       return true
-    } catch { return false }
-  }, [remapLabel])
+    } catch {
+      setPickerLoadError(t('error.loadFailed'))
+      return false
+    }
+  }, [remapLabel, t])
 
   const handleLoadPickerFile = useCallback(async () => {
+    setPickerLoadError(null)
     const result = await window.vialAPI.loadLayout(t('editor.keymap.pickerLoadFile'), ['.pipette', '.vil'])
-    if (!result.success || !result.data) return
+    if (!result.success || !result.data) {
+      if (result.error !== 'cancelled') setPickerLoadError(t('error.loadFailed'))
+      return
+    }
     loadPickerFromJson(result.data)
   }, [t, loadPickerFromJson])
 
   const handleLoadSnapshotEntry = useCallback(async (uid: string, entryId: string) => {
+    setPickerLoadError(null)
     const result = await window.vialAPI.snapshotStoreLoad(uid, entryId)
-    if (!result.success || !result.data) return
+    if (!result.success || !result.data) {
+      setPickerLoadError(t('error.loadFailed'))
+      return
+    }
     loadPickerFromJson(result.data)
-  }, [loadPickerFromJson])
+  }, [t, loadPickerFromJson])
 
   // --- Device probe handler ---
   const handleProbeDevice = useCallback(async (vendorId: number, productId: number, serialNumber: string) => {
@@ -705,12 +723,17 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           /* --- File browse view --- */
           <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
             <div className="flex min-h-[340px] max-h-[340px] flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
+            {pickerLoadError && (
+              <div className="rounded-lg bg-danger/10 px-3 py-2 text-xs text-danger">
+                {pickerLoadError}
+              </div>
+            )}
             {fileBrowseView === 'list' && (
               <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerSavedFiles')}</span>
             )}
             {fileBrowseView === 'entries' && (
               <button type="button" className="mb-2 self-start text-xs text-content-secondary hover:text-content"
-                onClick={() => { setFileBrowseView('list'); setSelectedFileUid(null) }}>
+                onClick={() => { setFileBrowseView('list'); setSelectedFileUid(null); setPickerLoadError(null) }}>
                 ← {t('common.back')}
               </button>
             )}
@@ -718,7 +741,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               storedKeyboards.length > 0 ? storedKeyboards.map((kb) => (
                 <button key={kb.uid} type="button"
                   className="flex items-center justify-between rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
-                  onClick={() => { setSelectedFileUid(kb.uid); setFileBrowseView('entries') }}>
+                  onClick={() => { setSelectedFileUid(kb.uid); setFileBrowseView('entries'); setPickerLoadError(null) }}>
                   <span className="font-medium text-content">{kb.name}</span>
                   <span className="text-xs text-content-muted">›</span>
                 </button>
@@ -773,14 +796,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         <div className="flex items-center gap-1">
           <button type="button" className={sourceBtnClass(pickerSource === 'device')}
             onClick={() => {
-              setPickerSource('device'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setDeviceBrowsing(true); setProbeStatus('idle')
+              setPickerSource('device'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setDeviceBrowsing(true); setProbeStatus('idle'); setPickerLoadError(null)
             }}>
             {pickerSource === 'device' && !deviceBrowsing
               ? t('editor.keymap.pickerBackToDevices')
               : t('editor.keymap.pickerSourceDevice')}
           </button>
           <button type="button" className={sourceBtnClass(pickerSource === 'file')}
-            onClick={() => { setPickerSource('file'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setFileBrowseView('list'); setDeviceBrowsing(false) }}>
+            onClick={() => { setPickerSource('file'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setFileBrowseView('list'); setDeviceBrowsing(false); setPickerLoadError(null) }}>
             {pickerSource === 'file' && pickerFileData ? t('editor.keymap.pickerBackToFiles') : t('editor.keymap.pickerSourceFile')}
           </button>
         </div>

--- a/src/renderer/components/editors/__tests__/KeymapEditor-pickerFileError.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-pickerFileError.test.tsx
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'editor.keymap.pickerSourceFile': 'File',
+        'editor.keymap.pickerLoadFile': 'Load from .pipette…',
+        'editor.keymap.pickerSavedFiles': 'Saved files',
+        'editor.keymap.pickerNoSavedFiles': 'No saved files',
+        'error.vilV1NotSupported': 'Legacy data format.',
+        'error.loadFailed': 'Load failed',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../../hooks/useAppConfig', () => ({
+  useAppConfig: () => ({ config: { maxKeymapHistory: 100 }, loading: false, set: () => {} }),
+}))
+
+vi.mock('../../keyboard/KeyboardWidget', () => ({
+  KeyboardWidget: () => <div data-testid="keyboard-widget">KeyboardWidget</div>,
+}))
+
+vi.mock('../../keycodes/TabbedKeycodes', () => ({
+  TabbedKeycodes: (props: Record<string, unknown>) => (
+    <div data-testid="tabbed-keycodes">
+      {props.keyboardPickerContent as React.ReactNode}
+    </div>
+  ),
+}))
+
+vi.mock('../../../../shared/keycodes/keycodes', () => ({
+  serialize: (code: number) => `KC_${code}`,
+  deserialize: () => 0,
+  isMask: () => false,
+  isTapDanceKeycode: () => false,
+  getTapDanceIndex: () => -1,
+  isMacroKeycode: () => false,
+  getMacroIndex: () => -1,
+  keycodeLabel: (qmkId: string) => qmkId,
+  keycodeTooltip: (qmkId: string) => qmkId,
+  isResetKeycode: () => false,
+  isModifiableKeycode: () => false,
+  extractModMask: () => 0,
+  extractBasicKey: (code: number) => code & 0xff,
+  buildModMaskKeycode: (mask: number, key: number) => (mask << 8) | key,
+  findKeycode: (qmkId: string) => ({ qmkId, label: qmkId }),
+}))
+
+vi.mock('../../keycodes/ModifierCheckboxStrip', () => ({
+  ModifierCheckboxStrip: () => null,
+}))
+
+vi.mock('../../../../preload/macro', () => ({
+  deserializeAllMacros: () => [],
+}))
+
+import { KeymapEditor } from '../KeymapEditor'
+import type { KleKey } from '../../../../shared/kle/types'
+
+const KEY_DEFAULTS: KleKey = {
+  x: 0, y: 0, width: 1, height: 1, row: 0, col: 0,
+  encoderIdx: -1, encoderDir: -1, layoutIndex: -1, layoutOption: -1,
+  decal: false, labels: [], x2: 0, y2: 0, width2: 1, height2: 1,
+  rotation: 0, rotationX: 0, rotationY: 0, color: '',
+  textColor: [], textSize: [], nub: false, stepped: false, ghost: false,
+}
+
+const makeLayout = () => ({ keys: [{ ...KEY_DEFAULTS, x: 0, col: 0 }] })
+
+const mockLoadLayout = vi.fn()
+const mockListStoredKeyboards = vi.fn().mockResolvedValue([])
+const mockSnapshotStoreList = vi.fn().mockResolvedValue({ success: true, entries: [] })
+const mockPipetteSettingsGet = vi.fn().mockResolvedValue(null)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  Object.defineProperty(window, 'vialAPI', {
+    value: {
+      loadLayout: mockLoadLayout,
+      listStoredKeyboards: mockListStoredKeyboards,
+      snapshotStoreList: mockSnapshotStoreList,
+      pipetteSettingsGet: mockPipetteSettingsGet,
+    },
+    writable: true,
+    configurable: true,
+  })
+})
+
+const defaultProps = {
+  layout: makeLayout(),
+  layers: 4,
+  currentLayer: 0,
+  keymap: new Map([['0,0,0', 1]]),
+  encoderLayout: new Map<string, number>(),
+  encoderCount: 0,
+  layoutOptions: new Map<number, number>(),
+  onSetKey: vi.fn().mockResolvedValue(undefined),
+  onSetKeysBulk: vi.fn().mockResolvedValue(undefined),
+  onSetEncoder: vi.fn().mockResolvedValue(undefined),
+}
+
+function switchToFileTab() {
+  const fileBtn = screen.getByText('File')
+  fireEvent.click(fileBtn)
+}
+
+function makeV1Vil() {
+  return {
+    uid: '0x1',
+    keymap: {},
+    encoderLayout: {},
+    macros: [],
+    layoutOptions: 0,
+    tapDance: [],
+    combo: [],
+    keyOverride: [],
+    altRepeatKey: [],
+    qmkSettings: {},
+  }
+}
+
+describe('KeymapEditor — picker file load error', () => {
+  it('shows V1 warning when loading a V1 .vil file', async () => {
+    const v1File = JSON.stringify(makeV1Vil())
+    mockLoadLayout.mockResolvedValue({ success: true, data: v1File })
+
+    render(<KeymapEditor {...defaultProps} />)
+
+    await act(async () => switchToFileTab())
+
+    const loadBtn = screen.getByText('Load from .pipette…')
+    await act(async () => fireEvent.click(loadBtn))
+
+    expect(screen.getByText('Legacy data format.')).toBeInTheDocument()
+  })
+
+  it('shows load failed error when loading an invalid file', async () => {
+    mockLoadLayout.mockResolvedValue({ success: true, data: '{"invalid": true}' })
+
+    render(<KeymapEditor {...defaultProps} />)
+
+    await act(async () => switchToFileTab())
+
+    const loadBtn = screen.getByText('Load from .pipette…')
+    await act(async () => fireEvent.click(loadBtn))
+
+    expect(screen.getByText('Load failed')).toBeInTheDocument()
+  })
+
+  it('clears error when retrying file load', async () => {
+    const v1File = JSON.stringify(makeV1Vil())
+    mockLoadLayout
+      .mockResolvedValueOnce({ success: true, data: v1File })
+      .mockResolvedValueOnce({ success: false, error: 'cancelled' })
+
+    render(<KeymapEditor {...defaultProps} />)
+
+    await act(async () => switchToFileTab())
+
+    const loadBtn = screen.getByText('Load from .pipette…')
+
+    // First load: V1 error
+    await act(async () => fireEvent.click(loadBtn))
+    expect(screen.getByText('Legacy data format.')).toBeInTheDocument()
+
+    // Retry: error is cleared at start even if load is cancelled
+    await act(async () => fireEvent.click(loadBtn))
+    expect(screen.queryByText('Legacy data format.')).not.toBeInTheDocument()
+  })
+
+  it('shows load failed error when IPC returns failure', async () => {
+    mockLoadLayout.mockResolvedValue({ success: false, error: 'read_error' })
+
+    render(<KeymapEditor {...defaultProps} />)
+
+    await act(async () => switchToFileTab())
+
+    const loadBtn = screen.getByText('Load from .pipette…')
+    await act(async () => fireEvent.click(loadBtn))
+
+    expect(screen.getByText('Load failed')).toBeInTheDocument()
+  })
+
+  it('does not show error when user cancels file dialog', async () => {
+    mockLoadLayout.mockResolvedValue({ success: false, error: 'cancelled' })
+
+    render(<KeymapEditor {...defaultProps} />)
+
+    await act(async () => switchToFileTab())
+
+    const loadBtn = screen.getByText('Load from .pipette…')
+    await act(async () => fireEvent.click(loadBtn))
+
+    expect(screen.queryByText('Load failed')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- Show a warning banner in the key picker's Keyboard tab when a V1 or otherwise invalid file is loaded.
- Also surface IPC failures as an error message (except for user-initiated cancels).
- Auto-clear the error on source switch, list navigation, or retry.

## Test plan
- [ ] Load a V1 `.vil` file in the Keyboard tab → the "old data format" warning appears
- [ ] Load an invalid file → the "failed to load" error appears
- [ ] Cancel the file dialog → no error is shown
- [ ] Select another file after an error → the previous error is cleared
- [ ] Switch between Device / File tabs → the error is cleared
- [ ] `pnpm test` — 2790 tests passed