### PR TITLE
fix(ui): make macro picker edits tentative until Save is pressed

### DIFF
--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -134,7 +134,6 @@ export function MacroEditor({
     selectedKey,
     setSelectedKey,
     setPopoverState,
-    preEditValueRef,
     isEditing,
     maskedSelection,
     tabContentOverride,
@@ -150,6 +149,8 @@ export function MacroEditor({
     handlePopoverKeycodeSelect,
     closePopover,
     revertAndDeselect,
+    commitAndDeselect,
+    beginAddAction,
   } = useMacroKeycodeSelection({
     currentActions,
     activeMacro,
@@ -193,21 +194,9 @@ export function MacroEditor({
   const handleAddActionType = useCallback(
     (type: ActionType) => {
       if (isRecording) return
-      const newAction = defaultAction(type)
-      const newIndex = currentActions.length
-      clearPending()
-      setPopoverState(null)
-      setMacros((prev) => {
-        const updated = [...prev]
-        updated[activeMacro] = [...currentActions, newAction]
-        return updated
-      })
-      setDirty(true)
-      if (isKeycodeAction(newAction)) {
-        setSelectedKey({ actionIndex: newIndex, keycodeIndex: 0 })
-      }
+      beginAddAction(defaultAction(type))
     },
-    [isRecording, currentActions, activeMacro, setMacros, setDirty, clearPending, setPopoverState, setSelectedKey],
+    [isRecording, beginAddAction],
   )
 
   const handleChange = useCallback(
@@ -233,13 +222,9 @@ export function MacroEditor({
   const handleEditClick = useCallback(
     (index: number, keycodeIndex: number) => {
       if (isRecording) return
-      const action = currentActions[index]
-      if (isKeycodeAction(action)) {
-        preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
-        setSelectedKey({ actionIndex: index, keycodeIndex })
-      }
+      handleKeycodeClick(index, keycodeIndex)
     },
-    [isRecording, currentActions, setSelectedKey, preEditValueRef],
+    [isRecording, handleKeycodeClick],
   )
 
   const handleDelete = useCallback(
@@ -448,7 +433,7 @@ export function MacroEditor({
                 type="button"
                 data-testid="macro-save"
                 className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
-                onClick={isEditing ? revertAndDeselect : handleSave}
+                onClick={isEditing ? commitAndDeselect : handleSave}
                 disabled={isEditing ? isRecording : (!dirty || hasInvalidText || isRecording)}
               >
                 {t('common.save')}

--- a/src/renderer/hooks/__tests__/useMacroKeycodeSelection.test.ts
+++ b/src/renderer/hooks/__tests__/useMacroKeycodeSelection.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useState } from 'react'
+import { useMacroKeycodeSelection } from '../useMacroKeycodeSelection'
+import { recreateKeyboardKeycodes, deserialize } from '../../../shared/keycodes/keycodes'
+import type { Keycode } from '../../../shared/keycodes/keycodes'
+import type { MacroAction } from '../../../preload/macro'
+
+beforeEach(() => {
+  recreateKeyboardKeycodes({
+    vialProtocol: 6,
+    layers: 4,
+    macroCount: 4,
+    tapDanceCount: 0,
+    customKeycodes: null,
+    midi: '',
+    supportedFeatures: new Set(),
+  })
+})
+
+function fakeKey(qmkId: string): Keycode {
+  return { qmkId, label: qmkId, masked: false, alias: [qmkId], hidden: false } as Keycode
+}
+
+function tap(keycodes: number[]): MacroAction {
+  return { type: 'tap', keycodes }
+}
+
+function useTestHarness(initial: MacroAction[][], autoAdvance = false) {
+  const [macros, setMacros] = useState<MacroAction[][]>(initial)
+  const selection = useMacroKeycodeSelection({
+    currentActions: macros[0] ?? [],
+    activeMacro: 0,
+    setMacros,
+    setDirty: vi.fn(),
+    clearPending: vi.fn(),
+    autoAdvance,
+  })
+  return { macros, setMacros, selection }
+}
+
+describe('useMacroKeycodeSelection revert/commit', () => {
+  it('revertAndDeselect restores original keycodes after a picker pick', () => {
+    const orig = [deserialize('KC_T'), deserialize('KC_T'), deserialize('KC_T'), deserialize('KC_Y')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]]))
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 3) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_W')) })
+    expect(result.current.macros[0][0]).toEqual(
+      tap([...orig.slice(0, 3), deserialize('KC_W')]),
+    )
+
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.macros[0][0]).toEqual(tap(orig))
+    expect(result.current.selection.selectedKey).toBeNull()
+  })
+
+  it('commitAndDeselect preserves the picked keycode', () => {
+    const orig = [deserialize('KC_T'), deserialize('KC_Y')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]]))
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 1) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_W')) })
+
+    act(() => { result.current.selection.commitAndDeselect() })
+    expect(result.current.macros[0][0]).toEqual(tap([orig[0], deserialize('KC_W')]))
+    expect(result.current.selection.selectedKey).toBeNull()
+  })
+
+  it('revertAndDeselect drops a virtual slot added via handleKeycodeAdd + pick', () => {
+    const orig = [deserialize('KC_T'), deserialize('KC_T'), deserialize('KC_T')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]]))
+
+    act(() => { result.current.selection.handleKeycodeAdd(0) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_W')) })
+    expect(result.current.macros[0][0]).toEqual(tap([...orig, deserialize('KC_W')]))
+
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.macros[0][0]).toEqual(tap(orig))
+  })
+
+  it('revertAndDeselect after beginAddAction removes the newly-added action entirely', () => {
+    const orig: MacroAction[] = [tap([deserialize('KC_T')])]
+    const { result } = renderHook(() => useTestHarness([orig]))
+
+    act(() => { result.current.selection.beginAddAction(tap([0])) })
+    expect(result.current.macros[0]).toHaveLength(2)
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_R')) })
+    expect(result.current.macros[0][1]).toEqual(tap([deserialize('KC_R')]))
+
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.macros[0]).toEqual(orig)
+  })
+
+  it('commitAndDeselect after beginAddAction keeps the newly-added action', () => {
+    const orig: MacroAction[] = [tap([deserialize('KC_T')])]
+    const { result } = renderHook(() => useTestHarness([orig]))
+
+    act(() => { result.current.selection.beginAddAction(tap([0])) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_R')) })
+    act(() => { result.current.selection.commitAndDeselect() })
+
+    expect(result.current.macros[0]).toEqual([orig[0], tap([deserialize('KC_R')])])
+  })
+
+  it('externally clearing selectedKey invalidates the snapshot (no stale revert)', () => {
+    const orig = [deserialize('KC_T'), deserialize('KC_Y')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]]))
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 1) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_W')) })
+
+    // Simulate an external commit path (e.g. updateActions / revertAction)
+    // that clears selectedKey without going through commitAndDeselect.
+    act(() => { result.current.selection.setSelectedKey(null) })
+
+    // A later revertAndDeselect must not resurrect the pre-edit keycodes.
+    const afterExternalClear = result.current.macros[0][0]
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.macros[0][0]).toEqual(afterExternalClear)
+  })
+
+  it('revertAndDeselect after autoAdvance picks restores the full original array', () => {
+    const orig = [deserialize('KC_A'), deserialize('KC_B'), deserialize('KC_C'), deserialize('KC_D')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]], /* autoAdvance */ true))
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 1) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_X')) })
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_Y')) })
+    expect(result.current.macros[0][0]).toEqual(tap([
+      orig[0], deserialize('KC_X'), deserialize('KC_Y'), orig[3],
+    ]))
+
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.macros[0][0]).toEqual(tap(orig))
+  })
+})

