### PR TITLE
feat(ui): redesign macro keycode editor with list/edit mode split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ CLAUDE.md
 .copilot/
 .github/copilot*
 .aider*
+.codex
 .env
 .env.*

--- a/src/preload/__tests__/macro.test.ts
+++ b/src/preload/__tests__/macro.test.ts
@@ -750,8 +750,13 @@ describe('macro', () => {
       expect(jsonToMacroActions('[["delay","500"]]')).toBeNull()
     })
 
-    it('returns null for tap with no keycodes', () => {
-      expect(jsonToMacroActions('[["tap"]]')).toBeNull()
+    it('accepts tap with no keycodes as empty array', () => {
+      expect(jsonToMacroActions('[["tap"]]')).toEqual([{ type: 'tap', keycodes: [] }])
+    })
+
+    it('accepts down/up with no keycodes as empty array', () => {
+      expect(jsonToMacroActions('[["down"]]')).toEqual([{ type: 'down', keycodes: [] }])
+      expect(jsonToMacroActions('[["up"]]')).toEqual([{ type: 'up', keycodes: [] }])
     })
 
     it('returns null for tap with non-string keycode', () => {

--- a/src/preload/macro.ts
+++ b/src/preload/macro.ts
@@ -298,7 +298,6 @@ export function jsonToMacroActions(json: string): MacroAction[] | null {
       case 'tap':
       case 'down':
       case 'up': {
-        if (item.length < 2) return null
         const keycodes: number[] = []
         for (let i = 1; i < item.length; i++) {
           if (typeof item[i] !== 'string') return null

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useRef, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { X } from 'lucide-react'
 import { serialize, keycodeTooltip, isMask } from '../../../shared/keycodes/keycodes'
 import { KeyWidget } from '../keyboard/KeyWidget'
 import type { KleKey } from '../../../shared/kle/types'
@@ -13,6 +15,8 @@ interface Props {
   onSelect: () => void
   onMaskPartClick?: (part: 'outer' | 'inner') => void
   onDoubleClick?: (rect: DOMRect) => void
+  onDelete?: () => void
+  noTooltip?: boolean
   label?: string
 }
 
@@ -52,9 +56,10 @@ const FACE_ORIGIN = KEY_FACE_INSET
 const FACE_SIZE = KEY_UNIT - KEY_SPACING - 2 * KEY_FACE_INSET
 export const KEYCODE_FIELD_SIZE = Math.round(FACE_SIZE)
 
-export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMaskPartClick, onDoubleClick, label }: Props) {
+export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMaskPartClick, onDoubleClick, onDelete, noTooltip, label }: Props) {
+  const { t } = useTranslation()
   const qmkId = serialize(value)
-  const tooltip = keycodeTooltip(qmkId)
+  const tooltip = noTooltip ? undefined : keycodeTooltip(qmkId)
   const clickTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isMasked = onMaskPartClick != null && isMask(qmkId)
 
@@ -96,14 +101,14 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
     [onDoubleClick],
   )
 
-  return (
+  const keyButton = (
     <button
       type="button"
       aria-label={label}
       aria-pressed={selected}
       title={tooltip}
       data-testid="keycode-field"
-      className={`flex shrink-0 rounded-sm ring-1 ${selected ? 'ring-accent' : 'ring-picker-item-border'}`}
+      className={`flex shrink-0 cursor-pointer rounded-sm ring-1 ${selected ? 'ring-accent' : 'ring-picker-item-border hover:ring-accent'}`}
       onClick={handleClick}
       onDoubleClick={isMasked ? undefined : handleDoubleClick}
     >
@@ -124,5 +129,22 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
         />
       </svg>
     </button>
+  )
+
+  if (!onDelete) return keyButton
+
+  return (
+    <div className="group relative">
+      {keyButton}
+      <button
+        type="button"
+        data-testid="keycode-delete"
+        aria-label={t('editor.macro.deleteKeycode')}
+        className="absolute -top-2 -right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-danger text-white opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+        onClick={(e) => { e.stopPropagation(); onDelete() }}
+      >
+        <X size={14} aria-hidden="true" />
+      </button>
+    </div>
   )
 }

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1012,7 +1012,8 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           macroBuffer={macroBuffer} vialProtocol={vialProtocol ?? 0} onSaveMacros={onSaveMacros}
           parsedMacros={parsedMacros} onClose={handleMacroModalClose} unlocked={unlocked} onUnlock={onUnlock}
           isDummy={isDummy} tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
-          quickSelect={quickSelect} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+          quickSelect={quickSelect} autoAdvance={autoAdvance} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+          layers={layers}
           hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
           hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
           onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('macro', entryId) : undefined}

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
-import { GripVertical } from 'lucide-react'
+import { GripVertical, X } from 'lucide-react'
 import { isValidMacroText, type MacroAction } from '../../../preload/macro'
 import { KeycodeField, KEYCODE_FIELD_SIZE } from './KeycodeField'
 
@@ -22,9 +22,12 @@ interface Props {
   onKeycodeClick: (keycodeIndex: number) => void
   onKeycodeDoubleClick: (keycodeIndex: number, rect: DOMRect) => void
   onKeycodeAdd: () => void
+  onKeycodeAddDoubleClick: (rect: DOMRect) => void
+  onKeycodeDelete?: (keycodeIndex: number) => void
+  onEditClick?: (keycodeIndex: number) => void
+  onCloseEdit?: () => void
   onMaskPartClick?: (keycodeIndex: number, part: 'outer' | 'inner') => void
   focusMode?: boolean
-  showConfirmHint?: boolean
 }
 
 export function defaultAction(type: ActionType): MacroAction {
@@ -34,7 +37,7 @@ export function defaultAction(type: ActionType): MacroAction {
     case 'tap':
     case 'down':
     case 'up':
-      return { type, keycodes: [1] }
+      return { type, keycodes: [] }
     case 'delay':
       return { type: 'delay', delay: 100 }
   }
@@ -55,9 +58,12 @@ export function MacroActionItem({
   onKeycodeClick,
   onKeycodeDoubleClick,
   onKeycodeAdd,
+  onKeycodeAddDoubleClick,
+  onKeycodeDelete,
+  onEditClick,
+  onCloseEdit,
   onMaskPartClick,
   focusMode,
-  showConfirmHint,
 }: Props) {
   const { t } = useTranslation()
 
@@ -93,30 +99,33 @@ export function MacroActionItem({
       case 'up':
         return (
           <div className="flex flex-wrap items-center gap-1 flex-1">
-            {action.keycodes.map((kc, ki) => {
-              const isSelected = selectedKeycodeIndex === ki
-              return (
-                <KeycodeField
-                  key={ki}
-                  value={kc}
-                  selected={isSelected}
-                  selectedMaskPart={isSelected && selectedMaskPart}
-                  onSelect={() => onKeycodeClick(ki)}
-                  onMaskPartClick={onMaskPartClick ? (part) => onMaskPartClick(ki, part) : undefined}
-                  onDoubleClick={isSelected ? (rect) => onKeycodeDoubleClick(ki, rect) : undefined}
+            {action.keycodes.map((kc, ki) => (
+              <KeycodeField
+                key={ki}
+                value={kc}
+                selected={false}
+                onSelect={() => onEditClick?.(ki)}
+                noTooltip
+              />
+            ))}
+            {onEditClick && (
+              <div className="group relative">
+                <button
+                  type="button"
+                  data-testid="macro-edit-action"
+                  style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
+                  className="flex shrink-0 rounded-sm outline outline-1 outline-dashed outline-edge hover:outline-accent"
+                  onClick={() => onEditClick(action.keycodes.length)}
+                  aria-label={t('editor.macro.addKeycode')}
                 />
-              )
-            })}
-            <button
-              type="button"
-              data-testid="macro-add-keycode"
-              style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
-              className="flex items-center justify-center rounded border border-dashed border-edge text-content-muted hover:border-accent hover:text-accent"
-              onClick={onKeycodeAdd}
-              title={t('editor.macro.addKeycode')}
-            >
-              +
-            </button>
+
+                <div className="pointer-events-none invisible absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg group-hover:visible">
+                  <div className="text-xs font-medium text-content whitespace-nowrap">
+                    {t('editor.macro.addKeycode')}
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         )
       case 'delay':
@@ -143,21 +152,57 @@ export function MacroActionItem({
 
   const isKeycodeType = action.type === 'tap' || action.type === 'down' || action.type === 'up'
 
-  if (focusMode && isKeycodeType && selectedKeycodeIndex !== null) {
-    const kc = action.keycodes[selectedKeycodeIndex]
+  if (focusMode && isKeycodeType) {
     return (
       <div className="flex items-center gap-3">
-        <label className="min-w-[140px] text-sm text-content">{typeLabels[action.type]}</label>
-        <KeycodeField
-          value={kc ?? 0}
-          selected
-          selectedMaskPart={selectedMaskPart}
-          onSelect={() => onKeycodeClick(selectedKeycodeIndex)}
-          onMaskPartClick={onMaskPartClick ? (part) => onMaskPartClick(selectedKeycodeIndex, part) : undefined}
-          onDoubleClick={(rect) => onKeycodeDoubleClick(selectedKeycodeIndex, rect)}
-        />
-        {showConfirmHint && (
-          <span className="text-xs text-content-muted">{t('editor.keymap.pickerDoubleClickHint')}</span>
+        <label className="min-w-[60px] text-sm text-content">{typeLabels[action.type]}</label>
+        <div className="flex flex-wrap items-center gap-1 flex-1">
+          {action.keycodes.map((kc, ki) => {
+            const isSelected = selectedKeycodeIndex === ki
+            return (
+              <KeycodeField
+                key={ki}
+                value={kc}
+                selected={isSelected}
+                selectedMaskPart={isSelected && selectedMaskPart}
+                onSelect={() => onKeycodeClick(ki)}
+                onMaskPartClick={onMaskPartClick ? (part) => onMaskPartClick(ki, part) : undefined}
+                onDoubleClick={isSelected ? (rect) => onKeycodeDoubleClick(ki, rect) : undefined}
+                onDelete={onKeycodeDelete ? () => onKeycodeDelete(ki) : undefined}
+              />
+            )
+          })}
+          <div className="group relative">
+            <button
+              type="button"
+              data-testid="macro-add-keycode"
+              style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
+              className={`flex shrink-0 rounded-sm outline outline-1 outline-dashed ${
+                selectedKeycodeIndex === action.keycodes.length
+                  ? 'outline-accent'
+                  : 'outline-edge hover:outline-accent'
+              }`}
+              onClick={onKeycodeAdd}
+              onDoubleClick={(e) => onKeycodeAddDoubleClick(e.currentTarget.getBoundingClientRect())}
+              aria-label={t('editor.macro.addKeycode')}
+            />
+            <div className="pointer-events-none invisible absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg group-hover:visible">
+              <div className="text-xs font-medium text-content whitespace-nowrap">
+                {t('editor.macro.addKeycode')}
+              </div>
+            </div>
+          </div>
+        </div>
+        {onCloseEdit && (
+          <button
+            type="button"
+            data-testid="macro-close-edit"
+            className="ml-auto rounded p-1 text-content-muted hover:text-content"
+            onClick={onCloseEdit}
+            aria-label={t('common.close')}
+          >
+            <X size={20} aria-hidden="true" />
+          </button>
         )}
       </div>
     )
@@ -187,9 +232,10 @@ export function MacroActionItem({
       <button
         type="button"
         onClick={() => onDelete(index)}
-        className="px-1.5 text-content-muted hover:text-danger"
+        className="rounded p-1 text-content-muted hover:text-danger"
+        aria-label={t('common.delete')}
       >
-        &times;
+        <X size={20} aria-hidden="true" />
       </button>
     </div>
   )

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -24,7 +24,7 @@ import { ConfirmButton } from './ConfirmButton'
 import { FavoriteStoreContent } from './FavoriteStoreContent'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
-import { parseMacroBuffer, isKeycodeAction } from './macro-editor-utils'
+import { parseMacroBuffer, isKeycodeAction, normalizeMacros, normalizeMacroActions } from './macro-editor-utils'
 
 interface Props {
   macroCount: number
@@ -51,8 +51,10 @@ interface Props {
   onRemoveFromHub?: (entryId: string) => void
   onRenameOnHub?: (entryId: string, hubPostId: string, newLabel: string) => void
   quickSelect?: boolean
+  autoAdvance?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  layers?: number
 }
 
 export function MacroEditor({
@@ -79,8 +81,10 @@ export function MacroEditor({
   onRemoveFromHub,
   onRenameOnHub,
   quickSelect,
+  autoAdvance,
   splitKeyMode,
   basicViewType,
+  layers,
 }: Props) {
   const { t } = useTranslation()
   const { guardAll, clearPending } = useUnlockGate({ unlocked, onUnlock })
@@ -98,7 +102,7 @@ export function MacroEditor({
 
   const favStore = useFavoriteStore({
     favoriteType: 'macro',
-    serialize: () => JSON.parse(macroActionsToJson(currentActions)),
+    serialize: () => JSON.parse(macroActionsToJson(normalizeMacroActions(currentActions))),
     apply: (data) => {
       const loaded = jsonToMacroActions(JSON.stringify(data))
       if (!loaded) throw new Error('Invalid macro data')
@@ -132,6 +136,7 @@ export function MacroEditor({
     handleKeycodeClick,
     handleKeycodeDoubleClick,
     handleKeycodeAdd,
+    handleKeycodeDelete,
     handleMaskPartClick,
     applyPopoverKeycode,
     handlePopoverKeycodeSelect,
@@ -147,6 +152,7 @@ export function MacroEditor({
     tapDanceEntries,
     deserializedMacros,
     quickSelect,
+    autoAdvance,
   })
 
   const updateActions = useCallback(
@@ -175,9 +181,21 @@ export function MacroEditor({
 
   const handleAddActionType = useCallback(
     (type: ActionType) => {
-      updateActions([...currentActions, defaultAction(type)])
+      const newAction = defaultAction(type)
+      const newIndex = currentActions.length
+      clearPending()
+      setPopoverState(null)
+      setMacros((prev) => {
+        const updated = [...prev]
+        updated[activeMacro] = [...currentActions, newAction]
+        return updated
+      })
+      setDirty(true)
+      if (isKeycodeAction(newAction)) {
+        setSelectedKey({ actionIndex: newIndex, keycodeIndex: 0 })
+      }
     },
-    [currentActions, updateActions],
+    [currentActions, activeMacro, setMacros, setDirty, clearPending, setPopoverState, setSelectedKey],
   )
 
   const handleChange = useCallback(
@@ -187,6 +205,27 @@ export function MacroEditor({
       updateActions(updated)
     },
     [currentActions, updateActions],
+  )
+
+  const handleKeycodeAddWithPopover = useCallback(
+    (actionIndex: number, rect: DOMRect) => {
+      const action = currentActions[actionIndex]
+      if (!isKeycodeAction(action)) return
+      handleKeycodeAdd(actionIndex)
+      setPopoverState({ actionIndex, keycodeIndex: action.keycodes.length, anchorRect: rect })
+    },
+    [currentActions, handleKeycodeAdd, setPopoverState],
+  )
+
+  const handleEditClick = useCallback(
+    (index: number, keycodeIndex: number) => {
+      const action = currentActions[index]
+      if (isKeycodeAction(action)) {
+        preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
+        setSelectedKey({ actionIndex: index, keycodeIndex })
+      }
+    },
+    [currentActions, setSelectedKey, preEditValueRef],
   )
 
   const handleDelete = useCallback(
@@ -226,7 +265,7 @@ export function MacroEditor({
 
   const handleSave = useCallback(async () => {
     await guardAll(async () => {
-      const current = macrosRef.current
+      const current = normalizeMacros(macrosRef.current)
       const buffer = serializeAllMacros(current, vialProtocol)
       await onSaveMacros(buffer, current)
       setDirty(false)
@@ -316,8 +355,8 @@ export function MacroEditor({
             </button>
           </div>
 
-        {/* Scrollable content: action list + picker */}
-        <div className={`flex-1 overflow-y-auto px-6 pb-6 ${isEditing ? 'pt-6' : ''}`}>
+        {/* Action list: shrink-0 in edit mode, scrollable in list mode */}
+        <div className={`px-6 pb-3 ${isEditing ? 'shrink-0 pt-6' : 'flex-1 overflow-y-auto'}`}>
           <div className="space-y-1" data-testid="macro-action-list">
             {currentActions.map((action, i) => {
               const isSelectedAction = selectedKey?.actionIndex === i
@@ -339,31 +378,32 @@ export function MacroEditor({
                   onKeycodeClick={(ki) => handleKeycodeClick(i, ki)}
                   onKeycodeDoubleClick={(ki, rect) => handleKeycodeDoubleClick(i, ki, rect)}
                   onKeycodeAdd={() => handleKeycodeAdd(i)}
+                  onKeycodeAddDoubleClick={(rect) => handleKeycodeAddWithPopover(i, rect)}
+                  onKeycodeDelete={(ki) => handleKeycodeDelete(i, ki)}
+                  onEditClick={(ki) => handleEditClick(i, ki)}
                   onMaskPartClick={(ki, part) => handleMaskPartClick(i, ki, part)}
                   focusMode={isEditing}
-                  showConfirmHint={isSelectedAction && isEditing && !popoverState && !quickSelect && isKeycodeAction(action) && action.keycodes[selectedKey.keycodeIndex] !== preEditValueRef.current}
+                  onCloseEdit={isEditing ? revertAndDeselect : undefined}
                 />
               )
             })}
           </div>
-
-          <div ref={pickerRef} className={`mt-3 ${isEditing ? '' : 'hidden'}`}>
-            <TabbedKeycodes
-              onKeycodeSelect={maskedSelection.pickerSelect}
-              onKeycodeDoubleClick={maskedSelection.pickerDoubleClick}
-              onConfirm={maskedSelection.confirm}
-              maskOnly={maskedSelection.maskOnly}
-              lmMode={maskedSelection.lmMode}
-              tabContentOverride={tabContentOverride}
-              splitKeyMode={splitKeyMode}
-              basicViewType={basicViewType}
-              onClose={revertAndDeselect}
-            />
-          </div>
         </div>
 
-        {/* Fixed footer: Clear / Revert / Save */}
-          <div className={`shrink-0 px-6 py-3 ${isEditing ? 'hidden' : ''}`}>
+        {/* Picker: own scroll, fills remaining space in edit mode */}
+        <div ref={pickerRef} className={`flex-1 overflow-y-auto px-6 pb-6 ${isEditing ? '' : 'hidden'}`}>
+          <TabbedKeycodes
+            onKeycodeSelect={maskedSelection.pickerSelect}
+            maskOnly={maskedSelection.maskOnly}
+            lmMode={maskedSelection.lmMode}
+            tabContentOverride={tabContentOverride}
+            splitKeyMode={splitKeyMode}
+            basicViewType={basicViewType}
+          />
+        </div>
+
+        {/* Fixed footer: Clear / Revert / Save — hidden in edit mode */}
+          <div data-macro-footer="true" className={`shrink-0 px-6 py-3 ${isEditing ? 'hidden' : ''}`}>
             <div className="flex justify-end gap-2">
               <ConfirmButton
                 testId="macro-clear"
@@ -391,17 +431,23 @@ export function MacroEditor({
             </div>
           </div>
 
-        {popoverState !== null && (
-          <KeyPopover
-            anchorRect={popoverState.anchorRect}
-            currentKeycode={popoverKeycode}
-            onKeycodeSelect={handlePopoverKeycodeSelect}
-            onRawKeycodeSelect={applyPopoverKeycode}
-            onClose={closePopover}
-            onConfirm={() => { closePopover(); maskedSelection.clearMask(); setSelectedKey(null) }}
-            quickSelect={quickSelect}
-          />
-        )}
+        {popoverState !== null && (() => {
+          const action = currentActions[popoverState.actionIndex]
+          const isVirtualSlot = isKeycodeAction(action) && popoverState.keycodeIndex >= action.keycodes.length
+          return (
+            <KeyPopover
+              anchorRect={popoverState.anchorRect}
+              currentKeycode={popoverKeycode}
+              emptyInitial={isVirtualSlot}
+              layers={layers}
+              onKeycodeSelect={handlePopoverKeycodeSelect}
+              onRawKeycodeSelect={applyPopoverKeycode}
+              onClose={closePopover}
+              onConfirm={() => { closePopover(); maskedSelection.clearMask() }}
+              quickSelect={quickSelect}
+            />
+          )
+        })()}
 
         {showTextEditor && (
           <MacroTextEditor

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -33,8 +33,10 @@ interface Props {
   onRemoveFromHub?: (entryId: string) => void
   onRenameOnHub?: (entryId: string, hubPostId: string, newLabel: string) => void
   quickSelect?: boolean
+  autoAdvance?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  layers?: number
 }
 
 export function MacroModal({
@@ -60,12 +62,14 @@ export function MacroModal({
   onRemoveFromHub,
   onRenameOnHub,
   quickSelect,
+  autoAdvance,
   splitKeyMode,
   basicViewType,
+  layers,
 }: Props) {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
-  const modalWidth = isDummy ? 'w-[1000px]' : 'w-[1050px]'
+  const modalWidth = isDummy ? 'w-[1200px]' : 'w-[1300px]'
 
   return (
     <div
@@ -74,7 +78,7 @@ export function MacroModal({
       onClick={onClose}
     >
       <div
-        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[90vw] h-[80vh] flex flex-col overflow-hidden`}
+        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-[90vh] flex flex-col overflow-hidden`}
         data-testid="macro-modal"
         onClick={(e) => e.stopPropagation()}
       >
@@ -115,8 +119,10 @@ export function MacroModal({
             onRemoveFromHub={onRemoveFromHub}
             onRenameOnHub={onRenameOnHub}
             quickSelect={quickSelect}
+            autoAdvance={autoAdvance}
             splitKeyMode={splitKeyMode}
             basicViewType={basicViewType}
+            layers={layers}
           />
         </div>
       </div>

--- a/src/renderer/components/editors/__tests__/KeycodeField.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeycodeField.test.tsx
@@ -59,6 +59,11 @@ describe('KeycodeField', () => {
     expect(screen.getByTestId('keycode-field')).not.toHaveAttribute('title')
   })
 
+  it('suppresses title when noTooltip is true', () => {
+    render(<KeycodeField value={4} selected={false} onSelect={() => {}} noTooltip />)
+    expect(screen.getByTestId('keycode-field')).not.toHaveAttribute('title')
+  })
+
   it('delays onSelect when onDoubleClick is provided', () => {
     vi.useFakeTimers()
     const onSelect = vi.fn()

--- a/src/renderer/components/editors/__tests__/MacroActionItem.test.tsx
+++ b/src/renderer/components/editors/__tests__/MacroActionItem.test.tsx
@@ -123,40 +123,57 @@ describe('MacroActionItem', () => {
       expect(keycodeFields).toHaveLength(2)
     })
 
-    it('renders add keycode button', () => {
+    it('renders edit button in list mode', () => {
+      const onEditClick = vi.fn()
       const tapAction: MacroAction = { type: 'tap', keycodes: [0x41] }
       render(
-        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} />,
+        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} onEditClick={onEditClick} />,
       )
-      expect(screen.getByTestId('macro-add-keycode')).toBeInTheDocument()
+      expect(screen.getByTestId('macro-edit-action')).toBeInTheDocument()
     })
 
-    it('calls onKeycodeAdd when + button is clicked', () => {
-      const onKeycodeAdd = vi.fn()
-      const tapAction: MacroAction = { type: 'tap', keycodes: [0x41] }
-      render(
-        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} onKeycodeAdd={onKeycodeAdd} />,
-      )
-      fireEvent.click(screen.getByTestId('macro-add-keycode'))
-      expect(onKeycodeAdd).toHaveBeenCalled()
-    })
-
-    it('calls onKeycodeClick when keycode button is clicked', () => {
+    it('keycodes are read-only in list mode', () => {
       const onKeycodeClick = vi.fn()
       const tapAction: MacroAction = { type: 'tap', keycodes: [0x41] }
       render(
         <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} onKeycodeClick={onKeycodeClick} />,
       )
       fireEvent.click(screen.getByTestId('keycode-field'))
-      // KeycodeField uses a timeout for single click when onDoubleClick is not provided
-      // When not selected, onDoubleClick is undefined so click fires immediately
-      expect(onKeycodeClick).toHaveBeenCalledWith(0)
+      expect(onKeycodeClick).not.toHaveBeenCalled()
     })
 
-    it('reflects selectedKeycodeIndex via aria-pressed', () => {
+    it('renders add keycode button in edit mode', () => {
+      const tapAction: MacroAction = { type: 'tap', keycodes: [0x41] }
+      render(
+        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} focusMode selectedKeycodeIndex={0} />,
+      )
+      expect(screen.getByTestId('macro-add-keycode')).toBeInTheDocument()
+    })
+
+    it('calls onKeycodeAdd when + button is clicked in edit mode', () => {
+      const onKeycodeAdd = vi.fn()
+      const tapAction: MacroAction = { type: 'tap', keycodes: [0x41] }
+      render(
+        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} onKeycodeAdd={onKeycodeAdd} focusMode selectedKeycodeIndex={0} />,
+      )
+      fireEvent.click(screen.getByTestId('macro-add-keycode'))
+      expect(onKeycodeAdd).toHaveBeenCalled()
+    })
+
+    it('calls onKeycodeClick when non-selected keycode is clicked in edit mode', () => {
+      const onKeycodeClick = vi.fn()
       const tapAction: MacroAction = { type: 'tap', keycodes: [0x41, 0x42] }
       render(
-        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} selectedKeycodeIndex={0} />,
+        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} onKeycodeClick={onKeycodeClick} focusMode selectedKeycodeIndex={0} />,
+      )
+      fireEvent.click(screen.getAllByTestId('keycode-field')[1])
+      expect(onKeycodeClick).toHaveBeenCalledWith(1)
+    })
+
+    it('reflects selectedKeycodeIndex via aria-pressed in edit mode', () => {
+      const tapAction: MacroAction = { type: 'tap', keycodes: [0x41, 0x42] }
+      render(
+        <MacroActionItem action={tapAction} index={0} {...defaultCallbacks} selectedKeycodeIndex={0} focusMode />,
       )
       const keycodeFields = screen.getAllByTestId('keycode-field')
       expect(keycodeFields[0]).toHaveAttribute('aria-pressed', 'true')

--- a/src/renderer/components/editors/macro-editor-utils.ts
+++ b/src/renderer/components/editors/macro-editor-utils.ts
@@ -11,6 +11,14 @@ export function isKeycodeAction(action: MacroAction): action is KeycodeAction {
   return action.type === 'tap' || action.type === 'down' || action.type === 'up'
 }
 
+export function normalizeMacroActions(actions: MacroAction[]): MacroAction[] {
+  return actions.filter((a) => !isKeycodeAction(a) || a.keycodes.length > 0)
+}
+
+export function normalizeMacros(macros: MacroAction[][]): MacroAction[][] {
+  return macros.map(normalizeMacroActions)
+}
+
 export function parseMacroBuffer(
   buffer: number[],
   protocol: number,

--- a/src/renderer/components/keyboard/KeyWidget.tsx
+++ b/src/renderer/components/keyboard/KeyWidget.tsx
@@ -209,7 +209,7 @@ function KeyWidgetInner({
         if (hoverMaskParts && masked) setHoveredPart(null)
         onHoverEnd?.()
       }}
-      style={{ cursor: isClickable ? 'pointer' : 'default' }}
+      style={isClickable ? { cursor: 'pointer' } : undefined}
     >
       {/* Key shape: unified path for ISO/stepped keys, simple rect for normal */}
       {unionPath ? (

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -35,6 +35,7 @@ type PendingAction = { kind: 'kc'; kc: Keycode } | { kind: 'raw'; code: number }
 interface KeyPopoverProps {
   anchorRect: DOMRect
   currentKeycode: number
+  emptyInitial?: boolean   // When true, start with empty search (no current keycode)
   maskOnly?: boolean
   layers?: number
   onKeycodeSelect: (kc: Keycode) => void
@@ -55,6 +56,7 @@ const POPOVER_GAP = 6
 export function KeyPopover({
   anchorRect,
   currentKeycode,
+  emptyInitial,
   maskOnly,
   layers = 16,
   onKeycodeSelect,
@@ -313,6 +315,7 @@ export function KeyPopover({
   return (
     <div
       ref={popoverRef}
+      data-popover="key"
       className="fixed z-50 rounded-lg border border-edge bg-surface-alt shadow-xl"
       style={{
         top: position.top,
@@ -414,6 +417,7 @@ export function KeyPopover({
             // After a mode switch away from LM, currentKeycode may still hold the stale LM value
             // for one render frame before the parent propagates the rebuilt keycode.
             currentKeycode={isLMKeycode(currentKeycode) ? 0 : currentKeycode}
+            emptyInitial={emptyInitial}
             maskOnly={maskOnly}
             modMask={currentModMask}
             basicKeyOnly={wrapperMode === 'lt' || wrapperMode === 'shT'}

--- a/src/renderer/components/keycodes/KeycodeButton.tsx
+++ b/src/renderer/components/keycodes/KeycodeButton.tsx
@@ -30,7 +30,7 @@ function KeycodeButtonInner({ keycode, onClick, onDoubleClick, onHover, onHoverE
 
   const size = sizeClass ?? 'w-[44px] h-[44px]'
   const hover = selected ? '' : 'hover:bg-picker-item-hover'
-  const base = `flex flex-col items-center justify-center rounded border border-transparent p-1 text-xs outline-none ${hover} active:bg-accent/20 ${size} transition-colors`
+  const base = `flex flex-col items-center justify-center rounded border border-transparent p-1 text-xs outline-none cursor-pointer ${hover} active:bg-accent/20 ${size} transition-colors`
   let variant: string
   if (selected) {
     variant = 'bg-accent/20 text-accent'

--- a/src/renderer/components/keycodes/PopoverTabKey.tsx
+++ b/src/renderer/components/keycodes/PopoverTabKey.tsx
@@ -37,6 +37,7 @@ function stripPrefix(id: string): string {
 
 interface Props {
   currentKeycode: number
+  emptyInitial?: boolean
   maskOnly?: boolean
   modMask?: number
   lmMode?: boolean
@@ -47,10 +48,11 @@ interface Props {
 
 const MAX_RESULTS = 50
 
-export function PopoverTabKey({ currentKeycode, maskOnly, modMask = 0, lmMode: lmModeProp, basicKeyOnly, onKeycodeSelect, onClose }: Props) {
+export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask = 0, lmMode: lmModeProp, basicKeyOnly, onKeycodeSelect, onClose }: Props) {
   const hasModMask = modMask > 0
   const { t } = useTranslation()
   const initialQuery = useMemo(() => {
+    if (emptyInitial) return ''
     // When modifier strip is active or in LT/SH_T mode, show the inner basic key
     if (modMask > 0 || basicKeyOnly) {
       const basicCode = extractBasicKey(currentKeycode)
@@ -73,7 +75,7 @@ export function PopoverTabKey({ currentKeycode, maskOnly, modMask = 0, lmMode: l
       return serialized.substring(0, serialized.indexOf('('))
     }
     return stripPrefix(serialized)
-  }, [currentKeycode, maskOnly, modMask, basicKeyOnly])
+  }, [currentKeycode, emptyInitial, maskOnly, modMask, basicKeyOnly])
   const [query, setQuery] = useState(initialQuery)
   const [suppressResults, setSuppressResults] = useState(false)
 

--- a/src/renderer/hooks/useMacroKeycodeSelection.ts
+++ b/src/renderer/hooks/useMacroKeycodeSelection.ts
@@ -6,7 +6,7 @@ import { type Keycode, deserialize } from '../../shared/keycodes/keycodes'
 import type { TapDanceEntry } from '../../shared/types/protocol'
 import { useMaskedKeycodeSelection } from './useMaskedKeycodeSelection'
 import { useTileContentOverride } from './useTileContentOverride'
-import { KC_TRNS, KC_NO, isKeycodeAction } from '../components/editors/macro-editor-utils'
+import { isKeycodeAction } from '../components/editors/macro-editor-utils'
 
 interface UseMacroKeycodeSelectionOptions {
   currentActions: MacroAction[]
@@ -18,6 +18,7 @@ interface UseMacroKeycodeSelectionOptions {
   tapDanceEntries?: TapDanceEntry[]
   deserializedMacros?: MacroAction[][]
   quickSelect?: boolean
+  autoAdvance?: boolean
 }
 
 export function useMacroKeycodeSelection({
@@ -30,6 +31,7 @@ export function useMacroKeycodeSelection({
   tapDanceEntries,
   deserializedMacros,
   quickSelect,
+  autoAdvance,
 }: UseMacroKeycodeSelectionOptions) {
   const [selectedKey, setSelectedKey] = useState<{
     actionIndex: number
@@ -88,11 +90,11 @@ export function useMacroKeycodeSelection({
   const handleKeycodeAdd = useCallback(
     (actionIndex: number) => {
       const action = currentActions[actionIndex]
-      if (isKeycodeAction(action)) {
-        setKeycodeAt(actionIndex, [...action.keycodes, KC_TRNS])
-      }
+      if (!isKeycodeAction(action)) return
+      preEditValueRef.current = 0
+      setSelectedKey({ actionIndex, keycodeIndex: action.keycodes.length })
     },
-    [currentActions, setKeycodeAt],
+    [currentActions],
   )
 
   const macroInitialValue = (() => {
@@ -103,27 +105,46 @@ export function useMacroKeycodeSelection({
       : undefined
   })()
 
+  const handleKeycodeDelete = useCallback(
+    (actionIndex: number, keycodeIndex: number) => {
+      const action = currentActions[actionIndex]
+      if (!isKeycodeAction(action)) return
+      const newKeycodes = action.keycodes.filter((_, i) => i !== keycodeIndex)
+      setKeycodeAt(actionIndex, newKeycodes)
+      if (selectedKey?.actionIndex === actionIndex) {
+        const nextIndex = keycodeIndex < selectedKey.keycodeIndex
+          ? selectedKey.keycodeIndex - 1
+          : Math.min(selectedKey.keycodeIndex, Math.max(newKeycodes.length - 1, 0))
+        preEditValueRef.current = newKeycodes[nextIndex] ?? 0
+        setSelectedKey({ actionIndex, keycodeIndex: nextIndex })
+      }
+    },
+    [currentActions, setKeycodeAt, selectedKey],
+  )
+
   const maskedSelection = useMaskedKeycodeSelection({
     onUpdate(code: number) {
       if (!selectedKey) return false
       const action = currentActions[selectedKey.actionIndex]
       if (!isKeycodeAction(action)) return false
 
-      if (code === KC_NO) {
-        // Delete this keycode, but keep at least one
-        if (action.keycodes.length <= 1) return false
-        setKeycodeAt(
-          selectedKey.actionIndex,
-          action.keycodes.filter((_, i) => i !== selectedKey.keycodeIndex),
-        )
+      const newKeycodes = [...action.keycodes]
+      if (selectedKey.keycodeIndex >= newKeycodes.length) {
+        newKeycodes.push(code)
       } else {
-        const newKeycodes = [...action.keycodes]
         newKeycodes[selectedKey.keycodeIndex] = code
-        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
+      }
+      setKeycodeAt(selectedKey.actionIndex, newKeycodes)
+
+      if (autoAdvance) {
+        const nextIndex = selectedKey.keycodeIndex + 1
+        preEditValueRef.current = newKeycodes[nextIndex] ?? 0
+        setSelectedKey({ actionIndex: selectedKey.actionIndex, keycodeIndex: nextIndex })
       }
     },
     onCommit() {
-      setSelectedKey(null)
+      // In macro edit mode, picker commits (quickSelect click, double-click)
+      // should not exit edit mode — user explicitly clicks × to close.
     },
     resetKey: selectedKey,
     initialValue: macroInitialValue,
@@ -174,20 +195,9 @@ export function useMacroKeycodeSelection({
   const pickerRef = useRef<HTMLDivElement>(null)
 
   const revertAndDeselect = useCallback(() => {
-    if (selectedKey) {
-      const action = currentActions[selectedKey.actionIndex]
-      if (
-        isKeycodeAction(action) &&
-        action.keycodes[selectedKey.keycodeIndex] !== preEditValueRef.current
-      ) {
-        const newKeycodes = [...action.keycodes]
-        newKeycodes[selectedKey.keycodeIndex] = preEditValueRef.current
-        setKeycodeAt(selectedKey.actionIndex, newKeycodes)
-      }
-    }
     maskedSelection.clearMask()
     setSelectedKey(null)
-  }, [selectedKey, currentActions, setKeycodeAt, maskedSelection.clearMask])
+  }, [maskedSelection.clearMask])
 
   // Close picker when clicking outside of it.
   useEffect(() => {
@@ -196,9 +206,11 @@ export function useMacroKeycodeSelection({
       const target = e.target as Node | null
       if (!target) return
       if (pickerRef.current?.contains(target)) return
-      // Resolve to Element for text node targets (e.g. spans inside buttons)
       const el = target instanceof Element ? target : target.parentElement
       if (el?.closest('[data-testid="keycode-field"]')) return
+      if (el?.closest('[data-testid="macro-action-list"]')) return
+      if (el?.closest('[data-macro-footer]')) return
+      if (el?.closest('[data-popover="key"]')) return
       revertAndDeselect()
     }
     window.addEventListener('click', handler)
@@ -227,6 +239,7 @@ export function useMacroKeycodeSelection({
     handleKeycodeClick,
     handleKeycodeDoubleClick,
     handleKeycodeAdd,
+    handleKeycodeDelete,
     handleMaskPartClick,
     applyPopoverKeycode,
     handlePopoverKeycodeSelect,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -146,6 +146,8 @@
       "textEditorTitle": "Edit Macro (Text)",
       "invalidJson": "Invalid JSON format",
       "addKeycode": "Add keycode",
+      "deleteKeycode": "Delete keycode",
+      "editAction": "Edit action",
       "asciiOnly": "Only ASCII characters (A-Z, 0-9, symbols) are supported",
       "unlockClickAgain": "After unlocking, click the macro key again to open the editor.",
       "unlockWarning": "Do not store passwords or sensitive information in macros, as they may be replayed or shared.",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -145,6 +145,8 @@
       "textEditorTitle": "マクロ編集 (テキスト)",
       "invalidJson": "無効なJSON形式",
       "addKeycode": "キーコード追加",
+      "deleteKeycode": "キーコード削除",
+      "editAction": "アクション編集",
       "asciiOnly": "ASCII文字（英数字・記号）のみ対応しています",
       "unlockClickAgain": "アンロック後、もう一度マクロキーをクリックしてエディタを開いてください。",
       "unlockWarning": "パスワードや機密情報をマクロに保存しないでください。再生・共有される可能性があります。",


### PR DESCRIPTION
## Summary
- Split the macro action UI into list mode (read-only keycodes + dashed add slot) and edit mode (clickable slots + hover delete + visible picker).
- Remove the vial-gui-inherited pattern of overloading `KC_NO` / `KC_TRNS` with UI roles; slot deletion is now a dedicated × button and additions go through a `+` affordance.
- Every picker / popover click commits immediately; the action closes only on an explicit × click.
- Plumb `layers` through MacroModal so the LM popover reflects the keyboard's actual layer count.

## Closes
- Closes #107
- Closes #109

## Test plan
- [x] `pnpm test` — 2801 passed
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm run lint` — clean
- [ ] Manual: add Tap → picker auto-opens, Auto Move advances through slots
- [ ] Manual: list mode — click a keycode enters edit mode at that index
- [ ] Manual: × button deletes a slot without exiting edit mode
- [ ] Manual: dashed + — single click selects, double click opens popover
- [ ] Manual: LM popover shows the keyboard's real layer count