### PR TITLE
feat(sync): expose credential failure reasons to the UI

### DIFF
--- a/src/main/__tests__/sync-crypto.test.ts
+++ b/src/main/__tests__/sync-crypto.test.ts
@@ -22,7 +22,7 @@ import {
   encrypt,
   decrypt,
   storePassword,
-  retrievePassword,
+  retrievePasswordResult,
   clearPassword,
   hasStoredPassword,
   checkPasswordStrength,
@@ -201,8 +201,8 @@ describe('sync-crypto', () => {
   describe('password storage (safeStorage)', () => {
     it('stores and retrieves password', async () => {
       await storePassword('my-secure-password')
-      const retrieved = await retrievePassword()
-      expect(retrieved).toBe('my-secure-password')
+      const result = await retrievePasswordResult()
+      expect(result).toEqual({ ok: true, password: 'my-secure-password' })
     })
 
     it('hasStoredPassword returns false when no password stored', async () => {
@@ -221,11 +221,6 @@ describe('sync-crypto', () => {
       await clearPassword()
       const has = await hasStoredPassword()
       expect(has).toBe(false)
-    })
-
-    it('retrievePassword returns null when no password stored', async () => {
-      const retrieved = await retrievePassword()
-      expect(retrieved).toBeNull()
     })
 
     it('storePassword throws when safeStorage unavailable', async () => {
@@ -264,6 +259,36 @@ describe('sync-crypto', () => {
     it('handles empty password', () => {
       const result = checkPasswordStrength('')
       expect(result.score).toBe(0)
+    })
+  })
+
+  describe('retrievePasswordResult', () => {
+    it('returns ok when file exists and decrypts', async () => {
+      await storePassword('p')
+      const result = await retrievePasswordResult()
+      expect(result).toEqual({ ok: true, password: 'p' })
+    })
+
+    it('returns no_password_file when no file exists', async () => {
+      const result = await retrievePasswordResult()
+      expect(result).toEqual({ ok: false, reason: 'noPasswordFile' })
+    })
+
+    it('returns decrypt_failed when decryptString throws', async () => {
+      const { safeStorage } = await import('electron')
+      await storePassword('p')
+      vi.mocked(safeStorage.decryptString).mockImplementationOnce(() => {
+        throw new Error('decrypt failed')
+      })
+      const result = await retrievePasswordResult()
+      expect(result).toEqual({ ok: false, reason: 'decryptFailed' })
+    })
+
+    it('returns keystore_unavailable when safeStorage is not available', async () => {
+      const { safeStorage } = await import('electron')
+      vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValueOnce(false)
+      const result = await retrievePasswordResult()
+      expect(result).toEqual({ ok: false, reason: 'keystoreUnavailable' })
     })
   })
 })

--- a/src/main/__tests__/sync-service.test.ts
+++ b/src/main/__tests__/sync-service.test.ts
@@ -68,7 +68,7 @@ vi.mock('../sync/google-auth', () => ({
 }))
 
 vi.mock('../sync/sync-crypto', () => ({
-  retrievePassword: vi.fn(async () => 'test-password'),
+  retrievePasswordResult: vi.fn(async () => ({ ok: true, password: 'test-password' })),
   storePassword: vi.fn(async () => {}),
   clearPassword: vi.fn(async () => {}),
   hasStoredPassword: vi.fn(async () => true),
@@ -1012,7 +1012,7 @@ describe('sync-service', () => {
       const syncPromise = executeSync('download')
 
       await expect(changePassword('new-password')).rejects.toThrow(
-        'Cannot change password while sync is in progress',
+        'sync.changePasswordInProgress',
       )
 
       await vi.advanceTimersByTimeAsync(200)
@@ -1024,10 +1024,10 @@ describe('sync-service', () => {
       expect(mockUploadFile).not.toHaveBeenCalled()
     })
 
-    it('throws when no password is stored', async () => {
+    it('throws SyncCredentialError(unauthenticated) when not signed in', async () => {
       mockGetAuthStatus.mockResolvedValueOnce({ authenticated: false })
 
-      await expect(changePassword('new-password')).rejects.toThrow('No stored password found')
+      await expect(changePassword('new-password')).rejects.toThrow('sync.changePasswordError.unauthenticated')
     })
 
     it('succeeds with no remote data files (password-check only)', async () => {

--- a/src/main/sync/sync-crypto.ts
+++ b/src/main/sync/sync-crypto.ts
@@ -9,7 +9,7 @@ import { promisify } from 'node:util'
 import { zxcvbn, zxcvbnOptions } from '@zxcvbn-ts/core'
 import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
 import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
-import type { SyncEnvelope } from '../../shared/types/sync'
+import type { SyncCredentialResult, SyncEnvelope } from '../../shared/types/sync'
 import type { PasswordStrength } from '../../shared/types/sync'
 
 const pbkdf2Async = promisify(pbkdf2)
@@ -104,12 +104,29 @@ export async function storePassword(password: string): Promise<void> {
   await writeFile(getPasswordPath(), encrypted)
 }
 
-export async function retrievePassword(): Promise<string | null> {
+/**
+ * Surface why we couldn't return a password instead of collapsing every failure
+ * into `null`. We probe the file first so the happy path skips the OS keychain
+ * availability check; the probe only runs when we actually have to disambiguate
+ * a decrypt failure from a missing keystore.
+ */
+export async function retrievePasswordResult(): Promise<SyncCredentialResult> {
+  let encrypted: Buffer
   try {
-    const encrypted = await readFile(getPasswordPath())
-    return safeStorage.decryptString(encrypted)
+    encrypted = await readFile(getPasswordPath())
   } catch {
-    return null
+    if (!safeStorage.isEncryptionAvailable()) {
+      return { ok: false, reason: 'keystoreUnavailable' }
+    }
+    return { ok: false, reason: 'noPasswordFile' }
+  }
+  try {
+    return { ok: true, password: safeStorage.decryptString(encrypted) }
+  } catch {
+    if (!safeStorage.isEncryptionAvailable()) {
+      return { ok: false, reason: 'keystoreUnavailable' }
+    }
+    return { ok: false, reason: 'decryptFailed' }
   }
 }
 

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -33,8 +33,9 @@ import {
   changePassword,
   checkPasswordCheckExists,
   setPasswordAndValidate,
+  SyncCredentialError,
 } from './sync-service'
-import type { SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, SyncScope, StoredKeyboardInfo, SyncDataScanResult } from '../../shared/types/sync'
+import type { SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, SyncScope, StoredKeyboardInfo, SyncDataScanResult, SyncCredentialFailureReason } from '../../shared/types/sync'
 import { secureHandle, secureOn } from '../ipc-guard'
 import type { FavoriteIndex, SavedFavoriteMeta } from '../../shared/types/favorite-store'
 import type { SnapshotIndex, SnapshotMeta } from '../../shared/types/snapshot-store'
@@ -51,6 +52,7 @@ import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 interface IpcResult {
   success: boolean
   error?: string
+  reason?: SyncCredentialFailureReason
 }
 
 async function wrapIpc(fallbackMessage: string, fn: () => Promise<void>): Promise<IpcResult> {
@@ -58,6 +60,9 @@ async function wrapIpc(fallbackMessage: string, fn: () => Promise<void>): Promis
     await fn()
     return { success: true }
   } catch (err) {
+    if (err instanceof SyncCredentialError) {
+      return { success: false, error: err.message, reason: err.reason }
+    }
     return { success: false, error: err instanceof Error ? err.message : fallbackMessage }
   }
 }

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -4,7 +4,7 @@
 import { app, BrowserWindow } from 'electron'
 import { join } from 'node:path'
 import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises'
-import { encrypt, decrypt, retrievePassword, storePassword, clearPassword } from './sync-crypto'
+import { encrypt, decrypt, retrievePasswordResult, storePassword, clearPassword } from './sync-crypto'
 import { loadAppConfig } from '../app-config'
 import { getAuthStatus } from './google-auth'
 import {
@@ -26,7 +26,16 @@ import {
   readKeyboardMetaIndex,
 } from './keyboard-meta'
 import { KEYBOARD_META_SYNC_UNIT, type KeyboardMetaIndex } from '../../shared/types/keyboard-meta'
-import type { SyncBundle, SyncProgress, SyncEnvelope, UndecryptableFile, SyncDataScanResult, SyncScope } from '../../shared/types/sync'
+import type { SyncBundle, SyncProgress, SyncEnvelope, UndecryptableFile, SyncDataScanResult, SyncScope, SyncCredentialFailureReason, SyncCredentialResult } from '../../shared/types/sync'
+import { syncCredentialI18nKey } from '../../shared/types/sync'
+
+export class SyncCredentialError extends Error {
+  readonly reason: SyncCredentialFailureReason
+  constructor(reason: SyncCredentialFailureReason, namespace: 'readiness' | 'changePasswordError' = 'changePasswordError') {
+    super(syncCredentialI18nKey(namespace, reason))
+    this.reason = reason
+  }
+}
 
 const SYNC_CONCURRENCY = 10
 const DEBOUNCE_MS = 10_000
@@ -133,18 +142,18 @@ function shouldDownloadSyncUnit(
   return true
 }
 
-async function requireSyncCredentials(): Promise<string | null> {
+async function requireSyncCredentials(): Promise<SyncCredentialResult> {
   const authStatus = await getAuthStatus()
-  if (!authStatus.authenticated) return null
-
-  return retrievePassword()
+  if (!authStatus.authenticated) return { ok: false, reason: 'unauthenticated' }
+  return retrievePasswordResult()
 }
 
 // --- Remote data inspection ---
 
 async function fetchValidatedDataFiles(): Promise<{ password: string; dataFiles: DriveFile[] } | null> {
-  const password = await requireSyncCredentials()
-  if (!password) return null
+  const credentials = await requireSyncCredentials()
+  if (!credentials.ok) return null
+  const { password } = credentials
   const remoteFiles = await listFiles()
 
   await validatePasswordCheck(password, remoteFiles)
@@ -243,11 +252,12 @@ export async function fetchRemoteBundle(syncUnit: string): Promise<SyncBundle | 
 // --- Non-destructive password change ---
 
 export async function changePassword(newPassword: string): Promise<void> {
-  if (isSyncing) throw new Error('Cannot change password while sync is in progress')
+  if (isSyncing) throw new Error('sync.changePasswordInProgress')
   isSyncing = true
   try {
-    const oldPassword = await requireSyncCredentials()
-    if (!oldPassword) throw new Error('No stored password found')
+    const credentials = await requireSyncCredentials()
+    if (!credentials.ok) throw new SyncCredentialError(credentials.reason)
+    const oldPassword = credentials.password
     if (newPassword === oldPassword) throw new Error('sync.samePassword')
     const remoteFiles = await listFiles()
 
@@ -484,8 +494,17 @@ export async function executeSync(
   isSyncing = true
 
   try {
-    const password = await requireSyncCredentials()
-    if (!password) return
+    const credentials = await requireSyncCredentials()
+    if (!credentials.ok) {
+      emitProgress({
+        direction,
+        status: 'error',
+        reason: credentials.reason,
+        message: syncCredentialI18nKey('readiness', credentials.reason),
+      })
+      return
+    }
+    const password = credentials.password
 
     emitProgress({ direction, status: 'syncing', message: 'Starting sync...' })
 
@@ -660,8 +679,9 @@ async function pollForRemoteChanges(): Promise<void> {
   isSyncing = true
 
   try {
-    const password = await requireSyncCredentials()
-    if (!password) return
+    const credentials = await requireSyncCredentials()
+    if (!credentials.ok) return  // polling stays silent — manual sync surfaces the reason
+    const password = credentials.password
 
     const remoteFiles = await listFiles()
 
@@ -766,12 +786,13 @@ async function flushPendingChanges(): Promise<void> {
       return
     }
 
-    const password = await requireSyncCredentials()
-    if (!password) {
+    const credentials = await requireSyncCredentials()
+    if (!credentials.ok) {
       pendingChanges.clear()
       broadcastPendingStatus()
       return
     }
+    const password = credentials.password
 
     const changes = new Set(pendingChanges)
     pendingChanges.clear()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,7 +12,7 @@ import type { DeviceInfo, KeyboardDefinition, ProbeResult } from '../shared/type
 import type { SnapshotMeta } from '../shared/types/snapshot-store'
 import type { SavedFavoriteMeta, FavoriteImportResult } from '../shared/types/favorite-store'
 import type { AppConfig } from '../shared/types/app-config'
-import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncDataScanResult, SyncScope, StoredKeyboardInfo } from '../shared/types/sync'
+import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncDataScanResult, SyncScope, StoredKeyboardInfo, SyncOperationResult } from '../shared/types/sync'
 import type { PipetteSettings } from '../shared/types/pipette-settings'
 import type { LanguageListEntry } from '../shared/types/language-store'
 import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyPostsParams, HubFetchMyKeyboardPostsResult, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams } from '../shared/types/hub'
@@ -210,15 +210,15 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.SYNC_AUTH_START),
   syncAuthStatus: (): Promise<SyncAuthStatus> =>
     ipcRenderer.invoke(IpcChannels.SYNC_AUTH_STATUS),
-  syncAuthSignOut: (): Promise<{ success: boolean; error?: string }> =>
+  syncAuthSignOut: (): Promise<SyncOperationResult> =>
     ipcRenderer.invoke(IpcChannels.SYNC_AUTH_SIGN_OUT),
-  syncExecute: (direction: 'download' | 'upload', scope?: SyncScope): Promise<{ success: boolean; error?: string }> =>
+  syncExecute: (direction: 'download' | 'upload', scope?: SyncScope): Promise<SyncOperationResult> =>
     ipcRenderer.invoke(IpcChannels.SYNC_EXECUTE, direction, scope),
-  syncSetPassword: (password: string): Promise<{ success: boolean; error?: string }> =>
+  syncSetPassword: (password: string): Promise<SyncOperationResult> =>
     ipcRenderer.invoke(IpcChannels.SYNC_SET_PASSWORD, password),
-  syncChangePassword: (newPassword: string): Promise<{ success: boolean; error?: string }> =>
+  syncChangePassword: (newPassword: string): Promise<SyncOperationResult> =>
     ipcRenderer.invoke(IpcChannels.SYNC_CHANGE_PASSWORD, newPassword),
-  syncResetTargets: (targets: SyncResetTargets): Promise<{ success: boolean; error?: string }> =>
+  syncResetTargets: (targets: SyncResetTargets): Promise<SyncOperationResult> =>
     ipcRenderer.invoke(IpcChannels.SYNC_RESET_TARGETS, targets),
   syncHasPassword: (): Promise<boolean> =>
     ipcRenderer.invoke(IpcChannels.SYNC_HAS_PASSWORD),

--- a/src/renderer/components/settings-modal/SettingsDataTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsDataTab.tsx
@@ -200,7 +200,12 @@ export function SettingsDataTab({
       </div>
 
       {/* Sync Status */}
-      <SyncStatusSection syncStatus={sync.syncStatus} progress={sync.progress} lastSyncResult={sync.lastSyncResult} />
+      <SyncStatusSection
+        syncStatus={sync.syncStatus}
+        progress={sync.progress}
+        lastSyncResult={sync.lastSyncResult}
+        syncReadinessReason={sync.syncReadinessReason}
+      />
 
       <hr className="my-4 border-edge" />
 

--- a/src/renderer/components/settings-modal/SyncStatusSection.tsx
+++ b/src/renderer/components/settings-modal/SyncStatusSection.tsx
@@ -3,22 +3,28 @@
 import { useTranslation } from 'react-i18next'
 import { SYNC_STATUS_CLASS } from '../sync-ui'
 import { formatDate } from '../editors/store-modal-shared'
-import type { SyncStatusType, LastSyncResult, SyncProgress } from '../../../shared/types/sync'
+import { syncCredentialI18nKey } from '../../../shared/types/sync'
+import type { SyncStatusType, LastSyncResult, SyncProgress, SyncCredentialFailureReason } from '../../../shared/types/sync'
 
 export interface SyncStatusSectionProps {
   syncStatus: SyncStatusType
   progress: SyncProgress | null
   lastSyncResult: LastSyncResult | null
+  syncReadinessReason?: SyncCredentialFailureReason | null
 }
 
-export function SyncStatusSection({ syncStatus, progress, lastSyncResult }: SyncStatusSectionProps) {
+export function SyncStatusSection({ syncStatus, progress, lastSyncResult, syncReadinessReason }: SyncStatusSectionProps) {
   const { t } = useTranslation()
+
+  const noneLabelKey = syncReadinessReason
+    ? syncCredentialI18nKey('readiness', syncReadinessReason)
+    : 'sync.noSyncYet'
 
   return (
     <section className="mb-6">
       {syncStatus === 'none' ? (
         <span className="text-sm text-content-muted" data-testid="sync-status-label">
-          {t('sync.noSyncYet')}
+          {t(noneLabelKey)}
         </span>
       ) : (
         <div className="space-y-1">

--- a/src/renderer/components/settings-modal/useSettingsSync.ts
+++ b/src/renderer/components/settings-modal/useSettingsSync.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import type { UseSyncReturn } from '../../hooks/useSync'
 import type { AppNotification } from '../../../shared/types/notification'
 import type { ModalTabId } from '../editors/modal-tabs'
+import { syncCredentialI18nKey } from '../../../shared/types/sync'
 
 export interface UseSettingsSyncOptions {
   sync: UseSyncReturn
@@ -132,7 +133,9 @@ export function useSettingsSync({
       if (result.success) {
         clearPasswordForm()
       } else {
-        const errorKey = result.error ?? t('sync.passwordSetFailed')
+        const errorKey = result.reason
+          ? syncCredentialI18nKey('changePasswordError', result.reason)
+          : (result.error ?? 'sync.passwordSetFailed')
         setPasswordError(t(errorKey, errorKey))
       }
     } finally {

--- a/src/renderer/hooks/useSync.ts
+++ b/src/renderer/hooks/useSync.ts
@@ -16,6 +16,8 @@ import type {
   UndecryptableFile,
   SyncDataScanResult,
   SyncScope,
+  SyncOperationResult,
+  SyncCredentialFailureReason,
 } from '../../shared/types/sync'
 
 /** Maps a SyncProgress status or LastSyncResult status to the UI SyncStatusType. */
@@ -42,19 +44,21 @@ export interface UseSyncReturn {
   hasRemotePassword: boolean | null
   checkingRemotePassword: boolean
   syncUnavailable: boolean
+  /** Why the sync subsystem isn't ready to run; null when ready. */
+  syncReadinessReason: SyncCredentialFailureReason | null
   retryRemoteCheck: () => void
   startAuth: () => Promise<void>
   signOut: () => Promise<void>
   setConfig: (patch: Partial<AppConfig>) => void
-  setPassword: (password: string) => Promise<{ success: boolean; error?: string }>
-  changePassword: (newPassword: string) => Promise<{ success: boolean; error?: string }>
-  resetSyncTargets: (targets: SyncResetTargets) => Promise<{ success: boolean; error?: string }>
+  setPassword: (password: string) => Promise<SyncOperationResult>
+  changePassword: (newPassword: string) => Promise<SyncOperationResult>
+  resetSyncTargets: (targets: SyncResetTargets) => Promise<SyncOperationResult>
   validatePassword: (password: string) => Promise<PasswordStrength>
   syncNow: (direction: 'download' | 'upload', scope?: SyncScope) => Promise<void>
   refreshStatus: () => Promise<void>
   listUndecryptable: () => Promise<UndecryptableFile[]>
   scanRemote: () => Promise<SyncDataScanResult>
-  deleteFiles: (fileIds: string[]) => Promise<{ success: boolean; error?: string }>
+  deleteFiles: (fileIds: string[]) => Promise<SyncOperationResult>
 }
 
 export function useSync(): UseSyncReturn {
@@ -244,6 +248,15 @@ export function useSync(): UseSyncReturn {
     return 'none'
   }, [progress, authStatus.authenticated, hasPassword, config.autoSync, hasPendingChangesState, lastSyncResult])
 
+  // Detailed keystore failures (decryptFailed / keystoreUnavailable) come back
+  // through password set/change IPC results, not from this aggregate.
+  const syncReadinessReason = useMemo<SyncCredentialFailureReason | null>(() => {
+    if (!authStatus.authenticated) return 'unauthenticated'
+    if (!hasPassword) return 'noPasswordFile'
+    if (syncUnavailable) return 'remoteCheckFailed'
+    return null
+  }, [authStatus.authenticated, hasPassword, syncUnavailable])
+
   return {
     config,
     authStatus,
@@ -256,6 +269,7 @@ export function useSync(): UseSyncReturn {
     hasRemotePassword,
     checkingRemotePassword,
     syncUnavailable,
+    syncReadinessReason,
     retryRemoteCheck,
     startAuth,
     signOut,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -523,6 +523,21 @@
     "statusSuccess": "Success",
     "statusError": "Error",
     "noSyncYet": "Not synced yet",
+    "readiness": {
+      "unauthenticated": "Sign in to Google to sync.",
+      "noPasswordFile": "Set a sync password to start syncing.",
+      "decryptFailed": "Stored password could not be read (the OS keychain may have changed).",
+      "keystoreUnavailable": "OS keychain is not available on this system.",
+      "remoteCheckFailed": "Couldn't reach Google Drive — sync is paused."
+    },
+    "changePasswordError": {
+      "unauthenticated": "Please sign in to Google before changing the password.",
+      "noPasswordFile": "No saved password to change. Set a password first.",
+      "decryptFailed": "Couldn't read the existing password (OS keychain rejected it).",
+      "keystoreUnavailable": "OS keychain is not available; password cannot be changed here.",
+      "remoteCheckFailed": "Couldn't reach Google Drive to verify the current password."
+    },
+    "changePasswordInProgress": "Cannot change password while sync is in progress.",
     "troubleshooting": "Troubleshooting",
     "localData": "Local Data",
     "import": "Import",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -522,6 +522,21 @@
     "statusSuccess": "成功",
     "statusError": "エラー",
     "noSyncYet": "未同期",
+    "readiness": {
+      "unauthenticated": "Google にサインインして同期を開始してください。",
+      "noPasswordFile": "同期パスワードを設定してください。",
+      "decryptFailed": "保存済みパスワードを読み出せませんでした (OS キーチェーンが変わった可能性)。",
+      "keystoreUnavailable": "この端末では OS キーチェーンが利用できません。",
+      "remoteCheckFailed": "Google Drive に接続できません — 同期を一時停止しています。"
+    },
+    "changePasswordError": {
+      "unauthenticated": "パスワードを変更する前に Google にサインインしてください。",
+      "noPasswordFile": "保存済みパスワードがありません。先にパスワードを設定してください。",
+      "decryptFailed": "既存パスワードを読み出せませんでした (OS キーチェーンに拒否されました)。",
+      "keystoreUnavailable": "OS キーチェーンが利用できないため、ここではパスワードを変更できません。",
+      "remoteCheckFailed": "現在のパスワードを検証するための Google Drive 接続に失敗しました。"
+    },
+    "changePasswordInProgress": "同期実行中のためパスワードを変更できません。",
     "troubleshooting": "トラブルシューティング",
     "localData": "ローカルデータ",
     "import": "インポート",

--- a/src/shared/types/sync.ts
+++ b/src/shared/types/sync.ts
@@ -45,6 +45,8 @@ export interface SyncProgress {
   current?: number
   total?: number
   failedUnits?: string[]
+  /** Surfaces a credential failure reason so the UI can localize the message. */
+  reason?: SyncCredentialFailureReason
 }
 
 export interface SyncAuthStatus {
@@ -110,3 +112,38 @@ export type SyncScope =
   | 'favorites'     // favorites/* only
   | { keyboard: string }  // keyboards/{uid}/* only
   | { favorites: true; keyboard: string }  // favorites/* + keyboards/{uid}/*
+
+/**
+ * Why the sync subsystem cannot proceed without prompting the user.
+ * The same UX surface ("Not synced yet" / "No stored password found") used to
+ * collapse all of these into one string, hiding root cause from the user.
+ * Values are camelCase so they slot directly into i18n keys
+ * (`sync.readiness.<reason>`, `sync.changePasswordError.<reason>`).
+ */
+export type SyncCredentialFailureReason =
+  | 'unauthenticated'         // Google sign-in incomplete / token revoked
+  | 'noPasswordFile'          // sync-password.enc has never been written
+  | 'decryptFailed'           // file exists but the OS keychain refuses it
+  | 'keystoreUnavailable'     // safeStorage.isEncryptionAvailable() === false
+  | 'remoteCheckFailed'       // can't reach the remote password-check (network / drive)
+
+export type SyncCredentialI18nNamespace = 'readiness' | 'changePasswordError'
+
+/** Single source of truth: reason → i18n key (used by progress, status, password UI). */
+export function syncCredentialI18nKey(
+  ns: SyncCredentialI18nNamespace,
+  reason: SyncCredentialFailureReason,
+): string {
+  return `sync.${ns}.${reason}`
+}
+
+export type SyncCredentialResult =
+  | { ok: true; password: string }
+  | { ok: false; reason: SyncCredentialFailureReason }
+
+/** Serializable IPC envelope so renderer code can branch on the reason. */
+export interface SyncOperationResult {
+  success: boolean
+  error?: string
+  reason?: SyncCredentialFailureReason
+}

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -16,7 +16,7 @@ import type {
 import type { SnapshotMeta } from './snapshot-store'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteImportResult } from './favorite-store'
 import type { AppConfig } from './app-config'
-import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncScope, SyncDataScanResult, StoredKeyboardInfo } from './sync'
+import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncScope, SyncDataScanResult, StoredKeyboardInfo, SyncOperationResult } from './sync'
 import type { PipetteSettings } from './pipette-settings'
 import type { LanguageListEntry } from './language-store'
 import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubFetchMyPostsParams, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams } from './hub'
@@ -131,13 +131,13 @@ export interface VialAPI {
   appConfigSet(key: string, value: unknown): Promise<void>
 
   // Sync
-  syncAuthStart(): Promise<{ success: boolean; error?: string }>
+  syncAuthStart(): Promise<SyncOperationResult>
   syncAuthStatus(): Promise<SyncAuthStatus>
-  syncAuthSignOut(): Promise<{ success: boolean; error?: string }>
-  syncExecute(direction: 'download' | 'upload', scope?: SyncScope): Promise<{ success: boolean; error?: string }>
-  syncSetPassword(password: string): Promise<{ success: boolean; error?: string }>
-  syncChangePassword(newPassword: string): Promise<{ success: boolean; error?: string }>
-  syncResetTargets(targets: SyncResetTargets): Promise<{ success: boolean; error?: string }>
+  syncAuthSignOut(): Promise<SyncOperationResult>
+  syncExecute(direction: 'download' | 'upload', scope?: SyncScope): Promise<SyncOperationResult>
+  syncSetPassword(password: string): Promise<SyncOperationResult>
+  syncChangePassword(newPassword: string): Promise<SyncOperationResult>
+  syncResetTargets(targets: SyncResetTargets): Promise<SyncOperationResult>
   syncHasPassword(): Promise<boolean>
   syncValidatePassword(password: string): Promise<PasswordStrength>
   syncOnProgress(callback: (progress: SyncProgress) => void): () => void


### PR DESCRIPTION
## Summary
- Replace the catch-all "Not synced yet" / "No stored password found" UI strings with a typed `SyncCredentialFailureReason` union (camelCase so it slots straight into i18n keys).
- `retrievePasswordResult()` returns a Result so calling code can distinguish unauthenticated / `noPasswordFile` / `decryptFailed` / `keystoreUnavailable` instead of collapsing every failure to `null`.
- `SyncCredentialError` carries the reason across the IPC boundary; `wrapIpc` forwards it as `SyncOperationResult.reason`, and `SyncProgress` got a `reason` field so `executeSync` can surface credential failures to the renderer.
- `useSync.syncReadinessReason` plus a single `syncCredentialI18nKey()` helper power both `SyncStatusSection` and `PasswordSection` (no more duplicated reason→key tables).
- Add `sync.readiness.*`, `sync.changePasswordError.*`, and `sync.changePasswordInProgress` keys in en/ja; raw English error strings no longer leak into the UI.

## Test plan
- [ ] `pnpm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `pnpm test`
- [ ] Manual: trigger each reason on a sandbox machine (not signed in / no password / corrupted password file / OS keychain disabled / Drive unreachable) and confirm the Settings modal shows the right localized text.