### PR TITLE
chore(build): bump version to 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pipette-desktop",
   "productName": "Pipette",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version from 0.4.3 to 0.4.4

## Included since 0.4.3
- fix(ui): harden theme pack and key label import validation (#164)
- docs(ui): add colorScheme field to theme pack authoring guide (#165)
- fix(ui): rename Language to Language Packs in i18n labels and screenshots (#166)