--- a/src/renderer/hooks/useMacroKeycodeSelection.ts
+++ b/src/renderer/hooks/useMacroKeycodeSelection.ts
@@ -43,12 +43,28 @@ export function useMacroKeycodeSelection({
     anchorRect: DOMRect
   } | null>(null)
   const preEditValueRef = useRef<number>(0)
+  // Snapshot of the full actions array at edit start. Restoring the whole
+  // array is what lets revert undo all in-flight edits (keycode change,
+  // virtual slot add, autoAdvance runs, newly-added action via Add Tap etc.)
+  // in a single step.
+  const preEditActionsRef = useRef<MacroAction[] | null>(null)
 
   const isEditing = selectedKey !== null
 
   useLayoutEffect(() => {
     onEditingChange?.(isEditing)
   }, [isEditing, onEditingChange])
+
+  // Invalidate the pre-edit snapshot when edit mode ends or the active macro
+  // changes. Covers external callers that clear selectedKey directly (e.g.
+  // updateActions, revertAction) and prevents cross-macro corruption.
+  useEffect(() => {
+    if (!isEditing) preEditActionsRef.current = null
+  }, [isEditing])
+
+  useEffect(() => {
+    preEditActionsRef.current = null
+  }, [activeMacro])
 
   /** Update keycodes for a specific action without clearing selectedKey. */
   const setKeycodeAt = useCallback(
@@ -74,6 +90,7 @@ export function useMacroKeycodeSelection({
       const action = currentActions[actionIndex]
       if (isKeycodeAction(action)) {
         preEditValueRef.current = action.keycodes[keycodeIndex] ?? 0
+        preEditActionsRef.current = [...currentActions]
       }
       setSelectedKey({ actionIndex, keycodeIndex })
     },
@@ -92,6 +109,7 @@ export function useMacroKeycodeSelection({
       const action = currentActions[actionIndex]
       if (!isKeycodeAction(action)) return
       preEditValueRef.current = 0
+      preEditActionsRef.current = [...currentActions]
       setSelectedKey({ actionIndex, keycodeIndex: action.keycodes.length })
     },
     [currentActions],
@@ -168,6 +186,7 @@ export function useMacroKeycodeSelection({
       const code = action.keycodes[keycodeIndex]
       if (code == null) return
       preEditValueRef.current = code
+      preEditActionsRef.current = [...currentActions]
       maskedSelection.enterMaskMode(code, part)
       setSelectedKey({ actionIndex, keycodeIndex })
     },
@@ -199,9 +218,48 @@ export function useMacroKeycodeSelection({
   const pickerRef = useRef<HTMLDivElement>(null)
 
   const revertAndDeselect = useCallback(() => {
+    const snapshot = preEditActionsRef.current
+    if (selectedKey && snapshot) {
+      clearPending()
+      setMacros((prev) => {
+        const updated = [...prev]
+        updated[activeMacro] = snapshot
+        return updated
+      })
+    }
+    preEditActionsRef.current = null
+    maskedSelection.clearMask()
+    setSelectedKey(null)
+  }, [selectedKey, activeMacro, clearPending, setMacros, maskedSelection.clearMask])
+
+  const commitAndDeselect = useCallback(() => {
+    preEditActionsRef.current = null
     maskedSelection.clearMask()
     setSelectedKey(null)
   }, [maskedSelection.clearMask])
+
+  /** Append a new action and, for keycode actions, enter edit mode on its
+   *  first slot. Snapshots the pre-append state so revertAndDeselect can
+   *  remove the new action entirely. */
+  const beginAddAction = useCallback(
+    (newAction: MacroAction) => {
+      clearPending()
+      setPopoverState(null)
+      const newIndex = currentActions.length
+      preEditActionsRef.current = [...currentActions]
+      setMacros((prev) => {
+        const updated = [...prev]
+        updated[activeMacro] = [...(prev[activeMacro] ?? []), newAction]
+        return updated
+      })
+      setDirty(true)
+      if (isKeycodeAction(newAction)) {
+        preEditValueRef.current = 0
+        setSelectedKey({ actionIndex: newIndex, keycodeIndex: 0 })
+      }
+    },
+    [currentActions, activeMacro, clearPending, setMacros, setDirty],
+  )
 
   // Close picker when clicking outside of it.
   useEffect(() => {
@@ -249,5 +307,7 @@ export function useMacroKeycodeSelection({
     handlePopoverKeycodeSelect,
     closePopover,
     revertAndDeselect,
+    commitAndDeselect,
+    beginAddAction,
   }
 }


### PR DESCRIPTION
## Summary
- Macro picker clicks no longer commit immediately — ESC / X / outside-click now revert the full macro state to what it was when edit mode started
- Save button in edit mode explicitly commits the staged edits
- Also picks up the AppArmor README note and 0.3.16 version bump that were pending on main

## Changes
- `useMacroKeycodeSelection.ts`: snapshot the full `MacroAction[]` of the active macro at edit entry (covers slot click, Add keycode, mask edit, and new `beginAddAction`). `revertAndDeselect` restores the snapshot; `commitAndDeselect` (new) clears it. Invalidation `useEffect`s null the snapshot when edit mode ends or `activeMacro` changes.
- `MacroEditor.tsx`: funnel `handleAddActionType` through the new `beginAddAction`, delegate `handleEditClick` to the hook's `handleKeycodeClick` so no snapshot-taking path is missed, and wire the Save button in edit mode to `commitAndDeselect`.

## Test plan
- [x] 7 new unit tests in `useMacroKeycodeSelection.test.ts` covering: existing-slot revert, commit, virtual-slot revert, autoAdvance revert, beginAddAction revert, beginAddAction commit, external selectedKey clear invalidation
- [x] 2855 / 2855 tests pass
- [x] lint / tsc clean
- [ ] Manual: existing Tap/Down/Up slot click → pick → ESC → original value restored
- [ ] Manual: Add keycode (virtual slot) → pick → ESC → slot not added
- [ ] Manual: Add Tap action → pick R → ESC → action disappears entirely
- [ ] Manual: autoAdvance pick several keys → ESC → all reverted
- [ ] Manual: Save button in edit mode commits the staged value and exits edit mode