### PR TITLE
fix(ui): swap picker zoom button order to match horizontal convention

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -833,24 +833,24 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           </button>
         </div>
         <div className={`flex items-center gap-1 ${pickerBrowseMode ? 'invisible' : ''}`}>
-          <Tooltip content={t('editor.keymap.zoomIn')}>
-            <button type="button" aria-label={t('editor.keymap.zoomIn')}
-              className="rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none"
-              disabled={pickerEffectiveScale >= MAX_SCALE}
-              onClick={() => { if (pickerFileData) setPickerScale(Math.min(MAX_SCALE, +(pickerEffectiveScale + 0.1).toFixed(1))); else onScaleChange?.(0.1) }}>
-              <ZoomIn size={14} aria-hidden="true" />
-            </button>
-          </Tooltip>
-          <ScaleInput scale={pickerEffectiveScale} onScaleChange={(delta) => {
-            if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, +(pickerEffectiveScale + delta).toFixed(1))))
-            else onScaleChange?.(delta)
-          }} />
           <Tooltip content={t('editor.keymap.zoomOut')}>
             <button type="button" aria-label={t('editor.keymap.zoomOut')}
               className="rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none"
               disabled={pickerEffectiveScale <= MIN_SCALE}
               onClick={() => { if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, +(pickerEffectiveScale - 0.1).toFixed(1))); else onScaleChange?.(-0.1) }}>
               <ZoomOut size={14} aria-hidden="true" />
+            </button>
+          </Tooltip>
+          <ScaleInput scale={pickerEffectiveScale} onScaleChange={(delta) => {
+            if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, +(pickerEffectiveScale + delta).toFixed(1))))
+            else onScaleChange?.(delta)
+          }} />
+          <Tooltip content={t('editor.keymap.zoomIn')}>
+            <button type="button" aria-label={t('editor.keymap.zoomIn')}
+              className="rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none"
+              disabled={pickerEffectiveScale >= MAX_SCALE}
+              onClick={() => { if (pickerFileData) setPickerScale(Math.min(MAX_SCALE, +(pickerEffectiveScale + 0.1).toFixed(1))); else onScaleChange?.(0.1) }}>
+              <ZoomIn size={14} aria-hidden="true" />
             </button>
           </Tooltip>
         </div>


### PR DESCRIPTION
## Summary
- Reorder picker toolbar zoom controls from `[+] [scale] [-]` to `[-] [scale] [+]` to align with the standard horizontal slider/volume convention.
- Vertical sidebar zoom controls remain unchanged (`[+]` on top), following the Google Maps / Apple Maps vertical convention.

## Test plan
- [x] ESLint passes
- [x] TypeScript type check passes
- [x] `KeymapEditor-zoom.test.tsx` passes (8/8)
- [ ] Manually verify picker toolbar shows `[-] [scale] [+]` when browsing a keymap (e.g., Trident42) under the Keyboard tab
- [ ] Manually verify zoom in / zoom out still operate correctly with new positions
- [ ] Manually verify vertical sidebar zoom controls are untouched

Closes #141