### PR TITLE
fix(ui): apply default window size on first typing view entry

### DIFF
--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -233,6 +233,25 @@ export function TypingTestPane({
     return { width: w, height: h }
   }, [keys, layoutOptions])
 
+  // App.tsx entry paths (analytics back, post-unlock, view restore, status bar)
+  // call setWindowCompactMode with an undefined saved size, which main skips —
+  // leaving the window at normal size. Apply the default here so every entry
+  // path lands on a sensibly sized window.
+  const appliedDefaultSizeRef = useRef(false)
+  useEffect(() => {
+    if (!viewOnly) {
+      appliedDefaultSizeRef.current = false
+      return
+    }
+    if (viewOnlyWindowSize) return
+    if (appliedDefaultSizeRef.current) return
+    if (keys.length === 0) return
+    appliedDefaultSizeRef.current = true
+    const size = getDefaultCompactSize()
+    window.vialAPI.setWindowCompactMode(true, size).catch(() => {})
+    onViewOnlyWindowSizeChangeRef.current?.(size)
+  }, [viewOnly, viewOnlyWindowSize, getDefaultCompactSize, keys.length])
+
   // Auto-fit using CSS transform + aspect ratio lock
   useEffect(() => {
     if (!viewOnly) return


### PR DESCRIPTION
## Summary

- App.tsx entry paths (analytics back, post-unlock, view restore, status bar) called `setWindowCompactMode` with an undefined saved size, which `src/main/index.ts:184` skipped — leaving the window at normal size on first entry to typing view.
- `TypingTestPane.tsx` now applies the calculated default size once when no saved size exists, so every entry path lands on a sensibly sized window. The first-time-only ref guard prevents double IPC, and the `viewOnlyWindowSize` check skips override when a size is already saved.

## Test plan

- [ ] Fresh keyboard with no saved typing-view window size: enter typing view from status bar → window compacts to default size
- [ ] Enter typing view → exit → re-enter: saved size honored (not overridden)
- [ ] Enter typing view via analytics back / view-restore / post-unlock paths: all default to compact size on first entry
- [ ] `pnpm test` passes