### PR TITLE
fix(ui): guard i18n pack-removal fallback until metas load

### DIFF
--- a/src/renderer/hooks/useI18nPackStore.ts
+++ b/src/renderer/hooks/useI18nPackStore.ts
@@ -126,6 +126,7 @@ export function useI18nPackStore(): UseI18nPackStoreReturn {
   // that no longer exists in the index (or is disabled / tombstoned),
   // flip back to builtin:en and stamp a notice.
   useEffect(() => {
+    if (loading) return
     const active = appConfig.config.language ?? 'builtin:en'
     if (!active.startsWith('pack:')) return
     const packId = active.slice('pack:'.length)
@@ -138,7 +139,7 @@ export function useI18nPackStore(): UseI18nPackStoreReturn {
     })
     appConfig.set('language', 'builtin:en')
     void i18n.changeLanguage('builtin:en')
-  }, [appConfig, metas])
+  }, [appConfig, loading, metas])
 
   const setEnabled = useCallback(async (id: string, enabled: boolean) => {
     const result = await window.vialAPI.i18nPackSetEnabled(id, enabled)


### PR DESCRIPTION
## Summary

- Fix language resetting to English when opening Settings
- Add `loading` guard to pack-removal fallback effect in `useI18nPackStore` to prevent it from firing before metas finish loading from IPC
- Matches the existing guard pattern used by the sibling activation effect

## Test plan

- [x] `npx eslint` passes
- [x] `npx tsc --noEmit` passes
- [x] SettingsModal tests pass (90/90)
- [ ] Open Settings with a non-English language pack active — language should not reset