### PR TITLE
feat(hub): multi-target layout comparison upload

### DIFF
--- a/src/main/hub/__tests__/hub-analytics.test.ts
+++ b/src/main/hub/__tests__/hub-analytics.test.ts
@@ -205,7 +205,7 @@ describe('buildAnalyticsExport', () => {
       ...baseInput(),
       layoutComparisonInputs: {
         source: { id: 'qwerty', map: { 'KC_A': 'a' } },
-        target: { id: 'colemak', map: { 'KC_A': 'a' } },
+        targets: [{ id: 'colemak', map: { 'KC_A': 'a' } }],
         metrics: [],
         kleKeys: [],
       },

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -331,7 +331,7 @@ async function computeLayoutComparisonForExport(
     machineHash,
     appScopes,
   )
-  return computeLayoutComparison({
+  const result = computeLayoutComparison({
     matrixCounts,
     snapshot,
     kleKeys: inputs.kleKeys,
@@ -340,6 +340,12 @@ async function computeLayoutComparisonForExport(
     metrics: inputs.metrics,
     layer,
   })
+  const nameById = new Map(inputs.targets.map((t) => [t.id, t.name]))
+  for (const target of result.targets) {
+    const name = nameById.get(target.layoutId)
+    if (name) target.layoutName = name
+  }
+  return result
 }
 
 export type AnalyticsValidationResult =

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -95,7 +95,7 @@ export interface BuildAnalyticsExportInput {
    * comparison and ships `data.layoutComparison: null`. */
   layoutComparisonInputs: {
     source: LayoutComparisonInputLayout
-    target: LayoutComparisonInputLayout
+    targets: LayoutComparisonInputLayout[]
     metrics: LayoutComparisonMetric[]
     /** KleKey geometry parsed from `snapshot.layout`. The renderer is
      * better positioned to do this — it already does it for the live
@@ -336,7 +336,7 @@ async function computeLayoutComparisonForExport(
     snapshot,
     kleKeys: inputs.kleKeys,
     source: inputs.source,
-    targets: [inputs.target],
+    targets: inputs.targets,
     metrics: inputs.metrics,
     layer,
   })

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -159,7 +159,7 @@ async function prepareAnalyticsExport(
   const layoutComparisonInputs: BuildAnalyticsExportInput['layoutComparisonInputs'] = layoutInputs
     ? {
         source: layoutInputs.source,
-        target: layoutInputs.target,
+        targets: layoutInputs.targets,
         metrics: filterValidLayoutMetrics(layoutInputs.metrics),
         kleKeys: layoutInputs.kleKeys as KleKey[],
         layer: layoutInputs.layer,

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -10,12 +10,14 @@
 // where the timestamps are local-time YYYYMMDDHHmm so the user can
 // see at a glance which range a file covers without reopening it.
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import type { TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
 import type { HeatmapFilters, LayoutComparisonFilters } from '../../../shared/types/analyze-filters'
-import { LAYOUT_BY_ID } from '../../data/keyboard-layouts'
+import { KEYBOARD_LAYOUTS, LAYOUT_BY_ID } from '../../data/keyboard-layouts'
+import { useKeyLabels } from '../../hooks/useKeyLabels'
+import { AnchoredPopover } from '../ui/AnchoredPopover'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { FILTER_BUTTON } from './analyze-filter-styles'
@@ -94,7 +96,7 @@ export interface AnalyzeUploadCallbacks {
   /** Confirm handler invoked with the user's category selection. The
    * parent runs the actual upload IPC and resolves with `{ ok }` so
    * the modal can decide whether to close itself. */
-  onConfirm: (categories: ReadonlySet<Category>) => Promise<{ ok: boolean }>
+  onConfirm: (categories: ReadonlySet<Category>, options?: { targetLayoutIds?: string[] }) => Promise<{ ok: boolean }>
   /** Whether the active entry already lives on Hub. Switches the
    * confirm button label between "Upload" and "Update". */
   isExisting: boolean
@@ -324,14 +326,50 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   const [selected, setSelected] = useState<Record<Category, boolean>>(allOn)
   const [exporting, setExporting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [selectedTargetIds, setSelectedTargetIds] = useState<string[]>([])
+  const [targetPickerOpen, setTargetPickerOpen] = useState(false)
+  const targetTriggerRef = useRef<HTMLButtonElement>(null)
+  const keyLabels = useKeyLabels()
 
-  // Reset toggles + error each time the modal reopens so a previous
-  // partial selection (or a stale error) doesn't carry across runs.
+  const layoutOptions = useMemo(() => {
+    const sourceId = ctx?.layoutComparison.sourceLayoutId
+    const seen = new Set<string>()
+    const out: { id: string; name: string }[] = []
+    for (const meta of keyLabels.metas) {
+      if (seen.has(meta.id) || meta.id === sourceId) continue
+      seen.add(meta.id)
+      out.push({ id: meta.id, name: meta.name })
+    }
+    for (const def of KEYBOARD_LAYOUTS) {
+      if (seen.has(def.id) || def.id === sourceId) continue
+      seen.add(def.id)
+      out.push({ id: def.id, name: def.name })
+    }
+    return out
+  }, [keyLabels.metas, ctx?.layoutComparison.sourceLayoutId])
+
+  const targetIdSet = useMemo(() => new Set(selectedTargetIds), [selectedTargetIds])
+
+  const targetButtonLabel = useMemo(() => {
+    if (selectedTargetIds.length === 0) return t('analyze.layoutComparison.noTargetOption')
+    if (selectedTargetIds.length === 1) {
+      const opt = layoutOptions.find((o) => o.id === selectedTargetIds[0])
+      return opt?.name ?? selectedTargetIds[0]
+    }
+    const first = layoutOptions.find((o) => o.id === selectedTargetIds[0])?.name ?? selectedTargetIds[0]
+    return `${first} +${selectedTargetIds.length - 1}`
+  }, [selectedTargetIds, layoutOptions, t])
+
+  const handleTargetClose = useCallback(() => setTargetPickerOpen(false), [])
+
   useEffect(() => {
     if (!isOpen) return
     setSelected(allOn())
     setError(null)
-  }, [isOpen])
+    setTargetPickerOpen(false)
+    const targetId = ctx?.layoutComparison.targetLayoutId
+    setSelectedTargetIds(targetId ? [targetId] : [])
+  }, [isOpen, ctx?.layoutComparison.targetLayoutId])
 
   useEscapeClose(onClose, isOpen)
 
@@ -340,7 +378,10 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   const isCategoryAvailable = (c: Category): boolean => {
     if (!ctx) return false
     if (REQUIRES_SNAPSHOT[c] && snapshotMissing) return false
-    if (c === 'layoutComparison' && ctx.layoutComparison.targetLayoutId === null) return false
+    if (c === 'layoutComparison') {
+      if (mode === 'upload') return true
+      return ctx.layoutComparison.targetLayoutId !== null
+    }
     return true
   }
 
@@ -349,6 +390,12 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   const handleToggle = (c: Category) => {
     if (!isCategoryAvailable(c)) return
     setSelected((prev) => ({ ...prev, [c]: !prev[c] }))
+  }
+
+  const handleTargetToggle = (id: string) => {
+    setSelectedTargetIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id],
+    )
   }
 
   const handleExport = async () => {
@@ -378,10 +425,13 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
     setError(null)
     const picked = new Set<Category>()
     for (const c of CATEGORIES) {
-      if (selected[c] && isCategoryAvailable(c)) picked.add(c)
+      if (selected[c] && isCategoryAvailable(c)) {
+        if (c === 'layoutComparison' && selectedTargetIds.length === 0) continue
+        picked.add(c)
+      }
     }
     try {
-      const result = await upload.onConfirm(picked)
+      const result = await upload.onConfirm(picked, { targetLayoutIds: selectedTargetIds })
       if (result.ok) onClose()
     } catch (err) {
       setError(err instanceof Error ? err.message : t('analyze.export.failed'))
@@ -434,27 +484,72 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
               const available = isCategoryAvailable(c)
               const active = available && selected[c]
               const specifics = ctx !== null ? specificsFor(c, ctx, t) : []
+              const showTargetPicker = c === 'layoutComparison' && mode === 'upload' && active
               return (
-                <button
-                  key={c}
-                  type="button"
-                  className={categoryRowClass(active)}
-                  aria-pressed={active}
-                  disabled={!available}
-                  onClick={() => handleToggle(c)}
-                  data-testid={`analyze-export-toggle-${c}`}
-                >
-                  <span className="text-[13px] font-semibold">
-                    {t(`analyze.export.category.${c}`)}
-                  </span>
-                  {specifics.length > 0 && (
-                    <span className="text-[11px] text-content-muted">
-                      {specifics.map((s, i) => (
-                        <span key={i} className={i === 0 ? '' : 'ml-3'}>{s}</span>
-                      ))}
+                <div key={c} className="flex flex-col">
+                  <button
+                    type="button"
+                    className={categoryRowClass(active)}
+                    aria-pressed={active}
+                    disabled={!available}
+                    onClick={() => handleToggle(c)}
+                    data-testid={`analyze-export-toggle-${c}`}
+                  >
+                    <span className="text-[13px] font-semibold">
+                      {t(`analyze.export.category.${c}`)}
                     </span>
+                    {specifics.length > 0 && !showTargetPicker && (
+                      <span className="text-[11px] text-content-muted">
+                        {specifics.map((s, i) => (
+                          <span key={i} className={i === 0 ? '' : 'ml-3'}>{s}</span>
+                        ))}
+                      </span>
+                    )}
+                  </button>
+                  {showTargetPicker && ctx !== null && (
+                    <div className="ml-3 mt-1 flex flex-col gap-1 text-[11px]">
+                      <div className="text-content-muted">
+                        {t('analyze.layoutComparison.sourceLabel')}: {LAYOUT_BY_ID.get(ctx.layoutComparison.sourceLayoutId)?.name ?? ctx.layoutComparison.sourceLayoutId}
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span className="text-content-muted">{t('analyze.layoutComparison.targetLabel')}:</span>
+                        <button
+                          ref={targetTriggerRef}
+                          type="button"
+                          className="rounded border border-edge bg-surface px-2 py-0.5 text-left text-content-secondary transition-colors hover:bg-surface-dim"
+                          onClick={() => setTargetPickerOpen((prev) => !prev)}
+                          aria-haspopup="listbox"
+                          aria-expanded={targetPickerOpen}
+                        >
+                          {targetButtonLabel}
+                        </button>
+                        <AnchoredPopover
+                          anchorRef={targetTriggerRef}
+                          open={targetPickerOpen}
+                          onClose={handleTargetClose}
+                          className="z-[60] max-h-72 min-w-[200px] overflow-y-auto rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+                          role="listbox"
+                          aria-multiselectable
+                        >
+                          {layoutOptions.map((opt) => (
+                            <label
+                              key={opt.id}
+                              className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
+                            >
+                              <input
+                                type="checkbox"
+                                className="cursor-pointer"
+                                checked={targetIdSet.has(opt.id)}
+                                onChange={() => handleTargetToggle(opt.id)}
+                              />
+                              <span className="flex-1 truncate">{opt.name}</span>
+                            </label>
+                          ))}
+                        </AnchoredPopover>
+                      </div>
+                    </div>
                   )}
-                </button>
+                </div>
               )
             })}
           </div>

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -340,16 +340,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   const isCategoryAvailable = (c: Category): boolean => {
     if (!ctx) return false
     if (REQUIRES_SNAPSHOT[c] && snapshotMissing) return false
-    // Layout Comparison also needs an explicit target — without one
-    // there is no "candidate vs current" diff to write to CSV.
-    // Upload mode currently never ships a layout comparison (the
-    // resolver pipeline lives in the renderer's LayoutComparisonView)
-    // so disable the toggle entirely for upload to make the limitation
-    // visible to the user.
-    if (c === 'layoutComparison') {
-      if (mode === 'upload') return false
-      if (ctx.layoutComparison.targetLayoutId === null) return false
-    }
+    if (c === 'layoutComparison' && ctx.layoutComparison.targetLayoutId === null) return false
     return true
   }
 

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -10,7 +10,7 @@
 // where the timestamps are local-time YYYYMMDDHHmm so the user can
 // see at a glance which range a file covers without reopening it.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import type { TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
@@ -160,6 +160,10 @@ function categoryRowClass(active: boolean): string {
     ? `${base} border-accent bg-accent/10 text-content`
     : `${base} border-edge text-content-muted hover:bg-surface-dim`
 }
+
+const TARGET_POPOVER_MAX_H = 288 // matches Tailwind max-h-72 (18rem)
+const TARGET_POPOVER_MIN_H = 120
+const VIEWPORT_EDGE_GAP = 16
 
 const DAY_MS_LOCAL = 24 * 60 * 60 * 1000
 
@@ -362,6 +366,20 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
 
   const handleTargetClose = useCallback(() => setTargetPickerOpen(false), [])
 
+  const [targetPopoverMaxH, setTargetPopoverMaxH] = useState(TARGET_POPOVER_MAX_H)
+  useLayoutEffect(() => {
+    if (!targetPickerOpen || !targetTriggerRef.current) return
+    const update = () => {
+      const rect = targetTriggerRef.current?.getBoundingClientRect()
+      if (!rect) return
+      const available = window.innerHeight - rect.bottom - VIEWPORT_EDGE_GAP
+      setTargetPopoverMaxH(Math.max(TARGET_POPOVER_MIN_H, Math.min(TARGET_POPOVER_MAX_H, available)))
+    }
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [targetPickerOpen])
+
   useEffect(() => {
     if (!isOpen) return
     setSelected(allOn())
@@ -379,7 +397,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
     if (!ctx) return false
     if (REQUIRES_SNAPSHOT[c] && snapshotMissing) return false
     if (c === 'layoutComparison') {
-      if (mode === 'upload') return true
+      if (mode === 'upload') return selectedTargetIds.length > 0
       return ctx.layoutComparison.targetLayoutId !== null
     }
     return true
@@ -484,12 +502,12 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
               const available = isCategoryAvailable(c)
               const active = available && selected[c]
               const specifics = ctx !== null ? specificsFor(c, ctx, t) : []
-              const showTargetPicker = c === 'layoutComparison' && mode === 'upload' && active
+              const showTargetPicker = c === 'layoutComparison' && mode === 'upload'
               return (
-                <div key={c} className="flex flex-col">
+                <div key={c} className={showTargetPicker ? categoryRowClass(active) : 'flex flex-col'}>
                   <button
                     type="button"
-                    className={categoryRowClass(active)}
+                    className={showTargetPicker ? 'text-left' : categoryRowClass(active)}
                     aria-pressed={active}
                     disabled={!available}
                     onClick={() => handleToggle(c)}
@@ -507,7 +525,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                     )}
                   </button>
                   {showTargetPicker && ctx !== null && (
-                    <div className="ml-3 mt-1 flex flex-col gap-1 text-[11px]">
+                    <div className="mt-1 flex flex-col gap-1 text-[11px]">
                       <div className="text-content-muted">
                         {t('analyze.layoutComparison.sourceLabel')}: {LAYOUT_BY_ID.get(ctx.layoutComparison.sourceLayoutId)?.name ?? ctx.layoutComparison.sourceLayoutId}
                       </div>
@@ -527,24 +545,26 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                           anchorRef={targetTriggerRef}
                           open={targetPickerOpen}
                           onClose={handleTargetClose}
-                          className="z-[60] max-h-72 min-w-[200px] overflow-y-auto rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+                          className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
                           role="listbox"
                           aria-multiselectable
                         >
-                          {layoutOptions.map((opt) => (
-                            <label
-                              key={opt.id}
-                              className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
-                            >
-                              <input
-                                type="checkbox"
-                                className="cursor-pointer"
-                                checked={targetIdSet.has(opt.id)}
-                                onChange={() => handleTargetToggle(opt.id)}
-                              />
-                              <span className="flex-1 truncate">{opt.name}</span>
-                            </label>
-                          ))}
+                          <div className="overflow-y-auto" style={{ maxHeight: targetPopoverMaxH }}>
+                            {layoutOptions.map((opt) => (
+                              <label
+                                key={opt.id}
+                                className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
+                              >
+                                <input
+                                  type="checkbox"
+                                  className="cursor-pointer"
+                                  checked={targetIdSet.has(opt.id)}
+                                  onChange={() => handleTargetToggle(opt.id)}
+                                />
+                                <span className="flex-1 truncate">{opt.name}</span>
+                              </label>
+                            ))}
+                          </div>
                         </AnchoredPopover>
                       </div>
                     </div>

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -98,12 +98,12 @@ function resolveLayoutComparisonInputs(
   if (targetIds.length === 0 || !snapshot) return null
   const sourceMap = lookup.getMap(filter.sourceLayoutId)
   if (!sourceMap) return null
-  const targets: Array<{ id: string; map: Record<string, string> }> = [
-    { id: filter.sourceLayoutId, map: sourceMap },
+  const targets: Array<{ id: string; name?: string; map: Record<string, string> }> = [
+    { id: filter.sourceLayoutId, name: lookup.getName(filter.sourceLayoutId), map: sourceMap },
   ]
   for (const tid of targetIds) {
     const map = lookup.getMap(tid)
-    if (map) targets.push({ id: tid, map })
+    if (map) targets.push({ id: tid, name: lookup.getName(tid), map })
   }
   if (targets.length < 2) return null
   return {

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -84,26 +84,33 @@ import { useKeyLabelLookup, type UseKeyLabelLookupReturn } from '../../hooks/use
 import type { KeyboardLayout } from '../../../shared/kle/types'
 import type { HubAnalyticsLayoutComparisonInputs } from '../../../shared/types/hub'
 
+function resolveKleKeys(snapshot: TypingKeymapSnapshot | null): unknown[] {
+  const layout = snapshot?.layout as KeyboardLayout | null
+  return layout && Array.isArray(layout.keys) ? layout.keys : []
+}
+
 function resolveLayoutComparisonInputs(
   filter: Required<LayoutComparisonFilters>,
   lookup: UseKeyLabelLookupReturn,
   snapshot: TypingKeymapSnapshot | null,
+  targetIds: string[],
 ): HubAnalyticsLayoutComparisonInputs | null {
-  const targetId = filter.targetLayoutId
-  if (targetId === null || !snapshot) return null
+  if (targetIds.length === 0 || !snapshot) return null
   const sourceMap = lookup.getMap(filter.sourceLayoutId)
-  const targetMap = lookup.getMap(targetId)
-  if (!sourceMap || !targetMap) return null
-  const layout = snapshot.layout as KeyboardLayout | null
-  const kleKeys: unknown[] = layout && Array.isArray(layout.keys) ? layout.keys : []
+  if (!sourceMap) return null
+  const targets: Array<{ id: string; map: Record<string, string> }> = [
+    { id: filter.sourceLayoutId, map: sourceMap },
+  ]
+  for (const tid of targetIds) {
+    const map = lookup.getMap(tid)
+    if (map) targets.push({ id: tid, map })
+  }
+  if (targets.length < 2) return null
   return {
     source: { id: filter.sourceLayoutId, map: sourceMap },
-    targets: [
-      { id: filter.sourceLayoutId, map: sourceMap },
-      { id: targetId, map: targetMap },
-    ],
+    targets,
     metrics: [...LAYOUT_COMPARISON_PHASE_1_METRICS],
-    kleKeys,
+    kleKeys: resolveKleKeys(snapshot),
   }
 }
 
@@ -830,9 +837,12 @@ export function AnalyzePane({
       thumbnailBase64,
       keyboard: hubKeyboard,
       fingerOverrides: fingerAssignments,
-      layoutComparisonInputs: resolveLayoutComparisonInputs(
-        layoutComparisonFilter, layoutLookup, keymapSnapshot,
-      ),
+      layoutComparisonInputs: layoutComparisonFilter.targetLayoutId !== null
+        ? resolveLayoutComparisonInputs(
+            layoutComparisonFilter, layoutLookup, keymapSnapshot,
+            [layoutComparisonFilter.targetLayoutId],
+          )
+        : null,
     }
   }, [selected, hubKeyboard, filterStore.entries, exportCtx, range, fingerAssignments,
     layoutComparisonFilter, layoutLookup, keymapSnapshot])
@@ -889,11 +899,20 @@ export function AnalyzePane({
         ? { kind: filterStore.hubUploadResult.kind, message: filterStore.hubUploadResult.message }
         : null,
       isExisting,
-      onConfirm: async (categories: ReadonlySet<string>) => {
+      onConfirm: async (categories: ReadonlySet<string>, options?: { targetLayoutIds?: string[] }) => {
         const baseInput = buildHubUploadInput(entry.id)
         if (!baseInput) return { ok: false }
+        const targetIds = options?.targetLayoutIds
+        let layoutComparisonInputs = baseInput.layoutComparisonInputs
+        if (targetIds && targetIds.length > 0) {
+          await Promise.all(targetIds.map((id) => layoutLookup.ensure(id)))
+          layoutComparisonInputs = resolveLayoutComparisonInputs(
+            layoutComparisonFilter, layoutLookup, keymapSnapshot, targetIds,
+          )
+        }
         const input = {
           ...baseInput,
+          layoutComparisonInputs,
           categories: Array.from(categories) as Parameters<typeof filterStore.uploadEntryToHub>[0]['categories'],
         }
         return isExisting
@@ -901,7 +920,8 @@ export function AnalyzePane({
           : filterStore.uploadEntryToHub(input)
       },
     }
-  }, [uploadEntryForModal, filterStore, buildHubUploadInput])
+  }, [uploadEntryForModal, filterStore, buildHubUploadInput,
+    layoutComparisonFilter, layoutLookup, keymapSnapshot])
 
   // Activity's per-tab filters render in two places: alongside Period
   // on Row 2 in split mode, or on Row 3 in single mode. Extracted so

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -31,6 +31,7 @@ import {
   WPM_VIEW_MODES,
   isAllScope,
   isHashScope,
+  type LayoutComparisonFilters,
 } from '../../../shared/types/analyze-filters'
 import type {
   ActivityCalendarMonthsToShow,
@@ -77,7 +78,34 @@ import { WpmChart } from './WpmChart'
 import { WpmByAppChart } from './WpmByAppChart'
 import { AppUsageChart } from './AppUsageChart'
 import { FILTER_LABEL, FILTER_SELECT } from './analyze-filter-styles'
+import { LAYOUT_COMPARISON_PHASE_1_METRICS } from './layout-comparison-metrics'
 import { shiftLocalMonth } from './analyze-streak-goal'
+import { useKeyLabelLookup, type UseKeyLabelLookupReturn } from '../../hooks/useKeyLabelLookup'
+import type { KeyboardLayout } from '../../../shared/kle/types'
+import type { HubAnalyticsLayoutComparisonInputs } from '../../../shared/types/hub'
+
+function resolveLayoutComparisonInputs(
+  filter: Required<LayoutComparisonFilters>,
+  lookup: UseKeyLabelLookupReturn,
+  snapshot: TypingKeymapSnapshot | null,
+): HubAnalyticsLayoutComparisonInputs | null {
+  const targetId = filter.targetLayoutId
+  if (targetId === null || !snapshot) return null
+  const sourceMap = lookup.getMap(filter.sourceLayoutId)
+  const targetMap = lookup.getMap(targetId)
+  if (!sourceMap || !targetMap) return null
+  const layout = snapshot.layout as KeyboardLayout | null
+  const kleKeys: unknown[] = layout && Array.isArray(layout.keys) ? layout.keys : []
+  return {
+    source: { id: filter.sourceLayoutId, map: sourceMap },
+    targets: [
+      { id: filter.sourceLayoutId, map: sourceMap },
+      { id: targetId, map: targetMap },
+    ],
+    metrics: [...LAYOUT_COMPARISON_PHASE_1_METRICS],
+    kleKeys,
+  }
+}
 
 const TAB_BTN_BASE =
   'rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors'
@@ -234,6 +262,7 @@ export function AnalyzePane({
     setLayoutComparison,
   } = useAnalyzeFilters(selectedUid, paneKey)
   const [keymapSnapshot, setKeymapSnapshot] = useState<TypingKeymapSnapshot | null>(null)
+  const layoutLookup = useKeyLabelLookup()
   const [snapshotLoading, setSnapshotLoading] = useState(false)
   const [snapshotSummaries, setSnapshotSummaries] = useState<TypingKeymapSnapshotSummary[]>([])
   const [summariesLoading, setSummariesLoading] = useState(false)
@@ -776,12 +805,13 @@ export function AnalyzePane({
     [selected],
   )
 
-  // Build the upload IPC input for a saved entry. Captures the
-  // thumbnail just-in-time so cancelled / never-clicked rows pay
-  // nothing for the canvas work. The title falls back to the entry's
-  // saved label so the user doesn't have to retype it. Returns null
-  // when prerequisites (selected keyboard / matching saved entry)
-  // aren't met so the modal callback can short-circuit.
+  useEffect(() => {
+    void layoutLookup.ensure(layoutComparisonFilter.sourceLayoutId)
+    if (layoutComparisonFilter.targetLayoutId !== null) {
+      void layoutLookup.ensure(layoutComparisonFilter.targetLayoutId)
+    }
+  }, [layoutLookup.ensure, layoutComparisonFilter.sourceLayoutId, layoutComparisonFilter.targetLayoutId])
+
   const buildHubUploadInput = useCallback((entryId: string) => {
     if (!selected || !hubKeyboard) return null
     const entry = filterStore.entries.find((e) => e.id === entryId)
@@ -791,9 +821,6 @@ export function AnalyzePane({
     const thumbnailBase64 = generateAnalyzeThumbnail({
       keyboardName: selected.productName,
       rangeLabel,
-      // The thumb is text-only today; the Hub-side post grid still
-      // surfaces the real keystroke total from the JSON. Skip the
-      // extra preview round-trip just for colouring the card.
       totalKeystrokes: 0,
       deviceLabel: exportCtx?.conditions.device,
     })
@@ -803,12 +830,12 @@ export function AnalyzePane({
       thumbnailBase64,
       keyboard: hubKeyboard,
       fingerOverrides: fingerAssignments,
-      // Layout Comparison upload remains a follow-up — see
-      // .claude/plans/done/Plan-hub-analytics-upload.md "Known
-      // Follow-up" notes. The Hub renders the empty-state for the tab.
-      layoutComparisonInputs: null,
+      layoutComparisonInputs: resolveLayoutComparisonInputs(
+        layoutComparisonFilter, layoutLookup, keymapSnapshot,
+      ),
     }
-  }, [selected, hubKeyboard, filterStore.entries, exportCtx, range, fingerAssignments])
+  }, [selected, hubKeyboard, filterStore.entries, exportCtx, range, fingerAssignments,
+    layoutComparisonFilter, layoutLookup, keymapSnapshot])
 
   // Open the export modal in upload mode for the given entry. Loads
   // the saved snapshot first so the modal's exportCtx (device / app /

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -216,7 +216,7 @@ export interface HubAnalyticsData {
  * geometry already in hand. `null` skips the comparison entirely. */
 export interface HubAnalyticsLayoutComparisonInputs {
   source: { id: string; map: Record<string, string> }
-  targets: Array<{ id: string; map: Record<string, string> }>
+  targets: Array<{ id: string; name?: string; map: Record<string, string> }>
   /** Subset of metrics the live chart computed; an empty array is fine
    * (Hub still gets totalEvents + skipRate). */
   metrics: string[]

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -216,7 +216,7 @@ export interface HubAnalyticsData {
  * geometry already in hand. `null` skips the comparison entirely. */
 export interface HubAnalyticsLayoutComparisonInputs {
   source: { id: string; map: Record<string, string> }
-  target: { id: string; map: Record<string, string> }
+  targets: Array<{ id: string; map: Record<string, string> }>
   /** Subset of metrics the live chart computed; an empty array is fine
    * (Hub still gets totalEvents + skipRate). */
   metrics: string[]

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -374,6 +374,7 @@ export interface LayoutComparisonOptions {
 
 export interface LayoutComparisonTargetResult {
   layoutId: string
+  layoutName?: string
   /** Events whose source-layout char resolved AND landed on a target
    * physical position. */
   totalEvents: number


### PR DESCRIPTION
## Summary
- Enable uploading multiple layout comparison targets from the Analyze export modal
- Replace inline checkbox target picker with AnchoredPopover-based list selector (matching AppSelect pattern)
- Unify `resolveLayoutComparisonInputs` into a single function accepting `targetIds[]`
- Change IPC type from single `target` to `targets` array

## Test plan
- [ ] Open Upload modal → Layout Comparison category enabled when snapshot exists
- [ ] Click target label → popover opens with scrollable checkbox list
- [ ] Select multiple targets → button label shows "Name +N"
- [ ] Upload with multiple targets → Hub receives all targets in export
- [ ] CSV export path unchanged (still uses single filter target)