### PR TITLE
docs(build): add HTML documentation guide with sidebar TOC

### DIFF
--- a/docs/build-guide.mjs
+++ b/docs/build-guide.mjs
@@ -1,0 +1,799 @@
+#!/usr/bin/env node
+/**
+ * docs/build-guide.mjs
+ * Converts OPERATION-GUIDE.md, OPERATION-GUIDE.ja.md, and Data.md
+ * into a single docs/guide.html with a left-sidebar TOC layout.
+ *
+ * Usage: node docs/build-guide.mjs
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+const esc = s =>
+  String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+
+function slugify(text) {
+  return text
+    .replace(/<[^>]+>/g, '')
+    .replace(/[^\w぀-鿿\s-]/g, ' ')
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+// Maps filename patterns in markdown links to their doc tab id
+const XDOC_LINK_PATTERNS = [
+  [/\[([^\]]+)\]\(OPERATION-GUIDE\.md(#[^)]*)?\)/g,    'en'],
+  [/\[([^\]]+)\]\(OPERATION-GUIDE\.ja\.md(#[^)]*)?\)/g, 'ja'],
+  [/\[([^\]]+)\]\(Data\.md(#[^)]*)?\)/g,               'data'],
+  [/\[([^\]]+)\]\(THEME-PACK-AUTHORING\.html[^)]*\)/g,  'theme'],
+];
+
+// ─── Markdown → HTML ─────────────────────────────────────────────────────────
+
+function convertMd(md, docId) {
+  const codeBlocks  = [];
+  const inlineCodes = [];
+
+  // 0. Strip embedded TOC sections — sidebar replaces them
+  md = md.replace(/^## (Table of Contents|目次)\n[\s\S]*?(?=^## )/m, '');
+
+  // 1. Extract fenced code blocks (protect from further processing)
+  md = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_, lang, body) => {
+    const i = codeBlocks.length;
+    codeBlocks.push(
+      `<pre class="code-block"><code>${esc(body.trimEnd())}</code></pre>`
+    );
+    return `\x00CB${i}\x00`;
+  });
+
+  // 2. Extract inline code
+  md = md.replace(/`([^`\n]+)`/g, (_, code) => {
+    const i = inlineCodes.length;
+    inlineCodes.push(`<code class="ic">${esc(code)}</code>`);
+    return `\x00IC${i}\x00`;
+  });
+
+  function inline(s) {
+    // Images
+    s = s.replace(/!\[([^\]]*)\]\(([^)]+)\)/g,
+      (_, alt, src) => `<img src="${src}" alt="${esc(alt)}" class="doc-img" loading="lazy">`);
+    // Cross-doc links (filename → tab id, optional hash)
+    for (const [pat, docTarget] of XDOC_LINK_PATTERNS) {
+      s = s.replace(pat, (_, t, h = '') => `<a href="#" class="xdoc" data-doc="${docTarget}" data-hash="${h}">${t}</a>`);
+    }
+    // Other .html links
+    s = s.replace(/\[([^\]]+)\]\(([^)]+\.html[^)]*)\)/g,
+      (_, t, href) => `<a href="${href}" target="_blank">${t}</a>`);
+    // External links
+    s = s.replace(/\[([^\]]+)\]\((https?:[^)]+)\)/g,
+      (_, t, href) => `<a href="${href}" target="_blank" rel="noopener">${t}</a>`);
+    // Internal anchor links (#section)
+    s = s.replace(/\[([^\]]+)\]\(#([^)]+)\)/g,
+      (_, t, anchor) => `<a href="#" class="ilink" data-doc="${docId}" data-hash="#${anchor}">${t}</a>`);
+    // Remaining links (relative paths like ../sample-packs/...)
+    s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, t, href) => `<a href="${href}">${t}</a>`);
+    // Bold (process before italic)
+    s = s.replace(/\*\*([^*\n]+)\*\*/g, '<strong>$1</strong>');
+    // Italic
+    s = s.replace(/\*([^*\n]+)\*/g, '<em>$1</em>');
+    return s;
+  }
+
+  const lines = md.split('\n');
+  const parts = [];
+  let i = 0;
+
+  const isBlockStart = l =>
+    !l.trim() || l.match(/^#{1,6} /) || l.startsWith('|') || l.startsWith('>') ||
+    /^[ \t]*[-*] /.test(l) || /^\d+\. /.test(l) || /^-{3,}$/.test(l) ||
+    l.match(/^\x00CB\d+\x00/);
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Skip empty lines
+    if (!line.trim()) { i++; continue; }
+
+    // Code block placeholder (on its own line)
+    const cbm = line.match(/^\x00CB(\d+)\x00$/);
+    if (cbm) {
+      parts.push(codeBlocks[+cbm[1]]);
+      i++; continue;
+    }
+
+    // Heading
+    const hm = line.match(/^(#{1,6}) (.+)$/);
+    if (hm) {
+      const lvl = hm[1].length;
+      const rawText = hm[2];
+      const cleanText = rawText.replace(/\x00IC\d+\x00/g, '').replace(/\*+/g, '');
+      const id = slugify(cleanText);
+      parts.push(`<h${lvl} id="${id}">${inline(rawText)}</h${lvl}>`);
+      i++; continue;
+    }
+
+    // Horizontal rule
+    if (/^-{3,}$/.test(line) || /^\*{3,}$/.test(line)) {
+      parts.push('<hr>');
+      i++; continue;
+    }
+
+    // Table (current line starts with | and next line is separator)
+    if (line.startsWith('|') && i + 1 < lines.length && /^\|[-: |]+\|$/.test(lines[i + 1])) {
+      const tLines = [];
+      while (i < lines.length && lines[i].startsWith('|')) {
+        tLines.push(lines[i]);
+        i++;
+      }
+      parts.push(buildTable(tLines, inline));
+      continue;
+    }
+
+    // Blockquote
+    if (line.startsWith('>')) {
+      const bqLines = [];
+      while (i < lines.length) {
+        const l = lines[i];
+        if (l.startsWith('>')) {
+          bqLines.push(l.replace(/^> ?/, ''));
+          i++;
+        } else if (l.trim() === '' && i + 1 < lines.length && lines[i + 1].startsWith('>')) {
+          bqLines.push('');
+          i++;
+        } else {
+          break;
+        }
+      }
+      parts.push(`<blockquote>${convertMd(bqLines.join('\n'), docId)}</blockquote>`);
+      continue;
+    }
+
+    // Unordered list
+    if (/^[ \t]*[-*] /.test(line)) {
+      const listLines = [];
+      while (i < lines.length) {
+        const l = lines[i];
+        if (/^[ \t]*[-*] /.test(l)) {
+          listLines.push(l);
+          i++;
+        } else if (l.trim() === '' && i + 1 < lines.length && /^[ \t]*[-*] /.test(lines[i + 1])) {
+          i++; // blank line between list items
+        } else {
+          break;
+        }
+      }
+      parts.push(buildUl(listLines, inline));
+      continue;
+    }
+
+    // Ordered list
+    if (/^\d+\. /.test(line)) {
+      const listLines = [];
+      while (i < lines.length && /^\d+\. /.test(lines[i])) {
+        listLines.push(lines[i]);
+        i++;
+      }
+      const items = listLines.map(l =>
+        `<li>${inline(l.replace(/^\d+\. /, ''))}</li>`
+      );
+      parts.push(`<ol>${items.join('')}</ol>`);
+      continue;
+    }
+
+    // Paragraph (everything else)
+    const pLines = [];
+    while (i < lines.length && !isBlockStart(lines[i])) {
+      pLines.push(lines[i]);
+      i++;
+    }
+    if (pLines.length > 0) {
+      const text = pLines.join(' ');
+      const processedText = inline(text);
+      // If paragraph contains only images, wrap differently
+      const isImageOnly = /^(\s*<img[^>]+>\s*)+$/.test(processedText);
+      if (isImageOnly) {
+        parts.push(`<div class="img-wrap">${processedText}</div>`);
+      } else {
+        parts.push(`<p>${processedText}</p>`);
+      }
+    }
+  }
+
+  let html = parts.join('\n');
+
+  // Restore inline code placeholders in a single O(n) pass
+  html = html.replace(/\x00IC(\d+)\x00/g, (_, i) => inlineCodes[+i]);
+
+  return html;
+}
+
+function buildTable(lines, inline) {
+  const rows = lines.map(l => l.split('|').slice(1, -1).map(c => c.trim()));
+  const header   = rows[0];
+  const alignRow = rows[1];
+  const body     = rows.slice(2);
+
+  const aligns = alignRow.map(c => {
+    if (/^:-+:$/.test(c)) return 'center';
+    if (/-+:$/.test(c))   return 'right';
+    return 'left';
+  });
+
+  const ths = header.map((c, i) =>
+    `<th style="text-align:${aligns[i] || 'left'}">${inline(c)}</th>`
+  ).join('');
+
+  const trs = body.map(row =>
+    '<tr>' +
+    row.map((c, i) =>
+      `<td style="text-align:${aligns[i] || 'left'}">${inline(c)}</td>`
+    ).join('') +
+    '</tr>'
+  ).join('');
+
+  return `<div class="table-wrap"><table><thead><tr>${ths}</tr></thead><tbody>${trs}</tbody></table></div>`;
+}
+
+function buildUl(lines, inline) {
+  const getIndent  = l => (l.match(/^(\s*)/) || ['', ''])[1].length;
+  const getContent = l => inline(l.replace(/^\s*[-*] /, ''));
+
+  function build(idx, minIndent) {
+    const items = [];
+    let j = idx;
+    while (j < lines.length && getIndent(lines[j]) >= minIndent) {
+      if (getIndent(lines[j]) === minIndent && /^[ \t]*[-*] /.test(lines[j])) {
+        const content = getContent(lines[j]);
+        j++;
+        if (j < lines.length && /^[ \t]*[-*] /.test(lines[j]) && getIndent(lines[j]) > minIndent) {
+          const [subHtml, nextJ] = build(j, getIndent(lines[j]));
+          items.push(`<li>${content}${subHtml}</li>`);
+          j = nextJ;
+        } else {
+          items.push(`<li>${content}</li>`);
+        }
+      } else {
+        j++;
+      }
+    }
+    return [`<ul>${items.join('')}</ul>`, j];
+  }
+
+  const [html] = build(0, getIndent(lines[0]));
+  return html;
+}
+
+// ─── HTML Doc Loader (for pre-authored HTML files) ───────────────────────────
+
+function loadHtmlDoc(filePath) {
+  const src = readFileSync(filePath, 'utf-8');
+
+  // Extract <style> block, stripping rules that conflict with guide layout
+  let css = '';
+  const styleMatch = src.match(/<style>([\s\S]*?)<\/style>/);
+  if (styleMatch) {
+    css = styleMatch[1]
+      .replace(/\*\s*\{[^}]+\}/g, '')   // * reset — already in guide
+      .replace(/\bbody\s*\{[^}]+\}/g, ''); // body rule — breaks guide layout
+  }
+
+  // Extract <body> content
+  const bodyMatch = src.match(/<body>([\s\S]*?)<\/body>/);
+  let body = bodyMatch ? bodyMatch[1].trim() : '';
+
+  // Strip <small> subtitle from h1 when embedded (guide header already shows app name)
+  body = body.replace(/<h1>([^<]+)<small>[^<]*<\/small><\/h1>/, '<h1>$1</h1>').trimEnd();
+
+  // Add IDs to h2/h3/h4 headings so the TOC can link to them
+  body = body.replace(/<h([2-4])>([^<]+)<\/h[2-4]>/g, (_, lvl, text) =>
+    `<h${lvl} id="${slugify(text)}">${text}</h${lvl}>`
+  );
+
+  return { css, body };
+}
+
+// ─── TOC Builder ─────────────────────────────────────────────────────────────
+
+function buildToc(html, docId) {
+  // Only h2 and h3 in the sidebar TOC (h4+ would be too long)
+  const re = /<h([23]) id="([^"]+)">(.*?)<\/h[23]>/g;
+  const items = [];
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    items.push({
+      level: +m[1],
+      id:    m[2],
+      text:  m[3].replace(/<[^>]+>/g, ''),
+    });
+  }
+
+  const liItems = items.map(({ level, id, text }) =>
+    `<li class="tl${level}"><a href="#" class="ilink" data-doc="${docId}" data-hash="#${id}">${esc(text)}</a></li>`
+  ).join('');
+
+  return `<ul class="toc">${liItems}</ul>`;
+}
+
+// ─── CSS ─────────────────────────────────────────────────────────────────────
+
+const CSS = `
+:root {
+  --bg:          #f5f6f8;
+  --sidebar-bg:  #f0f2f7;
+  --border:      #d8dce6;
+  --text:        #1a1d27;
+  --text2:       #5c6478;
+  --text3:       #8b94a8;
+  --accent:      #2563eb;
+  --accent-bg:   #eff4ff;
+  --code-bg:     #f0f2f7;
+  --header-bg:   #1e2128;
+  --header-text: #e8eaf0;
+  --sidebar-w:   268px;
+  --header-h:    48px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  font-size: 14px;
+}
+
+/* ── Header ── */
+header {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--header-h);
+  background: var(--header-bg);
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 0 20px;
+  z-index: 200;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.logo {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--header-text);
+  letter-spacing: -0.3px;
+  white-space: nowrap;
+}
+
+.tabs { display: flex; gap: 2px; }
+
+.tab {
+  background: transparent;
+  border: none;
+  color: rgba(232,234,240,0.55);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 5px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.tab:hover { background: rgba(255,255,255,0.1); color: var(--header-text); }
+.tab.active { background: var(--accent); color: #fff; }
+
+/* ── Layout ── */
+.layout {
+  display: flex;
+  padding-top: var(--header-h);
+  height: 100vh;
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  overflow-y: auto;
+  height: calc(100vh - var(--header-h));
+  position: sticky;
+  top: var(--header-h);
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 16px 0 40px;
+}
+
+.sidebar::-webkit-scrollbar { width: 4px; }
+.sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.toc-panel { display: none; }
+.toc-panel.active { display: block; }
+
+.toc { list-style: none; }
+
+.toc a {
+  display: block;
+  padding: 3px 14px;
+  font-size: 12.5px;
+  color: var(--text2);
+  text-decoration: none;
+  line-height: 1.45;
+  border-left: 2px solid transparent;
+  transition: color 0.1s, background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.toc a:hover { color: var(--accent); background: rgba(37,99,235,0.05); }
+.toc a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--accent-bg);
+  font-weight: 600;
+}
+
+.toc .tl2 a { padding-left: 14px; font-weight: 600; font-size: 12px; margin-top: 2px; }
+.toc .tl3 a { padding-left: 26px; font-size: 12px; }
+.toc .tl4 a { padding-left: 38px; font-size: 11.5px; color: var(--text3); }
+
+/* ── Content ── */
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 40px 56px 80px;
+}
+
+.content::-webkit-scrollbar { width: 6px; }
+.content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+.doc { display: none; max-width: 860px; }
+.doc.active { display: block; }
+
+/* ── Typography ── */
+.doc h1 {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.5px;
+  margin-bottom: 6px;
+}
+
+.doc h2 {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 6px;
+  margin: 40px 0 16px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h3 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 28px 0 10px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h4 {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  margin: 20px 0 8px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h5, .doc h6 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text3);
+  margin: 16px 0 6px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc p {
+  color: var(--text2);
+  margin-bottom: 12px;
+}
+
+.doc hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 32px 0;
+}
+
+.doc a { color: var(--accent); text-decoration: none; }
+.doc a:hover { text-decoration: underline; }
+
+.doc strong { color: var(--text); font-weight: 600; }
+.doc em { font-style: italic; }
+
+/* ── Code ── */
+.ic {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 12px;
+  background: var(--code-bg);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.code-block {
+  background: #1e2128;
+  color: #abb2bf;
+  border-radius: 8px;
+  padding: 16px 20px;
+  overflow-x: auto;
+  margin: 14px 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.code-block code {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  white-space: pre;
+}
+
+/* ── Images ── */
+.doc-img {
+  max-width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  display: block;
+}
+
+.img-wrap {
+  margin: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── Tables ── */
+.table-wrap {
+  overflow-x: auto;
+  margin: 14px 0;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  min-width: 320px;
+}
+
+.table-wrap thead th {
+  background: var(--code-bg);
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 9px 14px;
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.table-wrap tbody td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text2);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.table-wrap tbody tr:last-child td { border-bottom: none; }
+.table-wrap tbody tr:hover td { background: #f9fafb; }
+
+/* ── Lists ── */
+.doc ul, .doc ol {
+  padding-left: 22px;
+  margin: 6px 0 14px;
+  color: var(--text2);
+}
+.doc li { margin-bottom: 3px; line-height: 1.6; }
+.doc ul ul, .doc ol ul, .doc ul ol { margin: 3px 0; }
+
+/* ── Blockquote ── */
+.doc blockquote {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-bg);
+  padding: 10px 16px;
+  border-radius: 0 8px 8px 0;
+  margin: 14px 0;
+}
+.doc blockquote p { margin-bottom: 4px; color: var(--text2); }
+.doc blockquote p:last-child { margin-bottom: 0; }
+`;
+
+// ─── JavaScript ───────────────────────────────────────────────────────────────
+
+const JS = `
+const contentEl = document.querySelector('.content');
+const tabs      = [...document.querySelectorAll('.tab')];
+const docEls    = [...document.querySelectorAll('.doc')];
+const tocPanels = [...document.querySelectorAll('.toc-panel')];
+
+function switchDoc(id, hash) {
+  const tabId = DOC_TO_TAB[id] ?? id;
+  tabs.forEach(t => t.classList.toggle('active', t.dataset.doc === tabId));
+  docEls.forEach(d => d.classList.toggle('active', d.id === 'doc-' + id));
+  tocPanels.forEach(p => p.classList.toggle('active', p.id === 'toc-' + id));
+
+  if (hash) {
+    setTimeout(() => scrollToHash(id, hash), 60);
+  } else {
+    contentEl.scrollTop = 0;
+  }
+}
+
+function scrollToHash(docId, hash) {
+  // Use getElementById to avoid CSS selector restriction on numeric-starting IDs (e.g. #1-3-data)
+  const id = hash.startsWith('#') ? hash.slice(1) : hash;
+  const target = document.getElementById(id);
+  if (!target) return;
+  const offset = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 48;
+  const top = target.getBoundingClientRect().top + contentEl.scrollTop - offset - 16;
+  contentEl.scrollTo({ top, behavior: 'smooth' });
+}
+
+// Tab click
+tabs.forEach(tab => tab.addEventListener('click', () => switchDoc(tab.dataset.doc)));
+
+// Link click delegation
+document.addEventListener('click', e => {
+  const xdoc = e.target.closest('.xdoc');
+  if (xdoc) {
+    e.preventDefault();
+    switchDoc(xdoc.dataset.doc, xdoc.dataset.hash || null);
+    return;
+  }
+  const ilink = e.target.closest('.ilink');
+  if (ilink) {
+    e.preventDefault();
+    const docId = ilink.dataset.doc;
+    const hash  = ilink.dataset.hash;
+    const activeDoc = document.querySelector('.doc.active');
+    if (!activeDoc || activeDoc.id !== 'doc-' + docId) {
+      switchDoc(docId, hash || null);
+    } else if (hash) {
+      scrollToHash(docId, hash);
+    }
+  }
+});
+
+// Highlight active TOC link via IntersectionObserver
+function highlightToc(docId, headingId) {
+  const toc = document.getElementById('toc-' + docId);
+  if (!toc) return;
+  let found = null;
+  toc.querySelectorAll('a').forEach(a => {
+    const active = a.dataset.hash === '#' + headingId;
+    a.classList.toggle('active', active);
+    if (active) found = a;
+  });
+  // scroll the TOC sidebar to keep active item visible
+  if (found) {
+    const sidebar = document.querySelector('.sidebar');
+    const aTop  = found.getBoundingClientRect().top;
+    const { top: sTop, bottom: sBot } = sidebar.getBoundingClientRect();
+    if (aTop < sTop + 40 || aTop > sBot - 40) {
+      found.scrollIntoView({ block: 'nearest' });
+    }
+  }
+}
+
+docEls.forEach(docEl => {
+  const docId    = docEl.id.replace('doc-', '');
+  const headings = docEl.querySelectorAll('h2, h3');
+
+  const observer = new IntersectionObserver(entries => {
+    const visible = entries.filter(e => e.isIntersecting);
+    if (visible.length > 0) {
+      highlightToc(docId, visible[0].target.id);
+    }
+  }, {
+    root:       contentEl,
+    rootMargin: '-10% 0px -75% 0px',
+    threshold:  0,
+  });
+
+  headings.forEach(h => observer.observe(h));
+});
+`;
+
+// ─── Document definitions ─────────────────────────────────────────────────────
+
+const DOCS = [
+  { id: 'en',    label: 'Operation Guide', file: 'OPERATION-GUIDE.md',          lang: 'en' },
+  { id: 'ja',    label: '操作ガイド',       file: 'OPERATION-GUIDE.ja.md',        lang: 'ja', tab: 'en' },
+  { id: 'data',  label: 'Data Guide',       file: 'Data.md',                     lang: 'en' },
+  { id: 'theme', label: 'Theme Authoring',  file: 'THEME-PACK-AUTHORING.html',   lang: 'en', html: true },
+];
+
+// Tab bar only shows docs without a `tab` property (JA is accessed via in-doc links)
+const TAB_DOCS = DOCS.filter(d => !d.tab);
+
+// Map each doc id to the tab that owns it
+const DOC_TO_TAB = Object.fromEntries(DOCS.map(d => [d.id, d.tab ?? d.id]));
+
+// ─── Render ───────────────────────────────────────────────────────────────────
+
+const rendered = {};
+const tocs     = {};
+let   extraCss = '';
+
+for (const doc of DOCS) {
+  process.stdout.write(`  converting ${doc.file} … `);
+  if (doc.html) {
+    const { css, body } = loadHtmlDoc(join(__dir, doc.file));
+    extraCss        += css;
+    rendered[doc.id] = body;
+  } else {
+    const md = readFileSync(join(__dir, doc.file), 'utf-8');
+    rendered[doc.id] = convertMd(md, doc.id);
+  }
+  tocs[doc.id] = buildToc(rendered[doc.id], doc.id);
+  process.stdout.write('done\n');
+}
+
+const active = (i) => i === 0 ? ' active' : '';
+
+const tabButtons = TAB_DOCS.map((d, i) =>
+  `<button class="tab${active(i)}" data-doc="${d.id}">${esc(d.label)}</button>`
+).join('\n    ');
+
+const tocPanelHtml = DOCS.map((d, i) =>
+  `<div id="toc-${d.id}" class="toc-panel${active(i)}">\n${tocs[d.id]}\n</div>`
+).join('\n    ');
+
+const docPanelHtml = DOCS.map((d, i) =>
+  `<article id="doc-${d.id}" class="doc${active(i)}" lang="${d.lang}">\n${rendered[d.id]}\n</article>`
+).join('\n    ');
+
+const output = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pipette — Documentation</title>
+<style>${CSS}${extraCss}</style>
+</head>
+<body>
+
+<header>
+  <span class="logo">Pipette Docs</span>
+  <nav class="tabs">
+    ${tabButtons}
+  </nav>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    ${tocPanelHtml}
+  </aside>
+  <main class="content">
+    ${docPanelHtml}
+  </main>
+</div>
+
+<script>const DOC_TO_TAB=${JSON.stringify(DOC_TO_TAB)};${JS}</script>
+</body>
+</html>
+`;
+
+const outPath = join(__dir, 'guide.html');
+writeFileSync(outPath, output);
+console.log(`\n✓  docs/guide.html  (${Math.round(output.length / 1024)} KB)`);

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1,0 +1,2793 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Pipette — Documentation</title>
+<style>
+:root {
+  --bg:          #f5f6f8;
+  --sidebar-bg:  #f0f2f7;
+  --border:      #d8dce6;
+  --text:        #1a1d27;
+  --text2:       #5c6478;
+  --text3:       #8b94a8;
+  --accent:      #2563eb;
+  --accent-bg:   #eff4ff;
+  --code-bg:     #f0f2f7;
+  --header-bg:   #1e2128;
+  --header-text: #e8eaf0;
+  --sidebar-w:   268px;
+  --header-h:    48px;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.7;
+  font-size: 14px;
+}
+
+/* ── Header ── */
+header {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  height: var(--header-h);
+  background: var(--header-bg);
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 0 20px;
+  z-index: 200;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.06);
+}
+
+.logo {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--header-text);
+  letter-spacing: -0.3px;
+  white-space: nowrap;
+}
+
+.tabs { display: flex; gap: 2px; }
+
+.tab {
+  background: transparent;
+  border: none;
+  color: rgba(232,234,240,0.55);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 5px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.tab:hover { background: rgba(255,255,255,0.1); color: var(--header-text); }
+.tab.active { background: var(--accent); color: #fff; }
+
+/* ── Layout ── */
+.layout {
+  display: flex;
+  padding-top: var(--header-h);
+  height: 100vh;
+}
+
+/* ── Sidebar ── */
+.sidebar {
+  width: var(--sidebar-w);
+  flex-shrink: 0;
+  overflow-y: auto;
+  height: calc(100vh - var(--header-h));
+  position: sticky;
+  top: var(--header-h);
+  background: var(--sidebar-bg);
+  border-right: 1px solid var(--border);
+  padding: 16px 0 40px;
+}
+
+.sidebar::-webkit-scrollbar { width: 4px; }
+.sidebar::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+
+.toc-panel { display: none; }
+.toc-panel.active { display: block; }
+
+.toc { list-style: none; }
+
+.toc a {
+  display: block;
+  padding: 3px 14px;
+  font-size: 12.5px;
+  color: var(--text2);
+  text-decoration: none;
+  line-height: 1.45;
+  border-left: 2px solid transparent;
+  transition: color 0.1s, background 0.1s, border-color 0.1s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.toc a:hover { color: var(--accent); background: rgba(37,99,235,0.05); }
+.toc a.active {
+  color: var(--accent);
+  border-left-color: var(--accent);
+  background: var(--accent-bg);
+  font-weight: 600;
+}
+
+.toc .tl2 a { padding-left: 14px; font-weight: 600; font-size: 12px; margin-top: 2px; }
+.toc .tl3 a { padding-left: 26px; font-size: 12px; }
+.toc .tl4 a { padding-left: 38px; font-size: 11.5px; color: var(--text3); }
+
+/* ── Content ── */
+.content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 40px 56px 80px;
+}
+
+.content::-webkit-scrollbar { width: 6px; }
+.content::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+.doc { display: none; max-width: 860px; }
+.doc.active { display: block; }
+
+/* ── Typography ── */
+.doc h1 {
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: -0.5px;
+  margin-bottom: 6px;
+}
+
+.doc h2 {
+  font-size: 19px;
+  font-weight: 700;
+  color: var(--accent);
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 6px;
+  margin: 40px 0 16px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h3 {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 28px 0 10px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h4 {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  margin: 20px 0 8px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc h5, .doc h6 {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text3);
+  margin: 16px 0 6px;
+  scroll-margin-top: calc(var(--header-h) + 16px);
+}
+
+.doc p {
+  color: var(--text2);
+  margin-bottom: 12px;
+}
+
+.doc hr {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 32px 0;
+}
+
+.doc a { color: var(--accent); text-decoration: none; }
+.doc a:hover { text-decoration: underline; }
+
+.doc strong { color: var(--text); font-weight: 600; }
+.doc em { font-style: italic; }
+
+/* ── Code ── */
+.ic {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  font-size: 12px;
+  background: var(--code-bg);
+  color: #c7254e;
+  padding: 1px 5px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.code-block {
+  background: #1e2128;
+  color: #abb2bf;
+  border-radius: 8px;
+  padding: 16px 20px;
+  overflow-x: auto;
+  margin: 14px 0;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+
+.code-block code {
+  font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+  white-space: pre;
+}
+
+/* ── Images ── */
+.doc-img {
+  max-width: 100%;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  display: block;
+}
+
+.img-wrap {
+  margin: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* ── Tables ── */
+.table-wrap {
+  overflow-x: auto;
+  margin: 14px 0;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+}
+
+.table-wrap table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  min-width: 320px;
+}
+
+.table-wrap thead th {
+  background: var(--code-bg);
+  color: var(--accent);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 9px 14px;
+  border-bottom: 2px solid var(--border);
+  white-space: nowrap;
+  font-weight: 700;
+}
+
+.table-wrap tbody td {
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text2);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.table-wrap tbody tr:last-child td { border-bottom: none; }
+.table-wrap tbody tr:hover td { background: #f9fafb; }
+
+/* ── Lists ── */
+.doc ul, .doc ol {
+  padding-left: 22px;
+  margin: 6px 0 14px;
+  color: var(--text2);
+}
+.doc li { margin-bottom: 3px; line-height: 1.6; }
+.doc ul ul, .doc ol ul, .doc ul ol { margin: 3px 0; }
+
+/* ── Blockquote ── */
+.doc blockquote {
+  border-left: 3px solid var(--accent);
+  background: var(--accent-bg);
+  padding: 10px 16px;
+  border-radius: 0 8px 8px 0;
+  margin: 14px 0;
+}
+.doc blockquote p { margin-bottom: 4px; color: var(--text2); }
+.doc blockquote p:last-child { margin-bottom: 0; }
+
+  :root {
+    --doc-bg: #f5f6f8;
+    --doc-card: #ffffff;
+    --doc-text: #1a1d27;
+    --doc-text2: #5c6478;
+    --doc-text3: #8b94a8;
+    --doc-border: #d8dce6;
+    --doc-accent: #2563eb;
+    --doc-code-bg: #f0f2f7;
+  }
+  
+  
+  h1 { font-size: 28px; margin-bottom: 8px; }
+  h1 small { font-size: 14px; color: var(--doc-text3); font-weight: normal; }
+  h2 { font-size: 20px; margin: 40px 0 16px; color: var(--doc-accent); border-bottom: 2px solid var(--doc-accent); padding-bottom: 6px; }
+  h3 { font-size: 16px; margin: 24px 0 12px; color: var(--doc-text2); }
+  p { margin-bottom: 12px; color: var(--doc-text2); font-size: 14px; }
+  .subtitle { color: var(--doc-text3); font-size: 14px; margin-bottom: 32px; }
+
+  /* Cards */
+  .card {
+    background: var(--doc-card);
+    border: 1px solid var(--doc-border);
+    border-radius: 10px;
+    padding: 24px;
+    margin-bottom: 20px;
+  }
+
+  /* Color table */
+  .color-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  .color-table th {
+    text-align: left;
+    padding: 10px 12px;
+    background: var(--doc-code-bg);
+    color: var(--doc-accent);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border-bottom: 2px solid var(--doc-border);
+  }
+  .color-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--doc-border);
+    vertical-align: middle;
+  }
+  .color-table tr:last-child td { border-bottom: none; }
+  .color-table tr:hover td { background: #f9fafb; }
+
+  .token-name {
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--doc-text);
+  }
+  .token-desc { color: var(--doc-text2); font-size: 12px; line-height: 1.5; }
+  .token-usage { color: var(--doc-text3); font-size: 11px; font-style: italic; }
+
+  .swatch-cell { white-space: nowrap; }
+  .swatch {
+    display: inline-block;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    border: 1px solid rgba(0,0,0,0.12);
+    vertical-align: middle;
+    margin-right: 8px;
+  }
+  .swatch-value {
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    font-size: 12px;
+    color: var(--doc-text2);
+    vertical-align: middle;
+  }
+
+  .category-label {
+    background: var(--doc-accent);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    padding: 3px 10px;
+    border-radius: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+  .category-row td {
+    padding: 14px 12px 8px !important;
+    border-bottom: none !important;
+    background: transparent !important;
+  }
+
+  /* Preview mockups */
+  .preview-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    margin-bottom: 20px;
+  }
+  @media (max-width: 768px) { .preview-grid { grid-template-columns: 1fr; } }
+
+  .preview-box {
+    border-radius: 10px;
+    padding: 24px;
+    border: 1px solid;
+  }
+  .preview-box h4 {
+    font-size: 13px;
+    margin-bottom: 16px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    opacity: 0.7;
+  }
+
+  .preview-light {
+    background: #f5f6f8;
+    border-color: #d8dce6;
+    color: #1a1d27;
+  }
+  .preview-dark {
+    background: #0f1117;
+    border-color: #333a4d;
+    color: #e8eaf0;
+  }
+
+  /* Mock buttons */
+  .mock-btn {
+    display: inline-block;
+    padding: 6px 16px;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 500;
+    margin-right: 8px;
+    margin-bottom: 8px;
+    border: 1px solid transparent;
+  }
+
+  /* Mock keys */
+  .mock-key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 48px;
+    height: 38px;
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 500;
+    margin: 3px;
+    border-width: 1px;
+    border-style: solid;
+  }
+
+  /* Mock tabs */
+  .mock-tab {
+    display: inline-block;
+    padding: 6px 16px;
+    font-size: 13px;
+    border-bottom: 2px solid transparent;
+    margin-right: 4px;
+  }
+
+  /* Mock picker */
+  .mock-picker {
+    border-radius: 8px;
+    padding: 8px;
+    display: inline-block;
+  }
+  .mock-picker-item {
+    padding: 6px 14px;
+    border-radius: 5px;
+    font-size: 12px;
+    margin-bottom: 4px;
+    border-width: 1px;
+    border-style: solid;
+  }
+
+  /* Mock status dots */
+  .mock-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    margin-right: 6px;
+    vertical-align: middle;
+  }
+
+  /* Annotation callouts */
+  .anno {
+    font-size: 10px;
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(37, 99, 235, 0.1);
+    color: #2563eb;
+    white-space: nowrap;
+  }
+  .preview-dark .anno {
+    background: rgba(76, 141, 255, 0.15);
+    color: #6ba1ff;
+  }
+
+  .anno-line {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 6px;
+    font-size: 12px;
+  }
+
+  /* JSON template */
+  .json-block {
+    background: #1e1e2e;
+    color: #cdd6f4;
+    border-radius: 10px;
+    padding: 20px 24px;
+    font-family: "SF Mono", "Fira Code", "Consolas", monospace;
+    font-size: 12px;
+    line-height: 1.7;
+    overflow-x: auto;
+    position: relative;
+  }
+  .json-block .jk { color: #89b4fa; }
+  .json-block .jv { color: #a6e3a1; }
+  .json-block .jc { color: #6c7086; font-style: italic; }
+
+  .copy-btn {
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    background: #45475a;
+    color: #cdd6f4;
+    border: none;
+    padding: 5px 12px;
+    border-radius: 5px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .copy-btn:hover { background: #585b70; }
+
+  /* Tips */
+  .tip {
+    background: #eff6ff;
+    border-left: 4px solid #2563eb;
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    font-size: 13px;
+    color: #1e40af;
+    margin: 16px 0;
+  }
+  .tip strong { color: #1e3a8a; }
+
+  .warn {
+    background: #fef3c7;
+    border-left: 4px solid #f59e0b;
+    padding: 12px 16px;
+    border-radius: 0 8px 8px 0;
+    font-size: 13px;
+    color: #92400e;
+    margin: 16px 0;
+  }
+
+  /* Section labels */
+  .section-grid { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 16px; }
+  .section-chip {
+    font-size: 11px;
+    padding: 4px 12px;
+    border-radius: 20px;
+    font-weight: 600;
+    border: 1px solid;
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <span class="logo">Pipette Docs</span>
+  <nav class="tabs">
+    <button class="tab active" data-doc="en">Operation Guide</button>
+    <button class="tab" data-doc="data">Data Guide</button>
+    <button class="tab" data-doc="theme">Theme Authoring</button>
+  </nav>
+</header>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div id="toc-en" class="toc-panel active">
+<ul class="toc"><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#1-device-connection">1. Device Connection</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#1-1-device-selection-screen">1.1 Device Selection Screen</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#1-2-connecting-a-keyboard">1.2 Connecting a Keyboard</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#1-3-data">1.3 Data</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#1-4-analyze">1.4 Analyze</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#2-keymap-editor">2. Keymap Editor</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#2-1-screen-layout">2.1 Screen Layout</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#2-2-changing-keys">2.2 Changing Keys</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#2-3-layer-switching">2.3 Layer Switching</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#2-4-key-popover">2.4 Key Popover</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#2-5-layout-options">2.5 Layout Options</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#3-keycode-palette">3. Keycode Palette</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-1-basic">3.1 Basic</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-2-layers">3.2 Layers</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-3-modifiers">3.3 Modifiers</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-4-system">3.4 System</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-5-lighting">3.5 Lighting</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-6-tap-hold-tap-dance">3.6 Tap-Hold / Tap Dance</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-7-macro">3.7 Macro</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-8-combo">3.8 Combo</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-9-key-override">3.9 Key Override</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-10-alt-repeat-key">3.10 Alt Repeat Key</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-11-behavior">3.11 Behavior</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-12-user">3.12 User</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-13-keyboard-device-picker">3.13 Keyboard (Device Picker)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#3-14-keycodes-overlay-panel">3.14 Keycodes Overlay Panel</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#4-toolbar">4. Toolbar</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#4-1-zoom">4.1 Zoom</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#4-2-undo-redo-keymap-history">4.2 Undo / Redo (Keymap History)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#4-3-typing-test">4.3 Typing Test</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#5-detail-setting-editors">5. Detail Setting Editors</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-1-lighting-settings">5.1 Lighting Settings</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-2-combo">5.2 Combo</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-3-key-override">5.3 Key Override</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-4-alt-repeat-key">5.4 Alt Repeat Key</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-5-favorites">5.5 Favorites</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#5-6-json-editor">5.6 JSON Editor</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#6-editor-settings-panel">6. Editor Settings Panel</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#6-1-cloud-sync-google-drive-appdatafolder">6.1 Cloud Sync (Google Drive appDataFolder)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#6-2-key-labels-manage">6.2 Key Labels Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#6-3-language-packs-manage">6.3 Language Packs Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#6-4-theme-packs-manage">6.4 Theme Packs Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#6-5-zoom-ui-scale">6.5 Zoom (UI Scale)</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#7-pipette-hub">7. Pipette Hub</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#7-1-hub-setup">7.1 Hub Setup</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#7-2-uploading-a-keymap">7.2 Uploading a Keymap</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#7-3-uploading-favorite-entries">7.3 Uploading Favorite Entries</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#7-4-uploading-analytics">7.4 Uploading Analytics</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#7-5-hub-website">7.5 Hub Website</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#8-modal-interactions">8. Modal Interactions</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#escape-to-close">Escape to Close</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#unlock-dialog-protection">Unlock Dialog Protection</a></li><li class="tl3"><a href="#" class="ilink" data-doc="en" data-hash="#escape-suppression-during-busy-flows">Escape Suppression During Busy Flows</a></li><li class="tl2"><a href="#" class="ilink" data-doc="en" data-hash="#9-status-bar">9. Status Bar</a></li></ul>
+</div>
+    <div id="toc-ja" class="toc-panel">
+<ul class="toc"><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#1-デバイス接続">1. デバイス接続</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#1-1-デバイス選択画面">1.1 デバイス選択画面</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#1-2-キーボードの接続">1.2 キーボードの接続</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#1-3-データ">1.3 データ</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#1-4-分析">1.4 分析</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#2-キーマップエディタ">2. キーマップエディタ</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#2-1-画面構成">2.1 画面構成</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#2-2-キーの変更方法">2.2 キーの変更方法</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#2-3-レイヤー切替">2.3 レイヤー切替</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#2-4-キーポップオーバー">2.4 キーポップオーバー</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#2-5-レイアウトオプション">2.5 レイアウトオプション</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#3-キーコードパレット">3. キーコードパレット</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-1-basic">3.1 Basic</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-2-layers">3.2 Layers</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-3-modifiers">3.3 Modifiers</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-4-system">3.4 System</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-5-lighting">3.5 Lighting</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-6-tap-hold-tap-dance">3.6 Tap-Hold / Tap Dance</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-7-macro">3.7 Macro</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-8-combo">3.8 Combo</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-9-key-override">3.9 Key Override</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-10-alt-repeat-key">3.10 Alt Repeat Key</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-11-behavior">3.11 Behavior</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-12-user">3.12 User</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-13-keyboard-デバイスピッカー">3.13 Keyboard（デバイスピッカー）</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#3-14-キーコードオーバーレイパネル">3.14 キーコードオーバーレイパネル</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#4-ツールバー">4. ツールバー</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#4-1-ズーム">4.1 ズーム</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#4-2-元に戻す-やり直し-undo-redo-キーマップヒストリー">4.2 元に戻す / やり直し (Undo / Redo) — キーマップヒストリー</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#4-3-タイピングテスト">4.3 タイピングテスト</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#5-詳細設定エディタ">5. 詳細設定エディタ</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-1-ライティング設定">5.1 ライティング設定</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-2-combo">5.2 Combo</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-3-key-override">5.3 Key Override</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-4-alt-repeat-key">5.4 Alt Repeat Key</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-5-お気に入り-favorites">5.5 お気に入り (Favorites)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#5-6-json-エディタ">5.6 JSON エディタ</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#6-エディタ設定パネル">6. エディタ設定パネル</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#6-1-クラウド同期-google-drive-appdatafolder">6.1 クラウド同期 (Google Drive appDataFolder)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#6-2-key-labels-manage">6.2 Key Labels Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#6-3-language-packs-manage">6.3 Language Packs Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#6-4-theme-packs-manage">6.4 Theme Packs Manage</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#6-5-ズーム-ui-全体">6.5 ズーム（UI 全体）</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#7-pipette-hub">7. Pipette Hub</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#7-1-hub-のセットアップ">7.1 Hub のセットアップ</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#7-2-キーマップのアップロード">7.2 キーマップのアップロード</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#7-3-お気に入りエントリのアップロード">7.3 お気に入りエントリのアップロード</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#7-4-分析データのアップロード">7.4 分析データのアップロード</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#7-5-hub-ウェブサイト">7.5 Hub ウェブサイト</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#8-モーダルの操作">8. モーダルの操作</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#escape-で閉じる">Escape で閉じる</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#unlock-dialog-の保護">Unlock Dialog の保護</a></li><li class="tl3"><a href="#" class="ilink" data-doc="ja" data-hash="#busy-状態中の-escape-抑制">Busy 状態中の Escape 抑制</a></li><li class="tl2"><a href="#" class="ilink" data-doc="ja" data-hash="#9-ステータスバー">9. ステータスバー</a></li></ul>
+</div>
+    <div id="toc-data" class="toc-panel">
+<ul class="toc"><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#local-data">Local Data</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#app-settings">App Settings</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#per-keyboard-settings">Per-Keyboard Settings</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#typing-analytics">Typing Analytics</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#snapshots">Snapshots</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#favorites">Favorites</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#key-labels">Key Labels</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#ui-language-packs">UI Language Packs</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#typing-test-language-packs">Typing Test Language Packs</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#logs">Logs</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#authentication-credentials">Authentication Credentials</a></li><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#keyboard-side-data">Keyboard-Side Data</a></li><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#cloud-sync-google-drive-appdatafolder">Cloud Sync (Google Drive appDataFolder)</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#how-it-works">How It Works</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#what-is-synced">What Is Synced</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#security-privacy">Security &amp; Privacy</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#google-oauth-scopes">Google OAuth Scopes</a></li><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#pipette-hub">Pipette Hub</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#what-is-it">What Is It</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#how-it-works">How It Works</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#what-is-uploaded">What Is Uploaded</a></li><li class="tl3"><a href="#" class="ilink" data-doc="data" data-hash="#security-privacy">Security &amp; Privacy</a></li><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#export-formats">Export Formats</a></li><li class="tl2"><a href="#" class="ilink" data-doc="data" data-hash="#reset-operations">Reset Operations</a></li></ul>
+</div>
+    <div id="toc-theme" class="toc-panel">
+<ul class="toc"><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#1-token-categories">1. Token Categories</a></li><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#2-visual-reference">2. Visual Reference</a></li><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#3-complete-token-reference">3. Complete Token Reference</a></li><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#4-design-guidelines">4. Design Guidelines</a></li><li class="tl3"><a href="#" class="ilink" data-doc="theme" data-hash="#token-relationships">Token Relationships</a></li><li class="tl3"><a href="#" class="ilink" data-doc="theme" data-hash="#elevation-hierarchy">Elevation Hierarchy</a></li><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#5-json-template">5. JSON Template</a></li><li class="tl2"><a href="#" class="ilink" data-doc="theme" data-hash="#6-quick-start-workflow">6. Quick Start Workflow</a></li></ul>
+</div>
+  </aside>
+  <main class="content">
+    <article id="doc-en" class="doc active" lang="en">
+<h1 id="pipette-operation-guide">Pipette Operation Guide</h1>
+<p><a href="#" class="xdoc" data-doc="ja" data-hash="">日本語版はこちら</a></p>
+<p>This document explains how to use the Pipette desktop application. Screenshots were taken using a GPK60-63R keyboard unless otherwise noted.</p>
+<hr>
+<h2 id="1-device-connection">1. Device Connection</h2>
+<h3 id="1-1-device-selection-screen">1.1 Device Selection Screen</h3>
+<p>When you launch the app, a list of connected Vial-compatible keyboards is displayed.</p>
+<div class="img-wrap"><img src="screenshots/01-device-selection.png" alt="Device Selection Screen" class="doc-img" loading="lazy"></div>
+<ul><li>USB-connected keyboards are automatically detected</li><li>If multiple keyboards are connected, select one from the list</li><li>On Linux, udev rules may need to be configured if no devices are found</li></ul>
+<p><strong>File Tab</strong></p>
+<div class="img-wrap"><img src="screenshots/file-tab.png" alt="File Tab" class="doc-img" loading="lazy"></div>
+<p>The File tab allows offline editing of <code class="ic">.pipette</code> files without a physical keyboard connected:</p>
+<ul><li>Browse previously saved keyboards and select an entry to load</li><li>Load an external <code class="ic">.pipette</code> file from disk</li><li>A virtual keyboard is created from the embedded definition in the file</li><li>An unsaved changes indicator is shown when edits have not been saved</li></ul>
+<blockquote><p><strong>Use case:</strong> You want to tweak your keyboard's keymap, but the keyboard isn't with you right now. If you've previously saved its data, you can load it from the File tab, make your edits offline, and later connect the keyboard and load the modified data to apply your changes.</p></blockquote>
+<p><strong>Feature Availability: Device vs File Mode</strong></p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Feature</th><th style="text-align:center">Device (USB)</th><th style="text-align:center">File (.pipette)</th></tr></thead><tbody><tr><td style="text-align:left">Keymap editing</td><td style="text-align:center">Yes</td><td style="text-align:center">Yes</td></tr><tr><td style="text-align:left">Macro / Tap Dance editing</td><td style="text-align:center">Yes</td><td style="text-align:center">Yes</td></tr><tr><td style="text-align:left">Combo / Key Override / Alt Repeat Key</td><td style="text-align:center">Yes</td><td style="text-align:center">Yes</td></tr><tr><td style="text-align:left">QMK Settings</td><td style="text-align:center">Yes (device)</td><td style="text-align:center">Yes (local data)</td></tr><tr><td style="text-align:left">Typing Test</td><td style="text-align:center">Yes</td><td style="text-align:center">Yes</td></tr><tr><td style="text-align:left">Export (.vil / .c / .pdf)</td><td style="text-align:center">Yes</td><td style="text-align:center">Yes</td></tr><tr><td style="text-align:left">Lighting control</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Matrix Tester</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Lock / Unlock</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Snapshot save / load</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Hub upload</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">JSON sideload</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Device probe (Keyboard tab)</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr><tr><td style="text-align:left">Cloud Sync</td><td style="text-align:center">Yes</td><td style="text-align:center">No</td></tr></tbody></table></div>
+<h3 id="1-2-connecting-a-keyboard">1.2 Connecting a Keyboard</h3>
+<p>Click a keyboard name in the list to open the keymap editor. A connecting overlay shows loading progress while the keyboard data is read.</p>
+<p>If Cloud Sync is configured, sync progress is also displayed during connection (favorites first, then keyboard-specific data).</p>
+<h3 id="1-3-data">1.3 Data</h3>
+<p>The Data button on the device selection screen opens the Data panel for centralized management of keyboards, favorites, sync data, and Hub posts.</p>
+<div class="img-wrap"><img src="screenshots/data-sidebar-favorites.png" alt="Data — Favorites" class="doc-img" loading="lazy"></div>
+<p>The left sidebar provides a <strong>tree navigation</strong> with the following structure:</p>
+<ul><li><strong>Local</strong><ul><li><strong>Keyboards</strong>: Browse saved keyboard snapshots. Click a keyboard to view, load, export, or delete entries</li><li><strong>Favorites</strong>: Tap Dance, Macro, Combo, Key Override, Alt Repeat Key — each type shows its saved entries with rename, delete, export, and Hub actions</li><li><strong>Application</strong>: Import/export local data or reset selected targets (keyboard data, favorites, app settings)</li></ul></li><li><strong>Sync</strong> (when Cloud Sync is configured): Lists keyboards that exist only in Google Drive (not yet downloaded on this device). Each entry is labeled with the keyboard's real name, resolved from the synced name index rather than from the raw UID. Click a remote-only keyboard to download it on demand — a spinner is shown while fetching, and a failure message appears inline if the download cannot complete. Once downloaded, the keyboard moves into the <strong>Local › Keyboards</strong> branch. To clean up orphaned encrypted files that can no longer be decrypted, use <strong>Undecryptable Files</strong> in the Settings <strong>Data</strong> tab instead (see §6.1)</li><li><strong>Hub</strong> (when Hub is connected): Manage Hub posts grouped by keyboard name</li></ul>
+<div class="img-wrap"><img src="screenshots/data-sidebar-keyboard-saves.png" alt="Data — Keyboard Saves" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/data-sidebar-application.png" alt="Data — Application" class="doc-img" loading="lazy"></div>
+<p>Per-entry actions in the favorites list:</p>
+<ul><li>Click to rename, delete, or <strong>Export</strong> individual entries</li><li><strong>Hub actions</strong>: When Hub is connected, each entry shows <strong>Upload to Hub</strong> / <strong>Update on Hub</strong> / <strong>Remove from Hub</strong> buttons</li><li><strong>Import</strong> / <strong>Export All</strong> buttons at the footer for bulk operations</li></ul>
+<p>A <strong>breadcrumb navigation</strong> at the top of the content area shows the current path (e.g., "Local › Favorites › Tap Dance")</p>
+<h3 id="1-4-analyze">1.4 Analyze</h3>
+<p>The Analyze page shows how you actually type — per-key heatmaps, WPM trends, inter-keystroke intervals, hour-by-day activity, per-finger load, key-pair (bigram) timing, and per-layer usage. Data is recorded while you are in Typing View (the compact window opened from the status bar) and the Record toggle in the typing-test pane is set to Start. Typing-test results are recorded in the same stream.</p>
+<p><strong>Access</strong></p>
+<p>There are two entry points:</p>
+<ul><li><strong>Analyze tab</strong> on the device selection screen — open the page without connecting a keyboard. Useful for reviewing data from keyboards that are currently unplugged</li><li><strong>View Analytics</strong> button in the Typing Test pane — jumps to Analyze for the keyboard you are currently using, then returns to the typing view when you go back</li></ul>
+<p><strong>Keyboard selector</strong></p>
+<p>The Keyboards select at the top of the filter row lists every keyboard that has recorded typing data — pick one to populate the charts. Keyboards with no data never appear in the list. The Back button at the bottom of the page returns to the previous view (e.g. the device selector).</p>
+<p><strong>Analysis tabs</strong></p>
+<p>The tab bar above the chart groups ten analyses by intent — overview, performance, behavior, load, and optimization:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Group</th><th style="text-align:left">Tab</th><th style="text-align:left">What it shows</th></tr></thead><tbody><tr><td style="text-align:left">Overview</td><td style="text-align:left"><strong>Summary</strong></td><td style="text-align:left">Today / last-7-days deltas, typing profile cards (Speed / Hand balance / SFB / Fatigue), goal streak record</td></tr><tr><td style="text-align:left">Performance</td><td style="text-align:left"><strong>WPM</strong></td><td style="text-align:left">Words-per-minute over time, or by hour of day</td></tr><tr><td style="text-align:left">Performance</td><td style="text-align:left"><strong>Interval</strong></td><td style="text-align:left">Keystroke interval percentiles (min / p25 / median / p75 / max), as a time series or a distribution</td></tr><tr><td style="text-align:left">Behavior</td><td style="text-align:left"><strong>Activity</strong></td><td style="text-align:left">Hour × day-of-week grid or sliding-month calendar, colored by keystrokes / WPM / sessions</td></tr><tr><td style="text-align:left">Behavior</td><td style="text-align:left"><strong>By App</strong></td><td style="text-align:left">Active-application breakdown — App Usage Distribution donut and WPM by App horizontal bars. Requires Monitor App data</td></tr><tr><td style="text-align:left">Load</td><td style="text-align:left"><strong>Heatmap</strong></td><td style="text-align:left">Press count per physical key, overlaid on the keymap (per layer). Requires a keymap snapshot in range</td></tr><tr><td style="text-align:left">Load</td><td style="text-align:left"><strong>Ergonomics</strong></td><td style="text-align:left">Per-finger keystroke totals, with a manual finger-assignment editor and a Learning curve view. Requires a snapshot</td></tr><tr><td style="text-align:left">Load</td><td style="text-align:left"><strong>Bigrams</strong></td><td style="text-align:left">Top key-pair counts, pair-interval ranking, and per-finger IKI bar chart</td></tr><tr><td style="text-align:left">Load</td><td style="text-align:left"><strong>Layer</strong></td><td style="text-align:left">Per-layer keystroke counts or layer-op activations</td></tr><tr><td style="text-align:left">Optimization</td><td style="text-align:left"><strong>Layout Comparison</strong></td><td style="text-align:left">Simulate how your recorded typing would land on alternative layouts (Colemak / Dvorak / etc.). Requires a snapshot</td></tr></tbody></table></div>
+<p>The Heatmap, Ergonomics, Bigrams > Finger IKI, Layout Comparison, and Layer > Activations views need a keymap snapshot that overlaps the selected range. Pipette saves a snapshot automatically when typing recording is enabled on the keyboard; the empty state tells you when to start a recording session to capture one.</p>
+<p><strong>Common filters</strong></p>
+<p>The following filters are always available:</p>
+<ul><li><strong>Keymap snapshots</strong> — picks which recorded keymap to analyze against. Editing <strong>From</strong> / <strong>To</strong> stays inside the selected snapshot's active window so charts that need a snapshot (Heatmap / Ergonomics / Bigrams Finger IKI / Layer activations) never mix two layouts in one view. Snapshots are listed on the Keymap snapshot timeline so you can flip between recorded keymap revisions and "Current keymap" without leaving the page</li><li><strong>From</strong> / <strong>To</strong> — the time range to analyze. Both inputs are clamped to the active snapshot's window (or to the most recent 7 days when the keyboard has no snapshot recorded yet)</li><li><strong>Device</strong> — multi-select. Pick any combination of <code class="ic">This device</code> and remote-machine hashes to merge or isolate per-machine data. Hidden on the Interval tab when View is set to Distribution (distribution bins don't split by device)</li><li><strong>App</strong> — multi-select dropdown listing every active application name observed during the range. Defaults to <strong>All apps</strong> (no filter); selecting one or more apps narrows every chart except <strong>By App</strong> to minutes tagged with one of the chosen apps. The dropdown only populates after Monitor App has been enabled and at least one minute has been tagged with an app name. Persisted per keyboard</li></ul>
+<p>Individual tabs add their own filters above the chart (view mode, granularity, unit, etc.); those are described per tab in the sections below. The Heatmap tab keeps its <strong>Normalize</strong> / <strong>Aggregate</strong> / <strong>Group</strong> / <strong>Top N</strong> controls with the ranking row underneath the keyboard itself.</p>
+<p><strong>Saved search conditions</strong></p>
+<p>The bookmark icon in the panel header opens the <strong>Saved search conditions</strong> side panel. Save the active filters under a label, restore a saved set later, rename / delete entries, or export the current condition's chart data as CSV. Each saved entry shows a one-line summary of the filters (devices, apps, snapshot, range) under its label.</p>
+<ul><li>Up to <strong>50 entries per keyboard</strong> — the panel surfaces a cap warning when you reach the limit; delete an existing entry to make room</li><li>Synced via Cloud Sync (when enabled) so the same set is available on other signed-in machines</li><li>Loading an entry written by a newer Pipette release shows an unsupported-version error rather than guessing at unknown fields</li><li><strong>Overwrite</strong>: typing a label that already exists swaps the Save button to a danger-styled <strong>Overwrite?</strong> + Cancel pair. Editing the label clears the pending confirmation so you cannot overwrite a different entry by accident</li><li><strong>Load behavior</strong>: loading a saved entry always opens on the <strong>Summary</strong> tab regardless of which tab was active when the condition was saved</li><li><strong>Hub actions</strong>: when Pipette Hub is connected, each saved entry shows an additional Hub row with <strong>Upload to Hub</strong> / <strong>Update on Hub</strong> / <strong>Remove from Hub</strong> + <strong>Open in Browser</strong> — the same pattern as the keymap and favorites save panels (see §7.4)</li></ul>
+<h4 id="summary">Summary</h4>
+<p>The Summary tab is the default landing view. It collects four read-only cards built from the same minute-bucket aggregates as the rest of the page, so you can scan the latest highs / averages / streaks before drilling into a specific tab.</p>
+<div class="img-wrap"><img src="screenshots/analyze-summary.png" alt="Analyze — Summary" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Today</strong> — Keystrokes, WPM, Typing duration for the current local day</li><li><strong>Last 7 days</strong> — Keystrokes, WPM, Typing duration, Active days, each with a delta arrow comparing the prior 7 days. Insufficient prior data renders as <code class="ic">—</code></li><li><strong>Typing profile (last N days)</strong> — Four qualitative read-outs computed over the recent window:<ul><li><strong>Speed</strong> — overall WPM bucketed into Slow (<30) / Medium (30–50) / Fast (≥50)</li><li><strong>Hand balance</strong> — share of bigram keystrokes per hand. Within ±5% of 50/50 reads as Balanced</li><li><strong>SFB rate</strong> — share of bigrams typed with the same finger. <4% Low / 4–8% Medium / ≥8% High</li><li><strong>Fatigue risk</strong> — drop from peak hour to slowest hour WPM. Wider gap = higher risk</li></ul></li><li><strong>Goal streak record</strong> — Current cycle progress (<code class="ic">current / goalDays</code>), longest historical streak, and editable Goal settings (consecutive days × keystrokes/day). Changing the goal clears the current cycle counter. The <strong>Achievement history</strong> button opens a modal that lists every completed cycle with period, goal, days, total keystrokes, and average per day</li></ul>
+<p>The Summary tab respects the App filter — selecting one or more apps narrows every card to minutes tagged with those apps.</p>
+<h4 id="heatmap">Heatmap</h4>
+<p>The Heatmap tab counts every press per physical key and paints the result on the keymap layout, one layer at a time. It's useful for spotting over- or under-used keys per layer and for tuning the layout.</p>
+<p><strong>Keymap panel</strong></p>
+<p>Keys are tinted by press count (dim = low, saturated accent = high). When a keyboard has more than one layer, a layer toggle bar appears above the panel (<strong>Layer 0</strong>, <strong>Layer 1</strong>, …) and each button shows the per-layer count. Hovering a key opens a tooltip inside the chart with the bound keycode and the count; the tooltip never spills outside the heatmap frame.</p>
+<p><strong>Ranking controls</strong></p>
+<p>Below the heatmap is a ranking table. Four filters control what it shows:</p>
+<ul><li><strong>Normalize</strong> — <code class="ic">Absolute</code> (raw count), <code class="ic">Per hour</code> (count ÷ active hours), <code class="ic">Share of total</code> (% of total presses in range)</li><li><strong>Aggregate</strong> — <code class="ic">By cell</code> collapses every press of the same physical cell; <code class="ic">By character</code> collapses every press of the same keycode regardless of where on the keymap it sits</li><li><strong>Group</strong> — <code class="ic">All</code>, <code class="ic">Character</code>, <code class="ic">Modifier</code>, <code class="ic">Layer op</code></li><li><strong>Top N</strong> — 10 / 20 / 30 / … / 100</li></ul>
+<p>Columns are <strong>Key</strong>, <strong>Layer</strong> (only when the group spans multiple layers), <strong>Matrix</strong>, <strong>Count</strong>.</p>
+<div class="img-wrap"><img src="screenshots/analyze-heatmap.png" alt="Analyze — Heatmap" class="doc-img" loading="lazy"></div>
+<p><strong>Empty states</strong></p>
+<ul><li><strong>No snapshot</strong> — "No keymap snapshot recorded for this range. Start a record session to capture one."</li><li><strong>No layout</strong> — "Layout data not available for this snapshot." The snapshot exists but lacks KLE geometry</li><li><strong>No activity</strong> — "No key presses in this range." Ranking table only</li></ul>
+<h4 id="wpm">WPM</h4>
+<p>The WPM tab charts Words Per Minute — keystrokes per minute divided by 5 — either as a time series or binned by hour of day.</p>
+<p><strong>View Mode</strong></p>
+<ul><li><strong>Time series</strong> — WPM over the selected range as a line chart. A red dashed <strong>Bksp %</strong> line is always overlaid on a secondary right-hand axis (0–100 %) so speed and error rate sit together; click the Bksp legend entry to hide it if you only want the WPM line</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-wpm-time-series.png" alt="Analyze — WPM Time Series" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Time of day</strong> — Bar chart of the 24 hours in the local day. Each bar is the average WPM for that hour across the range. Bars that did not meet <strong>Min sample</strong> render in a muted tone</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-wpm-time-of-day.png" alt="Analyze — WPM Time of Day" class="doc-img" loading="lazy"></div>
+<p><strong>Min sample</strong> (both views)</p>
+<p><code class="ic">30s</code>, <code class="ic">1 min</code>, <code class="ic">2 min</code>, <code class="ic">5 min</code>. Minutes with fewer keystrokes than the chosen WPM-worth-of-keys threshold are dropped from the chart so very light sessions don't skew the line.</p>
+<p><strong>Granularity</strong> (Time series only)</p>
+<p>Bucket width of the time series (<code class="ic">Auto</code>, <code class="ic">1 min</code>, <code class="ic">5 min</code>, … <code class="ic">1 week</code>, <code class="ic">1 month</code>).</p>
+<p><strong>Summary cards</strong></p>
+<ul><li><strong>Time series</strong> — Total keystrokes, Active typing time, Overall WPM, Peak WPM, Lowest WPM, Weighted median WPM, Peak K/min, Peak K/day, Total Bksp, Overall Bksp %</li><li><strong>Time of day</strong> — Total keystrokes, Active typing time, Overall WPM, Peak hour, Slowest hour, Active hours (N / 24)</li></ul>
+<h4 id="interval">Interval</h4>
+<p>The Interval tab visualizes the time between consecutive keystrokes, either as percentile lines over time or as a distribution histogram.</p>
+<p><strong>View Mode</strong></p>
+<ul><li><strong>Time series</strong> — Five percentile lines on a log-scale Y axis: <strong>Min</strong>, <strong>p25</strong>, <strong>Median</strong>, <strong>p75</strong>, <strong>Max</strong>. The Median line is drawn thickest. Click a legend entry to hide a line. The Y-axis label reads <code class="ic">sec (log)</code> or <code class="ic">ms (log)</code> depending on Display</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-interval-time-series.png" alt="Analyze — Interval Time Series" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Distribution</strong> — Bar chart of nine fixed bins (<code class="ic">&lt;50ms</code>, <code class="ic">50-100ms</code>, <code class="ic">100-200ms</code>, <code class="ic">200-500ms</code>, <code class="ic">500ms-1s</code>, <code class="ic">1-2s</code>, <code class="ic">2-5s</code>, <code class="ic">5-10s</code>, <code class="ic">&gt;10s</code>). Bars are colored by band: <strong>Fast</strong> (green, <200ms), <strong>Normal</strong> (blue, 200–500ms), <strong>Slow</strong> (orange, 500ms–2s), <strong>Pause</strong> (red, ≥2s). The <strong>Device</strong> filter is hidden in Distribution mode because bins are always computed from this device alone</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-interval-distribution.png" alt="Analyze — Interval Distribution" class="doc-img" loading="lazy"></div>
+<p><strong>Display</strong> (both views)</p>
+<p><code class="ic">Seconds</code> / <code class="ic">Milliseconds</code>. Switches the unit used in tooltips and on the Y axis. The distribution bin labels stay in their native unit.</p>
+<p><strong>Granularity</strong> (Time series only)</p>
+<p>Same options as WPM.</p>
+<p><strong>Summary cards</strong></p>
+<ul><li><strong>Time series</strong> — Total keystrokes, Active typing time, Weighted median interval, Shortest interval (per min), Longest interval (per min)</li><li><strong>Distribution</strong> — Total keystrokes, Median interval, Fast (<200ms) share, Normal (200–500ms) share, Slow (500ms–2s) share, Pause (≥2s) share, Longest interval (per min), Longest session</li></ul>
+<h4 id="activity">Activity</h4>
+<p>The Activity tab groups typing by day-of-week × hour so you can see when you actually type. The filter row offers two orthogonal pickers: <strong>View</strong> (chart geometry) and <strong>Metric</strong> (what each cell measures).</p>
+<p><strong>View</strong></p>
+<ul><li><strong>Hour</strong> — the historical 24 × 7 hour-of-day × day-of-week grid (or sessions histogram when Metric = Sessions). Driven by the top-level Period picker</li><li><strong>Day</strong> — sliding-window day calendar. Adds a <strong>Range</strong> selector (1 / 3 / 6 / 12 months) plus prev / next month cursor buttons so you can browse the month-by-month heatmap. For 3 / 6 / 12-month ranges the current month stops at today so future days stay blank; the 1-month range shows the full calendar month including future empty days</li></ul>
+<p><strong>Metric</strong></p>
+<ul><li><strong>Keystrokes</strong> — keystroke count. Empty cells are dim, the busiest cell is fully saturated. In Grid view a non-empty cell tooltip shows both the raw count and its share of the range total (e.g. <code class="ic">Mon 09:00 — 1,234 keys (5.2% of total)</code>)</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-activity-keystrokes.png" alt="Analyze — Activity Keystrokes" class="doc-img" loading="lazy"></div>
+<ul><li><strong>WPM</strong> — average WPM per cell. In Grid view, cells that don't meet <strong>Min sample</strong> are desaturated instead of pinning the color scale</li><li><strong>Sessions</strong> — In Grid view this swaps to a histogram of session lengths in seven bins (<code class="ic">&lt;5 min</code>, <code class="ic">5-15 min</code>, <code class="ic">15-30 min</code>, <code class="ic">30-60 min</code>, <code class="ic">1-2 h</code>, <code class="ic">2-4 h</code>, <code class="ic">&gt;4 h</code>); in Calendar view each cell counts the <strong>sessions whose start fell on that date</strong> (not sessions active on that date)</li></ul>
+<p><strong>Day-only controls</strong> (View = Day)</p>
+<ul><li><strong>Normalize</strong> — <code class="ic">Absolute</code> colors by the peak day in the rendered window, <code class="ic">Share of week</code> divides each cell by the column's weekly total, <code class="ic">Share of total</code> divides by the grand total of the rendered range</li><li><strong>Range</strong> — <code class="ic">1 month</code>, <code class="ic">3 months</code>, <code class="ic">6 months</code>, <code class="ic">12 months</code>. Sets the visible window relative to the cursor month</li><li><strong>Prev / Next month buttons</strong> — slide the visible window one month earlier or later. The current month is the right-most column; future days stay blank (except in the 1-month view which shows the full month)</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-activity-calendar.png" alt="Analyze — Activity Calendar" class="doc-img" loading="lazy"></div>
+<p>A gradient legend bar below the calendar shows the color scale from low to peak value, so the intensity mapping is always visible at a glance.</p>
+<p>Clicking a populated cell jumps the rest of the Analyze pane to that single day. The snapshot picker auto-selects the snapshot that contains the date so dependent tabs (Heatmap, Ergonomics, Layer activations) stay aligned with the keymap that was active.</p>
+<p><strong>Min sample</strong> (View = Grid, Metric = WPM)</p>
+<p>Same options as the WPM tab.</p>
+<p><strong>Peak records</strong></p>
+<p>Four stat cards above the grid summarize the peaks across the selected range: Peak WPM, Peak K/min, Peak K/day, Longest session (min). They stay visible for every metric so you always see the overall highs at a glance.</p>
+<p><strong>Summary cards</strong></p>
+<p>Under the grid, the summary depends on the metric:</p>
+<ul><li><strong>Keystrokes</strong> — Total keystrokes, Active typing time, Busiest day, Busiest hour, Peak cell, Active cells (N / 168). The count context under each card also carries its share of the range total (e.g. <code class="ic">800 keys (40.0%)</code>)</li><li><strong>WPM</strong> — Total keystrokes, Active typing time, Overall WPM, Peak cell, Slowest cell, Active cells (N / 168)</li><li><strong>Sessions</strong> — Session count, Total duration, Mean duration, Median duration, Longest session, Shortest session</li></ul>
+<h4 id="ergonomics">Ergonomics</h4>
+<p>The Ergonomics tab reports the physical load of your typing — per finger, per hand, per row — based on the key → finger assignment in the snapshot keymap.</p>
+<p>Like Heatmap, this view needs a keymap snapshot that overlaps the range.</p>
+<p><strong>Sections</strong></p>
+<p>Three bar charts stack vertically:</p>
+<ol><li><strong>Finger Load</strong> — 10 vertical bars, one per finger from left pinky to right pinky</li><li><strong>Hand Balance</strong> — 2 horizontal bars (Left / Right)</li><li><strong>Row Usage</strong> — 6 horizontal bars (Function / Number / Top / Home / Bottom / Thumb)</li></ol>
+<div class="img-wrap"><img src="screenshots/analyze-ergonomics.png" alt="Analyze — Ergonomics" class="doc-img" loading="lazy"></div>
+<p><strong>Finger assignment</strong></p>
+<p>Each key is auto-assigned to a finger based on the layout's KLE metadata (column position and the standard column-to-finger mapping). Click the <strong>Finger assignment</strong> button at the top of the tab to override any key manually:</p>
+<div class="img-wrap"><img src="screenshots/analyze-finger-assignment-modal.png" alt="Analyze — Finger Assignment" class="doc-img" loading="lazy"></div>
+<ul><li>Each key shows a short finger code (<code class="ic">Lp</code>, <code class="ic">Lr</code>, <code class="ic">Lm</code>, <code class="ic">Li</code>, <code class="ic">Lt</code> / <code class="ic">Rt</code>, <code class="ic">Ri</code>, <code class="ic">Rm</code>, <code class="ic">Rr</code>, <code class="ic">Rp</code>). Manually overridden keys are prefixed with <code class="ic">*</code></li><li>Click a key → popover to pick a finger</li><li><strong>Save</strong> persists the overrides; <strong>Reset all</strong> clears every override (disabled when there are none). <strong>Reset to estimate</strong> in the per-key popover clears just that key</li><li>Overrides apply immediately once you close the modal — Finger Load, Hand Balance, and Row Usage all recompute</li></ul>
+<p><strong>Learning curve</strong></p>
+<p>Set the <strong>View</strong> filter to <strong>Learning curve</strong> to swap the four-pane snapshot for a weekly / monthly trend chart. The view buckets per-day matrix counts into the chosen <strong>Period</strong> (week / month) and folds each bucket into three sub-scores plus a composite score:</p>
+<ul><li><strong>Finger load</strong> — how evenly the 10 fingers share the load (1 = perfectly even, 0 = one-finger lock-in)</li><li><strong>Hand balance</strong> — how close the left / right split is to 50 / 50</li><li><strong>Home row stay</strong> — fraction of keystrokes on the home row</li></ul>
+<p>The bold line is the composite <strong>Overall</strong> score (weighted mean of the three sub-scores); the dashed lines are the individual sub-scores. The summary cards at the top show the latest bucket's overall score, the delta against the prior buckets, and the qualified bucket count (a bucket is qualified once its keystroke total clears the min-sample threshold; below-threshold buckets stay visible but are flagged in the tooltip).</p>
+<div class="img-wrap"><img src="screenshots/analyze-ergonomics-learning.png" alt="Analyze — Ergonomic Learning Curve" class="doc-img" loading="lazy"></div>
+<blockquote><p>The composite score is a <strong>relative trend indicator</strong>, not a calibrated absolute metric. The weights are heuristic and finger-stddev is sensitive to layout choices. Read the curve as "is my distribution improving over time?" rather than as a numeric grade.</p></blockquote>
+<p><strong>Empty states</strong></p>
+<ul><li><strong>No snapshot</strong> — same message as Heatmap</li><li><strong>No layout</strong> — "Layout data not available for this snapshot."</li><li><strong>No activity</strong> — "No keystrokes recorded in this range."</li><li><strong>No data</strong> (Learning curve only) — "Not enough matrix activity in this range. Type more or widen the period filter."</li></ul>
+<h4 id="bigrams">Bigrams</h4>
+<p>The Bigrams tab analyzes consecutive key-press pairs (bigrams) and the inter-key interval (IKI) between them. Bigrams are aggregated per minute as the typing happens, so the tab works over any selected range without re-scanning raw events.</p>
+<p><strong>Quadrant layout</strong></p>
+<p>The view is a 3-quadrant grid; each quadrant has its own list-size selector (10 / 20 / 30 / … / 100). Bars are rendered with recharts so tooltips track the cursor.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Quadrant</th><th style="text-align:left">What it shows</th></tr></thead><tbody><tr><td style="text-align:left"><strong>Top pairs</strong></td><td style="text-align:left">Pair ranking by total occurrence count. Click the <strong>Count</strong> or <strong>Avg IKI</strong> column to flip the sort</td></tr><tr><td style="text-align:left"><strong>Pair interval</strong></td><td style="text-align:left">Pair ranking by average IKI (slowest first). Click any of <strong>Count</strong>, <strong>Avg IKI</strong>, or <strong>p95</strong> to re-sort. The Avg interval threshold (see Common filters) hides faster-than-threshold pairs</td></tr><tr><td style="text-align:left"><strong>Finger IKI</strong></td><td style="text-align:left">Per-(from-finger → to-finger) average IKI bar chart. Bars are coloured blue for left-hand starts and red for right-hand starts. Same Avg interval threshold applies</td></tr></tbody></table></div>
+<div class="img-wrap"><img src="screenshots/analyze-bigrams.png" alt="Analyze — Bigrams" class="doc-img" loading="lazy"></div>
+<p><strong>Snapshot requirement</strong></p>
+<p>Only the <strong>Finger IKI</strong> quadrant needs a keymap snapshot — it has to map each numeric keycode in the bigram pairs to a finger, which depends on the snapshot's keymap and layout. The Top pairs and Pair interval quadrants both render directly from the recorded pair counts and work without a snapshot.</p>
+<p><strong>Common filters</strong></p>
+<ul><li><strong>Range</strong> — same <code class="ic">From</code> / <code class="ic">To</code> pickers as the rest of Analyze. The view re-aggregates over the chosen window</li><li><strong>Device</strong> — <code class="ic">This device</code> only or all synced devices, identical to the other tabs</li><li><strong>Avg interval (ms or slower)</strong> — minimum-IKI threshold rendered inline in both the Finger IKI and Slow pairs quadrant headers. Pairs whose average IKI is below the threshold are hidden in both quadrants at once (the input is shared, so editing it in one quadrant updates the other). <code class="ic">0</code> disables the filter; the value is persisted per keyboard via <code class="ic">PipetteSettings</code>. The IKI used for comparison is approximate (histogram bucket-center weighted average), so the cut-off is best treated as a coarse "ignore pairs faster than ~N ms" filter</li></ul>
+<p><strong>Empty states</strong></p>
+<ul><li><strong>No bigram data</strong> — "No bigram data in this range yet. Record some typing and try again." Shown when the range has no recorded pair activity</li><li><strong>No snapshot (Finger IKI quadrant only)</strong> — "Finger heatmap needs a keymap snapshot. Start a record session or pick a range with one." The other three quadrants still render</li><li><strong>Threshold filtered everything out</strong> — when <strong>Avg interval</strong> is set high enough that no pair survives, the Finger IKI and Pair interval quadrants both fall back to "No bigram data in this range yet." Lower the threshold to bring rows back</li></ul>
+<h4 id="by-app">By App</h4>
+<p>The By App tab breaks the recorded data down by the active application name captured during typing. It only populates after Monitor App has been enabled in the Typing View and at least one minute has been tagged with an app name. This tab intentionally <strong>ignores the App filter</strong> — applying it would collapse the chart to a single slice / bar.</p>
+<div class="img-wrap"><img src="screenshots/analyze-by-app.png" alt="Analyze — By App" class="doc-img" loading="lazy"></div>
+<p><strong>App Usage Distribution</strong> (donut)</p>
+<p>Per-app share of total keystrokes for the selected range. Minutes tagged with multiple apps fold into an <code class="ic">Unknown / Mixed</code> slice; minutes that pre-date Monitor App or were captured while it was disabled go to <code class="ic">Other</code>. Hover for the tooltip with the per-slice keystrokes count and share percentage.</p>
+<p><strong>WPM by App</strong> (horizontal bars)</p>
+<p>Per-app median WPM as a horizontal bar chart, ranked by share of activity. Bars below the configured min-sample threshold render in a muted tone. Hover for the per-bar WPM and keystroke count.</p>
+<p><strong>Empty state</strong></p>
+<ul><li>"No app data — turn on Monitor App and start REC to populate this chart." Shown when no app-tagged minutes exist in the range</li></ul>
+<h4 id="layout-comparison">Layout Comparison</h4>
+<p>The Layout Comparison simulates how your recorded typing would land on a different keyboard layout — Colemak, Dvorak, Colemak DH, and 30+ others — without touching your firmware. Pick a candidate from the dropdown and the tab folds your matrix activity through that layout's character map to show how your finger / hand / row workload would shift.</p>
+<p><strong>Pickers</strong></p>
+<ul><li><strong>Current layout</strong> — what character convention to interpret your recorded events with. Defaults to QWERTY; change it if your firmware fires keycodes for a different layout natively</li><li><strong>Compare to</strong> — the candidate layout to simulate against. Picks are persisted per keyboard so the comparison reopens to the same target after a reload</li></ul>
+<p><strong>Panels</strong></p>
+<p>Once a target is picked, all three panels render at once so you can read the spatial, per-finger, and tabular views together without flipping a sub-view:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Panel</th><th style="text-align:left">What it shows</th></tr></thead><tbody><tr><td style="text-align:left"><strong>Heatmap diff</strong> (top, full width)</td><td style="text-align:left">Per-physical-key delta painted over the keyboard. Red shades where the candidate sends more activity to that key, blue shades where it sends less</td></tr><tr><td style="text-align:left"><strong>Finger diff</strong> (bottom-left)</td><td style="text-align:left">Per-finger signed delta bar chart. Red bars mark fingers that take more load on the candidate, green bars mark fingers that take less</td></tr><tr><td style="text-align:left"><strong>Metric table</strong> (bottom-right)</td><td style="text-align:left">Side-by-side share-of-events table with finger load (per finger), hand balance (left / right), row distribution, and home-row stay rate</td></tr></tbody></table></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-heatmap-diff.png" alt="Analyze — Layout Comparison Heatmap Diff" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-finger-diff.png" alt="Analyze — Layout Comparison Finger Diff" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-metric.png" alt="Analyze — Layout Comparison Metric" class="doc-img" loading="lazy"></div>
+<p><strong>Skip-rate warning</strong></p>
+<p>Some events can't be mapped onto a candidate — for example, when the source character has no equivalent on the target layout, or the firmware hasn't bound the candidate's keycode anywhere. When that share rises above 5% the view shows a warning so you know the metrics are approximate.</p>
+<p><strong>Empty states</strong></p>
+<ul><li><strong>No snapshot</strong> — same empty state as the rest of the snapshot-bound tabs. Start a record session in the chosen range to capture one</li><li><strong>No target picked</strong> — the empty hint stays until you pick a comparison layout from the dropdown</li><li><strong>Fetch error</strong> — generic "failed to compute the layout comparison" message; reload or pick a smaller range and retry</li></ul>
+<p>The Layer tab breaks usage down by keyboard layer.</p>
+<p><strong>View Mode</strong></p>
+<ul><li><strong>Keystrokes</strong> — sums every press at the layer that was active at the time. Reflects <code class="ic">MO</code>, <code class="ic">LT</code>, <code class="ic">TG</code>, and any other layer op live, because the active layer is recorded when the press happens. Works with or without a keymap snapshot</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-layer-keystrokes.png" alt="Analyze — Layer Keystrokes" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Activations</strong> — counts how many times each layer was <em>reached</em> through a layer-op keycode. Requires a keymap snapshot so the layer-op target can be resolved:<ul><li><code class="ic">MO</code> / <code class="ic">TG</code> / <code class="ic">TO</code> / <code class="ic">DF</code> / <code class="ic">PDF</code> / <code class="ic">OSL</code> / <code class="ic">TT</code> — counted on press</li><li><code class="ic">LT</code> / <code class="ic">LM</code> — counted only on hold (so a tapped <code class="ic">LT0(KC_ESC)</code> doesn't look like a layer transition)</li></ul></li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-layer-activations.png" alt="Analyze — Layer Activations" class="doc-img" loading="lazy"></div>
+<p><strong>Base Layer</strong></p>
+<p>Appears only in Activations mode on keyboards with two or more layers. Selects the layer you are analyzing from — that layer is dropped from the bar list so a "hold the same layer you're already on" press (e.g., <code class="ic">LT0(KC_ESC)</code> while base = 0) doesn't show up as a transition.</p>
+<p><strong>Layer names</strong></p>
+<p>If you have named layers in the layer panel (see §2.3), the name is appended to the axis label (e.g., <code class="ic">Layer 0 · Base</code>) so you can tell layers apart without counting.</p>
+<p><strong>Empty states</strong></p>
+<ul><li><strong>Keystrokes, no activity</strong> — nothing pressed in range</li><li><strong>Activations, no activity</strong> — no layer-op keys pressed in range</li><li><strong>Activations, no snapshot</strong> — "Layer activations need a keymap snapshot. Start a record session in this range to capture one." Keystrokes mode keeps working without a snapshot</li></ul>
+<h4 id="export-upload">Export / Upload</h4>
+<p>The <strong>Export</strong> button on the panel header opens a category-pick modal that writes the chart data for the active filters as a <code class="ic">.csv</code> file. Ten categories can be ticked independently:</p>
+<ul><li><strong>Summary</strong> — today / last-7-days overview cards</li><li><strong>WPM</strong> — per-bucket WPM time series</li><li><strong>Interval</strong> — per-bucket interval percentiles</li><li><strong>Activity</strong> — hour × day-of-week or day-cell counts depending on the View setting</li><li><strong>By App</strong> — per-application breakdown</li><li><strong>Heatmap</strong> — per-cell press counts (snapshot-bound)</li><li><strong>Ergonomics</strong> — per-finger / per-hand / per-row totals (snapshot-bound)</li><li><strong>Bigrams</strong> — Top pairs / Pair interval / Finger IKI rows</li><li><strong>Layer</strong> — per-layer keystroke or activation counts</li><li><strong>Layout Comparison</strong> — per-finger / row / hand deltas (snapshot-bound)</li></ul>
+<p>The modal lists the active conditions (Device, App, Keymap, Period) above the category list so the file you save is unambiguous about which slice it captures. Heatmap, Ergonomics, and Layout Comparison entries are unavailable when the range has no overlapping snapshot — the modal shows a "snapshot missing" notice for those categories. Manual finger overrides are noted next to the Ergonomics row.</p>
+<p><strong>Upload mode</strong></p>
+<p>The same modal opens in <strong>upload mode</strong> when triggered from a saved entry's Hub action row (Upload to Hub / Update on Hub). In this mode the confirm button reads <strong>Upload</strong> or <strong>Update</strong> and the data is sent to Pipette Hub instead of written to a CSV file. Upload mode adds two additional selectors:</p>
+<ul><li><strong>Layout Comparison targets</strong> — a multi-select popover listing all installed key-label sets and built-in layouts. Pick one or more target layouts to include in the Hub post; the Layout Comparison toggle is disabled when no targets are selected</li><li><strong>Per-app data</strong> — a multi-select popover listing every app observed in the range. Select which apps to include as per-app breakdowns on Hub</li></ul>
+<p>See §7.4 for the full analytics upload flow and validation rules.</p>
+<hr>
+<h2 id="2-keymap-editor">2. Keymap Editor</h2>
+<h3 id="2-1-screen-layout">2.1 Screen Layout</h3>
+<p>The keymap editor consists of two main areas: the keyboard layout display and the keycode palette.</p>
+<div class="img-wrap"><img src="screenshots/02-keymap-editor-overview.png" alt="Keymap Editor Overview" class="doc-img" loading="lazy"></div>
+<ul><li>Top area: Physical keyboard layout (shows the current keycode assigned to each key)</li><li>Left side: Toolbar (zoom, undo/redo, etc.)</li><li>Bottom area: Keycode palette (tabbed interface) with overlay panel toggle</li><li>Right side (when open): Keycodes Overlay Panel (tools, save, layout options)</li><li>Bottom bar: Status bar</li></ul>
+<h3 id="2-2-changing-keys">2.2 Changing Keys</h3>
+<ol><li>Click a key on the keyboard layout to select it</li><li>Click a keycode from the keycode palette to assign it</li><li>The key display updates immediately</li><li>Changes are automatically sent to the keyboard</li></ol>
+<ul><li>Ctrl+click to select multiple keys</li><li>Shift+click for range selection</li><li>Press Escape to deselect all keys</li></ul>
+<p><strong>Instant Key Selection</strong> controls how keycode assignment behaves:</p>
+<ul><li><strong>ON</strong> (default): A single click on a keycode immediately assigns it and closes the selection. Fast workflow for quick edits.</li><li><strong>OFF</strong>: A single click selects a keycode (highlighted), double-click or press Enter to confirm and assign. A hint is shown at the bottom of the palette. Useful when you want to browse keycodes before committing.</li></ul>
+<p>This setting can be toggled per-keyboard in the Keycodes Overlay Panel (§3.14), and the global default can be set in Settings → Defaults (§6.1).</p>
+<h3 id="2-3-layer-switching">2.3 Layer Switching</h3>
+<p>Layer switching buttons are located on the left side of the keyboard layout.</p>
+<div class="img-wrap"><img src="screenshots/03-layer-0.png" alt="Layer 0" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/04-layer-1.png" alt="Layer 1" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/05-layer-2.png" alt="Layer 2" class="doc-img" loading="lazy"></div>
+<ul><li>Click layer number buttons to switch between layers</li><li>Layer 0 is the default layer</li><li>The number of available layers depends on the keyboard configuration</li></ul>
+<p>The layer panel can be collapsed to save space:</p>
+<div class="img-wrap"><img src="screenshots/layer-panel-collapsed.png" alt="Layer Panel Collapsed" class="doc-img" loading="lazy"></div>
+<p>Click the collapse button (chevron) to minimize the layer panel to just numbers. Click the expand button to restore full layer names.</p>
+<div class="img-wrap"><img src="screenshots/layer-panel-expanded.png" alt="Layer Panel Expanded" class="doc-img" loading="lazy"></div>
+<h3 id="2-4-key-popover">2.4 Key Popover</h3>
+<p>Double-click a key on the keyboard layout to open the Key Popover — a quick way to search and assign keycodes without scrolling through the palette.</p>
+<p><strong>Layer Sidebar</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-layer-sidebar.png" alt="Key Popover — Layer Sidebar" class="doc-img" loading="lazy"></div>
+<p>A vertical layer sidebar appears on the left side of the popover, matching the layer panel buttons. Click a layer number to switch layers without closing the popover. If the number of layers exceeds the popover height, the sidebar scrolls independently.</p>
+<p><strong>Key Tab</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-key.png" alt="Key Popover — Key Tab" class="doc-img" loading="lazy"></div>
+<ul><li>The search input is pre-filled with the current keycode name</li><li>Type to search by name, keycode name, or alias — results are ranked by relevance</li><li>Click a result to assign it immediately</li><li>The popover also appears when double-clicking key fields in detail editors (Tap Dance, Combo, Key Override, etc.)</li></ul>
+<p><strong>Code Tab</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-code.png" alt="Key Popover — Code Tab" class="doc-img" loading="lazy"></div>
+<ul><li>Enter a keycode value directly in hexadecimal (e.g., <code class="ic">0x0029</code> for Escape)</li><li>The resolved keycode name is displayed below the hex input</li><li>Click <strong>Apply</strong> to assign the entered keycode</li></ul>
+<p><strong>Wrapper Modes</strong></p>
+<p>The mode buttons at the top of the popover let you build composite keycodes:</p>
+<div class="img-wrap"><img src="screenshots/key-popover-modifier.png" alt="Key Popover — Modifier Mode" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Mod Mask</strong>: Combine a modifier with a key (e.g., <code class="ic">LSFT(KC_ESCAPE)</code>)</li><li><strong>Mod-Tap</strong>: Modifier on hold, key on tap (e.g., <code class="ic">LSFT_T(KC_ESCAPE)</code>)</li></ul>
+<p>Both modes show the modifier checkbox strip to select Left/Right Ctrl, Shift, Alt, or GUI. Left and Right modifiers cannot be mixed — selecting one side disables the other.</p>
+<div class="img-wrap"><img src="screenshots/key-popover-lt.png" alt="Key Popover — LT Mode" class="doc-img" loading="lazy"></div>
+<ul><li><strong>LT</strong>: Layer-Tap — activate a layer on hold, send a key on tap (e.g., <code class="ic">LT0(KC_ESCAPE)</code>). A layer selector appears to choose the target layer.</li><li><strong>SH_T</strong>: Swap Hands Tap — swap hands on hold, send a key on tap (e.g., <code class="ic">SH_T(KC_ESCAPE)</code>)</li><li><strong>LM</strong>: Layer-Mod — activate a layer with modifiers (e.g., <code class="ic">LM(0, MOD_LSFT)</code>). Shows both the layer selector and the modifier checkbox strip.</li></ul>
+<p>Click an active mode button to toggle it off and revert to a basic keycode.</p>
+<p><strong>Undo / Redo</strong>: The popover footer shows context-sensitive <strong>Undo</strong> and <strong>Redo</strong> buttons. Undo displays the previous keycode and reverts to it; Redo displays the next keycode and re-applies it. These buttons only appear when the most recent undo/redo history entry matches the key currently open in the popover (i.e., the last single change). For multi-step history navigation, use the toolbar buttons or keyboard shortcuts (see §4.2).</p>
+<div class="img-wrap"><img src="screenshots/key-popover-undo.png" alt="Key Popover — Undo" class="doc-img" loading="lazy"> <img src="screenshots/key-popover-redo.png" alt="Key Popover — Redo" class="doc-img" loading="lazy"></div>
+<p><strong>Confirmation</strong>: Press <strong>Enter</strong> to confirm the current selection and close the popover. Press <strong>Escape</strong> or click outside the popover to close it without changes.</p>
+<h3 id="2-5-layout-options">2.5 Layout Options</h3>
+<p>Some keyboards support multiple physical layouts (e.g., split backspace, ISO enter, different bottom row configurations). When a keyboard has layout options, a Layout Options button (grid icon) appears at the right end of the keycode palette tab bar.</p>
+<div class="img-wrap"><img src="screenshots/layout-options-open.png" alt="Layout Options Panel" class="doc-img" loading="lazy"></div>
+<ul><li>Click the grid icon to open the Layout Options panel</li><li><strong>Checkbox options</strong>: Toggle a layout variant on or off (e.g., "Macro Pad", "Split Backspace", "ISO Enter")</li><li><strong>Dropdown options</strong>: Select from multiple layout variants (e.g., "Bottom Section" with Full Grid / Macro Pad / Arrow Keys choices)</li><li>Changes are applied immediately — the keyboard layout display updates in real time to reflect the selected options</li></ul>
+<div class="img-wrap"><img src="screenshots/layout-options-changed.png" alt="Layout Options Changed" class="doc-img" loading="lazy"></div>
+<ul><li>Selecting a different option updates the visible keys on the keyboard layout</li><li>Layout options are saved to the keyboard and persist across sessions</li><li>Click outside the panel or press Escape to close it</li></ul>
+<blockquote><p><strong>Note</strong>: The Layout Options button only appears for keyboards that define multiple layout variants. Most keyboards with a single fixed layout do not show this button. Screenshots in this section were taken using a dummy JSON definition loaded via "Load from JSON file".</p></blockquote>
+<hr>
+<h2 id="3-keycode-palette">3. Keycode Palette</h2>
+<p>Select keycodes from different categories using the tabbed palette at the bottom of the screen.</p>
+<h3 id="3-1-basic">3.1 Basic</h3>
+<p>Standard character keys, function keys, modifier keys, and navigation keys. The Basic tab supports four view types, selectable from the view selector at the bottom of the Basic tab:</p>
+<p><strong>ANSI Keyboard View</strong> (default)</p>
+<div class="img-wrap"><img src="screenshots/basic-ansi-view.png" alt="Basic Tab — ANSI View" class="doc-img" loading="lazy"></div>
+<p>Displays keycodes as an ANSI keyboard layout. Click a key on the visual keyboard to assign it.</p>
+<p><strong>ISO Keyboard View</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-iso-view.png" alt="Basic Tab — ISO View" class="doc-img" loading="lazy"></div>
+<p>Displays keycodes as an ISO keyboard layout with the ISO-specific keys.</p>
+<p><strong>JIS Keyboard View</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-jis-view.png" alt="Basic Tab — JIS View" class="doc-img" loading="lazy"></div>
+<p>Displays keycodes as a JIS keyboard layout with JIS-specific keys (Yen, Ro, Henkan, Muhenkan, Katakana/Hiragana).</p>
+<p><strong>List View</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-list-view.png" alt="Basic Tab — List View" class="doc-img" loading="lazy"></div>
+<p>Displays keycodes in the traditional scrollable list format.</p>
+<p>All views include:</p>
+<ul><li>Character keys (A-Z, 0-9, symbols)</li><li>Function keys (F1-F24)</li><li>Editing keys (Enter, Tab, Backspace, Delete)</li><li>Navigation keys (arrows, Home, End, PageUp/Down)</li><li>Numpad keys</li><li>International keys (KC_INT1–KC_INT5)</li><li>Language keys (KC_LANG1–KC_LANG5)</li></ul>
+<h3 id="3-2-layers">3.2 Layers</h3>
+<p>Keycodes for layer operations.</p>
+<div class="img-wrap"><img src="screenshots/tab-layers.png" alt="Layers Tab" class="doc-img" loading="lazy"></div>
+<ul><li><strong>MO(n)</strong>: Momentarily activate layer n while held</li><li><strong>DF(n)</strong>: Set default layer to n</li><li><strong>TG(n)</strong>: Toggle layer n</li><li><strong>LT(n, kc)</strong>: Layer on hold, keycode on tap</li><li><strong>OSL(n)</strong>: Activate layer n for the next keypress only</li><li><strong>TO(n)</strong>: Switch to layer n</li></ul>
+<h3 id="3-3-modifiers">3.3 Modifiers</h3>
+<p>Keycodes for modifier key combinations and tap behavior settings.</p>
+<div class="img-wrap"><img src="screenshots/tab-modifiers.png" alt="Modifiers Tab" class="doc-img" loading="lazy"></div>
+<ul><li><strong>One-Shot Modifier (OSM)</strong>: Activate modifier for the next keypress only</li><li><strong>Mod-Tap</strong>: Modifier on hold, regular key on tap</li><li><strong>Mod Mask</strong>: Modifier key combinations</li></ul>
+<h3 id="3-4-system">3.4 System</h3>
+<p>Keycodes for mouse control, media playback, system utilities, and audio/haptic feedback.</p>
+<div class="img-wrap"><img src="screenshots/tab-system.png" alt="System Tab" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Mouse</strong>: buttons, movement, and scrolling</li><li><strong>Joystick</strong>: axis and button keycodes</li><li><strong>Audio</strong>: audio toggle and control keycodes</li><li><strong>Haptic</strong>: haptic feedback toggle and control keycodes</li><li><strong>Media Playback</strong>: play/stop/volume/track controls</li><li><strong>Locking Keys</strong>: Locking Caps Lock, Num Lock, Scroll Lock</li><li><strong>App / Browser</strong>: application launcher and browser navigation keys</li><li><strong>System Control</strong>: system power, sleep, wake</li><li><strong>Boot</strong>: enter bootloader mode (QK_BOOT)</li></ul>
+<blockquote><p><strong>Note</strong>: The MIDI tab is only displayed for MIDI-capable keyboards. When available, it appears between System and Lighting.</p></blockquote>
+<h3 id="3-5-lighting">3.5 Lighting</h3>
+<p>Keycodes for backlight and RGB lighting controls.</p>
+<div class="img-wrap"><img src="screenshots/tab-lighting.png" alt="Lighting Tab" class="doc-img" loading="lazy"></div>
+<ul><li>RGB Matrix controls</li><li>RGB Lighting controls</li><li>Backlight controls</li><li>LED Matrix controls</li></ul>
+<h3 id="3-6-tap-hold-tap-dance">3.6 Tap-Hold / Tap Dance</h3>
+<p>Keycodes that assign different actions to tap and hold.</p>
+<div class="img-wrap"><img src="screenshots/tab-tapDance.png" alt="Tap-Hold / Tap Dance Tab" class="doc-img" loading="lazy"></div>
+<p>The Tap Dance section displays a <strong>tile grid preview</strong> showing all entries at a glance:</p>
+<div class="img-wrap"><img src="screenshots/td-tile-grid.png" alt="Tap Dance Tile Grid" class="doc-img" loading="lazy"></div>
+<ul><li>Each tile shows the entry number and a summary of configured actions</li><li>Configured entries display their tap/hold actions; unconfigured tiles show the number only</li><li>Click a tile to open the Tap Dance edit modal directly to that entry</li><li>Configure tap, hold, double-tap, and other actions for each entry</li><li><strong>Edit JSON</strong> button at the bottom opens a JSON editor for bulk editing all entries (see §5.6)</li></ul>
+<h3 id="3-7-macro">3.7 Macro</h3>
+<p>Macro keycodes.</p>
+<div class="img-wrap"><img src="screenshots/tab-macro.png" alt="Macro Tab" class="doc-img" loading="lazy"></div>
+<p>The Macro section displays a <strong>tile grid preview</strong> showing all entries at a glance:</p>
+<div class="img-wrap"><img src="screenshots/macro-tile-grid.png" alt="Macro Tile Grid" class="doc-img" loading="lazy"></div>
+<ul><li>Each tile shows the macro number and a preview of the recorded sequence</li><li>Configured entries display a summary of key actions; unconfigured tiles show the number only</li><li>Click a tile to open the Macro edit modal directly to that entry</li><li>Record sequences of key inputs as macros</li><li><strong>Edit JSON</strong> button at the bottom opens a JSON editor for bulk editing all entries (see §5.6)</li></ul>
+<h4 id="macro-edit-modal-list-mode-and-edit-mode">Macro Edit Modal — List Mode and Edit Mode</h4>
+<p>Opening a macro action brings up the Macro Modal with two display modes that share the same row:</p>
+<ul><li><strong>List mode</strong> (default): The action's keycodes are shown as clickable tiles followed by a dashed <strong>add slot</strong>. Single-click a keycode tile to switch that index into edit mode. Single-click the dashed add slot to select it; double-click the dashed slot to open the keycode popover with an empty query (mirrors the keymap editor). The pencil "edit" icon from earlier versions is gone — clicking is the only affordance</li><li><strong>Edit mode</strong>: The keycode picker stays visible below the row. Each keycode tile shows a hover <strong>X</strong> button to delete that index, and the Tap row exposes a <strong>Close</strong> button to leave edit mode. Picker and popover selections are <strong>staged</strong> — they update the row visually but are not committed until you press the bottom <strong>Save</strong> button or <strong>Enter</strong>. The footer also shows a <strong>Revert</strong> ConfirmButton when you are editing an action that already existed (it is hidden when you just added the action via Add Action, since there is nothing prior to revert to). Save and Revert are disabled until a pick actually changes something. Pressing <strong>Escape</strong>, the per-row <strong>Close</strong> button, <strong>Revert</strong>, or clicking outside the picker / action list / footer / key popover rolls back the entire in-flight edit — including newly-appended Add-keycode slots or an entirely newly-added action — and leaves edit mode. Deleting a slot during edit shifts the selection so the session continues rather than exiting.</li></ul>
+<p>Empty keycode actions are tolerated while editing; they are normalized out silently when the macro is saved or exported to a favorite.</p>
+<h4 id="recording-lock">Recording Lock</h4>
+<p>While the built-in recorder is capturing keystrokes, the Macro Modal enters a strict disabled state to prevent accidental edits:</p>
+<ul><li>The Add Action select, Text Editor toggle, Clear, Revert, and bottom <strong>Save</strong> buttons are all disabled</li><li>Every existing MacroActionItem and its KeycodeField is disabled (native <code class="ic">disabled</code> attribute — Tab / hover / click are all suppressed)</li><li>The inline favorites panel is made invisible with its width preserved, so the layout does not jump</li><li>The modal's top-right Close button and backdrop click are inert — the modal cannot be dismissed until recording stops</li><li>The list-mode footer's Clear / Revert / Save buttons remain visible but disabled during recording. In per-action edit mode the list-level Clear / Revert are hidden, but the edit-mode Save (and Revert, for existing edits) are kept visible and disabled so you can see the affordance</li></ul>
+<h3 id="3-8-combo">3.8 Combo</h3>
+<p>Combo keycodes for simultaneous key-press combinations.</p>
+<div class="img-wrap"><img src="screenshots/tab-combo.png" alt="Combo Tab" class="doc-img" loading="lazy"></div>
+<p>The Combo tab displays a <strong>tile grid preview</strong> showing all entries. A note reads: "These features apply to the entire keyboard, not just the current layer."</p>
+<ul><li>Each tile shows the combo number and a summary (e.g., "A + B → C")</li><li>Click a tile to open the Combo edit modal directly to that entry (§5.2)</li><li>Combo keycodes (CMB_000–CMB_031) can be assigned to keys for triggering combos</li><li><strong>Settings: Configuration</strong> button at the bottom opens a settings modal for combo-related timeout configuration (e.g., Combo time out period)</li><li><strong>Edit JSON</strong> button at the bottom opens a JSON editor for bulk editing all entries (see §5.6)</li></ul>
+<h3 id="3-9-key-override">3.9 Key Override</h3>
+<p>Key Override keycodes for replacing key outputs when specific modifiers are held.</p>
+<div class="img-wrap"><img src="screenshots/tab-keyOverride.png" alt="Key Override Tab" class="doc-img" loading="lazy"></div>
+<p>The Key Override tab displays a <strong>tile grid preview</strong> showing all entries and a settings area.</p>
+<ul><li>Each tile shows the override number and a summary</li><li>Click a tile to open the Key Override edit modal directly to that entry (§5.3)</li><li><strong>Edit JSON</strong> button at the bottom opens a JSON editor for bulk editing all entries (see §5.6)</li></ul>
+<h3 id="3-10-alt-repeat-key">3.10 Alt Repeat Key</h3>
+<p>Alt Repeat Key keycodes for context-aware alternate repeat key bindings.</p>
+<div class="img-wrap"><img src="screenshots/tab-altRepeatKey.png" alt="Alt Repeat Key Tab" class="doc-img" loading="lazy"></div>
+<p>The Alt Repeat Key tab displays a <strong>tile grid preview</strong> showing all entries and a settings area.</p>
+<ul><li>Each tile shows the entry number and a summary</li><li>Click a tile to open the Alt Repeat Key edit modal directly to that entry (§5.4)</li><li><strong>Edit JSON</strong> button at the bottom opens a JSON editor for bulk editing all entries (see §5.6)</li></ul>
+<h3 id="3-11-behavior">3.11 Behavior</h3>
+<p>Keycodes for advanced QMK behavior features.</p>
+<ul><li><strong>Magic</strong>: Magic keycodes for swapping and toggling keyboard behaviors</li><li><strong>Mode</strong>: NKRO toggle, mode switching keycodes</li><li><strong>Auto Shift</strong>: Auto Shift toggle and configuration keycodes</li><li><strong>Swap Hands</strong>: Swap Hands keycodes and Swap Hands Tap variants</li><li><strong>Caps Word</strong>: Caps Word toggle</li></ul>
+<h3 id="3-12-user">3.12 User</h3>
+<p>User-defined keycodes.</p>
+<div class="img-wrap"><img src="screenshots/tab-user.png" alt="User Tab" class="doc-img" loading="lazy"></div>
+<ul><li>Custom keycodes defined in firmware (e.g., <code class="ic">CUSTOM_1</code>, <code class="ic">CUSTOM_2</code>)</li><li>When exporting <code class="ic">keymap.c</code>, custom keycodes use their configured names instead of generic <code class="ic">USER00</code>/<code class="ic">USER01</code> identifiers, and an <code class="ic">enum custom_keycodes</code> block is generated automatically</li></ul>
+<h3 id="3-13-keyboard-device-picker">3.13 Keyboard (Device Picker)</h3>
+<p>The Keyboard tab lets you copy keycodes from other connected keyboards or from saved files.</p>
+<blockquote><p><strong>Use case:</strong> While editing a keyboard, you wonder how another keyboard's keymap is set up — but that keyboard isn't connected right now. If you've previously saved its data (via the Save panel), you can load it from the <strong>File</strong> source in this tab to browse its keymap and copy keycodes directly into your current layout.</p></blockquote>
+<p><strong>Device List</strong></p>
+<div class="img-wrap"><img src="screenshots/keyboard-tab-device-list.png" alt="Keyboard Tab — Device List" class="doc-img" loading="lazy"></div>
+<p>When you open the Keyboard tab, a list of all connected Vial-compatible keyboards is displayed. This list updates in real time as you plug in or unplug devices.</p>
+<ul><li>Click a device to load its keymap — the currently connected keyboard shows its live keymap instantly; other devices are probed via a temporary USB connection</li></ul>
+<div class="img-wrap"><img src="screenshots/keyboard-tab-keymap.png" alt="Keyboard Tab — Keymap View" class="doc-img" loading="lazy"></div>
+<ul><li>Once loaded, click any key on the displayed keyboard to assign that keycode to the selected key on the main keymap</li><li>Use Ctrl+click for multi-select, Shift+click for range select</li><li>Layer buttons at the bottom right let you browse different layers</li><li>Zoom controls (+ / numeric input / −) adjust the picker keyboard size (30%–200%). When viewing another keyboard, its saved zoom level is loaded automatically</li><li>Press Escape to clear the picker selection</li></ul>
+<p><strong>File Source</strong></p>
+<p>Click the <strong>File</strong> button at the bottom to switch to the file source. This shows saved keyboard snapshots and allows loading <code class="ic">.pipette</code> files — the same keycode picking workflow applies.</p>
+<blockquote><p><strong>Note</strong>: Only V2 format (undefined) files are supported in the key picker. If a legacy V1 format file is selected, a warning is displayed prompting you to connect the keyboard and open the keymap to migrate the data.</p></blockquote>
+<p><strong>Composite Keycodes</strong></p>
+<p>When clicking a composite key (e.g., <code class="ic">LT1(KC_SPC)</code>) in the picker, the full keycode is assigned as-is. Inner/outer parts are not split — the complete keycode is copied to the target key.</p>
+<blockquote><p><strong>Note</strong>: The Keyboard tab is hidden when editing the inner part of a mask key (e.g., choosing the undefined inside undefined), since composite keycodes cannot be assigned to the inner byte.</p></blockquote>
+<h3 id="3-14-keycodes-overlay-panel">3.14 Keycodes Overlay Panel</h3>
+<p>The Keycodes Overlay Panel provides quick access to editor tools and save functions. Toggle it with the panel button at the right end of the keycode tab bar.</p>
+<p><strong>Settings Tab</strong></p>
+<div class="img-wrap"><img src="screenshots/overlay-tools.png" alt="Overlay Panel — Settings" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Key Editor Zoom</strong>: Set the UI zoom level (50–200%) applied while in key editor mode. Defaults to the global UI zoom (§6.5) when not configured. Saved and synced per keyboard</li><li><strong>Auto Advance</strong>: Toggle automatic advancement to the next key after assigning a keycode</li><li><strong>Instant Key Selection</strong>: Toggle instant key selection mode (see §2.2 for behavior details)</li><li><strong>Separate Shift in Key Picker</strong>: Toggle split display for combined keycodes (e.g., show Mod-Tap as two halves)</li><li><strong>Key Tester</strong>: Toggle Matrix Tester mode (supported keyboards only)</li><li><strong>Security</strong>: Shows lock status (Locked/Unlocked) with a Lock button</li><li><strong>Import</strong>: Restore from <code class="ic">.vil</code> files or sideload custom JSON definitions</li><li><strong>Reset Keyboard Data</strong>: Reset keyboard to factory defaults</li></ul>
+<p><strong>Save Tab</strong></p>
+<div class="img-wrap"><img src="screenshots/overlay-save.png" alt="Overlay Panel — Save" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Export Current State</strong>: Download keymap as <code class="ic">.vil</code>, <code class="ic">keymap.c</code>, PDF keymap cheat sheet, or PDF layout export (key outlines with summary pages for Tap Dance, Macro, Combo, Key Override, and Alt Repeat Key entries)</li><li><strong>Save Current State</strong>: Save a snapshot of the current keyboard state with a label</li><li><strong>Synced Data</strong>: List of saved snapshots with Load, Rename, Delete, and Export actions</li><li>This is the same Save panel as the standalone editor settings (§6)</li></ul>
+<p><strong>Layout Tab</strong> (when available)</p>
+<p>Some keyboards support layout options (see §2.5). When available, a Layout tab appears as the first tab in the overlay panel, providing access to the same layout options.</p>
+<hr>
+<h2 id="4-toolbar">4. Toolbar</h2>
+<p>The toolbar on the left side of the keymap editor provides the following features.</p>
+<div class="img-wrap"><img src="screenshots/toolbar.png" alt="Toolbar" class="doc-img" loading="lazy"></div>
+<h3 id="4-1-zoom">4.1 Zoom</h3>
+<p>Adjusts the keyboard layout display scale. Range: 30%–200% (default 100%).</p>
+<div class="img-wrap"><img src="screenshots/zoom-in.png" alt="Zoom In" class="doc-img" loading="lazy"></div>
+<ul><li>(+) button to zoom in</li><li>(-) button to zoom out</li><li>Can also be adjusted in editor settings</li><li>Zoom level is saved per keyboard and restored automatically on reconnect</li></ul>
+<h3 id="4-2-undo-redo-keymap-history">4.2 Undo / Redo (Keymap History)</h3>
+<p>The keymap editor automatically records a history of keycode changes. You can navigate through this history to undo or redo changes.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Method</th><th style="text-align:left">Scope</th><th style="text-align:left">How to use</th></tr></thead><tbody><tr><td style="text-align:left"><strong>Keyboard shortcuts</strong></td><td style="text-align:left">Full history (up to Max Keymap History, default 100)</td><td style="text-align:left">Ctrl/Cmd+Z (Undo), Ctrl+Y / Ctrl/Cmd+Shift+Z (Redo)</td></tr><tr><td style="text-align:left"><strong>Toolbar buttons</strong></td><td style="text-align:left">Full history</td><td style="text-align:left">Undo / Redo buttons in the left toolbar</td></tr><tr><td style="text-align:left"><strong>Popover buttons</strong></td><td style="text-align:left">Last single change only (must match the open key)</td><td style="text-align:left">Undo / Redo buttons in the popover footer (see §2.4)</td></tr></tbody></table></div>
+<ul><li>History is cleared when switching keyboards or disconnecting</li><li>The maximum history size can be configured in Settings → Defaults → <strong>Max Keymap History</strong> (see §6.1)</li><li>All keymap mutation paths are tracked: single key edits, popover selections, mod-mask changes, paste, and copy-layer operations</li></ul>
+<h3 id="4-3-typing-test">4.3 Typing Test</h3>
+<p>A typing practice feature. Test your typing with the current keymap while viewing the keyboard layout below. The layout highlights key presses in real time, so you can verify that your physical keymap matches the on-screen display.</p>
+<p>Click the <strong>Typing Test</strong> button in the status bar to enter typing test mode.</p>
+<h4 id="modes">Modes</h4>
+<p>Three test modes are available, selectable from the mode tabs at the top:</p>
+<p><strong>Words Mode</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-words-waiting.png" alt="Typing Test — Words Mode" class="doc-img" loading="lazy"></div>
+<ul><li>Type a fixed number of random words (15 / 30 / 60 / 120)</li><li>The test ends when all words are completed</li></ul>
+<p><strong>Time Mode</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-time-mode.png" alt="Typing Test — Time Mode" class="doc-img" loading="lazy"></div>
+<ul><li>Type as many words as possible within a time limit (15 / 30 / 60 / 120 seconds)</li><li>A countdown timer shows remaining time</li></ul>
+<p><strong>Quote Mode</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-quote-mode.png" alt="Typing Test — Quote Mode" class="doc-img" loading="lazy"></div>
+<ul><li>Type a real-world quote (short / medium / long / all)</li><li>The quote source is shown after completion</li></ul>
+<h4 id="options">Options</h4>
+<div class="img-wrap"><img src="screenshots/typing-test-words-options.png" alt="Typing Test — With Options" class="doc-img" loading="lazy"></div>
+<p>In Words and Time modes, you can toggle additional options:</p>
+<ul><li><strong>Punctuation</strong>: Adds punctuation marks (commas, periods, etc.) to the word list</li><li><strong>Numbers</strong>: Adds numbers to the word list</li></ul>
+<p>These toggles are not available in Quote mode, which uses the original text as-is.</p>
+<h4 id="during-a-test">During a Test</h4>
+<div class="img-wrap"><img src="screenshots/typing-test-running.png" alt="Typing Test — Running" class="doc-img" loading="lazy"></div>
+<p>While typing, the following stats are displayed in real time:</p>
+<ul><li><strong>WPM</strong>: Words Per Minute (current typing speed)</li><li><strong>Accuracy</strong>: Percentage of correctly typed characters</li><li><strong>Time</strong>: Elapsed time (or remaining time in Time mode)</li><li><strong>Words</strong>: Current word / total words</li></ul>
+<p>Correctly typed words turn green. Incorrect characters are highlighted in red with an underline. The cursor advances as you type, and words scroll automatically.</p>
+<ul><li>Press the restart button (↺) to restart the test at any time</li><li>Press Escape to exit typing test mode</li><li>The status bar's Disconnect button is hidden while Typing Test is active. To disconnect, first return to the editor with Escape or the Typing Test button</li><li>The keyboard layout below the test area shows key presses in real time via the Vial matrix tester protocol</li></ul>
+<h4 id="typing-view-view-only-mode">Typing View (View-Only Mode)</h4>
+<p>Typing View displays only the keyboard layout in a compact, resizable window — ideal for overlaying on top of other applications while practicing.</p>
+<p>Click the <strong>Typing View</strong> button in the status bar (visible when Typing Test is not active) to enter view-only mode.</p>
+<div class="img-wrap"><img src="screenshots/view-only-compact.png" alt="View-Only — Compact Window" class="doc-img" loading="lazy"></div>
+<ul><li>The window shows only the keyboard layout with real-time key press highlighting</li><li>The toolbar, keycode palette, typing test UI, and status bar are hidden</li><li>The window maintains its aspect ratio when resized</li></ul>
+<p><strong>Menu Pane</strong></p>
+<div class="img-wrap"><img src="screenshots/view-only-controls.png" alt="View-Only — Controls" class="doc-img" loading="lazy"></div>
+<p>Click anywhere on the keyboard area to toggle the menu pane (bottom-right popup). The pane is split into <strong>Window</strong> and <strong>REC</strong> tabs at the top, with a shared <strong>Base</strong> layer selector and <strong>Exit Typing View</strong> button at the bottom.</p>
+<p><strong>Window tab</strong> (default)</p>
+<ul><li><strong>Default Size</strong>: Reset the window to its default calculated size</li><li><strong>Fit Size</strong>: Adjust the window height to match the current width while preserving the aspect ratio</li><li><strong>Top</strong>: Keep the window above other windows (always-on-top; not available on Wayland)</li></ul>
+<p><strong>REC tab</strong></p>
+<p>Recording controls and the Monitor App toggle. Detailed in <strong>Typing analytics recording</strong> below.</p>
+<p><strong>Shared controls</strong> (visible in both tabs)</p>
+<ul><li><strong>Base</strong>: Select which layer to display (when the keyboard has multiple layers)</li><li><strong>Exit Typing View</strong>: Return to the full editor</li></ul>
+<p>Press Escape or click the keyboard area again to close the pane. A hint text appears at the bottom when hovering over the window. The window size, always-on-top preference, and the active menu tab are saved per keyboard.</p>
+<blockquote><p><strong>Note</strong>: Auto-lock is suspended while in Typing View mode. If the keyboard is disconnected while in view-only mode, the window automatically restores to its normal size.</p></blockquote>
+<h4 id="typing-analytics-recording">Typing analytics recording</h4>
+<p>While Typing View is open, the <strong>REC</strong> tab in the Menu Pane records per-key and per-minute statistics that feed the Analyze page (§1.4). Recording stays off by default.</p>
+<div class="img-wrap"><img src="screenshots/typing-test-rec-tab.png" alt="Typing Test — REC Tab" class="doc-img" loading="lazy"></div>
+<p><strong>Start / Stop</strong></p>
+<p>Press the toggle once to start recording — the button shows <strong>Start</strong> while idle and <strong>Stop</strong> while recording. The Recording indicator appears at the top of the Typing View window so you can tell at a glance whether data is being captured.</p>
+<p>The very first time you press Start, a consent dialog appears:</p>
+<div class="img-wrap"><img src="screenshots/typing-test-rec-consent.png" alt="Typing Test — Recording Consent" class="doc-img" loading="lazy"></div>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Section</th><th style="text-align:left">Items</th></tr></thead><tbody><tr><td style="text-align:left"><strong>What we collect</strong></td><td style="text-align:left">Per-minute character frequency · Per-key press counts (row / col / layer / keycode, tap vs hold) · Typing speed distribution (interval percentiles) · Active application name (only when Monitor App is on; minutes that observe multiple apps are recorded as unknown)</td></tr><tr><td style="text-align:left"><strong>What we do NOT collect</strong></td><td style="text-align:left">Individual keystroke timing · Text content / passwords / specific words · Window title / URL / file path</td></tr></tbody></table></div>
+<p>Click <strong>Enable</strong> to opt in — your consent is persisted in app settings (not synced) and the dialog never appears again. Click <strong>Cancel</strong> to back out without starting; you can press Start later to see the dialog again.</p>
+<p><strong>Monitor App</strong></p>
+<p>When the Monitor App toggle is on (and REC is in the Stop / recording state), Pipette resolves the foreground application name once per data flush so each minute can be tagged with the app that owned the keystrokes. Minutes that observed only one app carry that app's name; minutes that observed multiple apps are tagged as <code class="ic">Unknown / Mixed</code>. The tags drive the <strong>App</strong> filter and the <strong>By App</strong> tab in Analyze.</p>
+<ul><li>The button is greyed out while REC is <strong>Start</strong> (not recording) state — turning it on without REC has no effect, so the UI funnels you through Start first</li><li>The on/off state is global (AppConfig), not per-keyboard, and is <strong>not</strong> synced to other machines</li><li><strong>Linux / Wayland</strong>: requires the FocusedWindow GNOME Shell extension (see README). Without it, every minute is recorded as <code class="ic">null</code></li><li><strong>macOS</strong>: requires the Accessibility permission (see README). Without it, every minute is recorded as <code class="ic">null</code></li><li>Turning Monitor App off keeps existing tags in the database; only newly recorded minutes go untagged</li></ul>
+<p><strong>View Analytics</strong></p>
+<p>Jumps directly to the Analyze page for this keyboard so you can review the stream you just recorded. Going back returns you to Typing View.</p>
+<h4 id="view-mode-memory-and-auto-restore">View Mode Memory and Auto-Restore</h4>
+<p>The last view mode (Editor / Typing Test / Typing View) is remembered per keyboard and automatically restored the next time you connect that keyboard:</p>
+<ul><li><strong>Editor</strong>: The editor view is shown as usual</li><li><strong>Typing Test</strong>: Typing Test mode is re-entered automatically. If the keyboard is locked, the Unlock dialog appears first and the test starts after unlocking</li><li><strong>Typing View</strong>: The compact view-only window is re-entered automatically. If the keyboard is locked, the Unlock dialog appears first</li></ul>
+<p>View mode is stored per keyboard alongside preferences like keyboard layout, zoom scale, and window size. When Pipette Hub sync is enabled, view mode is synced to other devices as well (see §7).</p>
+<hr>
+<h2 id="5-detail-setting-editors">5. Detail Setting Editors</h2>
+<p>Open detail setting modals from their dedicated keycode tabs. Lighting opens via a <strong>Settings: Configuration</strong> button at the bottom of its tab; Combo, Key Override, and Alt Repeat Key detail editors open by clicking an entry on their respective tabs.</p>
+<h3 id="5-1-lighting-settings">5.1 Lighting Settings</h3>
+<p>Open from the <strong>Settings: Configuration</strong> button on the Lighting tab. Configure RGB lighting colors and effects.</p>
+<div class="img-wrap"><img src="screenshots/lighting-modal.png" alt="Lighting Settings" class="doc-img" loading="lazy"></div>
+<ul><li>Select colors with the HSV color picker</li><li>Choose colors from preset palette</li><li>Adjust effects and speed</li><li>Click Save to apply</li></ul>
+<h3 id="5-2-combo">5.2 Combo</h3>
+<p>Configure simultaneous key press combinations to trigger different keys. The Combo tab displays an inline tile grid; clicking an entry opens the detail editor modal directly.</p>
+<p><strong>Tile Grid (Combo tab)</strong></p>
+<div class="img-wrap"><img src="screenshots/combo-modal.png" alt="Combo List" class="doc-img" loading="lazy"></div>
+<p>The Combo tab shows entries as a numbered list (0--31). Configured entries display a summary (e.g., "A + B → C"). Click an entry to open the detail editor. Combo keycodes (Combo On, Combo Off, Combo Toggle) are shown below the list. A <strong>Settings: Configuration</strong> button at the bottom opens a settings modal for QMK Combo timeout configuration (e.g., Combo time out period).</p>
+<p><strong>Detail Editor</strong></p>
+<div class="img-wrap"><img src="screenshots/combo-detail.png" alt="Combo Detail" class="doc-img" loading="lazy"></div>
+<ul><li>Left panel: Combo editor with Key 1--4 and Output fields.</li><li>Right panel: Inline favorites panel (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> resets all fields; <strong>Revert</strong> restores the last saved state. Both use two-step confirmation.</li><li><strong>Save</strong> writes changes to the keyboard</li></ul>
+<h3 id="5-3-key-override">5.3 Key Override</h3>
+<p>Replace specific key inputs with different keys. The Key Override tab displays an inline tile grid; clicking an entry opens the detail editor modal directly.</p>
+<p><strong>Tile Grid (Key Override tab)</strong></p>
+<div class="img-wrap"><img src="screenshots/key-override-modal.png" alt="Key Override List" class="doc-img" loading="lazy"></div>
+<p>Shows entries as a numbered list. Configured entries display a summary. Click an entry to open the detail editor.</p>
+<p><strong>Detail Editor</strong></p>
+<div class="img-wrap"><img src="screenshots/key-override-detail.png" alt="Key Override Detail" class="doc-img" loading="lazy"></div>
+<ul><li>Left panel: Trigger Key, Replacement Key, enabled toggle, layer and modifier options</li><li>Right panel: Inline favorites panel (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> resets all fields; <strong>Revert</strong> restores the last saved state. Both use two-step confirmation.</li><li><strong>Save</strong> writes changes to the keyboard</li></ul>
+<h3 id="5-4-alt-repeat-key">5.4 Alt Repeat Key</h3>
+<p>Configure alternative actions for the Repeat Key. The Alt Repeat Key tab displays an inline tile grid; clicking an entry opens the detail editor modal directly.</p>
+<p><strong>Tile Grid (Alt Repeat Key tab)</strong></p>
+<div class="img-wrap"><img src="screenshots/alt-repeat-key-modal.png" alt="Alt Repeat Key List" class="doc-img" loading="lazy"></div>
+<p>Shows entries as a numbered list. Configured entries display a summary. Click an entry to open the detail editor.</p>
+<p><strong>Detail Editor</strong></p>
+<div class="img-wrap"><img src="screenshots/alt-repeat-key-detail.png" alt="Alt Repeat Key Detail" class="doc-img" loading="lazy"></div>
+<ul><li>Left panel: Last Key, Alt Key, enabled toggle, Allowed Mods, Options (DefaultToThisAltKey, Bidirectional, IgnoreModHandedness)</li><li>Right panel: Inline favorites panel (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> resets all fields; <strong>Revert</strong> restores the last saved state. Both use two-step confirmation.</li><li><strong>Save</strong> writes changes to the keyboard</li></ul>
+<h3 id="5-5-favorites">5.5 Favorites</h3>
+<p>Each editor modal (Tap Dance, Macro, Combo, Key Override, Alt Repeat Key) includes an inline <strong>Favorites panel</strong> on the right side of the editor.</p>
+<div class="img-wrap"><img src="screenshots/inline-favorites.png" alt="Inline Favorites Panel" class="doc-img" loading="lazy"></div>
+<p>The inline favorites panel provides:</p>
+<ul><li><strong>Save Current State</strong>: Enter a label and click Save to store the current entry configuration<ul><li><strong>Import</strong> / <strong>Export</strong> buttons: Import a <code class="ic">.pipette-fav</code> file to apply to the current entry, or export the current entry settings as a <code class="ic">.pipette-fav</code> file without saving to the store. Inline "Imported" / "Exported" feedback is shown after each action.</li></ul></li><li><strong>Synced Data</strong>: Previously saved entries are listed with Load, Rename, Delete, and Export actions</li><li><strong>Import</strong> / <strong>Export All</strong>: Footer buttons for bulk import/export of favorites</li></ul>
+<p>Within the Synced Data list:</p>
+<ul><li><strong>Load</strong>: Apply a saved configuration to the current entry</li><li><strong>Rename</strong>: Change the label of a saved entry (also synced to Hub if the entry is uploaded)</li><li><strong>Delete</strong>: Remove a saved entry</li><li><strong>Export</strong>: Download an individual saved entry as a file</li></ul>
+<p>When Pipette Hub is connected, each saved entry also shows Hub actions:</p>
+<div class="img-wrap"><img src="screenshots/hub-fav-inline.png" alt="Inline Favorites — Hub Actions" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Upload to Hub</strong>: Upload the favorite entry to Pipette Hub as a feature post</li><li><strong>Update on Hub</strong>: Re-upload the latest configuration to update the existing Hub post</li><li><strong>Remove from Hub</strong>: Delete the entry from Pipette Hub (two-step confirmation)</li><li><strong>Open in Browser</strong>: Open the individual Hub post page in your browser</li></ul>
+<h3 id="5-6-json-editor">5.6 JSON Editor</h3>
+<p>Each feature tab (Tap Dance, Macro, Combo, Key Override, Alt Repeat Key) provides an <strong>Edit JSON</strong> button at the bottom of the tab. This opens a JSON editor modal for bulk editing all entries as raw JSON text.</p>
+<div class="img-wrap"><img src="screenshots/json-editor-tap-dance.png" alt="JSON Editor — Tap Dance" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Text area</strong>: Edit all entries as a JSON array. Changes are validated in real time — parse errors are shown below the editor</li><li><strong>Export</strong> (left): Save the current JSON as a <code class="ic">.pipette-fav</code> file for backup or sharing</li><li><strong>Cancel</strong> (right): Close without saving</li><li><strong>Save</strong> (right): Apply the parsed JSON and write changes to the keyboard</li></ul>
+<div class="img-wrap"><img src="screenshots/json-editor-macro.png" alt="JSON Editor — Macro" class="doc-img" loading="lazy"></div>
+<p>For Macros, a warning is displayed indicating that keyboard unlock is required to save changes.</p>
+<blockquote><p><strong>Note</strong>: The JSON editor modifies all entries at once. Use with caution — invalid JSON will be rejected, but valid JSON with incorrect values may cause unexpected behavior.</p>
+<p><strong>Note</strong>: Favorites are not tied to a specific keyboard — saved entries can be loaded on any compatible keyboard. When Cloud Sync is enabled, favorites are also synced across devices (see §6.1). Favorites can also be managed from the Data modal on the device selection screen (see §1.3).</p></blockquote>
+<hr>
+<h2 id="6-editor-settings-panel">6. Editor Settings Panel</h2>
+<p>Open the editor settings panel from the save button (floppy disk icon) in the keycode tab bar, or use the Save tab in the Keycodes Overlay Panel (§3.14).</p>
+<div class="img-wrap"><img src="screenshots/editor-settings-save.png" alt="Editor Settings — Save" class="doc-img" loading="lazy"></div>
+<p>The editor settings panel now provides a single <strong>Save</strong> panel with the following features:</p>
+<ul><li><strong>Export Current State</strong>: Download keymap as <code class="ic">.vil</code>, <code class="ic">keymap.c</code>, PDF keymap cheat sheet, or PDF layout export (key outlines with summary pages for Tap Dance, Macro, Combo, Key Override, and Alt Repeat Key entries). An "Exported" inline feedback message appears after a successful export.</li><li><strong>Save Current State</strong>: Save a snapshot of the current keyboard state with a label. Enter a name in the Label field and click Save. If the Label field is left empty, the Save button is disabled. Saved snapshots appear in the Synced Data list below and can be loaded or deleted later</li><li><strong>Synced Data</strong>: List of saved snapshots. Click to load, rename, or delete entries</li><li><strong>Reset Keyboard Data</strong>: Reset keyboard to factory defaults (use with caution)</li></ul>
+<blockquote><p><strong>Note</strong>: Tool settings (auto advance, key tester, security) are in the Keycodes Overlay Panel (§3.14). Keyboard layout is available in the status bar quick settings (§9); Basic tab view type is selectable at the bottom of the Basic tab. Zoom is available in the toolbar (§4.1). Layer settings are managed directly via the layer panel on the left side of the editor.</p></blockquote>
+<h3 id="6-1-cloud-sync-google-drive-appdatafolder">6.1 Cloud Sync (Google Drive appDataFolder)</h3>
+<p>Pipette can sync your saved snapshots, favorites, and per-keyboard settings across multiple devices via Google Drive.</p>
+<p>Sync is configured in the <strong>Settings</strong> modal (gear icon on the device selection screen), under the <strong>Data</strong> tab:</p>
+<div class="img-wrap"><img src="screenshots/hub-settings-data-sync.png" alt="Data Tab" class="doc-img" loading="lazy"></div>
+<p>The Data tab contains the following sections: Google Account, Data Sync, and Pipette Hub. Additional troubleshooting and data management options are available in the Data panel (§1.3).</p>
+<h4 id="google-account">Google Account</h4>
+<ul><li>Click <strong>Connect</strong> to sign in with your Google account</li><li>Click <strong>Disconnect</strong> to sign out. If Pipette Hub is also connected, a warning confirms that Hub will be disconnected as well</li></ul>
+<h4 id="sync-encryption-password">Sync Encryption Password</h4>
+<ul><li>Set a password to encrypt all synced data (required). A strength indicator helps you choose a strong password</li><li>If a password already exists on the server (set from another device), a hint is shown asking you to enter the same password</li><li><strong>Change Password</strong>: Click <strong>Change Password</strong> to re-encrypt all synced files with a new password. No data is deleted — existing files are decrypted and re-encrypted in place</li></ul>
+<p><strong>Change Password error conditions</strong></p>
+<p>When a password change cannot proceed, Pipette shows a localized message instead of the raw error. The common cases are listed below; other underlying errors (network, Drive) may appear as their own messages.</p>
+<p>Credential failures (the 5 reasons come from the same typed <code class="ic">SyncCredentialFailureReason</code> set used for readiness — only 3 of them surface in <strong>Sync Status</strong> below):</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Reason</th><th style="text-align:left">Message</th><th style="text-align:left">Trigger</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">unauthenticated</code></td><td style="text-align:left">"Please sign in to Google before changing the password."</td><td style="text-align:left">Not signed in with Google</td></tr><tr><td style="text-align:left"><code class="ic">noPasswordFile</code></td><td style="text-align:left">"No saved password to change. Set a password first."</td><td style="text-align:left">No local sync password has ever been set</td></tr><tr><td style="text-align:left"><code class="ic">decryptFailed</code></td><td style="text-align:left">"Couldn't read the existing password (OS keychain rejected it)."</td><td style="text-align:left">The OS keychain entry is unreadable (keychain reset, profile move, etc.)</td></tr><tr><td style="text-align:left"><code class="ic">keystoreUnavailable</code></td><td style="text-align:left">"OS keychain is not available; password cannot be changed here."</td><td style="text-align:left"><code class="ic">safeStorage.isEncryptionAvailable()</code> returns false (typical on headless Linux without a keyring)</td></tr><tr><td style="text-align:left"><code class="ic">remoteCheckFailed</code></td><td style="text-align:left">"Couldn't reach Google Drive to verify the current password."</td><td style="text-align:left">Network or Drive outage — retry later</td></tr></tbody></table></div>
+<p>Operational errors (shown as the message directly, no reason code):</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Message</th><th style="text-align:left">Trigger</th></tr></thead><tbody><tr><td style="text-align:left">"Cannot change password while sync is in progress."</td><td style="text-align:left">A sync is already running — wait for it to finish</td></tr><tr><td style="text-align:left">"New password must be different from the current password."</td><td style="text-align:left">The new password matches the existing one</td></tr><tr><td style="text-align:left">"Some files cannot be decrypted. Please scan and delete undecryptable files first."</td><td style="text-align:left">Drive has files the current password cannot decrypt — use <strong>Undecryptable Files</strong> first</td></tr><tr><td style="text-align:left">"Sync password does not match. Please check your encryption password."</td><td style="text-align:left">The current password fails to decrypt the remote password check — reconfirm the password you are providing</td></tr></tbody></table></div>
+<h4 id="sync-controls">Sync Controls</h4>
+<ul><li><strong>Auto Sync</strong>: Toggle automatic sync on or off. When enabled, changes sync automatically with a 10-second debounce and periodic 3-minute polling</li><li><strong>Sync</strong>: Manually sync favorites and connected keyboard data. Only favorites and the currently connected keyboard are synced (not all keyboards)</li></ul>
+<h4 id="sync-status">Sync Status</h4>
+<ul><li>Displays current sync progress with the sync unit name and an item counter (current / total)</li><li>Shows error or partial-sync details if any units failed</li></ul>
+<p><strong>Readiness reasons</strong></p>
+<p>If sync cannot run because the client is not ready, a specific readiness reason is shown in place of the generic "Not synced yet" label. Only three reasons surface here; detailed keystore failures (<code class="ic">decryptFailed</code>, <code class="ic">keystoreUnavailable</code>) come through the password set/change flow instead.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Reason</th><th style="text-align:left">Message</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">unauthenticated</code></td><td style="text-align:left">"Sign in to Google to sync."</td></tr><tr><td style="text-align:left"><code class="ic">noPasswordFile</code></td><td style="text-align:left">"Set a sync password to start syncing."</td></tr><tr><td style="text-align:left"><code class="ic">remoteCheckFailed</code></td><td style="text-align:left">"Couldn't reach Google Drive — sync is paused."</td></tr></tbody></table></div>
+<h4 id="undecryptable-files">Undecryptable Files</h4>
+<ul><li>Files that cannot be decrypted with the current password or are otherwise unreadable (e.g., encrypted with a forgotten previous password)</li><li>Click <strong>Scan</strong> to detect undecryptable files, select the ones to remove, then click <strong>Delete Selected</strong> to permanently delete them from Google Drive</li></ul>
+<h4 id="sync-unavailable-alert">Sync Unavailable Alert</h4>
+<ul><li>Displayed when the sync backend cannot be reached. Click <strong>Retry</strong> to attempt reconnection</li></ul>
+<h4 id="data-storage">Data Storage</h4>
+<p>Synced data is stored in <a href="https://developers.google.com/workspace/drive/api/guides/appdata" target="_blank" rel="noopener">Google Drive appDataFolder</a> — a hidden, app-specific folder that only Pipette can access. Your personal Drive files are never touched.</p>
+<p>See the <a href="#" class="xdoc" data-doc="data" data-hash="">Data Guide</a> for details on what is synced and how your data is protected.</p>
+<h4 id="data-management">Data Management</h4>
+<p>Troubleshooting and data management functions are available in the <strong>Data</strong> panel (see §1.3):</p>
+<ul><li><strong>Local > Application</strong>: Import/export local data or reset selected targets (keyboard data, favorites, app settings)</li><li><strong>Sync</strong>: List remote-only keyboards by real name and download any one on demand (see §1.3). To delete encrypted files that cannot be decrypted, use the <strong>Undecryptable Files</strong> section above</li></ul>
+<h4 id="settings-defaults">Settings — Defaults</h4>
+<div class="img-wrap"><img src="screenshots/settings-defaults.png" alt="Settings — Defaults" class="doc-img" loading="lazy"></div>
+<p>The Tools tab in the Settings modal includes a <strong>Defaults</strong> section for setting initial preferences for new keyboard connections:</p>
+<ul><li><strong>Keyboard Layout</strong>: Default key labels for new keyboards. The dropdown lists every entry currently installed in the <strong>Key Labels</strong> store (see §6.2). QWERTY ships built-in; install more from Pipette Hub or import a <code class="ic">.json</code> via <strong>Key Labels Manage</strong>. The drop-down preserves the manual order set in the modal — drag a row up or down there and the dropdown follows</li><li><strong>Auto Advance</strong>: Default auto-advance behavior</li><li><strong>Instant Key Selection</strong>: Default instant key selection behavior (see §2.2)</li><li><strong>Layer Panel Open</strong>: Whether the layer panel starts expanded or collapsed</li><li><strong>Basic View Type</strong>: Default view type for the Basic tab (ANSI/ISO/JIS/List)</li><li><strong>Separate Shift in Key Picker</strong>: Default setting for separating Shift in the key picker</li><li><strong>Max Keymap History</strong>: Maximum number of keymap changes to keep in the current keyboard's edit history (default: 100). History is cleared on disconnect or keyboard switch. See §4.2 for details.</li></ul>
+<h3 id="6-2-key-labels-manage">6.2 Key Labels Manage</h3>
+<p>The Tools tab also exposes a <strong>Key Labels Manage</strong> row (next to the Language Packs row). Click <strong>Edit</strong> to open the Key Labels modal, which manages every label set the app uses to render keycaps in the editor, the Analyze view, and the Layout Comparison.</p>
+<p>QWERTY is built-in; every other label set (Dvorak, Colemak, French, Brazilian, …) is downloaded from Pipette Hub or imported from a local <code class="ic">.json</code> file. Installed entries sync across devices via Cloud Sync, so the same drag order and selection appear on every machine signed into the same account.</p>
+<p><strong>Installed tab</strong></p>
+<div class="img-wrap"><img src="screenshots/key-labels-installed.png" alt="Key Labels — Installed" class="doc-img" loading="lazy"></div>
+<p>Lists every label set already on this device. Each row shows the label name, the uploader name (when the entry came from Hub), the Hub-side last-update time (<code class="ic">YYYY-MM-DD HH:mm</code>, mirrors what the Hub website displays), an <code class="ic">.json</code> export shortcut, and a Delete button. Drag the grip handle on the left to reorder rows — the order is propagated to the Settings dropdown and to every Key Labels picker in the editor.</p>
+<p>A second line under each row exposes the Hub actions:</p>
+<ul><li><strong>Open</strong>: open the entry's Hub page in the system browser (only when the row is linked to a Hub post)</li><li><strong>Upload</strong>: publish a new Hub post from this local entry (only for entries that have not been uploaded yet)</li><li><strong>Update</strong>: push the current local content to the existing Hub post (owner only)</li><li><strong>Sync</strong>: pull the latest Hub content into this local entry without losing the local rename or drag position (shown for downloaded entries you do not own). A <strong>pulsing green dot</strong> appears next to the Sync button when the Hub-side post is newer than your local cache — opening the modal triggers a bulk freshness check (throttled to once per 5 min) so you can spot updates without manually clicking each row</li><li><strong>Remove</strong>: take the post down from Hub. Confirms inline before running</li></ul>
+<p>If the Hub freshness check finds a row whose post has been deleted upstream, the Updated column reads <strong><code class="ic">(removed)</code></strong> in red instead of a timestamp; clicking Sync on such a row will fail because the Hub no longer serves it.</p>
+<p>QWERTY shows no Hub actions and cannot be deleted, but it can be reordered like any other row.</p>
+<p><strong>Find on Hub tab</strong></p>
+<div class="img-wrap"><img src="screenshots/key-labels-hub.png" alt="Key Labels — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Searches Pipette Hub for label sets. Type 2 or more characters to start an automatic search (debounced); the <strong>Search</strong> button and <strong>Enter</strong> still work as manual triggers. Results show the label name, the uploader, and either a <strong>Download</strong> action or an <strong>Installed</strong> marker when the same name is already present locally. Re-importing a file with a name that already exists overwrites the local entry in place (<code class="ic">.json</code> content replaced, the Hub link is preserved).</p>
+<p><strong>Authoring a Key Label</strong></p>
+<p>A Key Label <code class="ic">.json</code> file is a small JSON object with three fields:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Brazilian (QWERTY)&quot;,
+  &quot;map&quot;: {
+    &quot;KC_2&quot;: &quot;2\n@&quot;,
+    &quot;KC_3&quot;: &quot;3\n#&quot;,
+    &quot;KC_LBRC&quot;: &quot;´\n`&quot;,
+    &quot;KC_QUOT&quot;: &quot;ç&quot;,
+    &quot;KC_GRAVE&quot;: &quot;KC_LALT&quot;
+  },
+  &quot;compositeLabels&quot;: {
+    &quot;LSFT(KC_2)&quot;: &quot;@&quot;,
+    &quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot;
+  }
+}</code></pre>
+<p>In the example above, <code class="ic">&quot;KC_GRAVE&quot;: &quot;KC_LALT&quot;</code> makes the editor render whichever cap is currently bound to <code class="ic">KC_GRAVE</code> with the canonical "LAlt" legend — the value is a keycode id, so <code class="ic">keycodeLabel()</code> resolves it on the fly.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Field</th><th style="text-align:center">Required</th><th style="text-align:left">Purpose</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Display name shown in the modal, in the Settings → Defaults dropdown, and in the Keycodes Overlay Panel</td></tr><tr><td style="text-align:left"><code class="ic">map</code></td><td style="text-align:center">Yes</td><td style="text-align:left"><code class="ic">QMK keycode id → label string</code>. Used as the keycap legend in the Keymap Editor whenever this label set is active</td></tr><tr><td style="text-align:left"><code class="ic">compositeLabels</code></td><td style="text-align:center">No</td><td style="text-align:left">Same shape as <code class="ic">map</code>, but for composite keycodes (e.g. <code class="ic">LSFT(KC_2)</code>, <code class="ic">LT(0,KC_A)</code>, <code class="ic">MT(MOD_LCTL,KC_ESC)</code>). Used to override the inner / outer text of the composite key. Omit the field if you don't need any composite override</td></tr></tbody></table></div>
+<p>A value can also be a plain QMK keycode id — the editor passes it through <code class="ic">keycodeLabel()</code> so something like <code class="ic">&quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot;</code> resolves to the canonical "LAlt" label without you having to spell the legend out by hand. The same shortcut works in <code class="ic">map</code>, so <code class="ic">&quot;KC_8&quot;: &quot;KC_LALT&quot;</code> would render the cap as "LAlt".</p>
+<p>The label string controls how the legend is rendered. Lines are separated by <code class="ic">\n</code> and the layout is chosen by part count:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Parts</th><th style="text-align:left">Layout</th><th style="text-align:left">Example</th></tr></thead><tbody><tr><td style="text-align:left">1</td><td style="text-align:left">Centred (existing behaviour)</td><td style="text-align:left"><code class="ic">&quot;8&quot;</code></td></tr><tr><td style="text-align:left">2</td><td style="text-align:left">Stacked top / bottom</td><td style="text-align:left"><code class="ic">&quot;(\n8&quot;</code> → <code class="ic">(</code> over <code class="ic">8</code></td></tr><tr><td style="text-align:left">3</td><td style="text-align:left">Three horizontal slices (top / middle / bottom)</td><td style="text-align:left"><code class="ic">&quot;a\nb\nc&quot;</code></td></tr><tr><td style="text-align:left">4</td><td style="text-align:left">2 × 2 quadrants — top-left, top-right, bottom-left, bottom-right</td><td style="text-align:left"><code class="ic">&quot;1\n2\n3\n4&quot;</code> →<code class="ic">1\|2 / 3\|4</code></td></tr><tr><td style="text-align:left">5+</td><td style="text-align:left">Excess parts beyond 4 are dropped</td><td style="text-align:left"></td></tr></tbody></table></div>
+<p>An empty string between separators leaves the corresponding slot blank, so <code class="ic">&quot;1\n2\n\n4&quot;</code> renders as:</p>
+<pre class="code-block"><code>1 | 2
+-----
+  | 4</code></pre>
+<p>Composite keycodes (LT, MT, modifier+key, …) render the inner key inside an inset rectangle that occupies the lower half of the cap, so only the first two <code class="ic">\n</code> parts of the outer label are honoured. Parts 3 and 4 are silently dropped to avoid colliding with the inner rect.</p>
+<p><code class="ic">name</code> is also the uniqueness key inside the local store: importing a <code class="ic">.json</code> whose name already exists overwrites the matching entry in place (the Hub post link, if any, is preserved). To start a brand-new entry, change the <code class="ic">name</code> before importing.</p>
+<h3 id="6-3-language-packs-manage">6.3 Language Packs Manage</h3>
+<p>The Tools tab shows a <strong>Language Packs</strong> row displaying the currently active UI language. Click <strong>Edit</strong> to open the Language Packs modal.</p>
+<p>English is built-in; every other language is imported from a local <code class="ic">.json</code> file or downloaded from Pipette Hub. Installed packs sync across devices via Cloud Sync. Hub-linked packs are automatically checked for updates at app startup and refreshed silently when newer versions are available.</p>
+<p><strong>Installed tab</strong></p>
+<div class="img-wrap"><img src="screenshots/language-packs-installed.png" alt="Language Packs — Installed" class="doc-img" loading="lazy"></div>
+<p>Lists every language pack on this device. Each row has a <strong>check circle</strong> on the left — click it to switch the active UI language immediately. The active row is highlighted with an accent border.</p>
+<p>Each row shows:</p>
+<ul><li><strong>Name</strong> (click to rename inline)</li><li><strong>Updated timestamp</strong> (<code class="ic">YYYY-MM-DD HH:mm</code>)</li><li><strong>Version</strong> chip when the pack covers every key of the current English baseline, or a <strong>not set keys</strong> button that opens a modal listing the missing translation keys</li><li><strong>Export</strong> / <strong>Delete</strong> actions on the first line</li><li><strong>Open</strong> / <strong>Upload</strong> / <strong>Update</strong> / <strong>Sync</strong> / <strong>Remove</strong> Hub actions on the second line (same pattern as Key Labels §6.2)</li></ul>
+<p>A <strong>pulsing green dot</strong> next to the Sync button indicates that the Hub-side post is newer than the local copy (freshness check runs once per 5 minutes when the modal is open).</p>
+<p>The <strong>Import</strong> button in the toolbar opens a file dialog to import a <code class="ic">.json</code> language pack. Re-importing a pack with the same <code class="ic">name</code> overwrites the existing entry.</p>
+<p><strong>Find on Hub tab</strong></p>
+<div class="img-wrap"><img src="screenshots/language-packs-hub.png" alt="Language Packs — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Searches Pipette Hub for language packs. Type 2 or more characters to start an automatic search (debounced). Results show the pack name, version, uploader, and either a <strong>Download</strong> action or an <strong>Installed</strong> marker.</p>
+<p><strong>Authoring a Language Pack</strong></p>
+<p>A language pack <code class="ic">.json</code> mirrors the structure of the built-in English pack. Export the English pack (built-in row → Export) to get a template with every key, then translate the values:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Japanese&quot;,
+  &quot;version&quot;: &quot;0.1.0&quot;,
+  &quot;common&quot;: {
+    &quot;save&quot;: &quot;保存&quot;,
+    &quot;cancel&quot;: &quot;キャンセル&quot;
+  },
+  &quot;editor&quot;: {
+    &quot;keymap&quot;: {
+      &quot;title&quot;: &quot;キーマップ&quot;
+    }
+  }
+}</code></pre>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Field</th><th style="text-align:center">Required</th><th style="text-align:left">Purpose</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Display name and uniqueness key for overwrite-on-import</td></tr><tr><td style="text-align:left"><code class="ic">version</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Semver string (e.g. <code class="ic">0.1.0</code>)</td></tr><tr><td style="text-align:left">(other keys)</td><td style="text-align:center">Yes</td><td style="text-align:left">Nested translation tree matching the English structure</td></tr></tbody></table></div>
+<p>Keys use dot-separated namespaces (e.g. <code class="ic">editor.keymap.title</code>). A pack that covers every key of the English baseline shows the version chip; partial packs show a "not set keys" link so translators can see what remains. Example language packs (including Japanese variants) are also available in the <a href="../sample-packs/i18n/"><code class="ic">sample-packs/i18n/</code></a> directory in the repository.</p>
+<h3 id="6-4-theme-packs-manage">6.4 Theme Packs Manage</h3>
+<p>The Tools tab shows a <strong>Theme Packs</strong> row displaying the currently active theme pack (if any). Click <strong>Edit</strong> to open the Theme Packs modal.</p>
+<p>Theme packs override the application's colour palette. The built-in Light / Dark / System themes remain available; a theme pack layers its colours on top. Installed packs sync across devices via Cloud Sync.</p>
+<blockquote><p><strong>For theme pack authors:</strong> See the <a href="#" class="xdoc" data-doc="theme" data-hash="36">Theme Pack Authoring Guide</a> for a complete colour token reference and design tips.</p></blockquote>
+<p><strong>Installed section</strong></p>
+<div class="img-wrap"><img src="screenshots/theme-packs-installed.png" alt="Theme Packs — Installed" class="doc-img" loading="lazy"></div>
+<p>Lists every theme pack on this device. Each row has a <strong>radio circle</strong> on the left — click it to apply that theme pack immediately. Click the active row again to deselect it and revert to the built-in theme. The three built-in options (Light / Dark / System) appear at the top.</p>
+<p>Each row shows:</p>
+<ul><li><strong>Name</strong> (click to rename inline)</li><li><strong>Updated timestamp</strong> (<code class="ic">YYYY-MM-DD HH:mm</code>)</li><li><strong>Version</strong> chip</li><li><strong>.json</strong> export shortcut and <strong>Delete</strong> button on the first line</li><li><strong>Open</strong> / <strong>Upload</strong> / <strong>Update</strong> / <strong>Sync</strong> / <strong>Remove</strong> Hub actions on the second line (same pattern as Key Labels §6.2)</li></ul>
+<p>A <strong>pulsing green dot</strong> next to the Sync button indicates that the Hub-side post is newer than the local copy (freshness check runs once per 5 minutes when the modal is open).</p>
+<p>The <strong>Import</strong> button in the toolbar opens a file dialog to import a <code class="ic">.json</code> theme pack. Re-importing a pack with the same <code class="ic">name</code> overwrites the existing entry.</p>
+<p><strong>Find on Hub tab</strong></p>
+<div class="img-wrap"><img src="screenshots/theme-packs-hub.png" alt="Theme Packs — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Searches Pipette Hub for theme packs. Type 2 or more characters to start an automatic search (debounced). Each result shows the pack name, version, uploader, a <strong>Preview</strong> button, and either a <strong>Download</strong> action or an <strong>Installed</strong> marker.</p>
+<p>Click <strong>Preview</strong> to temporarily apply the theme's colours without installing. The preview resets when you close the modal, switch to the Installed tab, or click <strong>Preview</strong> again to toggle it off.</p>
+<p><strong>Authoring a Theme Pack</strong></p>
+<p>A theme pack <code class="ic">.json</code> defines a <code class="ic">name</code>, <code class="ic">version</code>, and a <code class="ic">colors</code> object mapping every colour token to a CSS colour value:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Nord&quot;,
+  &quot;version&quot;: &quot;1.0.0&quot;,
+  &quot;colorScheme&quot;: &quot;dark&quot;,
+  &quot;colors&quot;: {
+    &quot;surface&quot;: &quot;#2e3440&quot;,
+    &quot;surface-alt&quot;: &quot;#3b4252&quot;,
+    &quot;surface-dim&quot;: &quot;#272c36&quot;,
+    &quot;surface-raised&quot;: &quot;#434c5e&quot;,
+    &quot;content&quot;: &quot;#eceff4&quot;,
+    &quot;content-secondary&quot;: &quot;#d8dee9&quot;,
+    &quot;content-muted&quot;: &quot;#7b88a1&quot;,
+    &quot;content-inverse&quot;: &quot;#2e3440&quot;,
+    &quot;edge&quot;: &quot;#4c566a&quot;,
+    &quot;edge-subtle&quot;: &quot;#3b4252&quot;,
+    &quot;edge-strong&quot;: &quot;#d8dee9&quot;,
+    &quot;accent&quot;: &quot;#88c0d0&quot;,
+    &quot;accent-hover&quot;: &quot;#81a1c1&quot;,
+    &quot;accent-alt&quot;: &quot;#5e81ac&quot;,
+    &quot;success&quot;: &quot;#a3be8c&quot;,
+    &quot;warning&quot;: &quot;#ebcb8b&quot;,
+    &quot;danger&quot;: &quot;#bf616a&quot;,
+    &quot;pending&quot;: &quot;#b48ead&quot;,
+    &quot;key-bg&quot;: &quot;#3b4252&quot;,
+    &quot;key-bg-hover&quot;: &quot;#434c5e&quot;,
+    &quot;key-bg-active&quot;: &quot;#4c566a&quot;,
+    &quot;key-border&quot;: &quot;#4c566a&quot;,
+    &quot;key-shadow&quot;: &quot;rgba(0,0,0,0.3)&quot;,
+    &quot;key-label&quot;: &quot;#eceff4&quot;,
+    &quot;key-sublabel&quot;: &quot;#d8dee9&quot;,
+    &quot;key-label-remap&quot;: &quot;#88c0d0&quot;,
+    &quot;key-bg-multi-selected&quot;: &quot;#434c5e&quot;,
+    &quot;tab-bg-active&quot;: &quot;#3b4252&quot;,
+    &quot;tab-text&quot;: &quot;#7b88a1&quot;,
+    &quot;tab-text-active&quot;: &quot;#eceff4&quot;,
+    &quot;picker-bg&quot;: &quot;#2e3440&quot;,
+    &quot;picker-item-bg&quot;: &quot;#3b4252&quot;,
+    &quot;picker-item-hover&quot;: &quot;#434c5e&quot;,
+    &quot;picker-item-text&quot;: &quot;#eceff4&quot;,
+    &quot;picker-item-border&quot;: &quot;#4c566a&quot;
+  }
+}</code></pre>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Field</th><th style="text-align:center">Required</th><th style="text-align:left">Purpose</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Display name and uniqueness key for overwrite-on-import</td></tr><tr><td style="text-align:left"><code class="ic">version</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Semver string (e.g. <code class="ic">1.0.0</code>)</td></tr><tr><td style="text-align:left"><code class="ic">colorScheme</code></td><td style="text-align:center">Yes</td><td style="text-align:left"><code class="ic">&quot;light&quot;</code> or <code class="ic">&quot;dark&quot;</code> — declares the intended brightness of the pack</td></tr><tr><td style="text-align:left"><code class="ic">colors</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Object mapping all 35 colour tokens to CSS colour values (<code class="ic">#hex</code>, <code class="ic">rgb()</code>, or <code class="ic">hsl()</code>)</td></tr></tbody></table></div>
+<p>All 35 colour tokens are required. Export any installed pack (row → <code class="ic">.json</code>) to get a complete template. Ready-to-use example theme packs (Kanagawa Wave / Dragon / Lotus and Solarized Light / Dark) are also available in the <a href="../sample-packs/themes/"><code class="ic">sample-packs/themes/</code></a> directory in the repository.</p>
+<h3 id="6-5-zoom-ui-scale">6.5 Zoom (UI Scale)</h3>
+<p>The Tools tab shows a <strong>Zoom</strong> row below Theme Packs. This setting scales the entire application UI (50–200%).</p>
+<div class="img-wrap"><img src="screenshots/settings-zoom.png" alt="Zoom Setting" class="doc-img" loading="lazy"></div>
+<ul><li>Enter a percentage value in the input field (50–200) and press <strong>Enter</strong> or click away to apply</li><li>The zoom level takes effect immediately across all windows</li><li>This is a machine-local setting — it is not synced to other devices via Cloud Sync</li></ul>
+<blockquote><p><strong>Note</strong>: This is separate from the per-keyboard zoom in the toolbar (§4.1), which only scales the keymap editor display, and from the <strong>Key Editor Zoom</strong> in the Keycodes Overlay Panel (§3.14), which overrides the window zoom level while in key editor mode. The UI zoom here is the baseline applied on all other screens.</p>
+<p><strong>Warning</strong>: Changing the zoom level may cause layout issues at extreme values. Use at your own risk.</p></blockquote>
+<hr>
+<h2 id="7-pipette-hub">7. Pipette Hub</h2>
+<p><a href="https://pipette-hub-worker.keymaps.workers.dev/" target="_blank" rel="noopener">Pipette Hub</a> is a community keymap gallery where you can upload and share your keyboard configurations and favorite entries.</p>
+<h3 id="7-1-hub-setup">7.1 Hub Setup</h3>
+<p>Hub features require Google account authentication. Please complete Google account authentication first. Configure Hub in the <strong>Settings</strong> modal (gear icon on the device selection screen):</p>
+<ol><li>In the <strong>Data</strong> tab, click <strong>Connect</strong> under the Google Account section to sign in with your Google account</li><li>Scroll down to the <strong>Pipette Hub</strong> section in the same Data tab — it should show <strong>Connected</strong></li><li>Set your <strong>Display Name</strong> — this name is shown on your Hub posts</li><li>Your uploaded keymaps appear in the <strong>My Posts</strong> list</li></ol>
+<h3 id="7-2-uploading-a-keymap">7.2 Uploading a Keymap</h3>
+<p>To upload a keymap to Hub:</p>
+<ol><li>Connect to your keyboard and open the editor settings (gear icon in the keymap editor)</li><li>Switch to the <strong>Data</strong> tab</li><li>Save the current state with a label (e.g., "Default")</li></ol>
+<div class="img-wrap"><img src="screenshots/hub-03-upload-button.png" alt="Upload Button" class="doc-img" loading="lazy"></div>
+<ol><li>Click the <strong>Upload</strong> button on the saved snapshot entry</li><li>After uploading, the entry shows <strong>Uploaded</strong> status with <strong>Open in Browser</strong>, <strong>Update</strong>, and <strong>Remove</strong> buttons</li></ol>
+<div class="img-wrap"><img src="screenshots/hub-04-uploaded.png" alt="Uploaded" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Open in Browser</strong>: Opens the Hub page for this keymap</li><li><strong>Update</strong>: Re-uploads the current keyboard state to update the existing Hub post</li><li><strong>Remove</strong>: Removes the keymap from Hub</li></ul>
+<blockquote><p><strong>Note</strong>: Hub uploads include a undefined file alongside the standard export formats, allowing other users to load the full keyboard state directly.</p></blockquote>
+<h3 id="7-3-uploading-favorite-entries">7.3 Uploading Favorite Entries</h3>
+<p>Individual favorite entries (Tap Dance, Macro, Combo, Key Override, Alt Repeat Key) can also be uploaded to Hub:</p>
+<div class="img-wrap"><img src="screenshots/hub-fav-data-modal.png" alt="Data Modal — Favorites Hub Actions" class="doc-img" loading="lazy"></div>
+<ol><li>Open any editor modal with the inline favorites panel, or use the Data modal from the device selection screen</li><li>In the favorites list, each entry shows an <strong>Upload to Hub</strong> button when Hub is connected</li><li>Click <strong>Upload to Hub</strong> to share the configuration</li><li>After uploading, <strong>Open in Browser</strong>, <strong>Update on Hub</strong>, and <strong>Remove from Hub</strong> buttons appear</li><li>Renaming a favorite that is uploaded to Hub also updates the title on Hub automatically</li></ol>
+<blockquote><p><strong>Note</strong>: A Display Name must be set before uploading. If no Display Name is configured, a warning is shown instead of the Upload button.</p></blockquote>
+<h3 id="7-4-uploading-analytics">7.4 Uploading Analytics</h3>
+<p>Saved Analyze conditions can be uploaded to Hub, sharing your typing analytics charts with the community.</p>
+<p><strong>Flow</strong></p>
+<ol><li>Open the Analyze page and set up the filters you want to share (keyboard, device, app, date range, keymap snapshot)</li><li>Save the condition with a label using the <strong>Saved search conditions</strong> panel (bookmark icon)</li><li>When Hub is connected, a <strong>Hub</strong> action row appears under each saved entry with an <strong>Upload to Hub</strong> button</li><li>Click <strong>Upload to Hub</strong> — the category-picker modal opens in upload mode (see §1.4 Export / Upload)</li><li>Select which chart categories to include, pick Layout Comparison targets and Per-app data if desired, then click <strong>Upload</strong></li><li>After uploading, the entry shows <strong>Open in Browser</strong>, <strong>Update on Hub</strong>, and <strong>Remove from Hub</strong> buttons</li></ol>
+<p><strong>Validation rules</strong></p>
+<p>The Hub enforces two guards before accepting an analytics upload:</p>
+<ul><li><strong>Minimum 100 keystrokes</strong> in the saved range — sub-100-keystroke charts are too sparse to be useful</li><li><strong>Maximum 30-day range</strong> — longer ranges produce payloads that exceed the Hub size budget</li></ul>
+<p>If either rule is violated, a localized error message explains what to fix (e.g., shorten the range or record more typing).</p>
+<p><strong>Upload-mode options</strong></p>
+<ul><li><strong>Layout Comparison targets</strong> — pick one or more alternative layouts to include. The Hub post will show how your typing would redistribute across each target. The toggle is disabled when no targets are selected</li><li><strong>Per-app data</strong> — choose which apps to include as per-app breakdowns. The Hub post renders per-app charts for the selected apps</li></ul>
+<p><strong>Update and Remove</strong></p>
+<ul><li><strong>Update on Hub</strong> re-uploads the latest chart data for the same saved condition (useful after more typing has been recorded)</li><li><strong>Remove from Hub</strong> deletes the analytics post from the Hub server (two-step confirmation)</li></ul>
+<p><strong>Error handling</strong></p>
+<p>Upload errors are localized. Common cases: authentication failure (sign out and back in), payload too large (reduce categories or shorten range), rate limit (wait and retry).</p>
+<blockquote><p><strong>Note</strong>: A Display Name must be set before uploading. If no Display Name is configured, a warning is shown instead of the Upload button.</p></blockquote>
+<h3 id="7-5-hub-website">7.5 Hub Website</h3>
+<p>The <a href="https://pipette-hub-worker.keymaps.workers.dev/" target="_blank" rel="noopener">Pipette Hub website</a> displays uploaded keymaps in a gallery format.</p>
+<div class="img-wrap"><img src="screenshots/hub-web-top.png" alt="Hub Top Page" class="doc-img" loading="lazy"></div>
+<ul><li>Browse uploaded keymaps from the community</li><li>Search by keyboard name</li><li>Download keymaps as <code class="ic">.vil</code>, <code class="ic">.c</code>, or <code class="ic">.pdf</code> files</li></ul>
+<h4 id="individual-keymap-page">Individual Keymap Page</h4>
+<p>Clicking a keymap card opens the detail page with a full keyboard layout visualization.</p>
+<div class="img-wrap"><img src="screenshots/hub-web-detail.png" alt="Hub Detail Page" class="doc-img" loading="lazy"></div>
+<ul><li>View all layers (Layer 0–3) of the uploaded keymap</li><li>Review Tap Dance, Macro, Combo, Alt Repeat Key, and Key Override configurations</li><li><strong>Copy URL</strong> or <strong>Share on X</strong> to share with others</li><li>Download in various formats (<code class="ic">.pdf</code>, <code class="ic">.c</code>, <code class="ic">.vil</code>)</li></ul>
+<p>See the <a href="#" class="xdoc" data-doc="data" data-hash="">Data Guide</a> for details on how Hub authentication works.</p>
+<hr>
+<h2 id="8-modal-interactions">8. Modal Interactions</h2>
+<p>Pipette applies a uniform set of keyboard and dismissal rules to every top-level modal (Settings, Data, Macro, QMK Settings, Tap Dance, Combo, Key Override, Alt Repeat Key, Notification, Language Packs, Theme Packs, Language Selector, Layout Store, Editor Settings, Favorite Store, and the History Toggle dialog).</p>
+<h3 id="escape-to-close">Escape to Close</h3>
+<p>Pressing <strong>Escape</strong> closes the modal, with the following exceptions so that Escape never interrupts text entry:</p>
+<ul><li>If the focused element is an <code class="ic">&lt;input&gt;</code>, <code class="ic">&lt;textarea&gt;</code>, <code class="ic">&lt;select&gt;</code>, or anything inside a <code class="ic">contenteditable</code> region, Escape is ignored (the element receives it instead)</li><li>During an IME composition (e.g., Japanese input), Escape is ignored so the composition can be cancelled without dismissing the modal</li></ul>
+<h3 id="unlock-dialog-protection">Unlock Dialog Protection</h3>
+<p>The Unlock Dialog (prompting for a physical key press after a boot-unlock keycode is invoked) <strong>intercepts Escape before it reaches the parent modal</strong>. Pressing Escape on top of an unlock prompt cannot leak through, preventing accidental dismissal of a half-configured Settings or Data modal by rapid Escape presses.</p>
+<h3 id="escape-suppression-during-busy-flows">Escape Suppression During Busy Flows</h3>
+<p>Escape-to-close is disabled while the containing modal is in a transient state that must complete:</p>
+<ul><li><strong>Settings / Data modals</strong>: disabled while a sync / troubleshooting flow is running</li><li><strong>Macro Modal</strong>: disabled while the recorder is actively capturing keystrokes (see §3.7 Recording Lock); the backdrop click and top-right Close button are also inert at the same time</li></ul>
+<hr>
+<h2 id="9-status-bar">9. Status Bar</h2>
+<p>The status bar at the bottom of the screen shows connection information and action buttons.</p>
+<div class="img-wrap"><img src="screenshots/status-bar.png" alt="Status Bar" class="doc-img" loading="lazy"></div>
+<p><strong>Status indicators</strong> (left side)</p>
+<ul><li><strong>Device name</strong>: Shows the name of the connected keyboard</li><li><strong>Loaded label</strong>: The label of the loaded snapshot (shown only when a snapshot is loaded)</li><li><strong>Auto Advance</strong>: Status of automatic key advancement after assigning a keycode (shown only when enabled)</li><li><strong>Locked / Unlocked</strong>: Keyboard lock status (prevents accidental changes to dangerous keycodes)</li><li><strong>Sync status</strong>: Cloud sync status (shown only when sync is configured)</li><li><strong>Hub connection</strong>: Pipette Hub connection status (shown only when Hub is configured)</li></ul>
+<p><strong>Quick Settings</strong> (right side, shown when a keyboard is connected)</p>
+<p>Inline selectors for common per-session preferences. A <code class="ic">|</code> separator divides them from the mode buttons.</p>
+<ul><li><strong>Language</strong>: Switch the UI language. Opens a dropdown of built-in languages and installed language packs (see §6.3)</li><li><strong>Theme</strong>: Switch the color theme. Options include System, Light, Dark, and any installed theme packs (see §6.4)</li><li><strong>Key Labels</strong>: Switch the key label set for the current keyboard. Options reflect the installed Key Labels store in drag order (see §6.2)</li><li><strong>Edit / Done</strong>: Toggle edit mode. Replaces the selectors with <strong>Language Packs</strong>, <strong>Theme Packs</strong>, and <strong>Key Labels</strong> management modal buttons for installing, syncing, or reordering entries</li></ul>
+<p><strong>Action buttons</strong> (right side)</p>
+<ul><li><strong>Key Tester</strong>: Toggle button for Matrix Tester mode (requires matrix tester support; hidden when Typing Test is active)</li><li><strong>Typing View</strong>: Toggle button to enter view-only mode — a compact window showing only the keyboard layout (see §4.3). Requires matrix tester support; hidden when Typing Test is active</li><li><strong>Typing Test</strong>: Toggle button for Typing Test mode (requires matrix tester support)</li><li><strong>Disconnect button</strong>: Disconnects from the keyboard and returns to the device selection screen (hidden while Typing Test is active)</li></ul>
+</article>
+    <article id="doc-ja" class="doc" lang="ja">
+<h1 id="pipette-操作ガイド">Pipette 操作ガイド</h1>
+<p><a href="#" class="xdoc" data-doc="en" data-hash="">English version</a></p>
+<p>このドキュメントでは Pipette デスクトップアプリの操作方法を説明します。 スクリーンショットは特に記載がない限り GPK60-63R キーボードを使用して撮影しています。</p>
+<hr>
+<h2 id="1-デバイス接続">1. デバイス接続</h2>
+<h3 id="1-1-デバイス選択画面">1.1 デバイス選択画面</h3>
+<p>アプリを起動すると、接続されている Vial 対応キーボードの一覧が表示されます。</p>
+<div class="img-wrap"><img src="screenshots/01-device-selection.png" alt="デバイス選択画面" class="doc-img" loading="lazy"></div>
+<ul><li>USB 接続されたキーボードが自動的に検出されます</li><li>複数のキーボードが接続されている場合は、一覧から選択できます</li><li>Linux で検出されない場合は、udev ルールの設定が必要です</li></ul>
+<p><strong>File タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/file-tab.png" alt="File タブ" class="doc-img" loading="lazy"></div>
+<p>File タブでは、物理キーボードを接続せずに <code class="ic">.pipette</code> ファイルをオフラインで編集できます:</p>
+<ul><li>保存済みのキーボードを閲覧してエントリを選択・読み込み</li><li>ディスクから外部 <code class="ic">.pipette</code> ファイルを読み込み</li><li>ファイルに埋め込まれた定義から仮想キーボードが作成されます</li><li>未保存の変更がある場合はインジケーターが表示されます</li></ul>
+<blockquote><p><strong>使用例:</strong> キーボードのキーマップを変更したいけれど、手元にキーボードがない場合。あらかじめデータを保存しておけば、File タブから読み込んでオフラインで編集し、後でキーボードを接続してデータをロードすれば変更を反映できます。</p></blockquote>
+<p><strong>機能の利用可否: デバイス接続 vs ファイル読み込み</strong></p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">機能</th><th style="text-align:center">デバイス (USB)</th><th style="text-align:center">ファイル (.pipette)</th></tr></thead><tbody><tr><td style="text-align:left">キーマップ編集</td><td style="text-align:center">o</td><td style="text-align:center">o</td></tr><tr><td style="text-align:left">マクロ / タップダンス編集</td><td style="text-align:center">o</td><td style="text-align:center">o</td></tr><tr><td style="text-align:left">コンボ / キーオーバーライド / Alt Repeat Key</td><td style="text-align:center">o</td><td style="text-align:center">o</td></tr><tr><td style="text-align:left">QMK Settings</td><td style="text-align:center">o (デバイス経由)</td><td style="text-align:center">o (ローカルデータ)</td></tr><tr><td style="text-align:left">タイピングテスト</td><td style="text-align:center">o</td><td style="text-align:center">o</td></tr><tr><td style="text-align:left">エクスポート (.vil / .c / .pdf)</td><td style="text-align:center">o</td><td style="text-align:center">o</td></tr><tr><td style="text-align:left">ライティング制御</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">マトリクステスター</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">ロック / アンロック</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">スナップショット保存 / 読込</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">Hub アップロード</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">JSON サイドロード</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">デバイスプローブ (Keyboard タブ)</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr><tr><td style="text-align:left">クラウド同期</td><td style="text-align:center">o</td><td style="text-align:center">x</td></tr></tbody></table></div>
+<h3 id="1-2-キーボードの接続">1.2 キーボードの接続</h3>
+<p>一覧からキーボード名をクリックすると、キーマップエディタに遷移します。接続中はオーバーレイにキーボードデータの読み込み進捗が表示されます。</p>
+<p>クラウド同期が設定されている場合、接続時に同期進捗も表示されます（お気に入りを先に同期し、次にキーボード固有データを同期）。</p>
+<h3 id="1-3-データ">1.3 データ</h3>
+<p>デバイス選択画面の Data ボタンをクリックすると、キーボード・お気に入り・同期データ・Hub 投稿を一元管理するデータパネルが開きます。</p>
+<div class="img-wrap"><img src="screenshots/data-sidebar-favorites.png" alt="データ — お気に入り" class="doc-img" loading="lazy"></div>
+<p>左側のサイドバーに<strong>ツリーナビゲーション</strong>が表示されます:</p>
+<ul><li><strong>Local</strong><ul><li><strong>Keyboards</strong>: 保存済みキーボードスナップショットの閲覧。クリックでロード、エクスポート、削除</li><li><strong>Favorites</strong>: Tap Dance、Macro、Combo、Key Override、Alt Repeat Key — タイプごとにリネーム、削除、エクスポート、Hub アクションが可能</li><li><strong>Application</strong>: ローカルデータのインポート/エクスポート、またはリセット対象の選択（キーボードデータ、お気に入り、アプリ設定）</li></ul></li><li><strong>Sync</strong> (クラウド同期設定時): このデバイスにまだダウンロードされていない Google Drive 上のキーボードを一覧表示します。各エントリは UID ではなく、同期された名前インデックスから解決された<strong>実際のキーボード名</strong>で表示されます。リモートのみのキーボードをクリックするとオンデマンドでダウンロードされ、取得中はスピナーが表示され、失敗時はインラインでエラーが表示されます。ダウンロードが完了すると、そのキーボードは <strong>Local › Keyboards</strong> に移動します。復号不能な孤立ファイルを削除したい場合は、設定の <strong>Data</strong> タブの <strong>復号不能ファイル</strong> を使ってください (§6.1 参照)</li><li><strong>Hub</strong> (Hub 接続時): キーボード名でグループ化された Hub 投稿を管理</li></ul>
+<div class="img-wrap"><img src="screenshots/data-sidebar-keyboard-saves.png" alt="データ — キーボード保存" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/data-sidebar-application.png" alt="データ — アプリケーション" class="doc-img" loading="lazy"></div>
+<p>お気に入りリストのエントリごとの操作:</p>
+<ul><li>クリックでリネーム、削除、または個別の <strong>Export</strong></li><li><strong>Hub アクション</strong>: Hub 接続時、各エントリに <strong>Upload to Hub</strong> / <strong>Update on Hub</strong> / <strong>Remove from Hub</strong> ボタンが表示</li><li>フッターの <strong>Import</strong> / <strong>Export All</strong> ボタンで一括操作</li></ul>
+<p>コンテンツエリア上部の<strong>パンくずナビゲーション</strong>で現在のパスを表示（例: 「Local › Favorites › Tap Dance」）</p>
+<h3 id="1-4-分析">1.4 分析</h3>
+<p>分析ページは実際の打鍵の内訳を可視化する。キーごとのヒートマップ、WPM 推移、打鍵間隔、時間帯別アクティビティ、指ごとの負荷、キーペア (バイグラム) 間隔、レイヤー別使用状況などを表示する。データはタイピングビュー（ステータスバーから開くコンパクトウィンドウ）を開いている状態で、タイピングテストペインの記録トグルが「開始」になっているときに記録される。タイピングテストの結果も同じストリームに記録される。</p>
+<p><strong>アクセス方法</strong></p>
+<p>入口は 2 つある:</p>
+<ul><li>デバイス選択画面の <strong>「分析」タブ</strong> — キーボードを接続せずに開ける。いま繋がっていないキーボードのデータを見るときに便利</li><li>タイピングテストペインの <strong>「分析ビュー」ボタン</strong> — 現在使用中のキーボードの分析ページに飛び、戻るとタイピングビューに戻る</li></ul>
+<p><strong>キーボードセレクタ</strong></p>
+<p>フィルタ行先頭の <strong>キーボード</strong> セレクトには、打鍵データが記録されているキーボードが一覧表示される。どれかを選ぶとチャートが埋まる。データが無いキーボードはリストに表示されない。ページ下部の <strong>戻る</strong> ボタンで前の画面（例: デバイス選択画面）に戻れる。</p>
+<p><strong>分析タブ</strong></p>
+<p>チャート上部のタブバーから 10 種類の分析を切り替えられる。タブは目的別にグルーピングされている (全体像 / パフォーマンス / 行動分析 / 負荷分析 / 最適化):</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">グループ</th><th style="text-align:left">タブ</th><th style="text-align:left">内容</th></tr></thead><tbody><tr><td style="text-align:left">全体像</td><td style="text-align:left"><strong>サマリー</strong></td><td style="text-align:left">今日 / 直近 7 日の差分、Typing profile（Speed / Hand balance / SFB / Fatigue）、ゴール連続記録</td></tr><tr><td style="text-align:left">パフォーマンス</td><td style="text-align:left"><strong>WPM</strong></td><td style="text-align:left">Words-per-minute の推移、または時間帯別分布</td></tr><tr><td style="text-align:left">パフォーマンス</td><td style="text-align:left"><strong>間隔</strong></td><td style="text-align:left">打鍵間隔の分位数（min / p25 / 中央値 / p75 / max）を時系列または分布で表示</td></tr><tr><td style="text-align:left">行動分析</td><td style="text-align:left"><strong>活動量</strong></td><td style="text-align:left">時間 × 曜日グリッド or 月単位スライディングカレンダーを打鍵数 / WPM / セッションで色分け</td></tr><tr><td style="text-align:left">行動分析</td><td style="text-align:left"><strong>アプリ別</strong></td><td style="text-align:left">アクティブアプリ別の内訳。App Usage Distribution（円）と WPM by App（横棒）。Monitor App のデータが必要</td></tr><tr><td style="text-align:left">負荷分析</td><td style="text-align:left"><strong>ヒートマップ</strong></td><td style="text-align:left">物理キーごとの押下回数をキーマップ上に重ねて表示（レイヤー別）。期間内のキーマップスナップショットが必要</td></tr><tr><td style="text-align:left">負荷分析</td><td style="text-align:left"><strong>エルゴノミクス</strong></td><td style="text-align:left">指ごとの打鍵数をバーチャートで表示。指アサインは手動編集可、学習曲線ビューもあり。スナップショットが必要</td></tr><tr><td style="text-align:left">負荷分析</td><td style="text-align:left"><strong>バイグラム</strong></td><td style="text-align:left">キーペアの出現回数・ペア平均間隔ランキング、指ペア別の打鍵間隔バーチャート</td></tr><tr><td style="text-align:left">負荷分析</td><td style="text-align:left"><strong>レイヤー</strong></td><td style="text-align:left">レイヤー別の打鍵数または layer-op 起動回数</td></tr><tr><td style="text-align:left">最適化</td><td style="text-align:left"><strong>レイアウト比較</strong></td><td style="text-align:left">打鍵ログを別レイアウト（Colemak / Dvorak など）に乗せた場合の負担分布を試算。スナップショットが必要</td></tr></tbody></table></div>
+<p>ヒートマップ、エルゴノミクス、バイグラム > Finger IKI、レイアウト比較、レイヤー > 起動回数は期間に重なるキーマップスナップショットが必要。記録を有効にしている間に Pipette が自動でスナップショットを保存するため、空状態の案内に従って記録セッションを開始するとスナップショットが取れる。</p>
+<p><strong>共通フィルタ</strong></p>
+<p>常に使えるフィルタ:</p>
+<ul><li><strong>キーマップ履歴</strong> — どの記録時点のキーマップを基準に分析するか選ぶ。<strong>From</strong> / <strong>To</strong> の編集は選んだスナップショットの有効期間内に閉じるため、スナップショットを必要とするタブ（ヒートマップ / エルゴノミクス / バイグラム Finger IKI / レイヤー起動回数）が複数のレイアウトを混ぜて表示することはない。スナップショットはタイムラインに並ぶので、記録時点ごとのキーマップ・「現在のキーマップ」を切り替えられる</li><li><strong>From</strong> / <strong>To</strong> — 分析対象の期間。両入力ともアクティブなスナップショット境界 (またはスナップショットが無いキーボードの場合は直近 7 日) に丸められる</li><li><strong>デバイス</strong> — マルチセレクト。<code class="ic">このデバイス</code> と他マシンの hash を任意の組み合わせで選択可能。間隔タブの表示を分布にしているときは非表示（分布ビンはデバイス別に分けないため）</li><li><strong>アプリ</strong> — マルチセレクトドロップダウン。期間中に観測されたアクティブアプリ名の一覧から任意組み合わせを選択。デフォルトは <strong>All apps</strong>（フィルタなし）。1 つ以上選ぶと、<strong>アプリ別</strong> タブを除く全チャートが選択アプリのいずれかでタグされた minute だけに絞り込まれる。Monitor App を有効にしてアプリ名がタグされた minute が記録されるまでドロップダウンは空。キーボード単位で永続化される</li></ul>
+<p>各タブには固有のフィルタ（表示モード、粒度、単位など）がチャート上部に追加される。詳細は各タブのサブセクションを参照。ヒートマップタブの <strong>正規化</strong> / <strong>集計</strong> / <strong>グループ</strong> / <strong>上位</strong> はキーボード直下のランキング行に置かれる。</p>
+<p><strong>検索条件の保存</strong></p>
+<p>ペインヘッダのブックマークアイコンで <strong>検索条件の保存</strong> サイドパネルが開く。現在のフィルタにラベルを付けて保存、保存済みエントリの呼び出し / リネーム / 削除、CSV エクスポートが可能。各エントリの下にはフィルタの 1 行サマリー（デバイス、アプリ、スナップショット、期間）が表示される。</p>
+<ul><li>1 キーボードあたり最大 <strong>50 件</strong> — 上限に達するとパネルに警告が出る。空きを作るには既存エントリを削除する</li><li>Cloud Sync 有効時は同期されるので、他のサインイン済みマシンでも同じセットを利用できる</li><li>新しいバージョンの Pipette で書かれたエントリを読み込もうとすると、未対応バージョンのエラーが表示される</li><li><strong>上書き</strong>: 既存と同名のラベルを入力すると Save ボタンが危険色の <strong>Overwrite?</strong> + Cancel に切り替わる。ラベルを編集すると確認がリセットされ、別エントリを誤って上書きすることがない</li><li><strong>Load 時の挙動</strong>: 保存済みエントリを読み込むと、保存時にどのタブがアクティブだったかに関わらず常に <strong>Summary</strong> タブに着地する</li><li><strong>Hub アクション</strong>: Pipette Hub 接続時、各エントリの下に Hub 行が追加表示される（<strong>Upload to Hub</strong> / <strong>Update on Hub</strong> / <strong>Remove from Hub</strong> + <strong>Open in Browser</strong>）。キーマップ保存パネルやお気に入りと同じパターン（§7.4 参照）</li></ul>
+<h4 id="サマリー">サマリー</h4>
+<p>サマリータブは分析ペインの起動時にデフォルトで表示されるビュー。他タブと同じ minute バケット集計を元に、4 つの読み取り専用カードで「直近のハイライト・平均・連続記録」を一望できる。</p>
+<div class="img-wrap"><img src="screenshots/analyze-summary.png" alt="分析 — サマリー" class="doc-img" loading="lazy"></div>
+<ul><li><strong>今日</strong> — 今日（ローカル日）の打鍵数 / WPM / 打鍵時間</li><li><strong>直近 7 日</strong> — 打鍵数 / WPM / 打鍵時間 / 活動日数。各値に前 7 日との比較矢印付き。前期間データが不足のときは <code class="ic">—</code> 表記</li><li><strong>Typing profile (直近 N 日)</strong> — 直近期間で算出した 4 つの定性的な読み取り:<ul><li><strong>Speed</strong> — 全体 WPM を Slow (<30) / Medium (30–50) / Fast (≥50) に分類</li><li><strong>Hand balance</strong> — バイグラム打鍵の左右シェア。50/50 から ±5% 以内なら Balanced</li><li><strong>SFB rate</strong> — 同じ指で連続打鍵したバイグラム比率。<4% Low / 4–8% Medium / ≥8% High</li><li><strong>Fatigue risk</strong> — ピーク時間帯と最遅時間帯の WPM 差分。差が大きいほどリスク高</li></ul></li><li><strong>ゴール連続記録</strong> — 現在の連続記録進捗（<code class="ic">current / goalDays</code>）、過去最長記録、編集可能なゴール設定（連続日数 × 日次打鍵数）。ゴール変更時は現在の連続記録カウンタがクリアされる。<strong>達成履歴</strong> ボタンで完了サイクル一覧モーダル（期間 / ゴール / 日数 / 合計打鍵 / 日平均）が開く</li></ul>
+<p>サマリータブもアプリフィルタを尊重する。1 つ以上のアプリを選ぶと全カードが選択アプリでタグされた minute だけに絞り込まれる。</p>
+<h4 id="ヒートマップ">ヒートマップ</h4>
+<p>ヒートマップタブは物理キーごとの押下回数を数え、キーマップレイアウトの上にレイヤー別で表示する。レイヤー単位で過剰に使われているキーや全く使われていないキーを洗い出し、レイアウト調整の材料にするのに使う。</p>
+<p><strong>キーマップ表示</strong></p>
+<p>キーは押下回数で色付けされる（薄い = 少ない、濃い = 多い）。レイヤーが複数あるキーボードではパネル上部にレイヤー切替のボタン列（<strong>Layer 0</strong>、<strong>Layer 1</strong>、…）が出て、各ボタンにレイヤー別の合計回数が併記される。キーにマウスを乗せるとチャート内にツールチップが開き、割り当てキーコードと回数を表示する。ツールチップはヒートマップの枠内に収まる。</p>
+<p><strong>ランキング操作</strong></p>
+<p>ヒートマップの下にはランキングテーブルがある。表示内容を 4 つのフィルタで制御する:</p>
+<ul><li><strong>正規化</strong> — <code class="ic">絶対数</code>（生の回数）、<code class="ic">1 時間あたり</code>（回数 ÷ 活動時間）、<code class="ic">総打鍵比 (%)</code>（期間中の全打鍵に対する比率）</li><li><strong>集計</strong> — <code class="ic">物理</code>は同じ物理セルの押下をまとめる、<code class="ic">文字</code>は同じキーコードを（物理位置に関係なく）まとめる</li><li><strong>グループ</strong> — <code class="ic">すべて</code> / <code class="ic">文字</code> / <code class="ic">修飾</code> / <code class="ic">レイヤー操作</code></li><li><strong>上位</strong> — 10 / 20 / … / 100</li></ul>
+<p>列は <strong>キー</strong>、<strong>レイヤー</strong>（グループが複数レイヤーにまたがるときのみ表示）、<strong>マトリクス</strong>、<strong>回数</strong>。</p>
+<div class="img-wrap"><img src="screenshots/analyze-heatmap.png" alt="分析 — ヒートマップ" class="doc-img" loading="lazy"></div>
+<p><strong>空状態</strong></p>
+<ul><li><strong>スナップショット無し</strong> — 「この期間のキーマップスナップショットが記録されていません。record を開始すると取得されます。」</li><li><strong>レイアウト無し</strong> — 「このスナップショットにレイアウトデータがありません。」スナップショットはあるが KLE 情報が欠けている場合</li><li><strong>活動なし</strong> — 「この期間に押下されたキーがありません。」ランキングテーブルのみ</li></ul>
+<h4 id="wpm">WPM</h4>
+<p>WPM タブは Words Per Minute（1 分あたりの打鍵数 ÷ 5）を、時系列または時間帯別で可視化する。</p>
+<p><strong>ビュー</strong></p>
+<ul><li><strong>時系列</strong> — 選択期間の WPM を折れ線で表示する。赤い破線の <strong>Bksp %</strong> が常に右側の副軸（0–100%）に重なり、打鍵速度とエラー率を同時に確認できる。WPM だけを見たい場合は凡例の Bksp エントリをクリックして非表示にできる</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-wpm-time-series.png" alt="分析 — WPM 時系列" class="doc-img" loading="lazy"></div>
+<ul><li><strong>時間帯別</strong> — 1 日 24 時間のバーチャート。各バーはその時間帯の平均 WPM。<strong>最小サンプル</strong> 閾値を満たさないバーは薄く表示される</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-wpm-time-of-day.png" alt="分析 — WPM 時間帯別" class="doc-img" loading="lazy"></div>
+<p><strong>最小サンプル</strong>（時系列・時間帯別 共通）</p>
+<p><code class="ic">30秒</code>、<code class="ic">1分</code>、<code class="ic">2分</code>、<code class="ic">5分</code>。閾値未満の 1 分バケットはチャートから除外され、打鍵数の少ないサンプルによる外れ値を抑制する。</p>
+<p><strong>粒度</strong>（時系列のみ）</p>
+<p>時系列のバケット幅を制御する（<code class="ic">自動</code>、<code class="ic">1分</code>、<code class="ic">5分</code>、… <code class="ic">1週間</code>、<code class="ic">1ヶ月</code>）。</p>
+<p><strong>サマリカード</strong></p>
+<ul><li><strong>時系列</strong> — 合計打鍵、実打鍵時間、平均WPM、最高 WPM、最低WPM、重み付き中央値WPM、1 分最大打鍵、1 日最大打鍵、Bksp 合計、平均 Bksp %</li><li><strong>時間帯別</strong> — 合計打鍵、実打鍵時間、平均WPM、ピーク時間帯、最遅時間帯、活動時間帯数（N/24）</li></ul>
+<h4 id="間隔">間隔</h4>
+<p>間隔タブは連続する打鍵の間隔（時間）を、分位数の時系列または分布ヒストグラムで可視化する。</p>
+<p><strong>ビュー</strong></p>
+<ul><li><strong>時系列</strong> — 対数スケールの Y 軸に 5 本の分位数ライン（<strong>最小</strong>、<strong>p25</strong>、<strong>中央値</strong>、<strong>p75</strong>、<strong>最大</strong>）を描画する。中央値の線が最も太い。凡例をクリックすると線を隠せる。Y 軸ラベルは <strong>表示</strong> の設定に応じて <code class="ic">秒 (log)</code> または <code class="ic">ms (log)</code></li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-interval-time-series.png" alt="分析 — 間隔 時系列" class="doc-img" loading="lazy"></div>
+<ul><li><strong>分布</strong> — 9 ビンのバーチャート（<code class="ic">&lt;50ms</code>、<code class="ic">50-100ms</code>、<code class="ic">100-200ms</code>、<code class="ic">200-500ms</code>、<code class="ic">500ms-1s</code>、<code class="ic">1-2s</code>、<code class="ic">2-5s</code>、<code class="ic">5-10s</code>、<code class="ic">&gt;10s</code>）。帯域別に色分け: <strong>高速</strong>（緑、<200ms）/ <strong>標準</strong>（青、200-500ms）/ <strong>緩慢</strong>（オレンジ、500ms-2s）/ <strong>ポーズ</strong>（赤、≥2s）。分布モードでは <strong>デバイス</strong> フィルタが非表示になる（ビン集計は常にこのデバイス単独で行うため）</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-interval-distribution.png" alt="分析 — 間隔 分布" class="doc-img" loading="lazy"></div>
+<p><strong>表示</strong>（時系列・分布 共通）</p>
+<p><code class="ic">秒</code> / <code class="ic">ミリ秒</code>。ツールチップと Y 軸の単位が切り替わる。ビンのラベル自体は固定表記。</p>
+<p><strong>粒度</strong>（時系列のみ）</p>
+<p>WPM タブと同じ選択肢。</p>
+<p><strong>サマリカード</strong></p>
+<ul><li><strong>時系列</strong> — 合計打鍵、実打鍵時間、重み付き中央値、最短打鍵間隔（1分）、最長打鍵間隔（1分）</li><li><strong>分布</strong> — 合計打鍵、中央値インターバル、高速 (<200ms) 割合、標準 (200-500ms) 割合、緩慢 (500ms-2s) 割合、ポーズ (>=2s) 割合、最長打鍵間隔（1分）、最長セッション</li></ul>
+<h4 id="活動量">活動量</h4>
+<p>活動量タブは打鍵を「曜日 × 時間帯」で集計し、どの時間帯にどれだけ打鍵しているかを俯瞰する。フィルタは独立した 2 軸で並ぶ: <strong>ビュー</strong>（チャート形状）、<strong>指標</strong>（セルの値）。</p>
+<p><strong>ビュー</strong></p>
+<ul><li><strong>時間</strong> — 既存の 24 × 7（時間 × 曜日）グリッド（指標 = セッション のときはヒストグラムに切替）。既存の Period がグリッドの時間幅を決める</li><li><strong>日</strong> — 月単位スライディングカレンダー。フィルタ行に <strong>期間</strong> セレクタ（1 / 3 / 6 / 12 ヶ月）と前月 / 翌月カーソルボタンが追加され、月単位ヒートマップを前後に動かせる。3 / 6 / 12 ヶ月では現在月は今日でストップ（未来日は描画しない）、1 ヶ月表示では未来日を含む月全体を表示する</li></ul>
+<p><strong>指標</strong></p>
+<ul><li><strong>打鍵数</strong> — 打鍵回数。空セルは薄く、最多セルは最も濃く。グリッド表示では 0 でないセルにマウスを乗せると「月 09:00 — 1,234 打鍵 (総打鍵の 5.2%)」のように回数と期間全体に対する比率を併記する</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-activity-keystrokes.png" alt="分析 — 活動量 打鍵数" class="doc-img" loading="lazy"></div>
+<ul><li><strong>WPM</strong> — セル別平均 WPM。グリッド表示では <strong>最小サンプル</strong> を満たさないセルは色スケールに貼り付けず、薄色で表示される</li><li><strong>セッション</strong> — グリッド表示ではセッション長の 7 ビンヒストグラム（<code class="ic">5分未満</code>、<code class="ic">5-15分</code>、<code class="ic">15-30分</code>、<code class="ic">30-60分</code>、<code class="ic">1-2時間</code>、<code class="ic">2-4時間</code>、<code class="ic">4時間以上</code>）。カレンダー表示では各セルが <strong>その日に開始したセッション数</strong>（DB 仕様上「その日に開始した」セッション。日跨ぎセッションは開始日にしか積まない）</li></ul>
+<p><strong>日ビュー専用コントロール</strong>（ビュー = 日）</p>
+<ul><li><strong>正規化</strong> — <code class="ic">絶対値</code> は表示窓内のピーク日基準、<code class="ic">週内シェア</code> は所属する週の合計で割り、<code class="ic">総合シェア</code> は表示範囲全体の合計で割る</li><li><strong>期間</strong> — <code class="ic">1 ヶ月</code> / <code class="ic">3 ヶ月</code> / <code class="ic">6 ヶ月</code> / <code class="ic">12 ヶ月</code>。現在月から遡って表示する範囲を選ぶ</li><li><strong>前月 / 翌月ボタン</strong> — 表示窓を 1 ヶ月単位でスライドする。現在月は右端に固定、未来日は空白のまま（1 ヶ月表示では月全体を表示）</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-activity-calendar.png" alt="分析 — 活動量 カレンダー" class="doc-img" loading="lazy"></div>
+<p>カレンダーの下にグラデーション凡例バーが表示され、色の濃淡がどの値に対応するか（Low → ピーク値）が一目で分かる。</p>
+<p>打鍵があるセルをクリックすると、Analyze ペイン全体がその 1 日に飛ぶ。snapshot ピッカーは該当日のキーマップを自動選択するので、ヒートマップ / エルゴノミクス / レイヤー起動回数といった snapshot 依存タブの内容も連動する。</p>
+<p><strong>最小サンプル</strong>（ビュー = グリッド、指標 = WPM）</p>
+<p>WPM タブと同じ選択肢。</p>
+<p><strong>ピーク記録</strong></p>
+<p>グリッドの上に、期間中のピーク値を 4 枚のカードで表示する: 最高 WPM、1 分最大打鍵、1 日最大打鍵、最長セッション（分）。指標を切り替えてもこれらは常に表示され、全体のピークが一目で確認できる。</p>
+<p><strong>サマリカード</strong></p>
+<p>グリッドの下には指標別のサマリが出る:</p>
+<ul><li><strong>打鍵数</strong> — 合計打鍵、実打鍵時間、最頻曜日、最頻時間帯、ピークセル、活動セル数（N/168）。各カードの回数表示には期間全体に対する比率も併記される（例: <code class="ic">800 打鍵 (40.0%)</code>）</li><li><strong>WPM</strong> — 合計打鍵、実打鍵時間、平均WPM、ピークセル、最遅セル、活動セル数（N/168）</li><li><strong>セッション</strong> — セッション数、合計時間、平均セッション長、中央値セッション長、最長セッション、最短セッション</li></ul>
+<h4 id="エルゴノミクス">エルゴノミクス</h4>
+<p>エルゴノミクスタブは打鍵の物理的な負荷を、指別 / 左右バランス / 段別 の 3 つの視点で表示する。スナップショット内のキー → 指の対応を元に集計する。</p>
+<p>ヒートマップと同じく、このビューは期間内のキーマップスナップショットが必要。</p>
+<p><strong>セクション</strong></p>
+<p>3 つのバーチャートが縦に並ぶ:</p>
+<ol><li><strong>指別打鍵量</strong> — 左小指から右小指までの 10 本の縦バー</li><li><strong>左右バランス</strong> — 左手 / 右手 の 2 本の横バー</li><li><strong>段別打鍵量</strong> — F 行 / 数字行 / 上段 / ホーム行 / 下段 / 親指段 の 6 本の横バー</li></ol>
+<div class="img-wrap"><img src="screenshots/analyze-ergonomics.png" alt="分析 — エルゴノミクス" class="doc-img" loading="lazy"></div>
+<p><strong>指割り当て</strong></p>
+<p>各キーの指アサインはレイアウトの KLE メタデータ（列位置と標準の列→指マッピング）から自動で決まる。キー個別に上書きしたい場合は、タブ上部の <strong>指割り当て</strong> ボタンからモーダルを開く:</p>
+<div class="img-wrap"><img src="screenshots/analyze-finger-assignment-modal.png" alt="分析 — 指割り当て" class="doc-img" loading="lazy"></div>
+<ul><li>各キーには指の短ラベル（<code class="ic">左小</code> <code class="ic">左薬</code> <code class="ic">左中</code> <code class="ic">左人</code> <code class="ic">左親</code> / <code class="ic">右親</code> <code class="ic">右人</code> <code class="ic">右中</code> <code class="ic">右薬</code> <code class="ic">右小</code>）が表示される。手動で上書きされたキーには <code class="ic">*</code> が付く</li><li>キーをクリックするとポップオーバーが開き、指を選べる</li><li><strong>保存</strong> で上書きを確定、<strong>全てリセット</strong> で全ての上書きを消す（上書きが無いときは無効）。キー個別のポップオーバーにある <strong>推定に戻す</strong> はそのキーの上書きだけを消す</li><li>モーダルを閉じると上書きが即座に反映され、指別打鍵量 / 左右バランス / 段別打鍵量 の全てが再集計される</li></ul>
+<p><strong>学習曲線</strong></p>
+<p>フィルター行の <strong>ビュー</strong> を <strong>学習曲線</strong> に切り替えると、4 連の snapshot ビューが週/月別のトレンドチャートに切り替わる。ビューは日別マトリクス集計を <strong>区間</strong>（週 / 月）でバケット化し、各バケットを 3 つのサブスコア + 合成スコアにまとめる:</p>
+<ul><li><strong>指の偏り</strong> — 10 指の打鍵分布の均等度（1 = 完全均等、0 = 一指集中）</li><li><strong>左右バランス</strong> — 左右比率が 50 / 50 にどれだけ近いか</li><li><strong>ホーム行率</strong> — 全打鍵に占めるホーム行の割合</li></ul>
+<p>太線は合成 <strong>総合</strong> スコア（3 サブスコアの加重平均）、点線は個別サブスコア。上部のサマリカードには直近バケットの総合スコア、過去バケットとの差分、有効バケット数が並ぶ（バケットは打鍵数が最小サンプルしきい値以上で「有効」になる。しきい値未満のバケットも線として表示されるが、ツールチップで「下限未満」と注記される）。</p>
+<div class="img-wrap"><img src="screenshots/analyze-ergonomics-learning.png" alt="分析 — エルゴノミクス学習曲線" class="doc-img" loading="lazy"></div>
+<blockquote><p>合成スコアは <strong>絶対評価ではなく相対トレンド指標</strong>。重みはヒューリスティックで、特に finger stddev はレイアウト依存・ノイズが大きい。点数として読まず「分布が時間とともに改善しているか」を見る指標として使う。</p></blockquote>
+<p><strong>空状態</strong></p>
+<ul><li><strong>スナップショット無し</strong> — ヒートマップと同じメッセージ</li><li><strong>レイアウト無し</strong> — 「このスナップショットにはレイアウト情報がありません。」</li><li><strong>活動なし</strong> — 「この期間の打鍵データがありません。」</li><li><strong>データ不足</strong>（学習曲線のみ） — 「この期間にはマトリクスの活動が十分にありません。打鍵を増やすか、期間を広げてください。」</li></ul>
+<h4 id="バイグラム">バイグラム</h4>
+<p>バイグラムタブは連続する 2 打鍵 (バイグラム) と、その間隔 (Inter-Key Interval / IKI) を分析する。バイグラムは打鍵時に分単位で集計されるので、選択期間を変えても生イベントの再走査なしに即時表示される。</p>
+<p><strong>3 分割レイアウト</strong></p>
+<p>ビューは 3 つのクォドラントで構成され、各クォドラントに件数セレクタ (10 / 20 / 30 / … / 100) が付く。バーは recharts でレンダリングされ、ツールチップがカーソル追従する。</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">クォドラント</th><th style="text-align:left">内容</th></tr></thead><tbody><tr><td style="text-align:left"><strong>頻出ペア</strong></td><td style="text-align:left">バイグラムを出現回数で降順ランキング。<strong>回数</strong> または <strong>平均間隔</strong> 列をクリックして並び替え可能</td></tr><tr><td style="text-align:left"><strong>ペア間隔</strong></td><td style="text-align:left">バイグラムを平均 IKI で降順ランキング (最も遅いペアが上)。<strong>回数</strong> / <strong>平均間隔</strong> / <strong>p95 間隔</strong> のいずれでも並び替え可能。共通フィルタの <strong>平均間隔</strong> しきい値より速いペアは除外される</td></tr><tr><td style="text-align:left"><strong>Finger IKI</strong></td><td style="text-align:left">(送り指 → 受け指) ペアの平均 IKI バーチャート。左手始まりは青、右手始まりは赤で色分け。同じ <strong>平均間隔</strong> しきい値が適用される</td></tr></tbody></table></div>
+<div class="img-wrap"><img src="screenshots/analyze-bigrams.png" alt="分析 — バイグラム" class="doc-img" loading="lazy"></div>
+<p><strong>スナップショット要件</strong></p>
+<p>キーマップスナップショットが必要なのは <strong>Finger IKI</strong> クォドラントだけ。バイグラムペアの数値キーコードを指に解決するためにスナップショットの keymap + layout が要る。<strong>頻出ペア</strong> / <strong>ペア間隔</strong> はペア集計データから直接描画されるためスナップショットなしでも動作する。</p>
+<p><strong>共通フィルタ</strong></p>
+<ul><li><strong>期間</strong> — 他のタブと同じ <code class="ic">From</code> / <code class="ic">To</code> ピッカー。期間変更で再集計される</li><li><strong>デバイス</strong> — <code class="ic">このデバイス</code> のみ、または同期済みの全デバイス。他のタブと同じ挙動</li><li><strong>平均間隔 (ms 以上)</strong> — 最小 IKI しきい値。<strong>指間隔</strong> と <strong>ペア間隔</strong> の両クォドラントヘッダにそれぞれ入力欄があり、設定値より平均 IKI が小さいペアは両方から除外される。入力欄は両クォドラントで共有される（片方を変更するともう片方の表示も連動して更新される）。<code class="ic">0</code> でフィルタ無効。値はキーボード単位で <code class="ic">PipetteSettings</code> に永続化される。比較に使う IKI は histogram bucket center による加重平均の概算値なので、しきい値は「およそ N ms より速いペアは無視する」程度のラフな絞り込みとして使う</li></ul>
+<p><strong>空状態</strong></p>
+<ul><li><strong>データなし</strong> — 「この期間のバイグラムデータはまだありません。打鍵を記録してから再度開いてください」 期間内にペア活動が記録されていないとき表示</li><li><strong>スナップショット無し (Finger IKI のみ)</strong> — 「Finger IKI には keymap snapshot が必要です。Record セッションを開始するか snapshot のある期間を選択してください」 他の 2 クォドラントは引き続き表示される</li><li><strong>しきい値で全件フィルタされた</strong> — <strong>平均間隔</strong> の値が高すぎて生き残るペアが無くなった場合、Finger IKI とペア間隔の両クォドラントが「この期間のバイグラムデータはまだありません」にフォールバックする。しきい値を下げて表示を戻す</li></ul>
+<h4 id="アプリ別">アプリ別</h4>
+<p>アプリ別タブは Typing View で取得したアクティブアプリ名で記録データを集計する。Monitor App を有効化し、アプリ名がタグされた minute が記録されないと表示は空になる。このタブは意図的に <strong>アプリフィルタを無視</strong> する（フィルタを掛けるとスライス / バーが 1 つに潰れるため）。</p>
+<div class="img-wrap"><img src="screenshots/analyze-by-app.png" alt="分析 — アプリ別" class="doc-img" loading="lazy"></div>
+<p><strong>App Usage Distribution</strong>（円）</p>
+<p>選択期間中のアプリ別打鍵数シェアをドーナツチャートで表示する。同一 minute 内に複数アプリを観測した場合は <code class="ic">Unknown / Mixed</code>、Monitor App 無効時 / Monitor App 導入前の minute は <code class="ic">Other</code> スライスに入る。ホバーするとスライス毎の打鍵数とシェア%がツールチップで出る。</p>
+<p><strong>WPM by App</strong>（横棒）</p>
+<p>アプリ別の中央値 WPM を活動シェアで降順ランキングした横棒チャート。最小サンプル閾値を満たさないバーは薄色で表示される。ホバーすると WPM と打鍵数がツールチップで出る。</p>
+<p><strong>空状態</strong></p>
+<ul><li>「アプリデータがありません — Monitor App を有効にして REC を開始するとチャートに反映されます」アプリタグ付き minute が範囲内に無いとき表示</li></ul>
+<h4 id="layout-comparison">Layout Comparison</h4>
+<p>Layout Comparison は、記録した打鍵ログを別レイアウト（Colemak / Dvorak / Colemak DH ほか 30+ 種類）に乗せた場合の指 / 手 / 行の負担分布をシミュレートする。ファームウェアを書き換えずに「もし Colemak だったら」を試算できる。</p>
+<p><strong>ピッカー</strong></p>
+<ul><li><strong>Current layout</strong> — 記録イベントを解釈する文字規約。デフォルトは QWERTY。ファームウェアが既に別レイアウトのキーコードを直接出している場合はそれを選ぶ</li><li><strong>Compare to</strong> — シミュレートする比較先レイアウト。選択はキーボードごとに永続化されるので再起動後も同じ比較に戻る</li></ul>
+<p><strong>パネル</strong></p>
+<p>target を選ぶと 3 つのパネルを 1 画面で同時表示する。サブビュー切替はなく、空間（位置）・指別・数値の 3 視点を一度に並べて読める:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">パネル</th><th style="text-align:left">内容</th></tr></thead><tbody><tr><td style="text-align:left"><strong>位置の差分</strong>（上段、フル幅）</td><td style="text-align:left">物理キー単位の差分をキーボードに塗布。赤系は比較先でアクティビティが増える物理位置、青系は減る位置</td></tr><tr><td style="text-align:left"><strong>指の差分</strong>（下段左）</td><td style="text-align:left">指別の符号付き差分バーチャート。赤バーは比較先で負担が増える指、緑バーは減る指</td></tr><tr><td style="text-align:left"><strong>数値表</strong>（下段右）</td><td style="text-align:left">各レイアウトを横並びにした share-of-events 表。指の負担（指別）、左右バランス、行分布、ホーム行率</td></tr></tbody></table></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-heatmap-diff.png" alt="分析 — Layout Comparison 位置差分" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-finger-diff.png" alt="分析 — Layout Comparison 指差分" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/analyze-layout-comparison-metric.png" alt="分析 — Layout Comparison 数値表" class="doc-img" loading="lazy"></div>
+<p><strong>Skip-rate 警告</strong></p>
+<p>比較先で打てない文字（対応するキーが無い、または現在のファームウェアに該当キーコードが割り当たっていない等）はスキップ扱いになる。スキップ率が 5% を超えると注意バナーが表示される。下の数値は参考値として読む。</p>
+<p><strong>空状態</strong></p>
+<ul><li><strong>スナップショット無し</strong> — 他のスナップショット必須タブと同じ。期間内に Record セッションを開始すると保存される</li><li><strong>target 未選択</strong> — 比較レイアウトを選ぶまでヒントだけが出る</li><li><strong>取得失敗</strong> — 「レイアウト比較の計算に失敗しました」 リロードまたは期間を狭めて再試行</li></ul>
+<h4 id="レイヤー">レイヤー</h4>
+<p>レイヤータブは使用状況をレイヤーごとに分解する。</p>
+<p><strong>表示</strong></p>
+<ul><li><strong>打鍵数</strong> — 押下時点でアクティブだったレイヤーを基に集計する。<code class="ic">MO</code> / <code class="ic">LT</code> / <code class="ic">TG</code> などの layer op は押下時のアクティブレイヤーが記録されるので、そのまま反映される。キーマップスナップショット無しでも動作する</li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-layer-keystrokes.png" alt="分析 — レイヤー打鍵数" class="doc-img" loading="lazy"></div>
+<ul><li><strong>起動回数</strong> — 各レイヤーに layer-op キーで「遷移」した回数を集計する。キーマップスナップショットが必須で、layer-op キーコードをターゲットレイヤーに解決する:<ul><li><code class="ic">MO</code> / <code class="ic">TG</code> / <code class="ic">TO</code> / <code class="ic">DF</code> / <code class="ic">PDF</code> / <code class="ic">OSL</code> / <code class="ic">TT</code> — 押下時点でカウント</li><li><code class="ic">LT</code> / <code class="ic">LM</code> — ホールド時のみカウント（<code class="ic">LT0(KC_ESC)</code> をタップしただけでは遷移扱いしない）</li></ul></li></ul>
+<div class="img-wrap">  <img src="screenshots/analyze-layer-activations.png" alt="分析 — レイヤー起動回数" class="doc-img" loading="lazy"></div>
+<p><strong>ベース</strong></p>
+<p>起動回数モードかつレイヤー数が 2 以上のときだけ表示される。分析元となるレイヤーを選ぶ。選んだレイヤーはバー一覧から除外されるので、「既にいるレイヤーを押し続ける」タイプ（例: ベース = 0 で <code class="ic">LT0(KC_ESC)</code> ホールド）が遷移として見えない。</p>
+<p><strong>レイヤー名</strong></p>
+<p>レイヤーパネル（§2.3 参照）でレイヤーに名前を付けていると、軸ラベルに名前が併記される（例: <code class="ic">レイヤー 0 · Base</code>）ため、番号だけでなく名前でも判別できる。</p>
+<p><strong>空状態</strong></p>
+<ul><li><strong>打鍵数、データなし</strong> — 期間中に打鍵が無い</li><li><strong>起動回数、データなし</strong> — 期間中に layer-op キーが押されていない</li><li><strong>起動回数、スナップショット無し</strong> — 「レイヤー起動回数の表示にはキーマップスナップショットが必要です。この期間に record を開始すると取得できます。」打鍵数モードはスナップショット無しでも動作する</li></ul>
+<h4 id="エクスポート-アップロード">エクスポート / アップロード</h4>
+<p>ペインヘッダの <strong>エクスポート</strong> ボタンでカテゴリ選択モーダルが開き、現在のフィルタ条件下でチャートデータを <code class="ic">.csv</code> ファイルとして書き出せる。10 カテゴリを独立して on/off 可能:</p>
+<ul><li><strong>サマリー</strong> — 今日 / 直近 7 日の概要カード</li><li><strong>WPM</strong> — バケット別 WPM 時系列</li><li><strong>間隔</strong> — バケット別間隔分位数</li><li><strong>活動量</strong> — ビュー設定に応じて 時間×曜日 グリッド or 日セルの集計値</li><li><strong>アプリ別</strong> — アプリケーション別の内訳</li><li><strong>ヒートマップ</strong> — セル別押下回数（スナップショット必須）</li><li><strong>エルゴノミクス</strong> — 指 / 手 / 段別の集計値（スナップショット必須）</li><li><strong>バイグラム</strong> — 頻出ペア / ペア間隔 / Finger IKI 行</li><li><strong>レイヤー</strong> — レイヤー別打鍵数または起動回数</li><li><strong>レイアウト比較</strong> — 指 / 段 / 手別の差分（スナップショット必須）</li></ul>
+<p>モーダル上部にはアクティブな条件（Device / App / Keymap / Period）が併記され、保存するファイルがどのスライスを切り取ったものか一目で分かる。期間にスナップショットが重ならない場合、ヒートマップ / エルゴノミクス / レイアウト比較は無効化され「snapshot missing」の注記が出る。指割り当ての手動上書きはエルゴノミクス行に併記される。</p>
+<p><strong>アップロードモード</strong></p>
+<p>保存済みエントリの Hub アクション行（Upload to Hub / Update on Hub）からトリガーすると、同じモーダルが <strong>アップロードモード</strong> で開く。確認ボタンが <strong>Upload</strong> または <strong>Update</strong> に変わり、データは CSV ではなく Pipette Hub に送信される。アップロードモードでは 2 つの追加セレクタが表示される:</p>
+<ul><li><strong>Layout Comparison ターゲット</strong> — インストール済みの Key Labels セットと built-in レイアウトを複数選択可能。Hub 投稿に含めるターゲットレイアウトを選ぶ。ターゲット未選択時は Layout Comparison トグルが無効化される</li><li><strong>Per-app data</strong> — 期間中に観測されたアプリの一覧から複数選択。Hub でアプリ別内訳として含めるアプリを選ぶ</li></ul>
+<p>詳細なアップロードフローとバリデーションルールは §7.4 を参照。</p>
+<hr>
+<h2 id="2-キーマップエディタ">2. キーマップエディタ</h2>
+<h3 id="2-1-画面構成">2.1 画面構成</h3>
+<p>キーマップエディタはキーボードレイアウト表示とキーコードパレットの 2 つの領域で構成されます。</p>
+<div class="img-wrap"><img src="screenshots/02-keymap-editor-overview.png" alt="キーマップエディタ全体" class="doc-img" loading="lazy"></div>
+<ul><li>画面上部: キーボードの物理レイアウト (各キーに現在のキーコードを表示)</li><li>画面左側: ツールバー (ズーム、Undo/Redo など)</li><li>画面下部: キーコードパレット (タブ切替式) とオーバーレイパネルトグル</li><li>右側 (展開時): キーコードオーバーレイパネル (ツール、保存、レイアウトオプション)</li><li>画面最下部: ステータスバー</li></ul>
+<h3 id="2-2-キーの変更方法">2.2 キーの変更方法</h3>
+<ol><li>キーボードレイアウト上のキーをクリックして選択</li><li>キーコードパレットから割り当てたいキーコードをクリック</li><li>キーの表示が更新されます</li><li>変更は自動的にキーボードに反映されます</li></ol>
+<ul><li>Ctrl+クリックで複数のキーを選択できます</li><li>Shift+クリックで範囲選択ができます</li><li>Escape キーで全選択を解除します</li></ul>
+<p><strong>キーの即時選択 (Instant Key Selection)</strong> はキーコード割り当ての動作を制御します:</p>
+<ul><li><strong>ON</strong> (デフォルト): キーコードをシングルクリックすると即座に割り当てが完了し、選択が閉じます。素早い編集に最適です。</li><li><strong>OFF</strong>: シングルクリックでキーコードを選択（ハイライト表示）し、ダブルクリックまたは Enter キーで確定・割り当て。パレット下部にヒントが表示されます。キーコードを確認してから決定したい場合に便利です。</li></ul>
+<p>この設定はキーコードオーバーレイパネル (§3.14) でキーボードごとに切り替えでき、グローバルなデフォルトは設定 → デフォルト (§6.1) で設定できます。</p>
+<h3 id="2-3-レイヤー切替">2.3 レイヤー切替</h3>
+<p>キーボードレイアウトの左側にレイヤー切替ボタンがあります。</p>
+<div class="img-wrap"><img src="screenshots/03-layer-0.png" alt="Layer 0" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/04-layer-1.png" alt="Layer 1" class="doc-img" loading="lazy"></div>
+<div class="img-wrap"><img src="screenshots/05-layer-2.png" alt="Layer 2" class="doc-img" loading="lazy"></div>
+<ul><li>レイヤー番号ボタンをクリックしてレイヤーを切り替えます</li><li>Layer 0 がデフォルトレイヤーです</li><li>利用可能なレイヤー数はキーボードの設定に依存します</li></ul>
+<p>レイヤーパネルは折りたたんでスペースを節約できます:</p>
+<div class="img-wrap"><img src="screenshots/layer-panel-collapsed.png" alt="レイヤーパネル 折りたたみ" class="doc-img" loading="lazy"></div>
+<p>折りたたみボタン (シェブロン) をクリックしてレイヤーパネルを番号のみに縮小できます。展開ボタンをクリックすると完全なレイヤー名が復元されます。</p>
+<div class="img-wrap"><img src="screenshots/layer-panel-expanded.png" alt="レイヤーパネル 展開" class="doc-img" loading="lazy"></div>
+<h3 id="2-4-キーポップオーバー">2.4 キーポップオーバー</h3>
+<p>キーボードレイアウト上のキーをダブルクリックすると、キーポップオーバーが開きます。パレットをスクロールせずに、素早くキーコードを検索・割り当てできます。</p>
+<p><strong>レイヤーサイドバー</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-layer-sidebar.png" alt="キーポップオーバー — レイヤーサイドバー" class="doc-img" loading="lazy"></div>
+<p>ポップオーバーの左側に縦並びのレイヤーサイドバーが表示されます。レイヤーパネルのボタンと同じスタイルで、レイヤー番号をクリックするとポップオーバーを閉じずにレイヤーを切り替えられます。レイヤー数がポップオーバーの高さを超える場合、サイドバーは独立してスクロールします。</p>
+<p><strong>Key タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-key.png" alt="キーポップオーバー — Key タブ" class="doc-img" loading="lazy"></div>
+<ul><li>検索入力には現在のキーコード名がプリセットされます</li><li>名前、キーコード名、エイリアスで検索でき、関連度順に結果が表示されます</li><li>検索結果をクリックするとすぐに割り当てられます</li><li>詳細エディタ (Tap Dance、Combo、Key Override など) のキーフィールドをダブルクリックしても同様にポップオーバーが表示されます</li></ul>
+<p><strong>Code タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/key-popover-code.png" alt="キーポップオーバー — Code タブ" class="doc-img" loading="lazy"></div>
+<ul><li>16進数でキーコード値を直接入力できます (例: <code class="ic">0x0029</code> で Escape)</li><li>入力欄の下に対応するキーコード名が表示されます</li><li><strong>Apply</strong> ボタンをクリックして割り当てます</li></ul>
+<p><strong>ラッパーモード</strong></p>
+<p>ポップオーバー上部のモードボタンで、複合キーコードを構築できます:</p>
+<div class="img-wrap"><img src="screenshots/key-popover-modifier.png" alt="キーポップオーバー — Modifier モード" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Mod Mask</strong>: 修飾キーとキーを組み合わせます (例: <code class="ic">LSFT(KC_ESCAPE)</code>)</li><li><strong>Mod-Tap</strong>: 長押しで修飾キー、タップでキー (例: <code class="ic">LSFT_T(KC_ESCAPE)</code>)</li></ul>
+<p>どちらのモードでも修飾キーチェックボックスが表示され、Left/Right の Ctrl、Shift、Alt、GUI を選択できます。Left と Right の修飾キーは同時に選択できません — 片方を選択するともう片方は無効になります。</p>
+<div class="img-wrap"><img src="screenshots/key-popover-lt.png" alt="キーポップオーバー — LT モード" class="doc-img" loading="lazy"></div>
+<ul><li><strong>LT</strong>: Layer-Tap — 長押しでレイヤーを有効化、タップでキーを送信 (例: <code class="ic">LT0(KC_ESCAPE)</code>)。レイヤーセレクタが表示され、対象レイヤーを選択できます。</li><li><strong>SH_T</strong>: Swap Hands Tap — 長押しでスワップハンド、タップでキーを送信 (例: <code class="ic">SH_T(KC_ESCAPE)</code>)</li><li><strong>LM</strong>: Layer-Mod — 修飾キー付きでレイヤーを有効化 (例: <code class="ic">LM(0, MOD_LSFT)</code>)。レイヤーセレクタと修飾キーチェックボックスの両方が表示されます。</li></ul>
+<p>アクティブなモードボタンをクリックするとモードが解除され、基本キーコードに戻ります。</p>
+<p><strong>元に戻す / やり直し (Undo / Redo)</strong>: ポップオーバーのフッターに、コンテキストに応じた <strong>Undo</strong> と <strong>Redo</strong> ボタンが表示されます。Undo は前のキーコードを表示して元に戻し、Redo は次のキーコードを表示して再適用します。これらのボタンは直近の undo/redo ヒストリーエントリがポップオーバーで開いているキーと一致する場合（直近1件の変更）のみ表示されます。複数ステップのヒストリー操作には、ツールバーボタンまたはキーボードショートカットを使用してください（§4.2 参照）。</p>
+<div class="img-wrap"><img src="screenshots/key-popover-undo.png" alt="キーポップオーバー — Undo" class="doc-img" loading="lazy"> <img src="screenshots/key-popover-redo.png" alt="キーポップオーバー — Redo" class="doc-img" loading="lazy"></div>
+<p><strong>確定</strong>: <strong>Enter</strong> キーで現在の選択を確定してポップオーバーを閉じます。<strong>Escape</strong> キーを押すか、ポップオーバーの外側をクリックすると変更なしで閉じます。</p>
+<h3 id="2-5-レイアウトオプション">2.5 レイアウトオプション</h3>
+<p>一部のキーボードは複数の物理レイアウトに対応しています（例: 分割バックスペース、ISO エンター、ボトムロウの構成変更など）。キーボードにレイアウトオプションがある場合、キーコードパレットのタブバー右端にレイアウトオプションボタン（グリッドアイコン）が表示されます。</p>
+<div class="img-wrap"><img src="screenshots/layout-options-open.png" alt="レイアウトオプションパネル" class="doc-img" loading="lazy"></div>
+<ul><li>グリッドアイコンをクリックしてレイアウトオプションパネルを開きます</li><li><strong>チェックボックスオプション</strong>: レイアウトバリアントのオン/オフを切り替えます（例: 「Macro Pad」「Split Backspace」「ISO Enter」）</li><li><strong>ドロップダウンオプション</strong>: 複数のレイアウトバリアントから選択します（例: 「Bottom Section」で Full Grid / Macro Pad / Arrow Keys を選択）</li><li>変更は即座に反映されます — 選択したオプションに応じてキーボードレイアウト表示がリアルタイムに更新されます</li></ul>
+<div class="img-wrap"><img src="screenshots/layout-options-changed.png" alt="レイアウトオプション変更後" class="doc-img" loading="lazy"></div>
+<ul><li>オプションを変更すると、キーボードレイアウト上の表示キーが更新されます</li><li>レイアウトオプションはキーボードに保存され、セッション間で保持されます</li><li>パネルの外側をクリックするか Escape キーを押すと閉じます</li></ul>
+<blockquote><p><strong>Note</strong>: レイアウトオプションボタンは、複数のレイアウトバリアントが定義されているキーボードでのみ表示されます。固定レイアウトのキーボードにはこのボタンは表示されません。このセクションのスクリーンショットは「JSONファイルから読み込み」機能でダミー JSON 定義を使用して撮影しています。</p></blockquote>
+<hr>
+<h2 id="3-キーコードパレット">3. キーコードパレット</h2>
+<p>画面下部のタブ付きパレットから、各カテゴリのキーコードを選択できます。</p>
+<h3 id="3-1-basic">3.1 Basic</h3>
+<p>通常の文字キー、ファンクションキー、修飾キー、ナビゲーションキーなどの基本キーコードです。Basic タブは 4 つのビュータイプに対応しており、Basic タブ下部のビューセレクターから切り替えできます:</p>
+<p><strong>ANSI キーボードビュー</strong> (デフォルト)</p>
+<div class="img-wrap"><img src="screenshots/basic-ansi-view.png" alt="Basic タブ — ANSI ビュー" class="doc-img" loading="lazy"></div>
+<p>キーコードを ANSI キーボードレイアウトとして表示します。ビジュアルキーボード上のキーをクリックして割り当てます。</p>
+<p><strong>ISO キーボードビュー</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-iso-view.png" alt="Basic タブ — ISO ビュー" class="doc-img" loading="lazy"></div>
+<p>ISO 固有のキーを含む ISO キーボードレイアウトとして表示します。</p>
+<p><strong>JIS キーボードビュー</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-jis-view.png" alt="Basic タブ — JIS ビュー" class="doc-img" loading="lazy"></div>
+<p>JIS 固有のキー (円記号、Ro、変換、無変換、カタカナ/ひらがな) を含む JIS キーボードレイアウトとして表示します。</p>
+<p><strong>リストビュー</strong></p>
+<div class="img-wrap"><img src="screenshots/basic-list-view.png" alt="Basic タブ — リストビュー" class="doc-img" loading="lazy"></div>
+<p>従来のスクロール可能なリスト形式でキーコードを表示します。</p>
+<p>全ビュー共通:</p>
+<ul><li>文字キー (A-Z, 0-9, 記号)</li><li>ファンクションキー (F1-F24)</li><li>編集キー (Enter, Tab, Backspace, Delete)</li><li>ナビゲーションキー (矢印, Home, End, PageUp/Down)</li><li>テンキー</li><li>International キー (KC_INT1〜KC_INT5)</li><li>Language キー (KC_LANG1〜KC_LANG5)</li></ul>
+<h3 id="3-2-layers">3.2 Layers</h3>
+<p>レイヤー操作用のキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-layers.png" alt="Layers タブ" class="doc-img" loading="lazy"></div>
+<ul><li><strong>MO(n)</strong>: 押している間だけレイヤー n に切り替え</li><li><strong>DF(n)</strong>: デフォルトレイヤーを n に変更</li><li><strong>TG(n)</strong>: レイヤー n をトグル</li><li><strong>LT(n, kc)</strong>: 長押しでレイヤー、タップでキーコード</li><li><strong>OSL(n)</strong>: 次のキー入力のみレイヤー n を有効化</li><li><strong>TO(n)</strong>: レイヤー n に切り替え</li></ul>
+<h3 id="3-3-modifiers">3.3 Modifiers</h3>
+<p>修飾キーの組み合わせやタップ時の動作を設定するキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-modifiers.png" alt="Modifiers タブ" class="doc-img" loading="lazy"></div>
+<ul><li><strong>One-Shot Modifier (OSM)</strong>: 次のキー入力のみ修飾キーを有効化</li><li><strong>Mod-Tap</strong>: 長押しで修飾キー、タップで通常キー</li><li><strong>Mod Mask</strong>: 修飾キーの組み合わせ</li></ul>
+<h3 id="3-4-system">3.4 System</h3>
+<p>マウス制御、メディア再生、システムユーティリティ、オーディオ/ハプティックフィードバック用のキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-system.png" alt="System タブ" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Mouse</strong>: マウスボタン・移動・スクロール</li><li><strong>Joystick</strong>: ジョイスティックの軸とボタンのキーコード</li><li><strong>Audio</strong>: オーディオ切り替え・制御キーコード</li><li><strong>Haptic</strong>: ハプティックフィードバック切り替え・制御キーコード</li><li><strong>Media Playback</strong>: 再生/停止/音量/トラック制御</li><li><strong>Locking Keys</strong>: Locking Caps Lock、Num Lock、Scroll Lock</li><li><strong>App / Browser</strong>: アプリケーション起動・ブラウザナビゲーションキー</li><li><strong>System Control</strong>: システム電源、スリープ、ウェイク</li><li><strong>Boot</strong>: ブートローダーモード (QK_BOOT)</li></ul>
+<blockquote><p><strong>Note</strong>: MIDI タブは MIDI 対応キーボードでのみ表示されます。表示される場合、System と Lighting の間に配置されます。</p></blockquote>
+<h3 id="3-5-lighting">3.5 Lighting</h3>
+<p>バックライトと RGB ライティング制御のキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-lighting.png" alt="Lighting タブ" class="doc-img" loading="lazy"></div>
+<ul><li>RGB Matrix 制御</li><li>RGB Lighting 制御</li><li>バックライト制御</li><li>LED Matrix 制御</li></ul>
+<h3 id="3-6-tap-hold-tap-dance">3.6 Tap-Hold / Tap Dance</h3>
+<p>タップとホールドで異なる動作を割り当てるキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-tapDance.png" alt="Tap-Hold / Tap Dance タブ" class="doc-img" loading="lazy"></div>
+<p>Tap Dance セクションは全エントリを一覧表示する<strong>タイルグリッドプレビュー</strong>を備えています:</p>
+<div class="img-wrap"><img src="screenshots/td-tile-grid.png" alt="Tap Dance タイルグリッド" class="doc-img" loading="lazy"></div>
+<ul><li>各タイルにはエントリ番号と設定済みアクションの概要が表示されます</li><li>設定済みエントリはタップ/ホールドアクションを表示し、未設定タイルは番号のみ表示</li><li>タイルをクリックして対応するエントリの Tap Dance 編集モーダルを直接開きます</li><li>各エントリにタップ・ホールド・ダブルタップなどの動作を設定できます</li><li>下部の <strong>Edit JSON</strong> ボタンで全エントリを JSON として一括編集できます (§5.6)</li></ul>
+<h3 id="3-7-macro">3.7 Macro</h3>
+<p>マクロキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-macro.png" alt="Macro タブ" class="doc-img" loading="lazy"></div>
+<p>Macro セクションは全エントリを一覧表示する<strong>タイルグリッドプレビュー</strong>を備えています:</p>
+<div class="img-wrap"><img src="screenshots/macro-tile-grid.png" alt="Macro タイルグリッド" class="doc-img" loading="lazy"></div>
+<ul><li>各タイルにはマクロ番号と記録されたシーケンスのプレビューが表示されます</li><li>設定済みエントリはキーアクションの概要を表示し、未設定タイルは番号のみ表示</li><li>タイルをクリックして対応するエントリの Macro 編集モーダルを直接開きます</li><li>キー入力のシーケンスをマクロとして登録できます</li><li>下部の <strong>Edit JSON</strong> ボタンで全エントリを JSON として一括編集できます (§5.6)</li></ul>
+<h4 id="macro-編集モーダル-リストモードと編集モード">Macro 編集モーダル — リストモードと編集モード</h4>
+<p>マクロアクションを開くと、Macro モーダルの同じ行が 2 つの表示モードを持ちます:</p>
+<ul><li><strong>リストモード</strong>（デフォルト）: アクションのキーコードはクリック可能なタイルとして表示され、末尾に点線の <strong>追加スロット</strong>が続きます。キーコードタイルを<strong>単クリック</strong>するとその位置が編集モードに切り替わります。点線スロットを<strong>単クリック</strong>で選択、<strong>ダブルクリック</strong>で空クエリのキーコードポップオーバーが開きます（キーマップエディタと同じ挙動）。以前の鉛筆「編集」アイコンは廃止され、クリックだけが操作手段です</li><li><strong>編集モード</strong>: キーコードピッカーが行の下に常時表示されます。各キーコードタイルにはホバー時の <strong>×</strong> 削除ボタンが表示され、Tap 行には編集モードを抜ける <strong>Close</strong> ボタンが表示されます。ピッカーやキーコードポップオーバーでの選択は <strong>ステージング</strong> され、行の見た目は更新されますが、下部の <strong>Save</strong> ボタンまたは <strong>Enter</strong> キーを押すまではコミットされません。フッターには、既存アクションを編集中のときのみ <strong>Revert</strong> ConfirmButton が追加表示されます（Add Action で新しく追加したアクションを編集している場合は、戻す先がないため Revert は非表示）。Save と Revert は、ピックによって実際に変更が生じるまでは disabled です。<strong>Escape</strong>・行の <strong>Close</strong> ボタン・<strong>Revert</strong>・ピッカー / アクションリスト / フッター / キーポップオーバー以外をクリックすると、Add keycode で追加したスロットや新規追加アクション丸ごとまで含めて <strong>in-flight 編集をすべてロールバック</strong> し、編集モードを抜けます。編集中にスロットを削除した場合は、セッションを抜けずに選択位置をずらして編集を継続します。</li></ul>
+<p>編集中に空のキーコードアクションは許容されますが、保存・お気に入りエクスポート時に<strong>自動的に正規化</strong>され取り除かれます。</p>
+<h4 id="記録中のロック">記録中のロック</h4>
+<p>組み込みレコーダーがキーストロークを記録中は、誤編集を防ぐために Macro モーダルが強制的に無効化状態になります:</p>
+<ul><li>Add Action セレクト、Text Editor トグル、Clear、Revert、下部の <strong>Save</strong> ボタンがすべて disabled</li><li>既存の MacroActionItem と KeycodeField は native <code class="ic">disabled</code> 属性で無効化され、Tab / hover / クリックが全て抑制されます</li><li>インラインお気に入りパネルは幅を保ったまま非表示になり、レイアウトが跳ねません</li><li>モーダル右上の Close ボタンと背景クリックは無効です。記録を止めるまでモーダルは閉じられません</li><li>リストモード用フッターの Clear / Revert / Save は記録中も表示されますが disabled になります。編集モード中はリストモード用の Clear / Revert は非表示ですが、編集モード用の Save（および既存編集時の Revert）は disabled 状態でそのまま表示されます</li></ul>
+<h3 id="3-8-combo">3.8 Combo</h3>
+<p>同時押しキーの組み合わせ用キーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-combo.png" alt="Combo タブ" class="doc-img" loading="lazy"></div>
+<p>Combo タブは全エントリを一覧表示する<strong>タイルグリッドプレビュー</strong>を備えています。「これらの機能はキーボード全体に適用されます（現在のレイヤーだけではありません）」という注記が表示されます。</p>
+<ul><li>各タイルには Combo 番号とサマリー（例: 「A + B → C」）が表示されます</li><li>タイルをクリックして対応するエントリの Combo 編集モーダルを直接開きます (§5.2)</li><li>Combo キーコード (CMB_000〜CMB_031) をキーに割り当てて Combo をトリガーできます</li><li>下部の <strong>Settings: Configuration</strong> ボタンから Combo タイムアウト設定モーダル（例: Combo time out period）を開けます</li><li>下部の <strong>Edit JSON</strong> ボタンで全エントリを JSON として一括編集できます (§5.6)</li></ul>
+<h3 id="3-9-key-override">3.9 Key Override</h3>
+<p>特定の修飾キーを押している時にキー出力を置き換えるキーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-keyOverride.png" alt="Key Override タブ" class="doc-img" loading="lazy"></div>
+<p>Key Override タブは全エントリを一覧表示する<strong>タイルグリッドプレビュー</strong>と設定エリアを備えています。</p>
+<ul><li>各タイルにはオーバーライド番号とサマリーが表示されます</li><li>タイルをクリックして対応するエントリの Key Override 編集モーダルを直接開きます (§5.3)</li><li>下部の <strong>Edit JSON</strong> ボタンで全エントリを JSON として一括編集できます (§5.6)</li></ul>
+<h3 id="3-10-alt-repeat-key">3.10 Alt Repeat Key</h3>
+<p>コンテキスト対応の代替リピートキーバインディング用キーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-altRepeatKey.png" alt="Alt Repeat Key タブ" class="doc-img" loading="lazy"></div>
+<p>Alt Repeat Key タブは全エントリを一覧表示する<strong>タイルグリッドプレビュー</strong>と設定エリアを備えています。</p>
+<ul><li>各タイルにはエントリ番号とサマリーが表示されます</li><li>タイルをクリックして対応するエントリの Alt Repeat Key 編集モーダルを直接開きます (§5.4)</li><li>下部の <strong>Edit JSON</strong> ボタンで全エントリを JSON として一括編集できます (§5.6)</li></ul>
+<h3 id="3-11-behavior">3.11 Behavior</h3>
+<p>QMK の高度な動作機能用のキーコードです。</p>
+<ul><li><strong>Magic</strong>: キーボード動作のスワップやトグル用 Magic キーコード</li><li><strong>Mode</strong>: NKRO トグル、モード切替キーコード</li><li><strong>Auto Shift</strong>: Auto Shift のトグルと設定キーコード</li><li><strong>Swap Hands</strong>: Swap Hands キーコードと Swap Hands Tap バリアント</li><li><strong>Caps Word</strong>: Caps Word トグル</li></ul>
+<h3 id="3-12-user">3.12 User</h3>
+<p>ユーザー定義キーコードです。</p>
+<div class="img-wrap"><img src="screenshots/tab-user.png" alt="User タブ" class="doc-img" loading="lazy"></div>
+<ul><li>ファームウェアで定義されたカスタムキーコード（例: <code class="ic">CUSTOM_1</code>、<code class="ic">CUSTOM_2</code>）</li><li><code class="ic">keymap.c</code> エクスポート時、カスタムキーコードは汎用の <code class="ic">USER00</code>/<code class="ic">USER01</code> ではなく設定された名前で出力され、<code class="ic">enum custom_keycodes</code> ブロックが自動生成されます</li></ul>
+<h3 id="3-13-keyboard-デバイスピッカー">3.13 Keyboard（デバイスピッカー）</h3>
+<p>Keyboard タブでは、他の接続中キーボードや保存済みファイルからキーコードをコピーできます。</p>
+<blockquote><p><strong>使用例:</strong> キーボードの編集中に、手元にない別のキーボードのキーマップが気になった場合。あらかじめデータを保存しておけば、このタブの <strong>File</strong> ソースから呼び出してキーマップを確認し、キーコードをそのままコピーできます。</p></blockquote>
+<p><strong>デバイスリスト</strong></p>
+<div class="img-wrap"><img src="screenshots/keyboard-tab-device-list.png" alt="Keyboard タブ — デバイスリスト" class="doc-img" loading="lazy"></div>
+<p>Keyboard タブを開くと、接続中の Vial 対応キーボードの一覧が表示されます。デバイスの抜き差しはリアルタイムで反映されます。</p>
+<ul><li>デバイスをクリックするとキーマップが読み込まれます。接続中のキーボードは即座に表示、それ以外は一時的な USB 接続でプローブされます</li></ul>
+<div class="img-wrap"><img src="screenshots/keyboard-tab-keymap.png" alt="Keyboard タブ — キーマップ表示" class="doc-img" loading="lazy"></div>
+<ul><li>表示されたキーボードのキーをクリックすると、メインキーマップの選択中キーにそのキーコードが割り当てられます</li><li>Ctrl+クリックで複数選択、Shift+クリックで範囲選択</li><li>右下のレイヤーボタンでレイヤーを切り替え</li><li>ズームコントロール（+ / 数値入力 / −）でピッカーキーボードのサイズを調整 (30%〜200%)。別のキーボードを表示する場合、保存済みズームレベルが自動で読み込まれます</li><li>Escape で選択を解除</li></ul>
+<p><strong>ファイルソース</strong></p>
+<p>下部の <strong>File</strong> ボタンをクリックするとファイルソースに切り替わります。保存済みキーボードスナップショットの閲覧や <code class="ic">.pipette</code> ファイルの読み込みが可能で、同じキーコードピッキング操作が使えます。</p>
+<blockquote><p><strong>注意</strong>: キーピッカーでは V2 形式（undefined）ファイルのみ対応しています。レガシー V1 形式のファイルを選択すると、キーボードを接続してキーマップを開きデータを移行するよう警告が表示されます。</p></blockquote>
+<p><strong>複合キーコード</strong></p>
+<p>ピッカーで複合キー（例: <code class="ic">LT1(KC_SPC)</code>）をクリックすると、フルキーコードがそのまま割り当てられます。インナー/アウターの分割は行われず、完全なキーコードがコピーされます。</p>
+<blockquote><p><strong>注意</strong>: マスクキーのインナー部分を編集中（例: undefined の undefined を選択中）は Keyboard タブは非表示になります。複合キーコードをインナーバイトに割り当てることはできないためです。</p></blockquote>
+<h3 id="3-14-キーコードオーバーレイパネル">3.14 キーコードオーバーレイパネル</h3>
+<p>キーコードオーバーレイパネルはエディタツールと保存機能への素早いアクセスを提供します。キーコードタブバー右端のパネルボタンでトグルします。</p>
+<p><strong>Settings タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/overlay-tools.png" alt="オーバーレイパネル — Settings" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Key Editor Zoom</strong>: キーエディタ画面のみに適用される UI 表示倍率（50–200%）。未設定時はグローバル UI ズーム (§6.5) が使用されます。キーボード単位で保存・同期されます</li><li><strong>Auto Advance</strong>: キーコード割り当て後に次のキーへ自動移動する機能の切替</li><li><strong>Instant Key Selection</strong>: キーの即時選択モードの切替 (動作の詳細は §2.2 参照)</li><li><strong>キーピッカーでShiftキーを分離</strong>: 複合キーコードの分割表示を切替 (例: Mod-Tap を 2 つに分けて表示)</li><li><strong>Key Tester</strong>: Matrix Tester モードの切替 (対応キーボードのみ)</li><li><strong>Security</strong>: ロック状態 (Locked/Unlocked) の表示と Lock ボタン</li><li><strong>Import</strong>: <code class="ic">.vil</code> ファイルからの復元、またはカスタム JSON 定義のサイドロード</li><li><strong>Reset Keyboard Data</strong>: キーボードを初期状態に戻す</li></ul>
+<p><strong>Save タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/overlay-save.png" alt="オーバーレイパネル — Save" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Export Current State</strong>: キーマップを <code class="ic">.vil</code>、<code class="ic">keymap.c</code>、PDF キーマップチートシート、PDF レイアウトエクスポート（キーアウトラインと Tap Dance・Macro・Combo・Key Override・Alt Repeat Key のサマリーページ付き）としてダウンロード</li><li><strong>Save Current State</strong>: 現在のキーボード状態をラベル付きで保存</li><li><strong>Synced Data</strong>: 保存済みスナップショットの一覧。Load・Rename・Delete・Export の操作が可能</li><li>エディタ設定パネル (§6) と同じ Save パネルです</li></ul>
+<p><strong>Layout タブ</strong> (利用可能時)</p>
+<p>一部のキーボードはレイアウトオプションに対応しています (§2.5 参照)。対応キーボードでは Layout タブがオーバーレイパネルの最初のタブとして表示され、同じレイアウトオプションにアクセスできます。</p>
+<hr>
+<h2 id="4-ツールバー">4. ツールバー</h2>
+<p>キーマップエディタ左側のツールバーには以下の機能があります。</p>
+<div class="img-wrap"><img src="screenshots/toolbar.png" alt="ツールバー" class="doc-img" loading="lazy"></div>
+<h3 id="4-1-ズーム">4.1 ズーム</h3>
+<p>キーボードレイアウトの表示倍率を変更します。範囲: 30%〜200% (デフォルト 100%)。</p>
+<div class="img-wrap"><img src="screenshots/zoom-in.png" alt="ズームイン" class="doc-img" loading="lazy"></div>
+<ul><li>(+) ボタンでズームイン</li><li>(-) ボタンでズームアウト</li><li>エディタ設定でも調整可能です</li><li>ズームレベルはキーボード毎に保存され、再接続時に自動で復元されます</li></ul>
+<h3 id="4-2-元に戻す-やり直し-undo-redo-キーマップヒストリー">4.2 元に戻す / やり直し (Undo / Redo) — キーマップヒストリー</h3>
+<p>キーマップエディタはキーコードの変更履歴（ヒストリー）を自動的に記録します。このヒストリーを遡って変更の取り消し（Undo）や、やり直し（Redo）が可能です。</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">操作方法</th><th style="text-align:left">対象範囲</th><th style="text-align:left">使い方</th></tr></thead><tbody><tr><td style="text-align:left"><strong>キーボードショートカット</strong></td><td style="text-align:left">ヒストリー全体（最大値は Max Keymap History、デフォルト 100）</td><td style="text-align:left">Ctrl/Cmd+Z (Undo), Ctrl+Y / Ctrl/Cmd+Shift+Z (Redo)</td></tr><tr><td style="text-align:left"><strong>ツールバーボタン</strong></td><td style="text-align:left">ヒストリー全体</td><td style="text-align:left">左ツールバーの Undo / Redo ボタン</td></tr><tr><td style="text-align:left"><strong>ポップオーバーボタン</strong></td><td style="text-align:left">直近1件の変更のみ（開いているキーと一致する場合）</td><td style="text-align:left">ポップオーバーフッターの Undo / Redo ボタン（§2.4 参照）</td></tr></tbody></table></div>
+<ul><li>ヒストリーはキーボード切替時または切断時にクリアされます</li><li>最大保持数は設定 → デフォルト → <strong>Max Keymap History</strong> で変更可能です（§6.1 参照）</li><li>すべてのキーマップ変更パスが追跡対象: 単一キー編集、ポップオーバー選択、Mod Mask 変更、貼り付け、レイヤーコピー</li></ul>
+<h3 id="4-3-タイピングテスト">4.3 タイピングテスト</h3>
+<p>タイピング練習機能です。現在のキーマップでタイピングテストを行えます。テスト中はキーボードレイアウトが下部に表示され、キー入力がリアルタイムでハイライトされるため、物理キーマップと画面表示の一致を確認できます。</p>
+<p>ステータスバーの <strong>Typing Test</strong> ボタンをクリックしてテストモードに入ります。</p>
+<h4 id="モード">モード</h4>
+<p>上部のモードタブから 3 つのテストモードを選択できます:</p>
+<p><strong>Words モード</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-words-waiting.png" alt="タイピングテスト — Words モード" class="doc-img" loading="lazy"></div>
+<ul><li>固定数のランダムな単語をタイプ (15 / 30 / 60 / 120 語)</li><li>全ての単語を入力すると終了</li></ul>
+<p><strong>Time モード</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-time-mode.png" alt="タイピングテスト — Time モード" class="doc-img" loading="lazy"></div>
+<ul><li>制限時間内にできるだけ多くの単語をタイプ (15 / 30 / 60 / 120 秒)</li><li>残り時間がカウントダウンで表示</li></ul>
+<p><strong>Quote モード</strong></p>
+<div class="img-wrap"><img src="screenshots/typing-test-quote-mode.png" alt="タイピングテスト — Quote モード" class="doc-img" loading="lazy"></div>
+<ul><li>実際の引用文をタイプ (short / medium / long / all)</li><li>完了後に引用元が表示</li></ul>
+<h4 id="オプション">オプション</h4>
+<div class="img-wrap"><img src="screenshots/typing-test-words-options.png" alt="タイピングテスト — オプション付き" class="doc-img" loading="lazy"></div>
+<p>Words モードと Time モードでは追加オプションを切り替えできます:</p>
+<ul><li><strong>Punctuation</strong>: 句読点（カンマ、ピリオドなど）を単語リストに追加</li><li><strong>Numbers</strong>: 数字を単語リストに追加</li></ul>
+<p>Quote モードではこれらのトグルは利用できません（原文がそのまま使用されます）。</p>
+<h4 id="テスト中">テスト中</h4>
+<div class="img-wrap"><img src="screenshots/typing-test-running.png" alt="タイピングテスト — タイピング中" class="doc-img" loading="lazy"></div>
+<p>タイピング中は以下の統計情報がリアルタイムで表示されます:</p>
+<ul><li><strong>WPM</strong>: Words Per Minute（現在のタイピング速度）</li><li><strong>Accuracy</strong>: 正確に入力された文字の割合</li><li><strong>Time</strong>: 経過時間（Time モードでは残り時間）</li><li><strong>Words</strong>: 現在の単語 / 総単語数</li></ul>
+<p>正しく入力された単語は緑色に変わります。誤った文字は赤色でアンダーライン表示されます。カーソルは入力に応じて進み、単語は自動的にスクロールします。</p>
+<ul><li>リスタートボタン (↺) を押すといつでもテストを再開できます</li><li>Escape キーでタイピングテストモードを終了します</li><li>タイピングテスト中はステータスバーの Disconnect ボタンが非表示になります。切断するには Escape キーか Typing Test ボタンで先にエディタに戻ってから切断してください</li><li>テスト領域下部のキーボードレイアウトは、Vial マトリクステスタープロトコルを通じてキー入力をリアルタイムで表示します</li></ul>
+<h4 id="typing-view-ビューオンリーモード">Typing View（ビューオンリーモード）</h4>
+<p>Typing View はキーボードレイアウトのみをコンパクトなリサイズ可能ウィンドウに表示します。他のアプリケーションの上に重ねて練習するのに最適です。</p>
+<p>ステータスバーの <strong>Typing View</strong> ボタン（タイピングテスト非アクティブ時に表示）をクリックしてビューオンリーモードに入ります。</p>
+<div class="img-wrap"><img src="screenshots/view-only-compact.png" alt="ビューオンリー — コンパクトウィンドウ" class="doc-img" loading="lazy"></div>
+<ul><li>キーボードレイアウトのみが表示され、キー入力がリアルタイムでハイライトされます</li><li>ツールバー、キーコードパレット、タイピングテスト UI、ステータスバーは非表示になります</li><li>ウィンドウはリサイズ時にアスペクト比を維持します</li></ul>
+<p><strong>メニューペイン</strong></p>
+<div class="img-wrap"><img src="screenshots/view-only-controls.png" alt="ビューオンリー — コントロール" class="doc-img" loading="lazy"></div>
+<p>キーボードエリアの任意の場所をクリックするとメニューペイン（右下ポップアップ）が開閉します。ペイン上部は <strong>Window</strong> と <strong>REC</strong> の 2 タブに分かれており、下部に <strong>Base</strong> レイヤー選択と <strong>タイピングビュー終了</strong> が両タブ共通で並びます。</p>
+<p><strong>Window タブ</strong>（デフォルト）</p>
+<ul><li><strong>初期サイズ</strong>: ウィンドウをデフォルトの計算されたサイズにリセット</li><li><strong>フィット</strong>: アスペクト比を維持しながら、ウィンドウの高さを現在の幅に合わせて調整</li><li><strong>最前面</strong>: ウィンドウを常に最前面に表示（Wayland では利用不可）</li></ul>
+<p><strong>REC タブ</strong></p>
+<p>録画コントロールと Monitor App トグル。詳細は下の <strong>タイピング分析の記録</strong> を参照。</p>
+<p><strong>共通コントロール</strong>（両タブで表示）</p>
+<ul><li><strong>Base</strong>: 表示するレイヤーを選択（複数レイヤーがある場合）</li><li><strong>タイピングビュー終了</strong>: フルエディタに戻る</li></ul>
+<p>Escape キーを押すかキーボードエリアを再度クリックするとペインが閉じます。ウィンドウにマウスを乗せるとヒントテキストが下部に表示されます。ウィンドウサイズ、最前面表示の設定、現在のメニュータブはキーボードごとに保存されます。</p>
+<blockquote><p><strong>注意</strong>: Typing View モード中はオートロックが停止されます。ビューオンリーモード中にキーボードが切断された場合、ウィンドウは自動的に通常サイズに復元されます。</p></blockquote>
+<h4 id="タイピング分析の記録">タイピング分析の記録</h4>
+<p>Typing View を開いている間、メニューペインの <strong>REC</strong> タブからキーごとと 1 分ごとの統計を記録できる。記録結果は分析ページ（§1.4）に流れる。デフォルトはオフ。</p>
+<div class="img-wrap"><img src="screenshots/typing-test-rec-tab.png" alt="タイピングテスト — REC タブ" class="doc-img" loading="lazy"></div>
+<p><strong>開始 / 停止</strong></p>
+<p>トグルをクリックすると記録の開始 / 停止が切り替わる。ボタンは待機中は <strong>開始</strong>、記録中は <strong>停止</strong> と表示される。記録中は Typing View 上部に「記録中」インジケータが表示され、データが捕捉されているかがひと目で分かる。</p>
+<p>最初に <strong>開始</strong> を押したときは、規約モーダルが表示される:</p>
+<div class="img-wrap"><img src="screenshots/typing-test-rec-consent.png" alt="タイピングテスト — 記録の同意" class="doc-img" loading="lazy"></div>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">セクション</th><th style="text-align:left">項目</th></tr></thead><tbody><tr><td style="text-align:left"><strong>収集する情報</strong></td><td style="text-align:left">1 分単位の文字頻度・キー押下回数（row / col / layer / keycode、tap / hold 別）・タイピング速度の分布（interval パーセンタイル）・アクティブなアプリケーション名（Monitor App ON 時のみ。1 分内に複数アプリを観測した場合は不明として記録）</td></tr><tr><td style="text-align:left"><strong>収集しない情報</strong></td><td style="text-align:left">個別の打鍵タイミング・入力テキスト / パスワード / 特定の単語・ウィンドウタイトル / URL / ファイルパス</td></tr></tbody></table></div>
+<p><strong>有効化</strong> で同意し記録を開始する。同意はアプリ設定に保存され（同期対象外）、以降このダイアログは表示されない。<strong>キャンセル</strong> で開始をやめると、再度 <strong>開始</strong> を押したときにダイアログが再表示される。</p>
+<p><strong>Monitor App</strong></p>
+<p>Monitor App トグルが ON で、かつ REC が <strong>停止</strong>（記録中）状態のとき、Pipette は flush ごとに 1 回だけアクティブなアプリ名を解決して各 1 分にタグ付けする。1 分内に単一アプリのみ観測した minute はそのアプリ名でタグされ、複数アプリを観測した minute は <code class="ic">Unknown / Mixed</code> とタグされる。タグは分析の <strong>アプリ</strong> フィルタと <strong>アプリ別</strong> タブの基礎データになる。</p>
+<ul><li>REC が <strong>開始</strong>（記録未スタート）状態のときはトグルが薄く表示される。REC を先に開始する流れに UI を寄せている</li><li>on/off 状態は AppConfig で管理（このマシン限定）。他のマシンには同期 <strong>されない</strong></li><li><strong>Linux / Wayland</strong>: FocusedWindow GNOME Shell 拡張が必要（README 参照）。未導入だと毎分 <code class="ic">null</code> で記録される</li><li><strong>macOS</strong>: アクセシビリティ権限が必要（README 参照）。未付与だと毎分 <code class="ic">null</code> で記録される</li><li>Monitor App をオフにしても既存タグはデータベースに残る。オフにした後の minute だけがタグなしになる</li></ul>
+<p><strong>View Analytics</strong></p>
+<p>そのキーボードの分析ページに直接ジャンプする。記録したストリームを即確認できる。戻ると Typing View に戻る。</p>
+<h4 id="表示モードの記憶と自動復元">表示モードの記憶と自動復元</h4>
+<p>キーボードごとに最後の表示モード（Editor / Typing Test / Typing View）が記憶され、次回同じキーボードに接続したときに自動で復元されます:</p>
+<ul><li><strong>Editor</strong>: そのままエディタ画面を表示します</li><li><strong>Typing Test</strong>: 自動的にタイピングテストモードに遷移します。キーボードがロックされている場合は Unlock ダイアログが表示され、解除後にテストへ入ります</li><li><strong>Typing View</strong>: 自動的にコンパクトウィンドウのビューオンリーモードに遷移します。キーボードがロックされている場合は Unlock ダイアログを経由します</li></ul>
+<p>表示モードはキーボードレイアウト、ズーム倍率、ウィンドウサイズなどと同様にキーボードごとに保存され、Pipette Hub 同期を有効にしている場合は他の端末にも同期されます（§7 参照）。</p>
+<hr>
+<h2 id="5-詳細設定エディタ">5. 詳細設定エディタ</h2>
+<p>各キーコードタブから詳細設定モーダルを開けます。Lighting はタブ下部の <strong>Settings: Configuration</strong> ボタンから、Combo・Key Override・Alt Repeat Key の詳細エディタはそれぞれのタブでエントリをクリックして開きます。</p>
+<h3 id="5-1-ライティング設定">5.1 ライティング設定</h3>
+<p>Lighting タブの <strong>Settings: Configuration</strong> ボタンから開きます。RGB ライティングの色やエフェクトを設定できます。</p>
+<div class="img-wrap"><img src="screenshots/lighting-modal.png" alt="ライティング設定" class="doc-img" loading="lazy"></div>
+<ul><li>HSV カラーピッカーで色を選択</li><li>プリセットパレットから色を選択</li><li>エフェクトとスピードを調整</li><li>Save ボタンで保存</li></ul>
+<h3 id="5-2-combo">5.2 Combo</h3>
+<p>複数キーの同時押しで別のキーを発動させる設定です。Combo タブにインラインタイルグリッドが表示され、エントリをクリックすると詳細エディタモーダルが直接開きます。</p>
+<p><strong>タイルグリッド (Combo タブ)</strong></p>
+<div class="img-wrap"><img src="screenshots/combo-modal.png" alt="Combo 一覧" class="doc-img" loading="lazy"></div>
+<p>Combo タブに番号付きリスト (0--31) が表示されます。設定済みエントリはサマリー表示（例: 「A + B → C」）。エントリをクリックして詳細エディタへ。Combo キーコード (Combo On, Combo Off, Combo Toggle) がリストの下に表示されます。下部の <strong>Settings: Configuration</strong> ボタンから QMK の Combo タイムアウト設定モーダル（例: Combo time out period）を開けます。</p>
+<p><strong>詳細エディタ</strong></p>
+<div class="img-wrap"><img src="screenshots/combo-detail.png" alt="Combo 詳細" class="doc-img" loading="lazy"></div>
+<ul><li>左パネル: Combo エディタ (Key 1--4, Output フィールド)。</li><li>右パネル: インラインお気に入りパネル (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> ボタンで全フィールドをリセット (2段階確認付き)</li><li><strong>Revert</strong> で最後に保存した状態に復元 (2段階確認付き)</li><li><strong>Save</strong> ボタンで変更をキーボードに書き込み</li></ul>
+<h3 id="5-3-key-override">5.3 Key Override</h3>
+<p>特定のキー入力を別のキーに置き換える設定です。Key Override タブにインラインタイルグリッドが表示され、エントリをクリックすると詳細エディタモーダルが直接開きます。</p>
+<p><strong>タイルグリッド (Key Override タブ)</strong></p>
+<div class="img-wrap"><img src="screenshots/key-override-modal.png" alt="Key Override 一覧" class="doc-img" loading="lazy"></div>
+<p>番号付きリストが表示されます。設定済みエントリはサマリー表示。エントリをクリックして詳細エディタへ。</p>
+<p><strong>詳細エディタ</strong></p>
+<div class="img-wrap"><img src="screenshots/key-override-detail.png" alt="Key Override 詳細" class="doc-img" loading="lazy"></div>
+<ul><li>左パネル: トリガーキーと置換キーの設定、有効/無効トグル、レイヤーと修飾キー条件</li><li>右パネル: インラインお気に入りパネル (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> ボタンで全フィールドをリセット (2段階確認付き)</li><li><strong>Revert</strong> で最後に保存した状態に復元 (2段階確認付き)</li><li><strong>Save</strong> ボタンで変更をキーボードに書き込み</li></ul>
+<h3 id="5-4-alt-repeat-key">5.4 Alt Repeat Key</h3>
+<p>Repeat Key の代替動作を設定します。Alt Repeat Key タブにインラインタイルグリッドが表示され、エントリをクリックすると詳細エディタモーダルが直接開きます。</p>
+<p><strong>タイルグリッド (Alt Repeat Key タブ)</strong></p>
+<div class="img-wrap"><img src="screenshots/alt-repeat-key-modal.png" alt="Alt Repeat Key 一覧" class="doc-img" loading="lazy"></div>
+<p>番号付きリストが表示されます。設定済みエントリはサマリー表示。エントリをクリックして詳細エディタへ。</p>
+<p><strong>詳細エディタ</strong></p>
+<div class="img-wrap"><img src="screenshots/alt-repeat-key-detail.png" alt="Alt Repeat Key 詳細" class="doc-img" loading="lazy"></div>
+<ul><li>左パネル: Last Key、Alt Key、有効/無効トグル、Allowed Mods、Options (DefaultToThisAltKey, Bidirectional, IgnoreModHandedness)</li><li>右パネル: インラインお気に入りパネル (Save Current State / Synced Data / Import / Export All)</li><li><strong>Clear</strong> ボタンで全フィールドをリセット (2段階確認付き)</li><li><strong>Revert</strong> で最後に保存した状態に復元 (2段階確認付き)</li><li><strong>Save</strong> ボタンで変更をキーボードに書き込み</li></ul>
+<h3 id="5-5-お気に入り-favorites">5.5 お気に入り (Favorites)</h3>
+<p>各エディタモーダル (Tap Dance、Macro、Combo、Key Override、Alt Repeat Key) には、エディタの右側にインライン<strong>お気に入りパネル</strong>があります。</p>
+<div class="img-wrap"><img src="screenshots/inline-favorites.png" alt="インラインお気に入りパネル" class="doc-img" loading="lazy"></div>
+<p>インラインお気に入りパネルの機能:</p>
+<ul><li><strong>Save Current State</strong>: ラベルを入力して Save をクリックすると、現在のエントリ設定が保存されます<ul><li><strong>Import</strong> / <strong>Export</strong> ボタン: <code class="ic">.pipette-fav</code> ファイルをインポートして現在のエントリに適用、または現在のエントリ設定をストアに保存せずに <code class="ic">.pipette-fav</code> ファイルとしてエクスポートできます。各操作後に「Imported」/「Exported」のインラインフィードバックが表示されます。</li></ul></li><li><strong>Synced Data</strong>: 保存済みのエントリが一覧表示され、Load・Rename・Delete・Export の操作が可能</li><li><strong>Import</strong> / <strong>Export All</strong>: フッターのボタンでファイルからのインポートや全エントリの一括エクスポートが可能</li></ul>
+<p>Synced Data リスト内:</p>
+<ul><li><strong>Load</strong>: 保存した設定を現在のエントリに適用</li><li><strong>Rename</strong>: 保存したエントリのラベルを変更（Hub にアップロード済みの場合、Hub 上のタイトルも同期されます）</li><li><strong>Delete</strong>: 保存したエントリを削除</li><li><strong>Export</strong>: 個別の保存済みエントリをファイルとしてダウンロード</li></ul>
+<p>Pipette Hub 接続時は、各エントリに Hub アクションも表示されます:</p>
+<div class="img-wrap"><img src="screenshots/hub-fav-inline.png" alt="インラインお気に入り — Hub アクション" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Upload to Hub</strong>: お気に入りエントリを Pipette Hub にフィーチャー投稿としてアップロード</li><li><strong>Update on Hub</strong>: 最新の設定で Hub 上の投稿を更新</li><li><strong>Remove from Hub</strong>: Hub からエントリを削除（2段階確認付き）</li><li><strong>Open in Browser</strong>: Hub の個別投稿ページをブラウザで開く</li></ul>
+<h3 id="5-6-json-エディタ">5.6 JSON エディタ</h3>
+<p>各機能タブ (Tap Dance、Macro、Combo、Key Override、Alt Repeat Key) の下部にある <strong>Edit JSON</strong> ボタンをクリックすると、全エントリを生の JSON テキストとして一括編集できる JSON エディタモーダルが開きます。</p>
+<div class="img-wrap"><img src="screenshots/json-editor-tap-dance.png" alt="JSON エディタ — Tap Dance" class="doc-img" loading="lazy"></div>
+<ul><li><strong>テキストエリア</strong>: 全エントリを JSON 配列として編集。変更はリアルタイムでバリデーションされ、パースエラーはエディタ下部に表示</li><li><strong>Export</strong> (左): 現在の JSON を <code class="ic">.pipette-fav</code> ファイルとして保存（バックアップや共有用）</li><li><strong>Cancel</strong> (右): 保存せずに閉じる</li><li><strong>Save</strong> (右): パースされた JSON を適用してキーボードに書き込む</li></ul>
+<div class="img-wrap"><img src="screenshots/json-editor-macro.png" alt="JSON エディタ — Macro" class="doc-img" loading="lazy"></div>
+<p>Macro の場合、変更を保存するにはキーボードのアンロックが必要という警告が表示されます。</p>
+<blockquote><p><strong>Note</strong>: JSON エディタは全エントリを一度に変更します。不正な JSON は拒否されますが、値が正しくない有効な JSON は予期しない動作を引き起こす可能性があるため注意してください。</p>
+<p><strong>Note</strong>: お気に入りは特定のキーボードに依存しません。保存したエントリは互換性のある別のキーボードでも読み込めます。クラウド同期を有効にすると、複数デバイス間でも同期されます (§6.1 参照)。お気に入りはデバイス選択画面のデータパネルからも管理できます (§1.3 参照)。</p></blockquote>
+<hr>
+<h2 id="6-エディタ設定パネル">6. エディタ設定パネル</h2>
+<p>キーコードタブバーの保存ボタン (フロッピーディスクアイコン)、またはキーコードオーバーレイパネルの Save タブ (§3.14) からエディタ設定パネルを開けます。</p>
+<div class="img-wrap"><img src="screenshots/editor-settings-save.png" alt="エディタ設定 — Save" class="doc-img" loading="lazy"></div>
+<p>エディタ設定パネルは単一の <strong>Save</strong> パネルを提供します:</p>
+<ul><li><strong>Export Current State</strong>: キーマップを <code class="ic">.vil</code>、<code class="ic">keymap.c</code>、PDF キーマップチートシート、PDF レイアウトエクスポート（キーアウトラインと Tap Dance・Macro・Combo・Key Override・Alt Repeat Key のサマリーページ付き）としてダウンロード。エクスポート成功時に「Exported」のインラインフィードバックが表示されます。</li><li><strong>Save Current State</strong>: 現在のキーボード状態をラベル付きで保存します。Label フィールドに名前を入力して Save をクリックします。Label が空の場合は Save ボタンが無効になります。保存したスナップショットは下の Synced Data リストに表示され、読み込みや削除ができます</li><li><strong>Synced Data</strong>: 保存済みスナップショットの一覧。クリックで読み込み・名前変更・削除</li><li><strong>キーボードデータリセット</strong>: キーボードを初期状態に戻す (要注意)</li></ul>
+<blockquote><p><strong>Note</strong>: ツール設定 (Auto Advance、Key Tester、セキュリティ) はキーコードオーバーレイパネル (§3.14) にあります。キーボードレイアウトはステータスバーのクイック設定 (§9) から変更できます。Basic タブのビュータイプは Basic タブ下部のセレクターで切り替えます。ズームはツールバー (§4.1) で操作できます。レイヤー設定はエディタ左側のレイヤーパネルから直接管理します。</p></blockquote>
+<h3 id="6-1-クラウド同期-google-drive-appdatafolder">6.1 クラウド同期 (Google Drive appDataFolder)</h3>
+<p>Pipette は保存したスナップショット、お気に入り、キーボードごとの設定を Google Drive 経由で複数デバイス間で同期できます。</p>
+<p>同期はデバイス選択画面の <strong>設定</strong> モーダル (歯車アイコン) の <strong>データ</strong> タブで設定します:</p>
+<div class="img-wrap"><img src="screenshots/hub-settings-data-sync.png" alt="データタブ" class="doc-img" loading="lazy"></div>
+<p>データタブには Google アカウント、データ同期、Pipette Hub の各セクションがあります。トラブルシューティングやデータ管理の追加機能は、データパネル (§1.3) で提供されます。</p>
+<h4 id="google-アカウント">Google アカウント</h4>
+<ul><li><strong>Connect</strong> をクリックして Google アカウントでサインイン</li><li><strong>Disconnect</strong> をクリックしてサインアウト。Pipette Hub も接続中の場合は、Hub も切断される旨の警告が表示されます</li></ul>
+<h4 id="同期暗号化パスワード">同期暗号化パスワード</h4>
+<ul><li>同期データを暗号化するためのパスワードを設定します (必須)。強度インジケーターで安全なパスワードを選択できます</li><li>別のデバイスで既にパスワードが設定されている場合は、同じパスワードを入力するようヒントが表示されます</li><li><strong>パスワード変更</strong>: <strong>Change Password</strong> をクリックすると、全ての同期ファイルが新しいパスワードで再暗号化されます。データは削除されず、既存ファイルがその場で復号・再暗号化されます</li></ul>
+<p><strong>パスワード変更時のエラー</strong></p>
+<p>パスワード変更を実行できないとき、Pipette は生のエラーではなくローカライズされたメッセージを表示します。主な条件を以下に示しますが、これ以外にもネットワークや Drive 由来のエラーがそのまま表示される場合があります。</p>
+<p><strong>認証情報の失敗</strong>（この 5 種類は同期準備に使われる <code class="ic">SyncCredentialFailureReason</code> と同じ集合 — ただし <strong>同期ステータス</strong> に露出するのは 3 種類のみ）:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">理由</th><th style="text-align:left">表示メッセージ</th><th style="text-align:left">発生条件</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">unauthenticated</code></td><td style="text-align:left">「パスワードを変更する前に Google にサインインしてください。」</td><td style="text-align:left">Google にサインインしていない</td></tr><tr><td style="text-align:left"><code class="ic">noPasswordFile</code></td><td style="text-align:left">「保存済みパスワードがありません。先にパスワードを設定してください。」</td><td style="text-align:left">ローカルに同期パスワードが未設定</td></tr><tr><td style="text-align:left"><code class="ic">decryptFailed</code></td><td style="text-align:left">「既存パスワードを読み出せませんでした (OS キーチェーンに拒否されました)。」</td><td style="text-align:left">OS キーチェーンのエントリが読めない（キーチェーンリセット・プロファイル移動など）</td></tr><tr><td style="text-align:left"><code class="ic">keystoreUnavailable</code></td><td style="text-align:left">「OS キーチェーンが利用できないため、ここではパスワードを変更できません。」</td><td style="text-align:left"><code class="ic">safeStorage.isEncryptionAvailable()</code> が false を返す（キーリングなしの Linux ヘッドレス環境など）</td></tr><tr><td style="text-align:left"><code class="ic">remoteCheckFailed</code></td><td style="text-align:left">「現在のパスワードを検証するための Google Drive 接続に失敗しました。」</td><td style="text-align:left">ネットワークや Drive の障害 — 時間を置いて再試行</td></tr></tbody></table></div>
+<p><strong>操作上のエラー</strong>（理由コードは介さずメッセージが直接表示される）:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">表示メッセージ</th><th style="text-align:left">発生条件</th></tr></thead><tbody><tr><td style="text-align:left">「同期実行中のためパスワードを変更できません。」</td><td style="text-align:left">同期が実行中 — 完了を待つ</td></tr><tr><td style="text-align:left">「現在と同じパスワードには変更できません。」</td><td style="text-align:left">新しいパスワードが現在のパスワードと同じ</td></tr><tr><td style="text-align:left">「復号できないファイルがあります。先に復号できないファイルをスキャンして削除してください。」</td><td style="text-align:left">Drive に現在のパスワードで復号できないファイルがある — 先に<strong>復号不能ファイル</strong>で整理</td></tr><tr><td style="text-align:left">「同期パスワードが一致しません。暗号化パスワードを確認してください。」</td><td style="text-align:left">現在のパスワードでリモートのパスワードチェックが復号できない — 入力中のパスワードを再確認</td></tr></tbody></table></div>
+<h4 id="同期コントロール">同期コントロール</h4>
+<ul><li><strong>Auto Sync</strong>: 自動同期のオン/オフを切り替え。有効時は変更が 10 秒のデバウンスで自動同期され、3 分間隔のポーリングも行われます</li><li><strong>Sync</strong>: お気に入りと接続中のキーボードデータを手動で同期します。全キーボードではなく、お気に入りと現在接続中のキーボードのみが同期対象です</li></ul>
+<h4 id="同期ステータス">同期ステータス</h4>
+<ul><li>同期ユニット名とアイテムカウンター (current / total) で同期進捗を表示</li><li>同期ユニットが失敗した場合はエラーや部分同期の詳細が表示されます</li></ul>
+<p><strong>準備未完了の理由 (Readiness reasons)</strong></p>
+<p>同期クライアントが準備できていない場合、「未同期」の汎用メッセージではなく具体的な理由が表示されます。ここに出るのは 3 種類のみで、キーチェーン固有の失敗 (<code class="ic">decryptFailed</code>, <code class="ic">keystoreUnavailable</code>) はパスワード設定・変更フロー側に表示されます。</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">理由</th><th style="text-align:left">表示メッセージ</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">unauthenticated</code></td><td style="text-align:left">「Google にサインインして同期を開始してください。」</td></tr><tr><td style="text-align:left"><code class="ic">noPasswordFile</code></td><td style="text-align:left">「同期パスワードを設定してください。」</td></tr><tr><td style="text-align:left"><code class="ic">remoteCheckFailed</code></td><td style="text-align:left">「Google Drive に接続できません — 同期を一時停止しています。」</td></tr></tbody></table></div>
+<h4 id="復号不能ファイル">復号不能ファイル</h4>
+<ul><li>現在のパスワードで復号できない、またはその他の理由で読み取れないファイル（例: 以前のパスワードで暗号化されたファイル）</li><li><strong>Scan</strong> をクリックして復号不能ファイルを検出し、削除対象を選択して <strong>Delete Selected</strong> で Google Drive から完全に削除</li></ul>
+<h4 id="同期不可アラート">同期不可アラート</h4>
+<ul><li>同期バックエンドに接続できない場合に表示されます。<strong>Retry</strong> をクリックして再接続を試行</li></ul>
+<h4 id="データの保存先">データの保存先</h4>
+<p>同期データは <a href="https://developers.google.com/workspace/drive/api/guides/appdata" target="_blank" rel="noopener">Google Drive appDataFolder</a> に保存されます。これは Pipette のみがアクセスできる非表示のアプリ専用フォルダです。個人の Drive ファイルには一切アクセスしません。</p>
+<p>詳細は <a href="#" class="xdoc" data-doc="data" data-hash="">Data Guide</a> を参照してください。</p>
+<h4 id="データ管理">データ管理</h4>
+<p>トラブルシューティングとデータ管理機能は<strong>データ</strong>パネルで提供されます (§1.3 参照):</p>
+<ul><li><strong>Local > Application</strong>: ローカルデータのインポート/エクスポート、またはリセット対象の選択（キーボードデータ、お気に入り、アプリ設定）</li><li><strong>Sync</strong>: リモートのみのキーボードを実名で一覧表示し、クリックで個別にダウンロード可能 (§1.3 参照)。復号不能な暗号化ファイルの削除は、上記の<strong>復号不能ファイル</strong>セクションを使用</li></ul>
+<h4 id="設定-デフォルト">設定 — デフォルト</h4>
+<div class="img-wrap"><img src="screenshots/settings-defaults.png" alt="設定 — デフォルト" class="doc-img" loading="lazy"></div>
+<p>設定モーダルの Tools タブには、新しいキーボード接続時の初期設定を行う<strong>デフォルト</strong>セクションがあります:</p>
+<ul><li><strong>Keyboard Layout</strong>: 新しいキーボード接続時に使用する Key Labels のデフォルト。ドロップダウンには <strong>Key Labels</strong> ストア (§6.2) に現在インストールされているエントリだけが表示されます。QWERTY のみ built-in で、それ以外は Pipette Hub からダウンロードするか、ローカル <code class="ic">.json</code> を import してください。<strong>Key Labels Manage</strong> モーダルで設定したドラッグ順がそのままドロップダウンの並び順になります</li><li><strong>Auto Advance</strong>: デフォルトの自動移動動作</li><li><strong>Instant Key Selection</strong>: デフォルトのキーの即時選択動作 (§2.2 参照)</li><li><strong>Layer Panel Open</strong>: レイヤーパネルを展開または折りたたんだ状態で開始するか</li><li><strong>Basic View Type</strong>: Basic タブのデフォルトビュータイプ (ANSI/ISO/JIS/List)</li><li><strong>キーピッカーでShiftキーを分離</strong>: デフォルトのキーピッカーでのShift分離設定</li><li><strong>Max Keymap History</strong>: 接続中のキーボードの編集ヒストリーに保持する変更の最大数（デフォルト: 100）。ヒストリーは切断やキーボード切替でクリアされます。詳細は §4.2 を参照。</li></ul>
+<h3 id="6-2-key-labels-manage">6.2 Key Labels Manage</h3>
+<p>Tools タブには Language Packs 行の隣に <strong>Key Labels Manage</strong> 行があります。<strong>Edit</strong> をクリックすると Key Labels モーダルが開き、エディタ・分析ビュー・Layout Comparison でキーキャップ表示に使うラベルセットを管理できます。</p>
+<p>QWERTY は built-in です。それ以外のラベルセット (Dvorak, Colemak, French, Brazilian など) は Pipette Hub からダウンロードするか、ローカル <code class="ic">.json</code> を import して追加します。インストール済みエントリは Cloud Sync を経由して全デバイスで共有されるため、同じアカウントで signed in している全マシンで同じ並び順・選択状態が再現されます。</p>
+<p><strong>Installed タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/key-labels-installed.png" alt="Key Labels — Installed" class="doc-img" loading="lazy"></div>
+<p>このマシンにあるラベルセットの一覧。各行にラベル名、アップローダー名 (Hub 由来の場合)、Hub 側の最終更新日時 (<code class="ic">YYYY-MM-DD HH:mm</code>、Hub サイト表示と一致)、<code class="ic">.json</code> エクスポートショートカット、Delete ボタンが表示されます。左端のグリップをドラッグすると並び替えでき、その順序が Settings ドロップダウンとエディタ内の各 Key Labels ピッカーへ反映されます。</p>
+<p>各行の下段には Hub 操作が並びます:</p>
+<ul><li><strong>Open</strong>: Hub 投稿ページをシステムブラウザで開く (Hub 投稿に紐づく行のみ)</li><li><strong>Upload</strong>: ローカルエントリから新しい Hub 投稿を作成 (未アップロードの行のみ)</li><li><strong>Update</strong>: 現在のローカル内容を既存 Hub 投稿へ反映 (オーナーのみ)</li><li><strong>Sync</strong>: Hub の最新内容をローカルへ取り込む。ローカルでの改名やドラッグ順は維持される (自分が所有していないダウンロード行のみ表示)。Hub 側の投稿がローカルキャッシュより新しいときは Sync ボタン横に <strong>緑の点滅ドット</strong> が出ます — モーダルを開いた時に一括鮮度チェック (5 分に 1 回スロットル) が走るので、行ごとに手動チェックしなくても更新を見逃しません</li><li><strong>Remove</strong>: Hub から投稿を取り下げる。インラインで確認してから実行</li></ul>
+<p>鮮度チェックで Hub 側から投稿が消えていることを検出すると、Updated 列は赤字で <strong><code class="ic">(削除済み)</code></strong> と表示されます。その行で Sync を押しても Hub から取得できないため失敗します。</p>
+<p>QWERTY は Hub 操作も Delete も無効ですが、他の行と同じくドラッグで並び替えできます。</p>
+<p><strong>Find on Hub タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/key-labels-hub.png" alt="Key Labels — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Pipette Hub からラベルセットを検索します。2 文字以上入力すると自動で検索が走ります (debounce 付き)。<strong>Search</strong> ボタンや <strong>Enter</strong> キーでも手動トリガー可能です。結果はラベル名、アップローダー、<strong>Download</strong> または既にインストール済みの場合の <strong>Installed</strong> 表示で表します。同じ名前のファイルを再 import すると既存ローカルエントリを上書きし (<code class="ic">.json</code> の中身は置き換え、Hub リンクは保持されます)。</p>
+<p><strong>Key Label の書き方</strong></p>
+<p>Key Label の <code class="ic">.json</code> は次の 3 フィールドを持つ小さな JSON オブジェクトです。</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Brazilian (QWERTY)&quot;,
+  &quot;map&quot;: {
+    &quot;KC_2&quot;: &quot;2\n@&quot;,
+    &quot;KC_3&quot;: &quot;3\n#&quot;,
+    &quot;KC_LBRC&quot;: &quot;´\n`&quot;,
+    &quot;KC_QUOT&quot;: &quot;ç&quot;,
+    &quot;KC_GRAVE&quot;: &quot;KC_LALT&quot;
+  },
+  &quot;compositeLabels&quot;: {
+    &quot;LSFT(KC_2)&quot;: &quot;@&quot;,
+    &quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot;
+  }
+}</code></pre>
+<p>上の例の <code class="ic">&quot;KC_GRAVE&quot;: &quot;KC_LALT&quot;</code> は、<code class="ic">KC_GRAVE</code> が割り当たってるキャップに自動的に「LAlt」のキーコード組み込みラベルを描画します。値が keycode id なので <code class="ic">keycodeLabel()</code> で解決される動作です。</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">フィールド</th><th style="text-align:center">必須</th><th style="text-align:left">用途</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">はい</td><td style="text-align:left">モーダル一覧、Settings → Defaults ドロップダウン、Keycodes Overlay Panel に表示する名前</td></tr><tr><td style="text-align:left"><code class="ic">map</code></td><td style="text-align:center">はい</td><td style="text-align:left"><code class="ic">QMK キーコード ID → ラベル文字列</code>。このラベルセットがアクティブな間、Keymap Editor のキーキャップ表示に使われます</td></tr><tr><td style="text-align:left"><code class="ic">compositeLabels</code></td><td style="text-align:center">いいえ</td><td style="text-align:left"><code class="ic">map</code> と同じ形式の辞書。Composite キーコード (例: <code class="ic">LSFT(KC_2)</code>, <code class="ic">LT(0,KC_A)</code>, <code class="ic">MT(MOD_LCTL,KC_ESC)</code>) の outer / inner テキストを上書きします。上書き不要なら省略可</td></tr></tbody></table></div>
+<p>値には任意の QMK キーコード ID も渡せます。エディタは値を <code class="ic">keycodeLabel()</code> 経由で表示するため、例えば <code class="ic">&quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot;</code> と書くと自動で「LAlt」というキーコード組み込みラベルが解決されます。同じショートカットは <code class="ic">map</code> 側でも有効です (<code class="ic">&quot;KC_8&quot;: &quot;KC_LALT&quot;</code> で「LAlt」が描画される)。</p>
+<p>ラベル文字列は <code class="ic">\n</code> で区切ると行数に応じてレイアウトが切り替わります。</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">部分数</th><th style="text-align:left">レイアウト</th><th style="text-align:left">例</th></tr></thead><tbody><tr><td style="text-align:left">1</td><td style="text-align:left">中央 (従来通り)</td><td style="text-align:left"><code class="ic">&quot;8&quot;</code></td></tr><tr><td style="text-align:left">2</td><td style="text-align:left">上下分割</td><td style="text-align:left"><code class="ic">&quot;(\n8&quot;</code> → <code class="ic">(</code> の下に <code class="ic">8</code></td></tr><tr><td style="text-align:left">3</td><td style="text-align:left">上中下の 3 段スライス</td><td style="text-align:left"><code class="ic">&quot;a\nb\nc&quot;</code></td></tr><tr><td style="text-align:left">4</td><td style="text-align:left">2 × 2 の 4 分割 — 左上 / 右上 / 左下 / 右下</td><td style="text-align:left"><code class="ic">&quot;1\n2\n3\n4&quot;</code> → <code class="ic">1\|2 / 3\|4</code></td></tr><tr><td style="text-align:left">5+</td><td style="text-align:left">5 個目以降は無視されます</td><td style="text-align:left"></td></tr></tbody></table></div>
+<p>区切りで空文字列を入れると対応するスロットが空になります。<code class="ic">&quot;1\n2\n\n4&quot;</code> の場合:</p>
+<pre class="code-block"><code>1 | 2
+-----
+  | 4</code></pre>
+<p>Composite キーコード (LT, MT, modifier+key 等) は inner キー描画用の小さな矩形がキー下半分を占めるため、outer ラベルは <code class="ic">\n</code> の <strong>先頭 2 部分のみ</strong> が使われます。3 番目以降の部分は inner rect と衝突するため自動的に捨てられます。</p>
+<p><code class="ic">name</code> はローカルストア内のユニークキーでもあるため、同じ <code class="ic">name</code> の <code class="ic">.json</code> を import すると既存エントリが in-place で上書きされます (Hub 投稿との紐付けは保持)。完全な新規エントリにしたい場合は <code class="ic">name</code> を変えてから import してください。</p>
+<h3 id="6-3-language-packs-manage">6.3 Language Packs Manage</h3>
+<p>Tools タブに <strong>Language Packs</strong> 行があり、現在のアクティブな UI 言語が表示されます。<strong>Edit</strong> をクリックすると Language Packs モーダルが開きます。</p>
+<p>English は built-in です。それ以外の言語はローカル <code class="ic">.json</code> ファイルの import か Pipette Hub からのダウンロードで追加します。インストール済みパックは Cloud Sync を経由して全デバイスで共有されます。Hub に紐づくパックはアプリ起動時に自動で更新チェックが行われ、新しいバージョンがあれば自動で取得されます。</p>
+<p><strong>Installed タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/language-packs-installed.png" alt="Language Packs — Installed" class="doc-img" loading="lazy"></div>
+<p>このマシンにある言語パックの一覧。各行の左側に <strong>チェックサークル</strong> があり、クリックすると即座にアクティブな UI 言語が切り替わります。アクティブな行はアクセントカラーの枠線でハイライトされます。</p>
+<p>各行に表示される内容:</p>
+<ul><li><strong>名前</strong> (クリックでインラインリネーム)</li><li><strong>更新日時</strong> (<code class="ic">YYYY-MM-DD HH:mm</code>)</li><li>パックが現在の English ベースラインの全キーをカバーしている場合は <strong>バージョン</strong> チップ、カバーしていない場合は <strong>未設定のキー</strong> ボタン (クリックすると未翻訳キー一覧モーダルが開く)</li><li>上段に <strong>Export</strong> / <strong>Delete</strong> アクション</li><li>下段に <strong>Open</strong> / <strong>Upload</strong> / <strong>Update</strong> / <strong>Sync</strong> / <strong>Remove</strong> の Hub アクション (Key Labels §6.2 と同じパターン)</li></ul>
+<p>Hub 側の投稿がローカルキャッシュより新しいときは Sync ボタン横に <strong>緑の点滅ドット</strong> が出ます (モーダル表示中に 5 分に 1 回鮮度チェック実行)。</p>
+<p>ツールバーの <strong>Import</strong> ボタンでファイルダイアログを開き、<code class="ic">.json</code> 言語パックを import できます。同じ <code class="ic">name</code> のパックを再 import すると既存エントリが上書きされます。</p>
+<p><strong>Find on Hub タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/language-packs-hub.png" alt="Language Packs — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Pipette Hub から言語パックを検索します。2 文字以上入力すると自動で検索が走ります (debounce 付き)。結果にはパック名、バージョン、アップローダー、<strong>Download</strong> または <strong>Installed</strong> が表示されます。</p>
+<p><strong>Language Pack の書き方</strong></p>
+<p>言語パック <code class="ic">.json</code> は built-in English パックと同じ構造です。English パックを export (built-in 行 → Export) してテンプレートを取得し、値を翻訳してください:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Japanese&quot;,
+  &quot;version&quot;: &quot;0.1.0&quot;,
+  &quot;common&quot;: {
+    &quot;save&quot;: &quot;保存&quot;,
+    &quot;cancel&quot;: &quot;キャンセル&quot;
+  },
+  &quot;editor&quot;: {
+    &quot;keymap&quot;: {
+      &quot;title&quot;: &quot;キーマップ&quot;
+    }
+  }
+}</code></pre>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">フィールド</th><th style="text-align:center">必須</th><th style="text-align:left">用途</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">はい</td><td style="text-align:left">表示名および import 時の上書き判定キー</td></tr><tr><td style="text-align:left"><code class="ic">version</code></td><td style="text-align:center">はい</td><td style="text-align:left">セマンティックバージョニング文字列 (例: <code class="ic">0.1.0</code>)</td></tr><tr><td style="text-align:left">(その他のキー)</td><td style="text-align:center">はい</td><td style="text-align:left">English の構造に合わせたネスト翻訳ツリー</td></tr></tbody></table></div>
+<p>キーはドット区切りの名前空間 (例: <code class="ic">editor.keymap.title</code>) を使います。English ベースラインの全キーをカバーするパックにはバージョンチップが表示され、部分的なパックには「未設定のキー」リンクが表示されるため、翻訳者は何が残っているかを確認できます。日本語バリアントを含むサンプル言語パックもリポジトリの <a href="../sample-packs/i18n/"><code class="ic">sample-packs/i18n/</code></a> ディレクトリにあります。</p>
+<h3 id="6-4-theme-packs-manage">6.4 Theme Packs Manage</h3>
+<p>Tools タブに <strong>Theme Packs</strong> 行があり、現在アクティブなテーマパック名が表示されます (未設定の場合は空)。<strong>Edit</strong> をクリックすると Theme Packs モーダルが開きます。</p>
+<p>テーマパックはアプリケーションのカラーパレットを上書きします。built-in の Light / Dark / System テーマはそのまま使用でき、テーマパックはその上にカラーを重ねます。インストール済みパックは Cloud Sync を経由して全デバイスで共有されます。</p>
+<blockquote><p><strong>テーマパック作成者向け:</strong> カラートークンの全リファレンスとデザインのコツは <a href="#" class="xdoc" data-doc="theme" data-hash="42">Theme Pack Authoring Guide</a> を参照してください。</p></blockquote>
+<p><strong>Installed セクション</strong></p>
+<div class="img-wrap"><img src="screenshots/theme-packs-installed.png" alt="Theme Packs — Installed" class="doc-img" loading="lazy"></div>
+<p>このマシンにあるテーマパックの一覧。各行の左側に <strong>ラジオサークル</strong> があり、クリックするとそのテーマパックが即座に適用されます。アクティブな行をもう一度クリックすると選択が解除され、built-in テーマに戻ります。先頭に Light / Dark / System の 3 つの built-in オプションが表示されます。</p>
+<p>各行に表示される内容:</p>
+<ul><li><strong>名前</strong> (クリックでインラインリネーム)</li><li><strong>更新日時</strong> (<code class="ic">YYYY-MM-DD HH:mm</code>)</li><li><strong>バージョン</strong> チップ</li><li>上段に <strong>.json</strong> エクスポートショートカットと <strong>Delete</strong> ボタン</li><li>下段に <strong>Open</strong> / <strong>Upload</strong> / <strong>Update</strong> / <strong>Sync</strong> / <strong>Remove</strong> の Hub アクション (Key Labels §6.2 と同じパターン)</li></ul>
+<p>Hub 側の投稿がローカルキャッシュより新しいときは Sync ボタン横に <strong>緑の点滅ドット</strong> が出ます (モーダル表示中に 5 分に 1 回鮮度チェック実行)。</p>
+<p>ツールバーの <strong>Import</strong> ボタンでファイルダイアログを開き、<code class="ic">.json</code> テーマパックを import できます。同じ <code class="ic">name</code> のパックを再 import すると既存エントリが上書きされます。</p>
+<p><strong>Find on Hub タブ</strong></p>
+<div class="img-wrap"><img src="screenshots/theme-packs-hub.png" alt="Theme Packs — Find on Hub" class="doc-img" loading="lazy"></div>
+<p>Pipette Hub からテーマパックを検索します。2 文字以上入力すると自動で検索が走ります (debounce 付き)。各結果にパック名、バージョン、アップローダー、<strong>Preview</strong> ボタン、<strong>Download</strong> または <strong>Installed</strong> が表示されます。</p>
+<p><strong>Preview</strong> をクリックすると、インストールせずにテーマの色を一時的に適用できます。モーダルを閉じる、Installed タブに切り替える、または <strong>Preview</strong> を再クリックすると元のテーマに戻ります。</p>
+<p><strong>テーマパックの書き方</strong></p>
+<p>テーマパック <code class="ic">.json</code> は <code class="ic">name</code>、<code class="ic">version</code>、およびすべてのカラートークンを CSS カラー値にマッピングする <code class="ic">colors</code> オブジェクトで構成されます:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Nord&quot;,
+  &quot;version&quot;: &quot;1.0.0&quot;,
+  &quot;colorScheme&quot;: &quot;dark&quot;,
+  &quot;colors&quot;: {
+    &quot;surface&quot;: &quot;#2e3440&quot;,
+    &quot;surface-alt&quot;: &quot;#3b4252&quot;,
+    &quot;surface-dim&quot;: &quot;#272c36&quot;,
+    &quot;surface-raised&quot;: &quot;#434c5e&quot;,
+    &quot;content&quot;: &quot;#eceff4&quot;,
+    &quot;content-secondary&quot;: &quot;#d8dee9&quot;,
+    &quot;content-muted&quot;: &quot;#7b88a1&quot;,
+    &quot;content-inverse&quot;: &quot;#2e3440&quot;,
+    &quot;edge&quot;: &quot;#4c566a&quot;,
+    &quot;edge-subtle&quot;: &quot;#3b4252&quot;,
+    &quot;edge-strong&quot;: &quot;#d8dee9&quot;,
+    &quot;accent&quot;: &quot;#88c0d0&quot;,
+    &quot;accent-hover&quot;: &quot;#81a1c1&quot;,
+    &quot;accent-alt&quot;: &quot;#5e81ac&quot;,
+    &quot;success&quot;: &quot;#a3be8c&quot;,
+    &quot;warning&quot;: &quot;#ebcb8b&quot;,
+    &quot;danger&quot;: &quot;#bf616a&quot;,
+    &quot;pending&quot;: &quot;#b48ead&quot;,
+    &quot;key-bg&quot;: &quot;#3b4252&quot;,
+    &quot;key-bg-hover&quot;: &quot;#434c5e&quot;,
+    &quot;key-bg-active&quot;: &quot;#4c566a&quot;,
+    &quot;key-border&quot;: &quot;#4c566a&quot;,
+    &quot;key-shadow&quot;: &quot;rgba(0,0,0,0.3)&quot;,
+    &quot;key-label&quot;: &quot;#eceff4&quot;,
+    &quot;key-sublabel&quot;: &quot;#d8dee9&quot;,
+    &quot;key-label-remap&quot;: &quot;#88c0d0&quot;,
+    &quot;key-bg-multi-selected&quot;: &quot;#434c5e&quot;,
+    &quot;tab-bg-active&quot;: &quot;#3b4252&quot;,
+    &quot;tab-text&quot;: &quot;#7b88a1&quot;,
+    &quot;tab-text-active&quot;: &quot;#eceff4&quot;,
+    &quot;picker-bg&quot;: &quot;#2e3440&quot;,
+    &quot;picker-item-bg&quot;: &quot;#3b4252&quot;,
+    &quot;picker-item-hover&quot;: &quot;#434c5e&quot;,
+    &quot;picker-item-text&quot;: &quot;#eceff4&quot;,
+    &quot;picker-item-border&quot;: &quot;#4c566a&quot;
+  }
+}</code></pre>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">フィールド</th><th style="text-align:center">必須</th><th style="text-align:left">用途</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">はい</td><td style="text-align:left">表示名および import 時の上書き判定キー</td></tr><tr><td style="text-align:left"><code class="ic">version</code></td><td style="text-align:center">はい</td><td style="text-align:left">セマンティックバージョニング文字列 (例: <code class="ic">1.0.0</code>)</td></tr><tr><td style="text-align:left"><code class="ic">colorScheme</code></td><td style="text-align:center">はい</td><td style="text-align:left"><code class="ic">&quot;light&quot;</code> または <code class="ic">&quot;dark&quot;</code> — パックが想定する明暗を宣言する</td></tr><tr><td style="text-align:left"><code class="ic">colors</code></td><td style="text-align:center">はい</td><td style="text-align:left">全 35 カラートークンを CSS カラー値 (<code class="ic">#hex</code>、<code class="ic">rgb()</code>、<code class="ic">hsl()</code>) にマッピングするオブジェクト</td></tr></tbody></table></div>
+<p>35 個すべてのカラートークンが必須です。インストール済みパックを export (行 → <code class="ic">.json</code>) すると完全なテンプレートが取得できます。すぐに使える Kanagawa Wave / Dragon / Lotus・Solarized Light / Dark などのサンプルテーマパックもリポジトリの <a href="../sample-packs/themes/"><code class="ic">sample-packs/themes/</code></a> ディレクトリにあります。</p>
+<h3 id="6-5-ズーム-ui-全体">6.5 ズーム（UI 全体）</h3>
+<p>Tools タブの Theme Packs の下に <strong>Zoom</strong> 行があります。アプリケーション UI 全体の表示倍率を変更できます（50–200%）。</p>
+<div class="img-wrap"><img src="screenshots/settings-zoom.png" alt="ズーム設定" class="doc-img" loading="lazy"></div>
+<ul><li>入力欄にパーセント値（50–200）を入力し、<strong>Enter</strong> を押すかフォーカスを外すと適用されます</li><li>ズームレベルは即座にすべてのウィンドウに反映されます</li><li>この設定はマシンローカルです — Cloud Sync を経由して他デバイスには同期されません</li></ul>
+<blockquote><p><strong>Note</strong>: これはツールバーのキーボード単位ズーム (§4.1)（キーマップ表示のみを拡大縮小）とも、キーコードオーバーレイパネルの <strong>Key Editor Zoom</strong> (§3.14)（キーエディタ画面中のウィンドウ全体の表示倍率を上書き）とも別の機能です。ここの UI ズームはそれ以外のすべての画面に適用されるベースラインです。</p>
+<p><strong>Warning</strong>: 極端な値ではレイアウトが崩れる場合があります。自己責任で変更してください。</p></blockquote>
+<hr>
+<h2 id="7-pipette-hub">7. Pipette Hub</h2>
+<p><a href="https://pipette-hub-worker.keymaps.workers.dev/" target="_blank" rel="noopener">Pipette Hub</a> は、キーマップやお気に入り設定をアップロードして共有できるコミュニティキーマップギャラリーです。</p>
+<h3 id="7-1-hub-のセットアップ">7.1 Hub のセットアップ</h3>
+<p>Hub 機能を使用するには Google アカウント認証が必要です。先に Google アカウントの認証を済ませてください。デバイス選択画面の <strong>設定</strong> モーダル (歯車アイコン) で設定します:</p>
+<ol><li><strong>データ</strong> タブで Google アカウントセクションの <strong>Connect</strong> をクリックして Google アカウントでサインイン</li><li>同じデータタブ内の <strong>Pipette Hub</strong> セクションまでスクロール — <strong>Connected</strong> と表示されていることを確認</li><li><strong>Display Name</strong> を設定 — Hub の投稿に表示される名前です</li><li>アップロードしたキーマップは <strong>My Posts</strong> リストに表示されます</li></ol>
+<h3 id="7-2-キーマップのアップロード">7.2 キーマップのアップロード</h3>
+<p>キーマップを Hub にアップロードする手順:</p>
+<ol><li>キーボードを接続し、キーマップエディタの設定ボタン (歯車アイコン) を開く</li><li><strong>Data</strong> タブに切り替える</li><li>現在の状態をラベル付きで保存 (例: "Default")</li></ol>
+<div class="img-wrap"><img src="screenshots/hub-03-upload-button.png" alt="Upload ボタン" class="doc-img" loading="lazy"></div>
+<ol><li>保存したスナップショットの <strong>Upload</strong> ボタンをクリック</li><li>アップロード完了後、エントリに <strong>Uploaded</strong> ステータスと <strong>Open in Browser</strong>、<strong>Update</strong>、<strong>Remove</strong> ボタンが表示されます</li></ol>
+<div class="img-wrap"><img src="screenshots/hub-04-uploaded.png" alt="アップロード完了" class="doc-img" loading="lazy"></div>
+<ul><li><strong>Open in Browser</strong>: このキーマップの Hub ページをブラウザで開く</li><li><strong>Update</strong>: 現在のキーボード状態で Hub の投稿を更新</li><li><strong>Remove</strong>: Hub からキーマップを削除</li></ul>
+<blockquote><p><strong>Note</strong>: Hub アップロードには標準エクスポート形式に加えて undefined ファイルが含まれ、他のユーザーがキーボードの完全な状態を直接読み込めます。</p></blockquote>
+<h3 id="7-3-お気に入りエントリのアップロード">7.3 お気に入りエントリのアップロード</h3>
+<p>個別のお気に入りエントリ (Tap Dance、Macro、Combo、Key Override、Alt Repeat Key) も Hub にアップロードできます:</p>
+<div class="img-wrap"><img src="screenshots/hub-fav-data-modal.png" alt="データモーダル — お気に入り Hub アクション" class="doc-img" loading="lazy"></div>
+<ol><li>インラインお気に入りパネルのあるエディタモーダル、またはデバイス選択画面のデータモーダルを開きます</li><li>お気に入りリストの各エントリに、Hub 接続時は <strong>Upload to Hub</strong> ボタンが表示されます</li><li><strong>Upload to Hub</strong> をクリックして設定を共有します</li><li>アップロード後、<strong>Open in Browser</strong>、<strong>Update on Hub</strong>、<strong>Remove from Hub</strong> ボタンが表示されます</li><li>Hub にアップロード済みのお気に入りをリネームすると、Hub 上のタイトルも自動的に更新されます</li></ol>
+<blockquote><p><strong>Note</strong>: アップロードには Display Name の設定が必要です。Display Name が未設定の場合、Upload ボタンの代わりに警告が表示されます。</p></blockquote>
+<h3 id="7-4-分析データのアップロード">7.4 分析データのアップロード</h3>
+<p>保存した Analyze 条件を Hub にアップロードして、タイピング分析チャートをコミュニティと共有できます。</p>
+<p><strong>フロー</strong></p>
+<ol><li>Analyze ページを開き、共有したいフィルタを設定（キーボード、デバイス、アプリ、日付範囲、キーマップスナップショット）</li><li><strong>検索条件の保存</strong> パネル（ブックマークアイコン）でラベルを付けて条件を保存</li><li>Hub 接続時、各エントリの下に Hub アクション行が表示され <strong>Upload to Hub</strong> ボタンが使える</li><li><strong>Upload to Hub</strong> をクリック — カテゴリ選択モーダルがアップロードモードで開く（§1.4 エクスポート / アップロード 参照）</li><li>含めるチャートカテゴリを選択し、必要に応じて Layout Comparison ターゲットや Per-app data を指定して <strong>Upload</strong> をクリック</li><li>アップロード完了後、エントリに <strong>Open in Browser</strong>、<strong>Update on Hub</strong>、<strong>Remove from Hub</strong> ボタンが表示される</li></ol>
+<p><strong>バリデーションルール</strong></p>
+<p>Hub は以下の 2 つのガードを適用する:</p>
+<ul><li><strong>最低 100 打鍵</strong> — 100 打鍵未満のチャートはデータが疎すぎて有用でないため拒否される</li><li><strong>最大 30 日間</strong> — これを超える期間はペイロードが Hub のサイズ上限を超えるため拒否される</li></ul>
+<p>いずれかに違反した場合、ローカライズされたエラーメッセージが修正方法を案内する（期間を短くする、もっと打鍵を記録するなど）。</p>
+<p><strong>アップロードモードのオプション</strong></p>
+<ul><li><strong>Layout Comparison ターゲット</strong> — 含める代替レイアウトを複数選択。Hub 投稿にはターゲットごとの打鍵再配分が表示される。ターゲット未選択時はトグルが無効化される</li><li><strong>Per-app data</strong> — アプリ別内訳として含めるアプリを選択。Hub 投稿には選択アプリのチャートが表示される</li></ul>
+<p><strong>更新と削除</strong></p>
+<ul><li><strong>Update on Hub</strong> — 同じ条件の最新チャートデータを再アップロードする（打鍵が増えた後に有用）</li><li><strong>Remove from Hub</strong> — Hub サーバーから分析投稿を削除する（2 段階確認あり）</li></ul>
+<p><strong>エラーハンドリング</strong></p>
+<p>アップロードエラーはローカライズ済み。代表的なケース: 認証失敗（サインアウト→再サインイン）、ペイロードが大きすぎる（カテゴリを減らすか期間を短縮）、レート制限（しばらく待ってリトライ）。</p>
+<blockquote><p><strong>Note</strong>: アップロードには Display Name の設定が必要です。Display Name が未設定の場合、Upload ボタンの代わりに警告が表示されます。</p></blockquote>
+<h3 id="7-5-hub-ウェブサイト">7.5 Hub ウェブサイト</h3>
+<p><a href="https://pipette-hub-worker.keymaps.workers.dev/" target="_blank" rel="noopener">Pipette Hub ウェブサイト</a> では、アップロードされたキーマップがギャラリー形式で表示されます。</p>
+<div class="img-wrap"><img src="screenshots/hub-web-top.png" alt="Hub トップページ" class="doc-img" loading="lazy"></div>
+<ul><li>コミュニティのキーマップを閲覧</li><li>キーボード名で検索</li><li><code class="ic">.vil</code>、<code class="ic">.c</code>、<code class="ic">.pdf</code> 形式でダウンロード</li></ul>
+<h4 id="個別キーマップページ">個別キーマップページ</h4>
+<p>キーマップカードをクリックすると、キーボードレイアウトの詳細ページが開きます。</p>
+<div class="img-wrap"><img src="screenshots/hub-web-detail.png" alt="Hub 詳細ページ" class="doc-img" loading="lazy"></div>
+<ul><li>アップロードされたキーマップの全レイヤー (Layer 0〜3) を表示</li><li>Tap Dance、Macro、Combo、Alt Repeat Key、Key Override の設定を確認</li><li><strong>Copy URL</strong> や <strong>Share on X</strong> で他の人と共有</li><li>各種形式 (<code class="ic">.pdf</code>、<code class="ic">.c</code>、<code class="ic">.vil</code>) でダウンロード</li></ul>
+<p>Hub 認証の詳細は <a href="#" class="xdoc" data-doc="data" data-hash="">Data Guide</a> を参照してください。</p>
+<hr>
+<h2 id="8-モーダルの操作">8. モーダルの操作</h2>
+<p>Pipette はすべての top-level モーダル (Settings、Data、Macro、QMK Settings、Tap Dance、Combo、Key Override、Alt Repeat Key、Notification、Language Packs、Theme Packs、Language Selector、Layout Store、Editor Settings、Favorite Store、および History Toggle ダイアログ) に共通のキーボード操作・閉じ方ルールを適用します。</p>
+<h3 id="escape-で閉じる">Escape で閉じる</h3>
+<p><strong>Escape</strong> キーを押すとモーダルが閉じます。ただし、入力操作を邪魔しないよう以下の例外があります:</p>
+<ul><li>フォーカスが <code class="ic">&lt;input&gt;</code>, <code class="ic">&lt;textarea&gt;</code>, <code class="ic">&lt;select&gt;</code>, <code class="ic">contenteditable</code> 領域にある場合、Escape は無視されます（要素自身がイベントを受け取ります）</li><li>IME 入力中（日本語入力の変換中など）は Escape を無視します — 変換のキャンセルでモーダルが閉じないようにするため</li></ul>
+<h3 id="unlock-dialog-の保護">Unlock Dialog の保護</h3>
+<p>Unlock Dialog（ブートアンロック系キーコード実行時に物理キー押下を要求するダイアログ）は <strong>親モーダルに到達する前に Escape を吸収 (swallow)</strong> します。アンロックプロンプト上で Escape を連打しても親モーダルに伝搬しないため、Settings や Data モーダルを設定途中で誤って閉じることはありません。</p>
+<h3 id="busy-状態中の-escape-抑制">Busy 状態中の Escape 抑制</h3>
+<p>モーダルが完了待ちの状態にあるとき、Escape-to-close は一時的に無効化されます:</p>
+<ul><li><strong>Settings / Data モーダル</strong>: 同期・トラブルシューティングフローの実行中は無効</li><li><strong>Macro モーダル</strong>: レコーダーがキーストロークを記録中は無効（§3.7 の記録中のロックを参照）。同じタイミングで背景クリックと右上の Close ボタンも無効になります</li></ul>
+<hr>
+<h2 id="9-ステータスバー">9. ステータスバー</h2>
+<p>画面下部のステータスバーには接続情報と操作ボタンが表示されます。</p>
+<div class="img-wrap"><img src="screenshots/status-bar.png" alt="ステータスバー" class="doc-img" loading="lazy"></div>
+<p><strong>ステータス表示</strong> (左側)</p>
+<ul><li><strong>デバイス名</strong>: 接続中のキーボード名を表示</li><li><strong>ロードラベル</strong>: 読み込んだスナップショットのラベル名 (スナップショット読み込み時のみ表示)</li><li><strong>自動移動</strong>: キー割り当て後に次のキーに自動移動する機能の状態 (有効時のみ表示)</li><li><strong>Locked / Unlocked</strong>: キーボードのロック状態 (一部の危険なキーコードの誤設定を防止)</li><li><strong>Sync ステータス</strong>: クラウド同期の状態 (同期設定時のみ表示)</li><li><strong>Hub 接続状態</strong>: Pipette Hub の接続状態 (Hub 設定時のみ表示)</li></ul>
+<p><strong>クイック設定</strong> (右側、キーボード接続時に表示)</p>
+<p>セッションごとの共通設定をインラインで変更できるセレクターです。<code class="ic">|</code> セパレーターで操作ボタンと区切られます。</p>
+<ul><li><strong>Language</strong>: UI 言語を切り替え。組み込み言語とインストール済み言語パックのドロップダウンが開きます (§6.3 参照)</li><li><strong>Theme</strong>: カラーテーマを切り替え。System / Light / Dark とインストール済みテーマパックが選択肢として表示されます (§6.4 参照)</li><li><strong>Key Labels</strong>: 現在のキーボードのキーラベルセットを切り替え。Key Labels ストアのインストール済みエントリがドラッグ順で表示されます (§6.2 参照)</li><li><strong>Edit / Done</strong>: 編集モードの切替。編集モードではセレクターが <strong>Language Packs</strong>・<strong>Theme Packs</strong>・<strong>Key Labels</strong> 管理モーダルのボタンに切り替わり、エントリのインストール・同期・並び替えができます</li></ul>
+<p><strong>操作ボタン</strong> (右側)</p>
+<ul><li><strong>Key Tester</strong>: Matrix Tester モードの切替ボタン (マトリクステスター対応時のみ。タイピングテストがアクティブ時は非表示)</li><li><strong>Typing View</strong>: ビューオンリーモードの切替ボタン — キーボードレイアウトのみをコンパクトウィンドウに表示 (§4.3 参照)。マトリクステスター対応時のみ。タイピングテストがアクティブ時は非表示</li><li><strong>Typing Test</strong>: タイピングテストモードの切替ボタン (マトリクステスター対応時のみ)</li><li><strong>Disconnect ボタン</strong>: キーボードとの接続を切断し、デバイス選択画面に戻ります（タイピングテスト中は非表示）</li></ul>
+</article>
+    <article id="doc-data" class="doc" lang="en">
+<h1 id="data-guide">Data Guide</h1>
+<p>This document describes what data Pipette stores, where it lives, and how external services are used.</p>
+<hr>
+<h2 id="local-data">Local Data</h2>
+<p>All local data is stored under the OS user data directory:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">OS</th><th style="text-align:left">Path</th></tr></thead><tbody><tr><td style="text-align:left">Linux</td><td style="text-align:left"><code class="ic">~/.config/Pipette/</code></td></tr><tr><td style="text-align:left">macOS</td><td style="text-align:left"><code class="ic">~/Library/Application Support/Pipette/</code></td></tr><tr><td style="text-align:left">Windows</td><td style="text-align:left"><code class="ic">%APPDATA%/Pipette/</code></td></tr></tbody></table></div>
+<h3 id="app-settings">App Settings</h3>
+<p>General preferences that apply across all keyboards.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Theme</td><td style="text-align:left">Light, Dark, or System</td></tr><tr><td style="text-align:left">Language</td><td style="text-align:left">Active UI language pack (built-in English or any imported pack)</td></tr><tr><td style="text-align:left">Auto-lock timer</td><td style="text-align:left">10 - 60 minutes</td></tr><tr><td style="text-align:left">Default keyboard layout</td><td style="text-align:left">QWERTY, Dvorak, etc.</td></tr><tr><td style="text-align:left">Default auto-advance</td><td style="text-align:left">Move to next key after assignment</td></tr><tr><td style="text-align:left">Default layer panel open</td><td style="text-align:left">Initial state of the layer list panel for new keyboards</td></tr><tr><td style="text-align:left">Default basic view type</td><td style="text-align:left">Default Basic tab view (ANSI / ISO / JIS / List)</td></tr><tr><td style="text-align:left">Default split key mode</td><td style="text-align:left">Default split-key display mode (split or flat)</td></tr><tr><td style="text-align:left">Default quick select</td><td style="text-align:left">Default quick-select mode for the keycode popover</td></tr><tr><td style="text-align:left">Max keymap history</td><td style="text-align:left">Maximum number of keymap changes kept in edit history</td></tr><tr><td style="text-align:left">Auto sync</td><td style="text-align:left">Enable/disable cloud sync</td></tr><tr><td style="text-align:left">Hub enabled</td><td style="text-align:left">Enable/disable Pipette Hub integration</td></tr><tr><td style="text-align:left">Window position & size</td><td style="text-align:left">Restored on next launch</td></tr><tr><td style="text-align:left">Typing recording consent</td><td style="text-align:left">Whether the typing-analytics recording consent dialog has been accepted (gates the REC tab Start button)</td></tr><tr><td style="text-align:left">Typing-view heatmap window</td><td style="text-align:left">Window length (minutes) for the typing-view real-time heatmap overlay</td></tr><tr><td style="text-align:left">Monitor App enabled</td><td style="text-align:left">Whether to capture the active application name during typing-analytics recording. Required for the App filter and By App tab in Analyze</td></tr></tbody></table></div>
+<h3 id="per-keyboard-settings">Per-Keyboard Settings</h3>
+<p>Settings tied to a specific keyboard, identified by its unique ID.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Keyboard layout override</td><td style="text-align:left">Display labels using a specific layout</td></tr><tr><td style="text-align:left">Auto-advance</td><td style="text-align:left">Per-keyboard override</td></tr><tr><td style="text-align:left">Layer names</td><td style="text-align:left">Custom names for each layer (Pipette-only; not written to firmware or visible in other apps)</td></tr><tr><td style="text-align:left">Layer panel open</td><td style="text-align:left">Whether the layer list panel is expanded</td></tr><tr><td style="text-align:left">Basic view type</td><td style="text-align:left">Basic tab view (ANSI / ISO / JIS / List)</td></tr><tr><td style="text-align:left">Split key mode</td><td style="text-align:left">How split-key tiles are displayed (split or flat)</td></tr><tr><td style="text-align:left">Quick select</td><td style="text-align:left">Quick-select mode for the keycode popover</td></tr><tr><td style="text-align:left">Keymap scale</td><td style="text-align:left">Keymap zoom level</td></tr><tr><td style="text-align:left">View mode</td><td style="text-align:left">Last active view (Editor / Typing Test / Typing View) — auto-restored on reconnect</td></tr><tr><td style="text-align:left">Typing test history</td><td style="text-align:left">WPM/accuracy records (up to 500 entries)</td></tr><tr><td style="text-align:left">Typing test config</td><td style="text-align:left">Mode, word count, and other test preferences</td></tr><tr><td style="text-align:left">Typing test language</td><td style="text-align:left">Selected language pack</td></tr><tr><td style="text-align:left">Typing view preferences</td><td style="text-align:left">Compact window size and always-on-top setting</td></tr><tr><td style="text-align:left">Record enabled</td><td style="text-align:left">User-chosen state of the REC toggle in the typing view; recording is gated additionally on Typing View being open</td></tr><tr><td style="text-align:left">Typing view menu tab</td><td style="text-align:left">Last active menu pane tab in Typing View (Window / REC)</td></tr><tr><td style="text-align:left">Typing sync span</td><td style="text-align:left">How many days of typing-analytics history to sync (per-device JSONL)</td></tr><tr><td style="text-align:left">Analyze finger assignments</td><td style="text-align:left">Manual <code class="ic">row,col → finger</code> overrides for the Ergonomics tab</td></tr><tr><td style="text-align:left">Analyze goal</td><td style="text-align:left">Daily keystroke goal, target consecutive days, and goal-edit history for the Streak / Goal cards</td></tr><tr><td style="text-align:left">Analyze filters</td><td style="text-align:left">Per-tab filter state (device scope, app scope, view modes, ranking limits, snapshot selection) for the Analyze dashboard</td></tr><tr><td style="text-align:left">Analyze compare filters</td><td style="text-align:left">Same shape as Analyze filters, bound to the secondary pane in the Analyze split-view</td></tr></tbody></table></div>
+<h3 id="typing-analytics">Typing Analytics</h3>
+<p>Per-keyboard typing history that feeds the Analyze page (see OPERATION-GUIDE §1.4). Recorded while you are in Typing View and the Record toggle in the typing-test pane is set to Start; typing-test results flow into the same stream.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Keystroke events</td><td style="text-align:left">Per-keystroke records aggregated into minute buckets</td></tr><tr><td style="text-align:left">Minute stats</td><td style="text-align:left">WPM, Backspace %, interval percentiles, and other per-minute summaries</td></tr><tr><td style="text-align:left">Matrix activity</td><td style="text-align:left">Per-cell press counts with the active layer at the time</td></tr><tr><td style="text-align:left">Sessions</td><td style="text-align:left">Start / end markers for each typing session</td></tr><tr><td style="text-align:left">Keymap snapshots</td><td style="text-align:left">Point-in-time keymap captures used to resolve heatmap positions and layer-op targets</td></tr><tr><td style="text-align:left">App tag</td><td style="text-align:left">Active application name attached to each minute when Monitor App is on. Minutes that observed only one app carry that name; minutes that observed multiple apps are tagged as unknown; minutes captured while Monitor App was off are not tagged. Powers the App filter and the By App tab in Analyze</td></tr></tbody></table></div>
+<p><strong>What is synced, what is local cache</strong></p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Storage</th><th style="text-align:left">Path (under user data directory)</th><th style="text-align:left">Scope</th></tr></thead><tbody><tr><td style="text-align:left">Per-device typing log (master)</td><td style="text-align:left"><code class="ic">sync/keyboards/{uid}/devices/{machineHash}/{YYYY-MM-DD}.jsonl</code></td><td style="text-align:left"><strong>Synced</strong> across your signed-in devices</td></tr><tr><td style="text-align:left">Keymap snapshots (master)</td><td style="text-align:left"><code class="ic">typing-analytics/keymaps/{uid}/{machineHash}/*.json</code></td><td style="text-align:left">Local only (per machine)</td></tr><tr><td style="text-align:left">Query cache (SQLite)</td><td style="text-align:left"><code class="ic">local/typing-analytics.db</code></td><td style="text-align:left">Local only — rebuilt from the JSONL master when missing or stale</td></tr></tbody></table></div>
+<p>The JSONL master is the source of truth and survives cache rebuilds. When the app can't find the SQLite cache (first launch on a new machine, file corruption, schema upgrade), it replays the JSONL log to rebuild it; no data is lost.</p>
+<p><strong>Layer names in the chart</strong> come from Per-Keyboard Settings above, not from typing analytics — renaming a layer in the layer panel updates the axis label in Analyze the next time you open it.</p>
+<h3 id="snapshots">Snapshots</h3>
+<p>Complete point-in-time captures of a keyboard's state. Each snapshot contains:</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Keymap</td><td style="text-align:left">All layers, all keys</td></tr><tr><td style="text-align:left">Encoder mappings</td><td style="text-align:left">Clockwise/counter-clockwise assignments per layer</td></tr><tr><td style="text-align:left">Layout options</td><td style="text-align:left">Physical layout selections</td></tr><tr><td style="text-align:left">Macros</td><td style="text-align:left">All macro definitions</td></tr><tr><td style="text-align:left">Tap Dance entries</td><td style="text-align:left">All tap dance configurations</td></tr><tr><td style="text-align:left">Combos</td><td style="text-align:left">All combo definitions</td></tr><tr><td style="text-align:left">Key Overrides</td><td style="text-align:left">All key override rules</td></tr><tr><td style="text-align:left">Alternate Repeat Keys</td><td style="text-align:left">All alt repeat key mappings</td></tr><tr><td style="text-align:left">QMK Settings</td><td style="text-align:left">All firmware settings</td></tr><tr><td style="text-align:left">Layer names</td><td style="text-align:left">Custom layer names</td></tr><tr><td style="text-align:left">Keyboard definition</td><td style="text-align:left">Physical key layout and matrix info (v2+)</td></tr></tbody></table></div>
+<p>Snapshots are created manually via "Save Current State" and stored as <code class="ic">.pipette</code> files. They can be restored to the keyboard or exported as <code class="ic">.vil</code> files.</p>
+<p>The <code class="ic">.pipette</code> format has two versions:</p>
+<ul><li><strong>v1</strong> (legacy): No <code class="ic">version</code> field, no keyboard definition embedded.</li><li><strong>v2</strong> (current): Includes <code class="ic">version: 2</code> and embeds the <code class="ic">KeyboardDefinition</code> (physical key layout, matrix dimensions) so the snapshot can render a virtual keyboard without a physical device connected.</li></ul>
+<p>Legacy v1 files are automatically migrated to v2 when loaded with a connected device.</p>
+<h3 id="favorites">Favorites</h3>
+<p>Reusable configurations that work across any keyboard. Individual entries can be uploaded to Pipette Hub.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Type</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Tap Dance</td><td style="text-align:left">Saved tap dance entry</td></tr><tr><td style="text-align:left">Macro</td><td style="text-align:left">Saved macro sequence</td></tr><tr><td style="text-align:left">Combo</td><td style="text-align:left">Saved combo definition</td></tr><tr><td style="text-align:left">Key Override</td><td style="text-align:left">Saved key override rule</td></tr><tr><td style="text-align:left">Alternate Repeat Key</td><td style="text-align:left">Saved alt repeat key mapping</td></tr></tbody></table></div>
+<p>Each favorite entry may have an associated <code class="ic">hubPostId</code> if it has been uploaded to Hub. Renaming a Hub-uploaded favorite also updates its title on Hub.</p>
+<h3 id="key-labels">Key Labels</h3>
+<p>Maps QMK keycode ids to keycap legends used by the Keymap Editor, the Keycodes Overlay Panel, the Settings → Defaults dropdown, and the Layout Comparison view. QWERTY ships built-in; every other label set (Dvorak, Colemak, French, Brazilian, …) is downloaded from Pipette Hub or imported as a <code class="ic">.json</code> file. The store is shared across keyboards (it survives Reset Keyboard Data) and syncs entry-by-entry across machines.</p>
+<p>A Key Label <code class="ic">.json</code> is a small JSON object:</p>
+<pre class="code-block"><code>{
+  &quot;name&quot;: &quot;Brazilian (QWERTY)&quot;,
+  &quot;map&quot;: { &quot;KC_2&quot;: &quot;2\n@&quot;, &quot;KC_QUOT&quot;: &quot;ç&quot;, &quot;KC_GRAVE&quot;: &quot;KC_LALT&quot; },
+  &quot;compositeLabels&quot;: { &quot;LSFT(KC_2)&quot;: &quot;@&quot;, &quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot; }
+}</code></pre>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Field</th><th style="text-align:center">Required</th><th style="text-align:left">Purpose</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">name</code></td><td style="text-align:center">Yes</td><td style="text-align:left">Display name and uniqueness key for overwrite-on-import</td></tr><tr><td style="text-align:left"><code class="ic">map</code></td><td style="text-align:center">Yes</td><td style="text-align:left"><code class="ic">QMK keycode id → label string</code>. Lines are split on <code class="ic">\n</code> to control the cap layout (1 = centred, 2 = stacked, 3 = three slices, 4 = 2 × 2 quadrants). Empty parts leave a slot blank</td></tr><tr><td style="text-align:left"><code class="ic">compositeLabels</code></td><td style="text-align:center">No</td><td style="text-align:left">Overrides for composite keycodes (e.g. <code class="ic">LT(0,KC_A)</code>, <code class="ic">LSFT(KC_2)</code>). Composite caps render the inner key in an inset rectangle, so only the first two <code class="ic">\n</code> parts of the outer label are honoured</td></tr></tbody></table></div>
+<p>Values may also be plain QMK keycode ids (e.g. <code class="ic">&quot;LALT(KC_L)&quot;: &quot;KC_LALT&quot;</code>). The editor runs the value through <code class="ic">keycodeLabel()</code> before display, so a keycode-id value resolves to that keycode's canonical legend automatically.</p>
+<p>See <code class="ic">docs/OPERATION-GUIDE.md</code> §6.2 for the full authoring guide and the modal walkthrough.</p>
+<h3 id="ui-language-packs">UI Language Packs</h3>
+<p>Translation packs that localise the entire Pipette UI. English is built-in; additional languages (e.g. Japanese) are imported from a <code class="ic">.json</code> file or downloaded from Pipette Hub. Managed in Settings → Tools → Language Packs (see <code class="ic">OPERATION-GUIDE.md</code> §6.3).</p>
+<p>Installed packs sync across devices via Cloud Sync. The active language selection is stored in App Settings (not synced).</p>
+<h3 id="typing-test-language-packs">Typing Test Language Packs</h3>
+<p>Word lists downloaded from the server for the typing test. Can be managed (download / delete) from the typing test language selector.</p>
+<h3 id="logs">Logs</h3>
+<p>Rotating log files for debugging. No keyboard data or personal information is logged.</p>
+<h3 id="authentication-credentials">Authentication Credentials</h3>
+<p>OAuth tokens and sync password are encrypted using the OS keychain (Electron <code class="ic">safeStorage</code>). These are never stored in plain text.</p>
+<hr>
+<h2 id="keyboard-side-data">Keyboard-Side Data</h2>
+<p>The following data is stored in the keyboard's own memory (EEPROM / dynamic RAM). This data persists even if Pipette is uninstalled — it is erased only by a keyboard factory reset.</p>
+<ul><li>Keymap (all layers)</li><li>Encoder mappings</li><li>Layout options</li><li>Macro buffer</li><li>Tap Dance, Combo, Key Override, Alternate Repeat Key entries</li><li>QMK Settings values</li><li>Lighting configuration (backlight, RGB)</li><li>Lock/unlock state</li></ul>
+<p>Pipette reads and writes this data via USB HID using the VIA/Vial protocol. Changes are applied directly to the keyboard when you edit them.</p>
+<hr>
+<h2 id="cloud-sync-google-drive-appdatafolder">Cloud Sync (Google Drive appDataFolder)</h2>
+<h3 id="how-it-works">How It Works</h3>
+<p>Pipette uses <a href="https://developers.google.com/workspace/drive/api/guides/appdata" target="_blank" rel="noopener">Google Drive <strong>appDataFolder</strong></a> to sync your data across devices. The appDataFolder is <strong>not</strong> regular Google Drive storage — it is a hidden, app-specific folder that only the app which created it (identified by its OAuth client ID) can access. Its contents are invisible to the user and to other Google Drive applications.</p>
+<ul><li>Sync is <strong>opt-in</strong> — you must sign in with Google and set a sync password to enable it</li><li>Synced data is <strong>end-to-end encrypted</strong> before upload (AES-256-GCM with a key derived from your sync password via PBKDF2)</li><li>Sync happens automatically when changes are detected (with a 10-second debounce) and via periodic polling (every 3 minutes)</li><li>Pending changes are flushed on app exit</li><li><strong>Selective sync scope</strong>: Not all keyboards' data is downloaded at once. On device connection, favorites are downloaded first, then the connected keyboard's snapshots and settings are downloaded (in full) once its UID is confirmed. Keyboards you have never connected on this machine are left undownloaded; their data is fetched on demand when you open them from the <strong>Data</strong> modal's Sync section. Manual sync (<strong>Sync</strong>) and background polling keep the currently connected keyboard and favorites in sync — other keyboards' data is never pulled down automatically</li><li><strong>Lightweight keyboard name index</strong>: A small synced index (UID → keyboard name) is kept so that remote-only keyboards can be shown by name in the Data modal before their full data is ever downloaded. The index holds only UIDs and keyboard names — no keymap, macro, or setting data</li></ul>
+<h3 id="what-is-synced">What Is Synced</h3>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Data</th><th style="text-align:left">Sync Unit</th></tr></thead><tbody><tr><td style="text-align:left">Snapshots</td><td style="text-align:left">Per keyboard</td></tr><tr><td style="text-align:left">Per-keyboard settings</td><td style="text-align:left">Per keyboard</td></tr><tr><td style="text-align:left">Favorites</td><td style="text-align:left">Per type (tap dance, macro, etc.)</td></tr><tr><td style="text-align:left">UI Language Packs</td><td style="text-align:left">Per pack (index + body)</td></tr><tr><td style="text-align:left">Keyboard name index (UID → name)</td><td style="text-align:left">Single shared index</td></tr></tbody></table></div>
+<p>App settings (theme, language, window state, etc.) are <strong>not</strong> synced.</p>
+<h3 id="security-privacy">Security & Privacy</h3>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Concern</th><th style="text-align:left">How it's addressed</th></tr></thead><tbody><tr><td style="text-align:left"><strong>What permissions does Pipette request?</strong></td><td style="text-align:left">The only Drive-related scope is <code class="ic">drive.appdata</code>, which allows access exclusively to Pipette's own Application Data folder. Additionally, <code class="ic">openid</code>, <code class="ic">email</code>, and <code class="ic">profile</code> are requested for identity verification (see scope table below).</td></tr><tr><td style="text-align:left"><strong>Can Pipette access my Google Drive files?</strong></td><td style="text-align:left"><strong>No.</strong> The <code class="ic">drive.appdata</code> scope grants access exclusively to a hidden folder created by Pipette. It cannot list, read, modify, or delete any of your personal files, documents, photos, or other Drive content.</td></tr><tr><td style="text-align:left"><strong>Can other apps see Pipette's data?</strong></td><td style="text-align:left"><strong>No.</strong> The Application Data folder is invisible to the user and to other applications. Only the app that created it (identified by its OAuth client ID) can access it.</td></tr><tr><td style="text-align:left"><strong>Is my data encrypted?</strong></td><td style="text-align:left"><strong>Yes.</strong> All data is encrypted with AES-256-GCM using a key derived from your sync password (PBKDF2, 600,000 iterations) before it leaves your device. Google stores only encrypted blobs.</td></tr><tr><td style="text-align:left"><strong>Can Pipette's developers read my synced data?</strong></td><td style="text-align:left"><strong>No.</strong> Encryption happens on your device with your password. Without your sync password, the encrypted data is unreadable.</td></tr><tr><td style="text-align:left"><strong>What happens if I sign out?</strong></td><td style="text-align:left">Local data is preserved. Cloud data remains in Google Drive appDataFolder but is no longer synced. You can sign back in to resume syncing.</td></tr><tr><td style="text-align:left"><strong>How do I delete all cloud data?</strong></td><td style="text-align:left">Use "Reset Sync Data" in settings and select both keyboard and favorite data. This removes selected <code class="ic">keyboards_*.enc</code> / <code class="ic">favorites_*.enc</code> files from Google Drive appDataFolder. The keyboard name index (<code class="ic">meta_keyboard-names.enc</code>) and password check (<code class="ic">password-check.enc</code>) are retained; deletions are propagated to other signed-in devices via tombstone entries in the name index (garbage-collected after 30 days).</td></tr><tr><td style="text-align:left"><strong>What is stored on Google?</strong></td><td style="text-align:left">Encrypted files named by sync unit (e.g., <code class="ic">keyboards_{uid}_snapshots.enc</code>, <code class="ic">favorites_tapDance.enc</code>, <code class="ic">meta_keyboard-names.enc</code>, <code class="ic">password-check.enc</code>). File names contain keyboard UIDs but no personal information.</td></tr><tr><td style="text-align:left"><strong>How does authentication work?</strong></td><td style="text-align:left">Standard Google OAuth 2.0 with PKCE (Proof Key for Code Exchange) via a local loopback redirect. No passwords are sent to any third-party server.</td></tr><tr><td style="text-align:left"><strong>What happens if I change my password?</strong></td><td style="text-align:left">All synced files are re-encrypted with the new password. No data is deleted — files are decrypted and re-encrypted in place.</td></tr><tr><td style="text-align:left"><strong>What are undecryptable files?</strong></td><td style="text-align:left">Files that cannot be decrypted with your current sync password or are otherwise unreadable (e.g., leftover from a previous password). You can scan for and delete them from the Data tab in settings.</td></tr></tbody></table></div>
+<h3 id="google-oauth-scopes">Google OAuth Scopes</h3>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Scope</th><th style="text-align:left">Purpose</th></tr></thead><tbody><tr><td style="text-align:left"><code class="ic">drive.appdata</code></td><td style="text-align:left">Read/write Pipette's own Application Data folder</td></tr><tr><td style="text-align:left"><code class="ic">openid</code></td><td style="text-align:left">Verify user identity</td></tr><tr><td style="text-align:left"><code class="ic">email</code></td><td style="text-align:left">Display signed-in email address</td></tr><tr><td style="text-align:left"><code class="ic">profile</code></td><td style="text-align:left">Display user name</td></tr></tbody></table></div>
+<hr>
+<h2 id="pipette-hub">Pipette Hub</h2>
+<h3 id="what-is-it">What Is It</h3>
+<p><a href="https://pipette-hub-worker.keymaps.workers.dev" target="_blank" rel="noopener">Pipette Hub</a> is a community keymap gallery where you can share your keyboard configurations.</p>
+<h3 id="how-it-works">How It Works</h3>
+<ul><li>Uploading requires signing in with the same Google account used for sync</li><li>Pipette sends your Google <code class="ic">id_token</code> to the Hub server, which verifies it against Google's public keys and issues a short-lived Hub session token</li><li><strong>Keyboard snapshot uploads</strong> include: keymap data (<code class="ic">.vil</code> and <code class="ic">.pipette</code> formats), a <code class="ic">keymap.c</code> export, a PDF cheat sheet, and a thumbnail screenshot</li><li><strong>Favorite entry uploads</strong> include: the favorite configuration as a JSON file (Pipette's favorite export format with QMK keycode names)</li></ul>
+<h3 id="what-is-uploaded">What Is Uploaded</h3>
+<p><strong>Keyboard Snapshots:</strong></p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Title</td><td style="text-align:left">User-provided post title</td></tr><tr><td style="text-align:left">Keyboard name</td><td style="text-align:left">Name of the keyboard</td></tr><tr><td style="text-align:left"><code class="ic">.vil</code> file</td><td style="text-align:left">Keymap in VIL format</td></tr><tr><td style="text-align:left"><code class="ic">.pipette</code> file</td><td style="text-align:left">Keymap in Pipette format</td></tr><tr><td style="text-align:left"><code class="ic">keymap.c</code></td><td style="text-align:left">QMK-compatible C source</td></tr><tr><td style="text-align:left">PDF</td><td style="text-align:left">Printable keymap cheat sheet</td></tr><tr><td style="text-align:left">Thumbnail</td><td style="text-align:left">Screenshot of the current keymap view</td></tr></tbody></table></div>
+<p><strong>Favorite Entries (Tap Dance, Macro, Combo, Key Override, Alt Repeat Key):</strong></p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Item</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">Title</td><td style="text-align:left">Favorite entry label</td></tr><tr><td style="text-align:left">Post type</td><td style="text-align:left">Entry type (<code class="ic">td</code>, <code class="ic">macro</code>, <code class="ic">combo</code>, <code class="ic">ko</code>, <code class="ic">ark</code>)</td></tr><tr><td style="text-align:left">JSON file</td><td style="text-align:left">Favorite configuration in Pipette export format (with QMK keycode names)</td></tr></tbody></table></div>
+<h3 id="security-privacy">Security & Privacy</h3>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Concern</th><th style="text-align:left">How it's addressed</th></tr></thead><tbody><tr><td style="text-align:left"><strong>What permissions does Hub require?</strong></td><td style="text-align:left">No additional permissions beyond the Google sign-in already used for sync. Hub authenticates using the same Google <code class="ic">id_token</code>.</td></tr><tr><td style="text-align:left"><strong>Can Hub access my Google Drive or other data?</strong></td><td style="text-align:left"><strong>No.</strong> Hub only receives and verifies your Google <code class="ic">id_token</code> to confirm your identity. It does not request any Google API scopes and cannot access any of your Google data.</td></tr><tr><td style="text-align:left"><strong>Who can upload and delete posts?</strong></td><td style="text-align:left">Only the authenticated owner. Pipette is the official client for uploading and deleting posts, and all actions require a valid Hub session token tied to your Google account.</td></tr><tr><td style="text-align:left"><strong>Can I delete my uploads?</strong></td><td style="text-align:left"><strong>Yes.</strong> You can delete your own posts from within Pipette.</td></tr><tr><td style="text-align:left"><strong>Where is Hub data stored?</strong></td><td style="text-align:left">On Cloudflare infrastructure (Workers, D1 database, R2 storage).</td></tr><tr><td style="text-align:left"><strong>Is the Hub server open source?</strong></td><td style="text-align:left">The Hub server is a separate project. Pipette's source code (this repository) is fully open — you can verify exactly what data is sent.</td></tr></tbody></table></div>
+<hr>
+<h2 id="export-formats">Export Formats</h2>
+<p>Pipette can export keymap data in several formats. These are local file downloads and do not involve any network requests.</p>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Format</th><th style="text-align:left">Extension</th><th style="text-align:left">Description</th></tr></thead><tbody><tr><td style="text-align:left">VIL</td><td style="text-align:left"><code class="ic">.vil</code></td><td style="text-align:left">Complete keyboard state (compatible with Vial GUI)</td></tr><tr><td style="text-align:left">Pipette</td><td style="text-align:left"><code class="ic">.pipette</code></td><td style="text-align:left">Pipette's snapshot format (includes layer names)</td></tr><tr><td style="text-align:left">keymap.c</td><td style="text-align:left"><code class="ic">.c</code></td><td style="text-align:left">QMK-compatible C source code</td></tr><tr><td style="text-align:left">PDF (Keymap)</td><td style="text-align:left"><code class="ic">.pdf</code></td><td style="text-align:left">Printable keymap cheat sheet</td></tr><tr><td style="text-align:left">PDF (Layout)</td><td style="text-align:left"><code class="ic">.pdf</code></td><td style="text-align:left">Layout export with key outlines and summary pages for dynamic entries</td></tr></tbody></table></div>
+<hr>
+<h2 id="reset-operations">Reset Operations</h2>
+<div class="table-wrap"><table><thead><tr><th style="text-align:left">Operation</th><th style="text-align:center">Snapshots</th><th style="text-align:center">Settings</th><th style="text-align:center">Favorites</th><th style="text-align:center">Cloud Data</th><th style="text-align:center">Hub Posts</th><th style="text-align:center">App Settings</th></tr></thead><tbody><tr><td style="text-align:left">Reset Keyboard Data</td><td style="text-align:center">Deleted</td><td style="text-align:center">Deleted</td><td style="text-align:center">-</td><td style="text-align:center">Deleted for that keyboard</td><td style="text-align:center">-</td><td style="text-align:center">-</td></tr><tr><td style="text-align:left">Reset Local Data</td><td style="text-align:center">Selected targets deleted</td><td style="text-align:center">Selected targets deleted</td><td style="text-align:center">Selected targets deleted</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">Selected targets reset to defaults</td></tr><tr><td style="text-align:left">Reset Sync Data</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">Selected targets deleted</td><td style="text-align:center">-</td><td style="text-align:center">-</td></tr><tr><td style="text-align:left">Change Password</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">All files re-encrypted</td><td style="text-align:center">-</td><td style="text-align:center">-</td></tr><tr><td style="text-align:left">Sign Out</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td></tr><tr><td style="text-align:left">Export/Import Local Data</td><td style="text-align:center">Included</td><td style="text-align:center">Included</td><td style="text-align:center">Included</td><td style="text-align:center">-</td><td style="text-align:center">-</td><td style="text-align:center">-</td></tr></tbody></table></div>
+<blockquote><p><strong>Note</strong>: Reset Local Data allows you to select individual targets — keyboard data, favorites, and app settings can each be reset independently.</p>
+<p><strong>Note</strong>: Reset Local Data and Reset Sync Data do not delete the local keyboard name index (undefined) or the remote index file (undefined). Reset Keyboard Data and Reset Sync Data mark the affected UIDs as deleted in the index (tombstone, 30-day TTL) so other signed-in devices see the removal; the index file itself is retained.</p></blockquote>
+</article>
+    <article id="doc-theme" class="doc" lang="en">
+<h1>Theme Pack Authoring Guide </h1>
+<p class="subtitle">A complete reference for creating custom colour themes. All 34 colour tokens explained with visual examples, default values, and design tips.</p>
+
+<!-- ======================================== -->
+<h2 id="1-token-categories">1. Token Categories</h2>
+<p>Theme packs define 34 colour tokens grouped into 7 categories. Every token is required.</p>
+
+<div class="section-grid">
+  <span class="section-chip" style="background:#e0e7ff;border-color:#a5b4fc;color:#3730a3;">Surface (4)</span>
+  <span class="section-chip" style="background:#fce7f3;border-color:#f9a8d4;color:#9d174d;">Content (4)</span>
+  <span class="section-chip" style="background:#d1fae5;border-color:#6ee7b7;color:#065f46;">Edge (3)</span>
+  <span class="section-chip" style="background:#fef3c7;border-color:#fcd34d;color:#92400e;">Semantic (6)</span>
+  <span class="section-chip" style="background:#e0f2fe;border-color:#7dd3fc;color:#0c4a6e;">Key (9)</span>
+  <span class="section-chip" style="background:#f3e8ff;border-color:#c4b5fd;color:#5b21b6;">Tab (3)</span>
+  <span class="section-chip" style="background:#ecfdf5;border-color:#86efac;color:#14532d;">Picker (5)</span>
+</div>
+
+<!-- ======================================== -->
+<h2 id="2-visual-reference">2. Visual Reference</h2>
+<p>See how tokens map to actual UI elements. Annotations show the token name used for each part.</p>
+
+<div class="preview-grid">
+  <!-- Light preview -->
+  <div class="preview-box preview-light">
+    <h4 id="light-theme-built-in-default">Light Theme (built-in default)</h4>
+
+    <div style="margin-bottom:16px;">
+      <div class="anno-line"><span class="anno">surface</span> Background</div>
+      <div style="background:#ffffff;border:1px solid #d8dce6;border-radius:8px;padding:16px;">
+        <div class="anno-line"><span class="anno">surface-alt</span> Card / raised panel</div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Buttons</div>
+          <span class="mock-btn" style="background:#2563eb;color:#fff;">Save <span class="anno">accent</span></span>
+          <span class="mock-btn" style="background:#fff;color:#1a1d27;border-color:#d8dce6;">Cancel <span class="anno">edge</span></span>
+          <span class="mock-btn" style="background:#ef4444;color:#fff;">Delete <span class="anno">danger</span></span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Status</div>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#10b981;"></span><span style="color:#10b981;font-weight:500;">Success</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#2563eb;"></span><span style="color:#2563eb;font-weight:500;">Synced</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#ea580c;"></span><span style="color:#ea580c;font-weight:500;">Pending</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#f59e0b;"></span><span style="color:#f59e0b;font-weight:500;">Warning</span></span>
+          <span style="font-size:13px;"><span class="mock-dot" style="background:#ef4444;"></span><span style="color:#ef4444;font-weight:500;">Error</span></span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Tabs</div>
+          <span class="mock-tab" style="background:#2563eb;color:#fff;border-radius:6px;">Active <span class="anno">tab-bg-active</span></span>
+          <span class="mock-tab" style="color:#6b7280;">Inactive <span class="anno">tab-text</span></span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Text</div>
+          <div style="color:#1a1d27;font-size:14px;font-weight:500;margin-bottom:2px;">Primary text <span class="anno">content</span></div>
+          <div style="color:#5c6478;font-size:13px;margin-bottom:2px;">Secondary text <span class="anno">content-secondary</span></div>
+          <div style="color:#8b94a8;font-size:13px;">Muted text <span class="anno">content-muted</span></div>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Keys</div>
+          <span class="mock-key" style="background:#ffffff;border-color:#c8cdd8;color:#1f2937;box-shadow:0 2px 0 #b0b8c8;">A</span>
+          <span class="mock-key" style="background:#f0f2f7;border-color:#c8cdd8;color:#1f2937;box-shadow:0 2px 0 #b0b8c8;">B <span style="font-size:8px;color:#7c8598;">hover</span></span>
+          <span class="mock-key" style="background:#2563eb;border-color:#2563eb;color:#fff;">C <span style="font-size:8px;">active</span></span>
+          <span class="mock-key" style="background:#93bbfd;border-color:#c8cdd8;color:#1f2937;">D <span style="font-size:8px;">multi</span></span>
+          <div style="margin-top:4px;">
+            <span class="anno">key-bg</span> <span class="anno">key-border</span> <span class="anno">key-shadow</span> <span class="anno">key-label</span>
+          </div>
+        </div>
+
+        <div>
+          <div style="font-size:11px;color:#8b94a8;margin-bottom:6px;">Picker</div>
+          <div class="mock-picker" style="background:#f8f9fb;">
+            <div class="mock-picker-item" style="background:#ffffff;border-color:#dfe3eb;color:#374151;">Item 1 <span class="anno">picker-item-bg</span></div>
+            <div class="mock-picker-item" style="background:#eef0f5;border-color:#dfe3eb;color:#374151;">Item 2 (hover) <span class="anno">picker-item-hover</span></div>
+            <div class="mock-picker-item" style="background:#ffffff;border-color:#dfe3eb;color:#374151;">Item 3</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Dark preview -->
+  <div class="preview-box preview-dark">
+    <h4 id="dark-theme-built-in-default">Dark Theme (built-in default)</h4>
+
+    <div style="margin-bottom:16px;">
+      <div class="anno-line"><span class="anno">surface</span> Background</div>
+      <div style="background:#1a1d27;border:1px solid #333a4d;border-radius:8px;padding:16px;">
+        <div class="anno-line"><span class="anno">surface-alt</span> Card / raised panel</div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Buttons</div>
+          <span class="mock-btn" style="background:#4c8dff;color:#fff;">Save</span>
+          <span class="mock-btn" style="background:#1a1d27;color:#e8eaf0;border-color:#333a4d;">Cancel</span>
+          <span class="mock-btn" style="background:#f87171;color:#fff;">Delete</span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Status</div>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#34d399;"></span><span style="color:#34d399;font-weight:500;">Success</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#4c8dff;"></span><span style="color:#4c8dff;font-weight:500;">Synced</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#fb923c;"></span><span style="color:#fb923c;font-weight:500;">Pending</span></span>
+          <span style="margin-right:12px;font-size:13px;"><span class="mock-dot" style="background:#fbbf24;"></span><span style="color:#fbbf24;font-weight:500;">Warning</span></span>
+          <span style="font-size:13px;"><span class="mock-dot" style="background:#f87171;"></span><span style="color:#f87171;font-weight:500;">Error</span></span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Tabs</div>
+          <span class="mock-tab" style="background:#4c8dff;color:#fff;border-radius:6px;">Active</span>
+          <span class="mock-tab" style="color:#8892a8;">Inactive</span>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Text</div>
+          <div style="color:#e8eaf0;font-size:14px;font-weight:500;margin-bottom:2px;">Primary text</div>
+          <div style="color:#9ba3b5;font-size:13px;margin-bottom:2px;">Secondary text</div>
+          <div style="color:#636d83;font-size:13px;">Muted text</div>
+        </div>
+
+        <div style="margin-bottom:12px;">
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Keys</div>
+          <span class="mock-key" style="background:#262b3a;border-color:#3d4560;color:#d4d8e3;box-shadow:0 2px 0 #0a0c12;">A</span>
+          <span class="mock-key" style="background:#323850;border-color:#3d4560;color:#d4d8e3;box-shadow:0 2px 0 #0a0c12;">B</span>
+          <span class="mock-key" style="background:#4c8dff;border-color:#4c8dff;color:#fff;">C</span>
+          <span class="mock-key" style="background:#3a6fcf;border-color:#3d4560;color:#d4d8e3;">D</span>
+        </div>
+
+        <div>
+          <div style="font-size:11px;color:#636d83;margin-bottom:6px;">Picker</div>
+          <div class="mock-picker" style="background:#1e2233;">
+            <div class="mock-picker-item" style="background:#282e40;border-color:#363e54;color:#c5cbd8;">Item 1</div>
+            <div class="mock-picker-item" style="background:#353d55;border-color:#363e54;color:#c5cbd8;">Item 2 (hover)</div>
+            <div class="mock-picker-item" style="background:#282e40;border-color:#363e54;color:#c5cbd8;">Item 3</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ======================================== -->
+<h2 id="3-complete-token-reference">3. Complete Token Reference</h2>
+<p>All 34 tokens with their default values in the built-in Light and Dark themes. When a theme pack is active, your single set of values replaces both columns — there is no per-mode split.</p>
+
+<div class="card" style="padding:0;overflow:hidden;">
+<table class="color-table">
+  <thead>
+    <tr>
+      <th style="width:30%;">Token</th>
+      <th style="width:30%;">Description</th>
+      <th style="width:20%;">Light Default</th>
+      <th style="width:20%;">Dark Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- Surface -->
+    <tr class="category-row"><td colspan="4"><span class="category-label">Surface</span> — Background layers and panels</td></tr>
+    <tr>
+      <td><span class="token-name">surface</span><br><span class="token-usage">Main application background</span></td>
+      <td class="token-desc">The base background colour for the entire app window. Everything sits on top of this.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f5f6f8;"></span><span class="swatch-value">#f5f6f8</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#0f1117;"></span><span class="swatch-value">#0f1117</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">surface-alt</span><br><span class="token-usage">Cards, modals, raised panels</span></td>
+      <td class="token-desc">Elevated containers that sit above <code>surface</code>. Cards, modals, sidebar panels, and dropdown menus use this.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#1a1d27;"></span><span class="swatch-value">#1a1d27</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">surface-dim</span><br><span class="token-usage">Recessed areas, code blocks</span></td>
+      <td class="token-desc">Slightly darker than <code>surface</code>. Used for recessed backgrounds, code blocks, and inset areas that should visually recede.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ebedf2;"></span><span class="swatch-value">#ebedf2</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#242836;"></span><span class="swatch-value">#242836</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">surface-raised</span><br><span class="token-usage">Tooltips, popovers, floating elements</span></td>
+      <td class="token-desc">The highest-elevation surface. Used for tooltips, popovers, and floating elements that stack above modals.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#2e3347;"></span><span class="swatch-value">#2e3347</span></td>
+    </tr>
+
+    <!-- Content -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#9d174d;">Content</span> — Text and foreground colours</td></tr>
+    <tr>
+      <td><span class="token-name">content</span><br><span class="token-usage">Primary text, headings</span></td>
+      <td class="token-desc">Main text colour. Used for headings, body text, labels, and any primary foreground content.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#1a1d27;"></span><span class="swatch-value">#1a1d27</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#e8eaf0;"></span><span class="swatch-value">#e8eaf0</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">content-secondary</span><br><span class="token-usage">Descriptions, metadata</span></td>
+      <td class="token-desc">Secondary text. Used for descriptions, metadata, timestamps, and less prominent labels.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#5c6478;"></span><span class="swatch-value">#5c6478</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#9ba3b5;"></span><span class="swatch-value">#9ba3b5</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">content-muted</span><br><span class="token-usage">Placeholders, disabled text</span></td>
+      <td class="token-desc">Low-emphasis text. Placeholders, disabled labels, and decorative text that should not draw attention.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#8b94a8;"></span><span class="swatch-value">#8b94a8</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#636d83;"></span><span class="swatch-value">#636d83</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">content-inverse</span><br><span class="token-usage">Text on accent/coloured backgrounds</span></td>
+      <td class="token-desc">Text placed on top of <code>accent</code>, <code>danger</code>, or other vivid backgrounds. Should contrast well against all semantic colours in your palette.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#0f1117;"></span><span class="swatch-value">#0f1117</span></td>
+    </tr>
+
+    <!-- Edge -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#065f46;">Edge</span> — Borders and dividers</td></tr>
+    <tr>
+      <td><span class="token-name">edge</span><br><span class="token-usage">Standard borders, dividers</span></td>
+      <td class="token-desc">Default border colour for cards, inputs, table rows, and horizontal dividers.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#d8dce6;"></span><span class="swatch-value">#d8dce6</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#333a4d;"></span><span class="swatch-value">#333a4d</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">edge-subtle</span><br><span class="token-usage">Light separators</span></td>
+      <td class="token-desc">Very light border for subtle separators and inner dividers that should barely be visible.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#e8ebf0;"></span><span class="swatch-value">#e8ebf0</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#272d3d;"></span><span class="swatch-value">#272d3d</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">edge-strong</span><br><span class="token-usage">Emphasised borders, focus rings</span></td>
+      <td class="token-desc">Stronger border for emphasis. Used for focused inputs, active selections, and borders that need more contrast.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#b8bfcf;"></span><span class="swatch-value">#b8bfcf</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#4a5270;"></span><span class="swatch-value">#4a5270</span></td>
+    </tr>
+
+    <!-- Semantic -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#92400e;">Semantic</span> — Accent and status colours</td></tr>
+    <tr>
+      <td><span class="token-name">accent</span><br><span class="token-usage">Primary action buttons, links, focus</span></td>
+      <td class="token-desc">The primary brand/action colour. "Save" buttons, active tabs, links, focus rings, and selection highlights.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#2563eb;"></span><span class="swatch-value">#2563eb</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#4c8dff;"></span><span class="swatch-value">#4c8dff</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">accent-hover</span><br><span class="token-usage">Accent button hover state</span></td>
+      <td class="token-desc">Hover/pressed state of accent-coloured elements. Slightly lighter or shifted variant of <code>accent</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#3b82f6;"></span><span class="swatch-value">#3b82f6</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#6ba1ff;"></span><span class="swatch-value">#6ba1ff</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">accent-alt</span><br><span class="token-usage">Secondary accent, info badges</span></td>
+      <td class="token-desc">An alternative accent for secondary calls-to-action or informational highlights that should differ from the primary accent.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#0ea5e9;"></span><span class="swatch-value">#0ea5e9</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#38bdf8;"></span><span class="swatch-value">#38bdf8</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">success</span><br><span class="token-usage">Success state, "synced" indicator</span></td>
+      <td class="token-desc">Positive status: successful operations, synced indicators, checkmarks, and confirmation messages.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#10b981;"></span><span class="swatch-value">#10b981</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#34d399;"></span><span class="swatch-value">#34d399</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">warning</span><br><span class="token-usage">Warning state, "syncing" indicator</span></td>
+      <td class="token-desc">Caution status: syncing in progress, version mismatches, and attention-required notices.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f59e0b;"></span><span class="swatch-value">#f59e0b</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#fbbf24;"></span><span class="swatch-value">#fbbf24</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">danger</span><br><span class="token-usage">Error state, delete buttons</span></td>
+      <td class="token-desc">Destructive/error status: delete buttons, error messages, failed operations, and critical alerts.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ef4444;"></span><span class="swatch-value">#ef4444</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f87171;"></span><span class="swatch-value">#f87171</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">pending</span><br><span class="token-usage">Pending state, in-progress</span></td>
+      <td class="token-desc">Pending/in-progress status: operations waiting to complete, upload progress, and queued actions.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ea580c;"></span><span class="swatch-value">#ea580c</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#fb923c;"></span><span class="swatch-value">#fb923c</span></td>
+    </tr>
+
+    <!-- Key -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#0c4a6e;">Key</span> — Keyboard key widgets</td></tr>
+    <tr>
+      <td><span class="token-name">key-bg</span><br><span class="token-usage">Default key background</span></td>
+      <td class="token-desc">Background of keyboard key caps in the keymap editor at rest.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#262b3a;"></span><span class="swatch-value">#262b3a</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-bg-hover</span><br><span class="token-usage">Hovered key</span></td>
+      <td class="token-desc">Background when the cursor hovers over a key cap.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f0f2f7;"></span><span class="swatch-value">#f0f2f7</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#323850;"></span><span class="swatch-value">#323850</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-bg-active</span><br><span class="token-usage">Selected / focused key</span></td>
+      <td class="token-desc">Background of the currently selected (clicked) key. Typically matches <code>accent</code> — labels on this key use <code>content-inverse</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#2563eb;"></span><span class="swatch-value">#2563eb</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#4c8dff;"></span><span class="swatch-value">#4c8dff</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-border</span><br><span class="token-usage">Key cap outline</span></td>
+      <td class="token-desc">Border around each key cap. Creates the 3D keycap effect together with <code>key-shadow</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#c8cdd8;"></span><span class="swatch-value">#c8cdd8</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#3d4560;"></span><span class="swatch-value">#3d4560</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-shadow</span><br><span class="token-usage">Key cap bottom shadow</span></td>
+      <td class="token-desc">The bottom shadow that gives key caps their 3D depth. Darker than <code>key-border</code>. Can be a colour value or <code>rgba()</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#b0b8c8;"></span><span class="swatch-value">#b0b8c8</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#0a0c12;"></span><span class="swatch-value">#0a0c12</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-label</span><br><span class="token-usage">Primary key legend</span></td>
+      <td class="token-desc">The main text label printed on each key cap (e.g. "A", "Ctrl", "Enter").</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#1f2937;"></span><span class="swatch-value">#1f2937</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#d4d8e3;"></span><span class="swatch-value">#d4d8e3</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-sublabel</span><br><span class="token-usage">Secondary key legend (shifted)</span></td>
+      <td class="token-desc">Secondary label on keys (e.g. shifted symbol, layer indicator). Dimmer than <code>key-label</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#7c8598;"></span><span class="swatch-value">#7c8598</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#7a839a;"></span><span class="swatch-value">#7a839a</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-label-remap</span><br><span class="token-usage">Remapped key label highlight</span></td>
+      <td class="token-desc">Label colour for keys that have been remapped from their default assignment. Draws attention to customised keys.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#0000ff;"></span><span class="swatch-value">#0000ff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f7a948;"></span><span class="swatch-value">#f7a948</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">key-bg-multi-selected</span><br><span class="token-usage">Multi-select / batch selection</span></td>
+      <td class="token-desc">Background for keys included in a multi-selection (e.g. combo key selection, batch reassignment).</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#93bbfd;"></span><span class="swatch-value">#93bbfd</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#3a6fcf;"></span><span class="swatch-value">#3a6fcf</span></td>
+    </tr>
+
+    <!-- Tab -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#5b21b6;">Tab</span> — Tab bar / navigation tabs</td></tr>
+    <tr>
+      <td><span class="token-name">tab-bg-active</span><br><span class="token-usage">Active tab background</span></td>
+      <td class="token-desc">Background fill for the currently active tab in editor tab bars (keymap, macro, tap dance, etc.).</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#2563eb;"></span><span class="swatch-value">#2563eb</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#4c8dff;"></span><span class="swatch-value">#4c8dff</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">tab-text</span><br><span class="token-usage">Inactive tab text</span></td>
+      <td class="token-desc">Text colour for inactive (unselected) tabs.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#6b7280;"></span><span class="swatch-value">#6b7280</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#8892a8;"></span><span class="swatch-value">#8892a8</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">tab-text-active</span><br><span class="token-usage">Active tab text</span></td>
+      <td class="token-desc">Text colour for the active tab. Should be readable on <code>tab-bg-active</code>.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+    </tr>
+
+    <!-- Picker -->
+    <tr class="category-row"><td colspan="4"><span class="category-label" style="background:#14532d;">Picker</span> — Keycode picker / palette</td></tr>
+    <tr>
+      <td><span class="token-name">picker-bg</span><br><span class="token-usage">Picker panel background</span></td>
+      <td class="token-desc">Background of the keycode picker panel (the searchable palette where you browse available keycodes).</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#f8f9fb;"></span><span class="swatch-value">#f8f9fb</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#1e2233;"></span><span class="swatch-value">#1e2233</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">picker-item-bg</span><br><span class="token-usage">Individual picker item</span></td>
+      <td class="token-desc">Background of each keycode item chip/card within the picker at rest.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#ffffff;"></span><span class="swatch-value">#ffffff</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#282e40;"></span><span class="swatch-value">#282e40</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">picker-item-hover</span><br><span class="token-usage">Hovered picker item</span></td>
+      <td class="token-desc">Background when hovering over a keycode item in the picker.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#eef0f5;"></span><span class="swatch-value">#eef0f5</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#353d55;"></span><span class="swatch-value">#353d55</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">picker-item-text</span><br><span class="token-usage">Picker item label</span></td>
+      <td class="token-desc">Text colour for keycode labels inside picker items.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#374151;"></span><span class="swatch-value">#374151</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#c5cbd8;"></span><span class="swatch-value">#c5cbd8</span></td>
+    </tr>
+    <tr>
+      <td><span class="token-name">picker-item-border</span><br><span class="token-usage">Picker item outline</span></td>
+      <td class="token-desc">Border around each keycode item in the picker.</td>
+      <td class="swatch-cell"><span class="swatch" style="background:#dfe3eb;"></span><span class="swatch-value">#dfe3eb</span></td>
+      <td class="swatch-cell"><span class="swatch" style="background:#363e54;"></span><span class="swatch-value">#363e54</span></td>
+    </tr>
+  </tbody>
+</table>
+</div>
+
+<!-- ======================================== -->
+<h2 id="4-design-guidelines">4. Design Guidelines</h2>
+
+<div class="tip">
+  <strong>Contrast matters.</strong> Ensure at least 4.5:1 contrast ratio between text tokens (<code>content</code>, <code>key-label</code>, <code>picker-item-text</code>) and their backgrounds (<code>surface</code>, <code>key-bg</code>, <code>picker-item-bg</code>).
+</div>
+
+<div class="tip">
+  <strong>One palette for everything.</strong> A theme pack overrides both light and dark built-in colours with a single set of 34 values — there is no separate light/dark split. Your palette is always applied as-is regardless of the system appearance setting.
+</div>
+
+<div class="warn">
+  <strong>key-shadow accepts <code>rgba()</code>.</strong> Unlike other tokens that typically use hex, <code>key-shadow</code> often benefits from semi-transparent values like <code>rgba(0,0,0,0.3)</code> to blend naturally with any <code>surface</code> colour beneath.
+</div>
+
+<h3 id="token-relationships">Token Relationships</h3>
+<div class="card">
+  <table style="width:100%;font-size:13px;border-collapse:collapse;">
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;font-weight:600;width:40%;">Foreground → Background</td>
+      <td style="padding:8px 12px;">Ensure readable contrast between these pairs</td>
+    </tr>
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;"><code>content</code> → <code>surface</code></td>
+      <td style="padding:8px 12px;">Primary text on app background</td>
+    </tr>
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;"><code>content-inverse</code> → <code>accent</code></td>
+      <td style="padding:8px 12px;">Button label on primary button</td>
+    </tr>
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;"><code>content-inverse</code> → <code>danger</code></td>
+      <td style="padding:8px 12px;">Button label on delete button</td>
+    </tr>
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;"><code>key-label</code> → <code>key-bg</code></td>
+      <td style="padding:8px 12px;">Key legend on key cap</td>
+    </tr>
+    <tr style="border-bottom:1px solid var(--doc-border);">
+      <td style="padding:8px 12px;"><code>tab-text-active</code> → <code>tab-bg-active</code></td>
+      <td style="padding:8px 12px;">Active tab text on active tab fill</td>
+    </tr>
+    <tr>
+      <td style="padding:8px 12px;"><code>picker-item-text</code> → <code>picker-item-bg</code></td>
+      <td style="padding:8px 12px;">Keycode label inside picker card</td>
+    </tr>
+  </table>
+</div>
+
+<h3 id="elevation-hierarchy">Elevation Hierarchy</h3>
+<div class="card">
+  <div style="display:flex;align-items:center;gap:12px;font-size:13px;flex-wrap:wrap;">
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="swatch" style="width:20px;height:20px;background:#ebedf2;"></span>
+      <code>surface-dim</code>
+    </div>
+    <span style="color:var(--doc-text3);">→</span>
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="swatch" style="width:20px;height:20px;background:#f5f6f8;"></span>
+      <code>surface</code>
+    </div>
+    <span style="color:var(--doc-text3);">→</span>
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="swatch" style="width:20px;height:20px;background:#ffffff;"></span>
+      <code>surface-alt</code>
+    </div>
+    <span style="color:var(--doc-text3);">→</span>
+    <div style="display:flex;align-items:center;gap:6px;">
+      <span class="swatch" style="width:20px;height:20px;background:#ffffff;border-color:#b8bfcf;"></span>
+      <code>surface-raised</code>
+    </div>
+    <span style="color:var(--doc-text3);font-size:12px;">(lowest → highest)</span>
+  </div>
+</div>
+
+<!-- ======================================== -->
+<h2 id="5-json-template">5. JSON Template</h2>
+<p>Copy this template and replace the colour values with your own. All 34 tokens are required.</p>
+
+<div class="json-block" id="json-template">
+<button class="copy-btn" onclick="copyTemplate()">Copy</button>
+<pre>{
+  <span class="jk">"name"</span>: <span class="jv">"My Theme"</span>,
+  <span class="jk">"version"</span>: <span class="jv">"1.0.0"</span>,
+  <span class="jk">"colors"</span>: {
+    <span class="jc">// Surface — background layers</span>
+    <span class="jk">"surface"</span>:          <span class="jv">"#f5f6f8"</span>,
+    <span class="jk">"surface-alt"</span>:      <span class="jv">"#ffffff"</span>,
+    <span class="jk">"surface-dim"</span>:      <span class="jv">"#ebedf2"</span>,
+    <span class="jk">"surface-raised"</span>:   <span class="jv">"#ffffff"</span>,
+
+    <span class="jc">// Content — text colours</span>
+    <span class="jk">"content"</span>:           <span class="jv">"#1a1d27"</span>,
+    <span class="jk">"content-secondary"</span>: <span class="jv">"#5c6478"</span>,
+    <span class="jk">"content-muted"</span>:     <span class="jv">"#8b94a8"</span>,
+    <span class="jk">"content-inverse"</span>:   <span class="jv">"#ffffff"</span>,
+
+    <span class="jc">// Edge — borders</span>
+    <span class="jk">"edge"</span>:              <span class="jv">"#d8dce6"</span>,
+    <span class="jk">"edge-subtle"</span>:       <span class="jv">"#e8ebf0"</span>,
+    <span class="jk">"edge-strong"</span>:       <span class="jv">"#b8bfcf"</span>,
+
+    <span class="jc">// Semantic — accent &amp; status</span>
+    <span class="jk">"accent"</span>:            <span class="jv">"#2563eb"</span>,
+    <span class="jk">"accent-hover"</span>:      <span class="jv">"#3b82f6"</span>,
+    <span class="jk">"accent-alt"</span>:        <span class="jv">"#0ea5e9"</span>,
+    <span class="jk">"success"</span>:           <span class="jv">"#10b981"</span>,
+    <span class="jk">"warning"</span>:           <span class="jv">"#f59e0b"</span>,
+    <span class="jk">"danger"</span>:            <span class="jv">"#ef4444"</span>,
+    <span class="jk">"pending"</span>:           <span class="jv">"#ea580c"</span>,
+
+    <span class="jc">// Key — keyboard key caps</span>
+    <span class="jk">"key-bg"</span>:            <span class="jv">"#ffffff"</span>,
+    <span class="jk">"key-bg-hover"</span>:      <span class="jv">"#f0f2f7"</span>,
+    <span class="jk">"key-bg-active"</span>:     <span class="jv">"#2563eb"</span>,
+    <span class="jk">"key-border"</span>:        <span class="jv">"#c8cdd8"</span>,
+    <span class="jk">"key-shadow"</span>:        <span class="jv">"#b0b8c8"</span>,
+    <span class="jk">"key-label"</span>:         <span class="jv">"#1f2937"</span>,
+    <span class="jk">"key-sublabel"</span>:      <span class="jv">"#7c8598"</span>,
+    <span class="jk">"key-label-remap"</span>:   <span class="jv">"#0000ff"</span>,
+    <span class="jk">"key-bg-multi-selected"</span>: <span class="jv">"#93bbfd"</span>,
+
+    <span class="jc">// Tab — navigation tabs</span>
+    <span class="jk">"tab-bg-active"</span>:     <span class="jv">"#2563eb"</span>,
+    <span class="jk">"tab-text"</span>:          <span class="jv">"#6b7280"</span>,
+    <span class="jk">"tab-text-active"</span>:   <span class="jv">"#ffffff"</span>,
+
+    <span class="jc">// Picker — keycode palette</span>
+    <span class="jk">"picker-bg"</span>:         <span class="jv">"#f8f9fb"</span>,
+    <span class="jk">"picker-item-bg"</span>:    <span class="jv">"#ffffff"</span>,
+    <span class="jk">"picker-item-hover"</span>: <span class="jv">"#eef0f5"</span>,
+    <span class="jk">"picker-item-text"</span>:  <span class="jv">"#374151"</span>,
+    <span class="jk">"picker-item-border"</span>:<span class="jv">"#dfe3eb"</span>
+  }
+}</pre>
+</div>
+
+<script>
+function copyTemplate() {
+  const json = `{
+  "name": "My Theme",
+  "version": "1.0.0",
+  "colors": {
+    "surface": "#f5f6f8",
+    "surface-alt": "#ffffff",
+    "surface-dim": "#ebedf2",
+    "surface-raised": "#ffffff",
+    "content": "#1a1d27",
+    "content-secondary": "#5c6478",
+    "content-muted": "#8b94a8",
+    "content-inverse": "#ffffff",
+    "edge": "#d8dce6",
+    "edge-subtle": "#e8ebf0",
+    "edge-strong": "#b8bfcf",
+    "accent": "#2563eb",
+    "accent-hover": "#3b82f6",
+    "accent-alt": "#0ea5e9",
+    "success": "#10b981",
+    "warning": "#f59e0b",
+    "danger": "#ef4444",
+    "pending": "#ea580c",
+    "key-bg": "#ffffff",
+    "key-bg-hover": "#f0f2f7",
+    "key-bg-active": "#2563eb",
+    "key-border": "#c8cdd8",
+    "key-shadow": "#b0b8c8",
+    "key-label": "#1f2937",
+    "key-sublabel": "#7c8598",
+    "key-label-remap": "#0000ff",
+    "key-bg-multi-selected": "#93bbfd",
+    "tab-bg-active": "#2563eb",
+    "tab-text": "#6b7280",
+    "tab-text-active": "#ffffff",
+    "picker-bg": "#f8f9fb",
+    "picker-item-bg": "#ffffff",
+    "picker-item-hover": "#eef0f5",
+    "picker-item-text": "#374151",
+    "picker-item-border": "#dfe3eb"
+  }
+}`;
+  navigator.clipboard.writeText(json).then(() => {
+    const btn = document.querySelector('.copy-btn');
+    btn.textContent = 'Copied!';
+    setTimeout(() => { btn.textContent = 'Copy'; }, 2000);
+  });
+}
+</script>
+
+<!-- ======================================== -->
+<h2 id="6-quick-start-workflow">6. Quick Start Workflow</h2>
+<div class="card">
+  <ol style="font-size:14px;color:var(--doc-text2);padding-left:20px;line-height:2;">
+    <li>Export any installed theme pack from Pipette (row → <strong>.json</strong>) as a starting template</li>
+    <li>Open the exported <code>.json</code> in your editor</li>
+    <li>Change <code>"name"</code> to your theme name and <code>"version"</code> to <code>"1.0.0"</code></li>
+    <li>Replace colour values — use this guide's token table and visual reference</li>
+    <li>Import in Pipette: <strong>Settings → Tools → Theme Packs → Edit → Import</strong></li>
+    <li>Apply and preview — click the radio circle next to your pack</li>
+    <li>Iterate: re-import with the same <code>"name"</code> to overwrite in place</li>
+    <li>Share on Pipette Hub via the <strong>Upload</strong> action</li>
+  </ol>
+</div>
+
+<p style="text-align:center;color:var(--doc-text3);font-size:12px;margin-top:40px;">
+  Pipette Desktop — Theme Pack Authoring Guide<br>
+  Accepted colour formats: <code>#hex</code>, <code>rgb()</code>, <code>hsl()</code>, <code>rgba()</code>
+</p>
+</article>
+  </main>
+</div>
+
+<script>const DOC_TO_TAB={"en":"en","ja":"en","data":"data","theme":"theme"};
+const contentEl = document.querySelector('.content');
+const tabs      = [...document.querySelectorAll('.tab')];
+const docEls    = [...document.querySelectorAll('.doc')];
+const tocPanels = [...document.querySelectorAll('.toc-panel')];
+
+function switchDoc(id, hash) {
+  const tabId = DOC_TO_TAB[id] ?? id;
+  tabs.forEach(t => t.classList.toggle('active', t.dataset.doc === tabId));
+  docEls.forEach(d => d.classList.toggle('active', d.id === 'doc-' + id));
+  tocPanels.forEach(p => p.classList.toggle('active', p.id === 'toc-' + id));
+
+  if (hash) {
+    setTimeout(() => scrollToHash(id, hash), 60);
+  } else {
+    contentEl.scrollTop = 0;
+  }
+}
+
+function scrollToHash(docId, hash) {
+  // Use getElementById to avoid CSS selector restriction on numeric-starting IDs (e.g. #1-3-data)
+  const id = hash.startsWith('#') ? hash.slice(1) : hash;
+  const target = document.getElementById(id);
+  if (!target) return;
+  const offset = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 48;
+  const top = target.getBoundingClientRect().top + contentEl.scrollTop - offset - 16;
+  contentEl.scrollTo({ top, behavior: 'smooth' });
+}
+
+// Tab click
+tabs.forEach(tab => tab.addEventListener('click', () => switchDoc(tab.dataset.doc)));
+
+// Link click delegation
+document.addEventListener('click', e => {
+  const xdoc = e.target.closest('.xdoc');
+  if (xdoc) {
+    e.preventDefault();
+    switchDoc(xdoc.dataset.doc, xdoc.dataset.hash || null);
+    return;
+  }
+  const ilink = e.target.closest('.ilink');
+  if (ilink) {
+    e.preventDefault();
+    const docId = ilink.dataset.doc;
+    const hash  = ilink.dataset.hash;
+    const activeDoc = document.querySelector('.doc.active');
+    if (!activeDoc || activeDoc.id !== 'doc-' + docId) {
+      switchDoc(docId, hash || null);
+    } else if (hash) {
+      scrollToHash(docId, hash);
+    }
+  }
+});
+
+// Highlight active TOC link via IntersectionObserver
+function highlightToc(docId, headingId) {
+  const toc = document.getElementById('toc-' + docId);
+  if (!toc) return;
+  let found = null;
+  toc.querySelectorAll('a').forEach(a => {
+    const active = a.dataset.hash === '#' + headingId;
+    a.classList.toggle('active', active);
+    if (active) found = a;
+  });
+  // scroll the TOC sidebar to keep active item visible
+  if (found) {
+    const sidebar = document.querySelector('.sidebar');
+    const aTop  = found.getBoundingClientRect().top;
+    const { top: sTop, bottom: sBot } = sidebar.getBoundingClientRect();
+    if (aTop < sTop + 40 || aTop > sBot - 40) {
+      found.scrollIntoView({ block: 'nearest' });
+    }
+  }
+}
+
+docEls.forEach(docEl => {
+  const docId    = docEl.id.replace('doc-', '');
+  const headings = docEl.querySelectorAll('h2, h3');
+
+  const observer = new IntersectionObserver(entries => {
+    const visible = entries.filter(e => e.isIntersecting);
+    if (visible.length > 0) {
+      highlightToc(docId, visible[0].target.id);
+    }
+  }, {
+    root:       contentEl,
+    rootMargin: '-10% 0px -75% 0px',
+    threshold:  0,
+  });
+
+  headings.forEach(h => observer.observe(h));
+});
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test:e2e": "playwright test",
     "test:e2e:dev": "E2E_MODE=dev playwright test",
     "generate:language-manifest": "tsx scripts/generate-language-manifest.ts",
-    "doc:screenshots": "npx tsx e2e/helpers/doc-capture.ts"
+    "doc:screenshots": "npx tsx e2e/helpers/doc-capture.ts",
+    "doc:guide": "node docs/build-guide.mjs"
   },
   "dependencies": {
     "@paymoapp/active-window": "^2.1.4",


### PR DESCRIPTION
## Summary
- Convert `OPERATION-GUIDE.md`, `OPERATION-GUIDE.ja.md`, `Data.md`, and `THEME-PACK-AUTHORING.html` into a single `docs/guide.html`
- Fixed header with 3-tab bar: Operation Guide (EN/JA via in-doc links) / Data Guide / Theme Authoring
- Left sidebar TOC with IntersectionObserver-based active heading tracking
- Cross-doc links switch tabs instead of opening externally
- Embedded TOC sections stripped from content (sidebar replaces them)
- Add `pnpm run doc:guide` script (`node docs/build-guide.mjs`)

## Test plan
- [ ] `pnpm run doc:guide` runs without error and produces `docs/guide.html`
- [ ] Tab bar switches between Operation Guide / Data Guide / Theme Authoring
- [ ] "日本語版はこちら" / "English version" links switch language within the tab
- [ ] Sidebar TOC highlights active heading while scrolling
- [ ] Theme Pack Authoring Guide links in content switch to Theme tab