### PR TITLE
feat(hub): emit FavoriteExportFile v3 with vial_protocol

### DIFF
--- a/src/main/__tests__/favorite-store.test.ts
+++ b/src/main/__tests__/favorite-store.test.ts
@@ -336,14 +336,15 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance') as { success: boolean }
+      const result = await handler(fakeEvent, 'tapDance', 6) as { success: boolean }
       expect(result.success).toBe(true)
 
       const exported = JSON.parse(await readFile(exportPath, 'utf-8'))
       expect(exported.app).toBe('pipette')
-      expect(exported.version).toBe(2)
+      expect(exported.version).toBe(3)
       expect(exported.scope).toBe('fav')
       expect(exported.exportedAt).toBeTruthy()
+      expect(exported.vial_protocol).toBe(6)
       expect(exported.categories.td).toHaveLength(1)
       expect(exported.categories.td[0].label).toBe('My TD')
       expect(exported.categories.td[0].savedAt).toBeTruthy()
@@ -361,7 +362,7 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance', saved1.entry.id) as { success: boolean }
+      const result = await handler(fakeEvent, 'tapDance', 6, saved1.entry.id) as { success: boolean }
       expect(result.success).toBe(true)
 
       const exported = JSON.parse(await readFile(exportPath, 'utf-8'))
@@ -382,7 +383,7 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance') as { success: boolean }
+      const result = await handler(fakeEvent, 'tapDance', 6) as { success: boolean }
       expect(result.success).toBe(true)
 
       const exported = JSON.parse(await readFile(exportPath, 'utf-8'))
@@ -394,14 +395,14 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: true, filePath: '' })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance') as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'tapDance', 6) as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('cancelled')
     })
 
     it('returns error for invalid scope', async () => {
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'qmkSettings') as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'qmkSettings', 6) as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('Invalid scope')
     })
@@ -414,7 +415,7 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      await handler(fakeEvent, 'tapDance')
+      await handler(fakeEvent, 'tapDance', 6)
 
       expect(dialog.showSaveDialog).toHaveBeenCalledWith(
         expect.anything(),
@@ -431,21 +432,21 @@ describe('favorite-store', () => {
       vi.mocked(BrowserWindow.fromWebContents).mockReturnValueOnce(null as unknown as Electron.BrowserWindow)
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance') as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'tapDance', 6) as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('No window')
     })
 
     it('returns error for non-string entryId', async () => {
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance', 123) as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'tapDance', 6, 123) as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('Invalid entryId')
     })
 
     it('returns error when single-entry export target does not exist', async () => {
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance', 'nonexistent-id') as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'tapDance', 6, 'nonexistent-id') as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('Entry not found')
     })
@@ -460,7 +461,7 @@ describe('favorite-store', () => {
       await deleteHandler(fakeEvent, 'tapDance', saved.entry.id)
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance', saved.entry.id) as { success: boolean; error: string }
+      const result = await handler(fakeEvent, 'tapDance', 6, saved.entry.id) as { success: boolean; error: string }
       expect(result.success).toBe(false)
       expect(result.error).toBe('Entry not found')
     })
@@ -476,7 +477,7 @@ describe('favorite-store', () => {
       vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
 
       const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
-      const result = await handler(fakeEvent, 'tapDance') as { success: boolean }
+      const result = await handler(fakeEvent, 'tapDance', 6) as { success: boolean }
       expect(result.success).toBe(true)
 
       const exported = JSON.parse(await readFile(exportPath, 'utf-8'))

--- a/src/main/__tests__/hub-ipc-favorite.test.ts
+++ b/src/main/__tests__/hub-ipc-favorite.test.ts
@@ -169,6 +169,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'My Tap Dance',
       })
 
@@ -189,6 +190,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'invalidType',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'Test',
       })
 
@@ -216,6 +218,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'a'.repeat(201),
       })
 
@@ -232,6 +235,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'nonexistent',
+        vialProtocol: 6,
         title: 'Test',
       })
 
@@ -246,6 +250,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'deleted-entry',
+        vialProtocol: 6,
         title: 'Test',
       })
 
@@ -264,6 +269,7 @@ describe('hub-ipc favorite handlers', () => {
       await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'My Tap Dance',
       })
 
@@ -272,8 +278,9 @@ describe('hub-ipc favorite handlers', () => {
       const jsonFile = call[3] as { name: string; data: Buffer }
       const parsed = JSON.parse(jsonFile.data.toString('utf-8'))
       expect(parsed.app).toBe('pipette')
-      expect(parsed.version).toBe(2)
+      expect(parsed.version).toBe(3)
       expect(parsed.scope).toBe('fav')
+      expect(parsed.vial_protocol).toBe(6)
       expect(parsed.categories.td).toHaveLength(1)
       const entry = parsed.categories.td[0]
       expect(entry.label).toBe('My Tap Dance')
@@ -307,6 +314,7 @@ describe('hub-ipc favorite handlers', () => {
       mockFavoriteFs()
       vi.mocked(updateFeaturePostOnHub).mockResolvedValueOnce({
         id: 'fav-post-1',
+        vialProtocol: 6,
         title: 'Updated Tap Dance',
       })
 
@@ -314,6 +322,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'Updated Tap Dance',
         postId: 'fav-post-1',
       })
@@ -336,6 +345,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'badType',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'Test',
         postId: 'fav-post-1',
       })
