### PR TITLE
feat(ui): add appDataApps multi-select and upload modal improvements

### DIFF
--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -16,6 +16,7 @@ import type {
   HubAnalyticsFilters,
   HubAnalyticsSnapshot,
 } from '../../shared/types/hub'
+import { TYPING_APP_UNKNOWN_NAME } from '../../shared/types/typing-analytics'
 import type {
   LayoutComparisonInputLayout,
   LayoutComparisonMetric,
@@ -145,7 +146,9 @@ export async function buildAnalyticsExport(
     appScopes,
   }
 
-  return {
+  const appData = await buildAppData(uid, range, machineHash, data, input)
+
+  const result: HubAnalyticsExportV1 = {
     version: 1,
     kind: 'analytics',
     exportedAt: new Date().toISOString(),
@@ -153,6 +156,39 @@ export async function buildAnalyticsExport(
     filters: input.filters,
     data,
   }
+  if (appData !== undefined) result.appData = appData
+  return result
+}
+
+async function buildAppData(
+  uid: string,
+  range: { fromMs: number; toMs: number },
+  machineHash: string | undefined,
+  aggregateData: HubAnalyticsData,
+  input: BuildAnalyticsExportInput,
+): Promise<Record<string, HubAnalyticsData> | undefined> {
+  const apps = aggregateData.appUsage.filter((a) => a.name !== TYPING_APP_UNKNOWN_NAME)
+  if (apps.length < 2) return undefined
+
+  const usageByName = new Map(aggregateData.appUsage.map((a) => [a.name, a]))
+  const wpmByName = new Map(aggregateData.wpmByApp.map((a) => [a.name, a]))
+
+  const collected = await Promise.all(
+    apps.map((app) => collectData(uid, range, [app.name], machineHash, input)),
+  )
+
+  const result: Record<string, HubAnalyticsData> = {}
+  for (let i = 0; i < apps.length; i++) {
+    const { totalKeystrokes: _tk, ...appData } = collected[i]!
+    appData.sessions = []
+    appData.peakRecords = { ...appData.peakRecords, longestSession: null }
+    const usage = usageByName.get(apps[i]!.name)
+    appData.appUsage = usage ? [usage] : []
+    const wpm = wpmByName.get(apps[i]!.name)
+    appData.wpmByApp = wpm ? [wpm] : []
+    result[apps[i]!.name] = appData
+  }
+  return result
 }
 
 async function resolveMachineHash(scope: DeviceScope): Promise<string | undefined> {

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -111,6 +111,9 @@ export interface BuildAnalyticsExportInput {
    * validator still accepts the payload. Undefined / empty fetches
    * everything (back-compat with the pre-modal pipeline). */
   categories?: ReadonlySet<AnalyticsCategoryId>
+  /** Which apps to include in `appData`. Undefined ships every app
+   * (back-compat). Empty array ships no per-app slices. */
+  appDataApps?: string[]
 }
 
 /** Helper: should a category's data section be included in the
@@ -167,7 +170,11 @@ async function buildAppData(
   aggregateData: HubAnalyticsData,
   input: BuildAnalyticsExportInput,
 ): Promise<Record<string, HubAnalyticsData> | undefined> {
-  const apps = aggregateData.appUsage.filter((a) => a.name !== TYPING_APP_UNKNOWN_NAME)
+  const appFilter = input.appDataApps
+  if (appFilter !== undefined && appFilter.length === 0) return undefined
+  const allApps = aggregateData.appUsage.filter((a) => a.name !== TYPING_APP_UNKNOWN_NAME)
+  const allowed = appFilter !== undefined ? new Set(appFilter) : undefined
+  const apps = allowed !== undefined ? allApps.filter((a) => allowed.has(a.name)) : allApps
   if (apps.length < 2) return undefined
 
   const usageByName = new Map(aggregateData.appUsage.map((a) => [a.name, a]))

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -173,6 +173,10 @@ async function prepareAnalyticsExport(
     ? new Set(params.categories.filter((c): c is HubAnalyticsCategoryId => typeof c === 'string'))
     : undefined
 
+  const appDataApps = Array.isArray(params.appDataApps)
+    ? params.appDataApps.filter((v): v is string => typeof v === 'string')
+    : undefined
+
   const exportData = await buildAnalyticsExport({
     uid: params.uid,
     productName: params.keyboard.productName,
@@ -185,6 +189,7 @@ async function prepareAnalyticsExport(
     filters,
     layoutComparisonInputs,
     categories,
+    appDataApps,
   })
 
   return { ok: true, exportData }

--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -53,6 +53,7 @@ if (typeof window !== 'undefined') {
     keyLabelHubUpload: noopOk,
     keyLabelHubUpdate: noopOk,
     keyLabelHubDelete: noopOk,
+    typingAnalyticsListAppsForRange: async () => [],
   }
   Object.defineProperty(window, 'vialAPI', {
     value: { ...stub, ...existing },

--- a/src/renderer/components/analyze/ActivityChart.tsx
+++ b/src/renderer/components/analyze/ActivityChart.tsx
@@ -225,31 +225,17 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
           </div>
         ))}
       </div>
-      <div className="flex items-center gap-2 pt-1 text-content-muted">
-        <UITooltip content={t('analyze.activity.legendLowDesc')} wrapperAs="span">
-          <span>{t('analyze.activity.legendLow')}</span>
-        </UITooltip>
-        <UITooltip
-          content={t('analyze.activity.legendScaleDesc')}
-          wrapperClassName="h-2 flex-1 rounded-sm"
-          wrapperProps={{
-            style: { background: 'linear-gradient(to right, var(--color-surface-dim), var(--color-accent))' },
-          }}
-        >
-          <div className="h-full w-full" aria-hidden="true" />
-        </UITooltip>
-        <UITooltip
-          content={metric === 'wpm'
-            ? t('analyze.activity.legendHighDescWpm', { wpm: formatWpm(peak) })
-            : t('analyze.activity.legendHighDesc', { count: peak.toLocaleString() })}
-          wrapperAs="span"
-        >
-          <span>
-            {metric === 'wpm'
-              ? t('analyze.activity.legendHighWpm', { wpm: formatWpm(peak) })
-              : t('analyze.activity.legendHigh', { count: peak.toLocaleString() })}
-          </span>
-        </UITooltip>
+      <div className="flex items-center gap-2 pt-1 text-[11px] text-content-muted">
+        <span>{t('analyze.activity.legendLow')}</span>
+        <div
+          className="h-2 flex-1 rounded-sm"
+          style={{ background: 'linear-gradient(to right, var(--color-surface-dim), var(--color-accent))' }}
+        />
+        <span>
+          {metric === 'wpm'
+            ? t('analyze.activity.legendHighWpm', { wpm: formatWpm(peak) })
+            : t('analyze.activity.legendHigh', { count: peak.toLocaleString() })}
+        </span>
       </div>
       {summaryItems !== null && (
         <AnalyzeStatGrid

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -43,6 +43,8 @@ import type {
   WpmViewMode,
 } from './analyze-types'
 import type { FingerType } from '../../../shared/kle/kle-ergonomics'
+import { scopeToSelectValue } from '../../../shared/types/analyze-filters'
+import { TYPING_APP_UNKNOWN_NAME } from '../../../shared/types/typing-analytics'
 
 export interface AnalyzeExportContext {
   uid: string
@@ -96,7 +98,7 @@ export interface AnalyzeUploadCallbacks {
   /** Confirm handler invoked with the user's category selection. The
    * parent runs the actual upload IPC and resolves with `{ ok }` so
    * the modal can decide whether to close itself. */
-  onConfirm: (categories: ReadonlySet<Category>, options?: { targetLayoutIds?: string[] }) => Promise<{ ok: boolean }>
+  onConfirm: (categories: ReadonlySet<Category>, options?: { targetLayoutIds?: string[]; appDataApps?: string[] }) => Promise<{ ok: boolean }>
   /** Whether the active entry already lives on Hub. Switches the
    * confirm button label between "Upload" and "Update". */
   isExisting: boolean
@@ -334,6 +336,10 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   const [targetPickerOpen, setTargetPickerOpen] = useState(false)
   const targetTriggerRef = useRef<HTMLButtonElement>(null)
   const keyLabels = useKeyLabels()
+  const [appDataApps, setAppDataApps] = useState<string[]>([])
+  const [appDataOptions, setAppDataOptions] = useState<string[]>([])
+  const [appPickerOpen, setAppPickerOpen] = useState(false)
+  const appTriggerRef = useRef<HTMLButtonElement>(null)
 
   const layoutOptions = useMemo(() => {
     const sourceId = ctx?.layoutComparison.sourceLayoutId
@@ -365,6 +371,26 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
   }, [selectedTargetIds, layoutOptions, t])
 
   const handleTargetClose = useCallback(() => setTargetPickerOpen(false), [])
+  const handleAppClose = useCallback(() => setAppPickerOpen(false), [])
+
+  const appDataSet = useMemo(() => new Set(appDataApps), [appDataApps])
+
+  const appButtonLabel = useMemo(() => {
+    if (appDataApps.length === 0) return t('analyze.export.appDataApps.none')
+    if (appDataApps.length === appDataOptions.length) return t('analyze.export.appDataApps.all')
+    if (appDataApps.length === 1) return appDataApps[0]
+    const first = appDataApps[0]
+    return `${first} +${appDataApps.length - 1}`
+  }, [appDataApps, appDataOptions.length, t])
+
+  const handleAppToggle = (name: string) => {
+    setAppDataApps((prev) =>
+      prev.includes(name) ? prev.filter((x) => x !== name) : [...prev, name],
+    )
+  }
+
+  const handleAppSelectAll = () => setAppDataApps([...appDataOptions])
+  const handleAppDeselectAll = () => setAppDataApps([])
 
   const [targetPopoverMaxH, setTargetPopoverMaxH] = useState(TARGET_POPOVER_MAX_H)
   useLayoutEffect(() => {
@@ -372,7 +398,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
     const update = () => {
       const rect = targetTriggerRef.current?.getBoundingClientRect()
       if (!rect) return
-      const available = window.innerHeight - rect.bottom - VIEWPORT_EDGE_GAP
+      const available = rect.top - VIEWPORT_EDGE_GAP
       setTargetPopoverMaxH(Math.max(TARGET_POPOVER_MIN_H, Math.min(TARGET_POPOVER_MAX_H, available)))
     }
     update()
@@ -385,9 +411,37 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
     setSelected(allOn())
     setError(null)
     setTargetPickerOpen(false)
+    setAppPickerOpen(false)
     const targetId = ctx?.layoutComparison.targetLayoutId
     setSelectedTargetIds(targetId ? [targetId] : [])
   }, [isOpen, ctx?.layoutComparison.targetLayoutId])
+
+  useEffect(() => {
+    if (!isOpen || mode !== 'upload' || !ctx) {
+      setAppDataOptions([])
+      setAppDataApps([])
+      return
+    }
+    let cancelled = false
+    const scope = scopeToSelectValue(ctx.deviceScope)
+    window.vialAPI
+      .typingAnalyticsListAppsForRange(ctx.uid, ctx.range.fromMs, ctx.range.toMs, scope)
+      .then((rows) => {
+        if (cancelled) return
+        const names = rows
+          .filter((r) => r.name !== TYPING_APP_UNKNOWN_NAME)
+          .map((r) => r.name)
+        setAppDataOptions(names)
+        setAppDataApps(names)
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setAppDataOptions([])
+          setAppDataApps([])
+        }
+      })
+    return () => { cancelled = true }
+  }, [isOpen, mode, ctx?.uid, ctx?.range.fromMs, ctx?.range.toMs, ctx?.deviceScope])
 
   useEscapeClose(onClose, isOpen)
 
@@ -449,7 +503,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
       }
     }
     try {
-      const result = await upload.onConfirm(picked, { targetLayoutIds: selectedTargetIds })
+      const result = await upload.onConfirm(picked, { targetLayoutIds: selectedTargetIds, appDataApps })
       if (result.ok) onClose()
     } catch (err) {
       setError(err instanceof Error ? err.message : t('analyze.export.failed'))
@@ -492,8 +546,12 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
               data-testid="analyze-export-common"
             >
               <div><span className="text-content-muted">{t('analyze.export.conditionLabel.device')}: </span>{ctx.conditions.device}</div>
-              <div><span className="text-content-muted">{t('analyze.export.conditionLabel.app')}: </span>{ctx.conditions.app}</div>
-              <div><span className="text-content-muted">{t('analyze.export.conditionLabel.keymap')}: </span>{ctx.conditions.keymap}</div>
+              {mode !== 'upload' && (
+                <div><span className="text-content-muted">{t('analyze.export.conditionLabel.app')}: </span>{ctx.conditions.app}</div>
+              )}
+              {mode !== 'upload' && (
+                <div><span className="text-content-muted">{t('analyze.export.conditionLabel.keymap')}: </span>{ctx.conditions.keymap}</div>
+              )}
               <div><span className="text-content-muted">{t('analyze.export.conditionLabel.range')}: </span>{ctx.conditions.range}</div>
             </div>
           )}
