### PR TITLE
fix(hub): remap fingerLoad keys to Hub wire format

### DIFF
--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -344,8 +344,28 @@ async function computeLayoutComparisonForExport(
   for (const target of result.targets) {
     const name = nameById.get(target.layoutId)
     if (name) target.layoutName = name
+    if (target.fingerLoad) {
+      target.fingerLoad = remapFingerKeys(target.fingerLoad)
+    }
   }
   return result
+}
+
+const FINGER_KEY_TO_HUB: Record<string, string> = {
+  'left-pinky': 'pinkyL', 'left-ring': 'ringL', 'left-middle': 'middleL',
+  'left-index': 'indexL', 'left-thumb': 'thumbL',
+  'right-thumb': 'thumbR', 'right-index': 'indexR', 'right-middle': 'middleR',
+  'right-ring': 'ringR', 'right-pinky': 'pinkyR',
+}
+
+function remapFingerKeys(
+  src: Partial<Record<string, number>>,
+): Partial<Record<string, number>> {
+  const out: Partial<Record<string, number>> = {}
+  for (const [k, v] of Object.entries(src)) {
+    if (v !== undefined) out[FINGER_KEY_TO_HUB[k] ?? k] = v
+  }
+  return out
 }
 
 export type AnalyticsValidationResult =


### PR DESCRIPTION
## Summary
- Remap `fingerLoad` keys from desktop's `left-pinky` format to Hub's `pinkyL` format in `computeLayoutComparisonForExport`
- Without this, Hub's layout comparison metric table shows dashes for all finger load values

## Test plan
- [ ] Upload analytics with layout comparison from desktop
- [ ] Verify finger load percentages display correctly on Hub (not "—")