### PR TITLE
fix(ui): scope Escape to inner picker/edit mode in keycode entry modals

### DIFF
--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -108,7 +108,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
     modalWidth,
   } = hook
 
-  useEscapeClose(handleClose)
+  useEscapeClose(selectedField ? handlePickerClose : handleClose)
 
   const isConfigured = editedEntry !== null && adapter.isConfigured(editedEntry)
 

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -262,7 +262,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
         <div className="flex min-h-0 flex-1 overflow-hidden" data-testid={adapter.bodyTestId ?? `editor-${prefix}`}>
           {/* Left panel */}
           <div className="flex-1 flex flex-col min-h-0">
-            <div className={`flex-1 overflow-y-auto px-6 pb-6 ${selectedField ? 'pt-6' : ''}`}>
+            <div className={`flex-1 overflow-y-auto px-6 pb-6 ${selectedField ? 'pt-6' : 'pt-1'}`}>
               {editedEntry && (
                 <>
                   <div className="space-y-2">

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -18,6 +18,7 @@ import {
 import type { TapDanceEntry } from '../../../shared/types/protocol'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { useFavoriteStore } from '../../hooks/useFavoriteStore'
 import { useMacroKeycodeSelection } from '../../hooks/useMacroKeycodeSelection'
 import { ConfirmButton } from './ConfirmButton'
@@ -161,6 +162,9 @@ export function MacroEditor({
     quickSelect,
     autoAdvance,
   })
+
+  // Guarded so MacroModal's ESC handler takes over outside edit mode and during recording.
+  useEscapeClose(revertAndDeselect, isEditing && !isRecording)
 
   const updateActions = useCallback(
     (newActions: MacroAction[]) => {

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -74,7 +74,7 @@ export function MacroModal({
   const modalWidth = isDummy ? 'w-[1200px]' : 'w-[1300px]'
   const modalHeight = isEditing ? 'max-h-[90vh]' : 'h-[90vh]'
 
-  useEscapeClose(onClose, !isRecording)
+  useEscapeClose(onClose, !isRecording && !isEditing)
 
   return (
     <div

--- a/src/renderer/components/editors/__tests__/KeycodeEntryModalShell.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeycodeEntryModalShell.test.tsx
@@ -300,4 +300,24 @@ describe('KeycodeEntryModalShell', () => {
     expect(screen.queryByText('Test - 0')).not.toBeInTheDocument()
     expect(screen.queryByTestId('test-modal-save')).not.toBeInTheDocument()
   })
+
+  it('Escape closes the outer modal when no field is selected', () => {
+    const hook = createMockHook()
+    render(
+      <KeycodeEntryModalShell adapter={testAdapter} hook={hook} index={0} />,
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(hook.handleClose).toHaveBeenCalledTimes(1)
+    expect(hook.handlePickerClose).not.toHaveBeenCalled()
+  })
+
+  it('Escape closes only the picker when a field is selected', () => {
+    const hook = createMockHook({ selectedField: 'fieldA' })
+    render(
+      <KeycodeEntryModalShell adapter={testAdapter} hook={hook} index={0} />,
+    )
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(hook.handlePickerClose).toHaveBeenCalledTimes(1)
+    expect(hook.handleClose).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/components/editors/__tests__/MacroModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/MacroModal.test.tsx
@@ -23,12 +23,13 @@ vi.mock('react-i18next', () => ({
 }))
 
 // Mock MacroEditor to verify props are passed through and let tests toggle
-// recording state from within the editor subtree.
+// recording/editing state from within the editor subtree.
 let capturedInitialMacro: number | undefined
 vi.mock('../MacroEditor', () => ({
   MacroEditor: (props: {
     initialMacro?: number
     onRecordingChange?: (recording: boolean) => void
+    onEditingChange?: (editing: boolean) => void
   }) => {
     capturedInitialMacro = props.initialMacro
     return (
@@ -39,6 +40,13 @@ vi.mock('../MacroEditor', () => ({
           onClick={() => props.onRecordingChange?.(true)}
         >
           start recording
+        </button>
+        <button
+          type="button"
+          data-testid="mock-edit-toggle"
+          onClick={() => props.onEditingChange?.(true)}
+        >
+          start editing
         </button>
       </div>
     )
@@ -115,6 +123,13 @@ describe('MacroModal', () => {
   it('does not close on Escape while recording', () => {
     render(<MacroModal {...defaultProps} />)
     fireEvent.click(screen.getByTestId('mock-record-toggle'))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(defaultProps.onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not close on Escape while MacroEditor is in edit mode', () => {
+    render(<MacroModal {...defaultProps} />)
+    fireEvent.click(screen.getByTestId('mock-edit-toggle'))
     fireEvent.keyDown(window, { key: 'Escape' })
     expect(defaultProps.onClose).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- Pressing Escape in the key picker no longer closes the outer TapDance / Combo / Key Override / Alt Repeat Key modal — it now only closes the picker and returns to the edit form
- Macro edit mode also survives Escape: `MacroEditor` exits edit mode via `revertAndDeselect` while `MacroModal` stays open
- Recording flow unchanged (Escape still suppressed while recording)

## Changes
- `KeycodeEntryModalShell.tsx`: `useEscapeClose(selectedField ? handlePickerClose : handleClose)`
- `MacroModal.tsx`: gate modal-level Escape on `!isRecording && !isEditing`
- `MacroEditor.tsx`: new `useEscapeClose(revertAndDeselect, isEditing && !isRecording)` so edit mode owns its own Escape exit

## Test plan
- [x] Unit: `KeycodeEntryModalShell.test.tsx` covers both branches (with / without selectedField)
- [x] Unit: `MacroModal.test.tsx` covers Escape while in edit mode does not close modal
- [x] Full suite: 2848 / 2848 pass
- [x] lint / tsc clean
- [ ] Manual: open TD(3) → click On Tap Hold → press Esc → picker closes, edit form remains
- [ ] Manual: same flow for Combo / Key Override / Alt Repeat Key
- [ ] Manual: open Macro → enter action edit mode → press Esc → returns to action list, modal stays