### PR TITLE
fix(ui): show full calendar month in 1-month view

### DIFF
--- a/src/renderer/components/analyze/ActivityCalendarChart.tsx
+++ b/src/renderer/components/analyze/ActivityCalendarChart.tsx
@@ -445,7 +445,9 @@ function resolveWindow({
   const lastDayOfEndMonth = new Date(endYear, endMonth, 0)
   const todayIso = toLocalDate(nowMs)
   const startOfTodayMs = parseLocalDate(todayIso)?.getTime() ?? nowMs
-  const visibleEndMs = Math.min(lastDayOfEndMonth.getTime(), startOfTodayMs)
+  const visibleEndMs = monthsToShow === 1
+    ? lastDayOfEndMonth.getTime()
+    : Math.min(lastDayOfEndMonth.getTime(), startOfTodayMs)
   return {
     dateFromIso: toLocalDate(startDate.getTime()),
     dateToIso: toLocalDate(visibleEndMs >= startDate.getTime() ? visibleEndMs : startDate.getTime()),


### PR DESCRIPTION
## Summary
- Remove today cap for `monthsToShow=1` so the calendar grid displays the entire month including future days without data as gray cells
- Aligns the 1-month view's display method with the 3/6/12-month views

## Test plan
- [ ] Select 1-month range in Activity calendar — verify full month grid is displayed
- [ ] Verify 3/6/12-month views remain unchanged (still cap at today)
- [ ] Confirm days without data show as gray (surfaceDim) cells