### PR TITLE
fix(ui): fall back to global zoom when per-keyboard key editor zoom is unset

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -793,7 +793,7 @@ export function App() {
             onLayerPanelOpenChange={devicePrefs.setLayerPanelOpen}
             scale={editorUI.keymapScale}
             onScaleChange={editorUI.adjustKeymapScale}
-            keyEditorZoom={devicePrefs.keyEditorZoom}
+            keyEditorZoom={devicePrefs.keyEditorZoom ?? (appConfig.config.zoomFactor ?? ZOOM_FACTOR_DEFAULT)}
             onKeyEditorZoomChange={devicePrefs.setKeyEditorZoom}
             typingTestMode={editorUI.typingTestMode}
             onTypingTestModeChange={editorUI.handleTypingTestModeChange}

--- a/src/renderer/components/editors/KeycodesOverlayPanel.tsx
+++ b/src/renderer/components/editors/KeycodesOverlayPanel.tsx
@@ -75,7 +75,9 @@ export function KeycodesOverlayPanel({
 }: Props) {
   const { t } = useTranslation()
   const [zoomInput, setZoomInput] = useState(String(keyEditorZoom ?? ''))
-  useEffect(() => { setZoomInput(String(keyEditorZoom ?? '')) }, [keyEditorZoom])
+  useEffect(() => {
+    setZoomInput(String(keyEditorZoom ?? ''))
+  }, [keyEditorZoom])
   const commitZoom = (val = zoomInput): void => {
     const raw = Number(val)
     if (!Number.isNaN(raw) && onKeyEditorZoomChange) {
@@ -188,11 +190,7 @@ export function KeycodesOverlayPanel({
                     min={ZOOM_FACTOR_MIN}
                     max={ZOOM_FACTOR_MAX}
                     value={zoomInput}
-                    onChange={(e) => {
-                      const val = e.target.value
-                      setZoomInput(val)
-                      if (!(e.nativeEvent as InputEvent).inputType) commitZoom(val)
-                    }}
+                    onChange={(e) => { setZoomInput(e.target.value) }}
                     onBlur={() => commitZoom()}
                     onKeyDown={(e) => e.key === 'Enter' && commitZoom()}
                     className="zoom-factor-input w-16 rounded border border-edge bg-surface pl-2 pr-1 py-0.5 text-xs text-content text-right"

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -10,7 +10,7 @@ import { VIEW_MODES, isTypingViewMenuTab } from '../../shared/types/pipette-sett
 import { trimResults } from '../typing-test/result-builder'
 import type { TypingTestConfig } from '../typing-test/types'
 import type { AutoLockMinutes, BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
-import { ZOOM_FACTOR_DEFAULT, clampZoomFactor } from '../../shared/types/app-config'
+import { clampZoomFactor } from '../../shared/types/app-config'
 
 export type { KeyboardLayoutId, AutoLockMinutes, BasicViewType, SplitKeyMode }
 

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -462,10 +462,6 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingViewMenuTab: 'window',
       viewMode: 'editor',
     }
-    if (resolved.keyEditorZoom === undefined) {
-      resolved.keyEditorZoom = clampZoomFactor(config.zoomFactor ?? ZOOM_FACTOR_DEFAULT)
-    }
-
     updateLayout(resolved.keyboardLayout)
     updateAutoAdvance(resolved.autoAdvance)
     updateLayerPanelOpen(resolved.layerPanelOpen)


### PR DESCRIPTION
## Summary

- Fix spurious `keyEditorZoom` save: `onChange` was incorrectly calling `commitZoom` on React's controlled input DOM updates (when `inputType` is empty string), causing the default value 100 to be written to Hub on every overlay open
- Fall back to global `zoomFactor` when per-keyboard `keyEditorZoom` is `undefined`, so unset keyboards show the correct global zoom in the overlay
- Remove stale closure fallback in `applyDevicePrefs` that was masking the issue

## Test plan

- [ ] Open key editor overlay with keyboard that has no saved `keyEditorZoom` — input shows global zoom (e.g. 120)
- [ ] Open key editor overlay with keyboard that has a saved `keyEditorZoom` — input shows the saved value
- [ ] Change zoom via input (blur/Enter) — saves correctly, no spurious saves on open