### PR TITLE
feat(sync): scope analytics list to one keyboard via Drive q filter

### DIFF
--- a/src/main/__tests__/google-drive.test.ts
+++ b/src/main/__tests__/google-drive.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // --- Mock electron ---
 vi.mock('electron', () => ({
@@ -36,7 +36,11 @@ vi.mock('node:fs/promises', () => {
   }
 })
 
-import { driveFileName, syncUnitFromFileName } from '../sync/google-drive'
+vi.mock('../sync/google-auth', () => ({
+  getAccessToken: vi.fn(async () => 'mock-token'),
+}))
+
+import { driveFileName, listFiles, syncUnitFromFileName } from '../sync/google-drive'
 
 describe('google-drive', () => {
   beforeEach(() => {
@@ -84,6 +88,69 @@ describe('google-drive', () => {
       expect(syncUnitFromFileName('other_thing.enc')).toBeNull()
       expect(syncUnitFromFileName('layerNames_0x1234.enc')).toBeNull()
       expect(syncUnitFromFileName('')).toBeNull()
+    })
+  })
+
+  describe('listFiles', () => {
+    function mockFetchOk(files: Array<{ id: string; name: string; modifiedTime: string }> = []): {
+      fetchSpy: ReturnType<typeof vi.fn>
+    } {
+      const fetchSpy = vi.fn(async () =>
+        new Response(JSON.stringify({ files }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      vi.stubGlobal('fetch', fetchSpy)
+      return { fetchSpy }
+    }
+
+    function extractFetchUrl(call: unknown): URL {
+      const args = call as readonly [string | URL, RequestInit?]
+      return new URL(typeof args[0] === 'string' ? args[0] : args[0].toString())
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('omits the `q` parameter when no nameContains is given', async () => {
+      const { fetchSpy } = mockFetchOk()
+
+      await listFiles()
+
+      expect(fetchSpy).toHaveBeenCalledOnce()
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.get('spaces')).toBe('appDataFolder')
+      expect(url.searchParams.get('pageSize')).toBe('1000')
+      expect(url.searchParams.has('q')).toBe(false)
+    })
+
+    it('adds `name contains` to the `q` parameter when nameContains is given', async () => {
+      const { fetchSpy } = mockFetchOk()
+
+      await listFiles({ nameContains: 'keyboards_0x1234_devices_' })
+
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.get('q')).toBe("name contains 'keyboards_0x1234_devices_'")
+    })
+
+    it('escapes single quotes in nameContains so the Drive `q` value stays valid', async () => {
+      const { fetchSpy } = mockFetchOk()
+
+      await listFiles({ nameContains: "weird'name" })
+
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.get('q')).toBe("name contains 'weird\\'name'")
+    })
+
+    it('treats an empty nameContains as no filter', async () => {
+      const { fetchSpy } = mockFetchOk()
+
+      await listFiles({ nameContains: '' })
+
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.has('q')).toBe(false)
     })
   })
 })

--- a/src/main/sync/google-drive.ts
+++ b/src/main/sync/google-drive.ts
@@ -22,13 +22,29 @@ async function authHeaders(): Promise<Record<string, string>> {
   return { Authorization: `Bearer ${token}` }
 }
 
-export async function listFiles(): Promise<DriveFile[]> {
+export interface ListFilesOptions {
+  /** Drive `q` substring filter on the `name` field. The value is wrapped
+   * in single quotes and any embedded quotes are backslash-escaped per the
+   * Drive search-query language. Use it to keep the response narrow when
+   * the caller only cares about a known filename prefix (e.g. analytics
+   * sync only needs files for one keyboard uid).
+   *
+   * Omit (or pass an empty string) to list every file in `appDataFolder`. */
+  nameContains?: string
+}
+
+export async function listFiles(options?: ListFilesOptions): Promise<DriveFile[]> {
   const headers = await authHeaders()
   const params = new URLSearchParams({
     spaces: 'appDataFolder',
     fields: 'files(id, name, modifiedTime)',
     pageSize: '1000',
   })
+  const filter = options?.nameContains
+  if (filter) {
+    const escaped = filter.replace(/'/g, "\\'")
+    params.set('q', `name contains '${escaped}'`)
+  }
 
   const response = await fetch(`${DRIVE_API}/files?${params}`, { headers })
   if (!response.ok) {
@@ -139,7 +155,16 @@ export function driveFileName(syncUnit: string): string {
   // "keyboards/0x1234/settings" -> "keyboards_0x1234_settings.enc"
   // "keyboards/0x1234/snapshots" -> "keyboards_0x1234_snapshots.enc"
   // "keyboards/0x1234/devices/{hash}" -> "keyboards_0x1234_devices_{hash}.enc"
-  return syncUnit.replaceAll('/', '_') + '.enc'
+  return driveFilenamePrefix(syncUnit) + '.enc'
+}
+
+/** Drive filename prefix for a given sync-unit path prefix (no `.enc`
+ * suffix). Pair with `listFiles({ nameContains })` so a single sync-unit
+ * subtree is the only thing returned by the Drive listing. Shares its
+ * encoding with `driveFileName` so the two stay in lockstep if the
+ * filename scheme ever changes. */
+export function driveFilenamePrefix(syncUnitPrefix: string): string {
+  return syncUnitPrefix.replaceAll('/', '_')
 }
 
 export function syncUnitFromFileName(fileName: string): string | null {

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -13,6 +13,7 @@ import {
   uploadFile,
   deleteFile,
   driveFileName,
+  driveFilenamePrefix,
   syncUnitFromFileName,
   type DriveFile,
 } from './google-drive'
@@ -1223,8 +1224,12 @@ export async function executeAnalyticsSync(uid: string): Promise<boolean> {
     if (!credentials.ok) return false
     const password = credentials.password
 
-    const remoteFiles = await listFiles()
+    // Drive-side prefix filter: scope the listing to this keyboard's
+    // analytics files. The in-memory `isAnalyticsSyncUnit` + `startsWith`
+    // checks below remain as a safety net in case Drive ever returns a
+    // looser substring match.
     const prefix = `keyboards/${uid}/devices/`
+    const remoteFiles = await listFiles({ nameContains: driveFilenamePrefix(prefix) })
     let anyFailure = false
     const limit = pLimit(SYNC_CONCURRENCY)
     // Units `mergeWithRemote` already handled — it uploads any


### PR DESCRIPTION
## Summary

- Add optional `nameContains` to `listFiles()` so Drive API filters with `q=name contains '...'` server-side instead of returning every file in `appDataFolder`.
- Use it from `executeAnalyticsSync` with `keyboards_<uid>_devices_` so the first Analyze open after typing only fetches this keyboard's analytics, not the full account snapshot.
- Add `driveFilenamePrefix()` so the syncUnit ↔ Drive filename encoding stays single-sourced; `driveFileName()` now uses it too.

## Why

`executeAnalyticsSync` runs on Analyze panel mount and used to pull every appDataFolder file (favorites, snapshots, settings, key-labels, keyboard-meta, all keyboards' per-day analytics) and discard everything except the target uid's analytics in memory. On a fresh install reusing an existing Google account, that listing dominated the first Analyze open. Filtering server-side trims transfer size, JSON parsing, and the in-memory filter loop in one shot. Other call sites that need the full listing keep the no-arg form and are unaffected.

The in-memory `isAnalyticsSyncUnit` + `startsWith(prefix)` checks remain as a safety net in case Drive ever loosens the substring match.

## Test plan

- [x] `pnpm test` (3754 pass / 22 skipped)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] New `listFiles` unit tests cover: no filter, prefix filter, single-quote escape, empty string treated as no filter
- [ ] Manual on-device check: open Analyze on a fresh keyboard while signed into an account that has prior sync data; confirm the initial sync completes meaningfully faster than before