### PR TITLE
feat(sync): lazy keyboard download with synced UID→name mapping

### DIFF
--- a/src/main/__tests__/google-drive.test.ts
+++ b/src/main/__tests__/google-drive.test.ts
@@ -69,6 +69,11 @@ describe('google-drive', () => {
       expect(syncUnitFromFileName('keyboards_0x1234_snapshots.enc')).toBe('keyboards/0x1234/snapshots')
     })
 
+    it('round-trips the keyboard-meta singleton sync unit', () => {
+      expect(driveFileName('meta/keyboard-names')).toBe('meta_keyboard-names.enc')
+      expect(syncUnitFromFileName('meta_keyboard-names.enc')).toBe('meta/keyboard-names')
+    })
+
     it('returns null for invalid filenames', () => {
       expect(syncUnitFromFileName('invalid.txt')).toBeNull()
       expect(syncUnitFromFileName('other_thing.enc')).toBeNull()

--- a/src/main/__tests__/keyboard-meta.test.ts
+++ b/src/main/__tests__/keyboard-meta.test.ts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+let mockUserDataPath = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+}))
+
+vi.mock('../sync/sync-crypto', () => ({
+  decrypt: vi.fn(async () => '{}'),
+}))
+
+vi.mock('../sync/google-drive', () => ({
+  downloadFile: vi.fn(async () => ({})),
+  driveFileName: (syncUnit: string) => syncUnit.replaceAll('/', '_') + '.enc',
+}))
+
+import {
+  extractDeviceNameFromFilename,
+  extractKeyboardUidsFromDriveFiles,
+  mergeKeyboardMetaIndex,
+  readKeyboardMetaIndex,
+  upsertKeyboardMeta,
+  tombstoneKeyboardMeta,
+  tombstoneAllKeyboardMeta,
+  applyRemoteKeyboardMetaIndex,
+  getActiveKeyboardMetaMap,
+} from '../sync/keyboard-meta'
+import type { KeyboardMetaIndex } from '../../shared/types/keyboard-meta'
+
+beforeEach(async () => {
+  mockUserDataPath = await mkdtemp(join(tmpdir(), 'keyboard-meta-test-'))
+})
+
+afterEach(async () => {
+  if (!mockUserDataPath) return
+  await rm(mockUserDataPath, { recursive: true, force: true })
+  mockUserDataPath = ''
+})
+
+describe('extractDeviceNameFromFilename', () => {
+  it('returns the device name prefix from a snapshot filename', () => {
+    expect(extractDeviceNameFromFilename('GPK60-63R_2026-04-16T10-00-00.000Z.pipette')).toBe('GPK60-63R')
+    expect(extractDeviceNameFromFilename('Jeneko Box 42R_2026-03-15T14-35-29.037Z.pipette')).toBe('Jeneko Box 42R')
+  })
+
+  it('returns null when the filename does not match the expected pattern', () => {
+    expect(extractDeviceNameFromFilename('not-a-snapshot.json')).toBeNull()
+    expect(extractDeviceNameFromFilename('')).toBeNull()
+  })
+})
+
+describe('extractKeyboardUidsFromDriveFiles', () => {
+  it('collects unique uids from snapshot filenames only', () => {
+    const uids = extractKeyboardUidsFromDriveFiles([
+      { id: '1', name: 'keyboards_0xAAA_snapshots.enc', modifiedTime: '' },
+      { id: '2', name: 'keyboards_0xAAA_settings.enc', modifiedTime: '' },
+      { id: '3', name: 'keyboards_0xBBB_snapshots.enc', modifiedTime: '' },
+      { id: '4', name: 'favorites_macro.enc', modifiedTime: '' },
+      { id: '5', name: 'meta_keyboard-names.enc', modifiedTime: '' },
+    ])
+    expect(uids.sort()).toEqual(['0xAAA', '0xBBB'])
+  })
+})
+
+describe('mergeKeyboardMetaIndex', () => {
+  function meta(entries: KeyboardMetaIndex['entries']): KeyboardMetaIndex {
+    return { type: 'keyboard-meta', version: 1, entries }
+  }
+
+  it('keeps remote entries that are unknown locally', () => {
+    const { merged, remoteNeedsUpdate } = mergeKeyboardMetaIndex(
+      meta([]),
+      meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-16T00:00:00.000Z' }]),
+    )
+    expect(merged.entries.map((e) => e.uid)).toEqual(['0xA'])
+    expect(remoteNeedsUpdate).toBe(false)
+  })
+
+  it('marks remote update needed when local has unique entries', () => {
+    const { remoteNeedsUpdate } = mergeKeyboardMetaIndex(
+      meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-16T00:00:00.000Z' }]),
+      meta([]),
+    )
+    expect(remoteNeedsUpdate).toBe(true)
+  })
+
+  it('newest updatedAt wins per uid (LWW)', () => {
+    const local = meta([{ uid: '0xA', deviceName: 'A-old', updatedAt: '2026-04-10T00:00:00.000Z' }])
+    const remote = meta([{ uid: '0xA', deviceName: 'A-new', updatedAt: '2026-04-16T00:00:00.000Z' }])
+    const { merged } = mergeKeyboardMetaIndex(local, remote)
+    expect(merged.entries[0].deviceName).toBe('A-new')
+  })
+
+  it('tombstone with later timestamp keeps deletion', () => {
+    const local = meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-10T00:00:00.000Z' }])
+    const remote = meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-16T00:00:00.000Z', deletedAt: '2026-04-16T00:00:00.000Z' }])
+    const { merged } = mergeKeyboardMetaIndex(local, remote)
+    expect(merged.entries[0].deletedAt).toBeDefined()
+  })
+
+  it('tombstone older than a save lets the save win', () => {
+    const local = meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-16T00:00:00.000Z' }])
+    const remote = meta([{ uid: '0xA', deviceName: 'A', updatedAt: '2026-04-10T00:00:00.000Z', deletedAt: '2026-04-10T00:00:00.000Z' }])
+    const { merged } = mergeKeyboardMetaIndex(local, remote)
+    expect(merged.entries[0].deletedAt).toBeUndefined()
+  })
+})
+
+describe('upsertKeyboardMeta + readKeyboardMetaIndex', () => {
+  it('creates and re-reads an entry, then becomes a no-op when unchanged', async () => {
+    const first = await upsertKeyboardMeta('0xA', 'A')
+    expect(first).toBe('upserted')
+    const noop = await upsertKeyboardMeta('0xA', 'A')
+    expect(noop).toBe('unchanged')
+    const index = await readKeyboardMetaIndex()
+    expect(index.entries).toHaveLength(1)
+    expect(index.entries[0]).toMatchObject({ uid: '0xA', deviceName: 'A' })
+  })
+
+  it('reviving a tombstoned entry updates updatedAt and clears deletedAt', async () => {
+    await upsertKeyboardMeta('0xA', 'A')
+    await tombstoneKeyboardMeta('0xA')
+    const reviveResult = await upsertKeyboardMeta('0xA', 'A')
+    expect(reviveResult).toBe('upserted')
+    const index = await readKeyboardMetaIndex()
+    expect(index.entries[0].deletedAt).toBeUndefined()
+  })
+})
+
+describe('tombstoneKeyboardMeta', () => {
+  it('marks an existing entry deleted and is idempotent', async () => {
+    await upsertKeyboardMeta('0xA', 'A')
+    const first = await tombstoneKeyboardMeta('0xA')
+    expect(first).toBe('tombstoned')
+    const second = await tombstoneKeyboardMeta('0xA')
+    expect(second).toBe('unchanged')
+  })
+
+  it('inserts a tombstone for an unknown uid so other devices learn about the deletion', async () => {
+    const result = await tombstoneKeyboardMeta('0xUnknown')
+    expect(result).toBe('tombstoned')
+    const index = await readKeyboardMetaIndex()
+    expect(index.entries).toHaveLength(1)
+    expect(index.entries[0].deletedAt).toBeDefined()
+  })
+})
+
+describe('tombstoneAllKeyboardMeta', () => {
+  it('tombstones every active entry and reports the count', async () => {
+    await upsertKeyboardMeta('0xA', 'A')
+    await upsertKeyboardMeta('0xB', 'B')
+    const count = await tombstoneAllKeyboardMeta()
+    expect(count).toBe(2)
+    const index = await readKeyboardMetaIndex()
+    expect(index.entries.every((e) => !!e.deletedAt)).toBe(true)
+  })
+})
+
+describe('applyRemoteKeyboardMetaIndex', () => {
+  it('persists merged result and surfaces remoteNeedsUpdate', async () => {
+    await upsertKeyboardMeta('0xA', 'A')
+    const remote: KeyboardMetaIndex = {
+      type: 'keyboard-meta',
+      version: 1,
+      entries: [{ uid: '0xB', deviceName: 'B', updatedAt: '2026-04-16T00:00:00.000Z' }],
+    }
+    const { remoteNeedsUpdate } = await applyRemoteKeyboardMetaIndex(remote)
+    expect(remoteNeedsUpdate).toBe(true)
+    const stored = await readKeyboardMetaIndex()
+    expect(stored.entries.map((e) => e.uid).sort()).toEqual(['0xA', '0xB'])
+  })
+})
+
+describe('getActiveKeyboardMetaMap', () => {
+  it('omits tombstoned entries and entries without a name', () => {
+    const map = getActiveKeyboardMetaMap({
+      type: 'keyboard-meta',
+      version: 1,
+      entries: [
+        { uid: '0xA', deviceName: 'A', updatedAt: 't' },
+        { uid: '0xB', deviceName: 'B', updatedAt: 't', deletedAt: 't' },
+        { uid: '0xC', deviceName: '', updatedAt: 't' },
+      ],
+    })
+    expect(map.get('0xA')).toBe('A')
+    expect(map.has('0xB')).toBe(false)
+    expect(map.has('0xC')).toBe(false)
+  })
+})

