### PR TITLE
feat(ui): analyze save panel overwrite + always-Summary on Load/Upload

### DIFF
--- a/src/main/__tests__/hub-ipc-analytics.test.ts
+++ b/src/main/__tests__/hub-ipc-analytics.test.ts
@@ -241,6 +241,32 @@ describe('HUB_UPLOAD_ANALYTICS_POST', () => {
     })
   })
 
+  it('pins the Hub initial-tab hint to summary even when the saved payload had a different tab', async () => {
+    // Saved condition was authored on the bigrams tab; the Hub hint
+    // should still come back as 'summary' so the post detail page
+    // lands on the at-a-glance Summary view (mirrors the local Load
+    // behaviour).
+    vi.mocked(readAnalyzeFilterEntry).mockResolvedValueOnce({
+      entry: {
+        id: 'entry-1',
+        label: 'My filter',
+        filename: 'entry-1.json',
+        savedAt: '2026-05-04T00:00:00.000Z',
+      },
+      data: JSON.stringify({
+        version: 1,
+        analysisTab: 'bigrams',
+        range: { fromMs: 1_700_000_000_000, toMs: 1_700_000_000_000 + 86_400_000 },
+        filters: { deviceScopes: ['all'], appScopes: [] },
+      }),
+    })
+    mockHubAuth()
+    const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)
+    await handler({}, uploadParams())
+    const call = vi.mocked(buildAnalyticsExport).mock.calls[0][0]
+    expect(call.filters.analysisTab).toBe('summary')
+  })
+
   it('refuses to upload when the saved entry is missing', async () => {
     vi.mocked(readAnalyzeFilterEntry).mockResolvedValueOnce(null)
     const handler = getHandler(IpcChannels.HUB_UPLOAD_ANALYTICS_POST)

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -245,7 +245,12 @@ function projectFiltersForHub(
     ? f.bigrams.pairIntervalThresholdMs
     : undefined
   return {
-    analysisTab: typeof payload.analysisTab === 'string' ? payload.analysisTab : 'summary',
+    // Always pin the Hub initial-tab hint to Summary so the post
+    // detail page lands on the at-a-glance view regardless of which
+    // tab was open when the saved condition was uploaded. Mirrors the
+    // local Load behaviour (handleLoadFilterSnapshot) which also
+    // forces Summary.
+    analysisTab: 'summary',
     heatmap: f.heatmap,
     wpm: f.wpm,
     interval: f.interval,

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -38,6 +38,12 @@ interface Props {
    * success, null on failure (so the caller can keep the input visible
    * for retry). */
   onSave: (label: string) => Promise<string | null>
+  /** Overwrite an existing entry that already has the same label. The
+   * panel asks the user to confirm before invoking this — same flow
+   * as the keymap save panel (`LayoutStoreContent`). When omitted the
+   * duplicate-label submit falls back to delete + onSave so the panel
+   * still works without a dedicated overwrite path. */
+  onOverwriteSave?: (entryId: string, label: string) => Promise<string | null>
   onLoad: (entryId: string) => Promise<boolean>
   onRename: (entryId: string, newLabel: string) => Promise<boolean>
   onDelete: (entryId: string) => Promise<boolean>
@@ -70,6 +76,7 @@ export function AnalyzeFilterStorePanel({
   saving,
   loading,
   onSave,
+  onOverwriteSave,
   onLoad,
   onRename,
   onDelete,
@@ -82,22 +89,61 @@ export function AnalyzeFilterStorePanel({
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [confirmHubRemoveId, setConfirmHubRemoveId] = useState<string | null>(null)
+  // Mirrors LayoutStoreContent's overwrite flow — first submit with a
+  // duplicate label sets this to the existing id and the submit button
+  // swaps to "Overwrite?" + Cancel; second submit calls onOverwriteSave
+  // (or falls back to delete + save when the parent didn't supply
+  // one). The id is cleared on input change so a retypeit re-runs the
+  // duplicate detection from scratch.
+  const [confirmOverwriteId, setConfirmOverwriteId] = useState<string | null>(null)
   const [showSaved, setShowSaved] = useState(false)
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   useEffect(() => () => clearTimeout(savedTimerRef.current), [])
 
+  const flashSaved = (): void => {
+    setSaveLabel('')
+    setShowSaved(true)
+    clearTimeout(savedTimerRef.current)
+    savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000)
+  }
+
   const handleSaveSubmit = async (e: React.FormEvent): Promise<void> => {
     e.preventDefault()
     const trimmed = saveLabel.trim()
     if (saving || !trimmed) return
-    const id = await onSave(trimmed)
-    if (id) {
-      setSaveLabel('')
-      setShowSaved(true)
-      clearTimeout(savedTimerRef.current)
-      savedTimerRef.current = setTimeout(() => setShowSaved(false), 2000)
+
+    // First submit with a duplicate label — ask for confirmation.
+    const existing = entries.find((entry) => entry.label === trimmed)
+    if (existing && !confirmOverwriteId) {
+      setConfirmOverwriteId(existing.id)
+      return
     }
+
+    // Second submit (confirmed overwrite).
+    if (confirmOverwriteId) {
+      const overwriteId = confirmOverwriteId
+      setConfirmOverwriteId(null)
+      if (onOverwriteSave) {
+        const id = await onOverwriteSave(overwriteId, trimmed)
+        if (id) flashSaved()
+        return
+      }
+      // No dedicated overwrite path — delete + save so the panel still
+      // works, accepting that hubPostId association would be lost.
+      await onDelete(overwriteId)
+    }
+
+    const id = await onSave(trimmed)
+    if (id) flashSaved()
+  }
+
+  const handleSaveLabelChange = (value: string): void => {
+    setSaveLabel(value)
+    // Editing the input invalidates a pending overwrite confirmation
+    // so the user doesn't accidentally overwrite a different entry by
+    // tweaking the label after triggering the prompt.
+    if (confirmOverwriteId) setConfirmOverwriteId(null)
   }
 
   const commitRename = async (entryId: string): Promise<void> => {
@@ -137,20 +183,41 @@ export function AnalyzeFilterStorePanel({
                 <input
                   type="text"
                   value={saveLabel}
-                  onChange={(e) => setSaveLabel(e.target.value)}
+                  onChange={(e) => handleSaveLabelChange(e.target.value)}
                   placeholder={t('common.labelPlaceholder')}
                   maxLength={200}
                   className="flex-1 rounded-lg border border-edge bg-surface px-3 py-1.5 text-xs text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
                   data-testid="analyze-filter-store-save-input"
                 />
-                <button
-                  type="submit"
-                  disabled={saving || !saveLabel.trim()}
-                  className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent/90 disabled:opacity-50"
-                  data-testid="analyze-filter-store-save-submit"
-                >
-                  {t('common.save')}
-                </button>
+                {confirmOverwriteId ? (
+                  <>
+                    <button
+                      type="submit"
+                      disabled={saving}
+                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-white hover:bg-danger/90 disabled:opacity-50"
+                      data-testid="analyze-filter-store-overwrite-confirm"
+                    >
+                      {t('analyzeFilterStore.confirmOverwrite')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmOverwriteId(null)}
+                      className="shrink-0 rounded-lg border border-edge px-3 py-1.5 text-xs font-medium text-content-muted hover:text-content"
+                      data-testid="analyze-filter-store-overwrite-cancel"
+                    >
+                      {t('common.cancel')}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="submit"
+                    disabled={saving || !saveLabel.trim()}
+                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent/90 disabled:opacity-50"
+                    data-testid="analyze-filter-store-save-submit"
+                  >
+                    {t('common.save')}
+                  </button>
+                )}
               </form>
               <div className="mt-2 flex items-center gap-1">
                 {showSaved && (

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -712,7 +712,12 @@ export function AnalyzePane({
     async (entryId: string): Promise<boolean> => {
       const payload = await filterStore.loadSnapshot(entryId)
       if (!payload) return false
-      setAnalysisTab(payload.analysisTab)
+      // Always land on Summary regardless of which tab was active when
+      // the condition was saved — the user opened the panel to inspect
+      // the loaded slice, and Summary is the at-a-glance entry point.
+      // The payload still carries `analysisTab` because the Hub upload
+      // uses it as an initial-tab hint on the post detail page.
+      setAnalysisTab('summary')
       setRange(payload.range)
       setDeviceScopes(payload.filters.deviceScopes)
       setAppScopes(payload.filters.appScopes)

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -643,47 +643,69 @@ export function AnalyzePane({
     void refreshFilterEntries()
   }, [refreshFilterEntries])
 
+  // Shared payload + summary build for both the save and overwrite
+  // entry points so the two stay byte-for-byte identical (the saved
+  // entry shape is what `useAnalyzeFilters` reads back on Load — any
+  // drift between the two writers would silently corrupt the loaded
+  // state).
+  const buildFilterSnapshotPayload = useCallback((): {
+    payload: AnalyzeFilterSnapshotPayload
+    summary: string | undefined
+  } => {
+    const payload: AnalyzeFilterSnapshotPayload = {
+      version: 1,
+      analysisTab,
+      range,
+      filters: {
+        deviceScopes,
+        appScopes,
+        heatmap: heatmapFilter,
+        wpm: wpmFilter,
+        interval: intervalFilter,
+        activity: activityFilter,
+        layer: layerFilter,
+        ergonomics: ergonomicsFilter,
+        bigrams: bigramsFilter,
+        layoutComparison: layoutComparisonFilter,
+      },
+    }
+    // Comma-separated condition values shown under the saved entry's
+    // label so the user can recognise it without loading the full
+    // snapshot. Built from `exportCtx` which already memoises the same
+    // user-visible labels the filter row renders. Keyboard name is
+    // omitted because the store is already scoped per keyboard.
+    const summary = exportCtx
+      ? [
+          exportCtx.conditions.device,
+          exportCtx.conditions.app,
+          exportCtx.conditions.keymap,
+          exportCtx.conditions.range,
+        ].filter(Boolean).join(', ')
+      : undefined
+    return { payload, summary }
+  }, [
+    analysisTab, range,
+    deviceScopes, appScopes, heatmapFilter, wpmFilter, intervalFilter,
+    activityFilter, layerFilter, ergonomicsFilter, bigramsFilter,
+    layoutComparisonFilter, exportCtx,
+  ])
+
   const handleSaveFilterSnapshot = useCallback(
     async (label: string): Promise<string | null> => {
       if (!selectedUid) return null
-      const payload: AnalyzeFilterSnapshotPayload = {
-        version: 1,
-        analysisTab,
-        range,
-        filters: {
-          deviceScopes,
-          appScopes,
-          heatmap: heatmapFilter,
-          wpm: wpmFilter,
-          interval: intervalFilter,
-          activity: activityFilter,
-          layer: layerFilter,
-          ergonomics: ergonomicsFilter,
-          bigrams: bigramsFilter,
-          layoutComparison: layoutComparisonFilter,
-        },
-      }
-      // Comma-separated condition values shown under the saved entry's
-      // label so the user can recognise it without loading the full
-      // snapshot. Built from `exportCtx` which already memoises the same
-      // user-visible labels the filter row renders. Keyboard name is
-      // omitted because the store is already scoped per keyboard.
-      const summary = exportCtx
-        ? [
-            exportCtx.conditions.device,
-            exportCtx.conditions.app,
-            exportCtx.conditions.keymap,
-            exportCtx.conditions.range,
-          ].filter(Boolean).join(', ')
-        : undefined
+      const { payload, summary } = buildFilterSnapshotPayload()
       return filterStore.saveSnapshot(label, payload, summary)
     },
-    [
-      selectedUid, analysisTab, range,
-      deviceScopes, appScopes, heatmapFilter, wpmFilter, intervalFilter,
-      activityFilter, layerFilter, ergonomicsFilter, bigramsFilter,
-      layoutComparisonFilter, filterStore, exportCtx,
-    ],
+    [selectedUid, buildFilterSnapshotPayload, filterStore],
+  )
+
+  const handleOverwriteFilterSnapshot = useCallback(
+    async (entryId: string, label: string): Promise<string | null> => {
+      if (!selectedUid) return null
+      const { payload, summary } = buildFilterSnapshotPayload()
+      return filterStore.overwriteSnapshot(entryId, label, payload, summary)
+    },
+    [selectedUid, buildFilterSnapshotPayload, filterStore],
   )
 
   const handleLoadFilterSnapshot = useCallback(
@@ -1455,6 +1477,7 @@ export function AnalyzePane({
               saving={filterStore.saving}
               loading={filterStore.loading}
               onSave={handleSaveFilterSnapshot}
+              onOverwriteSave={handleOverwriteFilterSnapshot}
               onLoad={handleLoadFilterSnapshot}
               onRename={filterStore.renameEntry}
               onDelete={filterStore.deleteEntry}

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -715,8 +715,10 @@ export function AnalyzePane({
       // Always land on Summary regardless of which tab was active when
       // the condition was saved — the user opened the panel to inspect
       // the loaded slice, and Summary is the at-a-glance entry point.
-      // The payload still carries `analysisTab` because the Hub upload
-      // uses it as an initial-tab hint on the post detail page.
+      // The Hub upload pipeline pins its `filters.analysisTab` to
+      // Summary too (see hub-ipc.projectFiltersForHub), so the saved
+      // `analysisTab` field is effectively unused today. We keep it on
+      // the payload for forward-compat in case per-tab Load comes back.
       setAnalysisTab('summary')
       setRange(payload.range)
       setDeviceScopes(payload.filters.deviceScopes)

--- a/src/renderer/components/analyze/__tests__/AnalyzeFilterStorePanel-overwrite.test.tsx
+++ b/src/renderer/components/analyze/__tests__/AnalyzeFilterStorePanel-overwrite.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Coverage for the duplicate-name overwrite flow on the analyze save
+// panel. Mirrors LayoutStoreContent's pattern: first submit detects a
+// duplicate label and switches the submit button to "Overwrite?" +
+// Cancel; second submit invokes onOverwriteSave (or falls back to
+// delete + save when no overwrite handler is wired in).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '../../../../../src/renderer/__tests__/setup'
+import { I18nextProvider } from 'react-i18next'
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import en from '../../../i18n/locales/en.json'
+
+import { AnalyzeFilterStorePanel } from '../AnalyzeFilterStorePanel'
+import type { AnalyzeFilterSnapshotMeta } from '../../../../shared/types/analyze-filter-store'
+
+if (!i18n.isInitialized) {
+  void i18n.use(initReactI18next).init({
+    lng: 'en',
+    fallbackLng: 'en',
+    resources: { en: { translation: en } },
+    interpolation: { escapeValue: false },
+  })
+}
+
+const ENTRIES: AnalyzeFilterSnapshotMeta[] = [
+  { id: 'entry-1', label: 'Daily', filename: 'a.json', savedAt: '2026-05-01T00:00:00.000Z' },
+  { id: 'entry-2', label: 'Weekly', filename: 'b.json', savedAt: '2026-05-02T00:00:00.000Z' },
+]
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof AnalyzeFilterStorePanel>> = {}) {
+  const props: React.ComponentProps<typeof AnalyzeFilterStorePanel> = {
+    uidSelected: true,
+    entries: ENTRIES,
+    saving: false,
+    loading: false,
+    onSave: vi.fn(async () => 'new-id'),
+    onOverwriteSave: vi.fn(async () => 'new-id'),
+    onLoad: vi.fn(async () => true),
+    onRename: vi.fn(async () => true),
+    onDelete: vi.fn(async () => true),
+    onExportCurrentCsv: null,
+    onExportEntryCsv: null,
+    hubActions: null,
+    ...overrides,
+  }
+  const utils = render(
+    <I18nextProvider i18n={i18n}>
+      <AnalyzeFilterStorePanel {...props} />
+    </I18nextProvider>,
+  )
+  return { ...utils, props }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('AnalyzeFilterStorePanel overwrite flow', () => {
+  it('shows the Save button by default', () => {
+    renderPanel()
+    expect(screen.getByTestId('analyze-filter-store-save-submit')).toBeInTheDocument()
+    expect(screen.queryByTestId('analyze-filter-store-overwrite-confirm')).toBeNull()
+  })
+
+  it('switches to Overwrite? + Cancel when the typed label matches an existing entry', () => {
+    renderPanel()
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Daily' } })
+    fireEvent.submit(input.closest('form')!)
+    expect(screen.queryByTestId('analyze-filter-store-save-submit')).toBeNull()
+    expect(screen.getByTestId('analyze-filter-store-overwrite-confirm')).toHaveTextContent('Overwrite')
+    expect(screen.getByTestId('analyze-filter-store-overwrite-cancel')).toBeInTheDocument()
+  })
+
+  it('invokes onOverwriteSave with the existing entry id when the user confirms', async () => {
+    const { props } = renderPanel()
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Daily' } })
+    fireEvent.submit(input.closest('form')!)
+    fireEvent.click(screen.getByTestId('analyze-filter-store-overwrite-confirm'))
+    await waitFor(() => expect(props.onOverwriteSave).toHaveBeenCalledTimes(1))
+    expect(props.onOverwriteSave).toHaveBeenCalledWith('entry-1', 'Daily')
+    expect(props.onSave).not.toHaveBeenCalled()
+  })
+
+  it('falls back to onDelete + onSave when no onOverwriteSave is provided', async () => {
+    const { props } = renderPanel({ onOverwriteSave: undefined })
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Daily' } })
+    fireEvent.submit(input.closest('form')!)
+    fireEvent.click(screen.getByTestId('analyze-filter-store-overwrite-confirm'))
+    await waitFor(() => expect(props.onDelete).toHaveBeenCalledWith('entry-1'))
+    await waitFor(() => expect(props.onSave).toHaveBeenCalledWith('Daily'))
+  })
+
+  it('cancels the overwrite when the Cancel button is clicked', () => {
+    renderPanel()
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Daily' } })
+    fireEvent.submit(input.closest('form')!)
+    fireEvent.click(screen.getByTestId('analyze-filter-store-overwrite-cancel'))
+    expect(screen.getByTestId('analyze-filter-store-save-submit')).toBeInTheDocument()
+    expect(screen.queryByTestId('analyze-filter-store-overwrite-confirm')).toBeNull()
+  })
+
+  it('clears the pending overwrite confirmation when the user edits the label', () => {
+    renderPanel()
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Daily' } })
+    fireEvent.submit(input.closest('form')!)
+    expect(screen.getByTestId('analyze-filter-store-overwrite-confirm')).toBeInTheDocument()
+    fireEvent.change(input, { target: { value: 'Daily 2' } })
+    expect(screen.queryByTestId('analyze-filter-store-overwrite-confirm')).toBeNull()
+    expect(screen.getByTestId('analyze-filter-store-save-submit')).toBeInTheDocument()
+  })
+
+  it('saves directly when the typed label is unique', async () => {
+    const { props } = renderPanel()
+    const input = screen.getByTestId('analyze-filter-store-save-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Brand new' } })
+    fireEvent.submit(input.closest('form')!)
+    await waitFor(() => expect(props.onSave).toHaveBeenCalledWith('Brand new'))
+    expect(props.onOverwriteSave).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/__tests__/useAnalyzeFilterStore-overwrite.test.ts
+++ b/src/renderer/hooks/__tests__/useAnalyzeFilterStore-overwrite.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Focused coverage for the analyze save panel's "overwrite same name"
+// flow. Mirrors the keymap save panel's `useHubState.handleOverwriteSave`
+// behaviour: delete the existing entry, save a fresh one with the same
+// label, and re-stamp the prior `hubPostId` so the Hub link survives.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAnalyzeFilterStore } from '../useAnalyzeFilterStore'
+import type { AnalyzeFilterSnapshotPayload } from '../useAnalyzeFilterStore'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+const PAYLOAD: AnalyzeFilterSnapshotPayload = {
+  version: 1,
+  analysisTab: 'summary',
+  range: { fromMs: 0, toMs: 86_400_000 },
+  filters: {
+    deviceScopes: ['own'],
+    appScopes: [],
+    heatmap: {},
+    wpm: {},
+    interval: {},
+    activity: { calendar: {} },
+    layer: {},
+    ergonomics: {},
+    bigrams: {},
+    layoutComparison: { targetLayoutId: null },
+  } as unknown as AnalyzeFilterSnapshotPayload['filters'],
+}
+
+const mockList = vi.fn()
+const mockSave = vi.fn()
+const mockDelete = vi.fn()
+const mockSetHubPostId = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).vialAPI = {
+    ...((window as { vialAPI?: object }).vialAPI ?? {}),
+    analyzeFilterStoreList: mockList,
+    analyzeFilterStoreSave: mockSave,
+    analyzeFilterStoreLoad: vi.fn(),
+    analyzeFilterStoreUpdate: vi.fn(),
+    analyzeFilterStoreRename: vi.fn(),
+    analyzeFilterStoreDelete: mockDelete,
+    analyzeFilterStoreSetHubPostId: mockSetHubPostId,
+  }
+})
+
+describe('useAnalyzeFilterStore.overwriteSnapshot', () => {
+  it('deletes the existing entry then saves a fresh one with the same label', async () => {
+    mockList.mockResolvedValue({
+      success: true,
+      entries: [{ id: 'old-id', label: 'My Filter', filename: 'old.json', savedAt: '2026-01-01T00:00:00.000Z' }],
+    })
+    mockDelete.mockResolvedValue({ success: true })
+    mockSave.mockResolvedValue({
+      success: true,
+      entry: { id: 'new-id', label: 'My Filter', filename: 'new.json', savedAt: '2026-05-04T00:00:00.000Z' },
+    })
+
+    const { result } = renderHook(() => useAnalyzeFilterStore({ uid: 'kb-1' }))
+    await act(async () => { await result.current.refreshEntries() })
+
+    let returned: string | null = null
+    await act(async () => {
+      returned = await result.current.overwriteSnapshot('old-id', 'My Filter', PAYLOAD, 'cond summary')
+    })
+
+    expect(returned).toBe('new-id')
+    expect(mockDelete).toHaveBeenCalledWith('kb-1', 'old-id')
+    expect(mockSave).toHaveBeenCalledWith(
+      'kb-1',
+      JSON.stringify(PAYLOAD, null, 2),
+      'My Filter',
+      'cond summary',
+    )
+    // No hubPostId to migrate — the setHubPostId IPC stays untouched.
+    expect(mockSetHubPostId).not.toHaveBeenCalled()
+  })
+
+  it('re-stamps the prior hubPostId on the new entry so the Hub link survives', async () => {
+    mockList.mockResolvedValue({
+      success: true,
+      entries: [{
+        id: 'old-id',
+        label: 'Hub Filter',
+        filename: 'old.json',
+        savedAt: '2026-01-01T00:00:00.000Z',
+        hubPostId: 'post-xyz',
+      }],
+    })
+    mockDelete.mockResolvedValue({ success: true })
+    mockSave.mockResolvedValue({
+      success: true,
+      entry: { id: 'new-id', label: 'Hub Filter', filename: 'new.json', savedAt: '2026-05-04T00:00:00.000Z' },
+    })
+    mockSetHubPostId.mockResolvedValue({ success: true })
+
+    const { result } = renderHook(() => useAnalyzeFilterStore({ uid: 'kb-1' }))
+    await act(async () => { await result.current.refreshEntries() })
+
+    await act(async () => {
+      await result.current.overwriteSnapshot('old-id', 'Hub Filter', PAYLOAD)
+    })
+
+    expect(mockSetHubPostId).toHaveBeenCalledWith('kb-1', 'new-id', 'post-xyz')
+  })
+
+  it('returns null + reports an error when the underlying delete fails', async () => {
+    mockList.mockResolvedValue({
+      success: true,
+      entries: [{ id: 'old-id', label: 'X', filename: 'old.json', savedAt: '' }],
+    })
+    mockDelete.mockResolvedValue({ success: false, error: 'IO error' })
+
+    const { result } = renderHook(() => useAnalyzeFilterStore({ uid: 'kb-1' }))
+    await act(async () => { await result.current.refreshEntries() })
+
+    let returned: string | null = 'sentinel'
+    await act(async () => {
+      returned = await result.current.overwriteSnapshot('old-id', 'X', PAYLOAD)
+    })
+
+    expect(returned).toBeNull()
+    expect(mockSave).not.toHaveBeenCalled()
+    expect(result.current.error).toBe('analyzeFilterStore.saveFailed')
+  })
+
+  it('treats max-entries reached after delete as a save failure (defensive — should not normally fire)', async () => {
+    mockList.mockResolvedValue({
+      success: true,
+      entries: [{ id: 'old-id', label: 'X', filename: 'old.json', savedAt: '' }],
+    })
+    mockDelete.mockResolvedValue({ success: true })
+    mockSave.mockResolvedValue({ success: false, error: 'max entries reached' })
+
+    const { result } = renderHook(() => useAnalyzeFilterStore({ uid: 'kb-1' }))
+    await act(async () => { await result.current.refreshEntries() })
+
+    let returned: string | null = 'sentinel'
+    await act(async () => {
+      returned = await result.current.overwriteSnapshot('old-id', 'X', PAYLOAD)
+    })
+
+    expect(returned).toBeNull()
+    expect(result.current.error).toBe('analyzeFilterStore.maxEntriesReached')
+  })
+
+  it('returns null without invoking IPCs when uid is null', async () => {
+    const { result } = renderHook(() => useAnalyzeFilterStore({ uid: null }))
+    let returned: string | null = 'sentinel'
+    await act(async () => {
+      returned = await result.current.overwriteSnapshot('old-id', 'X', PAYLOAD)
+    })
+    expect(returned).toBeNull()
+    expect(mockDelete).not.toHaveBeenCalled()
+    expect(mockSave).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/hooks/useAnalyzeFilterStore.ts
+++ b/src/renderer/hooks/useAnalyzeFilterStore.ts
@@ -131,6 +131,56 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
     }
   }, [uid, refreshEntries, t])
 
+  /** Overwrite an existing entry while preserving its `hubPostId` so
+   * the user's Hub link stays valid after the rewrite. Implemented as
+   * delete + re-save to mirror the keymap save panel
+   * (`useHubState.handleOverwriteSave`) — that approach refreshes
+   * `summary` + `savedAt` automatically and lets us re-stamp the
+   * postId on the freshly created entry. */
+  const overwriteSnapshot = useCallback(async (
+    entryId: string,
+    label: string,
+    payload: AnalyzeFilterSnapshotPayload,
+    summary?: string,
+  ): Promise<string | null> => {
+    if (!uid) return null
+    setError(null)
+    const previous = entries.find((e) => e.id === entryId)
+    const previousHubPostId = previous?.hubPostId
+    setSaving(true)
+    try {
+      const deleteResult = await window.vialAPI.analyzeFilterStoreDelete(uid, entryId)
+      if (!deleteResult.success) {
+        setError(t('analyzeFilterStore.saveFailed'))
+        return null
+      }
+      const json = JSON.stringify(payload, null, 2)
+      const saveResult = await window.vialAPI.analyzeFilterStoreSave(uid, json, label, summary)
+      if (!saveResult.success || !saveResult.entry) {
+        setError(saveResult.error === ANALYZE_FILTER_STORE_ERROR_MAX_ENTRIES
+          ? t('analyzeFilterStore.maxEntriesReached', { max: ANALYZE_FILTER_STORE_MAX_ENTRIES_PER_KEYBOARD })
+          : t('analyzeFilterStore.saveFailed'))
+        return null
+      }
+      const newEntryId = saveResult.entry.id
+      // Re-stamp the hubPostId so the Hub row keeps showing the same
+      // post id after the in-place overwrite. Best-effort: a failure
+      // here just downgrades to "row reverts to Upload affordance",
+      // not a save failure.
+      if (previousHubPostId) {
+        await window.vialAPI.analyzeFilterStoreSetHubPostId(uid, newEntryId, previousHubPostId)
+          .catch(() => { /* leave the row without a hub link rather than block the save */ })
+      }
+      await refreshEntries()
+      return newEntryId
+    } catch {
+      setError(t('analyzeFilterStore.saveFailed'))
+      return null
+    } finally {
+      setSaving(false)
+    }
+  }, [uid, entries, refreshEntries, t])
+
   const loadSnapshot = useCallback(async (
     entryId: string,
   ): Promise<AnalyzeFilterSnapshotPayload | null> => {
@@ -313,6 +363,7 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
     loading,
     refreshEntries,
     saveSnapshot,
+    overwriteSnapshot,
     loadSnapshot,
     renameEntry,
     deleteEntry,

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -520,7 +520,8 @@
     "maxEntriesReached": "Maximum saved conditions reached ({{max}}). Delete an existing entry to save a new one.",
     "csv": ".csv",
     "syncedCount": "Synced: {{count}}",
-    "empty": "No saved conditions yet."
+    "empty": "No saved conditions yet.",
+    "confirmOverwrite": "Overwrite?"
   },
   "sync": {
     "title": "Settings",

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -518,7 +518,8 @@
     "maxEntriesReached": "保存可能な上限 ({{max}}件) に達しました。古い条件を削除してください。",
     "csv": ".csv",
     "syncedCount": "同期データ: {{count}}",
-    "empty": "保存された検索条件はありません"
+    "empty": "保存された検索条件はありません",
+    "confirmOverwrite": "上書きしますか？"
   },
   "sync": {
     "title": "設定",


### PR DESCRIPTION
## Summary

- Adds the keymap save panel's "duplicate-name overwrite" flow to the analyze save panel: typing an existing label swaps the Save button to a danger-styled "Overwrite?" + Cancel pair, and a second submit calls onOverwriteSave (delete + re-save under the hood, with the prior `hubPostId` re-stamped on the new entry so the Hub link survives).
- Loading a saved condition now always lands on Summary regardless of which tab was active when the condition was saved — Summary is the at-a-glance entry point.
- Hub upload pins `filters.analysisTab` to Summary too, so the Hub post detail page mirrors the local Load behaviour.

## Test plan

- [ ] `pnpm test` passes (197 files / 3818 tests)
- [ ] `pnpm run lint` passes
- [ ] `npx tsc --noEmit` passes
- [ ] Manual: save a condition, then save again with the same label → "Overwrite?" prompt appears → confirm → entry is replaced (savedAt updates, hubPostId preserved if the entry was on Hub)
- [ ] Manual: Cancel from the overwrite prompt → button reverts to Save without modifying the entry
- [ ] Manual: edit the input after the prompt appears → confirmation auto-clears
- [ ] Manual: open a saved condition while on the Bigrams tab → panel reopens on Summary
- [ ] Manual: upload a saved condition that was authored on Heatmap tab → Hub post detail page opens on Summary