### PR TITLE
feat(ui): show macro Save button in keycode edit mode

### DIFF
--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -403,8 +403,10 @@ export function MacroEditor({
           </div>
         </div>
 
-        {/* Picker: own scroll, fills remaining space in edit mode */}
-        <div ref={pickerRef} className={`flex-1 overflow-y-auto px-6 pb-6 ${isEditing ? '' : 'hidden'}`}>
+        {/* Picker: shrink to content in edit mode so the Save footer sits close
+             to the keypicker content; list mode keeps the action list area
+             hidden via the sibling container. */}
+        <div ref={pickerRef} className={`overflow-y-auto px-6 pb-6 ${isEditing ? 'shrink-0' : 'hidden'}`}>
           <TabbedKeycodes
             onKeycodeSelect={maskedSelection.pickerSelect}
             maskOnly={maskedSelection.maskOnly}
@@ -415,31 +417,35 @@ export function MacroEditor({
           />
         </div>
 
-        {/* Fixed footer: Clear / Revert / Save — hidden in edit mode */}
-          <div data-macro-footer="true" className={`shrink-0 px-6 py-3 ${isEditing ? 'hidden' : ''}`}>
+        {/* Fixed footer: Clear / Revert (list mode only) / Save (always visible) */}
+          <div data-macro-footer="true" className="shrink-0 px-6 py-3">
             <div className="flex justify-end gap-2">
-              <ConfirmButton
-                testId="macro-clear"
-                confirming={clearAction.confirming}
-                onClick={() => { revertAction.reset(); clearAction.trigger() }}
-                labelKey="common.clear"
-                confirmLabelKey="common.confirmClear"
-                disabled={isRecording}
-              />
-              <ConfirmButton
-                testId="macro-revert"
-                confirming={revertAction.confirming}
-                onClick={() => { clearAction.reset(); revertAction.trigger() }}
-                labelKey="common.revert"
-                confirmLabelKey="common.confirmRevert"
-                disabled={isRecording}
-              />
+              {!isEditing && (
+                <>
+                  <ConfirmButton
+                    testId="macro-clear"
+                    confirming={clearAction.confirming}
+                    onClick={() => { revertAction.reset(); clearAction.trigger() }}
+                    labelKey="common.clear"
+                    confirmLabelKey="common.confirmClear"
+                    disabled={isRecording}
+                  />
+                  <ConfirmButton
+                    testId="macro-revert"
+                    confirming={revertAction.confirming}
+                    onClick={() => { clearAction.reset(); revertAction.trigger() }}
+                    labelKey="common.revert"
+                    confirmLabelKey="common.confirmRevert"
+                    disabled={isRecording}
+                  />
+                </>
+              )}
               <button
                 type="button"
                 data-testid="macro-save"
                 className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
-                onClick={handleSave}
-                disabled={!dirty || hasInvalidText || isRecording}
+                onClick={isEditing ? revertAndDeselect : handleSave}
+                disabled={isEditing ? isRecording : (!dirty || hasInvalidText || isRecording)}
               >
                 {t('common.save')}
               </button>

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -72,6 +72,7 @@ export function MacroModal({
   const [isEditing, setIsEditing] = useState(false)
   const [isRecording, setIsRecording] = useState(false)
   const modalWidth = isDummy ? 'w-[1200px]' : 'w-[1300px]'
+  const modalHeight = isEditing ? 'max-h-[90vh]' : 'h-[90vh]'
 
   useEscapeClose(onClose, !isRecording)
 
@@ -82,7 +83,7 @@ export function MacroModal({
       onClick={isRecording ? undefined : onClose}
     >
       <div
-        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-[90vh] flex flex-col overflow-hidden`}
+        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] ${modalHeight} flex flex-col overflow-hidden`}
         data-testid="macro-modal"
         onClick={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
## Summary
- Show the Save button while the macro editor is in keycode-edit mode. Pressing it returns to the action list (the modal stays open).
- List-mode Save keeps its original behaviour: writes to the device and closes the modal.
- While editing, the modal is capped at `max-h-[90vh]` and the picker uses `shrink-0`, bringing the Save button closer to the picker content and trimming vertical whitespace.
- Clear / Revert buttons are limited to list mode so out-of-scope actions are hidden while editing.

## Test plan
- [ ] Enter edit mode by selecting an action's tap/down/up keycode pill
- [ ] Change the key in the picker → Save returns to the action list
- [ ] List-mode Save writes to the device and closes the modal
- [ ] In edit mode the modal height shrinks to fit the content
- [ ] Clear / Revert are only visible in list mode
- [ ] `pnpm test` — all 2838 tests pass
- [ ] `pnpm lint` / `npx tsc --noEmit` pass