### PR TITLE
refactor(sync): drop v6 typing-analytics format and dead state

### DIFF
--- a/src/main/__tests__/google-drive.test.ts
+++ b/src/main/__tests__/google-drive.test.ts
@@ -56,7 +56,8 @@ describe('google-drive', () => {
     it('converts keyboard sync units to drive filename', () => {
       expect(driveFileName('keyboards/0x1234/settings')).toBe('keyboards_0x1234_settings.enc')
       expect(driveFileName('keyboards/0x1234/snapshots')).toBe('keyboards_0x1234_snapshots.enc')
-      expect(driveFileName('keyboards/0x1234/devices/hash-abc')).toBe('keyboards_0x1234_devices_hash-abc.enc')
+      expect(driveFileName('keyboards/0x1234/devices/hash-abc/days/2026-04-19'))
+        .toBe('keyboards_0x1234_devices_hash-abc_days_2026-04-19.enc')
     })
   })
 
@@ -74,8 +75,15 @@ describe('google-drive', () => {
       expect(syncUnitFromFileName('keyboards_0x1234_snapshots.enc')).toBe('keyboards/0x1234/snapshots')
     })
 
-    it('parses keyboard device JSONL drive filename to sync unit', () => {
-      expect(syncUnitFromFileName('keyboards_0x1234_devices_hash-abc.enc')).toBe('keyboards/0x1234/devices/hash-abc')
+    it('parses per-day device JSONL drive filename to sync unit', () => {
+      expect(syncUnitFromFileName('keyboards_0x1234_devices_hash-abc_days_2026-04-19.enc'))
+        .toBe('keyboards/0x1234/devices/hash-abc/days/2026-04-19')
+    })
+
+    it('returns null for the legacy flat device JSONL filename shape', () => {
+      // The flat `{hash}.enc` form (no `_days_` segment) was retired with
+      // the v7 cutover; it must no longer round-trip into a sync unit.
+      expect(syncUnitFromFileName('keyboards_0x1234_devices_hash-abc.enc')).toBeNull()
     })
 
     it('round-trips the keyboard-meta singleton sync unit', () => {

--- a/src/main/__tests__/sync-service.test.ts
+++ b/src/main/__tests__/sync-service.test.ts
@@ -97,17 +97,8 @@ vi.mock('../app-config', () => ({
 }))
 
 vi.mock('../typing-analytics/sync', () => ({
-  typingAnalyticsDeviceSyncUnit: (uid: string, machineHash: string) =>
-    `keyboards/${uid}/devices/${machineHash}`,
   typingAnalyticsDeviceDaySyncUnit: (uid: string, machineHash: string, day: string) =>
     `keyboards/${uid}/devices/${machineHash}/days/${day}`,
-  parseTypingAnalyticsDeviceSyncUnit: (syncUnit: string) => {
-    const parts = syncUnit.split('/')
-    if (parts.length !== 4) return null
-    if (parts[0] !== 'keyboards' || parts[2] !== 'devices') return null
-    if (parts[1].length === 0 || parts[3].length === 0) return null
-    return { uid: parts[1], machineHash: parts[3] }
-  },
   parseTypingAnalyticsDeviceDaySyncUnit: (syncUnit: string) => {
     const parts = syncUnit.split('/')
     if (parts.length !== 6) return null
@@ -143,9 +134,8 @@ vi.mock('../typing-analytics/machine-hash', () => ({
 }))
 
 interface MockTypingSyncState {
-  _rev: 2
+  _rev: 3
   my_device_id: string
-  read_pointers: Record<string, string | null>
   uploaded: Record<string, string[]>
   reconciled_at: Record<string, number | null>
   last_synced_at: number
@@ -159,9 +149,8 @@ vi.mock('../typing-analytics/sync-state', () => ({
   loadSyncState: (...args: unknown[]) => mockLoadSyncState(...args as [string]),
   saveSyncState: (...args: unknown[]) => mockSaveSyncState(...args as [string, MockTypingSyncState]),
   emptySyncState: (myDeviceId: string): MockTypingSyncState => ({
-    _rev: 2,
+    _rev: 3,
     my_device_id: myDeviceId,
-    read_pointers: {},
     uploaded: {},
     reconciled_at: {},
     last_synced_at: 0,
@@ -810,76 +799,6 @@ describe('sync-service', () => {
     })
   })
 
-  describe('typing-analytics device merge', () => {
-    const uid = '0xtype'
-    const remoteHash = 'hash-remote'
-    const fileName = `keyboards_${uid}_devices_${remoteHash}.enc`
-    const syncUnit = `keyboards/${uid}/devices/${remoteHash}`
-
-    function makeDeviceEnvelope(dataJsonl: string): Record<string, unknown> {
-      return {
-        version: 1,
-        syncUnit,
-        updatedAt: '2025-01-01T00:00:00.000Z',
-        salt: 's',
-        iv: 'i',
-        ciphertext: JSON.stringify({
-          type: 'typing-analytics-device',
-          key: `${uid}|${remoteHash}`,
-          index: { uid, entries: [] },
-          files: { 'data.jsonl': dataJsonl },
-        }),
-      }
-    }
-
-    it('writes the remote JSONL to disk and replays new rows into the cache', async () => {
-      mockListFiles.mockResolvedValue([
-        { id: 'dev-1', name: fileName, modifiedTime: '2025-01-01T00:00:00.000Z' },
-      ])
-      const payload = JSON.stringify({ id: 'x', kind: 'scope', updated_at: 1, payload: {} }) + '\n'
-      mockDownloadFile.mockResolvedValue(makeDeviceEnvelope(payload))
-
-      // Force local uid visibility so scope 'all' keeps the unit (lazy gate).
-      await mkdir(join(mockUserDataPath, 'sync', 'keyboards', uid), { recursive: true })
-
-      await executeSync('download')
-
-      const written = await readFile(
-        join(mockUserDataPath, 'sync', 'keyboards', uid, 'devices', `${remoteHash}.jsonl`),
-        'utf-8',
-      )
-      expect(written).toBe(payload)
-      expect(mockReadRows).toHaveBeenCalled()
-    })
-
-    it('surfaces cache-apply errors as failedUnits so polling can retry', async () => {
-      const progressEvents: SyncProgress[] = []
-      setProgressCallback((p) => progressEvents.push({ ...p }))
-
-      mockReadRows.mockResolvedValueOnce({
-        rows: [{ id: 'row-1', kind: 'scope', updated_at: 1, payload: {} } as unknown as { id: string }],
-        lastId: 'row-1',
-        partialLineSkipped: false,
-      } as unknown as { rows: never[]; lastId: string | null; partialLineSkipped: boolean })
-      mockApplyRowsToCache.mockImplementationOnce(() => {
-        throw new Error('sqlite schema mismatch')
-      })
-
-      mockListFiles.mockResolvedValue([
-        { id: 'dev-2', name: fileName, modifiedTime: '2025-01-01T00:00:00.000Z' },
-      ])
-      mockDownloadFile.mockResolvedValue(makeDeviceEnvelope('{"id":"row-1","kind":"scope","updated_at":1,"payload":{}}\n'))
-
-      await mkdir(join(mockUserDataPath, 'sync', 'keyboards', uid), { recursive: true })
-
-      await executeSync('download')
-
-      const final = progressEvents[progressEvents.length - 1]
-      expect(final.status).toBe('partial')
-      expect(final.failedUnits).toEqual([syncUnit])
-    })
-  })
-
   describe('settings timestamp NaN handling', () => {
     const uid = 'test-kb'
 
@@ -1344,15 +1263,16 @@ describe('sync-service', () => {
     })
 
     describe('isAnalyticsSyncUnit', () => {
-      it('identifies v7 per-day typing-analytics units', () => {
+      it('identifies per-day typing-analytics units', () => {
         expect(isAnalyticsSyncUnit('keyboards/0x1234/devices/hashabc/days/2026-04-19')).toBe(true)
-        expect(isAnalyticsSyncUnit('keyboards/uid-a/devices/machineHash-xyz')).toBe(true)
       })
 
       it('rejects non-analytics keyboard sub-units', () => {
         expect(isAnalyticsSyncUnit('keyboards/0x1234/settings')).toBe(false)
         expect(isAnalyticsSyncUnit('keyboards/0x1234/snapshots')).toBe(false)
         expect(isAnalyticsSyncUnit('keyboards/0x1234')).toBe(false)
+        // Legacy flat device form (no `/days/...`) is no longer recognised.
+        expect(isAnalyticsSyncUnit('keyboards/uid-a/devices/machineHash-xyz')).toBe(false)
       })
 
       it('rejects unrelated units', () => {
@@ -1922,9 +1842,8 @@ describe('sync-service', () => {
     // --- Reconcile rule 2: uploaded has, local missing → cloud delete ---
     it('reconcile rule 2: drops cloud file when uploaded lists a day but local file is gone', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: ['2026-04-17', '2026-04-18'] },
         reconciled_at: { [pointerKey(OWN_HASH)]: 1_000 },
         last_synced_at: 1_000,
@@ -1946,9 +1865,8 @@ describe('sync-service', () => {
     // --- Reconcile rule 3: uploaded has, cloud missing → local unlink ---
     it('reconcile rule 3: unlinks local file when uploaded has the day but cloud does not', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: ['2026-04-17', '2026-04-18'] },
         reconciled_at: { [pointerKey(OWN_HASH)]: 1_000 },
         last_synced_at: 1_000,
@@ -1971,9 +1889,8 @@ describe('sync-service', () => {
     // --- Reconcile orphan cleanup: first run ---
     it('reconcile orphan: deletes cloud-only days when reconciled_at is pending', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: [] },
         reconciled_at: { [pointerKey(OWN_HASH)]: null },
         last_synced_at: 0,
@@ -1994,9 +1911,8 @@ describe('sync-service', () => {
     // --- Reconcile skip: reconciled_at set ---
     it('reconcile skip: leaves cloud orphans alone once reconciled_at is a timestamp', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: [] },
         reconciled_at: { [pointerKey(OWN_HASH)]: 5_000 },
         last_synced_at: 5_000,
@@ -2014,9 +1930,8 @@ describe('sync-service', () => {
     // --- Rule 1 new-day upload + uploaded bookkeeping ---
     it('rule 1: uploading a new own-hash day records it into sync_state.uploaded', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: {},
         reconciled_at: { [pointerKey(OWN_HASH)]: 5_000 }, // reconcile already done
         last_synced_at: 5_000,
@@ -2102,9 +2017,8 @@ describe('sync-service', () => {
     // --- Reconcile: remote hashes are not touched ---
     it('reconcile hash-scope: remote device days stay intact (own-hash only)', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: [] },
         reconciled_at: { [pointerKey(OWN_HASH)]: null },
         last_synced_at: 0,
@@ -2122,9 +2036,8 @@ describe('sync-service', () => {
     // --- Same-day re-upload dedup: current day keeps `uploaded` at 1 ---
     it('same-day re-upload: uploaded array stays a single entry across repeated flushes', async () => {
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: {},
         reconciled_at: { [pointerKey(OWN_HASH)]: 5_000 },
         last_synced_at: 5_000,
@@ -2232,9 +2145,8 @@ describe('sync-service', () => {
       // key. The first upload pass must perform orphan cleanup and then
       // stamp `reconciled_at`.
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: {},
         reconciled_at: {}, // empty map — no key has been reconciled yet
         last_synced_at: 0,
@@ -2258,9 +2170,8 @@ describe('sync-service', () => {
       await writeDayFile('2026-04-17')
       await writeDayFile('2026-04-18')
       mockSyncState = {
-        _rev: 2,
+        _rev: 3,
         my_device_id: OWN_HASH,
-        read_pointers: {},
         uploaded: { [pointerKey(OWN_HASH)]: ['2026-04-17', '2026-04-18'] },
         reconciled_at: { [pointerKey(OWN_HASH)]: 5_000 },
         last_synced_at: 5_000,

--- a/src/main/sync/google-drive.ts
+++ b/src/main/sync/google-drive.ts
@@ -170,18 +170,10 @@ export function driveFilenamePrefix(syncUnitPrefix: string): string {
 export function syncUnitFromFileName(fileName: string): string | null {
   // "keyboards_0x1234_devices_{hash}_days_{YYYY-MM-DD}.enc"
   //   → "keyboards/0x1234/devices/{hash}/days/{YYYY-MM-DD}"
-  // Matched first so the trailing `_days_{date}` segment isn't eaten
-  // by the broader v6 `devices_(.+)` pattern below. The day regex
-  // pins to exactly `YYYY-MM-DD` so machineHash strings containing
-  // `_days_...` shaped substrings can't false-match.
+  // The day regex pins to exactly `YYYY-MM-DD` so machineHash strings
+  // containing `_days_...` shaped substrings can't false-match.
   const dayMatch = fileName.match(/^keyboards_(.+?)_devices_(.+?)_days_(\d{4}-\d{2}-\d{2})\.enc$/)
   if (dayMatch) return `keyboards/${dayMatch[1]}/devices/${dayMatch[2]}/days/${dayMatch[3]}`
-
-  // "keyboards_0x1234_devices_{hash}.enc" → "keyboards/0x1234/devices/{hash}"
-  // Matched before the 3-part pattern so machineHash segments with
-  // underscores don't get mis-split by the shorter regex.
-  const deviceMatch = fileName.match(/^keyboards_(.+?)_devices_(.+)\.enc$/)
-  if (deviceMatch) return `keyboards/${deviceMatch[1]}/devices/${deviceMatch[2]}`
 
   // "keyboards_0x1234_settings.enc" → "keyboards/0x1234/settings"
   // "keyboards_0x1234_snapshots.enc" → "keyboards/0x1234/snapshots"

--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -16,16 +16,13 @@ import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
 import {
   deviceDayJsonlPath,
-  deviceJsonlPath,
   listDeviceDays,
 } from '../typing-analytics/jsonl/paths'
 import { getTypingAnalyticsDB } from '../typing-analytics/db/typing-analytics-db'
 import { getMachineHash } from '../typing-analytics/machine-hash'
 import {
   parseTypingAnalyticsDeviceDaySyncUnit,
-  parseTypingAnalyticsDeviceSyncUnit,
   typingAnalyticsDeviceDaySyncUnit,
-  typingAnalyticsDeviceSyncUnit,
 } from '../typing-analytics/sync'
 import { log } from '../logger'
 
@@ -47,7 +44,7 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
   const parts = syncUnit.split('/')
   const userData = app.getPath('userData')
 
-  // Handle "keyboards/{uid}/devices/{hash}/days/{YYYY-MM-DD}" — v7 per-day
+  // Handle "keyboards/{uid}/devices/{hash}/days/{YYYY-MM-DD}" — per-day
   // JSONL master. One bundle per (uid, hash, day), so cloud storage grows
   // as new days are recorded and each day's file is uploaded / deleted
   // independently of the others.
@@ -60,26 +57,6 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
         type: 'typing-analytics-device',
         key: `${dayRef.uid}|${dayRef.machineHash}|${dayRef.utcDay}`,
         index: { uid: dayRef.uid, entries: [] } as SnapshotIndex,
-        files: { 'data.jsonl': content },
-      }
-    } catch {
-      return null
-    }
-  }
-
-  // Handle v6 "keyboards/{uid}/devices/{machineHash}" — flat JSONL master
-  // file. Kept while the v6 mirror write is still in place so existing
-  // remote devices' flat files remain readable. Removed in a later
-  // chunk once sync has fully switched to the per-day form.
-  const deviceRef = parseTypingAnalyticsDeviceSyncUnit(syncUnit)
-  if (deviceRef) {
-    const filePath = deviceJsonlPath(userData, deviceRef.uid, deviceRef.machineHash)
-    try {
-      const content = await readFile(filePath, 'utf-8')
-      return {
-        type: 'typing-analytics-device',
-        key: `${deviceRef.uid}|${deviceRef.machineHash}`,
-        index: { uid: deviceRef.uid, entries: [] } as SnapshotIndex,
         files: { 'data.jsonl': content },
       }
     } catch {
@@ -147,15 +124,14 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
   return { type, key, index, files }
 }
 
-/** typing-analytics v6 flat + v7 per-day sync units. Identified
- * through the existing parsers so the shape (including `utcDay`
- * validation for v7) is single-sourced and drifts with the parsers,
- * not with a separate regex. Connect-time initial sync and 3-minute
- * polling skip these; the Analyze panel pulls them on demand via
- * `executeAnalyticsSync`. See `.claude/rules/settings-persistence.md`. */
+/** typing-analytics per-day sync units. Identified through the existing
+ * parser so the shape (including `utcDay` validation) is single-sourced
+ * and drifts with the parser, not with a separate regex. Connect-time
+ * initial sync and 3-minute polling skip these; the Analyze panel pulls
+ * them on demand via `executeAnalyticsSync`. See
+ * `.claude/rules/settings-persistence.md`. */
 export function isAnalyticsSyncUnit(syncUnit: string): boolean {
   return parseTypingAnalyticsDeviceDaySyncUnit(syncUnit) !== null
-      || parseTypingAnalyticsDeviceSyncUnit(syncUnit) !== null
 }
 
 /** Own-hash typing-analytics units for one keyboard. Narrower than
@@ -167,10 +143,6 @@ export async function collectAnalyticsSyncUnitsForUid(uid: string): Promise<stri
   const units: string[] = []
   try {
     const machineHash = await getMachineHash()
-    // v6 flat mirror (harmless no-op when the file is absent — bundle
-    // returns null and the caller skips it). Kept so mixed v6/v7
-    // installs stay uploadable.
-    units.push(typingAnalyticsDeviceSyncUnit(uid, machineHash))
     for (const day of await listDeviceDays(userData, uid, machineHash)) {
       units.push(typingAnalyticsDeviceDaySyncUnit(uid, machineHash, day))
     }
@@ -225,12 +197,9 @@ export async function collectAllSyncUnits(): Promise<string[]> {
     const machineHash = await getMachineHash()
     const typingUids = getTypingAnalyticsDB().listLocalKeyboardUids(machineHash)
     for (const uid of typingUids) {
-      // v6 flat bundle: needed only while the mirror write keeps the
-      // flat file fresh. Dropped together with the mirror.
-      units.push(typingAnalyticsDeviceSyncUnit(uid, machineHash))
-      // v7 per-day bundles: one per day we've recorded against this uid.
+      // Per-day bundles: one per day we've recorded against this uid.
       // listDeviceDays returns an empty list if the per-day directory
-      // doesn't exist yet, so this silently no-ops on a pre-v7 store.
+      // doesn't exist yet, so this silently no-ops on first run.
       for (const day of await listDeviceDays(userData, uid, machineHash)) {
         units.push(typingAnalyticsDeviceDaySyncUnit(uid, machineHash, day))
       }

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -38,7 +38,6 @@ import { KEYBOARD_META_SYNC_UNIT, type KeyboardMetaIndex } from '../../shared/ty
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
 import {
   parseTypingAnalyticsDeviceDaySyncUnit,
-  parseTypingAnalyticsDeviceSyncUnit,
   typingAnalyticsDeviceDaySyncUnit,
 } from '../typing-analytics/sync'
 import { applyRowsToCache } from '../typing-analytics/jsonl/apply-to-cache'
@@ -46,8 +45,6 @@ import { readRows } from '../typing-analytics/jsonl/jsonl-reader'
 import {
   deviceDayDir,
   deviceDayJsonlPath,
-  deviceJsonlPath,
-  devicesDir,
   listDeviceDays,
   readPointerKey,
 } from '../typing-analytics/jsonl/paths'
@@ -427,7 +424,7 @@ async function uploadSyncUnit(
 
   await uploadFile(targetName, envelope, existing?.id)
 
-  // Post-upload bookkeeping: record a successful cloud upload for v7
+  // Post-upload bookkeeping: record a successful cloud upload for
   // per-day units so the reconcile logic can later distinguish
   // "never uploaded" from "uploaded then remotely deleted".
   const dayRef = parseTypingAnalyticsDeviceDaySyncUnit(syncUnit)
@@ -455,44 +452,11 @@ async function recordDayUploaded(dayRef: {
   await saveSyncState(userData, state)
 }
 
-/** Write the downloaded v6 flat JSONL to the owning device's local
- * path, then replay only the rows after the previously-applied pointer
- * into the cache DB. Leaves the sync-state file with an updated pointer
- * so the next pass skips already-applied rows. No-op when the unit's
- * machineHash matches our own (our local file is the authoritative copy
- * and will be re-uploaded on the next flush). */
-async function mergeDeviceBundle(
-  remoteBundle: SyncBundle,
-  deviceRef: { uid: string; machineHash: string },
-  userData: string,
-  ownHash: string,
-): Promise<void> {
-  if (deviceRef.machineHash === ownHash) return
-  const data = remoteBundle.files['data.jsonl']
-  if (!data) return
-
-  const localPath = deviceJsonlPath(userData, deviceRef.uid, deviceRef.machineHash)
-  await mkdir(devicesDir(userData, deviceRef.uid), { recursive: true })
-  await writeFile(localPath, data, 'utf-8')
-
-  const state = (await loadSyncState(userData)) ?? emptySyncState(ownHash)
-  const pointerKey = readPointerKey(deviceRef.uid, deviceRef.machineHash)
-  const priorPointer = state.read_pointers[pointerKey] ?? null
-
-  const { rows, lastId } = await readRows(localPath, { afterId: priorPointer })
-  if (rows.length > 0) {
-    applyRowsToCache(getTypingAnalyticsDB(), rows)
-  }
-  state.read_pointers[pointerKey] = lastId
-  state.last_synced_at = Date.now()
-  await saveSyncState(userData, state)
-}
-
-/** Write a downloaded v7 per-day JSONL under the owning device's
- * `{hash}/` directory and apply any rows newer than the pointer. Each
- * day is a distinct file so a partial download of one day does not
- * affect other days for the same remote hash. No-op when the unit's
- * machineHash matches our own. */
+/** Write a downloaded per-day JSONL under the owning device's `{hash}/`
+ * directory and apply every row in the file. Each day is a distinct
+ * file so a partial download of one day does not affect other days for
+ * the same remote hash. No-op when the unit's machineHash matches our
+ * own. */
 async function mergeDeviceDayBundle(
   remoteBundle: SyncBundle,
   dayRef: { uid: string; machineHash: string; utcDay: UtcDay },
@@ -507,12 +471,9 @@ async function mergeDeviceDayBundle(
   await mkdir(deviceDayDir(userData, dayRef.uid, dayRef.machineHash), { recursive: true })
   await writeFile(localPath, data, 'utf-8')
 
-  // Per-day bundles are replayed in full, not against the hash-level
-  // `read_pointers` — the pointer points at whatever day was last
-  // processed for this hash, so fetching an older day afterwards would
-  // see `afterId` already past every row in that file and apply 0
-  // rows. The LWW merge is idempotent, so replaying the whole day is
-  // cheap and correct. `read_pointers` only tracks v6 flat merges.
+  // Per-day bundles are replayed in full. The LWW merge is idempotent,
+  // so re-applying every row in the file is cheap, correct, and avoids
+  // any per-hash `afterId` bookkeeping at the merge layer.
   const { rows } = await readRows(localPath)
   if (rows.length > 0) {
     applyRowsToCache(getTypingAnalyticsDB(), rows)
@@ -548,11 +509,6 @@ async function mergeSyncUnit(
   const dayRef = parseTypingAnalyticsDeviceDaySyncUnit(syncUnit)
   if (dayRef) {
     await mergeDeviceDayBundle(remoteBundle, dayRef, userData, await getMachineHash())
-    return false
-  }
-  const deviceRef = parseTypingAnalyticsDeviceSyncUnit(syncUnit)
-  if (deviceRef) {
-    await mergeDeviceBundle(remoteBundle, deviceRef, userData, await getMachineHash())
     return false
   }
 
@@ -770,8 +726,8 @@ async function executeDownloadSync(
   return failedUnits
 }
 
-/** Scan the remote file list for v7 per-day typing-analytics units
- * owned by `ownHash`, grouped by keyboard uid. Units with a malformed
+/** Scan the remote file list for per-day typing-analytics units owned
+ * by `ownHash`, grouped by keyboard uid. Units with a malformed
  * filename are skipped. */
 function collectRemoteOwnHashDays(
   remoteFiles: DriveFile[],

--- a/src/main/typing-analytics/__tests__/cache-rebuild.test.ts
+++ b/src/main/typing-analytics/__tests__/cache-rebuild.test.ts
@@ -18,13 +18,14 @@ import {
   type JsonlRow,
 } from '../jsonl/jsonl-row'
 import { appendRowsToFile } from '../jsonl/jsonl-writer'
-import { deviceDayJsonlPath, deviceJsonlPath, readPointerKey } from '../jsonl/paths'
+import { deviceDayJsonlPath } from '../jsonl/paths'
 import {
   emptySyncState,
   loadSyncState,
   saveSyncState,
-  type TypingSyncState,
 } from '../sync-state'
+
+const SAMPLE_DAY = '2026-04-19'
 
 const UID_A = '0xAABB'
 const MY_HASH = 'hash-self'
@@ -148,18 +149,18 @@ describe('rebuildCacheFromMasterFiles', () => {
   })
 
   it('replays every local and remote device file into the cache', async () => {
-    await appendRowsToFile(deviceJsonlPath(tmpDir, UID_A, MY_HASH), [
+    await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, SAMPLE_DAY), [
       scope(MY_HASH),
       stats(MY_HASH, 10),
       char(MY_HASH, 'a', 5),
     ])
-    await appendRowsToFile(deviceJsonlPath(tmpDir, UID_A, REMOTE_HASH), [
+    await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, REMOTE_HASH, SAMPLE_DAY), [
       scope(REMOTE_HASH),
       stats(REMOTE_HASH, 3),
       char(REMOTE_HASH, 'b', 2),
     ])
 
-    const { result, pointers } = await rebuildCacheFromMasterFiles(db, tmpDir)
+    const result = await rebuildCacheFromMasterFiles(db, tmpDir)
     expect(result.scopes).toBe(2)
     expect(result.charMinutes).toBe(2)
     expect(result.minuteStats).toBe(2)
@@ -168,13 +169,10 @@ describe('rebuildCacheFromMasterFiles', () => {
     const conn = db.getConnection()
     const totals = conn.prepare('SELECT COUNT(*) AS n FROM typing_minute_stats').get() as { n: number }
     expect(totals.n).toBe(2)
-
-    expect(pointers[readPointerKey(UID_A, MY_HASH)]).toBe(char(MY_HASH, 'a', 5).id)
-    expect(pointers[readPointerKey(UID_A, REMOTE_HASH)]).toBe(char(REMOTE_HASH, 'b', 2).id)
   })
 
   it('starts from a clean slate each call (no double-counting on re-run)', async () => {
-    await appendRowsToFile(deviceJsonlPath(tmpDir, UID_A, MY_HASH), [
+    await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, SAMPLE_DAY), [
       scope(MY_HASH),
       char(MY_HASH, 'a', 4),
     ])
@@ -187,30 +185,26 @@ describe('rebuildCacheFromMasterFiles', () => {
   })
 
   it('handles a sync tree that does not yet exist', async () => {
-    const { result, pointers } = await rebuildCacheFromMasterFiles(db, tmpDir)
+    const result = await rebuildCacheFromMasterFiles(db, tmpDir)
     expect(result.jsonlFilesRead).toBe(0)
-    expect(pointers).toEqual({})
   })
 
-  it('still records the pointer for an empty JSONL file so the next pass skips it', async () => {
-    const path = deviceJsonlPath(tmpDir, UID_A, MY_HASH)
+  it('handles an empty JSONL file without applying any rows', async () => {
+    const path = deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, SAMPLE_DAY)
     // Create parent dir + empty file (simulates a freshly-placed download
     // that has not yet been appended to).
     const { mkdir, writeFile } = await import('node:fs/promises')
     const { dirname } = await import('node:path')
     await mkdir(dirname(path), { recursive: true })
     await writeFile(path, '')
-    const { pointers } = await rebuildCacheFromMasterFiles(db, tmpDir)
-    expect(pointers[readPointerKey(UID_A, MY_HASH)]).toBeNull()
+    const result = await rebuildCacheFromMasterFiles(db, tmpDir)
+    // Empty file contributes no rows; the rebuild treats it as a no-op
+    // rather than an error.
+    expect(result.jsonlFilesRead).toBe(0)
+    expect(result.charMinutes).toBe(0)
   })
 
-  it('replays v7 per-day files alongside v6 flat files in one pass', async () => {
-    // v6 flat (legacy) at devices/{hash}.jsonl
-    await appendRowsToFile(deviceJsonlPath(tmpDir, UID_A, REMOTE_HASH), [
-      scope(REMOTE_HASH),
-      char(REMOTE_HASH, 'b', 2),
-    ])
-    // v7 per-day at devices/{hash}/{date}.jsonl
+  it('replays multiple per-day files for the same hash in chronological order', async () => {
     await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, '2026-04-18'), [
       scope(MY_HASH),
       char(MY_HASH, 'a', 3),
@@ -219,17 +213,12 @@ describe('rebuildCacheFromMasterFiles', () => {
       char(MY_HASH, 'c', 4, 2_000),
     ])
 
-    const { result, pointers } = await rebuildCacheFromMasterFiles(db, tmpDir)
-    expect(result.jsonlFilesRead).toBe(3)
+    const result = await rebuildCacheFromMasterFiles(db, tmpDir)
+    expect(result.jsonlFilesRead).toBe(2)
 
     const conn = db.getConnection()
     const totals = conn.prepare('SELECT COUNT(*) AS n FROM typing_char_minute').get() as { n: number }
-    expect(totals.n).toBe(3)
-    // v7 day files are read after v6 flat; for a hash that has both, pointer
-    // lands on the last per-day row applied — `c` is the later day's only
-    // char row because both days share the same minute in this fixture.
-    expect(pointers[readPointerKey(UID_A, MY_HASH)]).toBe(char(MY_HASH, 'c', 4, 2_000).id)
-    expect(pointers[readPointerKey(UID_A, REMOTE_HASH)]).toBe(char(REMOTE_HASH, 'b', 2).id)
+    expect(totals.n).toBe(2)
   })
 })
 
@@ -248,7 +237,7 @@ describe('ensureCacheIsFresh', () => {
   })
 
   it('rebuilds when the sync-state file is missing', async () => {
-    await appendRowsToFile(deviceJsonlPath(tmpDir, UID_A, MY_HASH), [
+    await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, SAMPLE_DAY), [
       scope(MY_HASH),
       stats(MY_HASH, 1),
     ])
@@ -261,12 +250,14 @@ describe('ensureCacheIsFresh', () => {
   it('rebuilds when my_device_id changed (machine migration)', async () => {
     await saveSyncState(tmpDir, {
       ...emptySyncState('hash-old'),
-      read_pointers: { stale: 'x' },
-    } as TypingSyncState)
+      uploaded: { 'stale-key': ['2025-01-01'] },
+    })
     const { rebuilt, state } = await ensureCacheIsFresh(db, tmpDir, MY_HASH)
     expect(rebuilt).toBe(true)
     expect(state.my_device_id).toBe(MY_HASH)
-    expect(Object.keys(state.read_pointers)).not.toContain('stale')
+    // Migration starts from a clean state — the previous device's
+    // upload bookkeeping is dropped.
+    expect(Object.keys(state.uploaded)).not.toContain('stale-key')
   })
 
   it('skips rebuild when sync-state is valid and my_device_id matches', async () => {

--- a/src/main/typing-analytics/__tests__/sync-state.test.ts
+++ b/src/main/typing-analytics/__tests__/sync-state.test.ts
@@ -36,7 +36,8 @@ describe('sync-state persistence', () => {
   it('saves and round-trips a state document', async () => {
     const state = {
       ...emptySyncState('hash-self'),
-      read_pointers: { [readPointerKey('0xAABB', 'hash-a')]: 'char|s|60000|a' },
+      uploaded: { [readPointerKey('0xAABB', 'hash-self')]: ['2026-04-17'] },
+      reconciled_at: { [readPointerKey('0xAABB', 'hash-self')]: 1_700_000 },
       last_synced_at: 1_234_567,
     }
     await saveSyncState(tmpDir, state)
@@ -52,7 +53,6 @@ describe('sync-state persistence', () => {
       JSON.stringify({
         _rev: SYNC_STATE_REV + 1,
         my_device_id: 'x',
-        read_pointers: {},
         uploaded: {},
         reconciled_at: {},
         last_synced_at: 0,
@@ -61,7 +61,7 @@ describe('sync-state persistence', () => {
     expect(await loadSyncState(tmpDir)).toBeNull()
   })
 
-  it('migrates a v1 document by preserving pointers and initialising new fields', async () => {
+  it('migrates a v1 document by dropping read_pointers and initialising the new fields', async () => {
     const path = syncStatePath(tmpDir)
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(
@@ -76,14 +76,36 @@ describe('sync-state persistence', () => {
     expect(await loadSyncState(tmpDir)).toEqual({
       _rev: SYNC_STATE_REV,
       my_device_id: 'hash-self',
-      read_pointers: { [readPointerKey('0xAABB', 'hash-a')]: 'char|s|60000|a' },
       uploaded: {},
       reconciled_at: {},
       last_synced_at: 42,
     })
   })
 
-  it('round-trips a v2 document with uploaded + reconciled_at populated', async () => {
+  it('migrates a v2 document by dropping read_pointers and keeping uploaded + reconciled_at', async () => {
+    const path = syncStatePath(tmpDir)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(
+      path,
+      JSON.stringify({
+        _rev: 2,
+        my_device_id: 'hash-self',
+        read_pointers: { [readPointerKey('0xAABB', 'hash-a')]: 'char|s|60000|a' },
+        uploaded: { [readPointerKey('0xAABB', 'hash-self')]: ['2026-04-17'] },
+        reconciled_at: { [readPointerKey('0xAABB', 'hash-self')]: 1_700_000 },
+        last_synced_at: 99,
+      }),
+    )
+    expect(await loadSyncState(tmpDir)).toEqual({
+      _rev: SYNC_STATE_REV,
+      my_device_id: 'hash-self',
+      uploaded: { [readPointerKey('0xAABB', 'hash-self')]: ['2026-04-17'] },
+      reconciled_at: { [readPointerKey('0xAABB', 'hash-self')]: 1_700_000 },
+      last_synced_at: 99,
+    })
+  })
+
+  it('round-trips a current-rev document with uploaded + reconciled_at populated', async () => {
     const state = {
       ...emptySyncState('hash-self'),
       uploaded: { [readPointerKey('0xAABB', 'hash-self')]: ['2026-04-17', '2026-04-18'] },
@@ -93,7 +115,7 @@ describe('sync-state persistence', () => {
     expect(await loadSyncState(tmpDir)).toEqual(state)
   })
 
-  it('loadSyncState rejects a v2 document with non-ISO dates in uploaded', async () => {
+  it('loadSyncState rejects a document with non-ISO dates in uploaded', async () => {
     const path = syncStatePath(tmpDir)
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(
@@ -101,7 +123,6 @@ describe('sync-state persistence', () => {
       JSON.stringify({
         _rev: SYNC_STATE_REV,
         my_device_id: 'x',
-        read_pointers: {},
         uploaded: { 'k': ['2026/04/17'] },
         reconciled_at: {},
         last_synced_at: 0,
@@ -110,7 +131,7 @@ describe('sync-state persistence', () => {
     expect(await loadSyncState(tmpDir)).toBeNull()
   })
 
-  it('loadSyncState rejects a v2 document with non-finite reconciled_at', async () => {
+  it('loadSyncState rejects a document with non-finite reconciled_at', async () => {
     const path = syncStatePath(tmpDir)
     mkdirSync(dirname(path), { recursive: true })
     writeFileSync(
@@ -118,7 +139,6 @@ describe('sync-state persistence', () => {
       JSON.stringify({
         _rev: SYNC_STATE_REV,
         my_device_id: 'x',
-        read_pointers: {},
         uploaded: {},
         reconciled_at: { 'k': 'not-a-number' },
         last_synced_at: 0,
@@ -135,7 +155,6 @@ describe('sync-state persistence', () => {
       JSON.stringify({
         _rev: SYNC_STATE_REV,
         my_device_id: 'x',
-        read_pointers: {},
         uploaded: {},
         reconciled_at: { 'k': null },
         last_synced_at: 0,

--- a/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
+++ b/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
@@ -433,7 +433,12 @@ describe('typing-analytics-service', () => {
         expect(result.minuteStats).toBeGreaterThan(0)
         expect(listTypingDailySummaries(sampleKeyboard.uid)).toEqual([])
         const machineHash = await getMachineHash()
-        expect(notifier).toHaveBeenCalledWith(`keyboards/${sampleKeyboard.uid}/devices/${machineHash}`)
+        // Tombstone notify fires one per-day unit per affected UTC day.
+        expect(notifier).toHaveBeenCalledWith(
+          expect.stringMatching(
+            new RegExp(`^keyboards/${sampleKeyboard.uid}/devices/${machineHash}/days/\\d{4}-\\d{2}-\\d{2}$`),
+          ),
+        )
       })
 
       it('deleteAllTypingForKeyboard wipes every live row for the uid', async () => {
@@ -441,12 +446,20 @@ describe('typing-analytics-service', () => {
         setTypingAnalyticsSyncNotifier(notifier)
         await seedKeyboardData(sampleKeyboard, Date.UTC(2026, 3, 10, 12, 0, 0))
         await seedKeyboardData(sampleKeyboard, Date.UTC(2026, 3, 14, 12, 0, 0), 'b')
+        // Forget the per-day flush notifications fired during seeding so
+        // the assertion below sees only the delete-time notifies.
+        notifier.mockClear()
 
         const result = await deleteAllTypingForKeyboard(sampleKeyboard.uid)
         expect(result.charMinutes).toBeGreaterThan(0)
         expect(listTypingKeyboards().map((k) => k.uid)).not.toContain(sampleKeyboard.uid)
         const machineHash = await getMachineHash()
-        expect(notifier).toHaveBeenCalledWith(`keyboards/${sampleKeyboard.uid}/devices/${machineHash}`)
+        // Delete-all notifies one per-day unit per day captured before the
+        // unlink. Both seeded UTC days must show up exactly once.
+        const expectedUnits = ['2026-04-10', '2026-04-14'].map(
+          (day) => `keyboards/${sampleKeyboard.uid}/devices/${machineHash}/days/${day}`,
+        )
+        expect(notifier.mock.calls.map((call) => call[0]).sort()).toEqual(expectedUnits.sort())
       })
 
       it('deleteTypingDailySummaries is a no-op when the dates array is empty', async () => {
@@ -607,7 +620,7 @@ describe('typing-analytics-service', () => {
     })
   })
 
-  describe('v7 per-day JSONL output', () => {
+  describe('per-day JSONL output', () => {
     async function readDayRows(uid: string, machineHash: string, utcDay: string): Promise<JsonlRow[]> {
       const path = deviceDayJsonlPath(mockUserDataPath, uid, machineHash, utcDay)
       const { rows } = await readRows(path)
@@ -616,7 +629,7 @@ describe('typing-analytics-service', () => {
     const charsOnDay = (rows: JsonlRow[]): string[] =>
       rows.flatMap((r) => (r.kind === 'char-minute' ? [r.payload.char] : []))
 
-    it('writes each flush to {hash}/{utcDay}.jsonl and no longer mirrors the v6 flat path', async () => {
+    it('writes each flush to {hash}/{utcDay}.jsonl with no flat sibling', async () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
@@ -628,10 +641,11 @@ describe('typing-analytics-service', () => {
       const dayPath = deviceDayJsonlPath(mockUserDataPath, sampleKeyboard.uid, hash, '2026-04-14')
       expect(existsSync(dayPath)).toBe(true)
 
-      // Mirror write is dropped — flat `{hash}.jsonl` only exists
-      // for legacy v6 imports, never from a fresh v7 flush.
-      const legacyPath = join(deviceDayDir(mockUserDataPath, sampleKeyboard.uid, hash), '..', `${hash}.jsonl`)
-      expect(existsSync(legacyPath)).toBe(false)
+      // Guard against a stray flat `{hash}.jsonl` ever being written
+      // alongside the per-day directory — there is no code path for it
+      // anymore, but the assertion locks the invariant in place.
+      const flatPath = join(deviceDayDir(mockUserDataPath, sampleKeyboard.uid, hash), '..', `${hash}.jsonl`)
+      expect(existsSync(flatPath)).toBe(false)
 
       const rows = await readDayRows(sampleKeyboard.uid, hash, '2026-04-14')
       expect(rows.some((r) => r.kind === 'scope')).toBe(true)

--- a/src/main/typing-analytics/cache-rebuild.ts
+++ b/src/main/typing-analytics/cache-rebuild.ts
@@ -5,14 +5,9 @@
 // user rows, re-reads every master file, and re-applies every row via
 // the LWW merge path. See .claude/plans/typing-analytics.md.
 
-import { unlink } from 'node:fs/promises'
 import { applyRowsToCache } from './jsonl/apply-to-cache'
 import { readRows } from './jsonl/jsonl-reader'
-import {
-  listAllDeviceDayJsonlFiles,
-  listAllDeviceJsonlFiles,
-  readPointerKey,
-} from './jsonl/paths'
+import { listAllDeviceDayJsonlFiles } from './jsonl/paths'
 import { DATA_TABLE_NAMES } from './db/schema'
 import type { TypingAnalyticsDB } from './db/typing-analytics-db'
 import {
@@ -42,24 +37,16 @@ export function truncateCache(db: TypingAnalyticsDB): void {
   })()
 }
 
-/** Read every JSONL master file from disk, apply its rows to `db` in
- * order, and return the new `read_pointers` map plus the number of rows
- * touched in each table. Both the v6 flat layout
- * (`{uid}/devices/{hash}.jsonl`) and the v7 per-day layout
- * (`{uid}/devices/{hash}/{YYYY-MM-DD}.jsonl`) are read so rebuilds
- * survive the transition period. v6 files are applied first; v7 day
- * files are applied in ascending date order afterwards, so for a hash
- * that has both layouts the pointer lands on the latest per-day row.
- * The cache merge is LWW, so file order does not affect row content. */
+/** Read every per-day JSONL master file from disk, apply its rows to
+ * `db`, and return the number of rows touched per table. Per-day files
+ * (`{uid}/devices/{hash}/{YYYY-MM-DD}.jsonl`) are scanned in ascending
+ * date order; the cache merge is LWW so file order does not affect row
+ * content. */
 export async function rebuildCacheFromMasterFiles(
   db: TypingAnalyticsDB,
   userDataDir: string,
-): Promise<{
-  result: CacheRebuildResult
-  pointers: Record<string, string | null>
-}> {
+): Promise<CacheRebuildResult> {
   truncateCache(db)
-  const pointers: Record<string, string | null> = {}
   const result: CacheRebuildResult = {
     scopes: 0,
     charMinutes: 0,
@@ -69,13 +56,8 @@ export async function rebuildCacheFromMasterFiles(
     jsonlFilesRead: 0,
   }
 
-  const applyFile = async (ref: {
-    uid: string
-    machineHash: string
-    path: string
-  }): Promise<void> => {
-    const { rows, lastId } = await readRows(ref.path)
-    pointers[readPointerKey(ref.uid, ref.machineHash)] = lastId
+  const applyFile = async (ref: { path: string }): Promise<void> => {
+    const { rows } = await readRows(ref.path)
     if (rows.length === 0) return
     const applied = applyRowsToCache(db, rows)
     result.scopes += applied.scopes
@@ -86,40 +68,11 @@ export async function rebuildCacheFromMasterFiles(
     result.jsonlFilesRead += 1
   }
 
-  // Scan both layouts in parallel; they walk overlapping trees so the
-  // filesystem cache warms once. Apply serially afterwards because v7
-  // files must run after v6 for a hash that has both, and the cache
-  // merge itself is sequential inside better-sqlite3.
-  const [flatRefs, dayRefs] = await Promise.all([
-    listAllDeviceJsonlFiles(userDataDir),
-    listAllDeviceDayJsonlFiles(userDataDir),
-  ])
-  for (const ref of flatRefs) await applyFile(ref)
-  for (const ref of dayRefs) await applyFile(ref)
-
-  return { result, pointers }
-}
-
-/** Remove any v6 flat JSONL files discovered on disk. Safe to call
- * after rebuildCacheFromMasterFiles because the rows have already
- * been replayed into the cache from both the flat and per-day files.
- * Silently skips files that were already removed between the listing
- * and the unlink (expected on repeated runs). */
-export async function cleanupLegacyFlatMasterFiles(userDataDir: string): Promise<number> {
-  const refs = await listAllDeviceJsonlFiles(userDataDir)
-  let removed = 0
-  for (const ref of refs) {
-    try {
-      await unlink(ref.path)
-      removed += 1
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-        // Leave unexpected errors for the caller's log/tests to surface.
-        throw err
-      }
-    }
+  for (const ref of await listAllDeviceDayJsonlFiles(userDataDir)) {
+    await applyFile(ref)
   }
-  return removed
+
+  return result
 }
 
 export interface EnsureCacheOptions {
@@ -136,8 +89,8 @@ export interface EnsureCacheOptions {
  *    (user migrated / regenerated `installation-id`).
  *  - `options.force` is true.
  *
- * Returns the fresh sync-state (with updated pointers + timestamp) and
- * a flag indicating whether a rebuild actually ran. */
+ * Returns the fresh sync-state and a flag indicating whether a rebuild
+ * actually ran. */
 export async function ensureCacheIsFresh(
   db: TypingAnalyticsDB,
   userDataDir: string,
@@ -154,19 +107,9 @@ export async function ensureCacheIsFresh(
     return { rebuilt: false, state: existing }
   }
 
-  const { pointers } = await rebuildCacheFromMasterFiles(db, userDataDir)
-  // One-shot v7 migration: per-day files are the canonical master now,
-  // so delete any v6 flat `{hash}.jsonl` files after their rows have
-  // been replayed. Failures are tolerated — the flat files are still
-  // harmless, they just become a leftover the next rebuild will re-read.
-  try {
-    await cleanupLegacyFlatMasterFiles(userDataDir)
-  } catch {
-    /* non-fatal; rerun on next rebuild */
-  }
+  await rebuildCacheFromMasterFiles(db, userDataDir)
   const state: TypingSyncState = {
     ...emptySyncState(myDeviceId),
-    read_pointers: pointers,
     last_synced_at: Date.now(),
   }
   await saveSyncState(userDataDir, state)

--- a/src/main/typing-analytics/db/schema.ts
+++ b/src/main/typing-analytics/db/schema.ts
@@ -49,10 +49,10 @@ CREATE TABLE IF NOT EXISTS typing_char_minute (
   minute_ts INTEGER NOT NULL,
   char TEXT NOT NULL,
   count INTEGER NOT NULL,
-  -- Active application captured at flush time. NULL for v7 rows
-  -- predating Monitor App, for minutes that observed multiple apps,
-  -- and when the lookup failed. App-filtered analytics queries
-  -- compare against this column directly.
+  -- Active application captured at flush time. NULL for rows that
+  -- predate Monitor App, for minutes that observed multiple apps, and
+  -- when the lookup failed. App-filtered analytics queries compare
+  -- against this column directly.
   app_name TEXT,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -492,7 +492,7 @@ export class TypingAnalyticsDB {
       WHERE excluded.updated_at > typing_scopes.updated_at
     `)
 
-    // Merge variants pass-through app_name from the LWW winner. v7
+    // Merge variants pass-through app_name from the LWW winner. Older
     // remote payloads predate app_name and arrive without it; the
     // import layer normalizes missing fields to null so the bind
     // parameter is always defined.

--- a/src/main/typing-analytics/jsonl/__tests__/paths.test.ts
+++ b/src/main/typing-analytics/jsonl/__tests__/paths.test.ts
@@ -7,11 +7,9 @@ import { join } from 'node:path'
 import {
   deviceDayDir,
   deviceDayJsonlPath,
-  deviceJsonlPath,
   devicesDir,
   keyboardsRoot,
   listAllDeviceDayJsonlFiles,
-  listAllDeviceJsonlFiles,
   listDeviceDays,
   parseReadPointerKey,
   readPointerKey,
@@ -22,12 +20,6 @@ describe('path helpers', () => {
     expect(keyboardsRoot('/u')).toBe(join('/u', 'sync', 'keyboards'))
     expect(devicesDir('/u', '0xAABB')).toBe(
       join('/u', 'sync', 'keyboards', '0xAABB', 'devices'),
-    )
-  })
-
-  it('composes the per-device jsonl path from uid + machineHash', () => {
-    expect(deviceJsonlPath('/u', '0xAABB', 'hash-a')).toBe(
-      join('/u', 'sync', 'keyboards', '0xAABB', 'devices', 'hash-a.jsonl'),
     )
   })
 })
@@ -42,43 +34,6 @@ describe('readPointerKey / parseReadPointerKey', () => {
     expect(parseReadPointerKey('nopipe')).toBeNull()
     expect(parseReadPointerKey('|missing-uid')).toBeNull()
     expect(parseReadPointerKey('missing-hash|')).toBeNull()
-  })
-})
-
-describe('listAllDeviceJsonlFiles', () => {
-  let tmpDir: string
-
-  beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), 'pipette-jsonl-paths-'))
-  })
-
-  afterEach(() => {
-    rmSync(tmpDir, { recursive: true, force: true })
-  })
-
-  it('returns an empty list when the sync tree does not exist', async () => {
-    expect(await listAllDeviceJsonlFiles(tmpDir)).toEqual([])
-  })
-
-  it('returns every {uid}/devices/*.jsonl and ignores non-jsonl entries', async () => {
-    const a = devicesDir(tmpDir, '0xAABB')
-    const b = devicesDir(tmpDir, '0xCCDD')
-    mkdirSync(a, { recursive: true })
-    mkdirSync(b, { recursive: true })
-    writeFileSync(join(a, 'hash-a.jsonl'), '')
-    writeFileSync(join(a, 'hash-b.jsonl'), '')
-    writeFileSync(join(a, 'README.txt'), '')
-    writeFileSync(join(b, 'hash-a.jsonl'), '')
-
-    const refs = await listAllDeviceJsonlFiles(tmpDir)
-    const keys = refs.map((r) => `${r.uid}|${r.machineHash}`).sort()
-    expect(keys).toEqual(['0xAABB|hash-a', '0xAABB|hash-b', '0xCCDD|hash-a'])
-  })
-
-  it('skips uids that have no devices directory', async () => {
-    mkdirSync(join(tmpDir, 'sync', 'keyboards', '0xAABB'), { recursive: true })
-    writeFileSync(join(tmpDir, 'sync', 'keyboards', '0xAABB', 'settings.json'), '{}')
-    expect(await listAllDeviceJsonlFiles(tmpDir)).toEqual([])
   })
 })
 
@@ -151,7 +106,7 @@ describe('listAllDeviceDayJsonlFiles', () => {
     expect(await listAllDeviceDayJsonlFiles(tmpDir)).toEqual([])
   })
 
-  it('scans {uid}/devices/{hash}/{date}.jsonl and ignores v6 flat files', async () => {
+  it('scans {uid}/devices/{hash}/{date}.jsonl and ignores stray non-directory entries', async () => {
     const hashA = deviceDayDir(tmpDir, '0xAABB', 'hash-a')
     const hashB = deviceDayDir(tmpDir, '0xAABB', 'hash-b')
     const hashC = deviceDayDir(tmpDir, '0xCCDD', 'hash-a')
@@ -162,8 +117,9 @@ describe('listAllDeviceDayJsonlFiles', () => {
     writeFileSync(join(hashA, '2026-04-18.jsonl'), '')
     writeFileSync(join(hashB, '2026-04-19.jsonl'), '')
     writeFileSync(join(hashC, '2026-04-19.jsonl'), '')
-    // v6 flat form living alongside — must be ignored by the per-day scan.
-    writeFileSync(join(devicesDir(tmpDir, '0xAABB'), 'legacy.jsonl'), '')
+    // Stray .jsonl directly under devices/ — the scan only descends into
+    // hash directories, so plain files at this level are skipped.
+    writeFileSync(join(devicesDir(tmpDir, '0xAABB'), 'stray.jsonl'), '')
     // Junk files within a hash dir.
     writeFileSync(join(hashA, 'notes.txt'), '')
     writeFileSync(join(hashA, 'garbage.jsonl'), '')

--- a/src/main/typing-analytics/jsonl/jsonl-reader.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-reader.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Streaming reader for the per-device typing-analytics JSONL files. Takes
-// an optional `afterId` pointer and yields rows that appear strictly
-// after that id, so a call site tracking `read_pointers[deviceId]` only
-// pays for the tail it has not yet imported. A trailing line without a
-// newline terminator is treated as partial (crash-truncated) and
-// skipped — the caller keeps the previous pointer and retries next pass.
+// Streaming reader for the per-device typing-analytics JSONL files.
+// Reads every row in the file by default; an optional `afterId` pointer
+// lets a caller resume from a known row id without re-reading the head.
+// A trailing line without a newline terminator is treated as partial
+// (crash-truncated) and skipped — the caller keeps the previous pointer
+// and retries next pass.
 
 import { createReadStream } from 'node:fs'
 import { open } from 'node:fs/promises'

--- a/src/main/typing-analytics/jsonl/jsonl-row.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-row.ts
@@ -11,8 +11,8 @@ export const JSONL_SCHEMA_VERSION = 1
  * the lookup failed, or the minute observed a mix of apps (the
  * aggregator collapses size>1 sets to null so app-filtered analytics
  * always look at single-app minutes only). Optional on the wire for
- * backward compatibility with v7 master files written before this
- * field existed. */
+ * backward compatibility with master files written before this field
+ * existed. */
 export type AppNameField = string | null
 
 export type JsonlRowKind =
@@ -246,9 +246,10 @@ function isNumericOrNull(p: Record<string, unknown>, key: string): boolean {
   return value === null || (typeof value === 'number' && Number.isFinite(value))
 }
 
-/** appName is optional on the wire (v7 master files predate it). When
- * present it must be string | null; missing is treated the same as
- * null on read. Anything else (number, object, etc.) rejects the row. */
+/** appName is optional on the wire (master files written before the
+ * field was added omit it). When present it must be string | null;
+ * missing is treated the same as null on read. Anything else (number,
+ * object, etc.) rejects the row. */
 function isOptionalAppName(p: Record<string, unknown>): boolean {
   if (!('appName' in p)) return true
   const v = p.appName

--- a/src/main/typing-analytics/jsonl/paths.ts
+++ b/src/main/typing-analytics/jsonl/paths.ts
@@ -24,25 +24,9 @@ export function devicesDir(userDataDir: string, uid: string): string {
   return join(keyboardsRoot(userDataDir), uid, 'devices')
 }
 
-/** Returns the path to the per-device JSONL master file for a single
- * (keyboard uid, machineHash) pair. Each device writes only to its own
- * file — the 1-writer invariant follows from this convention. */
-export function deviceJsonlPath(
-  userDataDir: string,
-  uid: string,
-  machineHash: string,
-): string {
-  return join(devicesDir(userDataDir, uid), `${machineHash}.jsonl`)
-}
-
-export interface DeviceJsonlRef {
-  uid: string
-  machineHash: string
-  path: string
-}
-
-/** Stable identifier for a single JSONL file, used as the read_pointers
- * key in sync-state. Pairs with {@link parseReadPointerKey}. */
+/** Stable identifier for a single (uid, machineHash) pair, used as the
+ * key for `state.uploaded` and `state.reconciled_at` entries in
+ * sync-state. Pairs with {@link parseReadPointerKey}. */
 export function readPointerKey(uid: string, machineHash: string): string {
   return `${uid}|${machineHash}`
 }
@@ -61,38 +45,13 @@ async function safeReaddir(path: string): Promise<Dirent[]> {
   }
 }
 
-/** Discover every `{userDataDir}/sync/keyboards/{uid}/devices/*.jsonl`
- * file that exists on disk. Used by the cache rebuild path to enumerate
- * every source of truth without relying on sync-state (which can lag
- * behind the filesystem after a fresh Google Drive sync). Unreadable
- * directories are silently treated as empty. Uses `withFileTypes` so
- * each level avoids an extra `stat` per entry. */
-export async function listAllDeviceJsonlFiles(
-  userDataDir: string,
-): Promise<DeviceJsonlRef[]> {
-  const refs: DeviceJsonlRef[] = []
-  for (const uidEntry of await safeReaddir(keyboardsRoot(userDataDir))) {
-    if (!uidEntry.isDirectory()) continue
-    const uid = uidEntry.name
-    for (const devEntry of await safeReaddir(devicesDir(userDataDir, uid))) {
-      if (!devEntry.isFile()) continue
-      if (!devEntry.name.endsWith(JSONL_EXT)) continue
-      const machineHash = devEntry.name.slice(0, -JSONL_EXT.length)
-      if (machineHash.length === 0) continue
-      refs.push({ uid, machineHash, path: join(devicesDir(userDataDir, uid), devEntry.name) })
-    }
-  }
-  return refs
-}
-
-// --- v7 per-day layout ------------------------------------------------
+// --- per-day layout ---------------------------------------------------
 // Each device owns one directory per keyboard uid, and within it one
 // JSONL file per UTC calendar day:
 //
 //   {userDataDir}/sync/keyboards/{uid}/devices/{machineHash}/{YYYY-MM-DD}.jsonl
 //
-// The helpers below compose and enumerate that tree. They coexist with
-// the v6 flat helpers above until the flush/rebuild paths switch over.
+// The helpers below compose and enumerate that tree.
 
 /** Directory that holds one JSONL file per day for a single
  * (keyboard uid, machineHash). */
@@ -148,8 +107,7 @@ export async function listDeviceDays(
 
 /** Discover every
  * `{userDataDir}/sync/keyboards/{uid}/devices/{hash}/{YYYY-MM-DD}.jsonl`
- * file on disk. v6 flat files (`{hash}.jsonl` directly under
- * `devices/`) are ignored. Each returned ref is sorted by
+ * file on disk. Each returned ref is sorted by
  * `(uid, machineHash, utcDay)` ascending, which lets the cache-rebuild
  * path replay days chronologically per device. */
 export async function listAllDeviceDayJsonlFiles(

--- a/src/main/typing-analytics/sync-state.ts
+++ b/src/main/typing-analytics/sync-state.ts
@@ -1,27 +1,25 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Persistent pointer-bookkeeping for the typing-analytics JSONL master
-// files. Tracks, per JSONL file, the last row id that has already been
-// applied to the local SQLite cache so subsequent passes only read the
-// tail. See .claude/plans/typing-analytics.md.
+// Persistent bookkeeping for the typing-analytics sync pipeline.
+// Tracks per-keyboard own-hash upload state so the sync pass can tell
+// "never uploaded" apart from "uploaded then remotely deleted", plus a
+// reconcile-pending timestamp per own hash. See
+// .claude/plans/typing-analytics.md.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { readPointerKey } from './jsonl/paths'
 import { isUtcDay, type UtcDay } from './jsonl/utc-day'
 
-/** Current schema version. v1: read_pointers only. v2: adds `uploaded`
- * (per own-hash list of UTC days successfully uploaded to cloud) and
- * `reconciled_at` (timestamp of the last own-hash cloud orphan
- * reconcile, or `null` to force one on the next sync pass). */
-export const SYNC_STATE_REV = 2
+/** Current schema version.
+ *  - v1 / v2: tracked `read_pointers` for the now-removed flat-file
+ *    merge path; v2 added `uploaded` and `reconciled_at`.
+ *  - v3 drops `read_pointers` since per-day bundles are replayed in
+ *    full and the merge layer never consulted the pointer. */
+export const SYNC_STATE_REV = 3
 
 export interface TypingSyncState {
   _rev: typeof SYNC_STATE_REV
   my_device_id: string
-  /** key = `{uid}|{machineHash}`, value = composite id of the last row
-   * applied to the local cache from that file. `null` means "nothing
-   * applied yet" so the next pass reads from the top. */
-  read_pointers: Record<string, string | null>
   /** key = `{uid}|{ownHash}`, value = UTC days this device has uploaded
    * to cloud. Used to distinguish "new day, needs upload" from "day was
    * Sync-deleted remotely, clean local". Only populated for own hashes
@@ -30,9 +28,9 @@ export interface TypingSyncState {
   /** key = `{uid}|{ownHash}`, value = epoch-ms of the last successful
    * own-hash reconcile pass, or `null` when a reconcile is pending
    * (e.g. after a cache rebuild). A missing entry is treated the same
-   * as `null` by the sync pass (pending), so a v1→v2 migration that
-   * leaves this map empty still forces an initial reconcile for every
-   * own hash before the 3 upload rules run. */
+   * as `null` by the sync pass (pending), so an older state that
+   * migrates with an empty map still forces an initial reconcile for
+   * every own hash before the upload rules run. */
   reconciled_at: Record<string, number | null>
   last_synced_at: number
 }
@@ -45,19 +43,10 @@ export function emptySyncState(myDeviceId: string): TypingSyncState {
   return {
     _rev: SYNC_STATE_REV,
     my_device_id: myDeviceId,
-    read_pointers: {},
     uploaded: {},
     reconciled_at: {},
     last_synced_at: 0,
   }
-}
-
-function isPointersRecord(value: unknown): value is Record<string, string | null> {
-  if (typeof value !== 'object' || value === null) return false
-  for (const val of Object.values(value)) {
-    if (val !== null && typeof val !== 'string') return false
-  }
-  return true
 }
 
 function isUploadedRecord(value: unknown): value is Record<string, UtcDay[]> {
@@ -84,7 +73,6 @@ function parseSyncState(raw: unknown): TypingSyncState | null {
   if (typeof raw !== 'object' || raw === null) return null
   const obj = raw as Record<string, unknown>
   if (typeof obj.my_device_id !== 'string') return null
-  if (!isPointersRecord(obj.read_pointers)) return null
   if (typeof obj.last_synced_at !== 'number' || !Number.isFinite(obj.last_synced_at)) return null
 
   if (obj._rev === SYNC_STATE_REV) {
@@ -93,21 +81,32 @@ function parseSyncState(raw: unknown): TypingSyncState | null {
     return {
       _rev: SYNC_STATE_REV,
       my_device_id: obj.my_device_id,
-      read_pointers: obj.read_pointers,
       uploaded: obj.uploaded,
       reconciled_at: obj.reconciled_at,
       last_synced_at: obj.last_synced_at,
     }
   }
-  // v1 → v2: preserve read_pointers and my_device_id, initialise the
-  // new fields empty. Because missing entries in `reconciled_at` are
-  // treated as pending (see field comment), v1 users automatically go
-  // through the initial orphan-reconcile on their first v7 sync pass.
+  // v2 → v3: drop the removed `read_pointers` and keep the upload /
+  // reconcile bookkeeping. Older states forced an initial reconcile via
+  // the empty `reconciled_at` map; that property is preserved here.
+  if (obj._rev === 2) {
+    if (!isUploadedRecord(obj.uploaded)) return null
+    if (!isReconciledAtRecord(obj.reconciled_at)) return null
+    return {
+      _rev: SYNC_STATE_REV,
+      my_device_id: obj.my_device_id,
+      uploaded: obj.uploaded,
+      reconciled_at: obj.reconciled_at,
+      last_synced_at: obj.last_synced_at,
+    }
+  }
+  // v1 → v3: drop `read_pointers` and start with empty upload /
+  // reconcile maps so the first sync pass treats every own hash as
+  // pending reconcile.
   if (obj._rev === 1) {
     return {
       _rev: SYNC_STATE_REV,
       my_device_id: obj.my_device_id,
-      read_pointers: obj.read_pointers,
       uploaded: {},
       reconciled_at: {},
       last_synced_at: obj.last_synced_at,

--- a/src/main/typing-analytics/sync.ts
+++ b/src/main/typing-analytics/sync.ts
@@ -1,45 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sync-unit identifiers for the typing-analytics JSONL masters.
 //
-// v6 shape:  keyboards/{uid}/devices/{machineHash}
-//   (one unit per (uid, hash), bundles the flat `{hash}.jsonl`)
-//
-// v7 shape:  keyboards/{uid}/devices/{machineHash}/days/{YYYY-MM-DD}
+// Shape: keyboards/{uid}/devices/{machineHash}/days/{YYYY-MM-DD}
 //   (one unit per (uid, hash, day), bundles a single per-day file)
 //
-// Both forms are recognised during the transition so the mirror write
-// keeps shipping v6 bundles while v7 per-day bundles flow alongside.
 // See .claude/plans/typing-analytics.md.
 
 import type { UtcDay } from './jsonl/utc-day'
 import { isUtcDay } from './jsonl/utc-day'
 
-/** v6 sync-unit path for the flat JSONL master belonging to one
- * `(uid, machineHash)` pair. Owning device uploads; other devices
- * download + apply read-only. Retained while the v6 mirror write and
- * flat sync-service merge paths are still in place. */
-export function typingAnalyticsDeviceSyncUnit(
-  uid: string,
-  machineHash: string,
-): `keyboards/${string}/devices/${string}` {
-  return `keyboards/${uid}/devices/${machineHash}`
-}
-
-/** Returns `{uid, machineHash}` when `syncUnit` matches the v6 device
- * form, otherwise null. v7 per-day units are intentionally *not* matched
- * here — callers route those through
- * {@link parseTypingAnalyticsDeviceDaySyncUnit}. */
-export function parseTypingAnalyticsDeviceSyncUnit(
-  syncUnit: string,
-): { uid: string; machineHash: string } | null {
-  const parts = syncUnit.split('/')
-  if (parts.length !== 4) return null
-  if (parts[0] !== 'keyboards' || parts[2] !== 'devices') return null
-  if (parts[1].length === 0 || parts[3].length === 0) return null
-  return { uid: parts[1], machineHash: parts[3] }
-}
-
-/** v7 sync-unit path for a per-day JSONL master belonging to one
+/** Sync-unit path for a per-day JSONL master belonging to one
  * `(uid, machineHash, UTC day)` triple. */
 export function typingAnalyticsDeviceDaySyncUnit(
   uid: string,
@@ -49,7 +19,7 @@ export function typingAnalyticsDeviceDaySyncUnit(
   return `keyboards/${uid}/devices/${machineHash}/days/${utcDay}`
 }
 
-/** Returns `{uid, machineHash, utcDay}` when `syncUnit` matches the v7
+/** Returns `{uid, machineHash, utcDay}` when `syncUnit` matches the
  * per-day form, otherwise null. The day segment is validated against
  * `isUtcDay` so malformed inputs don't produce phantom bundles. */
 export function parseTypingAnalyticsDeviceDaySyncUnit(

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -58,10 +58,7 @@ import {
   type TypingTombstoneResult,
   type PeakRecords,
 } from './db/typing-analytics-db'
-import {
-  typingAnalyticsDeviceDaySyncUnit,
-  typingAnalyticsDeviceSyncUnit,
-} from './sync'
+import { typingAnalyticsDeviceDaySyncUnit } from './sync'
 import { getMachineHash } from './machine-hash'
 import { applyRowsToCache } from './jsonl/apply-to-cache'
 import {
@@ -84,7 +81,6 @@ import { computeLayoutComparison } from './compute-layout-comparison'
 import {
   deviceDayJsonlPath,
   listDeviceDays,
-  readPointerKey,
 } from './jsonl/paths'
 import { utcDayFromMs, type UtcDay } from './jsonl/utc-day'
 import {
@@ -234,7 +230,7 @@ export function setupTypingAnalyticsIpc(): void {
     },
   )
 
-  // v7 Local / Sync split handlers. The Local tab filters to own hash,
+  // Local / Sync split handlers. The Local tab filters to own hash,
   // the Sync tab iterates remote hashes. Cloud-facing handlers are
   // wired into sync-service so they share the same credential check.
   secureHandle(
@@ -1136,41 +1132,19 @@ function localDayRangeMs(date: string): { startMs: number; endMs: number } | nul
   return { startMs, endMs }
 }
 
-/** Append rows to a JSONL master file, apply them to the cache, and
- * advance the sync-state pointer for (uid, machineHash) to the last row
- * id in this batch. Does NOT save the sync state — callers batch the
- * write so multi-uid flushes hit disk once. */
-async function persistOwnJsonlAt(
-  path: string,
-  uid: string,
-  rows: readonly JsonlRow[],
-  machineHash: string,
-  state: TypingSyncState,
-): Promise<void> {
-  await appendRowsToFile(path, rows)
-  applyRowsToCache(getTypingAnalyticsDB(), rows)
-  const lastId = rows[rows.length - 1]?.id
-  if (lastId) state.read_pointers[readPointerKey(uid, machineHash)] = lastId
-}
-
-/** v7 per-day layout. Multiple days within a single flush must be
- * persisted in ascending chronological order so the pointer lands on
- * the most recent row. */
-function persistOwnJsonlDay(
+/** Append rows to a per-day JSONL master file and replay them into the
+ * local cache. The caller batches `saveSyncState` afterwards so a
+ * multi-uid flush hits disk once. */
+async function persistOwnJsonlDay(
   uid: string,
   utcDay: UtcDay,
   rows: readonly JsonlRow[],
   machineHash: string,
   userDataDir: string,
-  state: TypingSyncState,
 ): Promise<void> {
-  return persistOwnJsonlAt(
-    deviceDayJsonlPath(userDataDir, uid, machineHash, utcDay),
-    uid,
-    rows,
-    machineHash,
-    state,
-  )
+  const path = deviceDayJsonlPath(userDataDir, uid, machineHash, utcDay)
+  await appendRowsToFile(path, rows)
+  applyRowsToCache(getTypingAnalyticsDB(), rows)
 }
 
 /** Delete the local per-day JSONL files covering the requested
@@ -1220,7 +1194,7 @@ export async function deleteTypingDailySummaries(
     result.minuteStats += r.minuteStats
     result.sessions += r.sessions
   }
-  await notifySyncIfTouched(uid, result)
+  await notifySyncIfTouched(uid, result, [...utcDays])
   return result
 }
 
@@ -1232,7 +1206,12 @@ export async function deleteAllTypingForKeyboard(uid: string): Promise<TypingTom
   await flushNow({ final: true })
   const machineHash = await getMachineHash()
   const userDataDir = app.getPath('userData')
-  for (const day of await listDeviceDays(userDataDir, uid, machineHash)) {
+  // Snapshot the days *before* unlinking so the post-tombstone notify
+  // can still iterate over them — once the unlink loop has removed every
+  // per-day file, a fresh listDeviceDays would only see the now-empty
+  // directory and return [].
+  const days = await listDeviceDays(userDataDir, uid, machineHash)
+  for (const day of days) {
     try {
       await unlinkOwnDayFile(userDataDir, uid, machineHash, day)
     } catch (err) {
@@ -1242,7 +1221,7 @@ export async function deleteAllTypingForKeyboard(uid: string): Promise<TypingTom
   const db = getTypingAnalyticsDB()
   const updatedAt = Date.now()
   const result = db.tombstoneAllRowsForUid(uid, updatedAt)
-  await notifySyncIfTouched(uid, result)
+  await notifySyncIfTouched(uid, result, days)
   return result
 }
 
@@ -1259,14 +1238,24 @@ async function unlinkOwnDayFile(
   }
 }
 
-async function notifySyncIfTouched(uid: string, result: TypingTombstoneResult): Promise<void> {
+/** Emit one per-day sync-unit per affected day so the upload pipeline
+ * picks up the new rows for each `(uid, machineHash, day)` independently.
+ * Caller is responsible for materialising the affected `days` *before*
+ * any unlink so a delete-and-notify flow doesn't lose the day list. */
+async function notifySyncIfTouched(
+  uid: string,
+  result: TypingTombstoneResult,
+  days: readonly UtcDay[],
+): Promise<void> {
   const touched = result.charMinutes + result.matrixMinutes + result.minuteStats + result.sessions
-  if (touched === 0) return
+  if (touched === 0 || days.length === 0) return
   const notifier = syncNotifier
   if (!notifier) return
   try {
     const machineHash = await getMachineHash()
-    notifier(typingAnalyticsDeviceSyncUnit(uid, machineHash))
+    for (const day of days) {
+      notifier(typingAnalyticsDeviceDaySyncUnit(uid, machineHash, day))
+    }
   } catch (err) {
     log('warn', `typing-analytics sync notify failed for ${uid}: ${String(err)}`)
   }
@@ -1416,7 +1405,7 @@ function extractKleKeysFromSnapshot(snapshot: TypingKeymapSnapshot): KleKey[] {
 function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRow[] {
   // appName carries through to every per-minute row so the JSONL master
   // file is the source of truth for app filtering after a cache rebuild.
-  // Older v7 master files predate this field; the readers fall back to
+  // Older master files predate this field; the readers fall back to
   // null on missing.
   const appName = snapshot.appName
   const rows: JsonlRow[] = [
@@ -1665,7 +1654,7 @@ async function doFlushPass(options: { final: boolean }): Promise<void> {
       for (const day of orderedDays) {
         const rows = byDay.get(day)
         if (!rows || rows.length === 0) continue
-        await persistOwnJsonlDay(uid, day, rows, machineHash, userDataDir, state)
+        await persistOwnJsonlDay(uid, day, rows, machineHash, userDataDir)
         writtenDays.push(day)
       }
       if (writtenDays.length === 0) continue

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -103,7 +103,7 @@ export const IpcChannels = {
   TYPING_ANALYTICS_DELETE_ITEMS: 'typing-analytics:delete-items',
   TYPING_ANALYTICS_DELETE_ALL: 'typing-analytics:delete-all',
   TYPING_ANALYTICS_GET_MATRIX_HEATMAP: 'typing-analytics:get-matrix-heatmap',
-  // v7 Local/Sync split — hash-scoped list and delete
+  // Local/Sync split — hash-scoped list and delete
   TYPING_ANALYTICS_LIST_ITEMS_LOCAL: 'typing-analytics:list-items-local',
   TYPING_ANALYTICS_LIST_INTERVAL_ITEMS_LOCAL: 'typing-analytics:list-interval-items-local',
   TYPING_ANALYTICS_LIST_ACTIVITY_GRID_LOCAL: 'typing-analytics:list-activity-grid-local',


### PR DESCRIPTION
## Summary

- Remove the v6 flat typing-analytics format end to end: sync-unit factories, drive filename regex, bundle/merge branches, JSONL flat-path helpers, and the rebuild-time legacy cleanup all retire together.
- Retire `read_pointers` from sync-state — no reader survived the per-day merge cutover. Schema bumps to v3 with v1→v3 and v2→v3 migrations that strip the field while preserving `uploaded` and `reconciled_at`.
- `notifySyncIfTouched` now emits one per-day sync-unit per affected day; the two callers materialise the day list before any unlink so the post-tombstone notify still iterates the right set.

## Why

The per-day v7 format has been the only typing-analytics output since cutover, and `cleanupLegacyFlatMasterFiles` has been silently removing leftover flat masters during every cache rebuild. The compatibility scaffolding around the v6 format and the `read_pointers` field were keeping a no-longer-readable bookkeeping path alive. Dropping it removes ~330 net lines, simplifies the merge layer (full per-day replay only), tightens `syncUnitFromFileName` so legacy orphans no longer round-trip into a sync unit, and lets `rebuildCacheFromMasterFiles` shrink to a single per-day scan.

## Test plan

- [x] `pnpm test` — 3750 pass / 22 skipped
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint src/main src/preload src/shared` — clean
- [x] sync-state migration: v1→v3 and v2→v3 covered by new unit tests; the v2 migration verifies `read_pointers` is dropped while `uploaded` / `reconciled_at` carry through.
- [x] notifier assertion in `deleteAllTypingForKeyboard` upgraded from regex to exact day-set match (seeded 2 days, expected 2 unique unit emits after `mockClear`).
- [ ] Manual on-device check after merge: open Analyze on a fresh keyboard and confirm sync continues to push / pull per-day units; existing flat orphans on Drive simply stop round-tripping (intentional).