### PR TITLE
Fix for language specific nested keys

### DIFF
--- a/src/renderer/components/editors/KeyboardPane.tsx
+++ b/src/renderer/components/editors/KeyboardPane.tsx
@@ -16,6 +16,7 @@ export interface KeyboardPaneProps {
   keys: KleKey[]
   keycodes: Map<string, string>
   encoderKeycodes: Map<string, [string, string]>
+  encoderRemappedKeys?: Set<string>
   selectedKey: { row: number; col: number } | null
   selectedEncoder: { idx: number; dir: number } | null
   selectedMaskPart: boolean
@@ -44,6 +45,7 @@ export function KeyboardPane({
   keys,
   keycodes,
   encoderKeycodes,
+  encoderRemappedKeys,
   selectedKey,
   selectedEncoder,
   selectedMaskPart,
@@ -80,6 +82,7 @@ export function KeyboardPane({
           keys={keys}
           keycodes={keycodes}
           encoderKeycodes={encoderKeycodes}
+          encoderRemappedKeys={encoderRemappedKeys}
           selectedKey={isActive ? selectedKey : null}
           selectedEncoder={isActive ? selectedEncoder : null}
           selectedMaskPart={isActive ? selectedMaskPart : false}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -530,7 +530,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         const posKey = `${r},${c}`
         const qmkId = serialize(code)
         keycodes.set(posKey, remap(qmkId))
-        if (!isMask(qmkId) && checkRemapped(qmkId)) remapped.add(posKey)
+        if (checkRemapped(qmkId)) remapped.add(posKey)
       }
     }
     return { keycodes, remapped }
@@ -538,30 +538,45 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
   const buildEncoderKeycodesForLayer = useCallback((layer: number) => {
     const map = new Map<string, [string, string]>()
+    const remapped = new Set<string>()
+    const checkRemapped = isRemapped ?? (() => false)
     for (let i = 0; i < encoderCount; i++) {
       const cw = encoderLayout.get(`${layer},${i},0`) ?? 0
       const ccw = encoderLayout.get(`${layer},${i},1`) ?? 0
-      map.set(String(i), [remap(serialize(cw)), remap(serialize(ccw))])
+      const cwQmk = serialize(cw)
+      const ccwQmk = serialize(ccw)
+      map.set(String(i), [remap(cwQmk), remap(ccwQmk)])
+      if (checkRemapped(cwQmk)) remapped.add(`${i},0`)
+      if (checkRemapped(ccwQmk)) remapped.add(`${i},1`)
     }
-    return map
-  }, [encoderLayout, encoderCount, remap])
+    return { keycodes: map, remapped }
+  }, [encoderLayout, encoderCount, remap, isRemapped])
 
   const { keycodes: layerKeycodes, remapped: remappedKeys } = useMemo(() => buildKeycodesForLayer(currentLayer), [buildKeycodesForLayer, currentLayer])
-  const layerEncoderKeycodes = useMemo(() => buildEncoderKeycodesForLayer(currentLayer), [buildEncoderKeycodesForLayer, currentLayer])
+  const { keycodes: layerEncoderKeycodes, remapped: layerEncoderRemapped } = useMemo(
+    () => buildEncoderKeycodesForLayer(currentLayer),
+    [buildEncoderKeycodesForLayer, currentLayer],
+  )
 
 
   const { keycodes: typingTestKeycodes, remapped: typingTestRemapped } = useMemo(
     () => typingTestMode ? buildKeycodesForLayer(typingTest.effectiveLayer) : { keycodes: EMPTY_KEYCODES, remapped: EMPTY_REMAPPED },
     [buildKeycodesForLayer, typingTest.effectiveLayer, typingTestMode])
   const typingTestEncoderKeycodes = useMemo(
-    () => typingTestMode ? buildEncoderKeycodesForLayer(typingTest.effectiveLayer) : EMPTY_ENCODER_KEYCODES,
+    () => typingTestMode ? buildEncoderKeycodesForLayer(typingTest.effectiveLayer).keycodes : EMPTY_ENCODER_KEYCODES,
     [buildEncoderKeycodesForLayer, typingTest.effectiveLayer, typingTestMode])
+  const typingTestEncoderRemapped = useMemo(
+    () => typingTestMode ? buildEncoderKeycodesForLayer(typingTest.effectiveLayer).remapped : EMPTY_REMAPPED,
+    [buildEncoderKeycodesForLayer, typingTest.effectiveLayer, typingTestMode],
+  )
 
   // --- Layout picker keycodes ---
   const { keycodes: pickerKeycodes, remapped: pickerRemapped } = useMemo(
     () => buildKeycodesForLayer(pickerLayer), [buildKeycodesForLayer, pickerLayer])
-  const pickerEncoderKeycodes = useMemo(
-    () => buildEncoderKeycodesForLayer(pickerLayer), [buildEncoderKeycodesForLayer, pickerLayer])
+  const { keycodes: pickerEncoderKeycodes, remapped: pickerEncoderRemapped } = useMemo(
+    () => buildEncoderKeycodesForLayer(pickerLayer),
+    [buildEncoderKeycodesForLayer, pickerLayer],
+  )
 
   // Build ordered keycode numbers for picker multi-select (Shift+click range)
   const pickerTabKeycodeNumbers = useMemo(() => {
@@ -684,8 +699,8 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
   // Layout picker: keyboard-as-keycode-picker shown inside the picker panel
   const pickerData = pickerFileData
-    ? { keys: pickerFileData.layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: pickerFileData.layoutOptions, totalLayers: pickerFileData.layers, names: pickerFileData.layerNames }
-    : { keys: layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: effectiveLayoutOptions, totalLayers: layers, names: layerNames }
+    ? { keys: pickerFileData.layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, encoderRemapped: pickerEncoderRemapped, remapped: pickerRemapped, layoutOpts: pickerFileData.layoutOptions, totalLayers: pickerFileData.layers, names: pickerFileData.layerNames }
+    : { keys: layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, encoderRemapped: pickerEncoderRemapped, remapped: pickerRemapped, layoutOpts: effectiveLayoutOptions, totalLayers: layers, names: layerNames }
 
   const pickerEffectiveScale = pickerFileData ? (pickerScale ?? scaleProp) : scaleProp
   const activPickerKeycodes = pickerFileData ? filePickerKeycodes : pickerKeycodes
@@ -779,6 +794,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           <div ref={pickerContainerRef} className="picker-hover-keys relative flex h-full min-h-0 items-center justify-center">
             <KeyboardPane
               paneId="secondary" isActive={true}              keys={pickerData.keys} keycodes={activPickerKeycodes} encoderKeycodes={pickerData.encoderKeycodes}
+              encoderRemappedKeys={pickerData.encoderRemapped}
               selectedKey={null} selectedEncoder={null} selectedMaskPart={false} selectedKeycode={null}
               remappedKeys={pickerData.remapped} multiSelectedKeys={pickerHighlightPositions}
               layoutOptions={pickerData.layoutOpts} scale={pickerEffectiveScale}
@@ -907,6 +923,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               pressedKeys={pressedKeys}
               keycodes={typingTestKeycodes}
               encoderKeycodes={typingTestEncoderKeycodes}
+              encoderRemappedKeys={typingTestEncoderRemapped}
               remappedKeys={typingTestRemapped}
               layoutOptions={effectiveLayoutOptions}
               scale={scaleProp}
@@ -923,6 +940,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           ) : (
             <KeyboardPane
               paneId="primary" isActive={true}              keys={layout.keys} keycodes={layerKeycodes} encoderKeycodes={layerEncoderKeycodes}
+              encoderRemappedKeys={layerEncoderRemapped}
               selectedKey={selectedKey} selectedEncoder={selectedEncoder} selectedMaskPart={selectedMaskPart} selectedKeycode={selectedKeycode}
               pressedKeys={matrixMode ? pressedKeys : undefined} everPressedKeys={matrixMode ? everPressedKeys : undefined}
               remappedKeys={remappedKeys} multiSelectedKeys={multiSelectedKeys}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -25,6 +25,7 @@ export interface TypingTestPaneProps {
   pressedKeys: Set<string>
   keycodes: Map<string, string>
   encoderKeycodes: Map<string, [string, string]>
+  encoderRemappedKeys?: Set<string>
   remappedKeys: Set<string>
   layoutOptions: Map<number, number>
   scale: number
@@ -50,6 +51,7 @@ export function TypingTestPane({
   pressedKeys,
   keycodes,
   encoderKeycodes,
+  encoderRemappedKeys,
   remappedKeys,
   layoutOptions,
   scale,
@@ -293,6 +295,7 @@ export function TypingTestPane({
             keys={keys}
             keycodes={keycodes}
             encoderKeycodes={encoderKeycodes}
+            encoderRemappedKeys={encoderRemappedKeys}
             selectedKey={null}
             selectedEncoder={null}
             selectedMaskPart={false}

--- a/src/renderer/components/keyboard/EncoderWidget.tsx
+++ b/src/renderer/components/keyboard/EncoderWidget.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { memo, useId } from 'react'
-import { keycodeLabel, isMask, findInnerKeycode } from '../../../shared/keycodes/keycodes'
+import { keycodeLabel, isMask, findInnerKeycodeText } from '../../../shared/keycodes/keycodes'
 import type { KleKey } from '../../../shared/kle/types'
 import {
   KEY_UNIT,
@@ -11,11 +11,13 @@ import {
   KEY_SELECTED_COLOR,
   KEY_TEXT_COLOR,
   KEY_MASK_RECT_COLOR,
+  KEY_REMAP_COLOR,
 } from './constants'
 
 interface Props {
   kleKey: KleKey
   keycode: string
+  remapped?: boolean
   selected?: boolean
   selectedMaskPart?: boolean
   onClick?: (key: KleKey, direction: number, maskClicked: boolean) => void
@@ -26,6 +28,7 @@ interface Props {
 function EncoderWidgetInner({
   kleKey,
   keycode,
+  remapped,
   selected,
   selectedMaskPart,
   onClick,
@@ -48,6 +51,7 @@ function EncoderWidgetInner({
   const innerSelected = selected && selectedMaskPart && masked
   const fillColor = selected && !innerSelected ? KEY_SELECTED_COLOR : KEY_BG_COLOR
   const labelColor = selected && !innerSelected ? 'var(--content-inverse)' : KEY_TEXT_COLOR
+  const innerLabelColor = remapped ? KEY_REMAP_COLOR : KEY_TEXT_COLOR
   const fontSize = Math.max(8, Math.min(12, 12 * scale))
   const outerBorderActive = selected && !innerSelected
 
@@ -85,7 +89,7 @@ function EncoderWidgetInner({
 
   // --- Masked: split display with inner rect clipped to circle ---
   const outerLabel = keycodeLabel(keycode).split('\n')[0]
-  const innerLabel = keycodeLabel(findInnerKeycode(keycode)?.qmkId ?? '').split('\n')[0]
+  const innerLabel = keycodeLabel(findInnerKeycodeText(keycode)).split('\n')[0]
   const innerBorderActive = !!innerSelected
 
   // Inner rect: bottom 50% of circle, fully inside the circle
@@ -134,7 +138,7 @@ function EncoderWidgetInner({
       </text>
       {/* Inner label (basic key) */}
       <text x={cx} y={innerLabelY} textAnchor="middle" dominantBaseline="central"
-        fill={KEY_TEXT_COLOR} fontSize={fontSize} fontFamily="sans-serif" style={{ pointerEvents: 'none' }}>
+        fill={innerLabelColor} fontSize={fontSize} fontFamily="sans-serif" style={{ pointerEvents: 'none' }}>
         {innerLabel}
       </text>
     </g>

--- a/src/renderer/components/keyboard/KeyWidget.tsx
+++ b/src/renderer/components/keyboard/KeyWidget.tsx
@@ -5,7 +5,7 @@ import {
   keycodeLabel,
   isMask,
   findOuterKeycode,
-  findInnerKeycode,
+  findInnerKeycodeText,
 } from '../../../shared/keycodes/keycodes'
 import type { KleKey } from '../../../shared/kle/types'
 import {
@@ -102,14 +102,16 @@ function KeyWidgetInner({
   // for remapped keys in non-mask mode, default otherwise
   let labelColor = KEY_TEXT_COLOR
   if (invertText) labelColor = 'var(--content-inverse)'
-  else if (remapped) labelColor = KEY_REMAP_COLOR
+  else if (remapped && !masked) labelColor = KEY_REMAP_COLOR
+  const outerLabelColor = labelColor
+  const innerLabelColor = remapped ? KEY_REMAP_COLOR : KEY_TEXT_COLOR
 
   // Label
   const outerLabel = keycodeLabel(keycode)
   const innerLabel = maskKeycode
     ? keycodeLabel(maskKeycode)
     : masked
-      ? keycodeLabel(findInnerKeycode(keycode)?.qmkId ?? '')
+      ? keycodeLabel(findInnerKeycodeText(keycode))
       : ''
 
   // Text rendering: split by \n for multi-line labels
@@ -262,7 +264,7 @@ function KeyWidgetInner({
             y={y + h * 0.25}
             textAnchor="middle"
             dominantBaseline="central"
-            fill={labelColor}
+            fill={outerLabelColor}
             fontSize={fontSize * 0.85}
             fontFamily="sans-serif"
             style={{ pointerEvents: 'none' }}
@@ -275,7 +277,7 @@ function KeyWidgetInner({
             y={innerY + innerH / 2}
             textAnchor="middle"
             dominantBaseline="central"
-            fill={KEY_TEXT_COLOR}
+            fill={innerLabelColor}
             fontSize={fontSize * 0.85}
             fontFamily="sans-serif"
             style={{ pointerEvents: 'none' }}

--- a/src/renderer/components/keyboard/KeyboardWidget.tsx
+++ b/src/renderer/components/keyboard/KeyboardWidget.tsx
@@ -63,6 +63,7 @@ interface Props {
   keycodes: Map<string, string>
   maskKeycodes?: Map<string, string>
   encoderKeycodes?: Map<string, [string, string]>
+  encoderRemappedKeys?: Set<string>
   selectedKey?: { row: number; col: number } | null
   selectedEncoder?: { idx: number; dir: 0 | 1 } | null
   pressedKeys?: Set<string>
@@ -87,6 +88,7 @@ function KeyboardWidgetInner({
   keycodes,
   maskKeycodes,
   encoderKeycodes,
+  encoderRemappedKeys,
   selectedKey,
   selectedEncoder,
   selectedMaskPart,
@@ -170,6 +172,7 @@ function KeyboardWidgetInner({
               key={`enc-${key.encoderIdx}-${key.encoderDir}-${idx}`}
               kleKey={key}
               keycode={kc}
+              remapped={encoderRemappedKeys?.has(`${key.encoderIdx},${key.encoderDir}`)}
               selected={false}
               onClick={readOnly ? undefined : onEncoderClick}
               onDoubleClick={readOnly ? undefined : onEncoderDoubleClick}
@@ -216,6 +219,7 @@ function KeyboardWidgetInner({
               key={`enc-${key.encoderIdx}-${key.encoderDir}-${idx}`}
               kleKey={key}
               keycode={kc}
+              remapped={encoderRemappedKeys?.has(`${key.encoderIdx},${key.encoderDir}`)}
               selected
               selectedMaskPart={selectedMaskPart}
               onClick={readOnly ? undefined : onEncoderClick}

--- a/src/renderer/components/keyboard/__tests__/EncoderWidget.test.tsx
+++ b/src/renderer/components/keyboard/__tests__/EncoderWidget.test.tsx
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { EncoderWidget } from '../EncoderWidget'
+import { KEY_REMAP_COLOR, KEY_TEXT_COLOR } from '../constants'
+import type { KleKey } from '../../../../shared/kle/types'
+
+let mockIsMask = false
+
+vi.mock('../../../../shared/keycodes/keycodes', () => ({
+  keycodeLabel: (kc: string) => kc,
+  isMask: () => mockIsMask,
+  findInnerKeycodeText: () => 'KC_A',
+}))
+
+function makeEncoderKey(overrides: Partial<KleKey> = {}): KleKey {
+  return {
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    x2: 0,
+    y2: 0,
+    width2: 1,
+    height2: 1,
+    rotation: 0,
+    rotationX: 0,
+    rotationY: 0,
+    color: '',
+    labels: [],
+    textColor: [],
+    textSize: [],
+    row: 0,
+    col: 0,
+    encoderIdx: 0,
+    encoderDir: 0,
+    layoutIndex: -1,
+    layoutOption: -1,
+    decal: false,
+    nub: false,
+    stepped: false,
+    ghost: false,
+    ...overrides,
+  }
+}
+
+describe('EncoderWidget remap colors', () => {
+  beforeEach(() => {
+    mockIsMask = false
+  })
+
+  it('marks only inner label in remap color for masked encoder keycodes', () => {
+    mockIsMask = true
+    const { container } = render(
+      <svg>
+        <EncoderWidget kleKey={makeEncoderKey()} keycode="LT0(KC_A)" remapped />
+      </svg>,
+    )
+    const texts = container.querySelectorAll('text')
+    expect(texts[0].getAttribute('fill')).toBe(KEY_TEXT_COLOR)
+    expect(texts[1].getAttribute('fill')).toBe(KEY_REMAP_COLOR)
+  })
+})

--- a/src/renderer/components/keyboard/__tests__/KeyWidget.test.tsx
+++ b/src/renderer/components/keyboard/__tests__/KeyWidget.test.tsx
@@ -13,6 +13,7 @@ import {
   KEY_BORDER_COLOR,
   KEY_MASK_RECT_COLOR,
   KEY_TEXT_COLOR,
+  KEY_REMAP_COLOR,
 } from '../constants'
 import type { KleKey } from '../../../../shared/kle/types'
 
@@ -23,6 +24,10 @@ vi.mock('../../../../shared/keycodes/keycodes', () => ({
   isMask: () => mockIsMask,
   findOuterKeycode: () => ({ qmkId: 'LT0' }),
   findInnerKeycode: () => ({ qmkId: 'KC_A' }),
+  findInnerKeycodeText: (qmkId: string) => {
+    if (qmkId === 'LT0(Ä)') return 'Ä'
+    return 'KC_A'
+  },
 }))
 
 function makeKey(overrides: Partial<KleKey> = {}): KleKey {
@@ -296,6 +301,39 @@ describe('KeyWidget', () => {
       // Both labels use normal text color since outer has no fill
       expect(texts[0].getAttribute('fill')).toBe(KEY_TEXT_COLOR)
       expect(texts[1].getAttribute('fill')).toBe(KEY_TEXT_COLOR)
+    })
+
+    it('keeps displaying inner fallback text when inner keycode is not canonical', () => {
+      mockIsMask = true
+      const { container } = render(
+        <svg>
+          <KeyWidget kleKey={makeKey()} keycode="LT0(Ä)" />
+        </svg>,
+      )
+      const texts = container.querySelectorAll('text')
+      expect(texts[1].textContent).toBe('Ä')
+    })
+
+    it('uses remap color for inner masked label when key is remapped', () => {
+      mockIsMask = true
+      const { container } = render(
+        <svg>
+          <KeyWidget kleKey={makeKey()} keycode="LT0(KC_A)" remapped />
+        </svg>,
+      )
+      const texts = container.querySelectorAll('text')
+      expect(texts[1].getAttribute('fill')).toBe(KEY_REMAP_COLOR)
+    })
+
+    it('does not mark outer masked label as remapped when only inner changed', () => {
+      mockIsMask = true
+      const { container } = render(
+        <svg>
+          <KeyWidget kleKey={makeKey()} keycode="LT0(KC_A)" remapped />
+        </svg>,
+      )
+      const texts = container.querySelectorAll('text')
+      expect(texts[0].getAttribute('fill')).toBe(KEY_TEXT_COLOR)
     })
 
     it('shows accent border on non-masked key even if selectedMaskPart leaks true', () => {

--- a/src/renderer/hooks/__tests__/useKeyboardLayout.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyboardLayout.test.ts
@@ -136,6 +136,24 @@ describe('remapKeycode', () => {
     })
   })
 
+  describe('nested key remapping', () => {
+    it('remaps inner keycodes while preserving LT wrapper', () => {
+      expect(remapKeycode('LT0(KC_Y)', 'german')).toBe('LT0(Z)')
+    })
+
+    it('remaps inner keycodes while preserving modifier wrappers', () => {
+      expect(remapKeycode('LALT(KC_Y)', 'german')).toBe('LALT(Z)')
+    })
+
+    it('remaps nested arguments recursively', () => {
+      expect(remapKeycode('LALT(LSFT(KC_Y))', 'german')).toBe('LALT(LSFT(Z))')
+    })
+
+    it('keeps numeric arguments unchanged for wrapper expressions', () => {
+      expect(remapKeycode('LT(1,KC_Y)', 'german')).toBe('LT(1,Z)')
+    })
+  })
+
   describe('French mapping', () => {
     it('remaps French AZERTY keys to display strings', () => {
       expect(remapKeycode('KC_Q', 'french')).toBe('A')
@@ -167,6 +185,11 @@ describe('isRemappedKeycode', () => {
     expect(isRemappedKeycode('KC_Z', 'german')).toBe(true)
     expect(isRemappedKeycode('KC_LBRACKET', 'german')).toBe(true)
     expect(isRemappedKeycode('KC_SCOLON', 'german')).toBe(true)
+    expect(isRemappedKeycode('LT0(KC_Y)', 'german')).toBe(true)
+  })
+
+  it('returns true for nested remaps in other layouts as well', () => {
+    expect(isRemappedKeycode('LALT(KC_Q)', 'french')).toBe(true)
   })
 
   it('returns false for non-remapped keys in German layout', () => {

--- a/src/renderer/hooks/useKeyboardLayout.ts
+++ b/src/renderer/hooks/useKeyboardLayout.ts
@@ -13,16 +13,60 @@ function getRemapTable(layout: KeyboardLayoutId): Record<string, string> | null 
   return def.map
 }
 
+function isLiteralToken(token: string): boolean {
+  return /^-?(?:0x[0-9a-f]+|\d+)$/i.test(token)
+}
+
+function splitTopLevelArgs(content: string): string[] {
+  const args: string[] = []
+  let start = 0
+  let depth = 0
+
+  for (let i = 0; i < content.length; i++) {
+    const ch = content[i]
+    if (ch === '(') {
+      depth++
+    } else if (ch === ')') {
+      depth = Math.max(0, depth - 1)
+    } else if (ch === ',' && depth === 0) {
+      args.push(content.slice(start, i))
+      start = i + 1
+    }
+  }
+
+  args.push(content.slice(start))
+  return args
+}
+
+function remapNestedKeycode(qmkId: string, table: Record<string, string>): string {
+  const direct = table[qmkId]
+  if (direct !== undefined) return direct
+
+  const openIdx = qmkId.indexOf('(')
+  if (openIdx <= 0 || !qmkId.endsWith(')')) return qmkId
+
+  const head = qmkId.slice(0, openIdx)
+  const inner = qmkId.slice(openIdx + 1, -1)
+  const args = splitTopLevelArgs(inner)
+  if (args.length === 0) return qmkId
+
+  const remappedArgs = args.map((arg) => {
+    const trimmed = arg.trim()
+    if (trimmed.length === 0 || isLiteralToken(trimmed)) return trimmed
+    return remapNestedKeycode(trimmed, table)
+  })
+
+  return `${head}(${remappedArgs.join(',')})`
+}
+
 export function remapKeycode(qmkId: string, layout: KeyboardLayoutId): string {
   const table = getRemapTable(layout)
   if (!table) return qmkId
-  return table[qmkId] ?? qmkId
+  return remapNestedKeycode(qmkId, table)
 }
 
 export function isRemappedKeycode(qmkId: string, layout: KeyboardLayoutId): boolean {
-  const table = getRemapTable(layout)
-  if (!table) return false
-  return qmkId in table
+  return remapKeycode(qmkId, layout) !== qmkId
 }
 
 interface UseKeyboardLayoutReturn {

--- a/src/shared/keycodes/keycodes-utils.ts
+++ b/src/shared/keycodes/keycodes-utils.ts
@@ -404,6 +404,18 @@ export function findInnerKeycode(qmkId: string): Keycode | undefined {
   return findKeycode(qmkId)
 }
 
+/**
+ * Returns inner mask argument as qmkId when known, otherwise raw inner text.
+ * This preserves remapped display labels for nested keycodes that are no longer
+ * resolvable as canonical keycodes.
+ */
+export function findInnerKeycodeText(qmkId: string): string {
+  if (!isMask(qmkId)) return ''
+  const inner = qmkId.substring(qmkId.indexOf('(') + 1, qmkId.length - 1).trim()
+  if (inner.length === 0) return ''
+  return findKeycode(inner)?.qmkId ?? inner
+}
+
 export function findByRecorderAlias(alias: string): Keycode | undefined {
   return recorderAliasToKeycode.get(alias)
 }

--- a/src/shared/keycodes/keycodes.ts
+++ b/src/shared/keycodes/keycodes.ts
@@ -1184,6 +1184,7 @@ export {
   findKeycodeByLabel,
   findOuterKeycode,
   findInnerKeycode,
+  findInnerKeycodeText,
   findByRecorderAlias,
   findByQmkId,
   keycodeLabel,


### PR DESCRIPTION
Fix for nested keys like LT(kc) and LALT(kc), where the keycode inside did not change depending on the selected language (Key label). Also works for nested Encoder labels.
<img width="2370" height="1296" alt="CleanShot 2026-04-24 at 20 44 23@2x" src="https://github.com/user-attachments/assets/dd8226f8-7503-4752-a33e-3d4b635bf0bd" />

This is made with AI and to be honest: I dont fully understand the changes. If this is not good or you dont want to check it, feel free to dismiss it and see it as a bug report.

Thanks for again for this great software! 
