### PR TITLE
fix(ui): harden theme pack and key label import validation

### DIFF
--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -96,6 +96,34 @@ describe('key-label-store', () => {
     })
   })
 
+  describe('dangerous keys in map / compositeLabels', () => {
+    it('rejects __proto__ in map', async () => {
+      const map = Object.create(null) as Record<string, string>
+      map['KC_A'] = 'A'
+      map['__proto__'] = 'malicious'
+      const result = await saveRecord({ name: 'Proto', uploaderName: 'me', map })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_FILE')
+    })
+
+    it('rejects constructor in map', async () => {
+      const result = await saveRecord({ name: 'Ctor', uploaderName: 'me', map: { constructor: 'x' } })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_FILE')
+    })
+
+    it('rejects prototype in compositeLabels', async () => {
+      const result = await saveRecord({
+        name: 'CompositeProto',
+        uploaderName: 'me',
+        map: { KC_A: 'A' },
+        compositeLabels: { prototype: 'evil' },
+      })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_FILE')
+    })
+  })
+
   describe('listMetas / getRecord', () => {
     it('returns active entries only and resolves payload', async () => {
       const a = await saveRecord({ name: 'A', uploaderName: 'me', map: { KC_A: 'A' } })

--- a/src/main/key-label-store.ts
+++ b/src/main/key-label-store.ts
@@ -86,9 +86,12 @@ function validateName(value: unknown): KeyLabelStoreResult<string> {
   return ok(trimmed)
 }
 
+const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype'])
+
 function isLabelMap(value: unknown): value is Record<string, string> {
   if (!value || typeof value !== 'object') return false
-  for (const v of Object.values(value as Record<string, unknown>)) {
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (DANGEROUS_KEYS.has(k)) return false
     if (typeof v !== 'string') return false
   }
   return true

--- a/src/shared/theme/__tests__/validate.test.ts
+++ b/src/shared/theme/__tests__/validate.test.ts
@@ -300,6 +300,30 @@ describe('validateThemePack', () => {
     })
   })
 
+  describe('CSS injection via function colors', () => {
+    it('rejects hsl() with embedded closing paren and injected CSS', () => {
+      const colors = validColors()
+      colors['surface'] = 'hsl(0); --injected: evil)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+      expect(result.errors).toContain('Color "surface" has invalid CSS color value: "hsl(0); --injected: evil)"')
+    })
+
+    it('rejects rgb() with embedded closing paren', () => {
+      const colors = validColors()
+      colors['surface'] = 'rgb(0,0,0); pointer-events: none)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(false)
+    })
+
+    it('still accepts valid nested modern CSS color syntax', () => {
+      const colors = validColors()
+      colors['surface'] = 'hsl(200 50% 50%)'
+      const result = validateThemePack(validPack({ colors }))
+      expect(result.ok).toBe(true)
+    })
+  })
+
   describe('dangerous keys', () => {
     it.each(['constructor', 'prototype'])('rejects dangerous top-level key "%s"', (key) => {
       const pack = validPack()

--- a/src/shared/theme/validate.ts
+++ b/src/shared/theme/validate.ts
@@ -5,7 +5,7 @@ import { THEME_COLOR_KEYS, THEME_COLOR_SCHEMES, THEME_PACK_LIMITS, type ThemeCol
 const MAX_NAME_LENGTH = THEME_PACK_LIMITS.MAX_NAME_LENGTH
 const SEMVER_REGEX = /^\d+\.\d+\.\d+(-[\w.]+)?$/
 const HEX_COLOR_REGEX = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
-const CSS_FN_COLOR_REGEX = /^(?:rgb|hsl)a?\(.+\)$/i
+const CSS_FN_COLOR_REGEX = /^(?:rgb|hsl)a?\([^)]+\)$/i
 const DANGEROUS_KEYS: ReadonlySet<string> = new Set(['__proto__', 'constructor', 'prototype'])
 const REQUIRED_KEYS = new Set<ThemeColorKey>(THEME_COLOR_KEYS)
 


### PR DESCRIPTION
## Summary
- Tighten CSS function color regex (`CSS_FN_COLOR_REGEX`) from `.+` to `[^)]+` to reject values with embedded closing parens that could pass through injected CSS declarations
- Add prototype pollution key checks (`__proto__`, `constructor`, `prototype`) to key label `isLabelMap()` for parity with theme pack and i18n pack validators

## Test plan
- [x] Theme pack: malicious `hsl(0); --injected: evil)` is rejected
- [x] Theme pack: malicious `rgb(0,0,0); pointer-events: none)` is rejected
- [x] Theme pack: valid `hsl(200 50% 50%)` still accepted
- [x] Key label: `__proto__` in map is rejected
- [x] Key label: `constructor` in map is rejected
- [x] Key label: `prototype` in compositeLabels is rejected
- [x] All existing tests pass
- [x] Lint and type check clean