### PR TITLE
fix(ui): theme packs manage label and comprehensive pack tests

### DIFF
--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -274,7 +274,7 @@ describe('key-label-store', () => {
 
     it('appends unlisted active IDs at the end', async () => {
       const a = await saveRecord({ name: 'Listed', uploaderName: 'me', map: {} })
-      const b = await saveRecord({ name: 'Unlisted', uploaderName: 'me', map: {} })
+      await saveRecord({ name: 'Unlisted', uploaderName: 'me', map: {} })
 
       await reorderActive([a.data!.id])
 
@@ -370,7 +370,7 @@ describe('key-label-store', () => {
     })
 
     it('includes entries that listMetas excludes', async () => {
-      const a = await saveRecord({ name: 'Visible', uploaderName: 'me', map: {} })
+      await saveRecord({ name: 'Visible', uploaderName: 'me', map: {} })
       const b = await saveRecord({ name: 'Hidden', uploaderName: 'me', map: {} })
       await deleteRecord(b.data!.id)
 

--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -17,7 +17,7 @@ vi.mock('electron', () => ({
     },
   },
   ipcMain: { handle: vi.fn() },
-  dialog: { showOpenDialog: vi.fn() },
+  dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
   BrowserWindow: { fromWebContents: vi.fn() },
 }))
 
@@ -30,12 +30,15 @@ import { notifyChange } from '../sync/sync-service'
 import {
   saveRecord,
   listMetas,
+  listAllMetas,
   getRecord,
   renameRecord,
   deleteRecord,
   setHubPostId,
   hasActiveName,
   importFromDialog,
+  exportToDialog,
+  reorderActive,
   KEY_LABEL_SYNC_UNIT,
 } from '../key-label-store'
 
@@ -234,6 +237,229 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(false)
       expect(result.error).toBe('cancelled')
+    })
+  })
+
+  describe('reorderActive', () => {
+    it('reorders active entries by given ID array', async () => {
+      const a = await saveRecord({ name: 'Alpha', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'Beta', uploaderName: 'me', map: {} })
+      const c = await saveRecord({ name: 'Gamma', uploaderName: 'me', map: {} })
+
+      await reorderActive([c.data!.id, a.data!.id, b.data!.id])
+
+      const metas = await listMetas()
+      const names = metas.map((m) => m.name)
+      expect(names.indexOf('Gamma')).toBeLessThan(names.indexOf('Alpha'))
+      expect(names.indexOf('Alpha')).toBeLessThan(names.indexOf('Beta'))
+    })
+
+    it('keeps tombstones in the tail after reordered active entries', async () => {
+      const a = await saveRecord({ name: 'Keep', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'Remove', uploaderName: 'me', map: {} })
+      await deleteRecord(b.data!.id)
+
+      await reorderActive([a.data!.id])
+
+      const all = await listAllMetas()
+      const tombstoned = all.find((m) => m.id === b.data!.id)
+      expect(tombstoned).toBeDefined()
+      expect(tombstoned!.deletedAt).toBeTruthy()
+
+      const activeIds = all.filter((m) => !m.deletedAt).map((m) => m.id)
+      const tombIdx = all.findIndex((m) => m.id === b.data!.id)
+      const lastActiveIdx = all.findIndex((m) => m.id === activeIds[activeIds.length - 1])
+      expect(tombIdx).toBeGreaterThan(lastActiveIdx)
+    })
+
+    it('appends unlisted active IDs at the end', async () => {
+      const a = await saveRecord({ name: 'Listed', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'Unlisted', uploaderName: 'me', map: {} })
+
+      await reorderActive([a.data!.id])
+
+      const metas = await listMetas()
+      const names = metas.map((m) => m.name)
+      expect(names.indexOf('Listed')).toBeLessThan(names.indexOf('Unlisted'))
+    })
+
+    it('bumps updatedAt on all reordered metas', async () => {
+      const a = await saveRecord({ name: 'TimestampA', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'TimestampB', uploaderName: 'me', map: {} })
+      const origA = a.data!.updatedAt
+      const origB = b.data!.updatedAt
+
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000)
+      await reorderActive([b.data!.id, a.data!.id])
+      vi.mocked(Date.now).mockRestore()
+
+      const metas = await listMetas()
+      const metaA = metas.find((m) => m.id === a.data!.id)!
+      const metaB = metas.find((m) => m.id === b.data!.id)!
+      expect(metaA.updatedAt).not.toBe(origA)
+      expect(metaB.updatedAt).not.toBe(origB)
+    })
+
+    it('calls notifyChange after reorder', async () => {
+      await saveRecord({ name: 'Notify', uploaderName: 'me', map: {} })
+      vi.mocked(notifyChange).mockClear()
+
+      await reorderActive([])
+
+      expect(notifyChange).toHaveBeenCalledWith(KEY_LABEL_SYNC_UNIT)
+    })
+  })
+
+  describe('exportToDialog', () => {
+    it('writes correct JSON to the chosen path', async () => {
+      const created = await saveRecord({
+        name: 'Export Test',
+        uploaderName: 'me',
+        map: { KC_A: 'A', KC_B: 'B' },
+        compositeLabels: { KC_C: 'C' },
+      })
+
+      const exportPath = join(mockUserDataPath, 'exported.json')
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({
+        canceled: false,
+        filePath: exportPath,
+      })
+
+      const win = { id: 10 } as unknown as Electron.BrowserWindow
+      const result = await exportToDialog(win, created.data!.id)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.filePath).toBe(exportPath)
+
+      const raw = await readFile(exportPath, 'utf-8')
+      const parsed = JSON.parse(raw) as { name: string; map: Record<string, string>; composite_labels: Record<string, string> | null }
+      expect(parsed.name).toBe('Export Test')
+      expect(parsed.map).toEqual({ KC_A: 'A', KC_B: 'B' })
+      expect(parsed.composite_labels).toEqual({ KC_C: 'C' })
+    })
+
+    it('returns IO_ERROR when dialog is cancelled', async () => {
+      const created = await saveRecord({ name: 'Cancel Export', uploaderName: 'me', map: {} })
+
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({
+        canceled: true,
+        filePath: '',
+      })
+
+      const win = { id: 11 } as unknown as Electron.BrowserWindow
+      const result = await exportToDialog(win, created.data!.id)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('cancelled')
+    })
+  })
+
+  describe('listAllMetas', () => {
+    it('returns all entries including tombstones', async () => {
+      const a = await saveRecord({ name: 'Alive', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'Dead', uploaderName: 'me', map: {} })
+      await deleteRecord(b.data!.id)
+
+      const allMetas = await listAllMetas()
+      const allIds = allMetas.map((m) => m.id)
+      expect(allIds).toContain(a.data!.id)
+      expect(allIds).toContain(b.data!.id)
+
+      const tombstoned = allMetas.find((m) => m.id === b.data!.id)
+      expect(tombstoned!.deletedAt).toBeTruthy()
+    })
+
+    it('includes entries that listMetas excludes', async () => {
+      const a = await saveRecord({ name: 'Visible', uploaderName: 'me', map: {} })
+      const b = await saveRecord({ name: 'Hidden', uploaderName: 'me', map: {} })
+      await deleteRecord(b.data!.id)
+
+      const activeMetas = await listMetas()
+      const allMetas = await listAllMetas()
+
+      expect(activeMetas.find((m) => m.id === b.data!.id)).toBeUndefined()
+      expect(allMetas.find((m) => m.id === b.data!.id)).toBeDefined()
+      expect(allMetas.length).toBeGreaterThan(activeMetas.length)
+    })
+  })
+
+  describe('setHubPostId with optional parameters', () => {
+    it('sets uploaderName alongside hubPostId', async () => {
+      const created = await saveRecord({ name: 'Hub Author', uploaderName: 'original', map: {} })
+      const result = await setHubPostId(created.data!.id, 'hub-123', 'new-author')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBe('hub-123')
+      expect(result.data?.uploaderName).toBe('new-author')
+    })
+
+    it('sets hubUpdatedAt alongside hubPostId', async () => {
+      const created = await saveRecord({ name: 'Hub Time', uploaderName: 'me', map: {} })
+      const ts = '2026-01-15T10:00:00.000Z'
+      const result = await setHubPostId(created.data!.id, 'hub-456', undefined, ts)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBe('hub-456')
+      expect(result.data?.hubUpdatedAt).toBe(ts)
+    })
+
+    it('leaves uploaderName unchanged when undefined is passed', async () => {
+      const created = await saveRecord({ name: 'Keep Author', uploaderName: 'keep-me', map: {} })
+      const result = await setHubPostId(created.data!.id, 'hub-789', undefined)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.uploaderName).toBe('keep-me')
+    })
+
+    it('leaves hubUpdatedAt unchanged when undefined is passed', async () => {
+      const created = await saveRecord({
+        name: 'Keep Time',
+        uploaderName: 'me',
+        map: {},
+        hubPostId: 'hub-existing',
+        hubUpdatedAt: '2026-01-01T00:00:00.000Z',
+      })
+      const result = await setHubPostId(created.data!.id, 'hub-updated', undefined, undefined)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubUpdatedAt).toBe('2026-01-01T00:00:00.000Z')
+    })
+
+    it('clears hubUpdatedAt when hubPostId is set to null', async () => {
+      const created = await saveRecord({
+        name: 'Clear Time',
+        uploaderName: 'me',
+        map: {},
+        hubPostId: 'hub-clear',
+        hubUpdatedAt: '2026-06-01T00:00:00.000Z',
+      })
+      const result = await setHubPostId(created.data!.id, null)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBeUndefined()
+      expect(result.data?.hubUpdatedAt).toBeUndefined()
+    })
+  })
+
+  describe('QWERTY delete protection', () => {
+    it('rejects deletion of the QWERTY entry', async () => {
+      await listMetas()
+
+      const result = await deleteRecord('qwerty')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_NAME')
+      expect(result.error).toBe('QWERTY cannot be deleted')
+    })
+
+    it('QWERTY entry remains in the list after failed delete attempt', async () => {
+      await listMetas()
+      await deleteRecord('qwerty')
+
+      const metas = await listMetas()
+      const qwerty = metas.find((m) => m.id === 'qwerty')
+      expect(qwerty).toBeDefined()
+      expect(qwerty!.deletedAt).toBeUndefined()
     })
   })
 })

