### PR TITLE
docs(build): add index.html redirect for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<meta http-equiv="refresh" content="0; url=guide.html">
+<link rel="canonical" href="guide.html">
+<title>Pipette Docs</title>


### PR DESCRIPTION
## Summary
- Add `docs/index.html` that redirects to `guide.html` via meta-refresh
- Enables `https://darakuneko.github.io/pipette-desktop/` to land on the docs guide directly

## Test plan
- [ ] Visit `https://darakuneko.github.io/pipette-desktop/` → redirects to `guide.html`