### PR TITLE
feat(ui): disable lighting Save button until values change

### DIFF
--- a/src/renderer/components/editors/RGBConfigurator.tsx
+++ b/src/renderer/components/editors/RGBConfigurator.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { HSVColorPicker, hsvToRgb, rgbToHsv, rgbToHex, hexToRgb } from './HSVColorPicker'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
@@ -194,7 +194,9 @@ export function RGBConfigurator({
   }
 
   type LightingSnapshot = typeof currentValues
-  const savedRef = useRef<LightingSnapshot>(currentValues)
+  // Must be state (not ref) so saving/reverting triggers a re-render and the
+  // Save button's disabled state tracks the latest baseline.
+  const [savedSnapshot, setSavedSnapshot] = useState<LightingSnapshot>(currentValues)
 
   if (!lightingType || lightingType === 'none') {
     return (
@@ -211,14 +213,14 @@ export function RGBConfigurator({
   const hasVialRGB = lightingType === 'vialrgb' && vialRGBVersion === 1
   const sectionCount = Number(hasBacklight) + Number(hasRGBlight) + Number(hasVialRGB)
 
-  const isDirty = (Object.keys(savedRef.current) as (keyof LightingSnapshot)[]).some(
-    (k) => currentValues[k] !== savedRef.current[k],
+  const isDirty = (Object.keys(savedSnapshot) as (keyof LightingSnapshot)[]).some(
+    (k) => currentValues[k] !== savedSnapshot[k],
   )
 
   const revertAction = useConfirmAction(restoreSavedValues)
 
   async function restoreSavedValues(): Promise<void> {
-    const s = savedRef.current
+    const s = savedSnapshot
     try {
       if (hasBacklight) {
         await onSetBacklightBrightness(s.backlightBrightness)
@@ -462,12 +464,6 @@ export function RGBConfigurator({
         </section>
       )}
 
-      {isDirty && (
-        <p className="text-xs text-content-muted" data-testid="lighting-unsaved">
-          {t('editor.lighting.unsavedPreview')}
-        </p>
-      )}
-
       <div className="flex items-center justify-end gap-2">
         {isDirty && (
           <ConfirmButton
@@ -484,11 +480,12 @@ export function RGBConfigurator({
           onClick={async () => {
             try {
               await onSave()
-              savedRef.current = currentValues
+              setSavedSnapshot(currentValues)
             } catch (err) {
               console.error('[Lighting] save failed:', err)
             }
           }}
+          disabled={!isDirty}
           className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
         >
           {t('common.save')}

--- a/src/renderer/components/editors/__tests__/RGBConfigurator.test.tsx
+++ b/src/renderer/components/editors/__tests__/RGBConfigurator.test.tsx
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { RGBConfigurator } from '../RGBConfigurator'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../HSVColorPicker', () => ({
+  HSVColorPicker: () => <div data-testid="hsv-color-picker" />,
+  hsvToRgb: () => [0, 0, 0] as [number, number, number],
+  rgbToHsv: () => [0, 0, 0] as [number, number, number],
+  rgbToHex: () => '#000000',
+  hexToRgb: () => [0, 0, 0] as [number, number, number],
+}))
+
+function makeProps(overrides: Partial<Parameters<typeof RGBConfigurator>[0]> = {}): Parameters<typeof RGBConfigurator>[0] {
+  const noop = vi.fn().mockResolvedValue(undefined)
+  return {
+    lightingType: 'qmk_rgblight',
+    backlightBrightness: 0,
+    backlightEffect: 0,
+    rgblightBrightness: 128,
+    rgblightEffect: 0,
+    rgblightEffectSpeed: 128,
+    rgblightHue: 0,
+    rgblightSat: 255,
+    vialRGBVersion: 0,
+    vialRGBMode: 0,
+    vialRGBSpeed: 0,
+    vialRGBHue: 0,
+    vialRGBSat: 0,
+    vialRGBVal: 0,
+    vialRGBMaxBrightness: 255,
+    vialRGBSupported: [],
+    onSetBacklightBrightness: noop,
+    onSetBacklightEffect: noop,
+    onSetRgblightBrightness: noop,
+    onSetRgblightEffect: noop,
+    onSetRgblightEffectSpeed: noop,
+    onSetRgblightColor: noop,
+    onSetVialRGBMode: noop,
+    onSetVialRGBSpeed: noop,
+    onSetVialRGBColor: noop,
+    onSetVialRGBBrightness: noop,
+    onSetVialRGBHSV: noop,
+    onSave: noop,
+    ...overrides,
+  }
+}
+
+describe('RGBConfigurator (Save button dirty gating)', () => {
+  it('disables Save on initial render when no values have changed', () => {
+    render(<RGBConfigurator {...makeProps()} />)
+    expect(screen.getByTestId('lighting-save')).toBeDisabled()
+  })
+
+  it('enables Save when a tracked prop differs from the initial snapshot', () => {
+    const { rerender } = render(<RGBConfigurator {...makeProps({ rgblightEffectSpeed: 128 })} />)
+    expect(screen.getByTestId('lighting-save')).toBeDisabled()
+
+    rerender(<RGBConfigurator {...makeProps({ rgblightEffectSpeed: 200 })} />)
+    expect(screen.getByTestId('lighting-save')).toBeEnabled()
+  })
+
+  it('re-disables Save after a successful save without requiring extra re-renders', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    const { rerender } = render(<RGBConfigurator {...makeProps({ rgblightEffectSpeed: 128, onSave })} />)
+
+    rerender(<RGBConfigurator {...makeProps({ rgblightEffectSpeed: 200, onSave })} />)
+    expect(screen.getByTestId('lighting-save')).toBeEnabled()
+
+    fireEvent.click(screen.getByTestId('lighting-save'))
+    await waitFor(() => expect(onSave).toHaveBeenCalled())
+
+    // Save's post-action snapshot update must trigger a re-render on its own
+    // so the button reflects the new baseline without the parent having to
+    // send fresh props.
+    await waitFor(() => expect(screen.getByTestId('lighting-save')).toBeDisabled())
+  })
+})

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -166,7 +166,6 @@
       "value": "Value",
       "hex": "HEX",
       "noLighting": "This keyboard does not support lighting control.",
-      "unsavedPreview": "Preview — not saved to keyboard yet",
       "colorPicker": {
         "label": "Color Picker",
         "palette": "Palette",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -165,7 +165,6 @@
       "value": "明度",
       "hex": "HEX",
       "noLighting": "このキーボードはライティング制御をサポートしていません。",
-      "unsavedPreview": "プレビュー中 — まだキーボードに保存されていません",
       "colorPicker": {
         "label": "カラーピッカー",
         "palette": "パレット",


### PR DESCRIPTION
## Summary
- Add `disabled={!isDirty}` to the RGB lighting Save button so it can't be clicked while there are no unsaved changes.
- Switch the saved snapshot from `useRef` to `useState` so the button re-disables correctly after a save (ref updates alone didn't trigger a re-render).
- Remove the now-redundant "Preview — not saved to keyboard yet" notice along with its en/ja i18n keys.

## Test plan
- [ ] Save is disabled right after opening the Lighting modal
- [ ] Changing brightness / effect / colour enables Save
- [ ] Saving re-disables Save once values match the saved snapshot
- [ ] Revert still works as before
- [ ] `pnpm test` — all 2841 tests pass
- [ ] `pnpm lint` / `npx tsc --noEmit` pass