@@ -545,6 +603,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                           anchorRef={targetTriggerRef}
                           open={targetPickerOpen}
                           onClose={handleTargetClose}
+                          placement="top"
                           className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
                           role="listbox"
                           aria-multiselectable
@@ -573,6 +632,68 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
               )
             })}
           </div>
+          {mode === 'upload' && appDataOptions.length >= 2 && (
+            <div className="flex flex-col gap-1 rounded-md border border-edge px-3 py-2">
+              <div className="flex items-center gap-2 text-[12px]">
+                <span className="text-[13px] font-semibold text-content">{t('analyze.export.appDataApps.label')}</span>
+                <button
+                  ref={appTriggerRef}
+                  type="button"
+                  className="rounded border border-edge bg-surface px-2 py-0.5 text-left text-[12px] text-content-secondary transition-colors hover:bg-surface-dim"
+                  onClick={() => setAppPickerOpen((prev) => !prev)}
+                  aria-haspopup="listbox"
+                  aria-expanded={appPickerOpen}
+                >
+                  {appButtonLabel}
+                </button>
+                <AnchoredPopover
+                  anchorRef={appTriggerRef}
+                  open={appPickerOpen}
+                  onClose={handleAppClose}
+                  placement="top"
+                  className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+                  role="listbox"
+                  aria-multiselectable
+                >
+                  <div className="flex gap-1 px-2 py-1">
+                    <button
+                      type="button"
+                      className="text-accent text-[11px] hover:underline"
+                      onClick={handleAppSelectAll}
+                    >
+                      {t('analyze.export.appDataApps.selectAll')}
+                    </button>
+                    <span className="text-content-muted">/</span>
+                    <button
+                      type="button"
+                      className="text-accent text-[11px] hover:underline"
+                      onClick={handleAppDeselectAll}
+                    >
+                      {t('analyze.export.appDataApps.deselectAll')}
+                    </button>
+                  </div>
+                  <div className="my-0.5 border-t border-edge" />
+                  <div className="max-h-72 overflow-y-auto">
+                    {appDataOptions.map((name) => (
+                      <label
+                        key={name}
+                        className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
+                      >
+                        <input
+                          type="checkbox"
+                          className="cursor-pointer"
+                          checked={appDataSet.has(name)}
+                          onChange={() => handleAppToggle(name)}
+                        />
+                        <span className="flex-1 truncate">{name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </AnchoredPopover>
+              </div>
+              <p className="text-[11px] text-content-muted">{t('analyze.export.appDataApps.hint')}</p>
+            </div>
+          )}
           {snapshotMissing && (
             <p className="text-[11px] text-content-muted" data-testid="analyze-export-snapshot-warning">
               {t('analyze.export.snapshotMissing')}

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -899,7 +899,7 @@ export function AnalyzePane({
         ? { kind: filterStore.hubUploadResult.kind, message: filterStore.hubUploadResult.message }
         : null,
       isExisting,
-      onConfirm: async (categories: ReadonlySet<string>, options?: { targetLayoutIds?: string[] }) => {
+      onConfirm: async (categories: ReadonlySet<string>, options?: { targetLayoutIds?: string[]; appDataApps?: string[] }) => {
         const baseInput = buildHubUploadInput(entry.id)
         if (!baseInput) return { ok: false }
         const targetIds = options?.targetLayoutIds
@@ -914,6 +914,7 @@ export function AnalyzePane({
           ...baseInput,
           layoutComparisonInputs,
           categories: Array.from(categories) as Parameters<typeof filterStore.uploadEntryToHub>[0]['categories'],
+          appDataApps: options?.appDataApps,
         }
         return isExisting
           ? filterStore.updateEntryOnHub(input)

--- a/src/renderer/components/ui/AnchoredPopover.tsx
+++ b/src/renderer/components/ui/AnchoredPopover.tsx
@@ -26,9 +26,10 @@ export interface AnchoredPopoverProps
   anchorRef: RefObject<HTMLElement | null>
   open: boolean
   onClose: () => void
-  /** Vertical gap between the anchor's bottom edge and the popover's
-   * top edge, in CSS pixels. */
+  /** Vertical gap between the anchor edge and the popover edge. */
   offset?: number
+  /** `'bottom'` (default) opens below the anchor; `'top'` opens above. */
+  placement?: 'bottom' | 'top'
   children: ReactNode
 }
 
@@ -37,11 +38,12 @@ export function AnchoredPopover({
   open,
   onClose,
   offset = DEFAULT_OFFSET_PX,
+  placement = 'bottom',
   children,
   ...rest
 }: AnchoredPopoverProps) {
   const popoverRef = useRef<HTMLDivElement | null>(null)
-  const [position, setPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 })
+  const [position, setPosition] = useState<{ top: number; left: number; bottom?: number }>({ top: 0, left: 0 })
   const [mounted, setMounted] = useState(false)
 
   // Defer the createPortal call until after first commit so SSR /
@@ -62,8 +64,12 @@ export function AnchoredPopover({
       const anchor = anchorRef.current
       if (!anchor) return
       const rect = anchor.getBoundingClientRect()
-      const next = { top: rect.bottom + offset, left: rect.left }
-      setPosition((prev) => (prev.top === next.top && prev.left === next.left ? prev : next))
+      const next = placement === 'top'
+        ? { top: 0, bottom: window.innerHeight - rect.top + offset, left: rect.left }
+        : { top: rect.bottom + offset, left: rect.left }
+      setPosition((prev) =>
+        prev.top === next.top && prev.left === next.left && prev.bottom === next.bottom ? prev : next,
+      )
     }
     updatePosition()
     window.addEventListener('scroll', updatePosition, true)
@@ -72,7 +78,7 @@ export function AnchoredPopover({
       window.removeEventListener('scroll', updatePosition, true)
       window.removeEventListener('resize', updatePosition)
     }
-  }, [open, anchorRef, offset])
+  }, [open, anchorRef, offset, placement])
 
   useEffect(() => {
     if (!open) return
@@ -96,11 +102,9 @@ export function AnchoredPopover({
 
   if (!open || !mounted || typeof document === 'undefined') return null
 
-  const style: CSSProperties = {
-    position: 'fixed',
-    top: position.top,
-    left: position.left,
-  }
+  const style: CSSProperties = position.bottom !== undefined
+    ? { position: 'fixed', bottom: position.bottom, left: position.left }
+    : { position: 'fixed', top: position.top, left: position.left }
 
   return createPortal(
     <div ref={popoverRef} style={style} {...rest}>

--- a/src/renderer/hooks/useAnalyzeFilterStore.ts
+++ b/src/renderer/hooks/useAnalyzeFilterStore.ts
@@ -63,6 +63,8 @@ export interface UploadAnalyticsToHubInput {
   /** User's category selection from the upload modal. Empty / absent
    * ships everything (back-compat with the early build). */
   categories?: HubAnalyticsCategoryId[]
+  /** Which apps to include in `appData`. Undefined ships every app. */
+  appDataApps?: string[]
 }
 
 const HUB_RESULT_FLASH_MS = 4_000
@@ -257,6 +259,7 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
         fingerOverrides: input.fingerOverrides,
         layoutComparisonInputs: input.layoutComparisonInputs,
         categories: input.categories,
+        appDataApps: input.appDataApps,
       })
       if (result.success && result.postId) {
         ok = true
@@ -303,6 +306,7 @@ export function useAnalyzeFilterStore({ uid }: UseAnalyzeFilterStoreOptions) {
         fingerOverrides: input.fingerOverrides,
         layoutComparisonInputs: input.layoutComparisonInputs,
         categories: input.categories,
+        appDataApps: input.appDataApps,
         postId,
       })
       if (result.success) {

--- a/src/renderer/i18n/locales/en.json
+++ b/src/renderer/i18n/locales/en.json
@@ -696,6 +696,14 @@
         "bigrams": "Bigrams",
         "layer": "Layer",
         "layoutComparison": "Layout Comparison"
+      },
+      "appDataApps": {
+        "label": "Per-app data",
+        "all": "All apps",
+        "none": "None",
+        "selectAll": "All",
+        "deselectAll": "None",
+        "hint": "Select which apps to include as per-app breakdowns on Hub."
       }
     },
     "loading": {
@@ -814,10 +822,6 @@
       "legendLow": "0",
       "legendHigh": "{{count}} $t(analyze.unit.keys)",
       "legendHighWpm": "{{wpm}} WPM",
-      "legendLowDesc": "No keystrokes recorded in this cell.",
-      "legendHighDesc": "Peak ({{count}} $t(analyze.unit.keys)).\nCell opacity scales linearly from 0 to this value.",
-      "legendHighDescWpm": "Peak WPM ({{wpm}} WPM).\nCell opacity scales linearly to this value.\nDesaturated cells did not meet the Min sample threshold.",
-      "legendScaleDesc": "Linear opacity scale from 0 (empty) to the peak.",
       "summary": {
         "keysContext": "{{count}} $t(analyze.unit.keys) ({{share}}%)",
         "wpmContext": "{{wpm}} WPM"

--- a/src/renderer/i18n/locales/ja.json
+++ b/src/renderer/i18n/locales/ja.json
@@ -694,6 +694,14 @@
         "bigrams": "バイグラム",
         "layer": "レイヤー",
         "layoutComparison": "レイアウト比較"
+      },
+      "appDataApps": {
+        "label": "アプリ別データ",
+        "all": "すべてのアプリ",
+        "none": "なし",
+        "selectAll": "すべて",
+        "deselectAll": "なし",
+        "hint": "Hub にアプリ別の内訳データとして含めるアプリを選択します。"
       }
     },
     "loading": {
@@ -812,10 +820,6 @@
       "legendLow": "0",
       "legendHigh": "{{count}} $t(analyze.unit.keys)",
       "legendHighWpm": "{{wpm}} WPM",
-      "legendLowDesc": "このセルで打鍵がなかった状態",
-      "legendHighDesc": "ピーク値 ({{count}} $t(analyze.unit.keys))\nセルの濃度は 0 からこの値まで線形にスケール",
-      "legendHighDescWpm": "ピーク WPM ({{wpm}} WPM)\nセルの濃度はこの値まで線形にスケール\n薄く表示されるセルは Min sample 閾値を満たしていない",
-      "legendScaleDesc": "0 (空) からピーク値までの線形スケール",
       "summary": {
         "keysContext": "{{count}} $t(analyze.unit.keys) ({{share}}%)",
         "wpmContext": "{{wpm}} WPM"

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -267,6 +267,10 @@ export interface HubUploadAnalyticsPostParams {
    * ships every category (back-compat with the early build that did
    * not surface the picker). */
   categories?: HubAnalyticsCategoryId[]
+  /** Which apps to include in `appData`. Absent / undefined ships
+   * every app with ≥2 entries (back-compat). Empty array ships no
+   * per-app slices at all. */
+  appDataApps?: string[]
 }
 
 export interface HubUpdateAnalyticsPostParams extends HubUploadAnalyticsPostParams {

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -117,6 +117,7 @@ export interface HubAnalyticsExportV1 {
   snapshot: HubAnalyticsSnapshot
   filters: HubAnalyticsFilters
   data: HubAnalyticsData
+  appData?: Record<string, HubAnalyticsData>
 }
 
 export interface HubAnalyticsSnapshot {


### PR DESCRIPTION
## Summary
- Add per-app data selector (appDataApps) to analytics upload modal for controlling which apps go into appData
- Add upward placement support to AnchoredPopover (both layout comparison and app selectors open upward)
- Remove activity legend tooltips (desktop + hub alignment)

## Test plan
- [ ] Open analytics upload modal — app picker shows available apps with Select All/None
- [ ] Toggle individual apps, verify appDataApps is passed to upload
- [ ] App picker and layout comparison popovers open upward
- [ ] Activity legend shows without tooltips
- [ ] Upload with subset of apps — verify exported JSON contains only selected apps in appData