### PR TITLE
feat(hub): add Analytics Upload from saved Analyze conditions

### DIFF
--- a/src/main/__tests__/analyze-filter-store-hub-post-id.test.ts
+++ b/src/main/__tests__/analyze-filter-store-hub-post-id.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Smoke tests for the analyze-filter-store hubPostId handler. Mirrors
+// favorite-store-hub-post-id.test.ts so the two stores stay in sync on
+// the Hub upload contract.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+// --- Mock electron ---
+
+let mockUserDataPath = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+  ipcMain: {
+    handle: vi.fn(),
+  },
+}))
+
+vi.mock('../sync/sync-service', () => ({
+  notifyChange: vi.fn(),
+}))
+
+vi.mock('../ipc-guard', async () => {
+  const { ipcMain } = await import('electron')
+  return { secureHandle: ipcMain.handle }
+})
+
+// --- Import after mocking ---
+
+import { ipcMain } from 'electron'
+import { notifyChange } from '../sync/sync-service'
+import { setupAnalyzeFilterStore, setAnalyzeFilterHubPostId, readAnalyzeFilterEntry } from '../analyze-filter-store'
+import { IpcChannels } from '../../shared/ipc/channels'
+
+type IpcHandler = (...args: unknown[]) => Promise<unknown>
+
+function getHandler(channel: string): IpcHandler {
+  const calls = vi.mocked(ipcMain.handle).mock.calls
+  const match = calls.find(([ch]) => ch === channel)
+  if (!match) throw new Error(`No handler registered for ${channel}`)
+  return match[1] as IpcHandler
+}
+
+const fakeEvent = { sender: {} } as Electron.IpcMainInvokeEvent
+const UID = 'kb-uid-1'
+
+async function saveEntry(label = 'My filter'): Promise<{ id: string }> {
+  const saveHandler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SAVE)
+  const saved = await saveHandler(fakeEvent, UID, '{"version":1}', label) as {
+    entry: { id: string }
+  }
+  return saved.entry
+}
+
+async function readIndex(): Promise<{ entries: Array<{ id: string; hubPostId?: string }> }> {
+  const indexPath = join(mockUserDataPath, 'sync', 'keyboards', UID, 'analyze_filters', 'index.json')
+  const raw = await readFile(indexPath, 'utf-8')
+  return JSON.parse(raw) as { entries: Array<{ id: string; hubPostId?: string }> }
+}
+
+describe('analyze-filter-store set-hub-post-id', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'analyze-hub-post-id-test-'))
+    setupAnalyzeFilterStore()
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  it('sets hubPostId on an existing entry', async () => {
+    const entry = await saveEntry()
+
+    const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID)
+    const result = await handler(fakeEvent, UID, entry.id, 'post-123') as {
+      success: boolean
+    }
+    expect(result.success).toBe(true)
+
+    const index = await readIndex()
+    expect(index.entries[0].hubPostId).toBe('post-123')
+    expect(notifyChange).toHaveBeenLastCalledWith(`keyboards/${UID}/analyze_filters`)
+  })
+
+  it('clears hubPostId when given null', async () => {
+    const entry = await saveEntry()
+    await setAnalyzeFilterHubPostId(UID, entry.id, 'post-abc')
+
+    const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID)
+    const result = await handler(fakeEvent, UID, entry.id, null) as { success: boolean }
+    expect(result.success).toBe(true)
+
+    const index = await readIndex()
+    expect(index.entries[0].hubPostId).toBeUndefined()
+  })
+
+  it('treats whitespace-only hubPostId as clear', async () => {
+    const entry = await saveEntry()
+    await setAnalyzeFilterHubPostId(UID, entry.id, 'post-xyz')
+
+    const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID)
+    await handler(fakeEvent, UID, entry.id, '   ')
+
+    const index = await readIndex()
+    expect(index.entries[0].hubPostId).toBeUndefined()
+  })
+
+  it('returns error for missing entry', async () => {
+    const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID)
+    const result = await handler(fakeEvent, UID, 'no-such-id', 'post-1') as {
+      success: boolean
+      error?: string
+    }
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('Entry not found')
+  })
+
+  it('main-side helpers can read and stamp hubPostId without going through IPC', async () => {
+    const entry = await saveEntry('seed')
+
+    const stamped = await setAnalyzeFilterHubPostId(UID, entry.id, 'post-direct')
+    expect(stamped.success).toBe(true)
+
+    const read = await readAnalyzeFilterEntry(UID, entry.id)
+    expect(read).not.toBeNull()
+    expect(read!.entry.hubPostId).toBe('post-direct')
+    expect(JSON.parse(read!.data)).toEqual({ version: 1 })
+  })
+
+  it('readAnalyzeFilterEntry returns null for missing or tombstoned entries', async () => {
+    expect(await readAnalyzeFilterEntry(UID, 'missing')).toBeNull()
+
+    const entry = await saveEntry('to-delete')
+    const deleteHandler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_DELETE)
+    await deleteHandler(fakeEvent, UID, entry.id)
+    expect(await readAnalyzeFilterEntry(UID, entry.id)).toBeNull()
+  })
+})

--- a/src/main/__tests__/hub-ipc-analytics.test.ts
+++ b/src/main/__tests__/hub-ipc-analytics.test.ts
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// IPC handler tests for the Hub Analytics upload / update / preview
+// flow. Mirrors hub-ipc-favorite.test.ts so the two pipelines stay
+// shaped the same way (validate → withTokenRetry → setHubPostId on
+// success, surface validator failures without uploading).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Electron mocks ---------------------------------------------------
+
+vi.mock('electron', () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler)
+      }),
+      _handlers: handlers,
+    },
+    app: { getPath: () => '/tmp/userData' },
+  }
+})
+
+vi.mock('../ipc-guard', async () => {
+  const { ipcMain } = await import('electron')
+  return { secureHandle: ipcMain.handle }
+})
+
+vi.mock('../sync/sync-service', () => ({
+  notifyChange: vi.fn(),
+}))
+
+vi.mock('../key-label-store', () => ({
+  KEY_LABEL_SYNC_UNIT: 'key-labels',
+  getRecord: vi.fn(),
+  saveRecord: vi.fn(),
+  setHubPostId: vi.fn(),
+}))
+
+vi.mock('../sync/google-auth', () => ({
+  getIdToken: vi.fn(),
+}))
+
+vi.mock('../hub/hub-client', async () => {
+  const actual = await vi.importActual<typeof import('../hub/hub-client')>('../hub/hub-client')
+  return {
+    Hub401Error: actual.Hub401Error,
+    Hub403Error: actual.Hub403Error,
+    Hub409Error: actual.Hub409Error,
+    Hub429Error: actual.Hub429Error,
+    authenticateWithHub: vi.fn(),
+    uploadPostToHub: vi.fn(),
+    updatePostOnHub: vi.fn(),
+    patchPostOnHub: vi.fn(),
+    deletePostFromHub: vi.fn(),
+    fetchMyPosts: vi.fn(),
+    fetchMyPostsByKeyboard: vi.fn(),
+    fetchAuthMe: vi.fn(),
+    patchAuthMe: vi.fn(),
+    getHubOrigin: vi.fn(),
+    uploadFeaturePostToHub: vi.fn(),
+    updateFeaturePostOnHub: vi.fn(),
+    uploadAnalyticsPostToHub: vi.fn(async () => ({ id: 'post-1', title: 'My filter' })),
+    updateAnalyticsPostOnHub: vi.fn(async () => ({ id: 'post-1', title: 'My filter' })),
+  }
+})
+
+vi.mock('../hub/hub-analytics', () => ({
+  buildAnalyticsExport: vi.fn(),
+  validateAnalyticsExport: vi.fn(),
+  estimateAnalyticsExportSizeBytes: vi.fn(),
+}))
+
+vi.mock('../analyze-filter-store', () => ({
+  readAnalyzeFilterEntry: vi.fn(),
+  setAnalyzeFilterHubPostId: vi.fn(async () => ({ success: true })),
+}))
+
+vi.mock('../typing-analytics/keymap-snapshots', () => ({
+  getKeymapSnapshotForRange: vi.fn(),
+}))
+
+vi.mock('../typing-analytics/machine-hash', () => ({
+  getMachineHash: vi.fn(async () => 'own-hash'),
+}))
+
+// --- Imports after mocks ----------------------------------------------
+
+import { ipcMain } from 'electron'
+import { getIdToken } from '../sync/google-auth'
+import {
+  authenticateWithHub,
+  uploadAnalyticsPostToHub,
+  updateAnalyticsPostOnHub,
+} from '../hub/hub-client'
+import {
+  buildAnalyticsExport,
+  estimateAnalyticsExportSizeBytes,
+  validateAnalyticsExport,
+} from '../hub/hub-analytics'
+import { readAnalyzeFilterEntry, setAnalyzeFilterHubPostId } from '../analyze-filter-store'
+import { getKeymapSnapshotForRange } from '../typing-analytics/keymap-snapshots'
+import { setupHubIpc, clearHubTokenCache } from '../hub/hub-ipc'
+import { IpcChannels } from '../../shared/ipc/channels'
+import type { HubAnalyticsExportV1 } from '../../shared/types/hub'
+import type { TypingKeymapSnapshot } from '../../shared/types/typing-analytics'
+
+const SNAPSHOT: TypingKeymapSnapshot = {
+  uid: 'kb-1',
+  machineHash: 'own-hash',
+  productName: 'Test Board',
+  savedAt: 1_000_000,
+  layers: 1,
+  matrix: { rows: 1, cols: 1 },
+  keymap: [[['KC_A']]],
+  layout: {},
+}
+
+const SAVED_PAYLOAD = JSON.stringify({
+  version: 1,
+  analysisTab: 'summary',
+  range: { fromMs: 1_700_000_000_000, toMs: 1_700_000_000_000 + 86_400_000 },
+  filters: {
+    deviceScopes: ['all'],
+    appScopes: [],
+    bigrams: { topLimit: 99, slowLimit: 99, fingerLimit: 99 }, // overridden to fixed limits
+  },
+})
+
+const VALID_EXPORT: HubAnalyticsExportV1 = {
+  version: 1,
+  kind: 'analytics',
+  exportedAt: '2026-05-03T00:00:00.000Z',
+  snapshot: {
+    keyboard: { uid: 'kb-1', productName: 'Test Board', vendorId: 1, productId: 2 },
+    deviceScope: 'all',
+    keymapSnapshot: SNAPSHOT,
+    range: { fromMs: 1_700_000_000_000, toMs: 1_700_000_000_000 + 86_400_000 },
+    totalKeystrokes: 500,
+    appScopes: [],
+  },
+  filters: { analysisTab: 'summary', bigrams: { topLimit: 10, slowLimit: 10, fingerLimit: 20 } },
+  data: {
+    minuteStats: [],
+    matrixCells: [],
+    matrixCellsByDay: [],
+    layerUsage: [],
+    sessions: [],
+    bksMinute: [],
+    bigramTop: [],
+    bigramSlow: [],
+    appUsage: [],
+    wpmByApp: [],
+    peakRecords: {
+      peakWpm: null, lowestWpm: null,
+      peakKeystrokesPerMin: null, peakKeystrokesPerDay: null, longestSession: null,
+    },
+    layoutComparison: null,
+  },
+}
+
+function getHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handler = (ipcMain as any)._handlers.get(channel)
+  expect(handler).toBeDefined()
+  return handler
+}
+
+function uploadParams(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    uid: 'kb-1',
+    entryId: 'entry-1',
+    title: 'My filter',
+    thumbnailBase64: Buffer.from('thumb').toString('base64'),
+    keyboard: { productName: 'Test Board', vendorId: 1, productId: 2 },
+    fingerOverrides: {},
+    layoutComparisonInputs: null,
+    ...overrides,
+  }
+}
+
+function previewParams(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    uid: 'kb-1',
+    entryId: 'entry-1',
+    keyboard: { productName: 'Test Board', vendorId: 1, productId: 2 },
+    fingerOverrides: {},
+    layoutComparisonInputs: null,
+    ...overrides,
+  }
+}
+
+function mockHubAuth(): void {
+  vi.mocked(getIdToken).mockResolvedValueOnce('id-token')
+  vi.mocked(authenticateWithHub).mockResolvedValueOnce({
+    token: 'hub-jwt',
+    user: { id: 'u1', email: 't@example.com', display_name: null, role: 'user' },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearHubTokenCache()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(ipcMain as any)._handlers.clear()
+  setupHubIpc()
+  vi.mocked(readAnalyzeFilterEntry).mockResolvedValue({
+    entry: {
+      id: 'entry-1',
+      label: 'My filter',
+      filename: 'entry-1.json',
+      savedAt: '2026-05-03T00:00:00.000Z',
+    },
+    data: SAVED_PAYLOAD,
+  })
+  vi.mocked(getKeymapSnapshotForRange).mockResolvedValue(SNAPSHOT)
+  vi.mocked(buildAnalyticsExport).mockResolvedValue(VALID_EXPORT)
+  vi.mocked(validateAnalyticsExport).mockReturnValue({ ok: true })
+  vi.mocked(estimateAnalyticsExportSizeBytes).mockReturnValue(1234)
+})
+
+describe('HUB_UPLOAD_ANALYTICS_POST', () => {
+  it('uploads, stamps the postId on the saved entry, and returns the new id', async () => {
+    mockHubAuth()
+    const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)
+    const result = await handler({}, uploadParams()) as { success: boolean; postId?: string }
+    expect(result.success).toBe(true)
+    expect(result.postId).toBe('post-1')
+    expect(uploadAnalyticsPostToHub).toHaveBeenCalledTimes(1)
+    expect(setAnalyzeFilterHubPostId).toHaveBeenCalledWith('kb-1', 'entry-1', 'post-1')
+  })
+
+  it('forces the bigram limits to 10/10/20 regardless of the saved filter values', async () => {
+    mockHubAuth()
+    const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)
+    await handler({}, uploadParams())
+    const call = vi.mocked(buildAnalyticsExport).mock.calls[0][0]
+    expect(call.filters.bigrams).toEqual({
+      topLimit: 10, slowLimit: 10, fingerLimit: 20, pairIntervalThresholdMs: undefined,
+    })
+  })
+
+  it('refuses to upload when the saved entry is missing', async () => {
+    vi.mocked(readAnalyzeFilterEntry).mockResolvedValueOnce(null)
+    const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)
+    const result = await handler({}, uploadParams()) as { success: boolean; error?: string }
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Saved filter entry not found/)
+    expect(uploadAnalyticsPostToHub).not.toHaveBeenCalled()
+    expect(setAnalyzeFilterHubPostId).not.toHaveBeenCalled()
+  })
+
+  it('refuses to upload when the snapshot is missing for the range', async () => {
+    vi.mocked(getKeymapSnapshotForRange).mockResolvedValueOnce(null)
+    const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)
+    const result = await handler({}, uploadParams()) as { success: boolean; error?: string }
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/No keymap snapshot/)
+    expect(uploadAnalyticsPostToHub).not.toHaveBeenCalled()
+  })
+})
+
+describe('HUB_UPDATE_ANALYTICS_POST', () => {
+  it('rejects an invalid postId before authenticating', async () => {
+    const handler = getHandler(IpcChannels.HUB_UPDATE_ANALYTICS_POST)
+    const result = await handler({}, { ...uploadParams(), postId: 'bad id with space' }) as { success: boolean; error?: string }
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/Invalid post ID/)
+    expect(updateAnalyticsPostOnHub).not.toHaveBeenCalled()
+  })
+
+  it('updates and re-stamps the postId on success', async () => {
+    mockHubAuth()
+    const handler = getHandler(IpcChannels.HUB_UPDATE_ANALYTICS_POST)
+    const result = await handler({}, { ...uploadParams(), postId: 'post-1' }) as { success: boolean; postId?: string }
+    expect(result.success).toBe(true)
+    expect(updateAnalyticsPostOnHub).toHaveBeenCalledTimes(1)
+    expect(setAnalyzeFilterHubPostId).toHaveBeenCalledWith('kb-1', 'entry-1', 'post-1')
+  })
+})
+
+describe('HUB_PREVIEW_ANALYTICS_POST', () => {
+  it('returns size + validation without crossing the network', async () => {
+    const handler = getHandler(IpcChannels.HUB_PREVIEW_ANALYTICS_POST)
+    const result = await handler({}, previewParams()) as {
+      success: boolean
+      preview?: { totalKeystrokes: number; estimatedBytes: number; validation: { ok: boolean } }
+    }
+    expect(result.success).toBe(true)
+    expect(result.preview?.totalKeystrokes).toBe(500)
+    expect(result.preview?.estimatedBytes).toBe(1234)
+    expect(result.preview?.validation.ok).toBe(true)
+    expect(uploadAnalyticsPostToHub).not.toHaveBeenCalled()
+  })
+
+  it('reports a validation failure without uploading', async () => {
+    vi.mocked(validateAnalyticsExport).mockReturnValueOnce({ ok: false, reason: 'keystrokes below threshold' })
+    const handler = getHandler(IpcChannels.HUB_PREVIEW_ANALYTICS_POST)
+    const result = await handler({}, previewParams()) as {
+      preview?: { validation: { ok: boolean; reason?: string } }
+    }
+    expect(result.preview?.validation).toEqual({ ok: false, reason: 'keystrokes below threshold' })
+  })
+
+  it('falls back to a 0-byte preview when the snapshot is missing for the range', async () => {
+    vi.mocked(getKeymapSnapshotForRange).mockResolvedValueOnce(null)
+    const handler = getHandler(IpcChannels.HUB_PREVIEW_ANALYTICS_POST)
+    const result = await handler({}, previewParams()) as {
+      preview?: { estimatedBytes: number; validation: { ok: boolean; reason?: string } }
+    }
+    expect(result.preview?.estimatedBytes).toBe(0)
+    expect(result.preview?.validation.ok).toBe(false)
+    expect(result.preview?.validation.reason).toMatch(/No keymap snapshot/)
+  })
+})

--- a/src/main/__tests__/hub-ipc-favorite.test.ts
+++ b/src/main/__tests__/hub-ipc-favorite.test.ts
@@ -62,8 +62,30 @@ vi.mock('../hub/hub-client', async () => {
     getHubOrigin: vi.fn(() => 'https://pipette-hub-worker.keymaps.workers.dev'),
     uploadFeaturePostToHub: vi.fn(),
     updateFeaturePostOnHub: vi.fn(),
+    uploadAnalyticsPostToHub: vi.fn(),
+    updateAnalyticsPostOnHub: vi.fn(),
   }
 })
