### PR TITLE
fix(ui): show 'NO' in popover search input when KC_NO is selected

### DIFF
--- a/src/renderer/components/keycodes/PopoverTabKey.tsx
+++ b/src/renderer/components/keycodes/PopoverTabKey.tsx
@@ -205,7 +205,7 @@ export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask 
             key={`${entry.categoryId}-${entry.keycode.qmkId}`}
             type="button"
             className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-surface-dim"
-            onClick={() => { setTooltip(null); onKeycodeSelect(entry.keycode); setSuppressResults(true); setQuery(entry.keycode.label) }}
+            onClick={() => { setTooltip(null); onKeycodeSelect(entry.keycode); setSuppressResults(true); setQuery(entry.keycode.label || stripPrefix(entry.keycode.qmkId)) }}
             data-testid={`popover-result-${entry.keycode.qmkId}`}
           >
             <span className="min-w-[60px] font-mono text-xs font-medium">


### PR DESCRIPTION
## Summary
- When KC_NO was selected from the key popover results list, the search input went blank because `setQuery` received KC_NO's empty label (`''`)
- Fixed by falling back to `stripPrefix(qmkId)` when label is empty: `entry.keycode.label || stripPrefix(entry.keycode.qmkId)`
- KC_NO now shows `NO` in the input after selection, consistent with how it appears in the results list

## Test plan
- [ ] Open key popover, search "NO", select KC_NO from list → input shows "NO"
- [ ] Open key popover on a key with KC_NO → input shows "NO"
- [ ] Other keycodes (KC_A, KC_TRNS, etc.) unaffected — label still used when non-empty
- [ ] All 206 unit tests pass