### PR TITLE
fix(ui): update udev help to reference Vial User Manual

### DIFF
--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -35,7 +35,7 @@
     "connecting": "Connecting{{dots}}",
     "selectDevices": "Select Device",
     "connectedTo": "Connected to {{name}}",
-    "udevHelp": "If no devices are found on Linux, ensure udev rules are installed. See the project README for details.",
+    "udevHelp": "If no devices are found on Linux, ensure udev rules are installed. See Vial's User Manual for details.",
     "loadDummy": "Load from JSON file…",
     "keyboardTab": "Device",
     "fileTab": "File",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -35,7 +35,7 @@
     "connecting": "接続中{{dots}}",
     "selectDevices": "デバイスを選択",
     "connectedTo": "{{name}} に接続中",
-    "udevHelp": "Linuxでデバイスが見つからない場合は、udevルールがインストールされていることを確認してください。詳細はプロジェクトのREADMEを参照してください。",
+    "udevHelp": "Linuxでデバイスが見つからない場合は、udevルールがインストールされていることを確認してください。詳細はVialのユーザーマニュアルを参照してください。",
     "loadDummy": "JSONファイルから読み込み…",
     "keyboardTab": "デバイス",
     "fileTab": "ファイル",


### PR DESCRIPTION
## Summary

- Change the Linux udev hint on the device selector to point users to **Vial's User Manual** instead of the project README.
- The README udev section lives deep in the Development chapter and is hard to reach for AppImage users; Vial's manual ships a self-contained setup guide that covers the universal rule, vendor/product rules, and `udevadm` reload.
- Intentionally omit a fixed URL so the message stays valid if Vial's site restructures — users can search the manual by name.

## Test plan

- [ ] `pnpm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `pnpm test`
- [ ] Manual check: open Device Selector with no devices on Linux → confirm the new copy is rendered in both EN and JA.

Refs #125.