### PR TITLE
feat(ui): add compositeLabels override for composite keycodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,10 @@ Contributions are welcome! In particular:
 
 - **Translations** — Add a locale JSON file to `src/renderer/i18n/locales/` and register it in `src/renderer/i18n/index.ts`.
   PRs for new languages or corrections to existing translations are appreciated.
+- **Keyboard layout composite labels** — `KeyboardLayoutDef.compositeLabels` in `src/renderer/data/keyboard-layouts.ts`
+  lets a layout override the label of an individual composite keycode (e.g. `LALT(KC_L)` → "Cmd L" on macOS).
+  Add the full qmkId → display string mapping to the relevant layout. Reviewers must check that the
+  same label is not assigned to two different composite qmkIds within one layout (label collision).
 - **Bug reports & feature requests** — Open an issue to let us know.
 
 ## Acknowledgments

--- a/src/renderer/data/keyboard-layouts.ts
+++ b/src/renderer/data/keyboard-layouts.ts
@@ -8,6 +8,18 @@ export interface KeyboardLayoutDef {
   id: string
   name: string
   map: Record<string, string>
+  /**
+   * Optional override for composite keycodes such as `LALT(KC_L)` → "Cmd L".
+   *
+   * Looked up before `map` in `remapLabel` (see `useKeyboardLayout.ts`).
+   * Lets contributors attach OS × language specific labels to individual
+   * composite qmkIds without disturbing basic-key remap behavior.
+   *
+   * Pipette ships no defaults here — contributor PRs add layout-specific
+   * entries. Reviewers must check that the same label is not assigned to
+   * different composite qmkIds within one layout (label collision).
+   */
+  compositeLabels?: Record<string, string>
 }
 
 export const KEYBOARD_LAYOUTS: KeyboardLayoutDef[] = [

--- a/src/renderer/hooks/__tests__/useKeyboardLayout.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyboardLayout.test.ts
@@ -3,8 +3,33 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act } from '@testing-library/react'
-import { useKeyboardLayout, remapKeycode, isRemappedKeycode } from '../useKeyboardLayout'
+import { useKeyboardLayout, remapKeycode, remapLabel, isRemappedKeycode } from '../useKeyboardLayout'
 import { setupAppConfigMock, renderHookWithConfig } from './test-helpers'