--- a/src/main/__tests__/theme-pack-store.test.ts
+++ b/src/main/__tests__/theme-pack-store.test.ts
@@ -1,0 +1,594 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+let mockUserDataPath = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+  ipcMain: { handle: vi.fn() },
+  dialog: { showSaveDialog: vi.fn() },
+  BrowserWindow: { fromWebContents: vi.fn() },
+}))
+
+vi.mock('../sync/sync-service', () => ({
+  notifyChange: vi.fn(),
+}))
+
+import { notifyChange } from '../sync/sync-service'
+import {
+  savePack,
+  getPack,
+  listMetas,
+  listAllMetas,
+  renamePack,
+  deletePack,
+  setHubPostId,
+  hasActiveName,
+  purgeExpiredTombstones,
+  __testing,
+} from '../theme-pack-store'
+import {
+  THEME_COLOR_KEYS,
+  THEME_INDEX_SYNC_UNIT,
+  THEME_PACK_TOMBSTONE_TTL_MS,
+  THEME_PACK_LIMITS,
+} from '../../shared/types/theme-store'
+
+function makeValidPack(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const colors: Record<string, string> = {}
+  for (const key of THEME_COLOR_KEYS) {
+    colors[key] = '#aabbcc'
+  }
+  return {
+    name: 'Test Pack',
+    version: '1.0.0',
+    colorScheme: 'dark',
+    colors,
+    ...overrides,
+  }
+}
+
+describe('theme-pack-store', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'theme-pack-store-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  describe('Index I/O', () => {
+    it('returns empty metas when index file does not exist', async () => {
+      const index = await __testing.readIndex()
+      expect(index).toEqual({ metas: [] })
+    })
+
+    it('returns empty metas when index file is corrupt JSON', async () => {
+      const storeDir = __testing.getStoreDir()
+      await mkdir(storeDir, { recursive: true })
+      await writeFile(__testing.getIndexPath(), 'not-json!!!', 'utf-8')
+
+      const index = await __testing.readIndex()
+      expect(index).toEqual({ metas: [] })
+    })
+
+    it('returns empty metas when index is valid JSON but has no metas array', async () => {
+      const storeDir = __testing.getStoreDir()
+      await mkdir(storeDir, { recursive: true })
+      await writeFile(__testing.getIndexPath(), JSON.stringify({ foo: 'bar' }), 'utf-8')
+
+      const index = await __testing.readIndex()
+      expect(index).toEqual({ metas: [] })
+    })
+
+    it('reads a valid index file', async () => {
+      const meta = {
+        id: 'abc-123',
+        filename: 'packs/abc-123.json',
+        name: 'My Theme',
+        version: '1.0.0',
+        savedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      const storeDir = __testing.getStoreDir()
+      await mkdir(storeDir, { recursive: true })
+      await writeFile(__testing.getIndexPath(), JSON.stringify({ metas: [meta] }), 'utf-8')
+
+      const index = await __testing.readIndex()
+      expect(index.metas).toHaveLength(1)
+      expect(index.metas[0].name).toBe('My Theme')
+    })
+
+    it('writeIndex creates the store directory if missing', async () => {
+      await __testing.writeIndex({ metas: [] })
+      const raw = await readFile(__testing.getIndexPath(), 'utf-8')
+      expect(JSON.parse(raw)).toEqual({ metas: [] })
+    })
+  })
+
+  describe('savePack', () => {
+    it('persists meta + pack body and notifies sync', async () => {
+      const raw = makeValidPack({ name: 'Nord' })
+      const result = await savePack({ raw })
+
+      expect(result.success).toBe(true)
+      expect(result.data?.name).toBe('Nord')
+      expect(result.data?.version).toBe('1.0.0')
+      expect(result.data?.id).toBeTruthy()
+      expect(result.data?.savedAt).toBeTruthy()
+      expect(result.data?.updatedAt).toBeTruthy()
+
+      expect(notifyChange).toHaveBeenCalledWith(__testing.packSyncUnit(result.data!.id))
+      expect(notifyChange).toHaveBeenCalledWith(THEME_INDEX_SYNC_UNIT)
+
+      const packPath = __testing.getPackPath(result.data!.id)
+      const diskRaw = await readFile(packPath, 'utf-8')
+      const parsed = JSON.parse(diskRaw) as { name: string }
+      expect(parsed.name).toBe('Nord')
+    })
+
+    it('overwrites an existing pack with the same name (auto-overwrite)', async () => {
+      const raw1 = makeValidPack({ name: 'Dracula', version: '1.0.0' })
+      const first = await savePack({ raw: raw1 })
+      expect(first.success).toBe(true)
+
+      const raw2 = makeValidPack({ name: 'Dracula', version: '2.0.0' })
+      const second = await savePack({ raw: raw2 })
+      expect(second.success).toBe(true)
+      expect(second.data?.id).toBe(first.data!.id)
+      expect(second.data?.version).toBe('2.0.0')
+
+      const metas = await listMetas()
+      expect(metas.filter((m) => m.name === 'Dracula')).toHaveLength(1)
+    })
+
+    it('overwrites when explicit id is provided', async () => {
+      const raw1 = makeValidPack({ name: 'Solarized' })
+      const first = await savePack({ raw: raw1 })
+      expect(first.success).toBe(true)
+
+      const raw2 = makeValidPack({ name: 'Solarized Updated', version: '2.0.0' })
+      const second = await savePack({ raw: raw2, id: first.data!.id })
+      expect(second.success).toBe(true)
+      expect(second.data?.id).toBe(first.data!.id)
+      expect(second.data?.name).toBe('Solarized Updated')
+    })
+
+    it('rejects invalid theme pack data', async () => {
+      const result = await savePack({ raw: { name: 123, version: 'bad' } })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_FILE')
+    })
+
+    it('rejects a pack with missing colors', async () => {
+      const result = await savePack({ raw: { name: 'X', version: '1.0.0', colorScheme: 'dark', colors: {} } })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_FILE')
+    })
+
+    it('preserves hubPostId when provided', async () => {
+      const raw = makeValidPack({ name: 'Hub Theme' })
+      const result = await savePack({ raw, hubPostId: 'hub-id-1' })
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBe('hub-id-1')
+    })
+
+    it('preserves hubUpdatedAt when provided', async () => {
+      const raw = makeValidPack({ name: 'Hub Updated Theme' })
+      const ts = '2026-01-15T10:00:00.000Z'
+      const result = await savePack({ raw, hubPostId: 'hub-id-x', hubUpdatedAt: ts })
+      expect(result.success).toBe(true)
+      expect(result.data?.hubUpdatedAt).toBe(ts)
+    })
+
+    it('clears hubPostId when null is passed', async () => {
+      const raw = makeValidPack({ name: 'Clear Hub' })
+      const first = await savePack({ raw, hubPostId: 'hub-id-2' })
+      expect(first.data?.hubPostId).toBe('hub-id-2')
+
+      const raw2 = makeValidPack({ name: 'Clear Hub', version: '1.0.0' })
+      const second = await savePack({ raw: raw2, id: first.data!.id, hubPostId: null })
+      expect(second.success).toBe(true)
+      expect(second.data?.hubPostId).toBeUndefined()
+    })
+
+    it('treats empty-string hubUpdatedAt as null (explicit clear)', async () => {
+      const raw = makeValidPack({ name: 'Empty Updated' })
+      const first = await savePack({ raw, hubPostId: 'hid', hubUpdatedAt: '2026-01-01T00:00:00Z' })
+      expect(first.data?.hubUpdatedAt).toBe('2026-01-01T00:00:00Z')
+
+      const raw2 = makeValidPack({ name: 'Empty Updated' })
+      const second = await savePack({ raw: raw2, id: first.data!.id, hubUpdatedAt: '' })
+      expect(second.success).toBe(true)
+      expect(second.data?.hubUpdatedAt).toBeUndefined()
+    })
+
+    it('preserves savedAt across overwrites', async () => {
+      const raw = makeValidPack({ name: 'Keep SavedAt' })
+      const first = await savePack({ raw })
+      const originalSavedAt = first.data!.savedAt
+
+      const raw2 = makeValidPack({ name: 'Keep SavedAt', version: '2.0.0' })
+      const second = await savePack({ raw: raw2 })
+      expect(second.data?.savedAt).toBe(originalSavedAt)
+    })
+
+    it('returns DUPLICATE_NAME when another active pack has the same name and a different explicit id', async () => {
+      const raw1 = makeValidPack({ name: 'UniqueA' })
+      await savePack({ raw: raw1 })
+
+      const raw2 = makeValidPack({ name: 'UniqueA' })
+      const result = await savePack({ raw: raw2, id: 'different-explicit-id' })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('DUPLICATE_NAME')
+    })
+  })
+
+  describe('getPack', () => {
+    it('retrieves a saved pack', async () => {
+      const raw = makeValidPack({ name: 'Retrievable' })
+      const saved = await savePack({ raw })
+
+      const result = await getPack(saved.data!.id)
+      expect(result.success).toBe(true)
+      expect(result.data?.meta.name).toBe('Retrievable')
+      expect(result.data?.pack.name).toBe('Retrievable')
+      expect(result.data?.pack.colorScheme).toBe('dark')
+    })
+
+    it('returns NOT_FOUND for non-existent id', async () => {
+      const result = await getPack('non-existent-id')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+
+    it('returns NOT_FOUND for deleted (tombstoned) pack', async () => {
+      const raw = makeValidPack({ name: 'ToDelete' })
+      const saved = await savePack({ raw })
+      await deletePack(saved.data!.id)
+
+      const result = await getPack(saved.data!.id)
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+
+    it('returns NOT_FOUND for an unsafe pack id', async () => {
+      const result = await getPack('../../../etc/passwd')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+  })
+
+  describe('listMetas', () => {
+    it('returns empty array when no packs exist', async () => {
+      const metas = await listMetas()
+      expect(metas).toEqual([])
+    })
+
+    it('excludes deleted entries', async () => {
+      const a = await savePack({ raw: makeValidPack({ name: 'Alpha' }) })
+      await savePack({ raw: makeValidPack({ name: 'Beta' }) })
+      await deletePack(a.data!.id)
+
+      const metas = await listMetas()
+      expect(metas).toHaveLength(1)
+      expect(metas[0].name).toBe('Beta')
+    })
+
+    it('returns all active entries in order', async () => {
+      await savePack({ raw: makeValidPack({ name: 'First' }) })
+      await savePack({ raw: makeValidPack({ name: 'Second' }) })
+      await savePack({ raw: makeValidPack({ name: 'Third' }) })
+
+      const metas = await listMetas()
+      expect(metas.map((m) => m.name)).toEqual(['First', 'Second', 'Third'])
+    })
+  })
+
+  describe('listAllMetas', () => {
+    it('includes tombstoned entries', async () => {
+      const a = await savePack({ raw: makeValidPack({ name: 'Alive' }) })
+      await savePack({ raw: makeValidPack({ name: 'Also Alive' }) })
+      await deletePack(a.data!.id)
+
+      const all = await listAllMetas()
+      expect(all).toHaveLength(2)
+
+      const deleted = all.find((m) => m.name === 'Alive')
+      expect(deleted?.deletedAt).toBeTruthy()
+
+      const active = all.find((m) => m.name === 'Also Alive')
+      expect(active?.deletedAt).toBeUndefined()
+    })
+  })
+
+  describe('renamePack', () => {
+    it('updates the index name and pack body on disk', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'OldName' }) })
+      const result = await renamePack(saved.data!.id, 'NewName')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.name).toBe('NewName')
+
+      const record = await getPack(saved.data!.id)
+      expect(record.data?.meta.name).toBe('NewName')
+      expect(record.data?.pack.name).toBe('NewName')
+
+      expect(notifyChange).toHaveBeenCalledWith(__testing.packSyncUnit(saved.data!.id))
+      expect(notifyChange).toHaveBeenCalledWith(THEME_INDEX_SYNC_UNIT)
+    })
+
+    it('rejects rename to an existing name (case-insensitive)', async () => {
+      const a = await savePack({ raw: makeValidPack({ name: 'ThemeA' }) })
+      await savePack({ raw: makeValidPack({ name: 'ThemeB' }) })
+
+      const result = await renamePack(a.data!.id, 'themeb')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('DUPLICATE_NAME')
+    })
+
+    it('allows renaming to own name with different casing', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'myTheme' }) })
+      const result = await renamePack(saved.data!.id, 'MyTheme')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.name).toBe('MyTheme')
+    })
+
+    it('rejects empty name', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Valid' }) })
+      const result = await renamePack(saved.data!.id, '   ')
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_NAME')
+    })
+
+    it('rejects name exceeding max length', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Valid' }) })
+      const longName = 'x'.repeat(THEME_PACK_LIMITS.MAX_NAME_LENGTH + 1)
+      const result = await renamePack(saved.data!.id, longName)
+
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_NAME')
+    })
+
+    it('returns NOT_FOUND for non-existent id', async () => {
+      const result = await renamePack('no-such-id', 'Whatever')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+
+    it('returns NOT_FOUND for deleted pack', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Deleted' }) })
+      await deletePack(saved.data!.id)
+
+      const result = await renamePack(saved.data!.id, 'Renamed')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+  })
+
+  describe('deletePack', () => {
+    it('applies tombstone and excludes from listMetas', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Doomed' }) })
+      const result = await deletePack(saved.data!.id)
+
+      expect(result.success).toBe(true)
+
+      const metas = await listMetas()
+      expect(metas.find((m) => m.id === saved.data!.id)).toBeUndefined()
+
+      const allMetas = await listAllMetas()
+      const tombstoned = allMetas.find((m) => m.id === saved.data!.id)
+      expect(tombstoned?.deletedAt).toBeTruthy()
+
+      expect(notifyChange).toHaveBeenCalledWith(__testing.packSyncUnit(saved.data!.id))
+      expect(notifyChange).toHaveBeenCalledWith(THEME_INDEX_SYNC_UNIT)
+    })
+
+    it('returns NOT_FOUND for non-existent id', async () => {
+      const result = await deletePack('ghost-id')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+
+    it('pack body file remains on disk after soft-delete', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'SoftDelete' }) })
+      const packPath = __testing.getPackPath(saved.data!.id)
+
+      await deletePack(saved.data!.id)
+
+      const raw = await readFile(packPath, 'utf-8')
+      expect(raw).toBeTruthy()
+    })
+  })
+
+  describe('setHubPostId', () => {
+    it('sets hubPostId on a pack', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'HubSet' }) })
+      const result = await setHubPostId(saved.data!.id, 'hub-post-123')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBe('hub-post-123')
+      expect(notifyChange).toHaveBeenCalledWith(THEME_INDEX_SYNC_UNIT)
+    })
+
+    it('clears hubPostId and hubUpdatedAt when null is passed', async () => {
+      const saved = await savePack({
+        raw: makeValidPack({ name: 'HubClear' }),
+        hubPostId: 'hub-x',
+        hubUpdatedAt: '2026-01-01T00:00:00Z',
+      })
+      expect(saved.data?.hubPostId).toBe('hub-x')
+      expect(saved.data?.hubUpdatedAt).toBe('2026-01-01T00:00:00Z')
+
+      const result = await setHubPostId(saved.data!.id, null)
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBeUndefined()
+      expect(result.data?.hubUpdatedAt).toBeUndefined()
+    })
+
+    it('trims whitespace from hubPostId', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'HubTrim' }) })
+      const result = await setHubPostId(saved.data!.id, '  hub-trimmed  ')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBe('hub-trimmed')
+    })
+
+    it('treats empty string as null (clears)', async () => {
+      const saved = await savePack({
+        raw: makeValidPack({ name: 'HubEmpty' }),
+        hubPostId: 'existing',
+      })
+      const result = await setHubPostId(saved.data!.id, '   ')
+
+      expect(result.success).toBe(true)
+      expect(result.data?.hubPostId).toBeUndefined()
+    })
+
+    it('returns NOT_FOUND for non-existent id', async () => {
+      const result = await setHubPostId('no-such-id', 'hub-post')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+  })
+
+  describe('hasActiveName', () => {
+    it('returns true for existing active name (case-insensitive)', async () => {
+      await savePack({ raw: makeValidPack({ name: 'Monokai' }) })
+
+      const result = await hasActiveName('MONOKAI')
+      expect(result.success).toBe(true)
+      expect(result.data).toBe(true)
+    })
+
+    it('returns false when name does not exist', async () => {
+      const result = await hasActiveName('NonExistent')
+      expect(result.success).toBe(true)
+      expect(result.data).toBe(false)
+    })
+
+    it('returns false when the only match is excluded by id', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Catppuccin' }) })
+
+      const result = await hasActiveName('Catppuccin', saved.data!.id)
+      expect(result.success).toBe(true)
+      expect(result.data).toBe(false)
+    })
+
+    it('returns true when excludeId does not match the found entry', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Gruvbox' }) })
+
+      const result = await hasActiveName('Gruvbox', 'some-other-id')
+      expect(result.success).toBe(true)
+      expect(result.data).toBe(true)
+      expect(saved.data?.id).not.toBe('some-other-id')
+    })
+
+    it('returns false for deleted pack name', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Deleted Theme' }) })
+      await deletePack(saved.data!.id)
+
+      const result = await hasActiveName('Deleted Theme')
+      expect(result.success).toBe(true)
+      expect(result.data).toBe(false)
+    })
+  })
+
+  describe('purgeExpiredTombstones', () => {
+    it('removes tombstones older than TTL and deletes pack body', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Expired' }) })
+      const packPath = __testing.getPackPath(saved.data!.id)
+
+      const index = await __testing.readIndex()
+      const meta = index.metas.find((m) => m.id === saved.data!.id)!
+      const expiredDate = new Date(Date.now() - THEME_PACK_TOMBSTONE_TTL_MS - 1000).toISOString()
+      meta.deletedAt = expiredDate
+      meta.updatedAt = expiredDate
+      await __testing.writeIndex(index)
+
+      vi.mocked(notifyChange).mockClear()
+
+      await purgeExpiredTombstones()
+
+      const afterIndex = await __testing.readIndex()
+      expect(afterIndex.metas.find((m) => m.id === saved.data!.id)).toBeUndefined()
+
+      expect(notifyChange).toHaveBeenCalledWith(THEME_INDEX_SYNC_UNIT)
+
+      await expect(readFile(packPath, 'utf-8')).rejects.toThrow()
+    })
+
+    it('preserves non-expired tombstones', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Recent' }) })
+      await deletePack(saved.data!.id)
+
+      vi.mocked(notifyChange).mockClear()
+
+      await purgeExpiredTombstones()
+
+      const afterIndex = await __testing.readIndex()
+      const meta = afterIndex.metas.find((m) => m.id === saved.data!.id)
+      expect(meta).toBeTruthy()
+      expect(meta?.deletedAt).toBeTruthy()
+
+      expect(notifyChange).not.toHaveBeenCalled()
+    })
+
+    it('does nothing when there are no tombstones', async () => {
+      await savePack({ raw: makeValidPack({ name: 'Alive' }) })
+
+      vi.mocked(notifyChange).mockClear()
+
+      await purgeExpiredTombstones()
+
+      expect(notifyChange).not.toHaveBeenCalled()
+    })
+
+    it('preserves active entries when purging expired tombstones', async () => {
+      await savePack({ raw: makeValidPack({ name: 'Keeper' }) })
+      const doomed = await savePack({ raw: makeValidPack({ name: 'Doomed' }) })
+
+      const index = await __testing.readIndex()
+      const meta = index.metas.find((m) => m.id === doomed.data!.id)!
+      meta.deletedAt = new Date(Date.now() - THEME_PACK_TOMBSTONE_TTL_MS - 1000).toISOString()
+      await __testing.writeIndex(index)
+
+      await purgeExpiredTombstones()
+
+      const afterIndex = await __testing.readIndex()
+      expect(afterIndex.metas).toHaveLength(1)
+      expect(afterIndex.metas[0].name).toBe('Keeper')
+    })
+  })
+
+  describe('packSyncUnit', () => {
+    it('returns the expected sync unit path', () => {
+      expect(__testing.packSyncUnit('abc-123')).toBe('themes/packs/abc-123')
+    })
+  })
+
+  describe('getPackPath', () => {
+    it('rejects unsafe pack ids', () => {
+      expect(() => __testing.getPackPath('../escape')).toThrow('Invalid packId')
+      expect(() => __testing.getPackPath('has spaces')).toThrow('Invalid packId')
+      expect(() => __testing.getPackPath('')).toThrow('Invalid packId')
+    })
+
+    it('accepts valid pack ids', () => {
+      expect(() => __testing.getPackPath('valid-id-123')).not.toThrow()
+      expect(() => __testing.getPackPath('abc_def')).not.toThrow()
+    })
+  })
+})