+
+// Stub the analytics-side imports so the favorite test paths don't
+// pull in typing-analytics → app-config → electron-store. The
+// favorite tests don't exercise the analytics handlers, but the
+// module-level imports need to resolve.
+vi.mock('../hub/hub-analytics', () => ({
+  buildAnalyticsExport: vi.fn(),
+  validateAnalyticsExport: vi.fn(),
+  estimateAnalyticsExportSizeBytes: vi.fn(() => 0),
+}))
+vi.mock('../analyze-filter-store', () => ({
+  readAnalyzeFilterEntry: vi.fn(),
+  setAnalyzeFilterHubPostId: vi.fn(),
+}))
+vi.mock('../typing-analytics/keymap-snapshots', () => ({
+  getKeymapSnapshotForRange: vi.fn(),
+}))
+vi.mock('../typing-analytics/machine-hash', () => ({
+  getMachineHash: vi.fn(),
+}))
 
 // Mock node:fs/promises
 vi.mock('node:fs/promises', () => ({

--- a/src/main/__tests__/hub-ipc.test.ts
+++ b/src/main/__tests__/hub-ipc.test.ts
@@ -58,8 +58,33 @@ vi.mock('../hub/hub-client', async () => {
     fetchAuthMe: vi.fn(),
     patchAuthMe: vi.fn(),
     getHubOrigin: vi.fn(() => 'https://pipette-hub-worker.keymaps.workers.dev'),
+    uploadFeaturePostToHub: vi.fn(),
+    updateFeaturePostOnHub: vi.fn(),
+    uploadAnalyticsPostToHub: vi.fn(),
+    updateAnalyticsPostOnHub: vi.fn(),
   }
 })
+
+// Stub the analytics-side imports so the keymap / favorite test paths
+// don't pull in typing-analytics → app-config → electron-store, which
+// crashes outside an Electron runtime. Each of these is only consumed
+// from the analytics handlers; existing tests in this file don't
+// exercise those paths.
+vi.mock('../hub/hub-analytics', () => ({
+  buildAnalyticsExport: vi.fn(),
+  validateAnalyticsExport: vi.fn(),
+  estimateAnalyticsExportSizeBytes: vi.fn(() => 0),
+}))
+vi.mock('../analyze-filter-store', () => ({
+  readAnalyzeFilterEntry: vi.fn(),
+  setAnalyzeFilterHubPostId: vi.fn(),
+}))
+vi.mock('../typing-analytics/keymap-snapshots', () => ({
+  getKeymapSnapshotForRange: vi.fn(),
+}))
+vi.mock('../typing-analytics/machine-hash', () => ({
+  getMachineHash: vi.fn(),
+}))
 
 import { ipcMain } from 'electron'
 import { getIdToken } from '../sync/google-auth'

--- a/src/main/analyze-filter-store.ts
+++ b/src/main/analyze-filter-store.ts
@@ -228,4 +228,60 @@ export function setupAnalyzeFilterStore(): void {
     async (_event, uid: string, entryId: string) =>
       updateEntry(uid, entryId, (entry) => { entry.deletedAt = new Date().toISOString() }),
   )
+
+  // --- Set Hub Post ID ---
+  // Mirrors favorite-store's setHubPostId handler. Called by the Hub
+  // analytics upload IPC (`HUB_UPLOAD_ANALYTICS_POST`) on success so the
+  // condition-store row can switch its primary action from "↑ Hub" to
+  // "↻ Hub" without re-reading the saved JSON.
+  secureHandle(
+    IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID,
+    async (_event, uid: string, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }> => {
+      return updateEntry(uid, entryId, (entry) => {
+        const normalized = hubPostId?.trim() || null
+        if (normalized === null) {
+          delete entry.hubPostId
+        } else {
+          entry.hubPostId = normalized
+        }
+      })
+    },
+  )
+}
+
+/** Direct accessor used by Hub analytics IPC handlers — they need to
+ * read the saved JSON for an entry by id without going through the
+ * renderer round-trip. Returns the parsed payload + entry meta or
+ * `null` if the entry is missing / tombstoned. */
+export async function readAnalyzeFilterEntry(
+  uid: string,
+  entryId: string,
+): Promise<{ entry: AnalyzeFilterSnapshotMeta; data: string } | null> {
+  validateUid(uid)
+  const index = await readIndex(uid)
+  const entry = index.entries.find((e) => e.id === entryId)
+  if (!entry) return null
+  if (entry.deletedAt) return null
+  const filePath = getSafeFilePath(uid, entry.filename)
+  const data = await readFile(filePath, 'utf-8')
+  return { entry, data }
+}
+
+/** Direct setter used by Hub analytics IPC handlers (Phase 3) so the
+ * upload pipeline can stamp the new postId without going through the
+ * renderer. The IPC handler `ANALYZE_FILTER_STORE_SET_HUB_POST_ID`
+ * forwards to this function so renderer + main paths share one writer. */
+export async function setAnalyzeFilterHubPostId(
+  uid: string,
+  entryId: string,
+  hubPostId: string | null,
+): Promise<{ success: boolean; error?: string }> {
+  return updateEntry(uid, entryId, (entry) => {
+    const normalized = hubPostId?.trim() || null
+    if (normalized === null) {
+      delete entry.hubPostId
+    } else {
+      entry.hubPostId = normalized
+    }
+  })
 }

--- a/src/main/hub/__tests__/hub-analytics.test.ts
+++ b/src/main/hub/__tests__/hub-analytics.test.ts
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Unit tests for the Hub Analytics export builder. We mock the
+// typing-analytics service / DB layer so the assertions focus on the
+// export shape, the validation thresholds, and the size estimator.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// --- Mocks --------------------------------------------------------------
+
+vi.mock('../../typing-analytics/machine-hash', () => ({
+  getMachineHash: vi.fn(async () => 'own-hash'),
+}))
+
+const dbMock = {
+  getAppUsageForUidInRange: vi.fn(),
+  getWpmByAppForUidInRange: vi.fn(),
+  listBigramMinutesInRangeForUid: vi.fn(),
+  listBigramMinutesInRangeForUidAndHash: vi.fn(),
+  aggregateMatrixCountsForUidInRange: vi.fn(),
+}
+
+vi.mock('../../typing-analytics/db/typing-analytics-db', () => ({
+  getTypingAnalyticsDB: () => dbMock,
+}))
+
+vi.mock('../../typing-analytics/typing-analytics-service', () => ({
+  listTypingMinuteStatsInRange: vi.fn(),
+  listTypingMinuteStatsInRangeForHash: vi.fn(),
+  listTypingMatrixCellsInRange: vi.fn(() => []),
+  listTypingMatrixCellsInRangeForHash: vi.fn(() => []),
+  listTypingMatrixCellsByDayInRange: vi.fn(() => []),
+  listTypingMatrixCellsByDayInRangeForHash: vi.fn(() => []),
+  listTypingLayerUsageInRange: vi.fn(() => []),
+  listTypingLayerUsageInRangeForHash: vi.fn(() => []),
+  listTypingSessionsInRange: vi.fn(() => []),
+  listTypingSessionsInRangeForHash: vi.fn(() => []),
+  listTypingBksMinuteInRange: vi.fn(() => []),
+  listTypingBksMinuteInRangeForHash: vi.fn(() => []),
+  getTypingPeakRecordsInRange: vi.fn(() => emptyPeakRecords()),
+  getTypingPeakRecordsInRangeForHash: vi.fn(() => emptyPeakRecords()),
+}))
+
+vi.mock('../../typing-analytics/bigram-aggregate', () => ({
+  aggregatePairTotals: vi.fn(() => []),
+  rankBigramsByCount: vi.fn(() => []),
+  rankBigramsBySlow: vi.fn(() => []),
+}))
+
+vi.mock('../../typing-analytics/compute-layout-comparison', () => ({
+  computeLayoutComparison: vi.fn(() => ({ sourceLayoutId: 'src', targets: [] })),
+}))
+
+// --- Imports after mocks ------------------------------------------------
+
+import {
+  ANALYTICS_BIGRAM_SLOW_LIMIT,
+  ANALYTICS_BIGRAM_SLOW_MIN_SAMPLE,
+  ANALYTICS_BIGRAM_TOP_LIMIT,
+  ANALYTICS_MAX_RANGE_MS,
+  ANALYTICS_MIN_KEYSTROKES,
+  buildAnalyticsExport,
+  estimateAnalyticsExportSizeBytes,
+  validateAnalyticsExport,
+} from '../hub-analytics'
+import {
+  listTypingMinuteStatsInRange,
+  listTypingMinuteStatsInRangeForHash,
+} from '../../typing-analytics/typing-analytics-service'
+import { getMachineHash } from '../../typing-analytics/machine-hash'
+import {
+  aggregatePairTotals,
+  rankBigramsByCount,
+  rankBigramsBySlow,
+} from '../../typing-analytics/bigram-aggregate'
+import { computeLayoutComparison } from '../../typing-analytics/compute-layout-comparison'
+import type { TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
+import type { HubAnalyticsFilters } from '../../../shared/types/hub'
+
+function emptyPeakRecords(): {
+  peakWpm: null
+  lowestWpm: null
+  peakKeystrokesPerMin: null
+  peakKeystrokesPerDay: null
+  longestSession: null
+} {
+  return {
+    peakWpm: null,
+    lowestWpm: null,
+    peakKeystrokesPerMin: null,
+    peakKeystrokesPerDay: null,
+    longestSession: null,
+  }
+}
+
+const SNAPSHOT: TypingKeymapSnapshot = {
+  uid: 'kb-1',
+  machineHash: 'own-hash',
+  productName: 'Test Board',
+  savedAt: 1_000_000,
+  layers: 1,
+  matrix: { rows: 1, cols: 1 },
+  keymap: [[['KC_A']]],
+  layout: {},
+}
+
+const FILTERS: HubAnalyticsFilters = {
+  analysisTab: 'summary',
+  bigrams: { topLimit: 10, slowLimit: 10, fingerLimit: 20 },
+}
+
+const FROM_MS = 1_700_000_000_000
+const TO_MS = FROM_MS + 86_400_000
+
+function baseInput() {
+  return {
+    uid: 'kb-1',
+    productName: 'Test Board',
+    vendorId: 0xABCD,
+    productId: 0x1234,
+    snapshot: SNAPSHOT,
+    range: { fromMs: FROM_MS, toMs: TO_MS },
+    deviceScope: 'all' as const,
+    appScopes: [],
+    filters: FILTERS,
+    layoutComparisonInputs: null,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  dbMock.getAppUsageForUidInRange.mockReturnValue([{ name: 'VSCode', keystrokes: 500, activeMs: 50_000 }])
+  dbMock.getWpmByAppForUidInRange.mockReturnValue([{ name: 'VSCode', keystrokes: 500, activeMs: 50_000 }])
+  dbMock.listBigramMinutesInRangeForUid.mockReturnValue([])
+  dbMock.listBigramMinutesInRangeForUidAndHash.mockReturnValue([])
+  dbMock.aggregateMatrixCountsForUidInRange.mockReturnValue(new Map())
+  vi.mocked(listTypingMinuteStatsInRange).mockReturnValue([
+    { minuteMs: FROM_MS, keystrokes: 60, activeMs: 60_000, intervalMinMs: null, intervalP25Ms: null, intervalP50Ms: null, intervalP75Ms: null, intervalMaxMs: null },
+    { minuteMs: FROM_MS + 60_000, keystrokes: 100, activeMs: 60_000, intervalMinMs: null, intervalP25Ms: null, intervalP50Ms: null, intervalP75Ms: null, intervalMaxMs: null },
+  ])
+  vi.mocked(listTypingMinuteStatsInRangeForHash).mockReturnValue([
+    { minuteMs: FROM_MS, keystrokes: 200, activeMs: 60_000, intervalMinMs: null, intervalP25Ms: null, intervalP50Ms: null, intervalP75Ms: null, intervalMaxMs: null },
+  ])
+})
+
+describe('buildAnalyticsExport', () => {
+  it('produces a v1 export with totalKeystrokes summed from minuteStats', async () => {
+    const result = await buildAnalyticsExport(baseInput())
+    expect(result.version).toBe(1)
+    expect(result.kind).toBe('analytics')
+    expect(result.snapshot.totalKeystrokes).toBe(160) // 60 + 100
+    expect(result.snapshot.keyboard.uid).toBe('kb-1')
+    expect(result.snapshot.keyboard.productName).toBe('Test Board')
+    expect(result.snapshot.range).toEqual({ fromMs: FROM_MS, toMs: TO_MS })
+    expect(result.snapshot.deviceScope).toBe('all')
+    expect(result.filters).toBe(FILTERS)
+  })
+
+  it('uses the un-suffixed fetcher for "all" scope and the hash variant for hash scope', async () => {
+    await buildAnalyticsExport(baseInput())
+    expect(listTypingMinuteStatsInRange).toHaveBeenCalledTimes(1)
+    expect(listTypingMinuteStatsInRangeForHash).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+    vi.mocked(listTypingMinuteStatsInRangeForHash).mockReturnValue([
+      { minuteMs: FROM_MS, keystrokes: 200, activeMs: 60_000, intervalMinMs: null, intervalP25Ms: null, intervalP50Ms: null, intervalP75Ms: null, intervalMaxMs: null },
+    ])
+    await buildAnalyticsExport({
+      ...baseInput(),
+      deviceScope: { kind: 'hash', machineHash: 'remote-hash' },
+    })
+    expect(listTypingMinuteStatsInRangeForHash).toHaveBeenCalledWith(
+      'kb-1', 'remote-hash', FROM_MS, TO_MS, [],
+    )
+    expect(listTypingMinuteStatsInRange).not.toHaveBeenCalled()
+  })
+
+  it('resolves the own machineHash for "own" scope', async () => {
+    await buildAnalyticsExport({ ...baseInput(), deviceScope: 'own' })
+    expect(getMachineHash).toHaveBeenCalled()
+    expect(listTypingMinuteStatsInRangeForHash).toHaveBeenCalledWith(
+      'kb-1', 'own-hash', FROM_MS, TO_MS, [],
+    )
+  })
+
+  it('passes the fixed bigram limits (10 / 10 / minSample 5) to the rankers', async () => {
+    await buildAnalyticsExport(baseInput())
+    expect(aggregatePairTotals).toHaveBeenCalled()
+    expect(rankBigramsByCount).toHaveBeenCalledWith(expect.anything(), ANALYTICS_BIGRAM_TOP_LIMIT)
+    expect(rankBigramsBySlow).toHaveBeenCalledWith(
+      expect.anything(),
+      ANALYTICS_BIGRAM_SLOW_MIN_SAMPLE,
+      ANALYTICS_BIGRAM_SLOW_LIMIT,
+    )
+  })
+
+  it('omits layout comparison when no layout inputs are supplied', async () => {
+    const result = await buildAnalyticsExport(baseInput())
+    expect(result.data.layoutComparison).toBeNull()
+    expect(computeLayoutComparison).not.toHaveBeenCalled()
+  })
+
+  it('computes layout comparison when layout inputs are supplied', async () => {
+    const result = await buildAnalyticsExport({
+      ...baseInput(),
+      layoutComparisonInputs: {
+        source: { id: 'qwerty', map: { 'KC_A': 'a' } },
+        target: { id: 'colemak', map: { 'KC_A': 'a' } },
+        metrics: [],
+        kleKeys: [],
+      },
+    })
+    expect(computeLayoutComparison).toHaveBeenCalled()
+    expect(result.data.layoutComparison).toEqual({ sourceLayoutId: 'src', targets: [] })
+  })
+
+  it('forwards the App-tab aggregates for ByApp', async () => {
+    const result = await buildAnalyticsExport(baseInput())
+    expect(result.data.appUsage).toEqual([{ name: 'VSCode', keystrokes: 500, activeMs: 50_000 }])
+    expect(result.data.wpmByApp).toEqual([{ name: 'VSCode', keystrokes: 500, activeMs: 50_000 }])
+  })
+
+  it('respects the user category picker and ships unselected sections as empty', async () => {
+    const onlyHeatmap = await buildAnalyticsExport({
+      ...baseInput(),
+      categories: new Set(['heatmap']),
+    })
+    expect(onlyHeatmap.data.matrixCells).toEqual([])
+    // matrixCells fetcher *was* called (heatmap is enabled), the empty
+    // result is the mock's default returning `[]`.
+    // Skipped sections ship as empty arrays:
+    expect(onlyHeatmap.data.minuteStats).toEqual([])
+    expect(onlyHeatmap.data.layerUsage).toEqual([])
+    expect(onlyHeatmap.data.matrixCellsByDay).toEqual([])
+    expect(onlyHeatmap.data.bigramTop).toEqual([])
+    expect(onlyHeatmap.data.bigramSlow).toEqual([])
+    expect(aggregatePairTotals).not.toHaveBeenCalled()
+  })
+
+  it('still computes totalKeystrokes when no minute-based category is selected', async () => {
+    const result = await buildAnalyticsExport({
+      ...baseInput(),
+      categories: new Set(['heatmap']),
+    })
+    // baseInput's mocked listTypingMinuteStatsInRange returns 60 + 100
+    // — totalKeystrokes is derived off the unfiltered fetch so the
+    // 100-keystroke guard works even when minuteStats ships empty.
+    expect(result.snapshot.totalKeystrokes).toBe(160)
+  })
+})
+
+describe('validateAnalyticsExport', () => {
+  function makeExport(overrides: Partial<{ totalKeystrokes: number; fromMs: number; toMs: number }> = {}) {
+    return {
+      version: 1,
+      kind: 'analytics',
+      exportedAt: '2026-05-03T00:00:00.000Z',
+      snapshot: {
+        keyboard: { uid: 'kb-1', productName: 'Test', vendorId: 0, productId: 0 },
+        deviceScope: 'all',
+        keymapSnapshot: SNAPSHOT,
+        range: { fromMs: overrides.fromMs ?? FROM_MS, toMs: overrides.toMs ?? TO_MS },
+        totalKeystrokes: overrides.totalKeystrokes ?? 200,
+        appScopes: [],
+      },
+      filters: FILTERS,
+      data: {
+        minuteStats: [], matrixCells: [], matrixCellsByDay: [], layerUsage: [],
+        sessions: [], bksMinute: [], bigramTop: [], bigramSlow: [],
+        appUsage: [], wpmByApp: [],
+        peakRecords: emptyPeakRecords(),
+        layoutComparison: null,
+      },
+    } as const
+  }
+
+  it('accepts a payload at the threshold', () => {
+    const result = validateAnalyticsExport(makeExport({ totalKeystrokes: ANALYTICS_MIN_KEYSTROKES }))
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects below the keystroke threshold', () => {
+    const result = validateAnalyticsExport(makeExport({ totalKeystrokes: ANALYTICS_MIN_KEYSTROKES - 1 }))
+    expect(result).toEqual({ ok: false, reason: 'keystrokes below threshold' })
+  })
+
+  it('accepts a 30-day range exactly at the cap', () => {
+    const result = validateAnalyticsExport(makeExport({
+      fromMs: FROM_MS,
+      toMs: FROM_MS + ANALYTICS_MAX_RANGE_MS,
+    }))
+    expect(result.ok).toBe(true)
+  })
+
+  it('rejects a range exceeding 30 days by 1 ms', () => {
+    const result = validateAnalyticsExport(makeExport({
+      fromMs: FROM_MS,
+      toMs: FROM_MS + ANALYTICS_MAX_RANGE_MS + 1,
+    }))
+    expect(result).toEqual({ ok: false, reason: 'range exceeds 30 days' })
+  })
+
+  it('rejects an inverted range', () => {
+    const result = validateAnalyticsExport(makeExport({ fromMs: TO_MS, toMs: FROM_MS }))
+    expect(result.ok).toBe(false)
+  })
+})
+
+describe('estimateAnalyticsExportSizeBytes', () => {
+  it('returns the UTF-8 byte length of the JSON serialisation', async () => {
+    const exportData = await buildAnalyticsExport(baseInput())
+    const bytes = estimateAnalyticsExportSizeBytes(exportData)
+    expect(bytes).toBe(Buffer.byteLength(JSON.stringify(exportData), 'utf-8'))
+    // Smoke check: the export with 2 minute rows and a couple of app
+    // entries should land in the kilobyte range, not megabytes.
+    expect(bytes).toBeGreaterThan(100)
+    expect(bytes).toBeLessThan(50_000)
+  })
+})

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hub Analytics export builder. Assembles the
+// `analytics-export-v1.json` payload that the desktop ships to
+// pipette-hub. The full wire contract lives in
+// `.claude/docs/HUB-ANALYTICS-API.md`; this module is the only
+// production producer of that shape.
+//
+// The export is *all derived data*. We never include raw events:
+// minute-level (1 minute) is the smallest granularity, and bigram
+// IKIs ride along as bucketed histograms (`hist[]`) only.
+
+import type {
+  HubAnalyticsData,
+  HubAnalyticsExportV1,
+  HubAnalyticsFilters,
+  HubAnalyticsSnapshot,
+} from '../../shared/types/hub'
+import type {
+  LayoutComparisonInputLayout,
+  LayoutComparisonMetric,
+  LayoutComparisonResult,
+  TypingKeymapSnapshot,
+} from '../../shared/types/typing-analytics'
+import { aggregatePairTotals, rankBigramsByCount, rankBigramsBySlow } from '../typing-analytics/bigram-aggregate'
+import { computeLayoutComparison } from '../typing-analytics/compute-layout-comparison'
+import { getMachineHash } from '../typing-analytics/machine-hash'
+import { getTypingAnalyticsDB } from '../typing-analytics/db/typing-analytics-db'
+import {
+  getTypingPeakRecordsInRange,
+  getTypingPeakRecordsInRangeForHash,
+  listTypingBksMinuteInRange,
+  listTypingBksMinuteInRangeForHash,
+  listTypingLayerUsageInRange,
+  listTypingLayerUsageInRangeForHash,
+  listTypingMatrixCellsByDayInRange,
+  listTypingMatrixCellsByDayInRangeForHash,
+  listTypingMatrixCellsInRange,
+  listTypingMatrixCellsInRangeForHash,
+  listTypingMinuteStatsInRange,
+  listTypingMinuteStatsInRangeForHash,
+  listTypingSessionsInRange,
+  listTypingSessionsInRangeForHash,
+} from '../typing-analytics/typing-analytics-service'
+import type { KleKey } from '../../shared/kle/types'
+
+const MS_PER_DAY = 86_400_000
+
+/** Maximum window the Hub will accept for an analytics post. Mirrored in
+ * the Hub-side validator (`pipette-hub/src/worker/services/analytics-validation.ts`). */
+export const ANALYTICS_MAX_RANGE_MS = 30 * MS_PER_DAY
+
+/** Lower bound on `snapshot.totalKeystrokes`. Below this we refuse the
+ * upload entirely — both as a privacy guard (single-keystroke patterns
+ * could be reconstructed from a tiny dataset) and as a UX guard
+ * (sub-100-keystroke charts are noise). */
+export const ANALYTICS_MIN_KEYSTROKES = 100
+
+/** Bigram fan-out caps. Fixed (not user-configurable on upload) so the
+ * payload size and the privacy surface stay predictable across users.
+ * Top / Slow rankings ship the desktop default for the analyze panel. */
+export const ANALYTICS_BIGRAM_TOP_LIMIT = 10
+export const ANALYTICS_BIGRAM_SLOW_LIMIT = 10
+/** Minimum sample count for the slow ranking — drops one-off outliers
+ * the same way the live chart does. */
+export const ANALYTICS_BIGRAM_SLOW_MIN_SAMPLE = 5
+
+export type DeviceScope =
+  | 'all'
+  | 'own'
+  | { kind: 'hash'; machineHash: string }
+
+/** Category ids the renderer ships from the upload modal — kept as a
+ * loose string union so the Hub-side enum can grow without a shared
+ * import dance. */
+export type AnalyticsCategoryId =
+  | 'heatmap' | 'wpm' | 'interval' | 'activity'
+  | 'ergonomics' | 'bigrams' | 'layoutComparison' | 'layer'
+
+export interface BuildAnalyticsExportInput {
+  uid: string
+  productName: string
+  vendorId: number
+  productId: number
+  snapshot: TypingKeymapSnapshot
+  range: { fromMs: number; toMs: number }
+  deviceScope: DeviceScope
+  appScopes: string[]
+  /** Renderer-side filter snapshot. `analysisTab` is required so the
+   * Hub UI can land on the same tab the user uploaded from. */
+  filters: HubAnalyticsFilters
+  /** Pre-resolved layouts for the Layout Comparison tab. The renderer
+   * looks these up via `LAYOUT_BY_ID` / key-label-store before triggering
+   * the upload because that data is renderer-only. `null` skips the
+   * comparison and ships `data.layoutComparison: null`. */
+  layoutComparisonInputs: {
+    source: LayoutComparisonInputLayout
+    target: LayoutComparisonInputLayout
+    metrics: LayoutComparisonMetric[]
+    /** KleKey geometry parsed from `snapshot.layout`. The renderer is
+     * better positioned to do this — it already does it for the live
+     * chart — so we accept the parsed result instead of re-parsing. */
+    kleKeys: KleKey[]
+    /** Layer to read source labels from. Phase 1 of layout comparison
+     * uses layer 0; pass through whatever the live chart used. */
+    layer?: number
+  } | null
+  /** Optional category picker — only the listed sections get fetched.
+   * Sections not in the set ship as empty arrays so the Hub-side
+   * validator still accepts the payload. Undefined / empty fetches
+   * everything (back-compat with the pre-modal pipeline). */
+  categories?: ReadonlySet<AnalyticsCategoryId>
+}
+
+/** Helper: should a category's data section be included in the
+ * export? Undefined / empty `categories` means "include everything",
+ * matching the pre-modal behavior. */
+function isSectionEnabled(
+  categories: ReadonlySet<AnalyticsCategoryId> | undefined,
+  category: AnalyticsCategoryId,
+): boolean {
+  if (categories === undefined || categories.size === 0) return true
+  return categories.has(category)
+}
+
+export async function buildAnalyticsExport(
+  input: BuildAnalyticsExportInput,
+): Promise<HubAnalyticsExportV1> {
+  const { uid, range, appScopes, deviceScope } = input
+  const machineHash = await resolveMachineHash(deviceScope)
+  const collected = await collectData(uid, range, appScopes, machineHash, input)
+  const { totalKeystrokes, ...data } = collected
+
+  const snapshot: HubAnalyticsSnapshot = {
+    keyboard: {
+      uid,
+      productName: input.productName,
+      vendorId: input.vendorId,
+      productId: input.productId,
+    },
+    deviceScope,
+    keymapSnapshot: input.snapshot,
+    range,
+    totalKeystrokes,
+    appScopes,
+  }
+
+  return {
+    version: 1,
+    kind: 'analytics',
+    exportedAt: new Date().toISOString(),
+    snapshot,
+    filters: input.filters,
+    data,
+  }
+}
+
+async function resolveMachineHash(scope: DeviceScope): Promise<string | undefined> {
+  if (scope === 'all') return undefined
+  if (scope === 'own') return getMachineHash()
+  return scope.machineHash
+}
+
+async function collectData(
+  uid: string,
+  range: { fromMs: number; toMs: number },
+  appScopes: string[],
+  machineHash: string | undefined,
+  input: BuildAnalyticsExportInput,
+): Promise<HubAnalyticsData & { totalKeystrokes: number }> {
+  const { fromMs, toMs } = range
+  const cats = input.categories
+  // Map modal categories → which raw section to fetch. Several
+  // categories share underlying data so we OR them.
+  // - minuteStats fuels Summary / WPM / Interval / Activity
+  // - matrixCells fuels KeyHeatmap / Ergonomics / Layer activations
+  // - matrixCellsByDay only Ergonomics learning curve
+  // - layerUsage only Layer keystrokes
+  // - sessions only Activity (sessions metric) + Summary
+  // - bksMinute only Activity Backspace overlay
+  // - bigrams only Bigrams tab
+  // - layoutComparison only Layout Comparison tab
+  // PeakRecords + appUsage + wpmByApp aren't surfaced as modal
+  // categories — they back the always-on Summary / By-App tabs.
+  const needsMinuteStats =
+    isSectionEnabled(cats, 'wpm') ||
+    isSectionEnabled(cats, 'interval') ||
+    isSectionEnabled(cats, 'activity')
+  const needsMatrixCells =
+    isSectionEnabled(cats, 'heatmap') ||
+    isSectionEnabled(cats, 'ergonomics') ||
+    isSectionEnabled(cats, 'layer')
+  const needsMatrixCellsByDay = isSectionEnabled(cats, 'ergonomics')
+  const needsLayerUsage = isSectionEnabled(cats, 'layer')
+  const needsSessions = isSectionEnabled(cats, 'activity')
+  const needsBksMinute = isSectionEnabled(cats, 'activity')
+  const needsBigrams = isSectionEnabled(cats, 'bigrams')
+  const needsLayoutComparison = isSectionEnabled(cats, 'layoutComparison')
+
+  // Each per-tab fetch picks the same `*ForHash` / un-suffixed pair the
+  // live chart does. machineHash === undefined === "all devices".
+  // minuteStats is always fetched (even when no minute-based category
+  // is enabled) because `snapshot.totalKeystrokes` — used by the
+  // 100-keystrokes guard — is the sum of these rows. Skipping the
+  // fetch would leave totalKeystrokes at 0 and bounce every category-
+  // restricted upload.
+  const minuteStatsAll = machineHash === undefined
+    ? listTypingMinuteStatsInRange(uid, fromMs, toMs, appScopes)
+    : listTypingMinuteStatsInRangeForHash(uid, machineHash, fromMs, toMs, appScopes)
+  const minuteStats = needsMinuteStats ? minuteStatsAll : []
+
+  const matrixCells = needsMatrixCells
+    ? (machineHash === undefined
+        ? listTypingMatrixCellsInRange(uid, fromMs, toMs, appScopes)
+        : listTypingMatrixCellsInRangeForHash(uid, machineHash, fromMs, toMs, appScopes))
+    : []
+
+  const matrixCellsByDay = needsMatrixCellsByDay
+    ? (machineHash === undefined
+        ? listTypingMatrixCellsByDayInRange(uid, fromMs, toMs, appScopes)
+        : listTypingMatrixCellsByDayInRangeForHash(uid, machineHash, fromMs, toMs, appScopes))
+    : []
+
+  const layerUsage = needsLayerUsage
+    ? (machineHash === undefined
+        ? listTypingLayerUsageInRange(uid, fromMs, toMs, appScopes)
+        : listTypingLayerUsageInRangeForHash(uid, machineHash, fromMs, toMs, appScopes))
+    : []
+
+  const sessions = needsSessions
+    ? (machineHash === undefined
+        ? listTypingSessionsInRange(uid, fromMs, toMs)
+        : listTypingSessionsInRangeForHash(uid, machineHash, fromMs, toMs))
+    : []
+
+  const bksMinute = needsBksMinute
+    ? (machineHash === undefined
+        ? listTypingBksMinuteInRange(uid, fromMs, toMs, appScopes)
+        : listTypingBksMinuteInRangeForHash(uid, machineHash, fromMs, toMs, appScopes))
+    : []
+
+  // PeakRecords drives the always-on Summary cards. Use the existing
+  // unselected-fetch path; if minuteStats was skipped above, the
+  // server still has the rows it needs.
+  const peakRecords = machineHash === undefined
+    ? getTypingPeakRecordsInRange(uid, fromMs, toMs, appScopes)
+    : getTypingPeakRecordsInRangeForHash(uid, machineHash, fromMs, toMs, appScopes)
+
+  // App-scoped aggregates feed the By App tab. Hub side renders these
+  // independent of the App filter (you can't compare across apps if the
+  // dataset is already collapsed to one), so the live chart calls these
+  // with no app filter — mirror that here.
+  const db = getTypingAnalyticsDB()
+  const appHash: string | null = machineHash ?? null
+  const appUsage = db.getAppUsageForUidInRange(uid, appHash, fromMs, toMs)
+  const wpmByApp = db.getWpmByAppForUidInRange(uid, appHash, fromMs, toMs)
+
+  // Bigrams: pull raw minute rows, fold into pair totals, take the
+  // top/slow ranking with the fixed limits documented in the API spec.
+  let bigramTop: HubAnalyticsData['bigramTop'] = []
+  let bigramSlow: HubAnalyticsData['bigramSlow'] = []
+  if (needsBigrams) {
+    const bigramRows = machineHash === undefined
+      ? db.listBigramMinutesInRangeForUid(uid, fromMs, toMs, appScopes)
+      : db.listBigramMinutesInRangeForUidAndHash(uid, machineHash, fromMs, toMs, appScopes)
+    const bigramTotals = aggregatePairTotals(bigramRows)
+    bigramTop = rankBigramsByCount(bigramTotals, ANALYTICS_BIGRAM_TOP_LIMIT)
+    bigramSlow = rankBigramsBySlow(
+      bigramTotals,
+      ANALYTICS_BIGRAM_SLOW_MIN_SAMPLE,
+      ANALYTICS_BIGRAM_SLOW_LIMIT,
+    )
+  }
+
+  const layoutComparison = needsLayoutComparison
+    ? await computeLayoutComparisonForExport(
+        uid,
+        fromMs,
+        toMs,
+        machineHash,
+        appScopes,
+        input.layoutComparisonInputs,
+        input.snapshot,
+      )
+    : null
+
+  return {
+    minuteStats,
+    matrixCells,
+    matrixCellsByDay,
+    layerUsage,
+    sessions,
+    bksMinute,
+    bigramTop,
+    bigramSlow,
+    appUsage,
+    wpmByApp,
+    peakRecords,
+    layoutComparison,
+    // totalKeystrokes is derived from the unfiltered minute fetch so
+    // the validator's 100-keystroke guard works even when the user
+    // unchecks every minute-based category.
+    totalKeystrokes: minuteStatsAll.reduce((sum, m) => sum + m.keystrokes, 0),
+  }
+}
+
+async function computeLayoutComparisonForExport(
+  uid: string,
+  fromMs: number,
+  toMs: number,
+  machineHash: string | undefined,
+  appScopes: string[],
+  inputs: BuildAnalyticsExportInput['layoutComparisonInputs'],
+  snapshot: TypingKeymapSnapshot,
+): Promise<LayoutComparisonResult | null> {
+  if (inputs === null) return null
+  // Layer 0 is the Phase 1 default; the IPC handler does the same thing
+  // when the renderer doesn't override it.
+  const layer = inputs.layer ?? 0
+  // The live chart aligns to minute boundaries before reading matrix
+  // counts so the heatmap doesn't double-count the partial minute the
+  // user is currently typing in.
+  const MINUTE_MS = 60_000
+  const sinceMinuteMs = Math.floor(fromMs / MINUTE_MS) * MINUTE_MS
+  const untilMinuteMs = Math.ceil(toMs / MINUTE_MS) * MINUTE_MS
+  const matrixCounts = getTypingAnalyticsDB().aggregateMatrixCountsForUidInRange(
+    uid,
+    layer,
+    sinceMinuteMs,
+    untilMinuteMs,
+    machineHash,
+    appScopes,
+  )
+  return computeLayoutComparison({
+    matrixCounts,
+    snapshot,
+    kleKeys: inputs.kleKeys,
+    source: inputs.source,
+    targets: [inputs.target],
+    metrics: inputs.metrics,
+    layer,
+  })
+}
+
+export type AnalyticsValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string }
+
+/** Pre-flight check identical in spirit to the Hub-side server validator
+ * — fail fast on the desktop so we don't pay for serialization +
+ * upload only to bounce on the Worker. */
+export function validateAnalyticsExport(
+  exportData: HubAnalyticsExportV1,
+): AnalyticsValidationResult {
+  if (exportData.snapshot.totalKeystrokes < ANALYTICS_MIN_KEYSTROKES) {
+    return { ok: false, reason: 'keystrokes below threshold' }
+  }
+  const { fromMs, toMs } = exportData.snapshot.range
+  if (toMs < fromMs) {
+    return { ok: false, reason: 'snapshot.range.toMs must be >= fromMs' }
+  }
+  if (toMs - fromMs > ANALYTICS_MAX_RANGE_MS) {
+    return { ok: false, reason: 'range exceeds 30 days' }
+  }
+  return { ok: true }
+}
+
+/** Serialised byte length of the export. Used by the upload dialog so
+ * the user sees a concrete size before confirming. The string is
+ * thrown away — we only need the byte count, not the text. */
+export function estimateAnalyticsExportSizeBytes(exportData: HubAnalyticsExportV1): number {
+  return Buffer.byteLength(JSON.stringify(exportData), 'utf-8')
+}

--- a/src/main/hub/hub-client.ts
+++ b/src/main/hub/hub-client.ts
@@ -331,6 +331,65 @@ export function updateFeaturePostOnHub(
   return submitFeaturePost(jwt, 'PUT', `/api/files/${encodeURIComponent(postId)}`, title, postType, jsonFile, 'Hub feature update failed')
 }
 
+// --- Analytics post support ---
+//
+// Analytics posts share the `/api/files` endpoint but use a hybrid
+// multipart shape: title + post_type=analytics + json (analytics
+// export) + thumbnail (jpeg). Distinct from the keymap upload (5
+// files) and the favorite upload (json only).
+
+function buildAnalyticsMultipartBody(
+  title: string,
+  jsonFile: HubFeatureUploadFile,
+  thumbnail: HubFeatureUploadFile,
+): { body: Buffer; boundary: string } {
+  const mp = new MultipartBuilder()
+  mp.appendField('title', title)
+  mp.appendField('post_type', 'analytics')
+  mp.appendFile('json', jsonFile.name, jsonFile.data, 'application/json')
+  mp.appendFile('thumbnail', thumbnail.name, thumbnail.data, 'image/jpeg')
+  return mp.build()
+}
+
+async function submitAnalyticsPost(
+  jwt: string,
+  method: 'POST' | 'PUT',
+  path: string,
+  title: string,
+  jsonFile: HubFeatureUploadFile,
+  thumbnail: HubFeatureUploadFile,
+  label: string,
+): Promise<HubPostResponse> {
+  const { body, boundary } = buildAnalyticsMultipartBody(title, jsonFile, thumbnail)
+  return hubFetch<HubPostResponse>(`${HUB_API_BASE}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': `multipart/form-data; boundary=${boundary}`,
+    },
+    body,
+  }, label)
+}
+
+export function uploadAnalyticsPostToHub(
+  jwt: string,
+  title: string,
+  jsonFile: HubFeatureUploadFile,
+  thumbnail: HubFeatureUploadFile,
+): Promise<HubPostResponse> {
+  return submitAnalyticsPost(jwt, 'POST', '/api/files', title, jsonFile, thumbnail, 'Hub analytics upload failed')
+}
+
+export function updateAnalyticsPostOnHub(
+  jwt: string,
+  postId: string,
+  title: string,
+  jsonFile: HubFeatureUploadFile,
+  thumbnail: HubFeatureUploadFile,
+): Promise<HubPostResponse> {
+  return submitAnalyticsPost(jwt, 'PUT', `/api/files/${encodeURIComponent(postId)}`, title, jsonFile, thumbnail, 'Hub analytics update failed')
+}
+
 export function getHubOrigin(): string {
   return HUB_API_BASE
 }

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -4,9 +4,28 @@
 import { secureHandle } from '../ipc-guard'
 import { IpcChannels } from '../../shared/ipc/channels'
 import { HUB_ERROR_DISPLAY_NAME_CONFLICT, HUB_ERROR_ACCOUNT_DEACTIVATED, HUB_ERROR_RATE_LIMITED } from '../../shared/types/hub'
-import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubUserResult, HubFetchMyPostsParams, HubUploadFavoritePostParams, HubUpdateFavoritePostParams } from '../../shared/types/hub'
+import type {
+  HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult,
+  HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubUserResult, HubFetchMyPostsParams,
+  HubUploadFavoritePostParams, HubUpdateFavoritePostParams,
+  HubUploadAnalyticsPostParams, HubUpdateAnalyticsPostParams, HubPreviewAnalyticsPostParams,
+  HubAnalyticsPreview, HubAnalyticsFilters, HubAnalyticsCategoryId,
+} from '../../shared/types/hub'
 import { getIdToken } from '../sync/google-auth'
-import { Hub401Error, Hub403Error, Hub409Error, Hub429Error, authenticateWithHub, uploadPostToHub, updatePostOnHub, patchPostOnHub, deletePostFromHub, fetchMyPosts, fetchMyPostsByKeyboard, fetchAuthMe, patchAuthMe, getHubOrigin, uploadFeaturePostToHub, updateFeaturePostOnHub } from './hub-client'
+import { Hub401Error, Hub403Error, Hub409Error, Hub429Error, authenticateWithHub, uploadPostToHub, updatePostOnHub, patchPostOnHub, deletePostFromHub, fetchMyPosts, fetchMyPostsByKeyboard, fetchAuthMe, patchAuthMe, getHubOrigin, uploadFeaturePostToHub, updateFeaturePostOnHub, uploadAnalyticsPostToHub, updateAnalyticsPostOnHub } from './hub-client'
+import {
+  buildAnalyticsExport,
+  estimateAnalyticsExportSizeBytes,
+  validateAnalyticsExport,
+  type BuildAnalyticsExportInput,
+  type DeviceScope,
+} from './hub-analytics'
+import { readAnalyzeFilterEntry, setAnalyzeFilterHubPostId } from '../analyze-filter-store'
+import { getKeymapSnapshotForRange } from '../typing-analytics/keymap-snapshots'
+import { getMachineHash } from '../typing-analytics/machine-hash'
+import type { TypingKeymapSnapshot } from '../../shared/types/typing-analytics'
+import type { LayoutComparisonMetric } from '../../shared/types/typing-analytics'
+import type { KleKey } from '../../shared/kle/types'
 import type { HubAuthResult, HubUploadFiles } from './hub-client'
 import { fetchKeyLabelList, fetchKeyLabelDetail, fetchKeyLabelTimestamps, downloadKeyLabel, uploadKeyLabel, updateKeyLabel, deleteKeyLabel } from './hub-key-labels'
 import type { HubKeyLabelInput } from './hub-key-labels'
@@ -62,6 +81,181 @@ function clampInt(value: number | undefined, min: number, max: number): number |
   const floored = Math.floor(value)
   if (!Number.isFinite(floored)) return undefined
   return Math.max(min, Math.min(max, floored))
+}
+
+function sanitizeFilenameBase(productName: string, fallback: string): string {
+  const source = (productName || fallback || 'analytics').replace(/[^a-zA-Z0-9_-]/g, '_')
+  return source.length > 0 ? source : 'analytics'
+}
+
+interface AnalyticsExportPreparation {
+  ok: true
+  exportData: Awaited<ReturnType<typeof buildAnalyticsExport>>
+}
+interface AnalyticsExportPreparationFail {
+  ok: false
+  error: string
+  /** When the failure happens before the export can be assembled
+   * (e.g. snapshot missing) we still surface the bits the dialog
+   * needs to render the validation card. Default 0 / 0 keeps the
+   * card showing red without blowing up. */
+  totalKeystrokes: number
+  rangeMs: number
+}
+
+/** Shared assembly path for both upload and preview. Reads the saved
+ * filter snapshot, resolves the keymap snapshot main-side (snapshots
+ * are local-only), folds the user's filter shape into the Hub's
+ * `HubAnalyticsFilters` shape, and runs the builder. */
+async function prepareAnalyticsExport(
+  params: HubUploadAnalyticsPostParams | (HubPreviewAnalyticsPostParams & { title: string; thumbnailBase64: string }),
+): Promise<AnalyticsExportPreparation | AnalyticsExportPreparationFail> {
+  if (!params.uid || typeof params.uid !== 'string') {
+    return { ok: false, error: 'Invalid uid', totalKeystrokes: 0, rangeMs: 0 }
+  }
+  if (!params.entryId || typeof params.entryId !== 'string') {
+    return { ok: false, error: 'Invalid entryId', totalKeystrokes: 0, rangeMs: 0 }
+  }
+  const found = await readAnalyzeFilterEntry(params.uid, params.entryId)
+  if (!found) {
+    return { ok: false, error: 'Saved filter entry not found', totalKeystrokes: 0, rangeMs: 0 }
+  }
+
+  let payload: AnalyzeFilterSnapshotPayloadShape
+  try {
+    payload = JSON.parse(found.data) as AnalyzeFilterSnapshotPayloadShape
+  } catch {
+    return { ok: false, error: 'Saved filter payload is not valid JSON', totalKeystrokes: 0, rangeMs: 0 }
+  }
+  if (!payload || typeof payload !== 'object' || payload.version !== 1) {
+    return { ok: false, error: 'Unsupported saved filter version', totalKeystrokes: 0, rangeMs: 0 }
+  }
+  const range = payload.range
+  if (!range || typeof range.fromMs !== 'number' || typeof range.toMs !== 'number') {
+    return { ok: false, error: 'Saved filter has no range', totalKeystrokes: 0, rangeMs: 0 }
+  }
+  const rangeMs = Math.max(0, range.toMs - range.fromMs)
+
+  const deviceScope = resolveDeviceScopeFromPayload(payload.filters?.deviceScopes)
+  const appScopes = Array.isArray(payload.filters?.appScopes)
+    ? payload.filters.appScopes.filter((v): v is string => typeof v === 'string')
+    : []
+
+  // Snapshots are own-only — the typing-analytics service writes them
+  // against the local machine hash. The Analyze view itself reads the
+  // snapshot via `typingAnalyticsGetKeymapSnapshotForRange` which
+  // resolves the same hash internally.
+  const ownHash = await getMachineHash()
+  const snapshot = await getKeymapSnapshotForRange(
+    app.getPath('userData'), params.uid, ownHash, range.fromMs, range.toMs,
+  )
+  if (!snapshot) {
+    return { ok: false, error: 'No keymap snapshot recorded for this range', totalKeystrokes: 0, rangeMs }
+  }
+
+  const filters = projectFiltersForHub(payload, params.fingerOverrides)
+
+  const layoutInputs = params.layoutComparisonInputs
+  const layoutComparisonInputs: BuildAnalyticsExportInput['layoutComparisonInputs'] = layoutInputs
+    ? {
+        source: layoutInputs.source,
+        target: layoutInputs.target,
+        metrics: filterValidLayoutMetrics(layoutInputs.metrics),
+        kleKeys: layoutInputs.kleKeys as KleKey[],
+        layer: layoutInputs.layer,
+      }
+    : null
+
+  // Renderer-side category picker — only the listed sections get
+  // fetched. Unset / empty array ships everything (back-compat with
+  // the early build that did not surface the picker).
+  const categories = Array.isArray(params.categories) && params.categories.length > 0
+    ? new Set(params.categories.filter((c): c is HubAnalyticsCategoryId => typeof c === 'string'))
+    : undefined
+
+  const exportData = await buildAnalyticsExport({
+    uid: params.uid,
+    productName: params.keyboard.productName,
+    vendorId: params.keyboard.vendorId,
+    productId: params.keyboard.productId,
+    snapshot: snapshot as TypingKeymapSnapshot,
+    range: { fromMs: range.fromMs, toMs: range.toMs },
+    deviceScope,
+    appScopes,
+    filters,
+    layoutComparisonInputs,
+    categories,
+  })
+
+  return { ok: true, exportData }
+}
+
+/** Subset of the renderer-side AnalyzeFilterSnapshotPayload that the
+ * main-side preparer needs to read. Re-stating the shape here keeps
+ * the main module independent of the renderer-only hook file. */
+interface AnalyzeFilterSnapshotPayloadShape {
+  version: number
+  analysisTab?: string
+  range?: { fromMs?: number; toMs?: number }
+  filters?: {
+    deviceScopes?: unknown[]
+    appScopes?: unknown[]
+    heatmap?: Record<string, unknown>
+    wpm?: Record<string, unknown>
+    interval?: Record<string, unknown>
+    activity?: Record<string, unknown>
+    layer?: Record<string, unknown>
+    ergonomics?: Record<string, unknown>
+    bigrams?: Record<string, unknown>
+    layoutComparison?: Record<string, unknown>
+  }
+}
+
+function resolveDeviceScopeFromPayload(scopes: unknown): DeviceScope {
+  if (!Array.isArray(scopes) || scopes.length === 0) return 'own'
+  const first = scopes[0]
+  if (first === 'all' || first === 'own') return first
+  if (typeof first === 'object' && first !== null) {
+    const o = first as Record<string, unknown>
+    if (o.kind === 'hash' && typeof o.machineHash === 'string' && o.machineHash.length > 0) {
+      return { kind: 'hash', machineHash: o.machineHash }
+    }
+  }
+  return 'own'
+}
+
+const VALID_LAYOUT_METRICS: ReadonlySet<LayoutComparisonMetric> = new Set([
+  'fingerLoad', 'handBalance', 'rowDist', 'homeRow',
+])
+
+function filterValidLayoutMetrics(metrics: readonly string[] | undefined): LayoutComparisonMetric[] {
+  if (!Array.isArray(metrics)) return []
+  return metrics.filter((m): m is LayoutComparisonMetric => VALID_LAYOUT_METRICS.has(m as LayoutComparisonMetric))
+}
+
+function projectFiltersForHub(
+  payload: AnalyzeFilterSnapshotPayloadShape,
+  fingerOverrides: Record<string, string> | undefined,
+): HubAnalyticsFilters {
+  const f = payload.filters ?? {}
+  // Bigrams limits are fixed (10/10/20) per HUB-ANALYTICS-API.md §4.3
+  // — the desktop never sends user-tweaked counts so the Hub size /
+  // privacy surface stays predictable.
+  const pairThreshold = typeof f.bigrams?.pairIntervalThresholdMs === 'number'
+    ? f.bigrams.pairIntervalThresholdMs
+    : undefined
+  return {
+    analysisTab: typeof payload.analysisTab === 'string' ? payload.analysisTab : 'summary',
+    heatmap: f.heatmap,
+    wpm: f.wpm,
+    interval: f.interval,
+    activity: f.activity,
+    layer: f.layer,
+    ergonomics: f.ergonomics,
+    bigrams: { topLimit: 10, slowLimit: 10, fingerLimit: 20, pairIntervalThresholdMs: pairThreshold },
+    layoutComparison: f.layoutComparison,
+    fingerOverrides: fingerOverrides && Object.keys(fingerOverrides).length > 0 ? fingerOverrides : undefined,
+  }
 }
 
 function computeTotalPages(total: number, perPage: number): number {
@@ -434,6 +628,120 @@ export function setupHubIpc(): void {
         return { success: true, postId: result.id }
       } catch (err) {
         return { success: false, error: extractError(err, 'Update failed') }
+      }
+    },
+  )
+
+  // --- Analytics post handlers ---
+  //
+  // Pattern mirrors the favorite-post upload: validate inputs → assemble
+  // payload → withTokenRetry → save the postId on success. Distinct
+  // because the analytics build step is heavier (fetches across the
+  // typing-analytics DB) and ships a thumbnail alongside the JSON.
+
+  secureHandle(
+    IpcChannels.HUB_UPLOAD_ANALYTICS_POST,
+    async (_event, params: HubUploadAnalyticsPostParams): Promise<HubUploadResult> => {
+      try {
+        const built = await prepareAnalyticsExport(params)
+        if (!built.ok) return { success: false, error: built.error }
+        const title = validateTitle(params.title)
+        const baseName = sanitizeFilenameBase(params.keyboard.productName, params.uid)
+        const jsonBuffer = Buffer.from(JSON.stringify(built.exportData), 'utf-8')
+        const thumbnailBuffer = Buffer.from(params.thumbnailBase64, 'base64')
+        const result = await withTokenRetry((jwt) =>
+          uploadAnalyticsPostToHub(
+            jwt,
+            title,
+            { name: `${baseName}.json`, data: jsonBuffer },
+            { name: `${baseName}.jpg`, data: thumbnailBuffer },
+          ),
+        )
+        // Save the postId synchronously after upload so the panel can
+        // immediately show the "↻ Hub" / 🔗 affordances without a
+        // round-trip; failures here don't undo the upload (the entry
+        // would just appear unsynced and the next click would attempt
+        // a fresh upload).
+        await setAnalyzeFilterHubPostId(params.uid, params.entryId, result.id)
+        return { success: true, postId: result.id }
+      } catch (err) {
+        return { success: false, error: extractError(err, 'Analytics upload failed') }
+      }
+    },
+  )
+
+  secureHandle(
+    IpcChannels.HUB_UPDATE_ANALYTICS_POST,
+    async (_event, params: HubUpdateAnalyticsPostParams): Promise<HubUploadResult> => {
+      try {
+        validatePostId(params.postId)
+        const built = await prepareAnalyticsExport(params)
+        if (!built.ok) return { success: false, error: built.error }
+        const title = validateTitle(params.title)
+        const baseName = sanitizeFilenameBase(params.keyboard.productName, params.uid)
+        const jsonBuffer = Buffer.from(JSON.stringify(built.exportData), 'utf-8')
+        const thumbnailBuffer = Buffer.from(params.thumbnailBase64, 'base64')
+        const result = await withTokenRetry((jwt) =>
+          updateAnalyticsPostOnHub(
+            jwt,
+            params.postId,
+            title,
+            { name: `${baseName}.json`, data: jsonBuffer },
+            { name: `${baseName}.jpg`, data: thumbnailBuffer },
+          ),
+        )
+        // Re-stamp the postId in case the user manipulated the saved
+        // entry's metadata in another window between preview and
+        // upload — keeps the local index in sync with the Hub canon.
+        await setAnalyzeFilterHubPostId(params.uid, params.entryId, result.id)
+        return { success: true, postId: result.id }
+      } catch (err) {
+        return { success: false, error: extractError(err, 'Analytics update failed') }
+      }
+    },
+  )
+
+  // Preview path used by the upload dialog. Builds the payload with
+  // the same builder the upload uses but reports size + validation
+  // without crossing the network. The thumbnail is captured later
+  // (only when the user confirms), so it's intentionally absent from
+  // the preview params.
+  secureHandle(
+    IpcChannels.HUB_PREVIEW_ANALYTICS_POST,
+    async (_event, params: HubPreviewAnalyticsPostParams): Promise<{ success: boolean; preview?: HubAnalyticsPreview; error?: string }> => {
+      try {
+        const built = await prepareAnalyticsExport({
+          ...params,
+          // The preview path doesn't ship a thumbnail — pass empty
+          // strings to satisfy the shared param shape without
+          // triggering the buffer encode for nothing.
+          title: 'preview',
+          thumbnailBase64: '',
+        })
+        if (!built.ok) {
+          return {
+            success: true,
+            preview: {
+              totalKeystrokes: built.totalKeystrokes,
+              rangeMs: built.rangeMs,
+              estimatedBytes: 0,
+              validation: { ok: false, reason: built.error },
+            },
+          }
+        }
+        const validation = validateAnalyticsExport(built.exportData)
+        const estimatedBytes = estimateAnalyticsExportSizeBytes(built.exportData)
+        return {
+          success: true,
+          preview: {
+            totalKeystrokes: built.exportData.snapshot.totalKeystrokes,
+            rangeMs: built.exportData.snapshot.range.toMs - built.exportData.snapshot.range.fromMs,
+            estimatedBytes,
+            validation,
+          },
+        }
+      } catch (err) {
+        return { success: false, error: extractError(err, 'Analytics preview failed') }
       }
     },
   )

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,7 +43,7 @@ import type {
   TypingBigramAggregateView,
 } from '../shared/types/typing-analytics'
 import type { LanguageListEntry } from '../shared/types/language-store'
-import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyPostsParams, HubFetchMyKeyboardPostsResult, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams } from '../shared/types/hub'
+import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyPostsParams, HubFetchMyKeyboardPostsResult, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams, HubUploadAnalyticsPostParams, HubUpdateAnalyticsPostParams, HubPreviewAnalyticsPostParams, HubAnalyticsPreview } from '../shared/types/hub'
 import type { NotificationFetchResult } from '../shared/types/notification'
 
 /**
@@ -535,6 +535,18 @@ const vialAPI = {
   // --- Favorite Store extensions ---
   favoriteStoreSetHubPostId: (type: string, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.FAVORITE_STORE_SET_HUB_POST_ID, type, entryId, hubPostId),
+
+  // --- Hub Analytics posts ---
+  hubUploadAnalyticsPost: (params: HubUploadAnalyticsPostParams): Promise<HubUploadResult> =>
+    ipcRenderer.invoke(IpcChannels.HUB_UPLOAD_ANALYTICS_POST, params),
+  hubUpdateAnalyticsPost: (params: HubUpdateAnalyticsPostParams): Promise<HubUploadResult> =>
+    ipcRenderer.invoke(IpcChannels.HUB_UPDATE_ANALYTICS_POST, params),
+  hubPreviewAnalyticsPost: (params: HubPreviewAnalyticsPostParams): Promise<{ success: boolean; preview?: HubAnalyticsPreview; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.HUB_PREVIEW_ANALYTICS_POST, params),
+
+  // --- Analyze Filter Store extensions ---
+  analyzeFilterStoreSetHubPostId: (uid: string, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.ANALYZE_FILTER_STORE_SET_HUB_POST_ID, uid, entryId, hubPostId),
 
   // --- Snapshot Store extensions ---
   snapshotStoreSetHubPostId: (uid: string, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -79,10 +79,34 @@ export interface AnalyzeExportContext {
   }
 }
 
+/** Per-category result reported back to the parent for the Hub upload
+ * flow. The export flow stays self-contained (writes CSV files via
+ * exportCsvBundle), so no callback is needed there. */
+export interface AnalyzeUploadCallbacks {
+  /** Whether an upload IPC is currently in flight for the same entry —
+   * disables the confirm button + swaps the label to "Uploading…". */
+  isUploading: boolean
+  /** Last upload result for the active entry. Surfaced as a status
+   * banner under the categories list. `null` hides the banner. */
+  uploadResult: { kind: 'success' | 'error'; message: string } | null
+  /** Confirm handler invoked with the user's category selection. The
+   * parent runs the actual upload IPC and resolves with `{ ok }` so
+   * the modal can decide whether to close itself. */
+  onConfirm: (categories: ReadonlySet<Category>) => Promise<{ ok: boolean }>
+  /** Whether the active entry already lives on Hub. Switches the
+   * confirm button label between "Upload" and "Update". */
+  isExisting: boolean
+}
+
 interface Props {
   isOpen: boolean
   onClose: () => void
   ctx: AnalyzeExportContext | null
+  /** `'export'` is the historical CSV-bundle path. `'upload'` reuses
+   * the same category-picker UI but routes the confirm action to
+   * `upload.onConfirm` and swaps the button label. */
+  mode?: 'export' | 'upload'
+  upload?: AnalyzeUploadCallbacks
 }
 
 type Category = 'heatmap' | 'wpm' | 'interval' | 'activity' | 'ergonomics' | 'bigrams' | 'layoutComparison' | 'layer'
@@ -90,6 +114,7 @@ type Category = 'heatmap' | 'wpm' | 'interval' | 'activity' | 'ergonomics' | 'bi
 const CATEGORIES: readonly Category[] = [
   'heatmap', 'wpm', 'interval', 'activity', 'ergonomics', 'bigrams', 'layoutComparison', 'layer',
 ]
+export type AnalyzeExportCategory = Category
 
 // Heatmap, Ergonomics, and Layout Comparison need a keymap snapshot
 // (the comparison aligns target positions against the recorded
@@ -281,7 +306,7 @@ function pickBuilders(
   return out
 }
 
-export function AnalyzeExportModal({ isOpen, onClose, ctx }: Props) {
+export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', upload }: Props) {
   const { t } = useTranslation()
   const [selected, setSelected] = useState<Record<Category, boolean>>(allOn)
   const [exporting, setExporting] = useState(false)
@@ -304,7 +329,14 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx }: Props) {
     if (REQUIRES_SNAPSHOT[c] && snapshotMissing) return false
     // Layout Comparison also needs an explicit target — without one
     // there is no "candidate vs current" diff to write to CSV.
-    if (c === 'layoutComparison' && ctx.layoutComparison.targetLayoutId === null) return false
+    // Upload mode currently never ships a layout comparison (the
+    // resolver pipeline lives in the renderer's LayoutComparisonView)
+    // so disable the toggle entirely for upload to make the limitation
+    // visible to the user.
+    if (c === 'layoutComparison') {
+      if (mode === 'upload') return false
+      if (ctx.layoutComparison.targetLayoutId === null) return false
+    }
     return true
   }
 
@@ -336,6 +368,32 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx }: Props) {
       setExporting(false)
     }
   }
+
+  const handleUpload = async () => {
+    if (!ctx || !upload || !anySelected || upload.isUploading) return
+    setError(null)
+    const picked = new Set<Category>()
+    for (const c of CATEGORIES) {
+      if (selected[c] && isCategoryAvailable(c)) picked.add(c)
+    }
+    try {
+      const result = await upload.onConfirm(picked)
+      if (result.ok) onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('analyze.export.failed'))
+    }
+  }
+
+  const isUploading = mode === 'upload' && (upload?.isUploading ?? false)
+  const confirmLabel = mode === 'upload'
+    ? (isUploading
+        ? t(upload?.isExisting ? 'hub.updating' : 'hub.uploading')
+        : t(upload?.isExisting ? 'hub.updateOnHub' : 'hub.uploadToHub'))
+    : t('analyze.export.confirm')
+  const confirmDisabled = mode === 'upload'
+    ? !anySelected || isUploading || ctx === null
+    : !anySelected || exporting || ctx === null
+  const confirmHandler = mode === 'upload' ? handleUpload : handleExport
 
   if (!isOpen) return null
 
@@ -406,16 +464,25 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx }: Props) {
               {error}
             </p>
           )}
+          {mode === 'upload' && upload?.uploadResult && (
+            <p
+              className={`text-[12px] font-medium ${upload.uploadResult.kind === 'success' ? 'text-accent' : 'text-danger'}`}
+              data-testid="analyze-export-upload-result"
+              role={upload.uploadResult.kind === 'error' ? 'alert' : undefined}
+            >
+              {upload.uploadResult.message}
+            </p>
+          )}
         </div>
         <div className="flex items-center justify-end gap-2 border-t border-edge bg-surface px-5 py-3">
           <button
             type="button"
             className={FILTER_BUTTON}
-            onClick={handleExport}
-            disabled={!anySelected || exporting || ctx === null}
+            onClick={() => { void confirmHandler() }}
+            disabled={confirmDisabled}
             data-testid="analyze-export-confirm"
           >
-            {t('analyze.export.confirm')}
+            {confirmLabel}
           </button>
         </div>
       </div>

--- a/src/renderer/components/analyze/AnalyzeFilterStoreHubRow.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStoreHubRow.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hub action row for an Analyze saved-filter entry. Mirrors
+// LayoutStoreHubRow visually so the keymap save panel and the analyze
+// save panel share one pattern: a thin border-top, "Hub" label on the
+// left, and one or more action buttons on the right (Upload / Update /
+// Remove + Open). Status text appears below when the entry is the
+// active target of an in-flight upload or a recently completed result.
+
+import { useTranslation } from 'react-i18next'
+import { HUB_BTN, SHARE_LINK_BTN } from '../editors/layout-store-types'
+import type { HubEntryResult } from '../editors/layout-store-types'
+import { ACTION_BTN, CONFIRM_DELETE_BTN } from '../editors/store-modal-shared'
+import type { AnalyzeFilterSnapshotMeta } from '../../../shared/types/analyze-filter-store'
+
+interface ShareLinkProps {
+  url: string
+}
+
+function ShareLink({ url }: ShareLinkProps): JSX.Element {
+  const { t } = useTranslation()
+  function handleClick(e: React.MouseEvent): void {
+    e.preventDefault()
+    window.vialAPI.openExternal(url).catch(() => { /* user-triggered, ignore failures */ })
+  }
+  return (
+    <a
+      href={url}
+      onClick={handleClick}
+      className={SHARE_LINK_BTN}
+      data-testid="analyze-filter-store-hub-share-link"
+    >
+      {t('hub.openInBrowser')}
+    </a>
+  )
+}
+
+export interface AnalyzeFilterStoreHubRowProps {
+  entry: AnalyzeFilterSnapshotMeta
+  hubOrigin?: string
+  hubNeedsDisplayName?: boolean
+  /** Entry id currently being uploaded — buttons disable / status text
+   * switches to "Uploading…" while this matches the row's id. */
+  hubUploading?: string | null
+  /** Per-entry result of the last upload attempt. Stays visible until
+   * the next upload kicks off so the user can see "Uploaded" / failure
+   * for a few seconds. */
+  hubUploadResult?: HubEntryResult | null
+  fileDisabled?: boolean
+  confirmHubRemoveId: string | null
+  setConfirmHubRemoveId: (id: string | null) => void
+  onUploadToHub?: (entryId: string) => void
+  onUpdateOnHub?: (entryId: string) => void
+  onRemoveFromHub?: (entryId: string) => void
+}
+
+export function AnalyzeFilterStoreHubRow({
+  entry,
+  hubOrigin,
+  hubNeedsDisplayName,
+  hubUploading,
+  hubUploadResult,
+  fileDisabled,
+  confirmHubRemoveId,
+  setConfirmHubRemoveId,
+  onUploadToHub,
+  onUpdateOnHub,
+  onRemoveFromHub,
+}: AnalyzeFilterStoreHubRowProps): JSX.Element {
+  const { t } = useTranslation()
+  const hubPostId = entry.hubPostId
+  const isUploading = hubUploading === entry.id
+  const buttonsDisabled = !!hubUploading || fileDisabled
+  const resultMatches = hubUploadResult?.entryId === entry.id
+
+  return (
+    <div
+      className="mt-1.5 border-t border-edge pt-1.5"
+      data-testid={`analyze-filter-store-hub-row-${entry.id}`}
+    >
+      <div className="flex items-center justify-between">
+        <span className="text-[11px] font-medium text-accent">
+          {t('hub.pipetteHub')}
+        </span>
+        <div className="flex gap-1">
+          {hubPostId && hubOrigin && (
+            <ShareLink url={`${hubOrigin}/post/${encodeURIComponent(hubPostId)}`} />
+          )}
+          {hubPostId && confirmHubRemoveId === entry.id && (
+            <>
+              <button
+                type="button"
+                className={CONFIRM_DELETE_BTN}
+                onClick={() => { onRemoveFromHub?.(entry.id); setConfirmHubRemoveId(null) }}
+                data-testid={`analyze-filter-store-hub-remove-confirm-${entry.id}`}
+              >
+                {t('hub.confirmRemove')}
+              </button>
+              <button
+                type="button"
+                className={ACTION_BTN}
+                onClick={() => setConfirmHubRemoveId(null)}
+                data-testid={`analyze-filter-store-hub-remove-cancel-${entry.id}`}
+              >
+                {t('common.cancel')}
+              </button>
+            </>
+          )}
+          {hubPostId && confirmHubRemoveId !== entry.id && (
+            <>
+              {onUpdateOnHub && (
+                <button
+                  type="button"
+                  className={HUB_BTN}
+                  onClick={() => onUpdateOnHub(entry.id)}
+                  disabled={buttonsDisabled}
+                  data-testid={`analyze-filter-store-update-hub-${entry.id}`}
+                >
+                  {isUploading ? t('hub.updating') : t('hub.updateOnHub')}
+                </button>
+              )}
+              {onRemoveFromHub && (
+                <button
+                  type="button"
+                  className={HUB_BTN}
+                  onClick={() => setConfirmHubRemoveId(entry.id)}
+                  disabled={buttonsDisabled}
+                  data-testid={`analyze-filter-store-remove-hub-${entry.id}`}
+                >
+                  {t('hub.removeFromHub')}
+                </button>
+              )}
+            </>
+          )}
+          {!hubPostId && onUploadToHub && (
+            <button
+              type="button"
+              className={HUB_BTN}
+              onClick={() => onUploadToHub(entry.id)}
+              disabled={buttonsDisabled}
+              data-testid={`analyze-filter-store-upload-hub-${entry.id}`}
+            >
+              {isUploading ? t('hub.uploading') : t('hub.uploadToHub')}
+            </button>
+          )}
+        </div>
+      </div>
+      {hubNeedsDisplayName && (hubPostId ? !onUpdateOnHub : !onUploadToHub) && (
+        <div
+          className="mt-1 text-[11px] text-content-muted"
+          data-testid={`analyze-filter-store-hub-needs-display-name-${entry.id}`}
+        >
+          {t('hub.needsDisplayName')}
+        </div>
+      )}
+      {resultMatches && hubUploadResult && (
+        <div
+          className={`mt-1 flex items-center text-[11px] font-medium ${
+            hubUploadResult.kind === 'success' ? 'text-accent' : 'text-danger'
+          }`}
+          data-testid={`analyze-filter-store-hub-result-${entry.id}`}
+        >
+          {hubUploadResult.message}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -18,7 +18,9 @@ import {
   formatDate,
 } from '../editors/store-modal-shared'
 import { FORMAT_BTN } from '../editors/layout-store-types'
+import type { HubEntryResult } from '../editors/layout-store-types'
 import type { AnalyzeFilterSnapshotMeta } from '../../../shared/types/analyze-filter-store'
+import { AnalyzeFilterStoreHubRow } from './AnalyzeFilterStoreHubRow'
 
 // Only one tab today — kept as a single-element tab bar for visual
 // parity with the keymap editor's overlay and so the structure is
@@ -48,6 +50,18 @@ interface Props {
    * step. `null` when there's nothing to export — same null contract
    * as `onExportCurrentCsv`. */
   onExportEntryCsv: ((entryId: string) => void) | null
+  /** Render the Hub action row under each entry (mirrors the keymap
+   * save panel's pattern). `null` hides the row entirely (Hub feature
+   * unavailable, no Google login, etc.). */
+  hubActions: {
+    hubOrigin?: string
+    hubNeedsDisplayName?: boolean
+    hubUploading?: string | null
+    hubUploadResult?: HubEntryResult | null
+    onUploadToHub?: (entryId: string) => void
+    onUpdateOnHub?: (entryId: string) => void
+    onRemoveFromHub?: (entryId: string) => void
+  } | null
 }
 
 export function AnalyzeFilterStorePanel({
@@ -61,11 +75,13 @@ export function AnalyzeFilterStorePanel({
   onDelete,
   onExportCurrentCsv,
   onExportEntryCsv,
+  hubActions,
 }: Props) {
   const { t } = useTranslation()
   const [saveLabel, setSaveLabel] = useState('')
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [confirmHubRemoveId, setConfirmHubRemoveId] = useState<string | null>(null)
   const [showSaved, setShowSaved] = useState(false)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
@@ -257,7 +273,7 @@ export function AnalyzeFilterStorePanel({
                           </div>
                         )}
 
-                        {/* Bottom row: date + .csv export */}
+                        {/* Row 2: date + .csv export */}
                         <div className="flex items-center justify-between">
                           <span className="font-mono text-[11px] text-content-muted">
                             {formatDate(entry.savedAt)}
@@ -274,6 +290,25 @@ export function AnalyzeFilterStorePanel({
                             </button>
                           )}
                         </div>
+
+                        {/* Row 3: Hub actions — mirrors LayoutStoreHubRow
+                         * so the keymap save panel and the analyze save
+                         * panel feel like the same surface. */}
+                        {hubActions && (
+                          <AnalyzeFilterStoreHubRow
+                            entry={entry}
+                            hubOrigin={hubActions.hubOrigin}
+                            hubNeedsDisplayName={hubActions.hubNeedsDisplayName}
+                            hubUploading={hubActions.hubUploading}
+                            hubUploadResult={hubActions.hubUploadResult}
+                            fileDisabled={loading}
+                            confirmHubRemoveId={confirmHubRemoveId}
+                            setConfirmHubRemoveId={setConfirmHubRemoveId}
+                            onUploadToHub={hubActions.onUploadToHub}
+                            onUpdateOnHub={hubActions.onUpdateOnHub}
+                            onRemoveFromHub={hubActions.onRemoveFromHub}
+                          />
+                        )}
                       </div>
                     )
                   })}

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -65,6 +65,7 @@ import { LayoutComparisonSelector } from './LayoutComparisonSelector'
 import { LayoutComparisonView } from './LayoutComparisonView'
 import { FingerAssignmentModal } from './FingerAssignmentModal'
 import { AnalyzeExportModal, type AnalyzeExportContext } from './AnalyzeExportModal'
+import { generateAnalyzeThumbnail } from './analyze-thumbnail'
 import { formatDeviceLabel } from './DeviceMultiSelect'
 import { formatDateTime } from '../editors/store-modal-shared'
 import { IntervalChart } from './IntervalChart'
@@ -247,7 +248,16 @@ export function AnalyzePane({
   const [fingerAssignments, setFingerAssignments] = useState<Record<string, FingerType>>({})
   const [fingersLoading, setFingersLoading] = useState(false)
   const [fingerModalOpen, setFingerModalOpen] = useState(false)
-  const [exportModalOpen, setExportModalOpen] = useState(false)
+  // The export modal does double duty: CSV export when invoked with
+  // mode 'export', Hub upload when invoked with mode 'upload'. The
+  // upload variant pins the saved entry id so the modal's onConfirm
+  // can build the upload params for that specific entry.
+  const [modalState, setModalState] = useState<
+    | { kind: 'closed' }
+    | { kind: 'export' }
+    | { kind: 'upload'; entryId: string }
+  >({ kind: 'closed' })
+  const [hubOrigin, setHubOrigin] = useState<string | null>(null)
   const [storePanelOpen, setStorePanelOpen] = useState(false)
   const storePanelRef = useRef<HTMLDivElement>(null)
   const storeToggleRef = useRef<HTMLButtonElement>(null)
@@ -712,10 +722,130 @@ export function AnalyzePane({
   const handleExportEntryCsv = useCallback(
     async (entryId: string): Promise<void> => {
       const ok = await handleLoadFilterSnapshot(entryId)
-      if (ok) setExportModalOpen(true)
+      if (ok) setModalState({ kind: 'export' })
     },
     [handleLoadFilterSnapshot],
   )
+
+  // Resolve the Hub base URL once so the Hub row can build the
+  // "open on Hub" share link without round-tripping per click. Cached
+  // per pane so two panes don't both fetch.
+  useEffect(() => {
+    if (hubOrigin !== null) return
+    void window.vialAPI.hubGetOrigin()
+      .then((origin) => { if (origin) setHubOrigin(origin) })
+      .catch(() => { /* leave origin null — share link hides */ })
+  }, [hubOrigin])
+
+  // Keyboard meta the upload IPC needs. Reads off the active typing-
+  // keyboard summary so the Hub post header carries the same labels
+  // the live Analyze view already shows.
+  const hubKeyboard = useMemo(
+    () => selected
+      ? { productName: selected.productName, vendorId: selected.vendorId, productId: selected.productId }
+      : null,
+    [selected],
+  )
+
+  // Build the upload IPC input for a saved entry. Captures the
+  // thumbnail just-in-time so cancelled / never-clicked rows pay
+  // nothing for the canvas work. The title falls back to the entry's
+  // saved label so the user doesn't have to retype it. Returns null
+  // when prerequisites (selected keyboard / matching saved entry)
+  // aren't met so the modal callback can short-circuit.
+  const buildHubUploadInput = useCallback((entryId: string) => {
+    if (!selected || !hubKeyboard) return null
+    const entry = filterStore.entries.find((e) => e.id === entryId)
+    if (!entry) return null
+    const rangeLabel = exportCtx?.conditions.range
+      ?? `${formatDateTime(range.fromMs)} - ${formatDateTime(range.toMs)}`
+    const thumbnailBase64 = generateAnalyzeThumbnail({
+      keyboardName: selected.productName,
+      rangeLabel,
+      // The thumb is text-only today; the Hub-side post grid still
+      // surfaces the real keystroke total from the JSON. Skip the
+      // extra preview round-trip just for colouring the card.
+      totalKeystrokes: 0,
+      deviceLabel: exportCtx?.conditions.device,
+    })
+    return {
+      entryId,
+      title: entry.label,
+      thumbnailBase64,
+      keyboard: hubKeyboard,
+      fingerOverrides: fingerAssignments,
+      // Layout Comparison upload remains a follow-up — see
+      // .claude/plans/done/Plan-hub-analytics-upload.md "Known
+      // Follow-up" notes. The Hub renders the empty-state for the tab.
+      layoutComparisonInputs: null,
+    }
+  }, [selected, hubKeyboard, filterStore.entries, exportCtx, range, fingerAssignments])
+
+  // Open the export modal in upload mode for the given entry. Loads
+  // the saved snapshot first so the modal's exportCtx (device / app /
+  // keymap / range labels in the header) reflects what the user will
+  // actually upload, not whatever live state happened to be active.
+  // Bound to both "Upload" and "Update on Hub" Hub-row buttons — the
+  // distinction is decided inside the modal's onConfirm handler from
+  // the loaded entry's hubPostId.
+  const openHubUploadModal = useCallback(async (entryId: string): Promise<void> => {
+    const ok = await handleLoadFilterSnapshot(entryId)
+    if (ok) setModalState({ kind: 'upload', entryId })
+  }, [handleLoadFilterSnapshot])
+
+  const handleRemoveFromHub = useCallback((entryId: string) => {
+    void filterStore.removeEntryFromHub(entryId)
+  }, [filterStore])
+
+  // Single source of truth for the panel's hub action wiring. `null`
+  // hides the row entirely (no keyboard selected). Both Upload and
+  // Update buttons route through the same modal opener — the modal
+  // looks at the loaded entry's hubPostId to decide which IPC to
+  // invoke on confirm.
+  const hubActions = useMemo(
+    () => selected
+      ? {
+          hubOrigin: hubOrigin ?? undefined,
+          hubUploading: filterStore.hubUploading,
+          hubUploadResult: filterStore.hubUploadResult,
+          onUploadToHub: openHubUploadModal,
+          onUpdateOnHub: openHubUploadModal,
+          onRemoveFromHub: handleRemoveFromHub,
+        }
+      : null,
+    [selected, hubOrigin, filterStore.hubUploading, filterStore.hubUploadResult,
+     openHubUploadModal, handleRemoveFromHub],
+  )
+
+  // Pre-compute the modal's `upload` callbacks bundle for the active
+  // upload target. Falls back to `undefined` for export mode so the
+  // modal doesn't try to render the upload status banner.
+  const uploadEntryForModal = modalState.kind === 'upload'
+    ? filterStore.entries.find((e) => e.id === modalState.entryId) ?? null
+    : null
+  const modalUploadProps = useMemo(() => {
+    if (!uploadEntryForModal) return undefined
+    const entry = uploadEntryForModal
+    const isExisting = !!entry.hubPostId
+    return {
+      isUploading: filterStore.hubUploading === entry.id,
+      uploadResult: filterStore.hubUploadResult?.entryId === entry.id
+        ? { kind: filterStore.hubUploadResult.kind, message: filterStore.hubUploadResult.message }
+        : null,
+      isExisting,
+      onConfirm: async (categories: ReadonlySet<string>) => {
+        const baseInput = buildHubUploadInput(entry.id)
+        if (!baseInput) return { ok: false }
+        const input = {
+          ...baseInput,
+          categories: Array.from(categories) as Parameters<typeof filterStore.uploadEntryToHub>[0]['categories'],
+        }
+        return isExisting
+          ? filterStore.updateEntryOnHub(input)
+          : filterStore.uploadEntryToHub(input)
+      },
+    }
+  }, [uploadEntryForModal, filterStore, buildHubUploadInput])
 
   // Activity's per-tab filters render in two places: alongside Period
   // on Row 2 in split mode, or on Row 3 in single mode. Extracted so
@@ -1328,8 +1458,9 @@ export function AnalyzePane({
               onLoad={handleLoadFilterSnapshot}
               onRename={filterStore.renameEntry}
               onDelete={filterStore.deleteEntry}
-              onExportCurrentCsv={exportCtx !== null ? () => setExportModalOpen(true) : null}
+              onExportCurrentCsv={exportCtx !== null ? () => setModalState({ kind: 'export' }) : null}
               onExportEntryCsv={exportCtx !== null ? handleExportEntryCsv : null}
+              hubActions={hubActions}
             />
           </div>
         </div>
@@ -1342,9 +1473,11 @@ export function AnalyzePane({
         onSave={handleFingerAssignmentsSave}
       />
       <AnalyzeExportModal
-        isOpen={exportModalOpen}
-        onClose={() => setExportModalOpen(false)}
+        isOpen={modalState.kind !== 'closed'}
+        onClose={() => setModalState({ kind: 'closed' })}
         ctx={exportCtx}
+        mode={modalState.kind === 'upload' ? 'upload' : 'export'}
+        upload={modalUploadProps}
       />
     </>
   )

--- a/src/renderer/components/analyze/__tests__/AnalyzeExportModal-upload.test.tsx
+++ b/src/renderer/components/analyze/__tests__/AnalyzeExportModal-upload.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Coverage for the AnalyzeExportModal's upload mode. The export mode
+// stays untested here (it predates the dual-mode refactor); this suite
+// focuses on the new upload affordances: button label switch, status
+// banner, and the categories Set forwarded to the onConfirm callback.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '../../../../../src/renderer/__tests__/setup'
+import { I18nextProvider } from 'react-i18next'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import en from '../../../i18n/locales/en.json'
+
+import { AnalyzeExportModal, type AnalyzeUploadCallbacks } from '../AnalyzeExportModal'
+import type { AnalyzeExportContext } from '../AnalyzeExportModal'
+
+if (!i18n.isInitialized) {
+  void i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+  })
+}
+
+const SNAPSHOT = {
+  uid: 'kb-1',
+  machineHash: 'm',
+  productName: 'Test Board',
+  savedAt: 1_000_000,
+  layers: 1,
+  matrix: { rows: 1, cols: 1 },
+  keymap: [[['KC_NO']]],
+  layout: { keys: [] },
+}
+
+const CTX: AnalyzeExportContext = {
+  uid: 'kb-1',
+  keyboardName: 'Test Board',
+  machineHashOrAll: 'all',
+  range: { fromMs: 0, toMs: 86_400_000 },
+  deviceScope: 'all',
+  appScopes: [],
+  snapshot: SNAPSHOT as unknown as AnalyzeExportContext['snapshot'],
+  heatmap: {
+    selectedLayers: [0],
+    groups: [[0]],
+    frequentUsedN: 5,
+    aggregateMode: 'cell',
+    normalization: 'absolute',
+    keyGroupFilter: 'all',
+  },
+  wpm: { granularity: 'auto', viewMode: 'timeSeries', minActiveMs: 60_000 },
+  interval: { viewMode: 'timeSeries', granularity: 'auto' },
+  activity: { metric: 'keystrokes', minActiveMs: 60_000 },
+  layer: { baseLayer: 0 },
+  layoutComparison: { sourceLayoutId: '', targetLayoutId: null },
+  fingerOverrides: {},
+  conditions: { device: 'All', app: 'All', keymap: '—', range: '7 days' },
+}
+
+function renderModal(overrides: Partial<React.ComponentProps<typeof AnalyzeExportModal>> = {}) {
+  const upload: AnalyzeUploadCallbacks = {
+    isUploading: false,
+    uploadResult: null,
+    isExisting: false,
+    onConfirm: vi.fn(async () => ({ ok: true })),
+  }
+  const props: React.ComponentProps<typeof AnalyzeExportModal> = {
+    isOpen: true,
+    onClose: vi.fn(),
+    ctx: CTX,
+    mode: 'upload',
+    upload,
+    ...overrides,
+  }
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <AnalyzeExportModal {...props} />
+    </I18nextProvider>,
+  )
+  return { ...utils, props, upload }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AnalyzeExportModal (upload mode)', () => {
+  it('labels the confirm button "Upload" for a fresh entry', () => {
+    renderModal()
+    expect(screen.getByTestId('analyze-export-confirm')).toHaveTextContent('Upload')
+  })
+
+  it('labels the confirm button "Update" for an entry that already lives on Hub', () => {
+    renderModal({
+      upload: {
+        isUploading: false,
+        uploadResult: null,
+        isExisting: true,
+        onConfirm: vi.fn(async () => ({ ok: true })),
+      },
+    })
+    expect(screen.getByTestId('analyze-export-confirm')).toHaveTextContent('Update')
+  })
+
+  it('forwards the user category selection to onConfirm', async () => {
+    const onConfirm = vi.fn(async () => ({ ok: true }))
+    renderModal({
+      upload: { isUploading: false, uploadResult: null, isExisting: false, onConfirm },
+    })
+    // Toggle off "wpm" — the rest stay enabled (allOn default).
+    fireEvent.click(screen.getByTestId('analyze-export-toggle-wpm'))
+    fireEvent.click(screen.getByTestId('analyze-export-confirm'))
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledTimes(1))
+    const picked = onConfirm.mock.calls[0][0] as Set<string>
+    expect(picked.has('wpm')).toBe(false)
+    expect(picked.has('heatmap')).toBe(true)
+    // Layout Comparison is intentionally never available in upload
+    // mode (the renderer-side resolver isn't wired through), so it
+    // never lands in the Set.
+    expect(picked.has('layoutComparison')).toBe(false)
+  })
+
+  it('disables the confirm button while uploading and shows the busy label', () => {
+    renderModal({
+      upload: {
+        isUploading: true,
+        uploadResult: null,
+        isExisting: false,
+        onConfirm: vi.fn(async () => ({ ok: true })),
+      },
+    })
+    const button = screen.getByTestId('analyze-export-confirm') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    expect(button.textContent).toContain('Uploading')
+  })
+
+  it('renders the upload result banner when the parent reports a result', () => {
+    renderModal({
+      upload: {
+        isUploading: false,
+        uploadResult: { kind: 'success', message: 'Uploaded' },
+        isExisting: false,
+        onConfirm: vi.fn(async () => ({ ok: true })),
+      },
+    })
+    expect(screen.getByTestId('analyze-export-upload-result')).toHaveTextContent('Uploaded')
+  })
+
+  it('keeps the modal open when onConfirm reports failure', async () => {
+    const onConfirm = vi.fn(async () => ({ ok: false }))
+    const { props } = renderModal({
+      upload: { isUploading: false, uploadResult: null, isExisting: false, onConfirm },
+    })
+    fireEvent.click(screen.getByTestId('analyze-export-confirm'))
+    await waitFor(() => expect(onConfirm).toHaveBeenCalled())
+    // Parent's onClose stays untouched on failure — the modal lives on
+    // so the user can read the error banner / retry.
+    expect(props.onClose).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/analyze/__tests__/AnalyzeFilterStoreHubRow.test.tsx
+++ b/src/renderer/components/analyze/__tests__/AnalyzeFilterStoreHubRow.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Visual state coverage for the analyze save panel's Hub row. Mirrors
+// LayoutStoreHubRow behaviour: switch between Upload / Update+Remove
+// depending on whether the entry already has a hubPostId, propagate
+// the in-flight "Uploading…" / "Updating…" labels, and surface the
+// last result banner only when its entryId matches.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '../../../../../src/renderer/__tests__/setup'
+import { I18nextProvider } from 'react-i18next'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import en from '../../../i18n/locales/en.json'
+
+import { AnalyzeFilterStoreHubRow } from '../AnalyzeFilterStoreHubRow'
+import type { AnalyzeFilterSnapshotMeta } from '../../../../shared/types/analyze-filter-store'
+
+if (!i18n.isInitialized) {
+  void i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+  })
+}
+
+const ENTRY: AnalyzeFilterSnapshotMeta = {
+  id: 'entry-1',
+  label: 'My filter',
+  filename: 'entry-1.json',
+  savedAt: '2026-05-03T00:00:00.000Z',
+}
+
+function renderRow(overrides: Partial<React.ComponentProps<typeof AnalyzeFilterStoreHubRow>> = {}) {
+  const props: React.ComponentProps<typeof AnalyzeFilterStoreHubRow> = {
+    entry: ENTRY,
+    confirmHubRemoveId: null,
+    setConfirmHubRemoveId: vi.fn(),
+    onUploadToHub: vi.fn(),
+    onUpdateOnHub: vi.fn(),
+    onRemoveFromHub: vi.fn(),
+    ...overrides,
+  }
+  return {
+    ...render(
+      <I18nextProvider i18n={i18n}>
+        <AnalyzeFilterStoreHubRow {...props} />
+      </I18nextProvider>,
+    ),
+    props,
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AnalyzeFilterStoreHubRow', () => {
+  it('renders an Upload button when the entry has no hubPostId', () => {
+    const { props } = renderRow()
+    const upload = screen.getByTestId('analyze-filter-store-upload-hub-entry-1')
+    expect(upload).toHaveTextContent('Upload')
+    fireEvent.click(upload)
+    expect(props.onUploadToHub).toHaveBeenCalledWith('entry-1')
+    expect(screen.queryByTestId('analyze-filter-store-update-hub-entry-1')).toBeNull()
+    expect(screen.queryByTestId('analyze-filter-store-hub-share-link')).toBeNull()
+  })
+
+  it('switches to Update + Remove + share link once the entry has a hubPostId', () => {
+    renderRow({ entry: { ...ENTRY, hubPostId: 'post-1' }, hubOrigin: 'https://hub.example' })
+    expect(screen.getByTestId('analyze-filter-store-update-hub-entry-1')).toHaveTextContent('Update')
+    expect(screen.getByTestId('analyze-filter-store-remove-hub-entry-1')).toHaveTextContent('Remove')
+    const link = screen.getByTestId('analyze-filter-store-hub-share-link') as HTMLAnchorElement
+    expect(link.href).toBe('https://hub.example/post/post-1')
+  })
+
+  it('shows the in-flight label and disables the button while uploading', () => {
+    renderRow({ hubUploading: 'entry-1' })
+    const upload = screen.getByTestId('analyze-filter-store-upload-hub-entry-1') as HTMLButtonElement
+    expect(upload).toHaveTextContent('Uploading')
+    expect(upload.disabled).toBe(true)
+  })
+
+  it('surfaces the last upload result only when the entryId matches', () => {
+    const { rerender } = renderRow({
+      hubUploadResult: { kind: 'success', message: 'Uploaded', entryId: 'entry-1' },
+    })
+    expect(screen.getByTestId('analyze-filter-store-hub-result-entry-1')).toHaveTextContent('Uploaded')
+
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <AnalyzeFilterStoreHubRow
+          entry={ENTRY}
+          confirmHubRemoveId={null}
+          setConfirmHubRemoveId={vi.fn()}
+          hubUploadResult={{ kind: 'error', message: 'Boom', entryId: 'other' }}
+        />
+      </I18nextProvider>,
+    )
+    expect(screen.queryByTestId('analyze-filter-store-hub-result-entry-1')).toBeNull()
+  })
+
+  it('asks for confirmation before invoking onRemoveFromHub', () => {
+    const setConfirm = vi.fn()
+    const { props } = renderRow({
+      entry: { ...ENTRY, hubPostId: 'post-1' },
+      setConfirmHubRemoveId: setConfirm,
+    })
+    fireEvent.click(screen.getByTestId('analyze-filter-store-remove-hub-entry-1'))
+    expect(setConfirm).toHaveBeenCalledWith('entry-1')
+    expect(props.onRemoveFromHub).not.toHaveBeenCalled()
+  })
+
+  it('runs the remove handler when the user confirms', () => {
+    const { props } = renderRow({
+      entry: { ...ENTRY, hubPostId: 'post-1' },
+      confirmHubRemoveId: 'entry-1',
+    })
+    fireEvent.click(screen.getByTestId('analyze-filter-store-hub-remove-confirm-entry-1'))
+    expect(props.onRemoveFromHub).toHaveBeenCalledWith('entry-1')
+  })
+})

--- a/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
+++ b/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
@@ -142,6 +142,11 @@ Object.defineProperty(window, 'vialAPI', {
     // The overlay subscribes to sync progress events. The default stub
     // is a no-op subscriber returning a no-op unsubscribe function.
     syncOnProgress: () => () => {},
+    // Hub origin is fetched once on AnalyzePane mount to build "open
+    // on Hub" links. Returning a non-empty string keeps the upload
+    // panel rendering without forcing every test to override.
+    hubGetOrigin: () => Promise.resolve('https://pipette-hub-test.example'),
+    openExternal: () => Promise.resolve(undefined),
   },
   writable: true,
 })

--- a/src/renderer/components/analyze/analyze-thumbnail.ts
+++ b/src/renderer/components/analyze/analyze-thumbnail.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Generate a JPEG (base64) thumbnail card for Hub Analytics uploads.
+// Renders a small composition with the keyboard name + timestamp +
+// keystroke count on a canvas — keeps the thumbnail step
+// self-contained (no html2canvas / PDF detour) so the upload UX stays
+// responsive even on a slow machine.
+//
+// Hub displays the thumbnail at ~16:9 in the post grid, so the canvas
+// is sized to match the favorite/keymap thumbnails and exports as
+// JPEG (quality 0.85).
+
+const CANVAS_WIDTH = 800
+const CANVAS_HEIGHT = 450
+
+export interface AnalyzeThumbnailInput {
+  keyboardName: string
+  /** Local-time formatted "YYYY-MM-DD HH:mm" range. The dialog already
+   * has `formatDateTime` output handy from the live filter row. */
+  rangeLabel: string
+  /** Total keystrokes from the upload preview. Shown alongside range so
+   * the post grid card communicates "how big this dataset is" before
+   * the user clicks through. */
+  totalKeystrokes: number
+  /** Hub deviceScope label ("All devices" / "Own" / a hash). Optional. */
+  deviceLabel?: string
+}
+
+/**
+ * Returns the JPEG base64 string (no `data:` prefix). Throws if the
+ * canvas 2D context is unavailable (off-DOM or test runner without
+ * canvas mocks).
+ */
+export function generateAnalyzeThumbnail(input: AnalyzeThumbnailInput): string {
+  const canvas = document.createElement('canvas')
+  canvas.width = CANVAS_WIDTH
+  canvas.height = CANVAS_HEIGHT
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2D context unavailable')
+
+  // Background — slate gradient gives a recognisable Pipette look
+  // without needing a logo asset bundled.
+  const grad = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT)
+  grad.addColorStop(0, '#0f172a')
+  grad.addColorStop(1, '#1e293b')
+  ctx.fillStyle = grad
+  ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT)
+
+  // Accent stripe — narrow band along the top so the post grid can
+  // tell analytics posts apart from keymap posts at a glance.
+  ctx.fillStyle = '#0ea5e9'
+  ctx.fillRect(0, 0, CANVAS_WIDTH, 6)
+
+  // Title
+  ctx.fillStyle = '#e2e8f0'
+  ctx.font = 'bold 44px sans-serif'
+  ctx.fillText('Analytics', 48, 96)
+
+  // Keyboard name
+  ctx.fillStyle = '#cbd5e1'
+  ctx.font = 'bold 30px sans-serif'
+  ctx.fillText(truncate(ctx, input.keyboardName, CANVAS_WIDTH - 96), 48, 152)
+
+  // Period + device
+  ctx.fillStyle = '#94a3b8'
+  ctx.font = '22px sans-serif'
+  ctx.fillText(input.rangeLabel, 48, 220)
+  if (input.deviceLabel) {
+    ctx.fillText(input.deviceLabel, 48, 252)
+  }
+
+  // Big keystroke count — visually anchors the card the way the post
+  // grid expects (something distinctive to scan).
+  ctx.fillStyle = '#f1f5f9'
+  ctx.font = 'bold 64px sans-serif'
+  const formatted = input.totalKeystrokes.toLocaleString()
+  ctx.fillText(formatted, 48, 380)
+  ctx.fillStyle = '#94a3b8'
+  ctx.font = '22px sans-serif'
+  ctx.fillText('keystrokes', 48, 410)
+
+  return canvas
+    .toDataURL('image/jpeg', 0.85)
+    .replace(/^data:image\/jpeg;base64,/, '')
+}
+
+function truncate(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {
+  if (ctx.measureText(text).width <= maxWidth) return text
+  let lo = 0
+  let hi = text.length
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2)
+    if (ctx.measureText(`${text.slice(0, mid)}…`).width <= maxWidth) lo = mid
+    else hi = mid - 1
+  }
+  return `${text.slice(0, lo)}…`
+}

--- a/src/renderer/hooks/useAnalyzeFilterStore.ts
+++ b/src/renderer/hooks/useAnalyzeFilterStore.ts
@@ -6,7 +6,7 @@
 // the renderer-only AnalysisTab key — main only stores the JSON
 // opaquely.
 
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   ANALYZE_FILTER_STORE_ERROR_MAX_ENTRIES,
@@ -15,6 +15,12 @@ import {
 } from '../../shared/types/analyze-filter-store'
 import type { AnalysisTabKey, RangeMs } from '../components/analyze/analyze-types'
 import type { AnalyzeFiltersState } from './useAnalyzeFilters'
+import type {
+  HubAnalyticsCategoryId,
+  HubAnalyticsLayoutComparisonInputs,
+} from '../../shared/types/hub'
+import type { HubEntryResult } from '../components/editors/layout-store-types'
+import { localizeHubError } from '../utils/hub-error-i18n'
 
 /** Serialized snapshot payload. `version` lets us evolve the shape
  * later without losing already-saved entries — readers should bail out
@@ -42,12 +48,46 @@ export interface UseAnalyzeFilterStoreOptions {
   uid: string | null
 }
 
+/** Per-call inputs for the Hub upload pipeline. The hook stays
+ * decoupled from AnalyzePane state — the caller assembles the bits the
+ * IPC needs (keyboard meta, finger overrides, optional layout
+ * comparison maps, thumbnail, category picks) and the hook drives the
+ * round-trip + the panel's status flash. */
+export interface UploadAnalyticsToHubInput {
+  entryId: string
+  title: string
+  thumbnailBase64: string
+  keyboard: { productName: string; vendorId: number; productId: number }
+  fingerOverrides: Record<string, string>
+  layoutComparisonInputs: HubAnalyticsLayoutComparisonInputs | null
+  /** User's category selection from the upload modal. Empty / absent
+   * ships everything (back-compat with the early build). */
+  categories?: HubAnalyticsCategoryId[]
+}
+
+const HUB_RESULT_FLASH_MS = 4_000
+
 export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
   const { t } = useTranslation()
   const [entries, setEntries] = useState<AnalyzeFilterSnapshotMeta[]>([])
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [loading, setLoading] = useState(false)
+  // Mirrors useHubState's flash pattern: which entry is mid-upload, and
+  // the last upload's success/failure with the entry id stamped on it
+  // so the panel can show the row-local status banner.
+  const [hubUploading, setHubUploading] = useState<string | null>(null)
+  const [hubUploadResult, setHubUploadResult] = useState<HubEntryResult | null>(null)
+  const hubResultTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const hubInflightRef = useRef(false)
+
+  const flashHubResult = useCallback((result: HubEntryResult) => {
+    setHubUploadResult(result)
+    if (hubResultTimerRef.current) clearTimeout(hubResultTimerRef.current)
+    hubResultTimerRef.current = setTimeout(() => {
+      setHubUploadResult((current) => current === result ? null : current)
+    }, HUB_RESULT_FLASH_MS)
+  }, [])
 
   const refreshEntries = useCallback(async () => {
     // Clear first so a uid switch doesn't briefly show the prior
@@ -146,6 +186,126 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
     }
   }, [uid, refreshEntries])
 
+  const uploadEntryToHub = useCallback(async (input: UploadAnalyticsToHubInput): Promise<{ ok: boolean }> => {
+    if (!uid || hubInflightRef.current) return { ok: false }
+    hubInflightRef.current = true
+    setHubUploading(input.entryId)
+    let ok = false
+    try {
+      const result = await window.vialAPI.hubUploadAnalyticsPost({
+        uid,
+        entryId: input.entryId,
+        title: input.title,
+        thumbnailBase64: input.thumbnailBase64,
+        keyboard: input.keyboard,
+        fingerOverrides: input.fingerOverrides,
+        layoutComparisonInputs: input.layoutComparisonInputs,
+        categories: input.categories,
+      })
+      if (result.success && result.postId) {
+        ok = true
+        flashHubResult({ kind: 'success', message: t('hub.uploadSuccess'), entryId: input.entryId })
+        await refreshEntries()
+      } else {
+        flashHubResult({
+          kind: 'error',
+          message: localizeHubError(result.error, 'hub.uploadFailed', t),
+          entryId: input.entryId,
+        })
+      }
+    } catch (err) {
+      flashHubResult({
+        kind: 'error',
+        message: localizeHubError(err instanceof Error ? err.message : undefined, 'hub.uploadFailed', t),
+        entryId: input.entryId,
+      })
+    } finally {
+      hubInflightRef.current = false
+      setHubUploading(null)
+    }
+    return { ok }
+  }, [uid, refreshEntries, t, flashHubResult])
+
+  const updateEntryOnHub = useCallback(async (input: UploadAnalyticsToHubInput): Promise<{ ok: boolean }> => {
+    if (!uid || hubInflightRef.current) return { ok: false }
+    const entry = entries.find((e) => e.id === input.entryId)
+    const postId = entry?.hubPostId
+    if (!entry || !postId) {
+      flashHubResult({ kind: 'error', message: t('hub.updateFailed'), entryId: input.entryId })
+      return { ok: false }
+    }
+    hubInflightRef.current = true
+    setHubUploading(input.entryId)
+    let ok = false
+    try {
+      const result = await window.vialAPI.hubUpdateAnalyticsPost({
+        uid,
+        entryId: input.entryId,
+        title: input.title,
+        thumbnailBase64: input.thumbnailBase64,
+        keyboard: input.keyboard,
+        fingerOverrides: input.fingerOverrides,
+        layoutComparisonInputs: input.layoutComparisonInputs,
+        categories: input.categories,
+        postId,
+      })
+      if (result.success) {
+        ok = true
+        flashHubResult({ kind: 'success', message: t('hub.updateSuccess'), entryId: input.entryId })
+        await refreshEntries()
+      } else {
+        flashHubResult({
+          kind: 'error',
+          message: localizeHubError(result.error, 'hub.updateFailed', t),
+          entryId: input.entryId,
+        })
+      }
+    } catch (err) {
+      flashHubResult({
+        kind: 'error',
+        message: localizeHubError(err instanceof Error ? err.message : undefined, 'hub.updateFailed', t),
+        entryId: input.entryId,
+      })
+    } finally {
+      hubInflightRef.current = false
+      setHubUploading(null)
+    }
+    return { ok }
+  }, [uid, entries, refreshEntries, t, flashHubResult])
+
+  // Local-only "remove from Hub" — clears the saved entry's hubPostId
+  // metadata so the row reverts to the upload state. We don't issue a
+  // Hub DELETE here today (the Hub-side delete endpoint is the user's
+  // responsibility on the Hub site); this matches the analyze panel's
+  // narrower scope vs. the keymap save panel.
+  const removeEntryFromHub = useCallback(async (entryId: string): Promise<void> => {
+    if (!uid || hubInflightRef.current) return
+    hubInflightRef.current = true
+    setHubUploading(entryId)
+    try {
+      const result = await window.vialAPI.analyzeFilterStoreSetHubPostId(uid, entryId, null)
+      if (result.success) {
+        flashHubResult({ kind: 'success', message: t('hub.removeSuccess'), entryId })
+        await refreshEntries()
+      } else {
+        flashHubResult({
+          kind: 'error',
+          message: localizeHubError(result.error, 'hub.removeFailed', t),
+          entryId,
+        })
+      }
+    } catch (err) {
+      flashHubResult({
+        kind: 'error',
+        message: localizeHubError(err instanceof Error ? err.message : undefined, 'hub.removeFailed', t),
+        entryId,
+      })
+    } finally {
+      hubInflightRef.current = false
+      setHubUploading(null)
+    }
+  }, [uid, refreshEntries, t, flashHubResult])
+
   return {
     entries,
     error,
@@ -156,5 +316,10 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
     loadSnapshot,
     renameEntry,
     deleteEntry,
+    hubUploading,
+    hubUploadResult,
+    uploadEntryToHub,
+    updateEntryOnHub,
+    removeEntryFromHub,
   }
 }

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -1422,7 +1422,25 @@
     "displayNameRequired": "Required to upload to Hub",
     "authDisplayNameConflict": "Your Google account name conflicts with an existing display name. Please choose a different display name to continue.",
     "accountDeactivated": "Your account has been deactivated. Please contact support for assistance.",
-    "rateLimited": "Too many requests. Please try again later."
+    "rateLimited": "Too many requests. Please try again later.",
+    "error": {
+      "keystrokesBelow": "Not enough keystrokes recorded for this period (at least 100 are required).",
+      "rangeExceeds": "The selected period is longer than 30 days. Pick a shorter range and save the condition again.",
+      "unsupportedVersion": "This export was written by a newer version of Pipette and the Hub cannot read it. Please update the Hub.",
+      "kindMismatch": "The export payload is not an analytics post.",
+      "invalidPayload": "The Hub rejected the upload because the payload was invalid.",
+      "malformedPayload": "The Hub rejected the upload because some chart data was missing or in the wrong shape.",
+      "entryNotFound": "The saved condition no longer exists. Refresh the panel and try again.",
+      "malformedSavedPayload": "The saved condition file is corrupt and cannot be uploaded.",
+      "unsupportedSavedVersion": "The saved condition was written by a newer version of Pipette and cannot be uploaded.",
+      "noRange": "The saved condition does not have a time range — re-save it from the Analyze view first.",
+      "noSnapshot": "No keymap snapshot was recorded for this period. Type with the keyboard for a moment and try again.",
+      "invalidId": "The saved condition could not be identified. Refresh the panel and try again.",
+      "titleEmpty": "Title is required.",
+      "titleTooLong": "Title is too long (max 200 characters).",
+      "authFailed": "Authentication with the Hub failed. Sign out and back in, then retry.",
+      "payloadTooLarge": "The payload is too large to upload. Pick fewer chart categories or shorten the range."
+    }
   },
   "notification": {
     "title": "Notifications",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -1420,7 +1420,25 @@
     "displayNameRequired": "Hub へのアップロードに必要です",
     "authDisplayNameConflict": "Googleアカウント名が既存の投稿者名と重複しています。別の投稿者名を設定してください。",
     "accountDeactivated": "アカウントが無効化されています。サポートにお問い合わせください。",
-    "rateLimited": "リクエストが多すぎます。しばらくしてからもう一度お試しください。"
+    "rateLimited": "リクエストが多すぎます。しばらくしてからもう一度お試しください。",
+    "error": {
+      "keystrokesBelow": "この期間の打鍵数が足りません（100 打鍵以上が必要です）。",
+      "rangeExceeds": "選択した期間が 30 日を超えています。期間を短くして条件を保存し直してください。",
+      "unsupportedVersion": "新しいバージョンの Pipette で書き出されたデータのため Hub が読み込めません。Hub をアップデートしてください。",
+      "kindMismatch": "ペイロードが analytics 投稿ではありません。",
+      "invalidPayload": "ペイロードが不正なため Hub にアップロードできませんでした。",
+      "malformedPayload": "チャートデータの一部が欠けているか不正な形式のため Hub にアップロードできませんでした。",
+      "entryNotFound": "保存された条件が見つかりません。パネルを更新してから再試行してください。",
+      "malformedSavedPayload": "保存された条件ファイルが壊れているためアップロードできません。",
+      "unsupportedSavedVersion": "新しいバージョンの Pipette で保存された条件のためアップロードできません。",
+      "noRange": "保存された条件に期間情報がありません。Analyze 画面から保存し直してください。",
+      "noSnapshot": "この期間に対応するキーマップスナップショットがありません。少しキーボードを使ってから再試行してください。",
+      "invalidId": "保存された条件を特定できませんでした。パネルを更新してから再試行してください。",
+      "titleEmpty": "タイトルは必須です。",
+      "titleTooLong": "タイトルが長すぎます（200 文字以内）。",
+      "authFailed": "Hub の認証に失敗しました。一度サインアウトして再度サインインしてください。",
+      "payloadTooLarge": "ペイロードが大きすぎてアップロードできません。送信するチャートを減らすか期間を短くしてください。"
+    }
   },
   "notification": {
     "title": "お知らせ",

--- a/src/renderer/utils/__tests__/hub-error-i18n.test.ts
+++ b/src/renderer/utils/__tests__/hub-error-i18n.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Direct coverage for the renderer-side Hub error → i18n key mapping.
+// Stubs out the t() function with an identity returning the key, so
+// the assertions verify the *mapping* without dragging the live i18n
+// resource bundle into the test.
+
+import { describe, it, expect } from 'vitest'
+import {
+  HUB_ERROR_ACCOUNT_DEACTIVATED,
+  HUB_ERROR_RATE_LIMITED,
+} from '../../../shared/types/hub'
+import { localizeHubError } from '../hub-error-i18n'
+
+const tIdentity = ((k: string) => k) as unknown as Parameters<typeof localizeHubError>[2]
+
+describe('localizeHubError', () => {
+  it('returns the fallback key when raw is undefined / empty', () => {
+    expect(localizeHubError(undefined, 'hub.uploadFailed', tIdentity)).toBe('hub.uploadFailed')
+    expect(localizeHubError('', 'hub.uploadFailed', tIdentity)).toBe('hub.uploadFailed')
+  })
+
+  it('maps server sentinels to the dedicated key', () => {
+    expect(localizeHubError(HUB_ERROR_ACCOUNT_DEACTIVATED, 'hub.uploadFailed', tIdentity)).toBe('hub.accountDeactivated')
+    expect(localizeHubError(HUB_ERROR_RATE_LIMITED, 'hub.uploadFailed', tIdentity)).toBe('hub.rateLimited')
+  })
+
+  it('maps prepareAnalyticsExport rejections to user-readable copy', () => {
+    expect(localizeHubError('Saved filter entry not found', 'hub.uploadFailed', tIdentity)).toBe('hub.error.entryNotFound')
+    expect(localizeHubError('No keymap snapshot recorded for this range', 'hub.uploadFailed', tIdentity)).toBe('hub.error.noSnapshot')
+    expect(localizeHubError('Saved filter has no range', 'hub.uploadFailed', tIdentity)).toBe('hub.error.noRange')
+    expect(localizeHubError('Invalid uid', 'hub.uploadFailed', tIdentity)).toBe('hub.error.invalidId')
+    expect(localizeHubError('Invalid post ID', 'hub.uploadFailed', tIdentity)).toBe('hub.error.invalidId')
+  })
+
+  it('decodes INVALID_PAYLOAD reasons embedded inside HubHttpError bodies', () => {
+    const raw = 'Hub analytics upload failed: 400 {"ok":false,"error":"INVALID_PAYLOAD: keystrokes below threshold"}'
+    expect(localizeHubError(raw, 'hub.uploadFailed', tIdentity)).toBe('hub.error.keystrokesBelow')
+  })
+
+  it('handles each known INVALID_PAYLOAD reason', () => {
+    const cases: Array<[string, string]> = [
+      ['INVALID_PAYLOAD: keystrokes below threshold', 'hub.error.keystrokesBelow'],
+      ['INVALID_PAYLOAD: range exceeds 30 days', 'hub.error.rangeExceeds'],
+      ['INVALID_PAYLOAD: unsupported version', 'hub.error.unsupportedVersion'],
+      ['INVALID_PAYLOAD: kind mismatch', 'hub.error.kindMismatch'],
+      ['INVALID_PAYLOAD: minuteStats must be array', 'hub.error.malformedPayload'],
+      ['INVALID_PAYLOAD: bigramTop must be array', 'hub.error.malformedPayload'],
+      ['INVALID_PAYLOAD: peakRecords must be an object', 'hub.error.invalidPayload'],
+    ]
+    for (const [raw, key] of cases) {
+      expect(localizeHubError(raw, 'hub.uploadFailed', tIdentity)).toBe(key)
+    }
+  })
+
+  it('classifies HTTP status codes that the Hub server returns', () => {
+    expect(localizeHubError('Hub analytics upload failed: 401 Unauthorized', 'hub.uploadFailed', tIdentity)).toBe('hub.error.authFailed')
+    expect(localizeHubError('Hub analytics upload failed: 403 forbidden', 'hub.uploadFailed', tIdentity)).toBe('hub.accountDeactivated')
+    expect(localizeHubError('Hub analytics upload failed: 413 too large', 'hub.uploadFailed', tIdentity)).toBe('hub.error.payloadTooLarge')
+    expect(localizeHubError('Hub analytics upload failed: 429 slow down', 'hub.uploadFailed', tIdentity)).toBe('hub.rateLimited')
+  })
+
+  it('falls back to the supplied key for unrecognised strings', () => {
+    expect(localizeHubError('Some other error', 'hub.updateFailed', tIdentity)).toBe('hub.updateFailed')
+    expect(localizeHubError('network unreachable', 'hub.removeFailed', tIdentity)).toBe('hub.removeFailed')
+  })
+})

--- a/src/renderer/utils/hub-error-i18n.ts
+++ b/src/renderer/utils/hub-error-i18n.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Renderer-side mapper from raw Hub error strings to i18n keys.
+// Hub errors arrive at the renderer in three shapes:
+//
+//   1. Bare sentinel constants for "well-known" auth/quota issues
+//      (e.g. `HUB_ERROR_ACCOUNT_DEACTIVATED`, `HUB_ERROR_RATE_LIMITED`).
+//   2. Formatted HubHttpError strings from `hub-client.ts`:
+//      `<label>: <status> <body>` (e.g. `"Hub analytics upload failed:
+//      400 {\"ok\":false,\"error\":\"INVALID_PAYLOAD: keystrokes
+//      below threshold\"}"`).
+//   3. Plain main-process validation strings (`"Saved filter entry
+//      not found"`, `"No keymap snapshot recorded for this range"` …).
+//
+// Surfacing the raw text in the UI bleeds backend phrasing and JSON
+// punctuation into a user-facing modal — this helper recognises the
+// known patterns and rewrites them to localised messages, falling
+// back to the caller-supplied default for unknown shapes.
+
+import type { TFunction } from 'i18next'
+import {
+  HUB_ERROR_ACCOUNT_DEACTIVATED,
+  HUB_ERROR_DISPLAY_NAME_CONFLICT,
+  HUB_ERROR_RATE_LIMITED,
+} from '../../shared/types/hub'
+
+/** INVALID_PAYLOAD reasons the Hub server emits and the i18n key each
+ * one maps to. Listed explicitly so the renderer's localisation can't
+ * silently miss a new validation case — adding a server-side reason
+ * without a row here falls back to the generic `invalidPayload` key. */
+const INVALID_PAYLOAD_KEYS: Array<[reason: string, key: string]> = [
+  ['keystrokes below threshold', 'hub.error.keystrokesBelow'],
+  ['range exceeds 30 days', 'hub.error.rangeExceeds'],
+  ['unsupported version', 'hub.error.unsupportedVersion'],
+  ['kind mismatch', 'hub.error.kindMismatch'],
+]
+
+/** Bare main-process / server sentinels (no formatting around them). */
+const SENTINEL_KEYS: Record<string, string> = {
+  [HUB_ERROR_ACCOUNT_DEACTIVATED]: 'hub.accountDeactivated',
+  [HUB_ERROR_RATE_LIMITED]: 'hub.rateLimited',
+  [HUB_ERROR_DISPLAY_NAME_CONFLICT]: 'hub.displayNameTaken',
+  // Main-side prepareAnalyticsExport rejections.
+  'Saved filter entry not found': 'hub.error.entryNotFound',
+  'Saved filter payload is not valid JSON': 'hub.error.malformedSavedPayload',
+  'Unsupported saved filter version': 'hub.error.unsupportedSavedVersion',
+  'Saved filter has no range': 'hub.error.noRange',
+  'No keymap snapshot recorded for this range': 'hub.error.noSnapshot',
+  'Invalid uid': 'hub.error.invalidId',
+  'Invalid entryId': 'hub.error.invalidId',
+  'Invalid post ID': 'hub.error.invalidId',
+  'Title must not be empty': 'hub.error.titleEmpty',
+  'Title too long': 'hub.error.titleTooLong',
+}
+
+/** Any HubHttpError string contains `: <status> <body>`. We match the
+ * status to a localised category before falling through to the generic
+ * upload/update fallback. */
+const STATUS_KEY_BY_CODE: Record<string, string> = {
+  '401': 'hub.error.authFailed',
+  '403': 'hub.accountDeactivated',
+  '413': 'hub.error.payloadTooLarge',
+  '429': 'hub.rateLimited',
+}
+
+const INVALID_PAYLOAD_PREFIX = 'INVALID_PAYLOAD:'
+/** Matches the body that hub-client.ts wraps every HubHttpError in. */
+const HUB_HTTP_RE = /:\s+(\d{3})(?:\s|$)/
+
+/**
+ * Convert a raw error string from main into a localised user-facing
+ * message. `fallbackKey` is the i18n key used when no pattern matches
+ * (typically `hub.uploadFailed` / `hub.updateFailed`).
+ */
+export function localizeHubError(
+  raw: string | undefined,
+  fallbackKey: string,
+  t: TFunction,
+): string {
+  if (!raw) return t(fallbackKey)
+
+  // Sentinel constant or a bare prepareAnalyticsExport message.
+  const sentinelKey = SENTINEL_KEYS[raw]
+  if (sentinelKey) return t(sentinelKey)
+
+  // Hub-server `INVALID_PAYLOAD: <reason>` — search the raw string so
+  // we also catch cases where the validator nested it inside the
+  // formatted `Hub analytics upload failed: 400 {"ok":false,
+  // "error":"INVALID_PAYLOAD: ..."}` body.
+  const invalidIdx = raw.indexOf(INVALID_PAYLOAD_PREFIX)
+  if (invalidIdx !== -1) {
+    const tail = raw.slice(invalidIdx + INVALID_PAYLOAD_PREFIX.length).trim()
+    for (const [reason, key] of INVALID_PAYLOAD_KEYS) {
+      if (tail.startsWith(reason)) return t(key)
+    }
+    // `<field> must be array` covers ten different fields — collapse
+    // them rather than enumerate each one.
+    if (/ must be array/.test(tail)) return t('hub.error.malformedPayload')
+    return t('hub.error.invalidPayload')
+  }
+
+  // HubHttpError: `Label: <status> <body>` — look up the status code
+  // first because 401 / 403 / 413 / 429 each have specific copy.
+  const httpMatch = HUB_HTTP_RE.exec(raw)
+  if (httpMatch) {
+    const code = httpMatch[1]
+    const statusKey = STATUS_KEY_BY_CODE[code]
+    if (statusKey) return t(statusKey)
+  }
+
+  return t(fallbackKey)
+}

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -193,8 +193,16 @@ export const IpcChannels = {
   HUB_UPLOAD_FAVORITE_POST: 'hub:upload-favorite-post',
   HUB_UPDATE_FAVORITE_POST: 'hub:update-favorite-post',
 
+  // Hub Analytics posts
+  HUB_UPLOAD_ANALYTICS_POST: 'hub:upload-analytics-post',
+  HUB_UPDATE_ANALYTICS_POST: 'hub:update-analytics-post',
+  HUB_PREVIEW_ANALYTICS_POST: 'hub:preview-analytics-post',
+
   // Favorite Store extensions
   FAVORITE_STORE_SET_HUB_POST_ID: 'favorite-store:set-hub-post-id',
+
+  // Analyze Filter Store extensions
+  ANALYZE_FILTER_STORE_SET_HUB_POST_ID: 'analyze-filter-store:set-hub-post-id',
 
   // Key Label Store (renderer → main → renderer)
   KEY_LABEL_STORE_LIST: 'key-label-store:list',

--- a/src/shared/types/analyze-filter-store.ts
+++ b/src/shared/types/analyze-filter-store.ts
@@ -16,6 +16,11 @@ export interface AnalyzeFilterSnapshotMeta {
   savedAt: string // ISO 8601
   updatedAt?: string
   deletedAt?: string // tombstone
+  /** Pipette Hub post id once the saved snapshot has been uploaded as
+   * an analytics post. Absent / null means "not on Hub yet"; the panel
+   * uses this to switch the row's primary action between
+   * "↑ Hub" (initial upload) and "↻ Hub" (update). */
+  hubPostId?: string
 }
 
 export interface AnalyzeFilterSnapshotIndex {

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -101,3 +101,195 @@ export interface HubUploadFavoritePostParams {
 export interface HubUpdateFavoritePostParams extends HubUploadFavoritePostParams {
   postId: string
 }
+
+// --- Analytics post types ---
+//
+// Wire format for "Analyze 集計データ" uploads. The full contract lives in
+// `.claude/docs/HUB-ANALYTICS-API.md` (Hub agent's source of truth). The
+// types below mirror that contract; the validators in
+// `src/main/hub/hub-analytics.ts` enforce the runtime invariants.
+
+/** Hub-side `analytics-export-v1.json` payload. */
+export interface HubAnalyticsExportV1 {
+  version: 1
+  kind: 'analytics'
+  exportedAt: string
+  snapshot: HubAnalyticsSnapshot
+  filters: HubAnalyticsFilters
+  data: HubAnalyticsData
+}
+
+export interface HubAnalyticsSnapshot {
+  keyboard: {
+    uid: string
+    productName: string
+    vendorId: number
+    productId: number
+  }
+  /** `'all'` / `'own'` / `{ kind: 'hash', machineHash }` — must match the
+   * `DeviceScope` shape used by the Analyze panel. */
+  deviceScope: 'all' | 'own' | { kind: 'hash'; machineHash: string }
+  /** Snapshot of the active keymap at upload time. The exact shape is
+   * `TypingKeymapSnapshot` (re-stated here so the Hub side does not
+   * need to import the typing-analytics types directly). */
+  keymapSnapshot: {
+    savedAt: number
+    productName: string
+    layers: number
+    matrix: { rows: number; cols: number }
+    keymap: string[][][]
+    layout: unknown
+  }
+  range: { fromMs: number; toMs: number }
+  totalKeystrokes: number
+  appScopes: string[]
+}
+
+/** Initial-value hints for the Hub's display controls. The Hub UI is
+ * free to override every field — this is the value the desktop user
+ * had selected when the post was uploaded. */
+export interface HubAnalyticsFilters {
+  analysisTab: string
+  heatmap?: Record<string, unknown>
+  wpm?: Record<string, unknown>
+  interval?: Record<string, unknown>
+  activity?: Record<string, unknown>
+  layer?: Record<string, unknown>
+  ergonomics?: Record<string, unknown>
+  bigrams: { topLimit: 10; slowLimit: 10; fingerLimit: 20; pairIntervalThresholdMs?: number }
+  layoutComparison?: Record<string, unknown>
+  fingerOverrides?: Record<string, string>
+}
+
+/** Pre-aggregated chart data. Each array section is required; empty
+ * arrays mean "no rows for this tab". Hub-side validators reject
+ * missing keys with `<field> must be array`. */
+export interface HubAnalyticsData {
+  minuteStats: Array<{
+    minuteMs: number
+    keystrokes: number
+    activeMs: number
+    intervalMinMs: number | null
+    intervalP25Ms: number | null
+    intervalP50Ms: number | null
+    intervalP75Ms: number | null
+    intervalMaxMs: number | null
+  }>
+  matrixCells: Array<{ layer: number; row: number; col: number; count: number; tap: number; hold: number }>
+  matrixCellsByDay: Array<{ dayMs: number; layer: number; row: number; col: number; count: number; tap: number; hold: number }>
+  layerUsage: Array<{ layer: number; keystrokes: number }>
+  sessions: Array<{ id: string; startMs: number; endMs: number }>
+  bksMinute: Array<{ minuteMs: number; backspaceCount: number }>
+  bigramTop: Array<{ bigramId: string; count: number; hist: number[]; avgIki: number | null }>
+  bigramSlow: Array<{ bigramId: string; count: number; hist: number[]; avgIki: number | null; p95: number | null }>
+  appUsage: Array<{ name: string; keystrokes: number; activeMs: number }>
+  wpmByApp: Array<{ name: string; keystrokes: number; activeMs: number }>
+  peakRecords: {
+    peakWpm: { value: number; atMs: number } | null
+    lowestWpm: { value: number; atMs: number } | null
+    peakKeystrokesPerMin: { value: number; atMs: number } | null
+    peakKeystrokesPerDay: { value: number; day: string } | null
+    longestSession: { durationMs: number; startedAtMs: number } | null
+  }
+  layoutComparison: {
+    sourceLayoutId: string
+    targets: Array<{
+      layoutId: string
+      totalEvents: number
+      skippedEvents: number
+      skipRate: number
+      fingerLoad?: Record<string, number>
+      unmappedFinger?: number
+      handBalance?: { left: number; right: number }
+      rowDist?: Record<string, number>
+      homeRowStay?: number
+      cellCounts?: Record<string, number>
+    }>
+  } | null
+}
+
+/** Layout Comparison inputs the renderer pre-resolves from
+ * `LAYOUT_BY_ID` / key-label-store before triggering the upload. Main
+ * does not have access to the renderer-side keyboard layout catalog,
+ * so we cross the IPC boundary with the resolved maps + KleKey
+ * geometry already in hand. `null` skips the comparison entirely. */
+export interface HubAnalyticsLayoutComparisonInputs {
+  source: { id: string; map: Record<string, string> }
+  target: { id: string; map: Record<string, string> }
+  /** Subset of metrics the live chart computed; an empty array is fine
+   * (Hub still gets totalEvents + skipRate). */
+  metrics: string[]
+  /** Pre-parsed KleKey geometry from `snapshot.layout`. The renderer
+   * already has this for the live chart. Typed as `unknown[]` here so
+   * the shared types module stays decoupled from KLE internals; the
+   * main-side handler casts to `KleKey[]`. */
+  kleKeys: unknown[]
+  /** Layer to read source labels from. Defaults to 0 main-side. */
+  layer?: number
+}
+
+/** Per-tab toggles the renderer ships with the upload IPC. Mirrors the
+ * AnalyzeExportModal's category set so the user's "what to ship"
+ * choice maps 1:1 between CSV export and Hub upload. Each entry is
+ * the modal category id (`heatmap`, `wpm`, `interval`, `activity`,
+ * `ergonomics`, `bigrams`, `layoutComparison`, `layer`). Sections not
+ * in the set are skipped at fetch time and ship as empty arrays — the
+ * Hub side already renders empty arrays as the per-tab empty state. */
+export type HubAnalyticsCategoryId =
+  | 'heatmap' | 'wpm' | 'interval' | 'activity'
+  | 'ergonomics' | 'bigrams' | 'layoutComparison' | 'layer'
+
+/** Renderer → main upload trigger. The handler reads the saved entry
+ * from analyze-filter-store, builds the export, and uploads. The
+ * renderer pre-fetches the inputs main can't reach (snapshot keyboard
+ * meta, layout comparison maps, thumbnail capture, finger overrides)
+ * and passes them in. */
+export interface HubUploadAnalyticsPostParams {
+  uid: string
+  entryId: string
+  title: string
+  /** JPEG thumbnail base64 string. Same encoding the keymap upload
+   * already uses. */
+  thumbnailBase64: string
+  /** Keyboard meta resolved from `typingAnalyticsListKeyboards()`. */
+  keyboard: { productName: string; vendorId: number; productId: number }
+  /** Per-cell finger assignments the live Ergonomics chart uses. The
+   * renderer reads these from `pipetteSettingsGet(uid).analyze.
+   * fingerAssignments` so the Hub upload mirrors the user's current
+   * mapping. Empty / absent ships `{}`. */
+  fingerOverrides: Record<string, string>
+  /** Optional Layout Comparison inputs (`null` ships
+   * `data.layoutComparison: null`). */
+  layoutComparisonInputs: HubAnalyticsLayoutComparisonInputs | null
+  /** User's category picks from the upload modal. Absent / undefined
+   * ships every category (back-compat with the early build that did
+   * not surface the picker). */
+  categories?: HubAnalyticsCategoryId[]
+}
+
+export interface HubUpdateAnalyticsPostParams extends HubUploadAnalyticsPostParams {
+  postId: string
+}
+
+/** Pre-flight payload for the upload dialog. Mirrors the upload
+ * params minus the thumbnail (the dialog does not need to capture the
+ * screenshot until the user confirms). */
+export interface HubPreviewAnalyticsPostParams {
+  uid: string
+  entryId: string
+  keyboard: { productName: string; vendorId: number; productId: number }
+  fingerOverrides: Record<string, string>
+  layoutComparisonInputs: HubAnalyticsLayoutComparisonInputs | null
+}
+
+/** Renderer-side preview shown before the user confirms the upload —
+ * the dialog checks the validation and the byte size without paying
+ * for the network round-trip. */
+export interface HubAnalyticsPreview {
+  totalKeystrokes: number
+  rangeMs: number
+  estimatedBytes: number
+  validation:
+    | { ok: true }
+    | { ok: false; reason: string }
+}

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -45,7 +45,7 @@ import type {
   TypingBigramAggregateView,
 } from './typing-analytics'
 import type { LanguageListEntry } from './language-store'
-import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubFetchMyPostsParams, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams } from './hub'
+import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubFetchMyPostsParams, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams, HubUploadAnalyticsPostParams, HubUpdateAnalyticsPostParams, HubPreviewAnalyticsPostParams, HubAnalyticsPreview } from './hub'
 import type { NotificationFetchResult } from './notification'
 
 export interface VialAPI {
@@ -314,8 +314,16 @@ export interface VialAPI {
   hubUploadFavoritePost(params: HubUploadFavoritePostParams): Promise<HubUploadResult>
   hubUpdateFavoritePost(params: HubUpdateFavoritePostParams): Promise<HubUploadResult>
 
+  // Hub Analytics posts
+  hubUploadAnalyticsPost(params: HubUploadAnalyticsPostParams): Promise<HubUploadResult>
+  hubUpdateAnalyticsPost(params: HubUpdateAnalyticsPostParams): Promise<HubUploadResult>
+  hubPreviewAnalyticsPost(params: HubPreviewAnalyticsPostParams): Promise<{ success: boolean; preview?: HubAnalyticsPreview; error?: string }>
+
   // Favorite Store extensions
   favoriteStoreSetHubPostId(type: FavoriteType, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }>
+
+  // Analyze Filter Store extensions
+  analyzeFilterStoreSetHubPostId(uid: string, entryId: string, hubPostId: string | null): Promise<{ success: boolean; error?: string }>
 
   // Window management
   setWindowCompactMode(enabled: boolean, compactSize?: { width: number; height: number }): Promise<{ width: number; height: number } | null>


### PR DESCRIPTION
## Summary

- Wires the Analyze save panel's saved search conditions to Pipette Hub via a new "Hub" row that mirrors the keymap save panel (Upload / Update / Remove + share link). Click Upload / Update opens the existing AnalyzeExportModal in `mode='upload'` so the user picks which chart categories to ship and confirms with the shared modal UI.
- Adds main-side `buildAnalyticsExport` + IPC handlers (upload / update / preview), validators (>= 100 keystrokes, <= 30 days), category-aware fetchers, and an analytics-specific multipart hub-client. The Hub-side contract is in [`pipette-desktop/.claude/docs/HUB-ANALYTICS-API.md`](.claude/docs/HUB-ANALYTICS-API.md); this PR is the desktop-side implementation.
- Replaces the raw `Hub analytics upload failed: 400 …` error strings in the UI with `localizeHubError` — covers `INVALID_PAYLOAD: <reason>`, sentinel constants, prepareAnalyticsExport rejections, and HTTP status codes (401 / 403 / 413 / 429) in en.json and ja.json.

## Test plan

- [ ] `pnpm test` passes (195 files / 3806 tests)
- [ ] `pnpm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Manual: open Analyze, save a condition, click "Upload" on the row → modal opens in upload mode → toggle categories → click Upload → row flashes "Uploaded" / Hub URL share link appears
- [ ] Manual: try uploading with < 100 keystrokes → row shows the localised "Not enough keystrokes" message instead of the raw 400 body
- [ ] Manual: click "Update" on a previously uploaded entry → modal opens with "Update" button → confirms via the update IPC
- [ ] Manual: click "Remove" → confirm flow clears `hubPostId` locally