### PR TITLE
ci(build): align release workflow with ci.yml native-module deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      # Mirror ci.yml: tests rely on local wall-clock semantics that the
+      # codebase standardises on JST so date-based goal-history comparisons
+      # match the developer-machine baseline.
+      TZ: Asia/Tokyo
     steps:
       - uses: actions/checkout@v6
 
@@ -31,6 +36,9 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
+
+      - name: Install Linux build dependencies for native modules
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -64,7 +72,7 @@ jobs:
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Fix `Release` workflow `test` job failing on `pnpm install --frozen-lockfile` because `electron-rebuild` could not rebuild `node-hid` against `hidapi/libusb` without `libusb-1.0-0-dev`.
- Mirror `ci.yml`: install `libusb-1.0-0-dev libudev-dev` and set `TZ=Asia/Tokyo` on the `test` job.
- Also add `libusb-1.0-0-dev` to the `build` job's Linux step (previously only had `libudev-dev`).

Triggered by the v0.4.0 tag push: https://github.com/darakuneko/pipette-desktop/actions/runs/25252833926

## Test plan

- [ ] CI \`check\` passes on this PR
- [ ] After merge + re-tag (or workflow_dispatch on Release), the Release workflow's \`test\` job completes through \`pnpm test\`
- [ ] Release \`build\` job's Linux variant rebuilds node-hid without libusb errors