@@ -350,6 +360,7 @@ describe('hub-ipc favorite handlers', () => {
         const result = await handler({}, {
           type: 'tapDance',
           entryId: 'entry-1',
+          vialProtocol: 6,
           title: 'Test',
           postId,
         })
@@ -364,6 +375,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: '',
         postId: 'fav-post-1',
       })
@@ -379,6 +391,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'nonexistent',
+        vialProtocol: 6,
         title: 'Test',
         postId: 'fav-post-1',
       })
@@ -408,6 +421,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'evil-entry',
+        vialProtocol: 6,
         title: 'Test',
       })
 
@@ -434,6 +448,7 @@ describe('hub-ipc favorite handlers', () => {
       const result = await handler({}, {
         type: 'tapDance',
         entryId: 'entry-1',
+        vialProtocol: 6,
         title: 'Test',
       })
 
@@ -488,6 +503,7 @@ describe('hub-ipc favorite handlers', () => {
         const result = await handler({}, {
           type: favType,
           entryId: 'e1',
+          vialProtocol: 6,
           title: 'Test',
         })
 

--- a/src/main/favorite-store.ts
+++ b/src/main/favorite-store.ts
@@ -6,8 +6,8 @@ import { join } from 'node:path'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { IpcChannels } from '../shared/ipc/channels'
-import { isValidFavoriteType, isFavoriteDataFile, FAV_EXPORT_KEY_MAP, FAV_TYPE_TO_EXPORT_KEY, isValidFavExportFile, serializeFavData, deserializeFavData } from '../shared/favorite-data'
-import { serialize as serializeKeycode, deserialize as deserializeKeycode } from '../shared/keycodes/keycodes'
+import { isValidFavoriteType, isValidVialProtocol, isFavoriteDataFile, FAV_EXPORT_KEY_MAP, FAV_TYPE_TO_EXPORT_KEY, isValidFavExportFile, buildFavExportFile, serializeFavData, deserializeFavData } from '../shared/favorite-data'
+import { serialize as serializeKeycode, deserialize as deserializeKeycode, getProtocol, setProtocol } from '../shared/keycodes/keycodes'
 import { notifyChange } from './sync/sync-service'
 import { secureHandle } from './ipc-guard'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteIndex, FavoriteExportEntry, FavoriteImportResult } from '../shared/types/favorite-store'
@@ -58,6 +58,25 @@ async function findEntry(type: FavoriteType, entryId: string): Promise<{ index: 
   const entry = index.entries.find((e) => e.id === entryId)
   if (!entry) return null
   return { index, entry }
+}
+
+/**
+ * Run `body` with `getProtocol()` temporarily set to `protocol` so that
+ * `deserializeKeycode` resolves keycode strings against the file's protocol
+ * version. Restores the previous protocol in `finally`.
+ *
+ * If `protocol` is undefined (legacy v2 file or out-of-spec v3 without
+ * `vial_protocol`), runs `body` with the current default protocol.
+ */
+function withImportProtocol<T>(protocol: number | undefined, body: () => T): T {
+  if (protocol === undefined) return body()
+  const prev = getProtocol()
+  setProtocol(protocol)
+  try {
+    return body()
+  } finally {
+    setProtocol(prev)
+  }
 }
 
 export function setupFavoriteStore(): void {
@@ -175,12 +194,13 @@ export function setupFavoriteStore(): void {
   // --- Export ---
   secureHandle(
     IpcChannels.FAVORITE_STORE_EXPORT,
-    async (event, scope: unknown, entryId?: unknown): Promise<{ success: boolean; error?: string }> => {
+    async (event, scope: unknown, vialProtocol: unknown, entryId?: unknown): Promise<{ success: boolean; error?: string }> => {
       try {
         const win = BrowserWindow.fromWebContents(event.sender)
         if (!win) return { success: false, error: 'No window' }
 
         if (!isValidFavoriteType(scope)) return { success: false, error: 'Invalid scope' }
+        if (!isValidVialProtocol(vialProtocol)) return { success: false, error: 'Invalid vialProtocol' }
         if (entryId !== undefined && typeof entryId !== 'string') return { success: false, error: 'Invalid entryId' }
 
         const index = await readIndex(scope)
@@ -239,13 +259,7 @@ export function setupFavoriteStore(): void {
           return { success: false, error: 'cancelled' }
         }
 
-        const exportFile = {
-          app: 'pipette' as const,
-          version: 2 as const,
-          scope: 'fav' as const,
-          exportedAt: now.toISOString(),
-          categories,
-        }
+        const exportFile = buildFavExportFile(vialProtocol, categories, now.toISOString())
 
         await writeFile(result.filePath, JSON.stringify(exportFile, null, 2), 'utf-8')
         return { success: true }
@@ -258,12 +272,13 @@ export function setupFavoriteStore(): void {
   // --- Export Current (live state without saving first) ---
   secureHandle(
     IpcChannels.FAVORITE_STORE_EXPORT_CURRENT,
-    async (event, scope: unknown, dataJson: unknown): Promise<{ success: boolean; error?: string }> => {
+    async (event, scope: unknown, vialProtocol: unknown, dataJson: unknown): Promise<{ success: boolean; error?: string }> => {
       try {
         const win = BrowserWindow.fromWebContents(event.sender)
         if (!win) return { success: false, error: 'No window' }
 
         if (!isValidFavoriteType(scope)) return { success: false, error: 'Invalid scope' }
+        if (!isValidVialProtocol(vialProtocol)) return { success: false, error: 'Invalid vialProtocol' }
         if (typeof dataJson !== 'string') return { success: false, error: 'Invalid data' }
 
         const parsed = JSON.parse(dataJson) as Record<string, unknown>
@@ -289,19 +304,17 @@ export function setupFavoriteStore(): void {
           return { success: false, error: 'cancelled' }
         }
 
-        const exportFile = {
-          app: 'pipette' as const,
-          version: 2 as const,
-          scope: 'fav' as const,
-          exportedAt: now.toISOString(),
-          categories: {
+        const exportFile = buildFavExportFile(
+          vialProtocol,
+          {
             [exportKey]: [{
               label: 'Current',
               savedAt: now.toISOString(),
               data: serializedData,
             }],
           },
-        }
+          now.toISOString(),
+        )
 
         await writeFile(result.filePath, JSON.stringify(exportFile, null, 2), 'utf-8')
         return { success: true }
@@ -373,7 +386,9 @@ export function setupFavoriteStore(): void {
         }
 
         const firstEntry = entries[0]
-        const normalizedData = deserializeFavData(scope, firstEntry.data, deserializeKeycode)
+        const normalizedData = withImportProtocol(parsed.vial_protocol, () =>
+          deserializeFavData(scope, firstEntry.data, deserializeKeycode),
+        )
 
         return { success: true, data: normalizedData }
       } catch (err) {
@@ -423,7 +438,9 @@ export function setupFavoriteStore(): void {
           await mkdir(dir, { recursive: true })
 
           for (const entry of entries) {
-            const normalizedData = deserializeFavData(favType, entry.data, deserializeKeycode)
+            const normalizedData = withImportProtocol(parsed.vial_protocol, () =>
+              deserializeFavData(favType, entry.data, deserializeKeycode),
+            )
             if (!isFavoriteDataFile({ type: favType, data: normalizedData }, favType)) {
               skipped++
               continue

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -8,7 +8,7 @@ import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubU
 import { getIdToken } from '../sync/google-auth'
 import { Hub401Error, Hub403Error, Hub409Error, Hub429Error, authenticateWithHub, uploadPostToHub, updatePostOnHub, patchPostOnHub, deletePostFromHub, fetchMyPosts, fetchMyPostsByKeyboard, fetchAuthMe, patchAuthMe, getHubOrigin, uploadFeaturePostToHub, updateFeaturePostOnHub } from './hub-client'
 import type { HubAuthResult, HubUploadFiles } from './hub-client'
-import { isValidFavoriteType, FAV_TYPE_TO_EXPORT_KEY, serializeFavData } from '../../shared/favorite-data'
+import { isValidFavoriteType, isValidVialProtocol, FAV_TYPE_TO_EXPORT_KEY, serializeFavData, buildFavExportFile } from '../../shared/favorite-data'
 import { serialize as serializeKeycode } from '../../shared/keycodes/keycodes'
 import type { FavoriteType, FavoriteIndex } from '../../shared/types/favorite-store'
 import { readFile } from 'node:fs/promises'
@@ -180,7 +180,11 @@ function isSafePathSegment(segment: string): boolean {
   return /^[a-zA-Z0-9_.-]+$/.test(segment) && segment !== '.' && segment !== '..'
 }
 
-async function buildFavoriteExportJson(type: FavoriteType, entryId: string): Promise<string> {
+async function buildFavoriteExportJson(
+  type: FavoriteType,
+  entryId: string,
+  vialProtocol: number,
+): Promise<string> {
   const favDir = join(app.getPath('userData'), 'sync', 'favorites', type)
   const indexPath = join(favDir, 'index.json')
   const indexRaw = await readFile(indexPath, 'utf-8')
@@ -198,19 +202,13 @@ async function buildFavoriteExportJson(type: FavoriteType, entryId: string): Pro
   const exportKey = FAV_TYPE_TO_EXPORT_KEY[type]
   const serializedData = serializeFavData(type, parsed.data, serializeKeycode)
 
-  const exportFile = {
-    app: 'pipette' as const,
-    version: 2 as const,
-    scope: 'fav' as const,
-    exportedAt: new Date().toISOString(),
-    categories: {
-      [exportKey]: [{
-        label: entry.label,
-        savedAt: entry.savedAt,
-        data: serializedData,
-      }],
-    },
-  }
+  const exportFile = buildFavExportFile(vialProtocol, {
+    [exportKey]: [{
+      label: entry.label,
+      savedAt: entry.savedAt,
+      data: serializedData,
+    }],
+  })
 
   return JSON.stringify(exportFile)
 }
@@ -366,9 +364,10 @@ export function setupHubIpc(): void {
     params: HubUploadFavoritePostParams,
   ): Promise<{ title: string; postType: string; jsonFile: { name: string; data: Buffer } }> {
     if (!isValidFavoriteType(params.type)) throw new Error('Invalid favorite type')
+    if (!isValidVialProtocol(params.vialProtocol)) throw new Error('Invalid vialProtocol')
     const title = validateTitle(params.title)
     const postType = FAV_TYPE_TO_EXPORT_KEY[params.type]
-    const jsonStr = await buildFavoriteExportJson(params.type, params.entryId)
+    const jsonStr = await buildFavoriteExportJson(params.type, params.entryId, params.vialProtocol)
     return { title, postType, jsonFile: { name: `${postType}.json`, data: Buffer.from(jsonStr, 'utf-8') } }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -218,10 +218,10 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_RENAME, type, entryId, newLabel),
   favoriteStoreDelete: (type: string, entryId: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_DELETE, type, entryId),
-  favoriteStoreExport: (scope: string, entryId?: string): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT, scope, entryId),
-  favoriteStoreExportCurrent: (scope: string, data: string): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT_CURRENT, scope, data),
+  favoriteStoreExport: (scope: string, vialProtocol: number, entryId?: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT, scope, vialProtocol, entryId),
+  favoriteStoreExportCurrent: (scope: string, vialProtocol: number, data: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_EXPORT_CURRENT, scope, vialProtocol, data),
   favoriteStoreImport: (): Promise<FavoriteImportResult> =>
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_IMPORT),
   favoriteStoreImportToCurrent: (scope: string): Promise<{ success: boolean; data?: unknown; error?: string }> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -239,6 +239,7 @@ export function App() {
     buildHubPostParams: entryOps.buildHubPostParams,
     activityCount: keyboard.activityCount,
     pipetteFileSavedActivityRef: lifecycle.pipetteFileSavedActivityRef,
+    vialProtocol: keyboard.vialProtocol,
   })
 
   const migration = useSnapshotMigration({
@@ -955,6 +956,7 @@ export function App() {
           quickSelect={devicePrefs.quickSelect}
           splitKeyMode={devicePrefs.splitKeyMode}
           basicViewType={devicePrefs.basicViewType}
+          vialProtocol={keyboard.vialProtocol}
           onClose={() => editorUI.setComboInitialIndex(null)}
           hubOrigin={hub.hubReady ? hub.hubOrigin : undefined}
           hubNeedsDisplayName={hub.hubReady && !hub.hubCanUpload}
@@ -979,6 +981,7 @@ export function App() {
           quickSelect={devicePrefs.quickSelect}
           splitKeyMode={devicePrefs.splitKeyMode}
           basicViewType={devicePrefs.basicViewType}
+          vialProtocol={keyboard.vialProtocol}
           onClose={() => editorUI.setAltRepeatKeyInitialIndex(null)}
           hubOrigin={hub.hubReady ? hub.hubOrigin : undefined}
           hubNeedsDisplayName={hub.hubReady && !hub.hubCanUpload}
@@ -1003,6 +1006,7 @@ export function App() {
           quickSelect={devicePrefs.quickSelect}
           splitKeyMode={devicePrefs.splitKeyMode}
           basicViewType={devicePrefs.basicViewType}
+          vialProtocol={keyboard.vialProtocol}
           onClose={() => editorUI.setKeyOverrideInitialIndex(null)}
           hubOrigin={hub.hubReady ? hub.hubOrigin : undefined}
           hubNeedsDisplayName={hub.hubReady && !hub.hubCanUpload}

--- a/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
+++ b/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
@@ -31,6 +31,7 @@ interface Props {
   quickSelect?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  vialProtocol: number
 }
 
 const optionEntries = Object.entries(AltRepeatKeyOptions).filter(
@@ -65,7 +66,7 @@ export function AltRepeatKeyPanelModal({
   tapDanceEntries, deserializedMacros, onClose,
   hubOrigin, hubNeedsDisplayName, hubUploading, hubUploadResult,
   onUploadToHub, onUpdateOnHub, onRemoveFromHub, onRenameOnHub,
-  quickSelect, splitKeyMode, basicViewType,
+  quickSelect, splitKeyMode, basicViewType, vialProtocol,
 }: Props) {
   const { t } = useTranslation()
 
@@ -77,6 +78,7 @@ export function AltRepeatKeyPanelModal({
     unlocked,
     onUnlock,
     quickSelect,
+    vialProtocol,
     tapDanceEntries,
     deserializedMacros,
     splitKeyMode,

--- a/src/renderer/components/editors/ComboPanelModal.tsx
+++ b/src/renderer/components/editors/ComboPanelModal.tsx
@@ -29,6 +29,7 @@ interface Props {
   quickSelect?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  vialProtocol: number
 }
 
 const comboAdapter: KeycodeEntryModalAdapter<ComboEntry> = {
@@ -69,6 +70,7 @@ export function ComboPanelModal({
   quickSelect,
   splitKeyMode,
   basicViewType,
+  vialProtocol,
 }: Props) {
   const hook = useKeycodeEntryModal(comboAdapter, {
     entry: entries[initialIndex],
@@ -78,6 +80,7 @@ export function ComboPanelModal({
     unlocked,
     onUnlock,
     quickSelect,
+    vialProtocol,
     tapDanceEntries,
     deserializedMacros,
     splitKeyMode,

--- a/src/renderer/components/editors/KeyOverridePanelModal.tsx
+++ b/src/renderer/components/editors/KeyOverridePanelModal.tsx
@@ -32,6 +32,7 @@ interface Props {
   quickSelect?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  vialProtocol: number
 }
 
 type ModifierFieldName = 'triggerMods' | 'negativeMods' | 'suppressedMods'
@@ -76,7 +77,7 @@ export function KeyOverridePanelModal({
   tapDanceEntries, deserializedMacros, onClose,
   hubOrigin, hubNeedsDisplayName, hubUploading, hubUploadResult,
   onUploadToHub, onUpdateOnHub, onRemoveFromHub, onRenameOnHub,
-  quickSelect, splitKeyMode, basicViewType,
+  quickSelect, splitKeyMode, basicViewType, vialProtocol,
 }: Props) {
   const { t } = useTranslation()
 
@@ -88,6 +89,7 @@ export function KeyOverridePanelModal({
     unlocked,
     onUnlock,
     quickSelect,
+    vialProtocol,
     tapDanceEntries,
     deserializedMacros,
     splitKeyMode,

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1039,6 +1039,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           onSave={handleTdModalSave} onClose={handleTdModalClose} isDummy={isDummy}
           tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
           quickSelect={quickSelect} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+          vialProtocol={vialProtocol ?? 0}
           hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
           hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
           onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('tapDance', entryId) : undefined}

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -117,6 +117,7 @@ export function MacroEditor({
       updateActions(loaded)
     },
     enabled: !isDummy,
+    vialProtocol,
   })
 
   // Sync active macro when initialMacro changes (e.g. modal re-opened with different index)

--- a/src/renderer/components/editors/TapDanceModal.tsx
+++ b/src/renderer/components/editors/TapDanceModal.tsx
@@ -28,6 +28,7 @@ interface Props {
   quickSelect?: boolean
   splitKeyMode?: SplitKeyMode
   basicViewType?: BasicViewType
+  vialProtocol: number
 }
 
 const TAPPING_TERM_MIN = 0
@@ -57,7 +58,7 @@ export function TapDanceModal({
   tapDanceEntries, deserializedMacros,
   hubOrigin, hubNeedsDisplayName, hubUploading, hubUploadResult,
   onUploadToHub, onUpdateOnHub, onRemoveFromHub, onRenameOnHub,
-  quickSelect, splitKeyMode, basicViewType,
+  quickSelect, splitKeyMode, basicViewType, vialProtocol,
 }: Props) {
   const { t } = useTranslation()
 
@@ -68,6 +69,7 @@ export function TapDanceModal({
     onClose,
     isDummy,
     quickSelect,
+    vialProtocol,
     tapDanceEntries,
     deserializedMacros,
     splitKeyMode,

--- a/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
+++ b/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
@@ -34,7 +34,7 @@ const mockSerialize = vi.fn(() => MOCK_TAP_DANCE_DATA)
 const mockApply = vi.fn()
 
 function hookOpts(overrides: Record<string, unknown> = {}) {
-  return { favoriteType: 'tapDance' as const, serialize: mockSerialize, apply: mockApply, ...overrides }
+  return { favoriteType: 'tapDance' as const, serialize: mockSerialize, apply: mockApply, vialProtocol: 6, ...overrides }
 }
 
 beforeEach(() => {
@@ -406,7 +406,7 @@ describe('useFavoriteStore – exportFavorites', () => {
       await result.current.exportFavorites()
     })
 
-    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance')
+    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 6)
   })
 
   it('returns true on success', async () => {
@@ -556,7 +556,7 @@ describe('useFavoriteStore – exportEntry', () => {
       await result.current.exportEntry('entry-123')
     })
 
-    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 'entry-123')
+    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 6, 'entry-123')
   })
 
   it('returns true on success', async () => {

--- a/src/renderer/hooks/useFavoriteStore.ts
+++ b/src/renderer/hooks/useFavoriteStore.ts
@@ -10,6 +10,12 @@ export interface UseFavoriteStoreOptions {
   serialize: () => unknown
   apply: (data: unknown) => void
   enabled?: boolean
+  /**
+   * Vial protocol of the live keyboard. Written into v3 export files so
+   * importers can resolve protocol-specific keycode values. Falls back to
+   * 6 (current default) when no keyboard is connected.
+   */
+  vialProtocol: number
 }
 
 export interface FavoriteImportResultState {
@@ -40,7 +46,7 @@ export interface UseFavoriteStoreReturn {
   importFavorites: () => Promise<boolean>
 }
 
-export function useFavoriteStore({ favoriteType, serialize, apply, enabled = true }: UseFavoriteStoreOptions): UseFavoriteStoreReturn {
+export function useFavoriteStore({ favoriteType, serialize, apply, enabled = true, vialProtocol }: UseFavoriteStoreOptions): UseFavoriteStoreReturn {
   const { t } = useTranslation()
   const [entries, setEntries] = useState<SavedFavoriteMeta[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -155,7 +161,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     try {
       const data = serialize()
       const json = JSON.stringify({ type: favoriteType, data })
-      const result = await window.vialAPI.favoriteStoreExportCurrent(favoriteType, json)
+      const result = await window.vialAPI.favoriteStoreExportCurrent(favoriteType, vialProtocol, json)
       if (!result.success) {
         if (result.error !== 'cancelled') {
           setError(t('favoriteStore.exportFailed'))
@@ -169,7 +175,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } finally {
       setExporting(false)
     }
-  }, [enabled, favoriteType, serialize, t])
+  }, [enabled, favoriteType, serialize, vialProtocol, t])
 
   const importCurrent = useCallback(async (): Promise<boolean> => {
     setError(null)
@@ -194,8 +200,8 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     setExporting(true)
     try {
       const result = entryId !== undefined
-        ? await window.vialAPI.favoriteStoreExport(favoriteType, entryId)
-        : await window.vialAPI.favoriteStoreExport(favoriteType)
+        ? await window.vialAPI.favoriteStoreExport(favoriteType, vialProtocol, entryId)
+        : await window.vialAPI.favoriteStoreExport(favoriteType, vialProtocol)
       if (!result.success) {
         if (result.error !== 'cancelled') {
           setError(t('favoriteStore.exportFailed'))
@@ -209,7 +215,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } finally {
       setExporting(false)
     }
-  }, [favoriteType, t])
+  }, [favoriteType, vialProtocol, t])
 
   const exportFavorites = useCallback(async (): Promise<boolean> => {
     return doExport()

--- a/src/renderer/hooks/useHubState.ts
+++ b/src/renderer/hooks/useHubState.ts
@@ -33,6 +33,8 @@ interface Options {
   }>
   activityCount: number
   pipetteFileSavedActivityRef: React.MutableRefObject<number>
+  /** Vial protocol of the live keyboard. Forwarded to favorite Hub uploads (v3 export). */
+  vialProtocol: number
 }
 
 export function useHubState(options: Options) {
@@ -51,6 +53,7 @@ export function useHubState(options: Options) {
     buildHubPostParams,
     activityCount,
     pipetteFileSavedActivityRef,
+    vialProtocol,
   } = options
 
   const { t } = useTranslation()
@@ -447,7 +450,7 @@ export function useHubState(options: Options) {
     await runFavHubOperation(type, entryId, false, async (entry) => {
       try {
         const result = await window.vialAPI.hubUploadFavoritePost({
-          type, entryId, title: entry.label || type,
+          type, entryId, title: entry.label || type, vialProtocol,
         })
         if (result.success) {
           if (result.postId) await persistFavHubPostId(type, entryId, result.postId)
@@ -459,13 +462,13 @@ export function useHubState(options: Options) {
         setFavHubUploadResult({ kind: 'error', message: t('hub.uploadFailed'), entryId })
       }
     })
-  }, [runFavHubOperation, persistFavHubPostId, markAccountDeactivated, t])
+  }, [runFavHubOperation, persistFavHubPostId, markAccountDeactivated, t, vialProtocol])
 
   const handleFavUpdateOnHub = useCallback(async (type: FavoriteType, entryId: string) => {
     await runFavHubOperation(type, entryId, true, async (entry) => {
       try {
         const result = await window.vialAPI.hubUpdateFavoritePost({
-          type, entryId, title: entry.label || type, postId: entry.hubPostId!,
+          type, entryId, title: entry.label || type, postId: entry.hubPostId!, vialProtocol,
         })
         if (result.success) {
           setFavHubUploadResult({ kind: 'success', message: t('hub.updateSuccess'), entryId })
@@ -476,7 +479,7 @@ export function useHubState(options: Options) {
         setFavHubUploadResult({ kind: 'error', message: t('hub.updateFailed'), entryId })
       }
     })
-  }, [runFavHubOperation, persistFavHubPostId, markAccountDeactivated, t])
+  }, [runFavHubOperation, persistFavHubPostId, markAccountDeactivated, t, vialProtocol])
 
   const handleFavRemoveFromHub = useCallback(async (type: FavoriteType, entryId: string) => {
     await runFavHubOperation(type, entryId, true, async (entry) => {

--- a/src/renderer/hooks/useKeycodeEntryModal.ts
+++ b/src/renderer/hooks/useKeycodeEntryModal.ts
@@ -69,6 +69,8 @@ export interface KeycodeEntryModalOptions<TEntry extends Record<string, unknown>
   onUnlock?: () => void
   quickSelect?: boolean
   isDummy?: boolean
+  /** Vial protocol of the live keyboard. Forwarded to favorite export (v3) so importers can resolve protocol-specific keycode values. */
+  vialProtocol: number
   // TabbedKeycodes tile content
   tapDanceEntries?: TapDanceEntry[]
   deserializedMacros?: MacroAction[][]
@@ -129,6 +131,7 @@ export function useKeycodeEntryModal<TEntry extends Record<string, unknown>>(
   const {
     entry, index, onSave, onClose,
     unlocked, onUnlock, quickSelect, isDummy,
+    vialProtocol,
     tapDanceEntries, deserializedMacros,
   } = options
 
@@ -149,6 +152,7 @@ export function useKeycodeEntryModal<TEntry extends Record<string, unknown>>(
     serialize: () => editedEntry,
     apply: (data) => setEditedEntry(data as TEntry),
     enabled: showFavorites,
+    vialProtocol,
   })
 
   // Clear action

--- a/src/shared/__tests__/favorite-data.test.ts
+++ b/src/shared/__tests__/favorite-data.test.ts
@@ -278,7 +278,27 @@ describe('isValidFavExportFile', () => {
 
     it('rejects unsupported version', () => {
       const file = makeValidExportFile()
+      ;(file as Record<string, unknown>).version = 4
+      expect(isValidFavExportFile(file)).toBe(false)
+    })
+
+    it('accepts v3 file with vial_protocol', () => {
+      const file = makeValidExportFile()
       ;(file as Record<string, unknown>).version = 3
+      ;(file as Record<string, unknown>).vial_protocol = 6
+      expect(isValidFavExportFile(file)).toBe(true)
+    })
+
+    it('accepts v3 file without vial_protocol (lenient — falls back to default protocol on import)', () => {
+      const file = makeValidExportFile()
+      ;(file as Record<string, unknown>).version = 3
+      expect(isValidFavExportFile(file)).toBe(true)
+    })
+
+    it('rejects non-numeric vial_protocol', () => {
+      const file = makeValidExportFile()
+      ;(file as Record<string, unknown>).version = 3
+      ;(file as Record<string, unknown>).vial_protocol = '6'
       expect(isValidFavExportFile(file)).toBe(false)
     })
 

--- a/src/shared/favorite-data.ts
+++ b/src/shared/favorite-data.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import type { FavoriteType, FavoriteExportFile } from './types/favorite-store'
+import type { FavoriteType, FavoriteExportFile, FavoriteExportEntry } from './types/favorite-store'
 
 export const FAVORITE_TYPES: readonly FavoriteType[] = ['tapDance', 'macro', 'combo', 'keyOverride', 'altRepeatKey']
 
@@ -30,6 +30,25 @@ export const FAV_KEYCODE_FIELDS: Record<FavoriteType, readonly string[]> = {
 
 export function isValidFavoriteType(v: unknown): v is FavoriteType {
   return typeof v === 'string' && FAVORITE_TYPES.includes(v)
+}
+
+export function isValidVialProtocol(v: unknown): v is number {
+  return typeof v === 'number' && Number.isFinite(v)
+}
+
+export function buildFavExportFile(
+  vialProtocol: number,
+  categories: Record<string, FavoriteExportEntry[]>,
+  exportedAt: string = new Date().toISOString(),
+): FavoriteExportFile {
+  return {
+    app: 'pipette',
+    version: 3,
+    scope: 'fav',
+    exportedAt,
+    vial_protocol: vialProtocol,
+    categories,
+  }
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {
@@ -78,8 +97,13 @@ function isValidAltRepeatKeyData(data: unknown): boolean {
 
 export function isValidFavExportFile(v: unknown): v is FavoriteExportFile {
   if (!isRecord(v)) return false
-  if (v.app !== 'pipette' || v.version !== 2 || v.scope !== 'fav') return false
+  if (v.app !== 'pipette' || v.scope !== 'fav') return false
+  if (v.version !== 2 && v.version !== 3) return false
   if (typeof v.exportedAt !== 'string') return false
+  // vial_protocol: optional. v3 exports written by Pipette include it;
+  // v2 (legacy) and out-of-spec v3 without it both fall back to the
+  // default protocol on import.
+  if (v.vial_protocol !== undefined && typeof v.vial_protocol !== 'number') return false
   const cats = v.categories
   if (!isRecord(cats)) return false
   for (const key of Object.keys(cats)) {

--- a/src/shared/types/favorite-store.ts
+++ b/src/shared/types/favorite-store.ts
@@ -23,11 +23,23 @@ export interface FavoriteExportEntry {
   data: unknown
 }
 
+/**
+ * Pipette favorite export file.
+ *
+ * - v2 (legacy): no `vial_protocol` field. Imported with the current default protocol.
+ * - v3: `vial_protocol` is written by the exporter. Importer uses it to
+ *   resolve protocol-specific keycode values; if absent on a v3 file
+ *   (out-of-spec but tolerated), falls back to the default protocol.
+ *
+ * New exports always emit v3.
+ */
 export interface FavoriteExportFile {
   app: 'pipette'
-  version: 2
+  version: 2 | 3
   scope: 'fav'
   exportedAt: string
+  /** Vial protocol the exporter was using. Required on v3 exports, absent on v2. */
+  vial_protocol?: number
   categories: Record<string, FavoriteExportEntry[]>
 }
 

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -94,6 +94,8 @@ export interface HubUploadFavoritePostParams {
   type: FavoriteType
   entryId: string
   title: string
+  /** Vial protocol of the keyboard the entry was authored against. Written into the v3 export. */
+  vialProtocol: number
 }
 
 export interface HubUpdateFavoritePostParams extends HubUploadFavoritePostParams {

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -149,8 +149,8 @@ export interface VialAPI {
   favoriteStoreLoad(type: string, entryId: string): Promise<{ success: boolean; data?: string; error?: string }>
   favoriteStoreRename(type: string, entryId: string, newLabel: string): Promise<{ success: boolean; error?: string }>
   favoriteStoreDelete(type: string, entryId: string): Promise<{ success: boolean; error?: string }>
-  favoriteStoreExport(scope: string, entryId?: string): Promise<{ success: boolean; error?: string }>
-  favoriteStoreExportCurrent(scope: string, data: string): Promise<{ success: boolean; error?: string }>
+  favoriteStoreExport(scope: string, vialProtocol: number, entryId?: string): Promise<{ success: boolean; error?: string }>
+  favoriteStoreExportCurrent(scope: string, vialProtocol: number, data: string): Promise<{ success: boolean; error?: string }>
   favoriteStoreImport(): Promise<FavoriteImportResult>
   favoriteStoreImportToCurrent(scope: string): Promise<{ success: boolean; data?: unknown; error?: string }>
 


### PR DESCRIPTION
## Summary
- Bump favorite export envelope to v3 with top-level \`vial_protocol\`. Pipette emits v3 going forward; importers accept both v2 (legacy) and v3, and gracefully fall back to the default protocol when \`vial_protocol\` is absent on a v3 file.
- Plumb the live keyboard's \`vialProtocol\` through \`useFavoriteStore\` / \`useKeycodeEntryModal\` / \`useHubState\` and the four kc-entry modals, so local export, file import, and Hub favorite upload (\`hubUploadFavoritePost\` / \`hubUpdateFavoritePost\`) all carry the right protocol value.
- New shared helpers \`isValidVialProtocol\` and \`buildFavExportFile\` keep the three export call sites consistent. Import paths use \`withImportProtocol\` to temporarily switch the global protocol when deserializing keycode strings.

Matches the Hub README contract: v3 \`POST /api/files\` / \`PUT /api/files/:id\` accept the new \`vial_protocol\` field; v2 uploads are no longer emitted.

## Test plan
- [x] \`npx tsc --noEmit\`
- [x] \`pnpm run lint\`
- [x] \`pnpm test\` — 3719/3719 pass (new cases cover v3 with/without \`vial_protocol\`, v2 legacy acceptance, non-numeric rejection)
- [ ] CI \`check\` job (lint → test → build)