+import { KEYBOARD_LAYOUTS, LAYOUT_BY_ID } from '../../data/keyboard-layouts'
+
+const COMPOSITE_TEST_LAYOUT_ID = '__composite-test__'
+
+function withCompositeTestLayout(
+  compositeLabels: Record<string, string>,
+  body: () => void,
+): void {
+  const def = {
+    id: COMPOSITE_TEST_LAYOUT_ID,
+    name: 'Composite Test',
+    map: { KC_A: 'カスタムA' },
+    compositeLabels,
+  }
+  const insertedAt = KEYBOARD_LAYOUTS.push(def) - 1
+  LAYOUT_BY_ID.set(COMPOSITE_TEST_LAYOUT_ID, def)
+  try {
+    body()
+  } finally {
+    LAYOUT_BY_ID.delete(COMPOSITE_TEST_LAYOUT_ID)
+    if (KEYBOARD_LAYOUTS[insertedAt] === def) {
+      KEYBOARD_LAYOUTS.splice(insertedAt, 1)
+    }
+  }
+}
 
 describe('remapKeycode', () => {
   describe('QWERTY (identity)', () => {
@@ -182,6 +207,60 @@ describe('isRemappedKeycode', () => {
   it('returns false for non-remapped keys in Japanese layout', () => {
     expect(isRemappedKeycode('KC_A', 'japanese')).toBe(false)
     expect(isRemappedKeycode('KC_Q', 'japanese')).toBe(false)
+  })
+})
+
+describe('remapLabel (composite override)', () => {
+  it('returns the composite label when defined', () => {
+    withCompositeTestLayout({ 'LALT(KC_L)': 'Alt L' }, () => {
+      expect(remapLabel('LALT(KC_L)', COMPOSITE_TEST_LAYOUT_ID)).toBe('Alt L')
+    })
+  })
+
+  it('falls back to basic-key map when composite has no entry', () => {
+    withCompositeTestLayout({ 'LALT(KC_L)': 'Alt L' }, () => {
+      // Basic key still uses `map`
+      expect(remapLabel('KC_A', COMPOSITE_TEST_LAYOUT_ID)).toBe('カスタムA')
+    })
+  })
+
+  it('passes the qmkId through when neither table covers it', () => {
+    withCompositeTestLayout({ 'LALT(KC_L)': 'Alt L' }, () => {
+      expect(remapLabel('KC_Z', COMPOSITE_TEST_LAYOUT_ID)).toBe('KC_Z')
+    })
+  })
+
+  it('still works for layouts without compositeLabels (qwerty)', () => {
+    expect(remapLabel('KC_A', 'qwerty')).toBe('KC_A')
+    expect(remapLabel('LALT(KC_L)', 'qwerty')).toBe('LALT(KC_L)')
+  })
+
+  it('preserves existing remapKeycode behavior on layouts that only define map', () => {
+    expect(remapLabel('KC_S', 'dvorak')).toBe('O')
+    expect(remapLabel('KC_LBRACKET', 'japanese')).toBe('`\n@')
+  })
+
+  it('marks composite-only entries as remapped', () => {
+    withCompositeTestLayout({ 'LALT(KC_L)': 'Alt L' }, () => {
+      expect(isRemappedKeycode('LALT(KC_L)', COMPOSITE_TEST_LAYOUT_ID)).toBe(true)
+      // basic-key remap also still detected
+      expect(isRemappedKeycode('KC_A', COMPOSITE_TEST_LAYOUT_ID)).toBe(true)
+      expect(isRemappedKeycode('KC_Z', COMPOSITE_TEST_LAYOUT_ID)).toBe(false)
+    })
+  })
+
+  it('treats an empty compositeLabels object as no-op', () => {
+    withCompositeTestLayout({}, () => {
+      expect(remapLabel('LALT(KC_L)', COMPOSITE_TEST_LAYOUT_ID)).toBe('LALT(KC_L)')
+      expect(isRemappedKeycode('LALT(KC_L)', COMPOSITE_TEST_LAYOUT_ID)).toBe(false)
+    })
+  })
+
+  it('does not affect remapKeycode (basic-key-only) lookups', () => {
+    withCompositeTestLayout({ 'LALT(KC_L)': 'Alt L' }, () => {
+      // remapKeycode still ignores compositeLabels
+      expect(remapKeycode('LALT(KC_L)', COMPOSITE_TEST_LAYOUT_ID)).toBe('LALT(KC_L)')
+    })
   })
 })
 

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useRef } from 'react'
 import { LAYOUT_ID_SET } from '../data/keyboard-layouts'
 import type { KeyboardLayoutId } from '../data/keyboard-layouts'
-import { remapKeycode, isRemappedKeycode } from './useKeyboardLayout'
+import { remapLabel as remapLabelFn, isRemappedKeycode } from './useKeyboardLayout'
 import { useAppConfig } from './useAppConfig'
 import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
 import type { TypingTestResult, TypingViewMenuTab, ViewMode } from '../../shared/types/pipette-settings'
@@ -470,7 +470,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   }, [saveCurrentPrefs, defaultLayout, defaultAutoAdvance, defaultLayerPanelOpen, defaultBasicViewType, defaultSplitKeyMode, defaultQuickSelect])
 
   const remapLabel = useCallback(
-    (qmkId: string): string => remapKeycode(qmkId, layout),
+    (qmkId: string): string => remapLabelFn(qmkId, layout),
     [layout],
   )
 

--- a/src/renderer/hooks/useKeyboardLayout.ts
+++ b/src/renderer/hooks/useKeyboardLayout.ts
@@ -7,22 +7,32 @@ import { useAppConfig } from './useAppConfig'
 
 export type { KeyboardLayoutId }
 
-function getRemapTable(layout: KeyboardLayoutId): Record<string, string> | null {
-  const def = LAYOUT_BY_ID.get(layout)
-  if (!def || Object.keys(def.map).length === 0) return null
-  return def.map
+export function remapKeycode(qmkId: string, layout: KeyboardLayoutId): string {
+  const mapped = LAYOUT_BY_ID.get(layout)?.map[qmkId]
+  return mapped !== undefined ? mapped : qmkId
 }
 
-export function remapKeycode(qmkId: string, layout: KeyboardLayoutId): string {
-  const table = getRemapTable(layout)
-  if (!table) return qmkId
-  return table[qmkId] ?? qmkId
+/**
+ * Resolve a display label for a qmkId, consulting the layout's
+ * `compositeLabels` first (composite keycodes such as `LALT(KC_L)`),
+ * then falling back to the basic-key `map`.
+ *
+ * Returns the original qmkId when neither source has an entry.
+ */
+export function remapLabel(qmkId: string, layout: KeyboardLayoutId): string {
+  const def = LAYOUT_BY_ID.get(layout)
+  if (!def) return qmkId
+  const composite = def.compositeLabels?.[qmkId]
+  if (composite !== undefined) return composite
+  const mapped = def.map[qmkId]
+  return mapped !== undefined ? mapped : qmkId
 }
 
 export function isRemappedKeycode(qmkId: string, layout: KeyboardLayoutId): boolean {
-  const table = getRemapTable(layout)
-  if (!table) return false
-  return qmkId in table
+  const def = LAYOUT_BY_ID.get(layout)
+  if (!def) return false
+  if (def.compositeLabels && qmkId in def.compositeLabels) return true
+  return qmkId in def.map
 }
 
 interface UseKeyboardLayoutReturn {
@@ -43,9 +53,9 @@ export function useKeyboardLayout(): UseKeyboardLayoutReturn {
     set('currentKeyboardLayout', newLayout)
   }, [set])
 
-  const remapLabel = useCallback(
+  const remapLabelCb = useCallback(
     (qmkId: string): string => {
-      return remapKeycode(qmkId, layout)
+      return remapLabel(qmkId, layout)
     },
     [layout],
   )
@@ -57,5 +67,5 @@ export function useKeyboardLayout(): UseKeyboardLayoutReturn {
     [layout],
   )
 
-  return { layout, setLayout, remapLabel, isRemapped }
+  return { layout, setLayout, remapLabel: remapLabelCb, isRemapped }
 }


### PR DESCRIPTION
## Summary
- Add optional `KeyboardLayoutDef.compositeLabels?: Record<string, string>` so a layout can override the display label of an individual composite qmkId (e.g. `LALT(KC_L)` → "Cmd L").
- New exported `remapLabel(qmkId, layout)` consults `compositeLabels` first, then falls back to the existing basic-key `map` via `remapKeycode`. `useDevicePrefs.remapLabel` now goes through this resolver, so picker / DisplayKeyboard render paths pick up overrides automatically.
- `isRemappedKeycode` reports composite-only entries as remapped.
- Pipette ships no defaults; contributor PRs add layout-specific entries. README + `.claude/docs/KEYCODE-PATTERNS.md` document the contributor reviewer rule (label collision check within a layout).

Refs #127. The original issue is closed; this PR delivers the next-release scaffold promised in the follow-up comment so OS × language label data can be added incrementally without touching this resolver again.

## Test plan
- [x] `npx eslint` on changed files
- [x] `npx tsc --noEmit`
- [x] `npx vitest run src/renderer/hooks/__tests__/useKeyboardLayout.test.ts src/renderer/hooks/__tests__/useDevicePrefs.test.ts src/shared/keycodes/__tests__/keycodes.test.ts` — 341/341 pass (8 new composite-override cases)
- [ ] CI `check` job (lint → test → build)