### PR TITLE
fix(ui): restore double-click / Enter commit on TapDance and Macro tiles

### DIFF
--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -4,6 +4,17 @@ import { afterEach } from 'vitest'
 import { cleanup } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 
+// jsdom doesn't implement ResizeObserver, but several components (e.g.
+// BasicKeyboardView, MacroTileGrid) rely on it. A minimal no-op shim lets
+// jsdom-backed tests render them without the polyfill touching browser behavior.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as unknown as typeof ResizeObserver
+}
+
 afterEach(() => {
   cleanup()
 })

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -641,8 +641,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     return content
   }, [tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros, tapHoldSupported, mouseKeysSupported, magicSupported, autoShiftSupported, graveEscapeSupported, oneShotKeysSupported, comboSettingsSupported, onOpenLighting, t, openSettings])
 
-  const tabContentOverride = useTileContentOverride(tapDanceEntries, deserializedMacros, handleKeycodeSelect, {
-    comboEntries, onOpenCombo, keyOverrideEntries, onOpenKeyOverride, altRepeatKeyEntries, onOpenAltRepeatKey,
+  const tabContentOverride = useTileContentOverride({
+    tapDanceEntries,
+    deserializedMacros,
+    onSelect: handleKeycodeSelect,
+    settings: { comboEntries, onOpenCombo, keyOverrideEntries, onOpenKeyOverride, altRepeatKeyEntries, onOpenAltRepeatKey },
   })
 
   // For file/device mode, build keycodes per-layer on the fly

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -176,13 +176,19 @@ export function TabbedKeycodes({
     el.style.left = `${clampedLeft}px`
   }, [tooltip])
 
-  // Enter key confirms current selection and closes the picker
+  // Enter key confirms current selection and closes the picker.
+  // The picker's UI hint ("press Enter to close") promises this behavior for
+  // the whole picker surface — buttons inside the picker container are
+  // treated as confirm-capable so clicking any keycode / tile and pressing
+  // Enter commits. Buttons outside (e.g. the modal's Save/Cancel) still let
+  // native Enter→click through untouched.
   useEffect(() => {
     if (!onConfirm) return
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Enter') return
       const el = e.target as HTMLElement | null
-      if (el?.tagName === 'INPUT' || el?.tagName === 'TEXTAREA' || el?.tagName === 'BUTTON' || el?.isContentEditable) return
+      if (el?.tagName === 'INPUT' || el?.tagName === 'TEXTAREA' || el?.isContentEditable) return
+      if (el?.tagName === 'BUTTON' && !containerRef.current?.contains(el)) return
       e.preventDefault()
       onConfirm()
     }

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -147,11 +147,6 @@ export function TdTileGrid({ entries, onSelect, onDoubleClick }: TdTileGridProps
             className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
             onClick={select}
             onDoubleClick={commit}
-            onKeyDown={commit ? (e) => {
-              if (e.key !== 'Enter') return
-              e.preventDefault()
-              commit()
-            } : undefined}
           >
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">TD({i})</span>
             {configured ? (
@@ -226,11 +221,6 @@ export function MacroTileGrid({ macros, onSelect, onDoubleClick }: MacroTileGrid
             className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
             onClick={select}
             onDoubleClick={commit}
-            onKeyDown={commit ? (e) => {
-              if (e.key !== 'Enter') return
-              e.preventDefault()
-              commit()
-            } : undefined}
           >
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
             {configured ? (

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -125,14 +125,19 @@ function macroActionLabel(action: MacroAction): string {
 interface TdTileGridProps {
   entries: TapDanceEntry[]
   onSelect: (keycode: Keycode) => void
+  /** Double-click / Enter commit. When omitted, only onSelect runs on click. */
+  onDoubleClick?: (keycode: Keycode) => void
 }
 
-export function TdTileGrid({ entries, onSelect }: TdTileGridProps) {
+export function TdTileGrid({ entries, onSelect, onDoubleClick }: TdTileGridProps) {
   const { t } = useTranslation()
   return (
     <div className="grid grid-cols-12 auto-rows-fr gap-1">
       {entries.map((entry, i) => {
         const configured = entry.onTap !== 0 || entry.onHold !== 0 || entry.onDoubleTap !== 0 || entry.onTapHold !== 0
+        const kc = findKeycode(`TD(${i})`)
+        const select = kc ? () => onSelect(kc) : undefined
+        const commit = kc && onDoubleClick ? () => onDoubleClick(kc) : undefined
         return (
           <button
             key={i}
@@ -140,7 +145,13 @@ export function TdTileGrid({ entries, onSelect }: TdTileGridProps) {
             data-testid={`td-tile-${i}`}
             data-configured={configured || undefined}
             className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
-            onClick={() => { const kc = findKeycode(`TD(${i})`); if (kc) onSelect(kc) }}
+            onClick={select}
+            onDoubleClick={commit}
+            onKeyDown={commit ? (e) => {
+              if (e.key !== 'Enter') return
+              e.preventDefault()
+              commit()
+            } : undefined}
           >
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">TD({i})</span>
             {configured ? (
@@ -167,6 +178,8 @@ export function TdTileGrid({ entries, onSelect }: TdTileGridProps) {
 interface MacroTileGridProps {
   macros: MacroAction[][]
   onSelect: (keycode: Keycode) => void
+  /** Double-click / Enter commit. When omitted, only onSelect runs on click. */
+  onDoubleClick?: (keycode: Keycode) => void
 }
 
 function useMacroVisibleLines(gridRef: React.RefObject<HTMLDivElement | null>): number {
@@ -193,7 +206,7 @@ function useMacroVisibleLines(gridRef: React.RefObject<HTMLDivElement | null>): 
   return visibleLines
 }
 
-export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
+export function MacroTileGrid({ macros, onSelect, onDoubleClick }: MacroTileGridProps) {
   const { t } = useTranslation()
   const gridRef = useRef<HTMLDivElement>(null)
   const maxVisible = useMacroVisibleLines(gridRef)
@@ -201,6 +214,9 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
     <div ref={gridRef} className="grid grid-cols-12 auto-rows-fr gap-1">
       {macros.map((actions, i) => {
         const configured = actions.length > 0
+        const kc = findKeycode(`M${i}`)
+        const select = kc ? () => onSelect(kc) : undefined
+        const commit = kc && onDoubleClick ? () => onDoubleClick(kc) : undefined
         return (
           <button
             key={i}
@@ -208,7 +224,13 @@ export function MacroTileGrid({ macros, onSelect }: MacroTileGridProps) {
             data-testid={`macro-tile-${i}`}
             data-configured={configured || undefined}
             className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
-            onClick={() => { const kc = findKeycode(`M${i}`); if (kc) onSelect(kc) }}
+            onClick={select}
+            onDoubleClick={commit}
+            onKeyDown={commit ? (e) => {
+              if (e.key !== 'Enter') return
+              e.preventDefault()
+              commit()
+            } : undefined}
           >
             <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
             {configured ? (

--- a/src/renderer/components/keycodes/__tests__/TileGrids.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/TileGrids.test.tsx
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TdTileGrid, MacroTileGrid } from '../TileGrids'
+import type { TapDanceEntry } from '../../../../shared/types/protocol'
+import type { MacroAction } from '../../../../preload/macro'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+vi.mock('../../../../shared/keycodes/keycodes', () => ({
+  findKeycode: (id: string) => ({ qmkId: id, label: id, masked: false, hidden: false }),
+  codeToLabel: (code: number) => `code-${code}`,
+}))
+
+function tdEntry(overrides: Partial<TapDanceEntry> = {}): TapDanceEntry {
+  return { onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 200, ...overrides }
+}
+
+describe('TdTileGrid', () => {
+  const entries: TapDanceEntry[] = [tdEntry({ onTap: 0x04 }), tdEntry()]
+
+  it('fires onSelect with TD(i) on single click', () => {
+    const onSelect = vi.fn()
+    render(<TdTileGrid entries={entries} onSelect={onSelect} />)
+    fireEvent.click(screen.getByTestId('td-tile-1'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(1)' }))
+  })
+
+  it('fires onDoubleClick with TD(i) on double click', () => {
+    const onSelect = vi.fn()
+    const onDoubleClick = vi.fn()
+    render(<TdTileGrid entries={entries} onSelect={onSelect} onDoubleClick={onDoubleClick} />)
+    fireEvent.doubleClick(screen.getByTestId('td-tile-0'))
+    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(0)' }))
+  })
+
+  it('fires onDoubleClick with TD(i) on Enter keydown', () => {
+    const onSelect = vi.fn()
+    const onDoubleClick = vi.fn()
+    render(<TdTileGrid entries={entries} onSelect={onSelect} onDoubleClick={onDoubleClick} />)
+    fireEvent.keyDown(screen.getByTestId('td-tile-1'), { key: 'Enter' })
+    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(1)' }))
+  })
+
+  it('ignores non-Enter keys', () => {
+    const onDoubleClick = vi.fn()
+    render(<TdTileGrid entries={entries} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
+    fireEvent.keyDown(screen.getByTestId('td-tile-0'), { key: 'a' })
+    expect(onDoubleClick).not.toHaveBeenCalled()
+  })
+
+  it('falls back to native Enter→click when onDoubleClick is omitted', () => {
+    const onSelect = vi.fn()
+    render(<TdTileGrid entries={entries} onSelect={onSelect} />)
+    // Without onDoubleClick, onKeyDown is not attached, so Enter fires the
+    // browser default button activation (click event → onSelect).
+    const tile = screen.getByTestId('td-tile-0')
+    fireEvent.keyDown(tile, { key: 'Enter' })
+    fireEvent.click(tile) // native activation that would follow
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(0)' }))
+  })
+})
+
+describe('MacroTileGrid', () => {
+  const macros: MacroAction[][] = [
+    [{ type: 'tap', keycodes: [0x04] }],
+    [],
+  ]
+
+  it('fires onSelect with M{i} on single click', () => {
+    const onSelect = vi.fn()
+    render(<MacroTileGrid macros={macros} onSelect={onSelect} />)
+    fireEvent.click(screen.getByTestId('macro-tile-0'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'M0' }))
+  })
+
+  it('fires onDoubleClick with M{i} on double click', () => {
+    const onDoubleClick = vi.fn()
+    render(<MacroTileGrid macros={macros} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
+    fireEvent.doubleClick(screen.getByTestId('macro-tile-1'))
+    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'M1' }))
+  })
+
+  it('fires onDoubleClick with M{i} on Enter keydown', () => {
+    const onDoubleClick = vi.fn()
+    render(<MacroTileGrid macros={macros} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
+    fireEvent.keyDown(screen.getByTestId('macro-tile-0'), { key: 'Enter' })
+    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'M0' }))
+  })
+})

--- a/src/renderer/components/keycodes/__tests__/TileGrids.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/TileGrids.test.tsx
@@ -38,31 +38,9 @@ describe('TdTileGrid', () => {
     expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(0)' }))
   })
 
-  it('fires onDoubleClick with TD(i) on Enter keydown', () => {
-    const onSelect = vi.fn()
-    const onDoubleClick = vi.fn()
-    render(<TdTileGrid entries={entries} onSelect={onSelect} onDoubleClick={onDoubleClick} />)
-    fireEvent.keyDown(screen.getByTestId('td-tile-1'), { key: 'Enter' })
-    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(1)' }))
-  })
-
-  it('ignores non-Enter keys', () => {
-    const onDoubleClick = vi.fn()
-    render(<TdTileGrid entries={entries} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
-    fireEvent.keyDown(screen.getByTestId('td-tile-0'), { key: 'a' })
-    expect(onDoubleClick).not.toHaveBeenCalled()
-  })
-
-  it('falls back to native Enter→click when onDoubleClick is omitted', () => {
-    const onSelect = vi.fn()
-    render(<TdTileGrid entries={entries} onSelect={onSelect} />)
-    // Without onDoubleClick, onKeyDown is not attached, so Enter fires the
-    // browser default button activation (click event → onSelect).
-    const tile = screen.getByTestId('td-tile-0')
-    fireEvent.keyDown(tile, { key: 'Enter' })
-    fireEvent.click(tile) // native activation that would follow
-    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'TD(0)' }))
-  })
+  // Enter-to-commit is wired at the picker level (TabbedKeycodes window
+  // handler routes any Enter inside the picker container to onConfirm), not
+  // at individual tiles — so TileGrids itself doesn't attach an onKeyDown.
 })
 
 describe('MacroTileGrid', () => {
@@ -83,12 +61,5 @@ describe('MacroTileGrid', () => {
     render(<MacroTileGrid macros={macros} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
     fireEvent.doubleClick(screen.getByTestId('macro-tile-1'))
     expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'M1' }))
-  })
-
-  it('fires onDoubleClick with M{i} on Enter keydown', () => {
-    const onDoubleClick = vi.fn()
-    render(<MacroTileGrid macros={macros} onSelect={vi.fn()} onDoubleClick={onDoubleClick} />)
-    fireEvent.keyDown(screen.getByTestId('macro-tile-0'), { key: 'Enter' })
-    expect(onDoubleClick).toHaveBeenCalledWith(expect.objectContaining({ qmkId: 'M0' }))
   })
 })

--- a/src/renderer/hooks/useKeycodeEntryModal.ts
+++ b/src/renderer/hooks/useKeycodeEntryModal.ts
@@ -237,8 +237,15 @@ export function useKeycodeEntryModal<TEntry extends Record<string, unknown>>(
     quickSelect,
   })
 
-  // Tile content override
-  const tabContentOverride = useTileContentOverride(tapDanceEntries, deserializedMacros, maskedSelection.handleKeycodeSelect)
+  // pickerSelect/pickerDoubleClick honour quickSelect:
+  // quickSelect=false → single-click selects, double-click / Enter commits;
+  // quickSelect=true  → single-click already commits, double-click handler is undefined.
+  const tabContentOverride = useTileContentOverride({
+    tapDanceEntries,
+    deserializedMacros,
+    onSelect: maskedSelection.pickerSelect,
+    onDoubleClick: maskedSelection.pickerDoubleClick,
+  })
 
   // Field interactions
   const handleFieldSelect = useCallback((field: string & keyof TEntry) => {

--- a/src/renderer/hooks/useMacroKeycodeSelection.ts
+++ b/src/renderer/hooks/useMacroKeycodeSelection.ts
@@ -151,11 +151,15 @@ export function useMacroKeycodeSelection({
     quickSelect,
   })
 
-  const tabContentOverride = useTileContentOverride(
+  // Tile picker uses pickerSelect/pickerDoubleClick so the quickSelect and
+  // Enter-to-commit behavior matches regular keycode tiles. onCommit is a
+  // no-op in macro mode, so double-click simply acts like another single-click.
+  const tabContentOverride = useTileContentOverride({
     tapDanceEntries,
     deserializedMacros,
-    maskedSelection.handleKeycodeSelect,
-  )
+    onSelect: maskedSelection.pickerSelect,
+    onDoubleClick: maskedSelection.pickerDoubleClick,
+  })
 
   const handleMaskPartClick = useCallback(
     (actionIndex: number, keycodeIndex: number, part: 'outer' | 'inner') => {

--- a/src/renderer/hooks/useTileContentOverride.tsx
+++ b/src/renderer/hooks/useTileContentOverride.tsx
@@ -15,26 +15,37 @@ interface SettingsTabOptions {
   onOpenAltRepeatKey?: (index: number) => void
 }
 
-/**
- * Builds a `tabContentOverride` record for TabbedKeycodes,
- * rendering TD, Macro, Combo, Key Override, and Alt Repeat Key tile grid previews when data is available.
- */
-export function useTileContentOverride(
-  tapDanceEntries: TapDanceEntry[] | undefined,
-  deserializedMacros: MacroAction[][] | undefined,
-  onSelect: (keycode: Keycode) => void,
-  settings?: SettingsTabOptions,
-): Record<string, React.ReactNode> | undefined {
+interface UseTileContentOverrideOptions {
+  tapDanceEntries?: TapDanceEntry[]
+  deserializedMacros?: MacroAction[][]
+  onSelect: (keycode: Keycode) => void
+  /** Picker modals pass `pickerDoubleClick` to enable double-click / Enter
+   * commit on TD and Macro tiles. The keymap editor omits it because single
+   * click there already commits. */
+  onDoubleClick?: (keycode: Keycode) => void
+  settings?: SettingsTabOptions
+}
+
+/** Builds a `tabContentOverride` record for TabbedKeycodes, rendering TD,
+ * Macro, Combo, Key Override, and Alt Repeat Key tile grid previews when data
+ * is available. */
+export function useTileContentOverride({
+  tapDanceEntries,
+  deserializedMacros,
+  onSelect,
+  onDoubleClick,
+  settings,
+}: UseTileContentOverrideOptions): Record<string, React.ReactNode> | undefined {
   return useMemo(() => {
     const hasSettings = settings?.comboEntries?.length || settings?.keyOverrideEntries?.length || settings?.altRepeatKeyEntries?.length
     if (!tapDanceEntries?.length && !deserializedMacros && !hasSettings) return undefined
 
     const overrides: Record<string, React.ReactNode> = {}
     if (tapDanceEntries?.length) {
-      overrides.tapDance = <TdTileGrid entries={tapDanceEntries} onSelect={onSelect} />
+      overrides.tapDance = <TdTileGrid entries={tapDanceEntries} onSelect={onSelect} onDoubleClick={onDoubleClick} />
     }
     if (deserializedMacros) {
-      overrides.macro = <MacroTileGrid macros={deserializedMacros} onSelect={onSelect} />
+      overrides.macro = <MacroTileGrid macros={deserializedMacros} onSelect={onSelect} onDoubleClick={onDoubleClick} />
     }
     if (settings?.comboEntries?.length && settings.onOpenCombo) {
       overrides.combo = <ComboTileGrid entries={settings.comboEntries} onOpenCombo={settings.onOpenCombo} />
@@ -46,5 +57,5 @@ export function useTileContentOverride(
       overrides.altRepeatKey = <AltRepeatKeyTileGrid entries={settings.altRepeatKeyEntries} onOpen={settings.onOpenAltRepeatKey} />
     }
     return overrides
-  }, [tapDanceEntries, deserializedMacros, onSelect, settings?.comboEntries, settings?.onOpenCombo, settings?.keyOverrideEntries, settings?.onOpenKeyOverride, settings?.altRepeatKeyEntries, settings?.onOpenAltRepeatKey])
+  }, [tapDanceEntries, deserializedMacros, onSelect, onDoubleClick, settings?.comboEntries, settings?.onOpenCombo, settings?.keyOverrideEntries, settings?.onOpenKeyOverride, settings?.altRepeatKeyEntries, settings?.onOpenAltRepeatKey])
 }


### PR DESCRIPTION
## Summary

- Restore double-click / Enter commit on TapDance and Macro tiles in
  the keycode picker (#120). The picker's hint text still advertised
  "Double-click the same key again or press Enter to close", but
  `TdTileGrid` / `MacroTileGrid` only wired `onClick`, and the picker's
  window-level Enter handler bailed out whenever focus was on any
  button — so the promised behaviour had regressed for TD / Macro tiles
  and, by extension, for regular keycode buttons too.
- Wire `onDoubleClick` onto tile buttons, route tiles through
  `maskedSelection.pickerSelect` / `pickerDoubleClick` so they honour
  Quick Select the same way the regular keycode grid does, and refactor
  `useTileContentOverride` to an options object instead of positional
  args.
- Narrow the `TabbedKeycodes` window Enter handler: `BUTTON` is only
  excluded when it sits outside the picker container. Buttons inside
  the picker (tiles, keycode buttons, tab bar) now all route Enter to
  `onConfirm`; modal-level buttons (Save / Cancel) still activate
  natively.
- Move the `ResizeObserver` no-op shim into the shared renderer test
  setup so jsdom-based tests can render components that use it without
  per-file polyfills.

## Test plan
- [x] `pnpm lint` / `npx tsc --noEmit` clean
- [x] New `TileGrids.test.tsx` (4 cases): single click / double click
      for TD and Macro grids
- [x] All keycodes / modal-related tests (175+) pass
- [x] Live: Combo modal — pick TD(n) as a trigger key via double-click
      and via Enter
- [x] Live: Combo modal — pick M(n) as output via double-click and
      via Enter
- [x] Live: TapDance modal — pick regular keys via Enter after a
      single click
- [x] Live: KeymapEditor main picker (single-click commit) unchanged

Fixes #120