### PR TITLE
fix(ui): unify calendar color with grid view and add legend

### DIFF
--- a/src/renderer/components/analyze/ActivityCalendarChart.tsx
+++ b/src/renderer/components/analyze/ActivityCalendarChart.tsx
@@ -27,8 +27,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { isHashScope, isOwnScope, scopeToSelectValue } from '../../../shared/types/analyze-filters'
 import type { TypingSessionRow } from '../../../shared/types/typing-analytics'
-import { useEffectiveTheme } from '../../hooks/useEffectiveTheme'
-import { paletteColorFromIntensity } from '../../utils/chart-palette'
 import { Tooltip as UITooltip, type TooltipAlign, type TooltipSide } from '../ui/Tooltip'
 import {
   buildCalendarGrid,
@@ -88,7 +86,6 @@ export function ActivityCalendarChart({
   onShiftEndMonth,
 }: Props): JSX.Element {
   const { t } = useTranslation()
-  const theme = useEffectiveTheme()
   const scopeKey = scopeToSelectValue(deviceScope)
   const { normalization, monthsToShow, endMonthIso } = calendarFilter
 
@@ -242,7 +239,6 @@ export function ActivityCalendarChart({
                 <CalendarCellView
                   key={`c-${weekIndex}-${dow}`}
                   cell={week[dow]}
-                  theme={theme}
                   metric={metric}
                   t={t}
                   // Pin the tooltip to the cell's near edge so it stays
@@ -269,6 +265,18 @@ export function ActivityCalendarChart({
           ›
         </button>
       </div>
+      <div className="flex items-center gap-2 pt-1 text-[11px] text-content-muted">
+        <span>{t('analyze.activity.legendLow')}</span>
+        <div
+          className="h-2 flex-1 rounded-sm"
+          style={{ background: 'linear-gradient(to right, var(--color-surface-dim), var(--color-accent))' }}
+        />
+        <span>
+          {metric === 'wpm'
+            ? t('analyze.activity.legendHighWpm', { wpm: formatWpm(grid.summary.peakValue) })
+            : t('analyze.activity.legendHigh', { count: Math.round(grid.summary.peakValue).toLocaleString() })}
+        </span>
+      </div>
       {summaryItems !== null && (
         <AnalyzeStatGrid
           items={summaryItems}
@@ -282,16 +290,16 @@ export function ActivityCalendarChart({
 
 interface CellProps {
   cell: CalendarCell | null
-  theme: ReturnType<typeof useEffectiveTheme>
   metric: ActivityMetric
   t: ReturnType<typeof useTranslation>['t']
   align: TooltipAlign
   side: TooltipSide
 }
 
+const HEATMAP_MIN_OPACITY = 0.08
+
 function CalendarCellView({
   cell,
-  theme,
   metric,
   t,
   align,
@@ -300,9 +308,7 @@ function CalendarCellView({
   if (cell === null) {
     return <div role="gridcell" />
   }
-  const fill = cell.qualified
-    ? paletteColorFromIntensity(cell.intensity, theme) ?? 'var(--color-surface-dim)'
-    : 'var(--color-surface-dim)'
+  const opacity = !cell.qualified ? 0 : Math.max(HEATMAP_MIN_OPACITY, cell.intensity)
   const tooltip = formatCellTooltip(cell, metric, t)
   return (
     <UITooltip
@@ -315,7 +321,10 @@ function CalendarCellView({
     >
       <div
         className="h-full w-full rounded-[2px]"
-        style={{ backgroundColor: fill }}
+        style={{
+          backgroundColor: !cell.qualified ? 'var(--color-surface-dim)' : 'var(--color-accent)',
+          opacity: !cell.qualified ? undefined : opacity,
+        }}
         aria-hidden="true"
         data-testid={`analyze-activity-calendar-cell-${cell.date}`}
       />


### PR DESCRIPTION
## Summary
- Switch calendar cells from HSL palette to accent+opacity (same as Hour grid view)
- Add range legend bar showing peak value
- Remove unused paletteColorFromIntensity and useEffectiveTheme imports

## Test plan
- [ ] lint passes
- [ ] tests pass
- [ ] Calendar cells use same accent color as Hour grid
- [ ] Legend shows "0 — {peak value} keys" format