### PR TITLE
feat(ui): close modals on Escape and lock UI during macro recording

### DIFF
--- a/src/renderer/components/NotificationModal.tsx
+++ b/src/renderer/components/NotificationModal.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../hooks/useEscapeClose'
 import { ModalCloseButton } from './editors/ModalCloseButton'
 import { formatDateShort } from './editors/store-modal-shared'
 import type { AppNotification } from '../../shared/types/notification'
@@ -10,6 +11,7 @@ interface NotificationModalProps {
 
 export function NotificationModal({ notifications, onClose }: NotificationModalProps) {
   const { t } = useTranslation()
+  useEscapeClose(onClose)
 
   return (
     <div

--- a/src/renderer/components/__tests__/NotificationModal.test.tsx
+++ b/src/renderer/components/__tests__/NotificationModal.test.tsx
@@ -44,12 +44,12 @@ describe('NotificationModal', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     const onClose = vi.fn()
     render(<NotificationModal notifications={sampleNotifications} onClose={onClose} />)
 
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('calls onClose when backdrop is clicked', () => {

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTroubleshooting } from '../../hooks/useTroubleshooting'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { BTN_SECONDARY as SETTINGS_BTN_SECONDARY } from '../settings-modal/settings-modal-shared'
 import { HubPostRow, DEFAULT_PER_PAGE } from '../hub-post-shared'
@@ -70,6 +71,8 @@ export function DataModal({
     onResetStart,
     onResetEnd,
   })
+
+  useEscapeClose(onClose, !troubleshoot.busy)
 
   // Reset to null if hub tab becomes hidden while active
   useEffect(() => {

--- a/src/renderer/components/editors/ConfirmButton.tsx
+++ b/src/renderer/components/editors/ConfirmButton.tsx
@@ -9,6 +9,7 @@ interface Props {
   labelKey: string
   confirmLabelKey: string
   className?: string
+  disabled?: boolean
 }
 
 const STYLE_NORMAL = 'border-edge hover:bg-surface-dim'
@@ -21,6 +22,7 @@ export function ConfirmButton({
   labelKey,
   confirmLabelKey,
   className = 'rounded border px-4 py-2 text-sm',
+  disabled,
 }: Props) {
   const { t } = useTranslation()
 
@@ -28,8 +30,9 @@ export function ConfirmButton({
     <button
       type="button"
       data-testid={testId}
-      className={`${className} ${confirming ? STYLE_CONFIRMING : STYLE_NORMAL}`}
+      className={`${className} ${confirming ? STYLE_CONFIRMING : STYLE_NORMAL} disabled:opacity-50`}
       onClick={onClick}
+      disabled={disabled}
     >
       {confirming ? t(confirmLabelKey) : t(labelKey)}
     </button>

--- a/src/renderer/components/editors/EditorSettingsModal.tsx
+++ b/src/renderer/components/editors/EditorSettingsModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { LayoutStoreContent, type LayoutStoreContentProps } from './LayoutStoreModal'
 import { ModalCloseButton } from './ModalCloseButton'
 
@@ -31,6 +32,8 @@ export function EditorSettingsModal({
     const id = requestAnimationFrame(() => setOpen(true))
     return () => cancelAnimationFrame(id)
   }, [])
+
+  useEscapeClose(onClose)
 
   return (
     <div

--- a/src/renderer/components/editors/FavoriteStoreModal.tsx
+++ b/src/renderer/components/editors/FavoriteStoreModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalCloseButton } from './ModalCloseButton'
 import { FavoriteStoreContent, TYPE_LABEL_KEYS, type FavoriteStoreContentProps } from './FavoriteStoreContent'
 import type { FavoriteType } from '../../../shared/types/favorite-store'
@@ -16,6 +17,7 @@ export function FavoriteStoreModal({
   ...contentProps
 }: Props) {
   const { t } = useTranslation()
+  useEscapeClose(onClose)
 
   return (
     <div

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { TypingTestHistory } from '../../typing-test/TypingTestHistory'
 import { ModalCloseButton } from './ModalCloseButton'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
@@ -25,6 +26,9 @@ export function HistoryToggle({ results, deviceName }: HistoryToggleProps) {
     const prefix = deviceName ? `${deviceName}_typing-test-history` : undefined
     window.vialAPI.exportCsv(csv, prefix)
   }, [deviceName])
+
+  const closeHistory = useCallback(() => setShowHistory(false), [])
+  useEscapeClose(closeHistory, showHistory)
 
   return (
     <>

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import type { KeycodeEntryModalReturn, KeycodeEntryModalAdapter, KeycodeFieldDescriptor } from '../../hooks/useKeycodeEntryModal'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import { ConfirmButton } from './ConfirmButton'
@@ -106,6 +107,8 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
     showFavorites,
     modalWidth,
   } = hook
+
+  useEscapeClose(handleClose)
 
   const isConfigured = editedEntry !== null && adapter.isConfigured(editedEntry)
 

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -17,6 +17,7 @@ interface Props {
   onDoubleClick?: (rect: DOMRect) => void
   onDelete?: () => void
   noTooltip?: boolean
+  disabled?: boolean
   label?: string
 }
 
@@ -56,7 +57,7 @@ const FACE_ORIGIN = KEY_FACE_INSET
 const FACE_SIZE = KEY_UNIT - KEY_SPACING - 2 * KEY_FACE_INSET
 export const KEYCODE_FIELD_SIZE = Math.round(FACE_SIZE)
 
-export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMaskPartClick, onDoubleClick, onDelete, noTooltip, label }: Props) {
+export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMaskPartClick, onDoubleClick, onDelete, noTooltip, disabled, label }: Props) {
   const { t } = useTranslation()
   const qmkId = serialize(value)
   const tooltip = noTooltip ? undefined : keycodeTooltip(qmkId)
@@ -108,7 +109,8 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
       aria-pressed={selected}
       title={tooltip}
       data-testid="keycode-field"
-      className={`flex shrink-0 cursor-pointer rounded-sm ring-1 ${selected ? 'ring-accent' : 'ring-picker-item-border hover:ring-accent'}`}
+      disabled={disabled}
+      className={`flex shrink-0 rounded-sm ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
       onClick={handleClick}
       onDoubleClick={isMasked ? undefined : handleDoubleClick}
     >

--- a/src/renderer/components/editors/LayoutStoreModal.tsx
+++ b/src/renderer/components/editors/LayoutStoreModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalCloseButton } from './ModalCloseButton'
 import { LayoutStoreContent } from './LayoutStoreContent'
 import type { LayoutStoreContentProps } from './layout-store-types'
@@ -15,6 +16,7 @@ interface Props extends LayoutStoreContentProps {
 
 export function LayoutStoreModal({ onClose, ...contentProps }: Props) {
   const { t } = useTranslation()
+  useEscapeClose(onClose)
 
   return (
     <div

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -28,6 +28,7 @@ interface Props {
   onCloseEdit?: () => void
   onMaskPartClick?: (keycodeIndex: number, part: 'outer' | 'inner') => void
   focusMode?: boolean
+  disabled?: boolean
 }
 
 export function defaultAction(type: ActionType): MacroAction {
@@ -64,6 +65,7 @@ export function MacroActionItem({
   onCloseEdit,
   onMaskPartClick,
   focusMode,
+  disabled,
 }: Props) {
   const { t } = useTranslation()
 
@@ -86,7 +88,8 @@ export function MacroActionItem({
               value={action.text}
               onChange={(e) => onChange(index, { type: 'text', text: e.target.value })}
               placeholder={t('editor.macro.text')}
-              className={`w-full rounded border px-2 py-1 text-sm ${valid ? 'border-edge' : 'border-danger'}`}
+              disabled={disabled}
+              className={`w-full rounded border px-2 py-1 text-sm disabled:opacity-50 ${valid ? 'border-edge' : 'border-danger'}`}
             />
             {!valid && (
               <p className="mt-0.5 text-xs text-danger">{t('editor.macro.asciiOnly')}</p>
@@ -105,6 +108,7 @@ export function MacroActionItem({
                 value={kc}
                 selected={false}
                 onSelect={() => onEditClick?.(ki)}
+                disabled={disabled}
                 noTooltip
               />
             ))}
@@ -114,8 +118,9 @@ export function MacroActionItem({
                   type="button"
                   data-testid="macro-edit-action"
                   style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
-                  className="flex shrink-0 rounded-sm outline outline-1 outline-dashed outline-edge hover:outline-accent"
+                  className="flex shrink-0 rounded-sm outline outline-1 outline-dashed outline-edge hover:outline-accent disabled:opacity-50"
                   onClick={() => onEditClick(action.keycodes.length)}
+                  disabled={disabled}
                   aria-label={t('editor.macro.addKeycode')}
                 />
 
@@ -142,7 +147,8 @@ export function MacroActionItem({
                   delay: Math.max(0, parseInt(e.target.value, 10) || 0),
                 })
               }
-              className="w-24 rounded border border-edge px-2 py-1 text-sm"
+              disabled={disabled}
+              className="w-24 rounded border border-edge px-2 py-1 text-sm disabled:opacity-50"
             />
             <span className="text-sm text-content-secondary">ms</span>
           </div>
@@ -169,6 +175,7 @@ export function MacroActionItem({
                 onMaskPartClick={onMaskPartClick ? (part) => onMaskPartClick(ki, part) : undefined}
                 onDoubleClick={isSelected ? (rect) => onKeycodeDoubleClick(ki, rect) : undefined}
                 onDelete={onKeycodeDelete ? () => onKeycodeDelete(ki) : undefined}
+                disabled={disabled}
               />
             )
           })}
@@ -177,13 +184,14 @@ export function MacroActionItem({
               type="button"
               data-testid="macro-add-keycode"
               style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
-              className={`flex shrink-0 rounded-sm outline outline-1 outline-dashed ${
+              className={`flex shrink-0 rounded-sm outline outline-1 outline-dashed disabled:opacity-50 ${
                 selectedKeycodeIndex === action.keycodes.length
                   ? 'outline-accent'
                   : 'outline-edge hover:outline-accent'
               }`}
               onClick={onKeycodeAdd}
               onDoubleClick={(e) => onKeycodeAddDoubleClick(e.currentTarget.getBoundingClientRect())}
+              disabled={disabled}
               aria-label={t('editor.macro.addKeycode')}
             />
             <div className="pointer-events-none invisible absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg group-hover:visible">
@@ -197,8 +205,9 @@ export function MacroActionItem({
           <button
             type="button"
             data-testid="macro-close-edit"
-            className="ml-auto rounded p-1 text-content-muted hover:text-content"
+            className="ml-auto rounded p-1 text-content-muted hover:text-content disabled:opacity-50"
             onClick={onCloseEdit}
+            disabled={disabled}
             aria-label={t('common.close')}
           >
             <X size={20} aria-hidden="true" />
@@ -210,16 +219,16 @@ export function MacroActionItem({
 
   return (
     <div
-      onDragOver={onDragOver}
-      onDrop={(e) => { e.preventDefault(); onDrop() }}
+      onDragOver={disabled ? undefined : onDragOver}
+      onDrop={disabled ? undefined : (e) => { e.preventDefault(); onDrop() }}
       className={`flex items-center gap-2 rounded border border-edge bg-surface-alt px-2 py-1.5 ${dropIndicator === 'above' ? 'border-t-2 border-t-accent' : dropIndicator === 'below' ? 'border-b-2 border-b-accent' : ''}`}
     >
       <div
-        draggable
+        draggable={!disabled}
         data-testid="drag-handle"
-        onDragStart={(e) => { e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', ''); onDragStart() }}
-        onDragEnd={onDragEnd}
-        className="flex items-center gap-1.5 border-r border-edge py-1 pl-1 pr-3 cursor-grab active:cursor-grabbing"
+        onDragStart={disabled ? undefined : (e) => { e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', ''); onDragStart() }}
+        onDragEnd={disabled ? undefined : onDragEnd}
+        className={`flex items-center gap-1.5 border-r border-edge py-1 pl-1 pr-3 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       >
         <GripVertical className="shrink-0 text-content-muted" size={14} />
         <span className="min-w-[36px] text-center text-sm text-content-secondary">
@@ -232,7 +241,8 @@ export function MacroActionItem({
       <button
         type="button"
         onClick={() => onDelete(index)}
-        className="rounded p-1 text-content-muted hover:text-danger"
+        disabled={disabled}
+        className="rounded p-1 text-content-muted hover:text-danger disabled:opacity-50"
         aria-label={t('common.delete')}
       >
         <X size={20} aria-hidden="true" />

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -39,6 +39,7 @@ interface Props {
   onUnlock?: () => void
   isDummy?: boolean
   onEditingChange?: (editing: boolean) => void
+  onRecordingChange?: (recording: boolean) => void
   tapDanceEntries?: TapDanceEntry[]
   deserializedMacros?: MacroAction[][]
   // Hub integration (optional)
@@ -70,6 +71,7 @@ export function MacroEditor({
   onUnlock,
   isDummy,
   onEditingChange,
+  onRecordingChange,
   tapDanceEntries,
   deserializedMacros,
   hubOrigin,
@@ -91,6 +93,11 @@ export function MacroEditor({
   const [activeMacro, setActiveMacro] = useState(initialMacro ?? 0)
   const [dirty, setDirty] = useState(false)
   const [showTextEditor, setShowTextEditor] = useState(false)
+  const [isRecording, setIsRecording] = useState(false)
+
+  useEffect(() => {
+    onRecordingChange?.(isRecording)
+  }, [isRecording, onRecordingChange])
 
   const [macros, setMacros] = useState<MacroAction[][]>(() =>
     parsedMacrosProp ?? parseMacroBuffer(macroBuffer, vialProtocol, macroCount),
@@ -181,6 +188,7 @@ export function MacroEditor({
 
   const handleAddActionType = useCallback(
     (type: ActionType) => {
+      if (isRecording) return
       const newAction = defaultAction(type)
       const newIndex = currentActions.length
       clearPending()
@@ -195,7 +203,7 @@ export function MacroEditor({
         setSelectedKey({ actionIndex: newIndex, keycodeIndex: 0 })
       }
     },
-    [currentActions, activeMacro, setMacros, setDirty, clearPending, setPopoverState, setSelectedKey],
+    [isRecording, currentActions, activeMacro, setMacros, setDirty, clearPending, setPopoverState, setSelectedKey],
   )
 
   const handleChange = useCallback(
@@ -209,23 +217,25 @@ export function MacroEditor({
 
   const handleKeycodeAddWithPopover = useCallback(
     (actionIndex: number, rect: DOMRect) => {
+      if (isRecording) return
       const action = currentActions[actionIndex]
       if (!isKeycodeAction(action)) return
       handleKeycodeAdd(actionIndex)
       setPopoverState({ actionIndex, keycodeIndex: action.keycodes.length, anchorRect: rect })
     },
-    [currentActions, handleKeycodeAdd, setPopoverState],
+    [isRecording, currentActions, handleKeycodeAdd, setPopoverState],
   )
 
   const handleEditClick = useCallback(
     (index: number, keycodeIndex: number) => {
+      if (isRecording) return
       const action = currentActions[index]
       if (isKeycodeAction(action)) {
         preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
         setSelectedKey({ actionIndex: index, keycodeIndex })
       }
     },
-    [currentActions, setSelectedKey, preEditValueRef],
+    [isRecording, currentActions, setSelectedKey, preEditValueRef],
   )
 
   const handleDelete = useCallback(
@@ -330,8 +340,9 @@ export function MacroEditor({
             <div className="flex-1" />
             <select
               data-testid="macro-add-action"
-              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised"
+              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50"
               value=""
+              disabled={isRecording}
               onChange={(e) => {
                 if (e.target.value) handleAddActionType(e.target.value as ActionType)
                 e.target.value = ''
@@ -344,11 +355,12 @@ export function MacroEditor({
               <option value="up">{t('editor.macro.up')}</option>
               <option value="delay">{t('editor.macro.delay')}</option>
             </select>
-            <MacroRecorder onRecordComplete={handleRecordComplete} />
+            <MacroRecorder onRecordComplete={handleRecordComplete} onRecordingChange={setIsRecording} />
             <button
               type="button"
               data-testid="macro-text-editor-btn"
-              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised"
+              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50"
+              disabled={isRecording}
               onClick={() => setShowTextEditor(true)}
             >
               {t('editor.macro.textEditor')}
@@ -384,6 +396,7 @@ export function MacroEditor({
                   onMaskPartClick={(ki, part) => handleMaskPartClick(i, ki, part)}
                   focusMode={isEditing}
                   onCloseEdit={isEditing ? revertAndDeselect : undefined}
+                  disabled={isRecording}
                 />
               )
             })}
@@ -411,6 +424,7 @@ export function MacroEditor({
                 onClick={() => { revertAction.reset(); clearAction.trigger() }}
                 labelKey="common.clear"
                 confirmLabelKey="common.confirmClear"
+                disabled={isRecording}
               />
               <ConfirmButton
                 testId="macro-revert"
@@ -418,13 +432,14 @@ export function MacroEditor({
                 onClick={() => { clearAction.reset(); revertAction.trigger() }}
                 labelKey="common.revert"
                 confirmLabelKey="common.confirmRevert"
+                disabled={isRecording}
               />
               <button
                 type="button"
                 data-testid="macro-save"
                 className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
                 onClick={handleSave}
-                disabled={!dirty || hasInvalidText}
+                disabled={!dirty || hasInvalidText || isRecording}
               >
                 {t('common.save')}
               </button>
@@ -460,7 +475,7 @@ export function MacroEditor({
 
       {!isDummy && (
         <div
-          className={`w-[456px] shrink-0 flex flex-col ${isEditing ? 'hidden' : ''}`}
+          className={`w-[456px] shrink-0 flex flex-col ${isEditing ? 'hidden' : isRecording ? 'invisible' : ''}`}
           data-testid="macro-favorites-panel"
         >
           <FavoriteStoreContent

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { MacroEditor } from './MacroEditor'
 import { ModalCloseButton } from './ModalCloseButton'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import type { MacroAction } from '../../../preload/macro'
 import type { TapDanceEntry } from '../../../shared/types/protocol'
 import type { FavHubEntryResult } from './FavoriteHubActions'
@@ -69,13 +70,16 @@ export function MacroModal({
 }: Props) {
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
+  const [isRecording, setIsRecording] = useState(false)
   const modalWidth = isDummy ? 'w-[1200px]' : 'w-[1300px]'
+
+  useEscapeClose(onClose, !isRecording)
 
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       data-testid="macro-modal-backdrop"
-      onClick={onClose}
+      onClick={isRecording ? undefined : onClose}
     >
       <div
         className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-[90vh] flex flex-col overflow-hidden`}
@@ -88,7 +92,9 @@ export function MacroModal({
               <h3 className="text-lg font-semibold">
                 {t('editor.macro.editTitle', { index })}
               </h3>
-              <ModalCloseButton testid="macro-modal-close" onClick={onClose} />
+              {!isRecording && (
+                <ModalCloseButton testid="macro-modal-close" onClick={onClose} />
+              )}
             </div>
             <p className="mt-1 text-xs text-warning">{t('editor.macro.unlockWarning')}</p>
           </div>
@@ -108,6 +114,7 @@ export function MacroModal({
             onUnlock={onUnlock}
             isDummy={isDummy}
             onEditingChange={setIsEditing}
+            onRecordingChange={setIsRecording}
             tapDanceEntries={tapDanceEntries}
             deserializedMacros={deserializedMacros}
             hubOrigin={hubOrigin}

--- a/src/renderer/components/editors/MacroRecorder.tsx
+++ b/src/renderer/components/editors/MacroRecorder.tsx
@@ -7,6 +7,7 @@ import { findByRecorderAlias } from '../../../shared/keycodes/keycodes'
 
 interface Props {
   onRecordComplete: (actions: MacroAction[]) => void
+  onRecordingChange?: (recording: boolean) => void
 }
 
 const TAP_THRESHOLD_MS = 200
@@ -16,9 +17,13 @@ interface PendingKey {
   downTime: number
 }
 
-export function MacroRecorder({ onRecordComplete }: Props) {
+export function MacroRecorder({ onRecordComplete, onRecordingChange }: Props) {
   const { t } = useTranslation()
   const [recording, setRecording] = useState(false)
+
+  useEffect(() => {
+    onRecordingChange?.(recording)
+  }, [recording, onRecordingChange])
   const actionsRef = useRef<MacroAction[]>([])
   const pendingRef = useRef<Map<string, PendingKey>>(new Map())
 

--- a/src/renderer/components/editors/QmkSettingsModal.tsx
+++ b/src/renderer/components/editors/QmkSettingsModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { QmkSettings } from './QmkSettings'
 import { ModalCloseButton } from './ModalCloseButton'
 
@@ -27,6 +28,7 @@ function SettingsModal({
   onSettingsUpdate,
   onClose,
 }: SettingsModalProps) {
+  useEscapeClose(onClose)
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { KleKey } from '../../../shared/kle/types'
 import { KeyboardWidget } from '../keyboard'
+import { useEscapeSwallow } from '../../hooks/useEscapeClose'
 
 const UNLOCK_POLL_INTERVAL = 200 // ms
 const MAX_CONSECUTIVE_ERRORS = 5 // treat as disconnect after this many consecutive poll errors
@@ -51,6 +52,10 @@ export function UnlockDialog({
   onCompleteRef.current = onComplete
   onDisconnectRef.current = onDisconnect
   const busyRef = useRef(false)
+
+  // Swallow Escape while the unlock dialog is mounted so parent modals
+  // (KeymapEditor etc.) do not accidentally close on top of the unlock prompt.
+  useEscapeSwallow()
 
   // Single useEffect: send unlockStart once, then poll via setInterval.
   // setInterval (like Python's QTimer) guarantees exactly one poll loop.

--- a/src/renderer/components/editors/__tests__/AltRepeatKeyPanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/AltRepeatKeyPanelModal.test.tsx
@@ -177,12 +177,12 @@ describe('AltRepeatKeyPanelModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     render(
       <AltRepeatKeyPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('hides favorites panel when picker is open', () => {

--- a/src/renderer/components/editors/__tests__/ComboPanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/ComboPanelModal.test.tsx
@@ -151,12 +151,12 @@ describe('ComboPanelModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     render(
       <ComboPanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('hides favorites panel when picker is open', () => {

--- a/src/renderer/components/editors/__tests__/FavoriteStoreModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/FavoriteStoreModal.test.tsx
@@ -298,7 +298,7 @@ describe('FavoriteStoreModal', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     const onClose = vi.fn()
     render(
       <FavoriteStoreModal
@@ -308,9 +308,9 @@ describe('FavoriteStoreModal', () => {
       />,
     )
 
-    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.keyDown(window, { key: 'Escape' })
 
-    expect(onClose).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('shows loading state', () => {

--- a/src/renderer/components/editors/__tests__/KeyOverridePanelModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeyOverridePanelModal.test.tsx
@@ -183,12 +183,12 @@ describe('KeyOverridePanelModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     render(
       <KeyOverridePanelModal entries={[makeEntry()]} initialIndex={0} onSetEntry={onSetEntry} onClose={onClose} />,
     )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('hides favorites panel when picker is open', () => {

--- a/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
@@ -279,7 +279,7 @@ describe('LayoutStoreModal', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     const onClose = vi.fn()
     render(
       <LayoutStoreModal
@@ -289,9 +289,9 @@ describe('LayoutStoreModal', () => {
       />,
     )
 
-    fireEvent.keyDown(document, { key: 'Escape' })
+    fireEvent.keyDown(window, { key: 'Escape' })
 
-    expect(onClose).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('shows loading state', () => {

--- a/src/renderer/components/editors/__tests__/MacroModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/MacroModal.test.tsx
@@ -22,12 +22,26 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
-// Mock MacroEditor to verify props are passed through
+// Mock MacroEditor to verify props are passed through and let tests toggle
+// recording state from within the editor subtree.
 let capturedInitialMacro: number | undefined
 vi.mock('../MacroEditor', () => ({
-  MacroEditor: (props: { initialMacro?: number }) => {
+  MacroEditor: (props: {
+    initialMacro?: number
+    onRecordingChange?: (recording: boolean) => void
+  }) => {
     capturedInitialMacro = props.initialMacro
-    return <div data-testid="editor-macro">MacroEditor</div>
+    return (
+      <div data-testid="editor-macro">
+        <button
+          type="button"
+          data-testid="mock-record-toggle"
+          onClick={() => props.onRecordingChange?.(true)}
+        >
+          start recording
+        </button>
+      </div>
+    )
   },
 }))
 
@@ -72,15 +86,36 @@ describe('MacroModal', () => {
     expect(defaultProps.onClose).not.toHaveBeenCalled()
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     render(<MacroModal {...defaultProps} />)
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(defaultProps.onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(defaultProps.onClose).toHaveBeenCalled()
   })
 
   it('calls onClose when clicking Close button', () => {
     render(<MacroModal {...defaultProps} />)
     fireEvent.click(screen.getByTestId('macro-modal-close'))
     expect(defaultProps.onClose).toHaveBeenCalledOnce()
+  })
+
+  it('hides Close button while recording', () => {
+    render(<MacroModal {...defaultProps} />)
+    expect(screen.getByTestId('macro-modal-close')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('mock-record-toggle'))
+    expect(screen.queryByTestId('macro-modal-close')).not.toBeInTheDocument()
+  })
+
+  it('does not close on backdrop click while recording', () => {
+    render(<MacroModal {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('mock-record-toggle'))
+    fireEvent.click(screen.getByTestId('macro-modal-backdrop'))
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close on Escape while recording', () => {
+    render(<MacroModal {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('mock-record-toggle'))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/editors/__tests__/TapDanceModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/TapDanceModal.test.tsx
@@ -202,12 +202,12 @@ describe('TapDanceModal', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('does not close modal on Escape key', () => {
+  it('closes modal on Escape key', () => {
     render(
       <TapDanceModal index={0} entry={makeEntry()} onSave={onSave} onClose={onClose} />,
     )
-    fireEvent.keyDown(document, { key: 'Escape' })
-    expect(onClose).not.toHaveBeenCalled()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('updates tapping term locally', () => {

--- a/src/renderer/components/settings-modal/SettingsModal.tsx
+++ b/src/renderer/components/settings-modal/SettingsModal.tsx
@@ -9,6 +9,7 @@ import { SettingsToolsTab } from './SettingsToolsTab'
 import { SettingsDataTab } from './SettingsDataTab'
 import { SettingsNotificationTab } from './SettingsNotificationTab'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalTabBar, ModalTabPanel } from '../editors/modal-tabs'
 import { AboutTabContent } from '../AboutTabContent'
 import type { ModalTabId } from '../editors/modal-tabs'
@@ -54,6 +55,8 @@ export function SettingsModal({
     onHubEnabledChange,
     activeTab,
   })
+
+  useEscapeClose(onClose, !syncState.busy)
 
   return (
     <div

--- a/src/renderer/hooks/__tests__/useEscapeClose.test.ts
+++ b/src/renderer/hooks/__tests__/useEscapeClose.test.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, cleanup } from '@testing-library/react'
+import { useEscapeClose, useEscapeSwallow } from '../useEscapeClose'
+
+function pressEscape(target: EventTarget = window, init: KeyboardEventInit = {}): void {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true, ...init }))
+}
+
+describe('useEscapeClose', () => {
+  afterEach(() => {
+    cleanup()
+    document.body.innerHTML = ''
+  })
+
+  it('calls onClose when Escape is pressed on window', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call onClose for non-Escape keys', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose))
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not call onClose when disabled', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose, false))
+    pressEscape()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close when an INPUT is focused', () => {
+    const onClose = vi.fn()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(input)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close when a TEXTAREA is focused', () => {
+    const onClose = vi.fn()
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(textarea)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close when a SELECT is focused', () => {
+    const onClose = vi.fn()
+    const select = document.createElement('select')
+    document.body.appendChild(select)
+    select.focus()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(select)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close when a contenteditable element is focused', () => {
+    const onClose = vi.fn()
+    const div = document.createElement('div')
+    div.setAttribute('contenteditable', 'true')
+    div.tabIndex = 0
+    document.body.appendChild(div)
+    div.focus()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(div)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close when a descendant of a contenteditable region is focused', () => {
+    const onClose = vi.fn()
+    const outer = document.createElement('div')
+    outer.setAttribute('contenteditable', 'true')
+    const inner = document.createElement('span')
+    inner.tabIndex = 0
+    outer.appendChild(inner)
+    document.body.appendChild(outer)
+    inner.focus()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(inner)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('skips close while IME composition is active', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose))
+    pressEscape(window, { isComposing: true })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('falls back to document.activeElement when event target is not an element', () => {
+    const onClose = vi.fn()
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.focus()
+    renderHook(() => useEscapeClose(onClose))
+    // Dispatch from window (target becomes window) while INPUT remains focused
+    pressEscape()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('removes the listener on unmount', () => {
+    const onClose = vi.fn()
+    const { unmount } = renderHook(() => useEscapeClose(onClose))
+    unmount()
+    pressEscape()
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+describe('useEscapeSwallow', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('stops propagation so parent useEscapeClose never fires', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose))
+    renderHook(() => useEscapeSwallow())
+    // Dispatch on a descendant so the event traverses document (capture path)
+    // before reaching window (bubble listener).
+    pressEscape(document.body)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not install the listener when disabled', () => {
+    const onClose = vi.fn()
+    renderHook(() => useEscapeClose(onClose))
+    renderHook(() => useEscapeSwallow(false))
+    pressEscape(document.body)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/hooks/useEscapeClose.ts
+++ b/src/renderer/hooks/useEscapeClose.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useEffect } from 'react'
+
+/**
+ * Close a modal / dialog when the user presses Escape.
+ *
+ * The listener runs in the bubble phase so nested elements that consume
+ * Escape in the capture phase (KeyPopover, MacroRecorder, MacroTextEditor,
+ * JsonEditorModal, etc.) get first chance to stop propagation. This keeps
+ * inner popovers / recorders from accidentally closing the outer modal.
+ *
+ * Skips the close in the following "user is interacting" cases so pressing
+ * Escape cannot discard work:
+ * - IME composition is active (`e.isComposing`)
+ * - An input-like element (`<input>`, `<textarea>`, `<select>`, or any
+ *   `contenteditable`) is the event target or the current `activeElement`
+ *
+ * The caller can also pass `enabled = false` to disable the listener while
+ * the modal is busy (e.g. sync in progress).
+ */
+function isTypableElement(el: EventTarget | null): boolean {
+  if (!(el instanceof HTMLElement)) return false
+  const tag = el.tagName
+  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true
+  // Cover any element nested inside a contenteditable region
+  return el.closest('[contenteditable=""], [contenteditable="true"]') !== null
+}
+
+export function useEscapeClose(onClose: () => void, enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key !== 'Escape') return
+      if (e.isComposing) return
+      if (isTypableElement(e.target) || isTypableElement(document.activeElement)) return
+      onClose()
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [enabled, onClose])
+}
+
+/**
+ * Consume Escape keydowns in the capture phase without taking any action.
+ *
+ * Used by overlays that must not close on Escape themselves but also must not
+ * let the event reach a parent `useEscapeClose` listener (which would close
+ * the modal beneath). Registering in the capture phase + `stopPropagation`
+ * ensures the event is handled before any parent bubble-phase listener.
+ */
+export function useEscapeSwallow(enabled = true): void {
+  useEffect(() => {
+    if (!enabled) return
+    const handler = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') e.stopPropagation()
+    }
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
+  }, [enabled])
+}

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../hooks/useEscapeClose'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
 import { Check, Download, Trash2, Loader2 } from 'lucide-react'
 import type { LanguageListEntry } from '../../shared/types/language-store'
@@ -23,6 +24,8 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
   const backdropRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
+
+  useEscapeClose(onClose)
 
   useEffect(() => {
     let alive = true

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -163,7 +163,7 @@ describe('LanguageSelectorModal', () => {
     expect(screen.queryByTestId('language-delete-english')).not.toBeInTheDocument()
   })
 
-  it('does not close modal on Escape key', async () => {
+  it('closes modal on Escape key', async () => {
     const onClose = vi.fn()
 
     render(
@@ -174,9 +174,12 @@ describe('LanguageSelectorModal', () => {
       />,
     )
 
-    fireEvent.keyDown(document, { key: 'Escape' })
+    // Search input auto-focuses on mount; blur it so Escape is not treated as
+    // input-in-progress.
+    ;(document.activeElement as HTMLElement | null)?.blur()
+    fireEvent.keyDown(window, { key: 'Escape' })
 
-    expect(onClose).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('does not update state after unmount when langList resolves late', async () => {


### PR DESCRIPTION
## Summary
- Add `useEscapeClose` / `useEscapeSwallow` hooks and apply Escape-to-close uniformly across 11 modals (SettingsModal, DataModal, MacroModal, QmkSettingsModal, KeycodeEntryModalShell, NotificationModal, LanguageSelectorModal, LayoutStoreModal, EditorSettingsModal, FavoriteStoreModal, HistoryToggle).
- `useEscapeClose` skips when IME composition is active and when an input-like element (INPUT / TEXTAREA / SELECT / contenteditable descendant) is the event target or `document.activeElement`.
- `UnlockDialog` uses `useEscapeSwallow` (capture-phase stopPropagation) so Escape does not leak to the parent modal.
- Lock the whole Macro UI while a recording is in progress: the Close button is hidden, backdrop click / Escape are inert, the favorites panel is kept `invisible` (width preserved), and every keycode tile / row button / footer action is disabled via the new `disabled` prop on `KeycodeField` and `ConfirmButton`.
- Lift recording state from `MacroRecorder` → `MacroEditor` → `MacroModal` via an `onRecordingChange` callback.

## Closes
- Closes #108

## Test plan
- [x] `pnpm test` — 2817 tests pass (16 new)
- [x] `npx tsc --noEmit` — clean
- [x] `pnpm run lint` — clean
- [ ] Manual: press Escape on each top-level modal → closes (unless input-like element has focus)
- [ ] Manual: focus search / text input → Escape does nothing
- [ ] Manual: start macro recording → Close button / Escape / backdrop all inert until record stop
- [ ] Manual: UnlockDialog on top of Combo / KeyOverride / AltRepeatKey / Macro → Escape neither closes unlock nor parent