--- a/src/main/__tests__/sync-service.test.ts
+++ b/src/main/__tests__/sync-service.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
+import { access, mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 
 // --- Mock electron ---
@@ -918,7 +918,7 @@ describe('sync-service', () => {
       mockGetAuthStatus.mockResolvedValueOnce({ authenticated: false })
 
       const result = await scanRemoteData()
-      expect(result).toEqual({ keyboards: [], favorites: [], undecryptable: [] })
+      expect(result).toEqual({ keyboards: [], keyboardNames: {}, favorites: [], undecryptable: [] })
     })
 
     it('deduplicates keyboard UIDs', async () => {
@@ -1226,7 +1226,10 @@ describe('sync-service', () => {
         expect(downloadedIds).not.toContain('f4') // other keyboard excluded
       })
 
-      it('downloads all files when scope is omitted (backward compat)', async () => {
+      it('downloads all files when scope is omitted and the keyboard is already local', async () => {
+        // Lazy: scope='all' only pulls remote keyboards that already exist locally
+        await mkdir(join(mockUserDataPath, 'sync', 'keyboards', '0x1234'), { recursive: true })
+
         mockListFiles.mockResolvedValue([
           { id: 'f1', name: 'favorites_tapDance.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
           { id: 'f2', name: 'keyboards_0x1234_settings.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
@@ -1244,7 +1247,27 @@ describe('sync-service', () => {
         expect(downloadedIds).toContain('f2')
       })
 
+      it('does not materialize remote-only keyboards locally when scope is omitted (lazy download)', async () => {
+        mockListFiles.mockResolvedValue([
+          { id: 'f1', name: 'favorites_tapDance.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+          { id: 'f2', name: 'keyboards_0xRemoteOnly_snapshots.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+          PASSWORD_CHECK_DRIVE_FILE,
+        ])
+        // Default response covers password-check + favorites + any backfill probe
+        mockDownloadFile.mockResolvedValue(makePasswordCheckEnvelope())
+
+        await executeSync('download')
+
+        // mergeWithRemote should not have run for the remote-only keyboard
+        await expect(
+          access(join(mockUserDataPath, 'sync', 'keyboards', '0xRemoteOnly')),
+        ).rejects.toBeDefined()
+      })
+
       it('updates remote state for all files even with scoped download', async () => {
+        // Local copy of 0x1234 exists, so polling should still pick up changes for it
+        await mkdir(join(mockUserDataPath, 'sync', 'keyboards', '0x1234'), { recursive: true })
+
         const allFiles = [
           { id: 'f1', name: 'favorites_tapDance.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
           { id: 'f2', name: 'keyboards_0x1234_settings.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
@@ -1271,9 +1294,39 @@ describe('sync-service', () => {
         await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
         await flushIO()
 
-        // Polling should detect the keyboard file changed
+        // Polling should detect the keyboard file changed for the locally-tracked keyboard
         expect(mockDownloadFile).toHaveBeenCalledWith('f2')
 
+        stopPolling()
+      })
+
+      it('polling skips remote-only keyboards (lazy)', async () => {
+        // No local directory for 0xRemoteOnly — polling should not download it
+        const initialFiles = [
+          { id: 'f1', name: 'favorites_tapDance.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+          { id: 'f2', name: 'keyboards_0xRemoteOnly_snapshots.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+          PASSWORD_CHECK_DRIVE_FILE,
+        ]
+        mockListFiles.mockResolvedValue(initialFiles)
+        mockDownloadFile
+          .mockResolvedValueOnce(makePasswordCheckEnvelope())
+          .mockResolvedValueOnce(makeRemoteEnvelope('2025-01-01T00:00:00.000Z'))
+
+        await executeSync('download')
+
+        const updatedFiles = [
+          ...initialFiles.slice(0, 1),
+          { id: 'f2', name: 'keyboards_0xRemoteOnly_snapshots.enc', modifiedTime: '2025-01-02T00:00:00.000Z' },
+          PASSWORD_CHECK_DRIVE_FILE,
+        ]
+        mockListFiles.mockResolvedValue(updatedFiles)
+
+        mockDownloadFile.mockClear()
+        startPolling()
+        await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+        await flushIO()
+
+        expect(mockDownloadFile).not.toHaveBeenCalledWith('f2')
         stopPolling()
       })
 

--- a/src/main/snapshot-store.ts
+++ b/src/main/snapshot-store.ts
@@ -7,6 +7,8 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { IpcChannels } from '../shared/ipc/channels'
 import { notifyChange } from './sync/sync-service'
+import { upsertKeyboardMeta } from './sync/keyboard-meta'
+import { KEYBOARD_META_SYNC_UNIT } from '../shared/types/keyboard-meta'
 import { secureHandle } from './ipc-guard'
 import type { SnapshotMeta, SnapshotIndex } from '../shared/types/snapshot-store'
 
@@ -152,6 +154,12 @@ export function setupSnapshotStore(): void {
           await writeIndex(uid, index)
 
           notifyChange(`keyboards/${uid}/snapshots`)
+
+          const metaResult = await upsertKeyboardMeta(uid, deviceName)
+          if (metaResult === 'upserted') {
+            notifyChange(KEYBOARD_META_SYNC_UNIT)
+          }
+
           return { success: true, entry }
         })
       } catch (err) {

--- a/src/main/sync/google-drive.ts
+++ b/src/main/sync/google-drive.ts
@@ -3,6 +3,7 @@
 
 import { getAccessToken } from './google-auth'
 import { pLimit } from '../../shared/concurrency'
+import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import type { SyncEnvelope } from '../../shared/types/sync'
 
 const DRIVE_API = 'https://www.googleapis.com/drive/v3'
@@ -149,6 +150,8 @@ export function syncUnitFromFileName(fileName: string): string | null {
   // "favorites_tapDance.enc" → "favorites/tapDance"
   const favMatch = fileName.match(/^favorites_(.+)\.enc$/)
   if (favMatch) return `favorites/${favMatch[1]}`
+
+  if (fileName === driveFileName(KEYBOARD_META_SYNC_UNIT)) return KEYBOARD_META_SYNC_UNIT
 
   return null
 }

--- a/src/main/sync/keyboard-meta.ts
+++ b/src/main/sync/keyboard-meta.ts
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// UID -> deviceName mapping persisted as a synced "meta/keyboard-names" unit.
+
+import { app } from 'electron'
+import { join } from 'node:path'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { pLimit } from '../../shared/concurrency'
+import { decrypt } from './sync-crypto'
+import { downloadFile, driveFileName } from './google-drive'
+import type { DriveFile } from './google-drive'
+import type { SnapshotIndex } from '../../shared/types/snapshot-store'
+import {
+  createEmptyKeyboardMetaIndex,
+  type KeyboardMetaEntry,
+  type KeyboardMetaIndex,
+} from '../../shared/types/keyboard-meta'
+
+const META_DIR = 'meta'
+const META_FILE = 'keyboard-names.json'
+const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+const DEVICE_NAME_FROM_FILENAME = /^(.+?)_\d{4}-\d{2}-/
+const BACKFILL_CONCURRENCY = 5
+
+export function keyboardMetaFilePath(): string {
+  return join(app.getPath('userData'), 'sync', META_DIR, META_FILE)
+}
+
+function metaFilePath(): string {
+  return keyboardMetaFilePath()
+}
+
+export async function readKeyboardMetaIndex(): Promise<KeyboardMetaIndex> {
+  try {
+    const raw = await readFile(metaFilePath(), 'utf-8')
+    const parsed = JSON.parse(raw) as KeyboardMetaIndex
+    if (parsed?.type !== 'keyboard-meta' || !Array.isArray(parsed.entries)) {
+      return createEmptyKeyboardMetaIndex()
+    }
+    return parsed
+  } catch {
+    return createEmptyKeyboardMetaIndex()
+  }
+}
+
+async function writeKeyboardMetaIndex(index: KeyboardMetaIndex): Promise<void> {
+  const filePath = metaFilePath()
+  await mkdir(join(app.getPath('userData'), 'sync', META_DIR), { recursive: true })
+  await writeFile(filePath, JSON.stringify(index, null, 2), 'utf-8')
+}
+
+// Serialize writes so concurrent upsert/tombstone calls can't clobber each other.
+let metaWriteChain: Promise<unknown> = Promise.resolve()
+
+async function withMetaWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = metaWriteChain.then(() => fn(), () => fn())
+  metaWriteChain = next.catch(() => undefined)
+  return next
+}
+
+export function extractDeviceNameFromFilename(filename: string): string | null {
+  const match = filename.match(DEVICE_NAME_FROM_FILENAME)
+  return match ? match[1] : null
+}
+
+function findEntry(index: KeyboardMetaIndex, uid: string): KeyboardMetaEntry | undefined {
+  return index.entries.find((entry) => entry.uid === uid)
+}
+
+function gcKeyboardMetaTombstones(entries: KeyboardMetaEntry[], now = Date.now()): KeyboardMetaEntry[] {
+  return entries.filter((entry) => {
+    if (!entry.deletedAt) return true
+    const deletedTime = new Date(entry.deletedAt).getTime()
+    if (Number.isNaN(deletedTime)) return true
+    return now - deletedTime < TOMBSTONE_TTL_MS
+  })
+}
+
+export async function upsertKeyboardMeta(
+  uid: string,
+  deviceName: string,
+): Promise<'unchanged' | 'upserted'> {
+  const normalized = deviceName.trim()
+  if (!uid || !normalized) return 'unchanged'
+  return withMetaWriteLock(async () => {
+    const index = await readKeyboardMetaIndex()
+    const existing = findEntry(index, uid)
+    const now = new Date().toISOString()
+    if (existing) {
+      if (!existing.deletedAt && existing.deviceName === normalized) {
+        return 'unchanged'
+      }
+      existing.deviceName = normalized
+      existing.updatedAt = now
+      delete existing.deletedAt
+    } else {
+      index.entries.push({ uid, deviceName: normalized, updatedAt: now })
+    }
+    index.entries = gcKeyboardMetaTombstones(index.entries)
+    await writeKeyboardMetaIndex(index)
+    return 'upserted'
+  })
+}
+
+export async function tombstoneKeyboardMeta(uid: string): Promise<'unchanged' | 'tombstoned'> {
+  if (!uid) return 'unchanged'
+  return withMetaWriteLock(async () => {
+    const index = await readKeyboardMetaIndex()
+    const existing = findEntry(index, uid)
+    const now = new Date().toISOString()
+    if (!existing) {
+      index.entries.push({ uid, deviceName: '', updatedAt: now, deletedAt: now })
+    } else if (existing.deletedAt) {
+      return 'unchanged'
+    } else {
+      existing.updatedAt = now
+      existing.deletedAt = now
+    }
+    index.entries = gcKeyboardMetaTombstones(index.entries)
+    await writeKeyboardMetaIndex(index)
+    return 'tombstoned'
+  })
+}
+
+export async function tombstoneAllKeyboardMeta(): Promise<number> {
+  return withMetaWriteLock(async () => {
+    const index = await readKeyboardMetaIndex()
+    const now = new Date().toISOString()
+    let count = 0
+    for (const entry of index.entries) {
+      if (entry.deletedAt) continue
+      entry.updatedAt = now
+      entry.deletedAt = now
+      count++
+    }
+    if (count > 0) {
+      index.entries = gcKeyboardMetaTombstones(index.entries)
+      await writeKeyboardMetaIndex(index)
+    }
+    return count
+  })
+}
+
+function entryEffectiveTime(entry: KeyboardMetaEntry): number {
+  const source = entry.deletedAt ?? entry.updatedAt
+  const t = source ? new Date(source).getTime() : 0
+  return Number.isNaN(t) ? 0 : t
+}
+
+export function mergeKeyboardMetaIndex(
+  local: KeyboardMetaIndex,
+  remote: KeyboardMetaIndex,
+): { merged: KeyboardMetaIndex; remoteNeedsUpdate: boolean } {
+  const byUid = new Map<string, { local?: KeyboardMetaEntry; remote?: KeyboardMetaEntry }>()
+  for (const entry of local.entries) {
+    byUid.set(entry.uid, { ...(byUid.get(entry.uid) ?? {}), local: entry })
+  }
+  for (const entry of remote.entries) {
+    byUid.set(entry.uid, { ...(byUid.get(entry.uid) ?? {}), remote: entry })
+  }
+
+  const mergedEntries: KeyboardMetaEntry[] = []
+  let remoteNeedsUpdate = false
+
+  for (const { local: l, remote: r } of byUid.values()) {
+    if (l && !r) {
+      mergedEntries.push(l)
+      remoteNeedsUpdate = true
+    } else if (!l && r) {
+      mergedEntries.push(r)
+    } else if (l && r) {
+      const lt = entryEffectiveTime(l)
+      const rt = entryEffectiveTime(r)
+      if (rt > lt) {
+        mergedEntries.push(r)
+      } else if (lt > rt) {
+        mergedEntries.push(l)
+        remoteNeedsUpdate = true
+      } else {
+        mergedEntries.push(l)
+      }
+    }
+  }
+
+  const gced = gcKeyboardMetaTombstones(mergedEntries)
+  if (gced.length !== mergedEntries.length) {
+    remoteNeedsUpdate = true
+  }
+
+  return {
+    merged: { type: 'keyboard-meta', version: 1, entries: gced },
+    remoteNeedsUpdate,
+  }
+}
+
+export function extractKeyboardUidsFromDriveFiles(driveFiles: DriveFile[]): string[] {
+  const uids = new Set<string>()
+  for (const file of driveFiles) {
+    const match = file.name.match(/^keyboards_(.+?)_snapshots\.enc$/)
+    if (match) uids.add(match[1])
+  }
+  return Array.from(uids)
+}
+
+async function resolveDeviceNameFromLocalSnapshots(uid: string): Promise<string | null> {
+  const snapshotIndexPath = join(
+    app.getPath('userData'),
+    'sync',
+    'keyboards',
+    uid,
+    'snapshots',
+    'index.json',
+  )
+  try {
+    const raw = await readFile(snapshotIndexPath, 'utf-8')
+    const parsed = JSON.parse(raw) as SnapshotIndex
+    const active = parsed.entries?.find((entry) => !entry.deletedAt)
+    if (!active) return null
+    return extractDeviceNameFromFilename(active.filename)
+  } catch {
+    return null
+  }
+}
+
+async function resolveDeviceNameFromRemoteSnapshots(
+  uid: string,
+  password: string,
+  driveFiles: DriveFile[],
+): Promise<string | null> {
+  const target = driveFiles.find((file) => file.name === driveFileName(`keyboards/${uid}/snapshots`))
+  if (!target) return null
+  try {
+    const envelope = await downloadFile(target.id)
+    const plaintext = await decrypt(envelope, password)
+    const bundle = JSON.parse(plaintext) as { index?: SnapshotIndex }
+    const active = bundle.index?.entries?.find((entry) => !entry.deletedAt)
+    if (!active) return null
+    return extractDeviceNameFromFilename(active.filename)
+  } catch {
+    return null
+  }
+}
+
+export interface BackfillResult {
+  resolved: number
+  failed: string[]
+}
+
+export async function backfillKeyboardMeta(
+  password: string,
+  driveFiles: DriveFile[],
+): Promise<BackfillResult> {
+  const metaIndex = await readKeyboardMetaIndex()
+  // Skip both active AND tombstoned uids: a tombstone explicitly opts the uid out of backfill
+  // until a fresh `upsertKeyboardMeta` (e.g. snapshot save) revives it intentionally.
+  const knownUids = new Set(metaIndex.entries.map((entry) => entry.uid))
+  const driveUids = extractKeyboardUidsFromDriveFiles(driveFiles)
+  const missingUids = driveUids.filter((uid) => !knownUids.has(uid))
+  if (missingUids.length === 0) return { resolved: 0, failed: [] }
+
+  const limit = pLimit(BACKFILL_CONCURRENCY)
+  const settled = await Promise.allSettled(
+    missingUids.map((uid) =>
+      limit(async () => {
+        const local = await resolveDeviceNameFromLocalSnapshots(uid)
+        const deviceName = local ?? (await resolveDeviceNameFromRemoteSnapshots(uid, password, driveFiles))
+        return { uid, deviceName }
+      }),
+    ),
+  )
+
+  const toUpsert: { uid: string; deviceName: string }[] = []
+  const failed: string[] = []
+  for (const r of settled) {
+    if (r.status !== 'fulfilled') continue
+    if (r.value.deviceName) {
+      toUpsert.push({ uid: r.value.uid, deviceName: r.value.deviceName })
+    } else {
+      failed.push(r.value.uid)
+    }
+  }
+
+  const resolved = await batchUpsertKeyboardMeta(toUpsert)
+  return { resolved, failed }
+}
+
+export async function batchUpsertKeyboardMeta(
+  entries: ReadonlyArray<{ uid: string; deviceName: string }>,
+): Promise<number> {
+  if (entries.length === 0) return 0
+  return withMetaWriteLock(async () => {
+    const index = await readKeyboardMetaIndex()
+    const now = new Date().toISOString()
+    let count = 0
+    for (const { uid, deviceName } of entries) {
+      const normalized = deviceName.trim()
+      if (!uid || !normalized) continue
+      const existing = findEntry(index, uid)
+      if (existing) {
+        if (!existing.deletedAt && existing.deviceName === normalized) continue
+        existing.deviceName = normalized
+        existing.updatedAt = now
+        delete existing.deletedAt
+      } else {
+        index.entries.push({ uid, deviceName: normalized, updatedAt: now })
+      }
+      count++
+    }
+    if (count > 0) {
+      index.entries = gcKeyboardMetaTombstones(index.entries)
+      await writeKeyboardMetaIndex(index)
+    }
+    return count
+  })
+}
+
+export function getActiveKeyboardMetaMap(index: KeyboardMetaIndex): Map<string, string> {
+  const map = new Map<string, string>()
+  for (const entry of index.entries) {
+    if (entry.deletedAt || !entry.deviceName) continue
+    map.set(entry.uid, entry.deviceName)
+  }
+  return map
+}
+
+export async function applyRemoteKeyboardMetaIndex(
+  remote: KeyboardMetaIndex,
+): Promise<{ remoteNeedsUpdate: boolean }> {
+  return withMetaWriteLock(async () => {
+    const local = await readKeyboardMetaIndex()
+    const { merged, remoteNeedsUpdate } = mergeKeyboardMetaIndex(local, remote)
+    await writeKeyboardMetaIndex(merged)
+    return { remoteNeedsUpdate }
+  })
+}

--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -5,10 +5,12 @@ import { app } from 'electron'
 import { join } from 'node:path'
 import { readFile, readdir, access } from 'node:fs/promises'
 import { gcTombstones } from './merge'
+import { keyboardMetaFilePath, readKeyboardMetaIndex } from './keyboard-meta'
 import { FAVORITE_TYPES } from '../../shared/favorite-data'
 import type { FavoriteIndex } from '../../shared/types/favorite-store'
 import type { SnapshotIndex } from '../../shared/types/snapshot-store'
 import type { SyncBundle } from '../../shared/types/sync'
+import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 
 export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | null> {
   try {
@@ -20,6 +22,11 @@ export async function readIndexFile(dir: string): Promise<FavoriteIndex | Snapsh
 }
 
 export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | null> {
+  if (syncUnit === KEYBOARD_META_SYNC_UNIT) {
+    const index = await readKeyboardMetaIndex()
+    return { type: 'keyboard-meta', key: 'keyboard-names', index, files: {} }
+  }
+
   const parts = syncUnit.split('/')
   const userData = app.getPath('userData')
 
@@ -68,7 +75,12 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
 
 export async function collectAllSyncUnits(): Promise<string[]> {
   const userData = app.getPath('userData')
-  const units = FAVORITE_TYPES.map((type) => `favorites/${type}`)
+  const units: string[] = FAVORITE_TYPES.map((type) => `favorites/${type}`)
+
+  try {
+    await access(keyboardMetaFilePath())
+    units.push(KEYBOARD_META_SYNC_UNIT)
+  } catch { /* no meta */ }
 
   // Scan sync/keyboards/{uid}/ for settings and snapshots
   const keyboardsDir = join(userData, 'sync', 'keyboards')

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -38,6 +38,15 @@ import type { SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTarget
 import { secureHandle, secureOn } from '../ipc-guard'
 import type { FavoriteIndex, SavedFavoriteMeta } from '../../shared/types/favorite-store'
 import type { SnapshotIndex, SnapshotMeta } from '../../shared/types/snapshot-store'
+import {
+  extractDeviceNameFromFilename,
+  getActiveKeyboardMetaMap,
+  readKeyboardMetaIndex,
+  tombstoneAllKeyboardMeta,
+  tombstoneKeyboardMeta,
+  upsertKeyboardMeta,
+} from './keyboard-meta'
+import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 
 interface IpcResult {
   success: boolean
@@ -178,20 +187,26 @@ export function setupSyncIpc(): void {
       }
       if (!hasKeyboards && !targets.favorites) throw new Error('No targets selected')
       if (isSyncInProgress()) throw new Error('Cannot reset while sync is in progress')
+      let metaChanged = false
       if (targets.keyboards === true) {
         cancelPendingChanges('keyboards/')
         await deleteFilesByPrefix('keyboards_')
+        const tombstoned = await tombstoneAllKeyboardMeta()
+        if (tombstoned > 0) metaChanged = true
       } else if (Array.isArray(targets.keyboards)) {
         for (const uid of targets.keyboards) {
           if (typeof uid !== 'string' || !isSafeKey(uid)) throw new Error('Invalid keyboard UID')
           cancelPendingChanges(`keyboards/${uid}/`)
           await deleteFilesByPrefix(`keyboards_${uid}_`)
+          const result = await tombstoneKeyboardMeta(uid)
+          if (result === 'tombstoned') metaChanged = true
         }
       }
       if (targets.favorites) {
         cancelPendingChanges('favorites/')
         await deleteFilesByPrefix('favorites_')
       }
+      if (metaChanged) notifyChange(KEYBOARD_META_SYNC_UNIT)
     }),
   )
 
@@ -226,27 +241,34 @@ export function setupSyncIpc(): void {
     const userData = app.getPath('userData')
     const keyboardsDir = join(userData, 'sync', 'keyboards')
     const results: StoredKeyboardInfo[] = []
+    const metaIndex = await readKeyboardMetaIndex()
+    const metaMap = getActiveKeyboardMetaMap(metaIndex)
+    let metaBackfilled = false
     try {
       const entries = await readdir(keyboardsDir, { withFileTypes: true })
       for (const entry of entries) {
         if (!entry.isDirectory()) continue
         const uid = entry.name
         if (!isSafeKey(uid)) continue
-        let name = uid
-        // Try to extract device name from first snapshot entry filename
-        try {
-          const raw = await readFile(join(keyboardsDir, uid, 'snapshots', 'index.json'), 'utf-8')
-          const index = JSON.parse(raw) as SnapshotIndex
-          const active = index.entries.find((e) => !e.deletedAt)
-          if (active) {
-            // filename: "{deviceName}_{ISO_timestamp}.pipette"
-            const match = active.filename.match(/^(.+?)_\d{4}-\d{2}-/)
-            if (match) name = match[1]
-          }
-        } catch { /* no snapshots */ }
+        let name = metaMap.get(uid) ?? uid
+        // Fallback: derive name from snapshot filename and backfill meta
+        if (name === uid) {
+          try {
+            const raw = await readFile(join(keyboardsDir, uid, 'snapshots', 'index.json'), 'utf-8')
+            const index = JSON.parse(raw) as SnapshotIndex
+            const active = index.entries.find((e) => !e.deletedAt)
+            const extracted = active ? extractDeviceNameFromFilename(active.filename) : null
+            if (extracted) {
+              name = extracted
+              const result = await upsertKeyboardMeta(uid, extracted)
+              if (result === 'upserted') metaBackfilled = true
+            }
+          } catch { /* no snapshots */ }
+        }
         results.push({ uid, name })
       }
     } catch { /* dir doesn't exist */ }
+    if (metaBackfilled) notifyChange(KEYBOARD_META_SYNC_UNIT)
     return results
   })
 
@@ -262,6 +284,11 @@ export function setupSyncIpc(): void {
       await rm(join(userData, 'sync', 'keyboards', uid), { recursive: true, force: true })
       // Best-effort remote deletion
       await deleteFilesByPrefix(`keyboards_${uid}_`).catch(() => {})
+      // Tombstone meta entry so other devices see the removal
+      const tombstoneResult = await tombstoneKeyboardMeta(uid)
+      if (tombstoneResult === 'tombstoned') {
+        notifyChange(KEYBOARD_META_SYNC_UNIT)
+      }
     }),
   )
 

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -3,7 +3,7 @@
 
 import { app, BrowserWindow } from 'electron'
 import { join } from 'node:path'
-import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises'
 import { encrypt, decrypt, retrievePassword, storePassword, clearPassword } from './sync-crypto'
 import { loadAppConfig } from '../app-config'
 import { getAuthStatus } from './google-auth'
@@ -19,6 +19,13 @@ import { pLimit } from '../../shared/concurrency'
 import { IpcChannels } from '../../shared/ipc/channels'
 import { mergeEntries, gcTombstones } from './merge'
 import { readIndexFile, bundleSyncUnit, collectAllSyncUnits } from './sync-bundle'
+import {
+  applyRemoteKeyboardMetaIndex,
+  backfillKeyboardMeta,
+  getActiveKeyboardMetaMap,
+  readKeyboardMetaIndex,
+} from './keyboard-meta'
+import { KEYBOARD_META_SYNC_UNIT, type KeyboardMetaIndex } from '../../shared/types/keyboard-meta'
 import type { SyncBundle, SyncProgress, SyncEnvelope, UndecryptableFile, SyncDataScanResult, SyncScope } from '../../shared/types/sync'
 
 const SYNC_CONCURRENCY = 10
@@ -89,11 +96,41 @@ function errorMessage(err: unknown, fallback: string): string {
 export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean {
   if (scope === 'all') return true
   if (syncUnit === null) return false
+  if (syncUnit === KEYBOARD_META_SYNC_UNIT) return true // meta follows every scope
   if (scope === 'favorites') return syncUnit.startsWith('favorites/')
   if (typeof scope === 'object' && 'favorites' in scope) {
     return syncUnit.startsWith('favorites/') || syncUnit.startsWith(`keyboards/${scope.keyboard}/`)
   }
   return syncUnit.startsWith(`keyboards/${scope.keyboard}/`)
+}
+
+async function listLocalKeyboardUids(): Promise<Set<string>> {
+  const userData = app.getPath('userData')
+  const keyboardsDir = join(userData, 'sync', 'keyboards')
+  const uids = new Set<string>()
+  try {
+    const entries = await readdir(keyboardsDir, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isDirectory()) uids.add(entry.name)
+    }
+  } catch { /* dir doesn't exist */ }
+  return uids
+}
+
+function shouldDownloadSyncUnit(
+  syncUnit: string | null,
+  scope: SyncScope,
+  localKeyboardUids: Set<string>,
+): boolean {
+  if (!syncUnit) return false
+  if (!matchesScope(syncUnit, scope)) return false
+  // Lazy: when scope is 'all' only download keyboards/<uid>/* that already exist locally.
+  // Explicit keyboard scopes always download in full.
+  if (syncUnit.startsWith('keyboards/') && scope === 'all') {
+    const uid = syncUnit.split('/')[1]
+    return !!uid && localKeyboardUids.has(uid)
+  }
+  return true
 }
 
 async function requireSyncCredentials(): Promise<string | null> {
@@ -147,7 +184,7 @@ export async function listUndecryptableFiles(): Promise<UndecryptableFile[]> {
 
 export async function scanRemoteData(): Promise<SyncDataScanResult> {
   const result = await fetchValidatedDataFiles()
-  if (!result) return { keyboards: [], favorites: [], undecryptable: [] }
+  if (!result) return { keyboards: [], keyboardNames: {}, favorites: [], undecryptable: [] }
   const { password, dataFiles } = result
 
   // Categorize from filenames (no download needed)
@@ -165,10 +202,22 @@ export async function scanRemoteData(): Promise<SyncDataScanResult> {
     }
   }
 
+  // Use whatever names are already in the local meta index (populated by executeSync/backfill
+  // and the LIST_STORED_KEYBOARDS safety net). scanRemoteData stays read-only here so it
+  // doesn't trigger extra downloads or writes.
+  const metaIndex = await readKeyboardMetaIndex()
+  const metaMap = getActiveKeyboardMetaMap(metaIndex)
+  const keyboardNames: Record<string, string> = {}
+  for (const uid of keyboardUids) {
+    const name = metaMap.get(uid)
+    if (name) keyboardNames[uid] = name
+  }
+
   const undecryptable = await findUndecryptableFiles(password, dataFiles)
 
   return {
     keyboards: [...keyboardUids],
+    keyboardNames,
     favorites: [...favoriteTypes],
     undecryptable,
   }
@@ -330,6 +379,13 @@ async function mergeSyncUnit(
   const plaintext = await decrypt(envelope, password)
   const remoteBundle = JSON.parse(plaintext) as SyncBundle
 
+  // Handle meta/keyboard-names (entry-level LWW, no data files)
+  if (syncUnit === KEYBOARD_META_SYNC_UNIT) {
+    const remoteIndex = remoteBundle.index as KeyboardMetaIndex
+    const { remoteNeedsUpdate } = await applyRemoteKeyboardMetaIndex(remoteIndex)
+    return remoteNeedsUpdate
+  }
+
   const parts = syncUnit.split('/')
   const userData = app.getPath('userData')
 
@@ -445,6 +501,13 @@ export async function executeSync(
     let failedUnits: string[]
     if (direction === 'download') {
       failedUnits = await executeDownloadSync(password, initialFiles, scope)
+      if (scope === 'all') {
+        const { resolved } = await backfillKeyboardMeta(password, initialFiles)
+        if (resolved > 0) {
+          pendingChanges.add(KEYBOARD_META_SYNC_UNIT)
+          broadcastPendingStatus()
+        }
+      }
     } else {
       failedUnits = await executeUploadSync(password, initialFiles, scope)
       // Clear pending changes matching the scope, then re-add failed units
@@ -487,9 +550,10 @@ async function executeDownloadSync(
   const remoteFiles = prefetchedFiles ?? await listFiles()
   updateRemoteState(remoteFiles) // Always record full remote state for polling
 
+  const localKeyboardUids = await listLocalKeyboardUids()
   const filesToDownload = remoteFiles.filter((f) => {
     const syncUnit = syncUnitFromFileName(f.name)
-    return matchesScope(syncUnit, scope)
+    return shouldDownloadSyncUnit(syncUnit, scope, localKeyboardUids)
   })
 
   const total = filesToDownload.length
@@ -612,9 +676,12 @@ async function pollForRemoteChanges(): Promise<void> {
       return
     }
 
-    const changedFiles = remoteFiles.filter(
-      (file) => lastKnownRemoteState.get(file.name) !== file.modifiedTime,
-    )
+    const localKeyboardUids = await listLocalKeyboardUids()
+    const changedFiles = remoteFiles.filter((file) => {
+      if (lastKnownRemoteState.get(file.name) === file.modifiedTime) return false
+      const syncUnit = syncUnitFromFileName(file.name)
+      return shouldDownloadSyncUnit(syncUnit, 'all', localKeyboardUids)
+    })
 
     updateRemoteState(remoteFiles)
 
@@ -634,7 +701,9 @@ async function pollForRemoteChanges(): Promise<void> {
               message: 'Sync complete',
             })
           } catch {
-            // Polling merge failed — will retry next poll
+            // Forget the modifiedTime so the next poll re-detects this file as changed
+            // and gets another chance to merge it.
+            lastKnownRemoteState.delete(remoteFile.name)
           }
         }),
       ),

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -272,6 +272,9 @@ export function DataModal({
               hubKeyboardNames={hubKeyboardNames}
               syncScanResult={nav.syncScanResult}
               syncScanning={nav.syncScanning}
+              onSyncKeyboardSelect={nav.onSyncKeyboardSelect}
+              downloadingUid={nav.downloadingUid}
+              downloadErrorByUid={nav.downloadErrorByUid}
             />
           </div>
 

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import { Fragment } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DataNavPath } from './data-modal-types'
 import type { StoredKeyboardInfo, SyncDataScanResult } from '../../../shared/types/sync'
@@ -15,6 +16,9 @@ interface Props {
   hubKeyboardNames: string[]
   syncScanResult: SyncDataScanResult | null
   syncScanning: boolean
+  onSyncKeyboardSelect: (uid: string, name: string) => void | Promise<void>
+  downloadingUid: string | null
+  downloadErrorByUid: Record<string, string>
 }
 
 const FAVORITE_TYPES: { type: FavoriteType; labelKey: string }[] = [
@@ -102,8 +106,16 @@ function Branch({ label, depth, open, onToggle, testId, children }: BranchProps)
   )
 }
 
-export function DataNavTree({ storedKeyboards, activePath, onNavigate, isExpanded, onToggle, showHubTab, hubKeyboardNames, syncScanResult, syncScanning }: Props) {
+export function DataNavTree({ storedKeyboards, activePath, onNavigate, isExpanded, onToggle, showHubTab, hubKeyboardNames, syncScanResult, syncScanning, onSyncKeyboardSelect, downloadingUid, downloadErrorByUid }: Props) {
   const { t } = useTranslation()
+
+  function resolveSyncKeyboardName(uid: string): string {
+    return (
+      syncScanResult?.keyboardNames?.[uid] ??
+      storedKeyboards.find((kb) => kb.uid === uid)?.name ??
+      uid
+    )
+  }
 
   return (
     <div className="flex flex-col gap-0.5 py-2 px-1" data-testid="data-nav-tree">
@@ -207,16 +219,32 @@ export function DataNavTree({ storedKeyboards, activePath, onNavigate, isExpande
             onToggle={() => onToggle('sync-keyboards')}
             testId="nav-sync-keyboards"
           >
-            {syncScanResult.keyboards.map((uid) => (
-              <Leaf
-                key={uid}
-                label={storedKeyboards.find((kb) => kb.uid === uid)?.name ?? uid}
-                depth={2}
-                active={isActivePath(activePath, { section: 'sync', page: 'sync-keyboard', uid, name: '' })}
-                onClick={() => onNavigate({ section: 'sync', page: 'sync-keyboard', uid, name: storedKeyboards.find((kb) => kb.uid === uid)?.name ?? uid })}
-                testId={`nav-sync-kb-${uid}`}
-              />
-            ))}
+            {syncScanResult.keyboards.map((uid) => {
+              const name = resolveSyncKeyboardName(uid)
+              const isDownloading = downloadingUid === uid
+              const error = downloadErrorByUid[uid]
+              const label = isDownloading ? `${name} (${t('sync.downloading')})` : name
+              return (
+                <Fragment key={uid}>
+                  <Leaf
+                    label={label}
+                    depth={2}
+                    active={isActivePath(activePath, { section: 'sync', page: 'sync-keyboard', uid, name })}
+                    onClick={() => { if (!isDownloading) void onSyncKeyboardSelect(uid, name) }}
+                    testId={`nav-sync-kb-${uid}`}
+                  />
+                  {error && (
+                    <div
+                      className="text-[11px] text-danger py-1"
+                      style={{ paddingLeft: `${2 * 14 + 8}px` }}
+                      data-testid={`nav-sync-kb-${uid}-error`}
+                    >
+                      {error}
+                    </div>
+                  )}
+                </Fragment>
+              )
+            })}
           </Branch>
         )}
       </Branch>

--- a/src/renderer/components/data-modal/useDataNavTree.ts
+++ b/src/renderer/components/data-modal/useDataNavTree.ts
@@ -9,6 +9,10 @@ export interface UseDataNavTreeOptions {
   syncEnabled: boolean
 }
 
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'Download failed'
+}
+
 // Persist tree state across modal open/close within the same session
 let cachedExpandedNodes: Set<string> | null = null
 let cachedActivePath: DataNavPath | null = null
@@ -31,6 +35,10 @@ export function useDataNavTree({ showHubTab, syncEnabled }: UseDataNavTreeOption
   const [syncScanResult, setSyncScanResult] = useState<SyncDataScanResult | null>(null)
   const [syncScanning, setSyncScanning] = useState(false)
   const syncScannedRef = useRef(false)
+
+  // Lazy-download state for sync keyboards
+  const [downloadingUid, setDownloadingUid] = useState<string | null>(null)
+  const [downloadErrorByUid, setDownloadErrorByUid] = useState<Record<string, string>>({})
 
   useEffect(() => {
     if (fetchedRef.current) return
@@ -82,6 +90,43 @@ export function useDataNavTree({ showHubTab, syncEnabled }: UseDataNavTreeOption
     setStoredKeyboards(keyboards)
   }, [])
 
+  const onSyncKeyboardSelect = useCallback(
+    async (uid: string, name: string) => {
+      // Already local — switch immediately, no network needed
+      const local = storedKeyboards.find((kb) => kb.uid === uid)
+      if (local) {
+        setActivePath({ section: 'local', page: 'keyboard', uid, name: local.name })
+        return
+      }
+      // Block concurrent downloads: executeSync silently no-ops while another sync runs,
+      // so dispatching multiple clicks would otherwise "succeed" without producing data.
+      if (downloadingUid !== null) return
+      setDownloadingUid(uid)
+      setDownloadErrorByUid((prev) => {
+        if (!(uid in prev)) return prev
+        const next = { ...prev }
+        delete next[uid]
+        return next
+      })
+      try {
+        await window.vialAPI.syncExecute('download', { keyboard: uid })
+        const refreshed = await window.vialAPI.listStoredKeyboards()
+        setStoredKeyboards(refreshed)
+        const downloaded = refreshed.find((kb) => kb.uid === uid)
+        if (downloaded) {
+          setActivePath({ section: 'local', page: 'keyboard', uid, name: downloaded.name || name })
+        } else {
+          setDownloadErrorByUid((prev) => ({ ...prev, [uid]: 'Downloaded data not found locally' }))
+        }
+      } catch (err) {
+        setDownloadErrorByUid((prev) => ({ ...prev, [uid]: errorMessage(err) }))
+      } finally {
+        setDownloadingUid(null)
+      }
+    },
+    [storedKeyboards, downloadingUid],
+  )
+
   const toggleExpand = useCallback((nodeId: string) => {
     setExpandedNodes((prev) => {
       const next = new Set(prev)
@@ -105,5 +150,8 @@ export function useDataNavTree({ showHubTab, syncEnabled }: UseDataNavTreeOption
     syncScanResult: filteredSyncScanResult,
     syncScanning,
     handleSyncScan,
+    onSyncKeyboardSelect,
+    downloadingUid,
+    downloadErrorByUid,
   }
 }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -537,6 +537,7 @@
     "scanRemoteDesc": "Scan remote data to see what is stored in Google Drive.",
     "scanUndecryptable": "Scan",
     "scanning": "Scanning...",
+    "downloading": "Downloading...",
     "noRemoteData": "No remote data found",
     "noUndecryptable": "No undecryptable files found",
     "undecryptableCount": "{{count}} undecryptable file(s)",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -536,6 +536,7 @@
     "scanRemoteDesc": "Google Drive に保存されているデータをスキャンします。",
     "scanUndecryptable": "スキャン",
     "scanning": "スキャン中...",
+    "downloading": "ダウンロード中...",
     "noRemoteData": "リモートデータはありません",
     "noUndecryptable": "復号できないファイルはありません",
     "undecryptableCount": "{{count}} 件の復号できないファイル",

--- a/src/shared/types/keyboard-meta.ts
+++ b/src/shared/types/keyboard-meta.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+export interface KeyboardMetaEntry {
+  uid: string
+  deviceName: string
+  updatedAt: string
+  deletedAt?: string
+}
+
+export interface KeyboardMetaIndex {
+  type: 'keyboard-meta'
+  version: 1
+  entries: KeyboardMetaEntry[]
+}
+
+export const KEYBOARD_META_SYNC_UNIT = 'meta/keyboard-names' as const
+export type KeyboardMetaSyncUnit = typeof KEYBOARD_META_SYNC_UNIT
+
+export function createEmptyKeyboardMetaIndex(): KeyboardMetaIndex {
+  return { type: 'keyboard-meta', version: 1, entries: [] }
+}

--- a/src/shared/types/sync.ts
+++ b/src/shared/types/sync.ts
@@ -3,6 +3,7 @@
 import type { FavoriteType, FavoriteIndex } from './favorite-store'
 import type { SnapshotIndex } from './snapshot-store'
 import type { AppConfig } from './app-config'
+import type { KeyboardMetaIndex, KeyboardMetaSyncUnit } from './keyboard-meta'
 
 export type { AppConfig }
 export { DEFAULT_APP_CONFIG } from './app-config'
@@ -17,10 +18,10 @@ export interface SyncEnvelope {
 }
 
 export interface SyncBundle {
-  type: 'favorite' | 'layout' | 'settings'
-  key: string // FavoriteType or UID
-  index: FavoriteIndex | SnapshotIndex
-  files: Record<string, string> // filename -> content
+  type: 'favorite' | 'layout' | 'settings' | 'keyboard-meta'
+  key: string // FavoriteType, UID, or 'keyboard-names' for meta
+  index: FavoriteIndex | SnapshotIndex | KeyboardMetaIndex
+  files: Record<string, string> // filename -> content (empty for meta)
 }
 
 export type SyncDirection = 'upload' | 'download'
@@ -54,7 +55,11 @@ export interface SyncAuthStatus {
 export type FavoriteSyncUnit = `favorites/${FavoriteType}`
 export type KeyboardSettingsSyncUnit = `keyboards/${string}/settings`
 export type KeyboardSnapshotsSyncUnit = `keyboards/${string}/snapshots`
-export type SyncUnit = FavoriteSyncUnit | KeyboardSettingsSyncUnit | KeyboardSnapshotsSyncUnit
+export type SyncUnit =
+  | FavoriteSyncUnit
+  | KeyboardSettingsSyncUnit
+  | KeyboardSnapshotsSyncUnit
+  | KeyboardMetaSyncUnit
 
 export interface PasswordStrength {
   score: number // 0-4
@@ -89,6 +94,8 @@ export interface UndecryptableFile {
 
 export interface SyncDataScanResult {
   keyboards: string[]
+  /** uid -> deviceName from synced meta (when available) */
+  keyboardNames: Record<string, string>
   favorites: string[]
   undecryptable: UndecryptableFile[]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import os from 'node:os'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+
+// Leave 2 cores free so high-parallelism workers don't starve fake-timer-based
+// polling tests (race-prone under saturated CPU).
+const TEST_MAX_THREADS = Math.max(1, os.cpus().length - 2)
 
 export default defineConfig({
   plugins: [react()],
@@ -13,5 +18,13 @@ export default defineConfig({
     // Component tests use // @vitest-environment jsdom directive
     include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
     setupFiles: ['src/renderer/__tests__/setup.ts'],
+    // Retry timer/concurrency-sensitive tests up to 3 times before failing the suite.
+    retry: 3,
+    poolOptions: {
+      threads: {
+        maxThreads: TEST_MAX_THREADS,
+        minThreads: 1,
+      },
+    },
   },
 })


### PR DESCRIPTION
## Summary
- Add a synced `meta/keyboard-names` unit (entry-level LWW + tombstones) so the Data modal shows real keyboard names everywhere, including newly provisioned machines.
- Stop downloading remote-only keyboards on full sync; download on demand when the user opens a keyboard from the Sync section of the Data modal, with spinner and per-uid error feedback.
- Backfill missing names from local snapshot indexes first, then via a single Drive download per uid, batched into one meta upsert. Tombstones are preserved across backfill so resets are not silently reverted.
- Recover polling failures by clearing the cached `modifiedTime` on merge errors so the next poll retries instead of dropping the change.
- Cap vitest worker threads (`cpus - 2`) and enable test retries to remove CPU-saturation flakes from timer-based polling tests.

## Test plan
- [ ] `pnpm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `pnpm test`
- [ ] Manual: open the Data modal on a fresh machine and confirm Sync > Keyboards shows device names (not UIDs).
- [ ] Manual: click a remote-only keyboard and confirm spinner → success → switch to the local keyboard view.
- [ ] Manual: rename / delete a keyboard on PC-A, sync on PC-B, and confirm the rename propagates and the deletion is not reverted by backfill.