--- a/src/main/hub/__tests__/hub-theme.test.ts
+++ b/src/main/hub/__tests__/hub-theme.test.ts
@@ -1,0 +1,514 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import {
+  fetchThemePostList,
+  downloadThemePostBody,
+  fetchThemePackTimestamps,
+  uploadThemePostToHub,
+  updateThemePostOnHub,
+  deleteThemePostFromHub,
+  MAX_HUB_THEME_JSON_BYTES,
+} from '../hub-theme'
+import { Hub401Error, Hub403Error, Hub409Error, Hub429Error } from '../hub-client'
+import type { HubThemePackBody } from '../../../shared/types/hub'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+const HUB_BASE = 'https://pipette-hub-worker.keymaps.workers.dev'
+
+function okJson<T>(data: T): {
+  ok: true
+  status: number
+  json: () => Promise<{ ok: true; data: T }>
+  text: () => Promise<string>
+  headers: Headers
+} {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ ok: true, data }),
+    text: async () => '',
+    headers: new Headers(),
+  }
+}
+
+function rawJson<T>(raw: T): {
+  ok: true
+  status: number
+  json: () => Promise<T>
+  text: () => Promise<string>
+  headers: Headers
+} {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => raw,
+    text: async () => '',
+    headers: new Headers(),
+  }
+}
+
+function failResponse(
+  status: number,
+  body = 'err',
+  retryAfter?: string,
+): {
+  ok: false
+  status: number
+  json: () => Promise<unknown>
+  text: () => Promise<string>
+  headers: Headers
+} {
+  const headers = new Headers()
+  if (retryAfter) headers.set('Retry-After', retryAfter)
+  return {
+    ok: false,
+    status,
+    json: async () => ({ ok: false, error: body }),
+    text: async () => body,
+    headers,
+  }
+}
+
+function samplePack(overrides?: Partial<HubThemePackBody>): HubThemePackBody {
+  return {
+    name: 'Nord',
+    version: '1.0.0',
+    colorScheme: 'both',
+    colors: { '--bg': '#2e3440', '--fg': '#eceff4' },
+    ...overrides,
+  }
+}
+
+describe('hub-theme', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeAll(() => {
+    savedEnv.PIPETTE_HUB_URL = process.env.PIPETTE_HUB_URL
+    savedEnv.ELECTRON_RENDERER_URL = process.env.ELECTRON_RENDERER_URL
+    delete process.env.PIPETTE_HUB_URL
+    delete process.env.ELECTRON_RENDERER_URL
+  })
+
+  afterAll(() => {
+    if (savedEnv.PIPETTE_HUB_URL !== undefined) process.env.PIPETTE_HUB_URL = savedEnv.PIPETTE_HUB_URL
+    if (savedEnv.ELECTRON_RENDERER_URL !== undefined) process.env.ELECTRON_RENDERER_URL = savedEnv.ELECTRON_RENDERER_URL
+  })
+
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  describe('fetchThemePostList', () => {
+    it('passes q/name/page/per_page as query params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          items: [],
+          total: 0,
+          page: 2,
+          per_page: 10,
+        }),
+      )
+
+      await fetchThemePostList({ q: 'nord', name: 'Nord Theme', page: 2, perPage: 10 })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs?q=nord&name=Nord+Theme&page=2&per_page=10`,
+        { method: 'GET' },
+      )
+    })
+
+    it('omits empty/undefined params', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({ items: [], total: 0, page: 1, per_page: 20 }),
+      )
+
+      await fetchThemePostList({})
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs`,
+        { method: 'GET' },
+      )
+    })
+
+    it('trims whitespace-only q param', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({ items: [], total: 0, page: 1, per_page: 20 }),
+      )
+
+      await fetchThemePostList({ q: '   ' })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs`,
+        { method: 'GET' },
+      )
+    })
+
+    it('maps snake_case response fields to camelCase', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          items: [
+            {
+              id: 'theme-1',
+              name: 'Nord',
+              version: '1.0.0',
+              uploaded_by: 'user-abc',
+              uploader_name: 'Alice',
+              created_at: '2026-05-01T00:00:00Z',
+              updated_at: '2026-05-10T00:00:00Z',
+            },
+          ],
+          total: 1,
+          page: 1,
+          per_page: 20,
+        }),
+      )
+
+      const result = await fetchThemePostList({})
+
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0]).toEqual({
+        id: 'theme-1',
+        name: 'Nord',
+        version: '1.0.0',
+        uploadedBy: 'user-abc',
+        uploaderName: 'Alice',
+        createdAt: '2026-05-01T00:00:00Z',
+        updatedAt: '2026-05-10T00:00:00Z',
+      })
+      expect(result.total).toBe(1)
+      expect(result.page).toBe(1)
+      expect(result.perPage).toBe(20)
+    })
+
+    it('defaults uploadedBy/uploaderName to null when absent', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          items: [
+            {
+              id: 'theme-2',
+              name: 'Solarized',
+              version: '2.0.0',
+              created_at: '2026-05-02T00:00:00Z',
+            },
+          ],
+          total: 1,
+          page: 1,
+          per_page: 20,
+        }),
+      )
+
+      const result = await fetchThemePostList({})
+
+      expect(result.items[0].uploadedBy).toBeNull()
+      expect(result.items[0].uploaderName).toBeNull()
+    })
+  })
+
+  describe('downloadThemePostBody', () => {
+    it('GETs the download route and returns the body', async () => {
+      const pack = samplePack()
+      mockFetch.mockResolvedValueOnce(okJson(pack))
+
+      const result = await downloadThemePostBody('theme-1')
+
+      expect(result).toEqual(pack)
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/theme-1/download`,
+        { method: 'GET' },
+      )
+    })
+
+    it('encodes special characters in postId', async () => {
+      mockFetch.mockResolvedValueOnce(okJson(samplePack()))
+
+      await downloadThemePostBody('abc/def')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/abc%2Fdef/download`,
+        { method: 'GET' },
+      )
+    })
+
+    it('handles raw JSON response without envelope', async () => {
+      const pack = samplePack()
+      mockFetch.mockResolvedValueOnce(rawJson(pack))
+
+      const result = await downloadThemePostBody('theme-1')
+
+      expect(result).toEqual(pack)
+    })
+  })
+
+  describe('fetchThemePackTimestamps', () => {
+    it('POSTs ids to /api/theme-packs/timestamps and returns items', async () => {
+      mockFetch.mockResolvedValueOnce(
+        okJson({
+          items: [
+            { id: 'theme-1', updated_at: '2026-05-10T01:00:00.000Z' },
+            { id: 'theme-2', updated_at: '2026-05-10T02:00:00.000Z' },
+          ],
+        }),
+      )
+
+      const result = await fetchThemePackTimestamps(['theme-1', 'theme-2'])
+
+      expect(result.items).toHaveLength(2)
+      expect(result.items[0]).toEqual({
+        id: 'theme-1',
+        updated_at: '2026-05-10T01:00:00.000Z',
+      })
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/timestamps`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+        }),
+      )
+      const init = mockFetch.mock.calls[0][1] as { body: string }
+      expect(JSON.parse(init.body)).toEqual({ ids: ['theme-1', 'theme-2'] })
+    })
+
+    it('handles empty ids array', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ items: [] }))
+
+      const result = await fetchThemePackTimestamps([])
+
+      expect(result.items).toHaveLength(0)
+    })
+  })
+
+  describe('uploadThemePostToHub', () => {
+    it('POSTs multipart body with auth header', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ id: 'new-theme', title: 'Nord' }))
+      const pack = samplePack()
+
+      const result = await uploadThemePostToHub('my-jwt', pack)
+
+      expect(result.id).toBe('new-theme')
+      expect(result.title).toBe('Nord')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer my-jwt',
+          }),
+        }),
+      )
+    })
+
+    it('sends multipart content type with boundary', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ id: 'new-theme', title: 'Nord' }))
+
+      await uploadThemePostToHub('jwt', samplePack())
+
+      const init = mockFetch.mock.calls[0][1] as { headers: Record<string, string> }
+      expect(init.headers['Content-Type']).toMatch(
+        /^multipart\/form-data; boundary=----PipetteThemeBoundary\d+$/,
+      )
+    })
+
+    it('includes JSON pack data in multipart body', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ id: 'new-theme', title: 'Nord' }))
+      const pack = samplePack()
+
+      await uploadThemePostToHub('jwt', pack)
+
+      const init = mockFetch.mock.calls[0][1] as { body: Buffer }
+      const bodyStr = init.body.toString('utf-8')
+      expect(bodyStr).toContain('Content-Disposition: form-data; name="json"; filename="theme-pack.json"')
+      expect(bodyStr).toContain('Content-Type: application/json')
+      expect(bodyStr).toContain(JSON.stringify(pack))
+    })
+  })
+
+  describe('updateThemePostOnHub', () => {
+    it('PUTs to /api/theme-packs/:postId', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ id: 'theme-99', title: 'Updated' }))
+
+      await updateThemePostOnHub('jwt', 'theme-99', samplePack())
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/theme-99`,
+        expect.objectContaining({
+          method: 'PUT',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer jwt',
+          }),
+        }),
+      )
+    })
+
+    it('encodes special characters in postId', async () => {
+      mockFetch.mockResolvedValueOnce(okJson({ id: 'a/b', title: 'X' }))
+
+      await updateThemePostOnHub('jwt', 'a/b', samplePack())
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/a%2Fb`,
+        expect.objectContaining({ method: 'PUT' }),
+      )
+    })
+  })
+
+  describe('deleteThemePostFromHub', () => {
+    it('DELETEs and resolves on success', async () => {
+      mockFetch.mockResolvedValueOnce(okJson(null))
+
+      await deleteThemePostFromHub('jwt', 'theme-42')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/theme-42`,
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: expect.objectContaining({ Authorization: 'Bearer jwt' }),
+        }),
+      )
+    })
+
+    it('encodes special characters in postId', async () => {
+      mockFetch.mockResolvedValueOnce(okJson(null))
+
+      await deleteThemePostFromHub('jwt', 'x/y/z')
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        `${HUB_BASE}/api/theme-packs/x%2Fy%2Fz`,
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+  })
+
+  describe('error handling', () => {
+    it('throws Hub401Error on 401', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(401, 'unauthorized'))
+      await expect(uploadThemePostToHub('bad-jwt', samplePack())).rejects.toBeInstanceOf(
+        Hub401Error,
+      )
+    })
+
+    it('throws Hub403Error on 403', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(403, 'forbidden'))
+      await expect(deleteThemePostFromHub('jwt', 'theme-1')).rejects.toBeInstanceOf(
+        Hub403Error,
+      )
+    })
+
+    it('throws Hub409Error on 409', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(409, 'name taken'))
+      await expect(uploadThemePostToHub('jwt', samplePack())).rejects.toBeInstanceOf(
+        Hub409Error,
+      )
+    })
+
+    it('throws Hub429Error on 429 with retryAfterSeconds', async () => {
+      mockFetch.mockResolvedValue(failResponse(429, 'rate limited', '999'))
+      await expect(fetchThemePostList({})).rejects.toSatisfy((err) => {
+        expect(err).toBeInstanceOf(Hub429Error)
+        expect((err as Hub429Error).retryAfterSeconds).toBe(999)
+        return true
+      })
+    })
+
+    it('throws generic Error on other status codes', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(500, 'internal'))
+      await expect(fetchThemePostList({})).rejects.toThrow('Hub theme list failed: 500 internal')
+    })
+
+    it('throws on wrapped error response with ok:false', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false, error: 'pack validation failed' }),
+        text: async () => '',
+        headers: new Headers(),
+      })
+      await expect(fetchThemePostList({})).rejects.toThrow('pack validation failed')
+    })
+
+    it('throws on wrapped error response with ok:false and no error message', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: false }),
+        text: async () => '',
+        headers: new Headers(),
+      })
+      await expect(fetchThemePostList({})).rejects.toThrow('unknown error')
+    })
+  })
+
+  describe('rate limit retry (429)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('retries once after Retry-After delay and succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce(failResponse(429, 'slow down', '1'))
+        .mockResolvedValueOnce(okJson({ items: [], total: 0, page: 1, per_page: 20 }))
+
+      const promise = fetchThemePostList({})
+      await vi.advanceTimersByTimeAsync(1000)
+      const result = await promise
+
+      expect(result.items).toHaveLength(0)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws Hub429Error when Retry-After exceeds MAX_RETRY_AFTER_S', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(429, 'slow down', '61'))
+
+      await expect(fetchThemePostList({})).rejects.toBeInstanceOf(Hub429Error)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws Hub429Error when Retry-After is absent on first attempt', async () => {
+      mockFetch.mockResolvedValueOnce(failResponse(429, 'slow down'))
+
+      await expect(fetchThemePostList({})).rejects.toBeInstanceOf(Hub429Error)
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('throws Hub429Error on second 429 even with valid Retry-After', async () => {
+      mockFetch
+        .mockResolvedValueOnce(failResponse(429, 'slow down', '1'))
+        .mockResolvedValueOnce(failResponse(429, 'still slow', '1'))
+
+      const promise = fetchThemePostList({}).catch((err: unknown) => {
+        expect(err).toBeInstanceOf(Hub429Error)
+        return err
+      })
+      await vi.advanceTimersByTimeAsync(1000)
+      await promise
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it('retries with Retry-After at the MAX_RETRY_AFTER_S boundary', async () => {
+      mockFetch
+        .mockResolvedValueOnce(failResponse(429, 'slow down', '60'))
+        .mockResolvedValueOnce(okJson({ items: [], total: 0, page: 1, per_page: 20 }))
+
+      const promise = fetchThemePostList({})
+      await vi.advanceTimersByTimeAsync(60_000)
+      const result = await promise
+
+      expect(result.items).toHaveLength(0)
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('MAX_HUB_THEME_JSON_BYTES', () => {
+    it('is exported as 64 KiB', () => {
+      expect(MAX_HUB_THEME_JSON_BYTES).toBe(64 * 1024)
+    })
+  })
+})

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -1,0 +1,797 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params && 'name' in params) return `${key}:${String(params.name)}`
+      return key
+    },
+  }),
+  Trans: ({
+    i18nKey,
+    components,
+  }: {
+    i18nKey: string
+    components?: Record<string, JSX.Element>
+  }) => (
+    <>
+      {i18nKey}
+      {components
+        ? Object.entries(components).map(([key, node]) => (
+            <span key={key}>{node}</span>
+          ))
+        : null}
+    </>
+  ),
+}))
+
+const refresh = vi.fn().mockResolvedValue(undefined)
+const renameFn = vi.fn()
+const removeFn = vi.fn()
+const importFromDialog = vi.fn()
+const applyImport = vi.fn()
+const setEnabled = vi.fn()
+
+let storeMetas: Array<{
+  id: string
+  name: string
+  version: string
+  enabled: boolean
+  hubPostId?: string
+  hubUpdatedAt?: string
+  filename: string
+  savedAt: string
+  updatedAt: string
+  deletedAt?: string
+  matchedBaseVersion?: string
+  coverage?: { totalKeys: number; coveredKeys: number }
+  appVersionAtImport?: string
+  dangerousKeyCount?: number
+}> = []
+
+vi.mock('../../../hooks/useI18nPackStore', () => ({
+  useI18nPackStore: () => ({
+    metas: storeMetas,
+    loading: false,
+    refresh,
+    rename: renameFn,
+    remove: removeFn,
+    importFromDialog,
+    applyImport,
+    setEnabled,
+    packRemovedNotice: null,
+    dismissPackRemovedNotice: vi.fn(),
+  }),
+}))
+
+let mockLanguage: string = 'builtin:en'
+const mockAppConfigSet = vi.fn()
+
+vi.mock('../../../hooks/useAppConfig', () => ({
+  useAppConfig: () => ({
+    config: { language: mockLanguage },
+    loading: false,
+    set: mockAppConfigSet,
+  }),
+}))
+
+vi.mock('../../../hooks/useHubFreshness', () => ({
+  useHubFreshness: ({ enabled, candidates, fetchTimestamps }: {
+    enabled: boolean
+    candidates: Array<{ localId: string; hubPostId: string }>
+    fetchTimestamps: (ids: string[]) => Promise<unknown>
+  }) => {
+    if (enabled && candidates.length > 0) {
+      void fetchTimestamps(candidates.map((c) => c.hubPostId))
+    }
+    return new Map()
+  },
+  hasUpdate: () => false,
+}))
+
+vi.mock('../../../i18n', () => ({
+  default: { changeLanguage: vi.fn().mockResolvedValue(undefined) },
+}))
+
+vi.mock('../../../../shared/i18n/validate', () => ({
+  validatePack: (raw: unknown) => {
+    if (!raw || typeof raw !== 'object') {
+      return { ok: false, errors: ['Pack must be a JSON object'], warnings: [], dangerousKeys: [] }
+    }
+    const obj = raw as Record<string, unknown>
+    if (obj.__dangerous) {
+      return { ok: true, errors: [], warnings: [], dangerousKeys: ['__proto__'], header: { name: String(obj.name), version: String(obj.version) } }
+    }
+    if (obj.__invalid) {
+      return { ok: false, errors: ['version must be a valid semver (e.g. 0.1.0)'], warnings: [], dangerousKeys: [] }
+    }
+    return { ok: true, errors: [], warnings: [], dangerousKeys: [], header: { name: String(obj.name), version: String(obj.version) } }
+  },
+}))
+
+vi.mock('../../../../shared/i18n/coverage', () => ({
+  computeCoverage: () => ({
+    totalKeys: 100,
+    coveredKeys: 100,
+    missingKeys: [],
+    excessKeys: [],
+    coverageRatio: 1,
+  }),
+}))
+
+vi.mock('../../../i18n/coverage-cache', () => ({
+  BASE_REVISION: '0.1.0',
+  ENGLISH_PACK_BODY: { name: 'English', version: '0.1.0', common: { save: 'Save' } },
+}))
+
+vi.mock('../../../i18n/locales/english.json', () => ({
+  default: { name: 'English', version: '0.1.0', common: { save: 'Save' } },
+}))
+
+vi.mock('../../../utils/download-json', () => ({
+  downloadJson: vi.fn(),
+}))
+
+vi.mock('../../../utils/format-timestamp', () => ({
+  formatTimestamp: (iso: string) => iso === 'now' ? '' : iso,
+}))
+
+const vialAPI = {
+  hubGetOrigin: vi.fn(),
+  hubListI18nPosts: vi.fn(),
+  hubDownloadI18nPost: vi.fn(),
+  hubUploadI18nPost: vi.fn(),
+  hubUpdateI18nPost: vi.fn(),
+  hubDeleteI18nPost: vi.fn(),
+  i18nPackGet: vi.fn(),
+  i18nPackExport: vi.fn(),
+  i18nPackSetHubPostId: vi.fn(),
+  i18nPackHubTimestamps: vi.fn(),
+  openExternal: vi.fn(),
+}
+
+Object.defineProperty(window, 'vialAPI', { value: vialAPI, writable: true })
+
+import { LanguagePacksModal } from '../LanguagePacksModal'
+import { downloadJson } from '../../../utils/download-json'
+
+function meta(over: Partial<{
+  id: string
+  name: string
+  version: string
+  enabled: boolean
+  hubPostId: string
+  hubUpdatedAt: string
+  deletedAt: string
+  matchedBaseVersion: string
+  coverage: { totalKeys: number; coveredKeys: number }
+}> = {}) {
+  return {
+    id: over.id ?? 'a',
+    name: over.name ?? 'Pack A',
+    version: over.version ?? '0.1.0',
+    enabled: over.enabled ?? true,
+    filename: `${over.id ?? 'a'}.json`,
+    savedAt: 'now',
+    updatedAt: 'now',
+    ...(over.hubPostId ? { hubPostId: over.hubPostId } : {}),
+    ...(over.hubUpdatedAt ? { hubUpdatedAt: over.hubUpdatedAt } : {}),
+    ...(over.deletedAt ? { deletedAt: over.deletedAt } : {}),
+    ...(over.matchedBaseVersion !== undefined ? { matchedBaseVersion: over.matchedBaseVersion } : {}),
+    ...(over.coverage ? { coverage: over.coverage } : {}),
+  }
+}
+
+async function switchToHubTab(): Promise<void> {
+  fireEvent.click(screen.getByTestId('language-packs-tab-hub'))
+  await waitFor(() => expect(screen.getByTestId('language-packs-search-input')).toBeTruthy())
+}
+
+describe('LanguagePacksModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeMetas = []
+    mockLanguage = 'builtin:en'
+    removeFn.mockResolvedValue({ success: true })
+    renameFn.mockResolvedValue({ success: true })
+    importFromDialog.mockResolvedValue({ canceled: true })
+    applyImport.mockResolvedValue({ success: true, meta: meta() })
+    vialAPI.hubGetOrigin.mockResolvedValue('https://hub.example.com')
+    vialAPI.hubListI18nPosts.mockResolvedValue({ success: true, data: { items: [] } })
+    vialAPI.hubDownloadI18nPost.mockResolvedValue({ success: true, data: { pack: { name: 'DL', version: '0.1.0', common: {} } } })
+    vialAPI.hubUploadI18nPost.mockResolvedValue({ success: true })
+    vialAPI.hubUpdateI18nPost.mockResolvedValue({ success: true })
+    vialAPI.hubDeleteI18nPost.mockResolvedValue({ success: true })
+    vialAPI.i18nPackGet.mockResolvedValue({ success: true, data: { pack: { name: 'P', version: '0.1.0', common: {} } } })
+    vialAPI.i18nPackExport.mockResolvedValue({ success: true })
+    vialAPI.i18nPackSetHubPostId.mockResolvedValue({ success: true })
+    vialAPI.i18nPackHubTimestamps.mockResolvedValue({ success: true, data: { items: [] } })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <LanguagePacksModal open={false} onClose={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders modal content when open', () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-modal')).toBeTruthy()
+    expect(screen.getByText('i18n.modalTitle')).toBeTruthy()
+  })
+
+  it('shows Installed and Hub tabs', () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-tab-installed')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-tab-hub')).toBeTruthy()
+  })
+
+  it('shows built-in English row on Installed tab', () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-row-builtin:en')).toBeTruthy()
+    expect(screen.getByText('English')).toBeTruthy()
+  })
+
+  it('built-in English row shows export but not delete', () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-export-builtin:en')).toBeTruthy()
+    expect(screen.queryByTestId('language-packs-delete-builtin:en')).toBeNull()
+  })
+
+  it('switches to Hub tab and shows search input', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    expect(screen.getByTestId('language-packs-search-input')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-search-button')).toBeTruthy()
+  })
+
+  it('switches back to Installed tab', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    fireEvent.click(screen.getByTestId('language-packs-tab-installed'))
+    expect(screen.getByTestId('language-packs-row-builtin:en')).toBeTruthy()
+    expect(screen.queryByTestId('language-packs-search-input')).toBeNull()
+  })
+
+  it('renders imported pack rows', () => {
+    storeMetas = [meta({ id: 'p1', name: 'Japanese' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-row-p1')).toBeTruthy()
+    expect(screen.getByText('Japanese')).toBeTruthy()
+  })
+
+  it('skips tombstoned (deleted) metas in installed rows', () => {
+    storeMetas = [meta({ id: 'del1', name: 'Deleted', deletedAt: '2026-01-01' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.queryByTestId('language-packs-row-del1')).toBeNull()
+  })
+
+  it('selects a language via the select button', () => {
+    storeMetas = [meta({ id: 'p1', name: 'Japanese' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-select-p1'))
+    expect(mockAppConfigSet).toHaveBeenCalledWith('language', 'pack:p1')
+  })
+
+  it('does not call set when selecting the already-active language', () => {
+    storeMetas = [meta({ id: 'p1', name: 'Japanese' })]
+    mockLanguage = 'pack:p1'
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-select-p1'))
+    expect(mockAppConfigSet).not.toHaveBeenCalled()
+  })
+
+  it('import button triggers importFromDialog', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+  })
+
+  it('import applies the raw data when dialog returns a file', async () => {
+    const raw = { name: 'Imported', version: '0.1.0', common: { ok: 'OK' } }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'imp1', name: 'Imported' }) })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalled())
+  })
+
+  it('import shows error on parse failure', async () => {
+    importFromDialog.mockResolvedValueOnce({ canceled: false, parseError: 'Bad format' })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-error')).toBeTruthy()
+    })
+  })
+
+  it('import shows error for invalid pack validation', async () => {
+    const raw = { name: 'Bad', version: 'not-semver', __invalid: true }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-error')).toBeTruthy()
+    })
+  })
+
+  it('import shows error for dangerous keys', async () => {
+    const raw = { name: 'Danger', version: '0.1.0', __dangerous: true }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-error')).toBeTruthy()
+    })
+  })
+
+  it('overwrite import with hubPostId auto-syncs to Hub', async () => {
+    const raw = { name: 'Synced', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 's1', name: 'Synced', hubPostId: 'hp1' }) })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(vialAPI.hubUpdateI18nPost).toHaveBeenCalled())
+  })
+
+  it('delete asks for confirmation before invoking remove', () => {
+    storeMetas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-delete-p1'))
+    expect(screen.getByTestId('language-packs-confirm-delete-p1')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-cancel-delete-p1')).toBeTruthy()
+  })
+
+  it('confirmed delete calls store.remove', async () => {
+    storeMetas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-delete-p1'))
+    fireEvent.click(screen.getByTestId('language-packs-confirm-delete-p1'))
+    await waitFor(() => expect(removeFn).toHaveBeenCalledWith('p1'))
+  })
+
+  it('cancel delete hides the confirmation', () => {
+    storeMetas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-delete-p1'))
+    fireEvent.click(screen.getByTestId('language-packs-cancel-delete-p1'))
+    expect(screen.queryByTestId('language-packs-confirm-delete-p1')).toBeNull()
+  })
+
+  it('delete also calls hubDeleteI18nPost for hub-linked pack', async () => {
+    storeMetas = [meta({ id: 'hd1', name: 'Hub Delete', hubPostId: 'hp-hd1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-delete-hd1'))
+    fireEvent.click(screen.getByTestId('language-packs-confirm-delete-hd1'))
+    await waitFor(() => expect(vialAPI.hubDeleteI18nPost).toHaveBeenCalledWith('hp-hd1', 'hd1'))
+    await waitFor(() => expect(removeFn).toHaveBeenCalledWith('hd1'))
+  })
+
+  it('export action triggers i18nPackExport for imported rows', async () => {
+    storeMetas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-export-p1'))
+    await waitFor(() => expect(vialAPI.i18nPackExport).toHaveBeenCalledWith('p1'))
+  })
+
+  it('export action triggers downloadJson for built-in English', () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-export-builtin:en'))
+    expect(downloadJson).toHaveBeenCalled()
+  })
+
+  it('upload action calls hubUploadI18nPost', async () => {
+    storeMetas = [meta({ id: 'u1', name: 'Upload Me' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-upload-u1'))
+    await waitFor(() => expect(vialAPI.i18nPackGet).toHaveBeenCalledWith('u1'))
+    await waitFor(() => expect(vialAPI.hubUploadI18nPost).toHaveBeenCalled())
+  })
+
+  it('upload button is hidden when hubCanWrite is false', () => {
+    storeMetas = [meta({ id: 'nw1', name: 'No Write' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite={false} />,
+    )
+    expect(screen.queryByTestId('language-packs-upload-nw1')).toBeNull()
+  })
+
+  it('update action calls pushPackToHub', async () => {
+    storeMetas = [meta({ id: 'up1', name: 'Update Me', hubPostId: 'hp-up1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-update-up1'))
+    await waitFor(() => expect(vialAPI.i18nPackGet).toHaveBeenCalledWith('up1'))
+    await waitFor(() => expect(vialAPI.hubUpdateI18nPost).toHaveBeenCalled())
+  })
+
+  it('update and remove buttons are visible when hubCanWrite is true for hub-linked row', () => {
+    storeMetas = [meta({ id: 'w1', name: 'Write Hub', hubPostId: 'hp-w1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    expect(screen.getByTestId('language-packs-update-w1')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-remove-w1')).toBeTruthy()
+    expect(screen.queryByTestId('language-packs-sync-w1')).toBeNull()
+  })
+
+  it('update and remove buttons are hidden when hubCanWrite is false for hub-linked row', () => {
+    storeMetas = [meta({ id: 'nw2', name: 'No Write Hub', hubPostId: 'hp-nw2' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite={false} />,
+    )
+    expect(screen.queryByTestId('language-packs-update-nw2')).toBeNull()
+    expect(screen.queryByTestId('language-packs-remove-nw2')).toBeNull()
+    expect(screen.getByTestId('language-packs-sync-nw2')).toBeTruthy()
+  })
+
+  it('sync action calls hubDownloadI18nPost and applyImport', async () => {
+    storeMetas = [meta({ id: 'sy1', name: 'Sync Me', hubPostId: 'hp-sy1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite={false} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-sync-sy1'))
+    await waitFor(() => expect(vialAPI.hubDownloadI18nPost).toHaveBeenCalledWith('hp-sy1'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalled())
+  })
+
+  it('remove action asks for confirmation', () => {
+    storeMetas = [meta({ id: 'rm1', name: 'Remove Me', hubPostId: 'hp-rm1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-remove-rm1'))
+    expect(screen.getByTestId('language-packs-confirm-remove-rm1')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-cancel-remove-rm1')).toBeTruthy()
+  })
+
+  it('confirmed remove calls hubDeleteI18nPost', async () => {
+    storeMetas = [meta({ id: 'rm2', name: 'Remove Me', hubPostId: 'hp-rm2' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-remove-rm2'))
+    fireEvent.click(screen.getByTestId('language-packs-confirm-remove-rm2'))
+    await waitFor(() => expect(vialAPI.hubDeleteI18nPost).toHaveBeenCalledWith('hp-rm2', 'rm2'))
+  })
+
+  it('cancel remove hides the confirmation', () => {
+    storeMetas = [meta({ id: 'rm3', name: 'Remove Me', hubPostId: 'hp-rm3' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-remove-rm3'))
+    fireEvent.click(screen.getByTestId('language-packs-cancel-remove-rm3'))
+    expect(screen.queryByTestId('language-packs-confirm-remove-rm3')).toBeNull()
+  })
+
+  it('Hub search button is disabled when query is less than 2 chars', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'a' } })
+    const btn = screen.getByTestId('language-packs-search-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('Hub search triggers when Search button clicked with 2+ chars', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'japanese' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => expect(vialAPI.hubListI18nPosts).toHaveBeenCalledWith({ q: 'japanese' }))
+  })
+
+  it('debounced search fires after typing 2+ chars and waiting', async () => {
+    vi.useFakeTimers()
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await act(async () => { fireEvent.click(screen.getByTestId('language-packs-tab-hub')) })
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'french' } })
+    })
+    expect(vialAPI.hubListI18nPosts).not.toHaveBeenCalled()
+    await act(async () => { vi.advanceTimersByTime(300) })
+    expect(vialAPI.hubListI18nPosts).toHaveBeenCalledWith({ q: 'french' })
+    vi.useRealTimers()
+  })
+
+  it('shows hub results after search returns items', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-99', name: 'French Pack', version: '1.0', uploaderName: 'someone' },
+        ],
+      },
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'french' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-hub-row-hub-99')).toBeTruthy()
+      expect(screen.getByText('French Pack')).toBeTruthy()
+    })
+  })
+
+  it('hub download action calls hubDownloadI18nPost and persistImportedPack', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-dl', name: 'German', version: '1.0', uploaderName: null },
+        ],
+      },
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'german' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-hub-download-hub-dl')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('language-packs-hub-download-hub-dl'))
+    await waitFor(() => expect(vialAPI.hubDownloadI18nPost).toHaveBeenCalledWith('hub-dl'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalled())
+  })
+
+  it('hub row shows installed label when pack is already installed', async () => {
+    storeMetas = [meta({ id: 'local1', name: 'Existing', hubPostId: 'hub-3' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-3', name: 'Existing', version: '1.0', uploaderName: null },
+        ],
+      },
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'exist' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-hub-row-hub-3')).toBeTruthy())
+    expect(screen.queryByTestId('language-packs-hub-download-hub-3')).toBeNull()
+  })
+
+  it('does not treat deleted (tombstoned) metas as installed in hub rows', async () => {
+    storeMetas = [meta({ id: 'del1', name: 'Deleted', hubPostId: 'hp-del1', deletedAt: '2026-01-01' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hp-del1', name: 'Deleted', version: '1.0', uploaderName: null },
+        ],
+      },
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'deleted' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-hub-row-hp-del1')).toBeTruthy())
+    expect(screen.getByTestId('language-packs-hub-download-hp-del1')).toBeTruthy()
+  })
+
+  it('hub empty message when search returns no results', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: true,
+      data: { items: [] },
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'zzz' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-hub-empty')).toBeTruthy()
+      expect(screen.getByText('i18n.hubEmpty')).toBeTruthy()
+    })
+  })
+
+  it('hub initial hint when no search has been performed', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    expect(screen.getByTestId('language-packs-hub-empty')).toBeTruthy()
+    expect(screen.getByText('common.findOnHubHint')).toBeTruthy()
+  })
+
+  it('hub search error is displayed', async () => {
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: false,
+      error: 'Network error',
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'fail' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-error')).toBeTruthy()
+      expect(screen.getByText('Network error')).toBeTruthy()
+    })
+  })
+
+  it('rename triggers inline edit and commits on blur', async () => {
+    storeMetas = [meta({ id: 'r1', name: 'Old Name' })]
+    renameFn.mockResolvedValueOnce({ success: true, meta: meta({ id: 'r1', name: 'New Name' }) })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-name-r1'))
+    const input = screen.getByTestId('language-packs-rename-input-r1')
+    expect(input).toBeTruthy()
+    fireEvent.change(input, { target: { value: 'New Name' } })
+    fireEvent.blur(input)
+    await waitFor(() => expect(renameFn).toHaveBeenCalledWith('r1', 'New Name'))
+  })
+
+  it('open in browser calls openExternal for hub-linked row', async () => {
+    storeMetas = [meta({ id: 'o1', name: 'Open Me', hubPostId: 'hp-o1' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    await waitFor(() => expect(vialAPI.hubGetOrigin).toHaveBeenCalled())
+    fireEvent.click(screen.getByTestId('language-packs-open-o1'))
+    await waitFor(() => expect(vialAPI.openExternal).toHaveBeenCalled())
+  })
+
+  it('backdrop click calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <LanguagePacksModal open onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-modal-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('close button calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <LanguagePacksModal open onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-modal-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('shows version badge for complete packs', () => {
+    storeMetas = [meta({ id: 'c1', name: 'Complete', matchedBaseVersion: '0.1.0' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-version-c1')).toBeTruthy()
+    expect(screen.getByTestId('language-packs-version-c1').textContent).toBe('v0.1.0')
+  })
+
+  it('shows not-set-keys button for incomplete packs', () => {
+    storeMetas = [meta({ id: 'ic1', name: 'Incomplete' })]
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    expect(screen.getByTestId('language-packs-not-set-keys-ic1')).toBeTruthy()
+  })
+
+  it('not-set-keys button opens MissingKeysModal', async () => {
+    storeMetas = [meta({ id: 'ic1', name: 'Incomplete' })]
+    vialAPI.i18nPackGet.mockResolvedValueOnce({
+      success: true,
+      data: { pack: { name: 'Incomplete', version: '0.1.0', common: {} } },
+    })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-not-set-keys-ic1'))
+    await waitFor(() => expect(vialAPI.i18nPackGet).toHaveBeenCalledWith('ic1'))
+    await waitFor(() => expect(screen.getByTestId('missing-keys-modal')).toBeTruthy())
+  })
+
+  it('upload shows error result on failure', async () => {
+    storeMetas = [meta({ id: 'uf1', name: 'Upload Fail' })]
+    vialAPI.i18nPackGet.mockResolvedValueOnce({ success: false, error: 'Not found' })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-upload-uf1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-result-uf1')).toBeTruthy()
+    })
+  })
+
+  it('export shows error on failure', async () => {
+    storeMetas = [meta({ id: 'ef1', name: 'Export Fail' })]
+    vialAPI.i18nPackExport.mockResolvedValueOnce({ success: false, error: 'Export failed' })
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('language-packs-export-ef1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-result-ef1')).toBeTruthy()
+    })
+  })
+
+  it('clears error and result state when modal closes and reopens', async () => {
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <LanguagePacksModal open onClose={onClose} />,
+    )
+    await switchToHubTab()
+    vialAPI.hubListI18nPosts.mockResolvedValueOnce({
+      success: false,
+      error: 'Network error',
+    })
+    fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'fail' } })
+    fireEvent.click(screen.getByTestId('language-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-error')).toBeTruthy())
+    rerender(<LanguagePacksModal open={false} onClose={onClose} />)
+    rerender(<LanguagePacksModal open onClose={onClose} />)
+    expect(screen.queryByTestId('language-packs-error')).toBeNull()
+  })
+})

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -302,4 +302,34 @@ describe('KeyLabelsModal', () => {
     const upload = screen.getByTestId('key-labels-upload-mine') as HTMLButtonElement
     expect(upload.disabled).toBe(true)
   })
+
+  it('Delete on a hub-linked entry calls remove(id)', async () => {
+    metas = [meta({ id: 'hubbed', name: 'Hubbed', uploaderName: 'me', hubPostId: 'hub-99' })]
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+    fireEvent.click(screen.getByTestId('key-labels-delete-hubbed'))
+    const confirm = await screen.findByTestId('key-labels-confirm-delete-hubbed')
+    fireEvent.click(confirm)
+    await waitFor(() => expect(remove).toHaveBeenCalledWith('hubbed'))
+  })
+
+  it('auto-pushes to Hub when importing over an entry with hubPostId', async () => {
+    const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
+    importFromFile.mockResolvedValueOnce({ success: true, data: importedMeta })
+    hubUpdate.mockResolvedValueOnce({ success: true, data: importedMeta })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
+  })
+
+  it('shows error when hub auto-sync fails after import', async () => {
+    const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
+    importFromFile.mockResolvedValueOnce({ success: true, data: importedMeta })
+    hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
+    await waitFor(() => {
+      expect(screen.getByText('network error')).toBeTruthy()
+    })
+  })
 })

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -14,7 +14,7 @@ import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useThemePackStore } from '../../hooks/useThemePackStore'
 import { applyPackColors, clearPackColors, isPackTheme, extractPackId } from '../../hooks/useTheme'
-import type { ThemePackColors } from '../../../shared/types/theme-store'
+import type { ThemeColorScheme, ThemePackColors } from '../../../shared/types/theme-store'
 import type { HubThemePostListItem, HubThemePackBody } from '../../../shared/types/hub'
 import { buildHubCategoryUrl, HUB_CATEGORY } from '../../../shared/hub-urls'
 import { useHubFreshness } from '../../hooks/useHubFreshness'
@@ -60,6 +60,8 @@ export function ThemePacksModal({
   const [hubOrigin, setHubOrigin] = useState('')
   const [previewPostId, setPreviewPostId] = useState<string | null>(null)
   const previewSeqRef = useRef(0)
+  const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
+  const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
 
   const activeTheme = appConfig.config.theme
 
@@ -131,11 +133,17 @@ export function ThemePacksModal({
     clearPackColors()
     if (isPackTheme(activeTheme)) {
       const packId = extractPackId(activeTheme)
-      void window.vialAPI.themePackGet(packId).then((result) => {
-        if (result.success && result.data) {
-          applyPackColors(result.data.pack.colors, result.data.pack.colorScheme)
-        }
-      })
+      const cached = activePackCacheRef.current
+      if (cached && cached.id === packId) {
+        applyPackColors(cached.colors, cached.colorScheme)
+      } else {
+        void window.vialAPI.themePackGet(packId).then((result) => {
+          if (result.success && result.data) {
+            activePackCacheRef.current = { id: packId, colors: result.data.pack.colors, colorScheme: result.data.pack.colorScheme }
+            applyPackColors(result.data.pack.colors, result.data.pack.colorScheme)
+          }
+        })
+      }
     }
     setPreviewPostId(null)
   }, [activeTheme])
@@ -145,11 +153,18 @@ export function ThemePacksModal({
       restoreActiveTheme()
       return
     }
+    const cached = hubPreviewCacheRef.current.get(postId)
+    if (cached) {
+      applyPackColors(cached.colors as ThemePackColors, cached.colorScheme)
+      setPreviewPostId(postId)
+      return
+    }
     const seq = ++previewSeqRef.current
     setPendingId(postId)
     try {
       const result = await window.vialAPI.hubDownloadThemePost(postId)
       if (!result.success || !result.data || previewSeqRef.current !== seq) return
+      hubPreviewCacheRef.current.set(postId, result.data)
       applyPackColors(result.data.colors as ThemePackColors, result.data.colorScheme)
       setPreviewPostId(postId)
     } finally {
@@ -164,8 +179,14 @@ export function ThemePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
+      hubPreviewCacheRef.current.clear()
+      activePackCacheRef.current = null
     }
   }, [open, previewPostId, restoreActiveTheme])
+
+  useEffect(() => {
+    activePackCacheRef.current = null
+  }, [activeTheme])
 
   const pushPackToHub = useCallback(async (
     packId: string,

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -241,11 +241,14 @@ export function ThemePacksModal({
       }
       const result = await store.remove(id)
       if (!result.success && result.error) setActionError(result.error)
+      if (result.success && isPackTheme(activeTheme) && extractPackId(activeTheme) === id) {
+        onThemeChange('system')
+      }
     } finally {
       setPendingId(null)
       setConfirmDeleteId(null)
     }
-  }, [store])
+  }, [store, activeTheme, onThemeChange])
 
   const handleImportFile = useCallback(async () => {
     setActionError(null)

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -133,7 +133,7 @@ export function ThemePacksModal({
       const packId = extractPackId(activeTheme)
       void window.vialAPI.themePackGet(packId).then((result) => {
         if (result.success && result.data) {
-          applyPackColors(result.data.pack.colors)
+          applyPackColors(result.data.pack.colors, result.data.pack.colorScheme)
         }
       })
     }
@@ -150,7 +150,7 @@ export function ThemePacksModal({
     try {
       const result = await window.vialAPI.hubDownloadThemePost(postId)
       if (!result.success || !result.data || previewSeqRef.current !== seq) return
-      applyPackColors(result.data.colors as ThemePackColors)
+      applyPackColors(result.data.colors as ThemePackColors, result.data.colorScheme)
       setPreviewPostId(postId)
     } finally {
       if (previewSeqRef.current === seq) setPendingId(null)

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -1,0 +1,663 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      if (params && 'name' in params) return `${key}:${String(params.name)}`
+      return key
+    },
+  }),
+  Trans: ({
+    i18nKey,
+    components,
+  }: {
+    i18nKey: string
+    components?: Record<string, JSX.Element>
+  }) => (
+    <>
+      {i18nKey}
+      {components
+        ? Object.entries(components).map(([key, node]) => (
+            <span key={key}>{node}</span>
+          ))
+        : null}
+    </>
+  ),
+}))
+
+const refresh = vi.fn().mockResolvedValue(undefined)
+const renameFn = vi.fn()
+const removeFn = vi.fn()
+const importFromDialog = vi.fn()
+const applyImport = vi.fn()
+const exportPack = vi.fn()
+
+let metas: Array<{
+  id: string
+  name: string
+  version: string
+  hubPostId?: string
+  hubUpdatedAt?: string
+  filename: string
+  savedAt: string
+  updatedAt: string
+  deletedAt?: string
+}> = []
+
+vi.mock('../../../hooks/useThemePackStore', () => ({
+  useThemePackStore: () => ({
+    metas,
+    loading: false,
+    refresh,
+    rename: renameFn,
+    remove: removeFn,
+    importFromDialog,
+    applyImport,
+    exportPack,
+  }),
+}))
+
+let mockTheme: string = 'system'
+
+vi.mock('../../../hooks/useAppConfig', () => ({
+  useAppConfig: () => ({
+    config: { theme: mockTheme },
+    loading: false,
+    set: vi.fn(),
+  }),
+}))
+
+vi.mock('../../../hooks/useHubFreshness', () => ({
+  useHubFreshness: ({ enabled, candidates, fetchTimestamps }: {
+    enabled: boolean
+    candidates: Array<{ localId: string; hubPostId: string }>
+    fetchTimestamps: (ids: string[]) => Promise<unknown>
+  }) => {
+    if (enabled && candidates.length > 0) {
+      void fetchTimestamps(candidates.map((c) => c.hubPostId))
+    }
+    return new Map()
+  },
+  hasUpdate: () => false,
+}))
+
+vi.mock('../../../hooks/useTheme', () => ({
+  applyPackColors: vi.fn(),
+  clearPackColors: vi.fn(),
+  isPackTheme: (t: string) => t.startsWith('pack:'),
+  extractPackId: (t: string) => t.slice(5),
+}))
+
+const vialAPI = {
+  hubGetOrigin: vi.fn(),
+  hubListThemePosts: vi.fn(),
+  hubDownloadThemePost: vi.fn(),
+  hubUploadThemePost: vi.fn(),
+  hubUpdateThemePost: vi.fn(),
+  hubDeleteThemePost: vi.fn(),
+  themePackGet: vi.fn(),
+  themePackHubTimestamps: vi.fn(),
+  openExternal: vi.fn(),
+}
+
+Object.defineProperty(window, 'vialAPI', { value: vialAPI, writable: true })
+
+import { ThemePacksModal } from '../ThemePacksModal'
+
+function meta(over: Partial<{
+  id: string
+  name: string
+  version: string
+  hubPostId: string
+  hubUpdatedAt: string
+  deletedAt: string
+}> = {}) {
+  return {
+    id: over.id ?? 'a',
+    name: over.name ?? 'Pack A',
+    version: over.version ?? '1.0',
+    filename: 'a.json',
+    savedAt: 'now',
+    updatedAt: 'now',
+    ...(over.hubPostId ? { hubPostId: over.hubPostId } : {}),
+    ...(over.hubUpdatedAt ? { hubUpdatedAt: over.hubUpdatedAt } : {}),
+    ...(over.deletedAt ? { deletedAt: over.deletedAt } : {}),
+  }
+}
+
+describe('ThemePacksModal', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    metas = []
+    mockTheme = 'system'
+    removeFn.mockResolvedValue({ success: true })
+    renameFn.mockResolvedValue({ success: true })
+    importFromDialog.mockResolvedValue({ canceled: true })
+    applyImport.mockResolvedValue({ success: true, meta: meta() })
+    exportPack.mockResolvedValue({ success: true })
+    vialAPI.hubGetOrigin.mockResolvedValue('https://hub.example.com')
+    vialAPI.hubListThemePosts.mockResolvedValue({ success: true, data: { items: [] } })
+    vialAPI.hubDownloadThemePost.mockResolvedValue({ success: true, data: { name: 'DL', version: '1', colorScheme: 'dark', colors: {} } })
+    vialAPI.hubUploadThemePost.mockResolvedValue({ success: true })
+    vialAPI.hubUpdateThemePost.mockResolvedValue({ success: true })
+    vialAPI.hubDeleteThemePost.mockResolvedValue({ success: true })
+    vialAPI.themePackGet.mockResolvedValue({ success: true, data: { meta: {}, pack: { name: 'P', version: '1', colorScheme: 'dark', colors: {} } } })
+    vialAPI.themePackHubTimestamps.mockResolvedValue({ success: true, data: { items: [] } })
+  })
+
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <ThemePacksModal open={false} onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders modal content when open', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    expect(screen.getByTestId('theme-packs-modal')).toBeTruthy()
+    expect(screen.getByText('themePacks.title')).toBeTruthy()
+  })
+
+  it('shows Installed and Hub tabs', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    expect(screen.getByTestId('theme-packs-tab-installed')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-tab-hub')).toBeTruthy()
+  })
+
+  it('switches to Hub tab and shows search input', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    expect(screen.getByTestId('theme-packs-search-input')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-search-button')).toBeTruthy()
+  })
+
+  it('switches back to Installed tab', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.click(screen.getByTestId('theme-packs-tab-installed'))
+    expect(screen.getByTestId('theme-packs-builtin-system')).toBeTruthy()
+    expect(screen.queryByTestId('theme-packs-search-input')).toBeNull()
+  })
+
+  it('renders built-in theme buttons (system, light, dark)', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    expect(screen.getByTestId('theme-packs-builtin-system')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-builtin-light')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-builtin-dark')).toBeTruthy()
+  })
+
+  it('selects a built-in theme and calls onThemeChange', () => {
+    const onThemeChange = vi.fn()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-builtin-dark'))
+    expect(onThemeChange).toHaveBeenCalledWith('dark')
+  })
+
+  it('does not call onThemeChange when selecting the already-active theme', () => {
+    mockTheme = 'dark'
+    const onThemeChange = vi.fn()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-builtin-dark'))
+    expect(onThemeChange).not.toHaveBeenCalled()
+  })
+
+  it('renders imported pack rows', () => {
+    metas = [meta({ id: 'p1', name: 'My Theme' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    expect(screen.getByTestId('theme-packs-row-p1')).toBeTruthy()
+    expect(screen.getByText('My Theme')).toBeTruthy()
+  })
+
+  it('selects a pack theme via the select button', () => {
+    metas = [meta({ id: 'p1', name: 'My Theme' })]
+    const onThemeChange = vi.fn()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-select-p1'))
+    expect(onThemeChange).toHaveBeenCalledWith('pack:p1')
+  })
+
+  it('falls back to system when active pack is deleted', async () => {
+    metas = [meta({ id: 'p1', name: 'Active Pack' })]
+    mockTheme = 'pack:p1'
+    const onThemeChange = vi.fn()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-delete-p1'))
+    const confirm = await screen.findByTestId('theme-packs-confirm-delete-p1')
+    fireEvent.click(confirm)
+    await waitFor(() => expect(removeFn).toHaveBeenCalledWith('p1'))
+    await waitFor(() => expect(onThemeChange).toHaveBeenCalledWith('system'))
+  })
+
+  it('delete asks for confirmation before invoking remove', async () => {
+    metas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-delete-p1'))
+    expect(screen.getByTestId('theme-packs-confirm-delete-p1')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-cancel-delete-p1')).toBeTruthy()
+  })
+
+  it('cancel delete hides the confirmation', () => {
+    metas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-delete-p1'))
+    fireEvent.click(screen.getByTestId('theme-packs-cancel-delete-p1'))
+    expect(screen.queryByTestId('theme-packs-confirm-delete-p1')).toBeNull()
+  })
+
+  it('export action triggers exportPack for the row', async () => {
+    metas = [meta({ id: 'p1', name: 'Pack' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-export-p1'))
+    await waitFor(() => expect(exportPack).toHaveBeenCalledWith('p1'))
+  })
+
+  it('import button triggers importFromDialog', async () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+  })
+
+  it('import applies the raw data when dialog returns a file', async () => {
+    const raw = { name: 'Imported', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'new1', name: 'Imported' }) })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalledWith(raw))
+  })
+
+  it('import shows error on parse failure', async () => {
+    importFromDialog.mockResolvedValueOnce({ canceled: false, parseError: 'Bad format' })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-error')).toBeTruthy()
+      expect(screen.getByText('Bad format')).toBeTruthy()
+    })
+  })
+
+  it('import with hubPostId auto-syncs to hub', async () => {
+    const raw = { name: 'Synced', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 's1', name: 'Synced', hubPostId: 'hp1' }) })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(vialAPI.hubUpdateThemePost).toHaveBeenCalled())
+  })
+
+  it('Hub search button is disabled when query is less than 2 chars', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'a' } })
+    const btn = screen.getByTestId('theme-packs-search-button') as HTMLButtonElement
+    expect(btn.disabled).toBe(true)
+  })
+
+  it('Hub search triggers when Search button clicked with 2+ chars', async () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'retro' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: 'retro' }))
+  })
+
+  it('debounced search fires after typing 2+ chars and waiting', async () => {
+    vi.useFakeTimers()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'neon' } })
+    expect(vialAPI.hubListThemePosts).not.toHaveBeenCalled()
+    await act(async () => { vi.advanceTimersByTime(300) })
+    vi.useRealTimers()
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: 'neon' }))
+  })
+
+  it('shows hub results after search returns items', async () => {
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-1', name: 'Retro Theme', version: '2.0', uploaderName: 'alice', createdAt: '', updatedAt: '' },
+        ],
+      },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'retro' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-hub-row-hub-1')).toBeTruthy()
+      expect(screen.getByText('Retro Theme')).toBeTruthy()
+    })
+  })
+
+  it('hub download action calls hubDownloadThemePost and applyImport', async () => {
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-2', name: 'Dark Pro', version: '1.0', uploaderName: null, createdAt: '', updatedAt: '' },
+        ],
+      },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'dark' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-hub-download-hub-2')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('theme-packs-hub-download-hub-2'))
+    await waitFor(() => expect(vialAPI.hubDownloadThemePost).toHaveBeenCalledWith('hub-2'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalled())
+  })
+
+  it('hub row shows installed label when pack is already installed', async () => {
+    metas = [meta({ id: 'local1', name: 'Existing', hubPostId: 'hub-3' })]
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-3', name: 'Existing', version: '1.0', uploaderName: null, createdAt: '', updatedAt: '' },
+        ],
+      },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'exist' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-hub-row-hub-3')).toBeTruthy())
+    const row = screen.getByTestId('theme-packs-hub-row-hub-3')
+    expect(row.querySelector('span.text-xs.text-content-muted')?.textContent).toBe('common.installed')
+    expect(screen.queryByTestId('theme-packs-hub-download-hub-3')).toBeNull()
+  })
+
+  it('hub empty message when search returns no results', async () => {
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: { items: [] },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'zzz' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-hub-empty')).toBeTruthy()
+      expect(screen.getByText('themePacks.hubEmpty')).toBeTruthy()
+    })
+  })
+
+  it('hub initial hint when no search has been performed', () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    expect(screen.getByTestId('theme-packs-hub-empty')).toBeTruthy()
+    expect(screen.getByText('common.findOnHubHint')).toBeTruthy()
+  })
+
+  it('preview button calls hubDownloadThemePost', async () => {
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hub-p', name: 'Preview Pack', version: '1.0', uploaderName: null, createdAt: '', updatedAt: '' },
+        ],
+      },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'preview' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-hub-preview-hub-p')).toBeTruthy())
+    fireEvent.click(screen.getByTestId('theme-packs-hub-preview-hub-p'))
+    await waitFor(() => expect(vialAPI.hubDownloadThemePost).toHaveBeenCalledWith('hub-p'))
+  })
+
+  it('upload action calls hubUploadThemePost', async () => {
+    metas = [meta({ id: 'u1', name: 'Upload Me' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-upload-u1'))
+    await waitFor(() => expect(vialAPI.themePackGet).toHaveBeenCalledWith('u1'))
+    await waitFor(() => expect(vialAPI.hubUploadThemePost).toHaveBeenCalled())
+  })
+
+  it('update action calls hubUpdateThemePost', async () => {
+    metas = [meta({ id: 'up1', name: 'Update Me', hubPostId: 'hp-up1' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-update-up1'))
+    await waitFor(() => expect(vialAPI.themePackGet).toHaveBeenCalledWith('up1'))
+    await waitFor(() => expect(vialAPI.hubUpdateThemePost).toHaveBeenCalled())
+  })
+
+  it('sync action calls hubDownloadThemePost and applyImport', async () => {
+    metas = [meta({ id: 'sy1', name: 'Sync Me', hubPostId: 'hp-sy1' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite={false} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-sync-sy1'))
+    await waitFor(() => expect(vialAPI.hubDownloadThemePost).toHaveBeenCalledWith('hp-sy1'))
+    await waitFor(() => expect(applyImport).toHaveBeenCalled())
+  })
+
+  it('remove action asks for confirmation', async () => {
+    metas = [meta({ id: 'rm1', name: 'Remove Me', hubPostId: 'hp-rm1' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-remove-rm1'))
+    expect(screen.getByTestId('theme-packs-confirm-remove-rm1')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-cancel-remove-rm1')).toBeTruthy()
+  })
+
+  it('confirmed remove calls hubDeleteThemePost', async () => {
+    metas = [meta({ id: 'rm2', name: 'Remove Me', hubPostId: 'hp-rm2' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-remove-rm2'))
+    fireEvent.click(screen.getByTestId('theme-packs-confirm-remove-rm2'))
+    await waitFor(() => expect(vialAPI.hubDeleteThemePost).toHaveBeenCalledWith('hp-rm2', 'rm2'))
+  })
+
+  it('cancel remove hides the confirmation', () => {
+    metas = [meta({ id: 'rm3', name: 'Remove Me', hubPostId: 'hp-rm3' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-remove-rm3'))
+    fireEvent.click(screen.getByTestId('theme-packs-cancel-remove-rm3'))
+    expect(screen.queryByTestId('theme-packs-confirm-remove-rm3')).toBeNull()
+  })
+
+  it('error display shows actionError', async () => {
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: false,
+      error: 'Network error',
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'fail' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-error')).toBeTruthy()
+      expect(screen.getByText('Network error')).toBeTruthy()
+    })
+  })
+
+  it('export error is displayed', async () => {
+    metas = [meta({ id: 'e1', name: 'Export Fail' })]
+    exportPack.mockResolvedValueOnce({ success: false, error: 'Export failed' })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-export-e1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-error')).toBeTruthy()
+      expect(screen.getByText('Export failed')).toBeTruthy()
+    })
+  })
+
+  it('upload shows error result on failure', async () => {
+    metas = [meta({ id: 'uf1', name: 'Upload Fail' })]
+    vialAPI.themePackGet.mockResolvedValueOnce({ success: false, error: 'Not found' })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-upload-uf1'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-result-uf1')).toBeTruthy()
+    })
+  })
+
+  it('upload button is hidden when hubCanWrite is false', () => {
+    metas = [meta({ id: 'nw1', name: 'No Write' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite={false} />,
+    )
+    expect(screen.queryByTestId('theme-packs-upload-nw1')).toBeNull()
+  })
+
+  it('update and remove buttons are hidden when hubCanWrite is false for hub-linked row', () => {
+    metas = [meta({ id: 'nw2', name: 'No Write Hub', hubPostId: 'hp-nw2' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite={false} />,
+    )
+    expect(screen.queryByTestId('theme-packs-update-nw2')).toBeNull()
+    expect(screen.queryByTestId('theme-packs-remove-nw2')).toBeNull()
+    expect(screen.getByTestId('theme-packs-sync-nw2')).toBeTruthy()
+  })
+
+  it('update and remove buttons are visible when hubCanWrite is true for hub-linked row', () => {
+    metas = [meta({ id: 'w1', name: 'Write Hub', hubPostId: 'hp-w1' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} hubCanWrite />,
+    )
+    expect(screen.getByTestId('theme-packs-update-w1')).toBeTruthy()
+    expect(screen.getByTestId('theme-packs-remove-w1')).toBeTruthy()
+    expect(screen.queryByTestId('theme-packs-sync-w1')).toBeNull()
+  })
+
+  it('backdrop click calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <ThemePacksModal open onClose={onClose} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-backdrop'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('close button calls onClose', () => {
+    const onClose = vi.fn()
+    render(
+      <ThemePacksModal open onClose={onClose} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-close'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('delete also calls hubDeleteThemePost for hub-linked pack', async () => {
+    metas = [meta({ id: 'hd1', name: 'Hub Delete', hubPostId: 'hp-hd1' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-delete-hd1'))
+    fireEvent.click(screen.getByTestId('theme-packs-confirm-delete-hd1'))
+    await waitFor(() => expect(vialAPI.hubDeleteThemePost).toHaveBeenCalledWith('hp-hd1', 'hd1'))
+    await waitFor(() => expect(removeFn).toHaveBeenCalledWith('hd1'))
+  })
+
+  it('does not fall back to system when deleting a non-active pack', async () => {
+    metas = [meta({ id: 'na1', name: 'Not Active' })]
+    mockTheme = 'dark'
+    const onThemeChange = vi.fn()
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-delete-na1'))
+    fireEvent.click(screen.getByTestId('theme-packs-confirm-delete-na1'))
+    await waitFor(() => expect(removeFn).toHaveBeenCalledWith('na1'))
+    expect(onThemeChange).not.toHaveBeenCalled()
+  })
+
+  it('does not treat deleted (tombstoned) metas as installed in hub rows', async () => {
+    metas = [meta({ id: 'del1', name: 'Deleted', hubPostId: 'hp-del1', deletedAt: '2026-01-01' })]
+    vialAPI.hubListThemePosts.mockResolvedValueOnce({
+      success: true,
+      data: {
+        items: [
+          { id: 'hp-del1', name: 'Deleted', version: '1', uploaderName: null, createdAt: '', updatedAt: '' },
+        ],
+      },
+    })
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'deleted' } })
+    fireEvent.click(screen.getByTestId('theme-packs-search-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-hub-row-hp-del1')).toBeTruthy())
+    expect(screen.getByTestId('theme-packs-hub-download-hp-del1')).toBeTruthy()
+  })
+})

--- a/src/renderer/hooks/__tests__/useKeyLabels.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyLabels.test.ts
@@ -16,6 +16,8 @@ const mockHubDownload = vi.fn()
 const mockHubUpload = vi.fn()
 const mockHubUpdate = vi.fn()
 const mockHubDelete = vi.fn()
+const mockHubSync = vi.fn()
+const mockHubTimestamps = vi.fn()
 
 Object.defineProperty(window, 'vialAPI', {
   value: {
@@ -30,6 +32,8 @@ Object.defineProperty(window, 'vialAPI', {
     keyLabelHubUpload: mockHubUpload,
     keyLabelHubUpdate: mockHubUpdate,
     keyLabelHubDelete: mockHubDelete,
+    keyLabelHubSync: mockHubSync,
+    keyLabelHubTimestamps: mockHubTimestamps,
   },
   writable: true,
 })
@@ -59,6 +63,8 @@ describe('useKeyLabels', () => {
     mockHubUpload.mockResolvedValue({ success: true, data: meta() })
     mockHubUpdate.mockResolvedValue({ success: true, data: meta() })
     mockHubDelete.mockResolvedValue({ success: true })
+    mockHubSync.mockResolvedValue({ success: true, data: meta() })
+    mockHubTimestamps.mockResolvedValue({ success: true, data: { items: [] } })
   })
 
   it('preserves store order on mount (no client-side sort)', async () => {
@@ -154,5 +160,135 @@ describe('useKeyLabels', () => {
     })
 
     expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('refreshes after hubSync succeeds', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      await result.current.hubSync('a')
+    })
+
+    expect(mockHubSync).toHaveBeenCalledWith('a')
+    expect(mockList).toHaveBeenCalled()
+  })
+
+  it('does not refresh when hubSync fails', async () => {
+    mockHubSync.mockResolvedValueOnce({ success: false, error: 'sync failed' })
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      const res = await result.current.hubSync('a')
+      expect(res.success).toBe(false)
+    })
+
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('hubTimestamps calls with correct parameters', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+
+    await act(async () => {
+      await result.current.hubTimestamps(['a', 'b'])
+    })
+
+    expect(mockHubTimestamps).toHaveBeenCalledWith(['a', 'b'])
+  })
+
+  it('hubTimestamps does not trigger a refresh', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      await result.current.hubTimestamps(['a'])
+    })
+
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('refreshes after hubDelete succeeds', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      await result.current.hubDelete('a')
+    })
+
+    expect(mockHubDelete).toHaveBeenCalledWith('a')
+    expect(mockList).toHaveBeenCalled()
+  })
+
+  it('does not refresh when hubDelete fails', async () => {
+    mockHubDelete.mockResolvedValueOnce({ success: false, error: 'delete failed' })
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      const res = await result.current.hubDelete('a')
+      expect(res.success).toBe(false)
+    })
+
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('refreshes after reorder succeeds', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      await result.current.reorder(['a', 'b'])
+    })
+
+    expect(mockReorder).toHaveBeenCalledWith(['a', 'b'])
+    expect(mockList).toHaveBeenCalled()
+  })
+
+  it('does not refresh when reorder fails', async () => {
+    mockReorder.mockResolvedValueOnce({ success: false, error: 'reorder failed' })
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      const res = await result.current.reorder(['a', 'b'])
+      expect(res.success).toBe(false)
+    })
+
+    expect(mockList).not.toHaveBeenCalled()
+  })
+
+  it('refreshes after importFromFile succeeds', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+    mockList.mockClear()
+
+    await act(async () => {
+      await result.current.importFromFile()
+    })
+
+    expect(mockImport).toHaveBeenCalled()
+    expect(mockList).toHaveBeenCalled()
+  })
+
+  it('importFromFile returns the import result data', async () => {
+    const { result } = renderHook(() => useKeyLabels())
+    await waitFor(() => expect(result.current.metas).toHaveLength(2))
+
+    let res: Awaited<ReturnType<typeof result.current.importFromFile>>
+    await act(async () => {
+      res = await result.current.importFromFile()
+    })
+
+    expect(res!.success).toBe(true)
+    expect(res!.data).toEqual(expect.objectContaining({ id: 'c', name: 'C' }))
   })
 })

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -4,7 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { useAppConfig } from './useAppConfig'
 import type { ThemeMode, ThemeSelection } from '../../shared/types/app-config'
 import { THEME_COLOR_KEYS } from '../../shared/types/theme-store'
-import type { ThemePackColors, ThemePackEntryFile } from '../../shared/types/theme-store'
+import type { ThemeColorScheme, ThemePackColors, ThemePackEntryFile } from '../../shared/types/theme-store'
 import { useEffectiveTheme, type EffectiveTheme } from './useEffectiveTheme'
 
 export type { ThemeMode, ThemeSelection }
@@ -34,11 +34,12 @@ function applyThemeClass(effective: EffectiveTheme): void {
   }
 }
 
-export function applyPackColors(colors: ThemePackColors): void {
+export function applyPackColors(colors: ThemePackColors, colorScheme: ThemeColorScheme): void {
   const root = document.documentElement
   for (const key of THEME_COLOR_KEYS) {
     root.style.setProperty(`--${key}`, colors[key])
   }
+  root.style.setProperty('color-scheme', colorScheme)
 }
 
 export function clearPackColors(): void {
@@ -53,10 +54,8 @@ function applyPackTheme(
   pack: ThemePackEntryFile,
   setEffectiveTheme: (t: EffectiveTheme) => void,
 ): void {
-  const effective = resolveEffectiveTheme('system')
-  setEffectiveTheme(effective)
-  applyPackColors(pack.colors)
-  document.documentElement.style.setProperty('color-scheme', effective)
+  setEffectiveTheme(pack.colorScheme)
+  applyPackColors(pack.colors, pack.colorScheme)
 }
 
 export function isPackTheme(theme: ThemeSelection): theme is `pack:${string}` {

--- a/src/renderer/hooks/useTheme.ts
+++ b/src/renderer/hooks/useTheme.ts
@@ -134,7 +134,12 @@ export function useTheme(): UseThemeReturn {
     const packId = extractPackId(config.theme)
     const unsubscribe = window.vialAPI.themePackOnChanged?.(() => {
       window.vialAPI.themePackGet(packId).then((result) => {
-        if (!result.success || !result.data) return
+        if (!result.success || !result.data) {
+          clearPackColors()
+          set('theme', 'system')
+          setEffectiveTheme(resolveEffectiveTheme('system'))
+          return
+        }
         const { pack } = result.data
         cachedPackRef.current = { id: packId, pack }
         applyPackTheme(pack, setEffectiveTheme)

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -472,7 +472,7 @@
     "system": "System"
   },
   "themePacks": {
-    "manageRow": "Theme Packs",
+    "manageRow": "Theme Packs Manage",
     "title": "Theme Packs",
     "import": "Import Theme Pack",
     "parseError": "Failed to parse file",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -472,7 +472,7 @@
     "system": "システム"
   },
   "themePacks": {
-    "manageRow": "テーマパック",
+    "manageRow": "テーマパック管理",
     "title": "テーマパック",
     "import": "テーマパックをインポート",
     "parseError": "ファイルの解析に失敗しました",

--- a/src/shared/theme/__tests__/validate.test.ts
+++ b/src/shared/theme/__tests__/validate.test.ts
@@ -1,0 +1,429 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { validateThemePack, validateName, validateVersion } from '../validate'
+import { THEME_COLOR_KEYS, THEME_PACK_LIMITS } from '../../types/theme-store'
+
+function validColors(): Record<string, string> {
+  const colors: Record<string, string> = {}
+  for (const key of THEME_COLOR_KEYS) {
+    colors[key] = '#aabbcc'
+  }
+  return colors
+}
+
+function validPack(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: 'My Theme',
+    version: '1.0.0',
+    colorScheme: 'dark',
+    colors: validColors(),
+    ...overrides,
+  }
+}
+
+describe('validateThemePack', () => {
+  describe('valid pack', () => {
+    it('returns ok for a fully valid light pack', () => {
+      const result = validateThemePack(validPack({ colorScheme: 'light' }))
+      expect(result.ok).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+      expect(result.header).toEqual({ name: 'My Theme', version: '1.0.0' })
+    })
+
+    it('returns ok for a fully valid dark pack', () => {
+      const result = validateThemePack(validPack({ colorScheme: 'dark' }))
+      expect(result.ok).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(result.header).toEqual({ name: 'My Theme', version: '1.0.0' })
+    })
+
+    it('trims name and version in header', () => {
+      const result = validateThemePack(validPack({ name: '  Trimmed  ', version: '  2.0.0  ' }))
+      expect(result.ok).toBe(true)
+      expect(result.header).toEqual({ name: 'Trimmed', version: '2.0.0' })
+    })
+
+    it('accepts hex colors with alpha (#RRGGBBAA)', () => {
+      const colors = validColors()
+      colors['surface'] = '#aabbccdd'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts shorthand hex (#RGB)', () => {
+      const colors = validColors()
+      colors['surface'] = '#abc'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts shorthand hex with alpha (#RGBA)', () => {
+      const colors = validColors()
+      colors['surface'] = '#abcd'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts rgb() function colors', () => {
+      const colors = validColors()
+      colors['surface'] = 'rgb(255, 128, 0)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts rgba() function colors', () => {
+      const colors = validColors()
+      colors['surface'] = 'rgba(255, 128, 0, 0.5)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts hsl() function colors', () => {
+      const colors = validColors()
+      colors['surface'] = 'hsl(180, 50%, 50%)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts hsla() function colors', () => {
+      const colors = validColors()
+      colors['surface'] = 'hsla(180, 50%, 50%, 0.8)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('accepts semver with pre-release tag', () => {
+      const result = validateThemePack(validPack({ version: '1.0.0-beta.1' }))
+      expect(result.ok).toBe(true)
+    })
+  })
+
+  describe('non-object input', () => {
+    it.each([null, undefined, 42, 'string', true])('returns error for %s', (input) => {
+      const result = validateThemePack(input)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Theme pack must be a JSON object')
+    })
+
+    it('returns error for array', () => {
+      const result = validateThemePack([1, 2, 3])
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Theme pack must be a JSON object')
+    })
+  })
+
+  describe('colorScheme validation', () => {
+    it('returns error when colorScheme is missing', () => {
+      const pack = validPack()
+      delete pack.colorScheme
+      const result = validateThemePack(pack)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colorScheme must be exactly "light" or "dark"')
+    })
+
+    it('returns error when colorScheme is not "light" or "dark"', () => {
+      const result = validateThemePack(validPack({ colorScheme: 'auto' }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colorScheme must be exactly "light" or "dark"')
+    })
+
+    it('returns error when colorScheme is a number', () => {
+      const result = validateThemePack(validPack({ colorScheme: 0 }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colorScheme must be exactly "light" or "dark"')
+    })
+  })
+
+  describe('missing required color keys', () => {
+    it('reports each missing key', () => {
+      const colors = validColors()
+      delete colors['surface']
+      delete colors['accent']
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Missing required color: "surface"')
+      expect(result.errors).toContain('Missing required color: "accent"')
+    })
+
+    it('reports error when colors is empty object', () => {
+      const result = validateThemePack(validPack({ colors: {} }))
+      expect(result.ok).toBe(false)
+      expect(result.errors.filter((e) => e.startsWith('Missing required color'))).toHaveLength(
+        THEME_COLOR_KEYS.length,
+      )
+    })
+
+    it('reports error when colors is not an object', () => {
+      const result = validateThemePack(validPack({ colors: 'not-object' }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colors must be an object')
+    })
+
+    it('reports error when colors is an array', () => {
+      const result = validateThemePack(validPack({ colors: ['#fff'] }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colors must be an object')
+    })
+
+    it('reports error when colors is null', () => {
+      const result = validateThemePack(validPack({ colors: null }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colors must be an object')
+    })
+  })
+
+  describe('invalid CSS color values', () => {
+    it('rejects named color', () => {
+      const colors = validColors()
+      colors['surface'] = 'red'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "surface" has invalid CSS color value: "red"')
+    })
+
+    it('rejects hex without hash', () => {
+      const colors = validColors()
+      colors['accent'] = 'aabbcc'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "accent" has invalid CSS color value: "aabbcc"')
+    })
+
+    it('rejects invalid hex length', () => {
+      const colors = validColors()
+      colors['edge'] = '#abcde'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "edge" has invalid CSS color value: "#abcde"')
+    })
+
+    it('rejects non-string color value', () => {
+      const colors = validColors() as Record<string, unknown>
+      colors['surface'] = 123
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "surface" must be a string')
+    })
+
+    it('rejects empty string', () => {
+      const colors = validColors()
+      colors['content'] = ''
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "content" has invalid CSS color value: ""')
+    })
+  })
+
+  describe('unknown color keys', () => {
+    it('produces warnings for unknown keys but still succeeds', () => {
+      const colors = validColors()
+      ;(colors as Record<string, string>)['custom-color'] = '#ff0000'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+      expect(result.warnings).toContain('Unknown color key "custom-color" will be ignored')
+    })
+
+    it('produces multiple warnings for multiple unknown keys', () => {
+      const colors = validColors()
+      ;(colors as Record<string, string>)['foo'] = '#111'
+      ;(colors as Record<string, string>)['bar'] = '#222'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+      expect(result.warnings).toHaveLength(2)
+    })
+  })
+
+  describe('name validation within validateThemePack', () => {
+    it('rejects missing name', () => {
+      const pack = validPack()
+      delete pack.name
+      const result = validateThemePack(pack)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('name must be a string')
+    })
+
+    it('rejects empty name', () => {
+      const result = validateThemePack(validPack({ name: '' }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('name must not be empty')
+    })
+
+    it('rejects whitespace-only name', () => {
+      const result = validateThemePack(validPack({ name: '   ' }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('name must not be empty')
+    })
+
+    it('rejects name exceeding max length', () => {
+      const longName = 'a'.repeat(THEME_PACK_LIMITS.MAX_NAME_LENGTH + 1)
+      const result = validateThemePack(validPack({ name: longName }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain(
+        `name must be at most ${THEME_PACK_LIMITS.MAX_NAME_LENGTH} characters`,
+      )
+    })
+
+    it('accepts name at exact max length', () => {
+      const name = 'a'.repeat(THEME_PACK_LIMITS.MAX_NAME_LENGTH)
+      const result = validateThemePack(validPack({ name }))
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects non-string name', () => {
+      const result = validateThemePack(validPack({ name: 42 }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('name must be a string')
+    })
+  })
+
+  describe('version validation within validateThemePack', () => {
+    it('rejects missing version', () => {
+      const pack = validPack()
+      delete pack.version
+      const result = validateThemePack(pack)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('version must be a string')
+    })
+
+    it('rejects invalid semver', () => {
+      const result = validateThemePack(validPack({ version: 'v1.0' }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('version must be a valid semver (e.g. 1.0.0)')
+    })
+
+    it('rejects non-string version', () => {
+      const result = validateThemePack(validPack({ version: 1 }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('version must be a string')
+    })
+  })
+
+  describe('dangerous keys', () => {
+    it.each(['constructor', 'prototype'])('rejects dangerous top-level key "%s"', (key) => {
+      const pack = validPack()
+      ;(pack as Record<string, unknown>)[key] = 'malicious'
+      const result = validateThemePack(pack)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain(`Dangerous key "${key}" is not allowed`)
+    })
+
+    it('rejects dangerous top-level key "__proto__"', () => {
+      const pack = Object.create(null) as Record<string, unknown>
+      const base = validPack()
+      for (const k of Object.keys(base)) pack[k] = base[k]
+      pack['__proto__'] = 'malicious'
+      const result = validateThemePack(pack)
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Dangerous key "__proto__" is not allowed')
+    })
+
+    it.each(['constructor', 'prototype'])('rejects dangerous key "%s" inside colors', (key) => {
+      const colors = validColors()
+      ;(colors as Record<string, string>)[key] = '#ff0000'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain(`Dangerous key "colors.${key}" is not allowed`)
+    })
+
+    it('rejects dangerous key "__proto__" inside colors', () => {
+      const colors = Object.create(null) as Record<string, string>
+      for (const [k, v] of Object.entries(validColors())) colors[k] = v
+      colors['__proto__'] = '#ff0000'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Dangerous key "colors.__proto__" is not allowed')
+    })
+  })
+
+  describe('multiple errors', () => {
+    it('collects errors from name, version, colorScheme, and colors at once', () => {
+      const result = validateThemePack({
+        name: '',
+        version: 'bad',
+        colorScheme: 'neon',
+        colors: {},
+      })
+      expect(result.ok).toBe(false)
+      expect(result.errors.length).toBeGreaterThanOrEqual(4)
+    })
+
+    it('does not include header when validation fails', () => {
+      const result = validateThemePack(validPack({ name: '' }))
+      expect(result.ok).toBe(false)
+      expect(result.header).toBeUndefined()
+    })
+  })
+
+  describe('early return when colors is not an object', () => {
+    it('returns immediately without checking individual color keys', () => {
+      const result = validateThemePack(validPack({ colors: 42 }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('colors must be an object')
+      expect(result.errors.filter((e) => e.startsWith('Missing required'))).toHaveLength(0)
+    })
+  })
+})
+
+describe('validateName', () => {
+  it('returns null for valid name', () => {
+    expect(validateName('My Theme')).toBeNull()
+  })
+
+  it('returns error for non-string', () => {
+    expect(validateName(42)).toBe('name must be a string')
+    expect(validateName(null)).toBe('name must be a string')
+    expect(validateName(undefined)).toBe('name must be a string')
+  })
+
+  it('returns error for empty string', () => {
+    expect(validateName('')).toBe('name must not be empty')
+  })
+
+  it('returns error for whitespace-only string', () => {
+    expect(validateName('   ')).toBe('name must not be empty')
+    expect(validateName('\t\n')).toBe('name must not be empty')
+  })
+
+  it('returns error when exceeding max length', () => {
+    const longName = 'x'.repeat(THEME_PACK_LIMITS.MAX_NAME_LENGTH + 1)
+    expect(validateName(longName)).toBe(
+      `name must be at most ${THEME_PACK_LIMITS.MAX_NAME_LENGTH} characters`,
+    )
+  })
+
+  it('returns null at exact max length', () => {
+    const name = 'x'.repeat(THEME_PACK_LIMITS.MAX_NAME_LENGTH)
+    expect(validateName(name)).toBeNull()
+  })
+})
+
+describe('validateVersion', () => {
+  it('returns null for valid semver', () => {
+    expect(validateVersion('1.0.0')).toBeNull()
+    expect(validateVersion('0.0.1')).toBeNull()
+    expect(validateVersion('12.34.56')).toBeNull()
+  })
+
+  it('returns null for semver with pre-release', () => {
+    expect(validateVersion('1.0.0-alpha')).toBeNull()
+    expect(validateVersion('1.0.0-beta.1')).toBeNull()
+    expect(validateVersion('1.0.0-rc.2.3')).toBeNull()
+  })
+
+  it('returns error for non-string', () => {
+    expect(validateVersion(42)).toBe('version must be a string')
+    expect(validateVersion(null)).toBe('version must be a string')
+    expect(validateVersion(undefined)).toBe('version must be a string')
+  })
+
+  it('returns error for invalid semver format', () => {
+    expect(validateVersion('1.0')).toBe('version must be a valid semver (e.g. 1.0.0)')
+    expect(validateVersion('v1.0.0')).toBe('version must be a valid semver (e.g. 1.0.0)')
+    expect(validateVersion('1')).toBe('version must be a valid semver (e.g. 1.0.0)')
+    expect(validateVersion('')).toBe('version must be a valid semver (e.g. 1.0.0)')
+    expect(validateVersion('abc')).toBe('version must be a valid semver (e.g. 1.0.0)')
+    expect(validateVersion('1.0.0.0')).toBe('version must be a valid semver (e.g. 1.0.0)')
+  })
+})

--- a/src/shared/theme/validate.ts
+++ b/src/shared/theme/validate.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { THEME_COLOR_KEYS, THEME_PACK_LIMITS, type ThemeColorKey } from '../types/theme-store'
+import { THEME_COLOR_KEYS, THEME_COLOR_SCHEMES, THEME_PACK_LIMITS, type ThemeColorKey } from '../types/theme-store'
 
 const MAX_NAME_LENGTH = THEME_PACK_LIMITS.MAX_NAME_LENGTH
 const SEMVER_REGEX = /^\d+\.\d+\.\d+(-[\w.]+)?$/
@@ -53,6 +53,10 @@ export function validateThemePack(raw: unknown): ValidateThemePackResult {
   if (nameError) errors.push(nameError)
   const versionError = validateVersion(obj.version)
   if (versionError) errors.push(versionError)
+
+  if (typeof obj.colorScheme !== 'string' || !THEME_COLOR_SCHEMES.includes(obj.colorScheme as 'light' | 'dark')) {
+    errors.push(`colorScheme must be exactly "light" or "dark"`)
+  }
 
   if (!obj.colors || typeof obj.colors !== 'object' || Array.isArray(obj.colors)) {
     errors.push('colors must be an object')

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -2,6 +2,7 @@
 // Shared types for Hub upload operations
 
 import type { FavoriteType } from './favorite-store'
+import type { ThemeColorScheme } from './theme-store'
 
 // --- i18n language pack posts -------------------------------------------------
 
@@ -81,6 +82,7 @@ export const HUB_I18N_PACK_TIMESTAMPS_BATCH_LIMIT = 100
 export interface HubThemePackBody {
   name: string
   version: string
+  colorScheme: ThemeColorScheme
   colors: Record<string, string>
 }
 

--- a/src/shared/types/theme-store.ts
+++ b/src/shared/types/theme-store.ts
@@ -31,9 +31,14 @@ export type ThemeColorKey = (typeof THEME_COLOR_KEYS)[number]
 
 export type ThemePackColors = Record<ThemeColorKey, string>
 
+export type ThemeColorScheme = 'light' | 'dark'
+
+export const THEME_COLOR_SCHEMES: readonly ThemeColorScheme[] = ['light', 'dark'] as const
+
 export interface ThemePackEntryFile {
   name: string
   version: string
+  colorScheme: ThemeColorScheme
   colors: ThemePackColors
 }
 


### PR DESCRIPTION
## Summary
- Fix theme packs settings row label to "Theme Packs Manage"
- Add colorScheme field to theme packs
- Cache Hub preview downloads and active pack restore
- Fall back to system theme when active pack is deleted
- Add comprehensive tests for theme/language/key-labels packs (266 new tests)

## Test plan
- [x] All 4119 tests pass (206 test files, 0 failures)
- [x] Theme pack validation: 60 tests (valid/invalid packs, colorScheme, dangerous keys, CSS colors)
- [x] Theme pack store: 51 tests (CRUD, tombstone, Hub fields, duplicate detection)
- [x] Hub theme API: 30 tests (list/download/upload/update/delete, error handling, rate limit retry)
- [x] ThemePacksModal: 44 tests (tabs, import, delete, preview, Hub operations)
- [x] LanguagePacksModal: 52 tests (tabs, import, delete, Hub search/download, coverage badge)
- [x] Key Labels gaps filled: +29 tests (active deletion, Hub auto-sync, reorder, export, QWERTY protection)