### PR TITLE
fix(ui): add macro edit-mode Revert and block Enter duplicate insert

### DIFF
--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -151,6 +151,8 @@ export function MacroEditor({
     revertAndDeselect,
     commitAndDeselect,
     beginAddAction,
+    hasPendingEdit,
+    isExistingEdit,
   } = useMacroKeycodeSelection({
     currentActions,
     activeMacro,
@@ -284,12 +286,24 @@ export function MacroEditor({
     setDirty(false)
   }, [macroBuffer, vialProtocol, macroCount, clearPending, setSelectedKey, setPopoverState]))
 
+  // Edit-mode Revert (per-slot) — confirms like the list-level Revert but
+  // only rolls back the in-flight picker edit via revertAndDeselect.
+  const editRevertAction = useConfirmAction(revertAndDeselect)
+
+  // Enter in the picker commits the staged edit and exits edit mode,
+  // mirroring the Save button's enabled state so an empty commit can't
+  // sneak through.
+  const pickerEnterCommit = useCallback(() => {
+    if (isEditing && !isRecording && hasPendingEdit) commitAndDeselect()
+  }, [isEditing, isRecording, hasPendingEdit, commitAndDeselect])
+
   // Clear selection state when switching macros to avoid stale indices
   useEffect(() => {
     setSelectedKey(null)
     setPopoverState(null)
     clearAction.reset()
     revertAction.reset()
+    editRevertAction.reset()
   }, [activeMacro])
 
   const memoryUsed = useMemo(() => {
@@ -398,6 +412,7 @@ export function MacroEditor({
         <div ref={pickerRef} className={`overflow-y-auto px-6 pb-6 ${isEditing ? 'shrink-0' : 'hidden'}`}>
           <TabbedKeycodes
             onKeycodeSelect={maskedSelection.pickerSelect}
+            onConfirm={pickerEnterCommit}
             maskOnly={maskedSelection.maskOnly}
             lmMode={maskedSelection.lmMode}
             tabContentOverride={tabContentOverride}
@@ -429,12 +444,24 @@ export function MacroEditor({
                   />
                 </>
               )}
+              {isEditing && isExistingEdit && (
+                <ConfirmButton
+                  testId="macro-edit-revert"
+                  confirming={editRevertAction.confirming}
+                  onClick={editRevertAction.trigger}
+                  labelKey="common.revert"
+                  confirmLabelKey="common.confirmRevert"
+                  disabled={isRecording || !hasPendingEdit}
+                />
+              )}
               <button
                 type="button"
                 data-testid="macro-save"
                 className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
                 onClick={isEditing ? commitAndDeselect : handleSave}
-                disabled={isEditing ? isRecording : (!dirty || hasInvalidText || isRecording)}
+                disabled={isEditing
+                  ? (isRecording || !hasPendingEdit)
+                  : (!dirty || hasInvalidText || isRecording)}
               >
                 {t('common.save')}
               </button>

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -177,20 +177,22 @@ export function TabbedKeycodes({
   }, [tooltip])
 
   // Enter key confirms current selection and closes the picker.
-  // The picker's UI hint ("press Enter to close") promises this behavior for
-  // the whole picker surface — buttons inside the picker container are
-  // treated as confirm-capable so clicking any keycode / tile and pressing
-  // Enter commits. Buttons outside (e.g. the modal's Save/Cancel) still let
-  // native Enter→click through untouched.
+  // Always block the browser's native "Enter re-clicks the focused button"
+  // for buttons inside the picker surface — otherwise picking a keycode
+  // leaves that tile focused and a subsequent Enter silently inserts the
+  // same keycode again. Buttons outside the picker (e.g. the modal's
+  // Save/Cancel) still let native Enter→click through.
+  //
+  // When onConfirm is provided, Enter also commits (TapDance / Combo / etc.
+  // use this for the "press Enter to close" UI hint).
   useEffect(() => {
-    if (!onConfirm) return
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'Enter') return
       const el = e.target as HTMLElement | null
       if (el?.tagName === 'INPUT' || el?.tagName === 'TEXTAREA' || el?.isContentEditable) return
       if (el?.tagName === 'BUTTON' && !containerRef.current?.contains(el)) return
       e.preventDefault()
-      onConfirm()
+      onConfirm?.()
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)

--- a/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
@@ -143,4 +143,22 @@ describe('TabbedKeycodes', () => {
     expect(btnA.className).toContain('text-accent')
     expect(btnB.className).not.toContain('text-accent')
   })
+
+  it('Enter on a focused picker button is preventDefaulted even without onConfirm (no duplicate insert)', () => {
+    render(<TabbedKeycodes onKeycodeSelect={vi.fn()} />)
+    const btn = screen.getByText('A').closest('button')!
+    btn.focus()
+    const ev = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    window.dispatchEvent(ev)
+    expect(ev.defaultPrevented).toBe(true)
+  })
+
+  it('Enter on a focused picker button calls onConfirm when provided', () => {
+    const onConfirm = vi.fn()
+    render(<TabbedKeycodes onKeycodeSelect={vi.fn()} onConfirm={onConfirm} />)
+    const btn = screen.getByText('A').closest('button')!
+    btn.focus()
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/hooks/__tests__/useMacroKeycodeSelection.test.ts
+++ b/src/renderer/hooks/__tests__/useMacroKeycodeSelection.test.ts
@@ -106,6 +106,34 @@ describe('useMacroKeycodeSelection revert/commit', () => {
     expect(result.current.macros[0]).toEqual([orig[0], tap([deserialize('KC_R')])])
   })
 
+  it('hasPendingEdit tracks whether currentActions differs from the snapshot', () => {
+    const orig = [deserialize('KC_T'), deserialize('KC_Y')]
+    const { result } = renderHook(() => useTestHarness([[tap(orig)]]))
+
+    expect(result.current.selection.hasPendingEdit).toBe(false)
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 1) })
+    expect(result.current.selection.hasPendingEdit).toBe(false)
+
+    act(() => { result.current.selection.maskedSelection.pickerSelect(fakeKey('KC_W')) })
+    expect(result.current.selection.hasPendingEdit).toBe(true)
+
+    act(() => { result.current.selection.revertAndDeselect() })
+    expect(result.current.selection.hasPendingEdit).toBe(false)
+  })
+
+  it('isExistingEdit is true for an existing-slot edit and false for beginAddAction', () => {
+    const orig: MacroAction[] = [tap([deserialize('KC_T')])]
+    const { result } = renderHook(() => useTestHarness([orig]))
+
+    act(() => { result.current.selection.handleKeycodeClick(0, 0) })
+    expect(result.current.selection.isExistingEdit).toBe(true)
+    act(() => { result.current.selection.commitAndDeselect() })
+
+    act(() => { result.current.selection.beginAddAction(tap([0])) })
+    expect(result.current.selection.isExistingEdit).toBe(false)
+  })
+
   it('externally clearing selectedKey invalidates the snapshot (no stale revert)', () => {
     const orig = [deserialize('KC_T'), deserialize('KC_Y')]
     const { result } = renderHook(() => useTestHarness([[tap(orig)]]))

--- a/src/renderer/hooks/useMacroKeycodeSelection.ts
+++ b/src/renderer/hooks/useMacroKeycodeSelection.ts
@@ -8,6 +8,30 @@ import { useMaskedKeycodeSelection } from './useMaskedKeycodeSelection'
 import { useTileContentOverride } from './useTileContentOverride'
 import { isKeycodeAction } from '../components/editors/macro-editor-utils'
 
+/** Structural equality for a MacroAction[] — cheap enough per-render because
+ *  macros are small (< 50 actions, each with a handful of keycodes). */
+function actionsEqual(a: MacroAction[], b: MacroAction[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    if (x.type !== y.type) return false
+    if (x.type === 'text' && y.type === 'text') {
+      if (x.text !== y.text) return false
+    } else if (x.type === 'delay' && y.type === 'delay') {
+      if (x.delay !== y.delay) return false
+    } else if ('keycodes' in x && 'keycodes' in y) {
+      if (x.keycodes.length !== y.keycodes.length) return false
+      for (let j = 0; j < x.keycodes.length; j++) {
+        if (x.keycodes[j] !== y.keycodes[j]) return false
+      }
+    } else {
+      return false
+    }
+  }
+  return true
+}
+
 interface UseMacroKeycodeSelectionOptions {
   currentActions: MacroAction[]
   activeMacro: number
@@ -287,6 +311,15 @@ export function useMacroKeycodeSelection({
       : 0
   })()
 
+  // isExistingEdit is false while editing a freshly-added action
+  // (beginAddAction grew the array) — that's how the Revert button stays
+  // hidden for new actions.
+  const snapshot = preEditActionsRef.current
+  const hasPendingEdit =
+    isEditing && snapshot !== null && !actionsEqual(snapshot, currentActions)
+  const isExistingEdit =
+    isEditing && snapshot !== null && snapshot.length === currentActions.length
+
   return {
     selectedKey,
     setSelectedKey,
@@ -309,5 +342,7 @@ export function useMacroKeycodeSelection({
     revertAndDeselect,
     commitAndDeselect,
     beginAddAction,
+    hasPendingEdit,
+    isExistingEdit,
   }
 }


### PR DESCRIPTION
## Summary
- Macro editor now shows a Revert ConfirmButton in edit mode when editing an existing action, and the Save button in edit mode is disabled until there are pending changes
- Enter no longer silently re-inserts the last-picked keycode in either the Keymap picker or the Macro picker — TabbedKeycodes always preventDefaults Enter on picker buttons
- In the Macro picker, Enter now commits the staged edit (mirrors the Save button's enabled state)

## Changes
- `useMacroKeycodeSelection.ts`: added `actionsEqual` helper and two derived booleans — `hasPendingEdit` (snapshot ≠ currentActions) and `isExistingEdit` (snapshot length matches, so not a beginAddAction-created action)
- `MacroEditor.tsx`: destructure the new booleans, add a Revert ConfirmButton wired to `revertAndDeselect` (confirms like the list-level Revert), update Save disabled to factor hasPendingEdit, reset the new confirm state when activeMacro changes, and pass a commit-on-Enter handler to TabbedKeycodes
- `TabbedKeycodes.tsx`: drop the `if (!onConfirm) return` short-circuit so Enter is always preventDefaulted on picker-container buttons; still calls `onConfirm?.()` when provided

## Test plan
- [x] 2 new TabbedKeycodes tests (Enter preventDefault w/o onConfirm; Enter calls onConfirm when provided)
- [x] 2 new useMacroKeycodeSelection tests (hasPendingEdit transitions; isExistingEdit existing vs beginAddAction)
- [x] 2859 / 2859 tests pass
- [x] lint / tsc clean
- [ ] Manual: Keymap picker — click G, press Enter → no duplicate insert
- [ ] Manual: Macro picker — click a slot, pick G, press Enter → Save commits (no duplicate)
- [ ] Manual: Macro edit mode with no changes → Save disabled, Revert disabled
- [ ] Manual: Macro edit mode on newly added Tap (beginAddAction) → Revert button hidden