### PR TITLE
chore(build): rebuild docs/guide.html in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
       - run: npx tsx scripts/check-hook-deps-tdz.ts
       - run: pnpm test
       - run: pnpm build
+      - run: pnpm run doc:guide
+      - name: Verify docs/guide.html is up to date
+        run: git diff --exit-code docs/guide.html || (echo "docs/guide.html is stale — run 'pnpm run doc:guide' and commit the result." && exit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
       - run: pnpm test
+      - run: pnpm run doc:guide
 
   build:
     needs: test


### PR DESCRIPTION
## Summary
- **ci.yml**: Run `pnpm run doc:guide` after build, then fail if `docs/guide.html` is stale — ensures every PR that touches source docs also commits the rebuilt guide
- **release.yml**: Run `pnpm run doc:guide` in the test job — confirms the guide builds cleanly at release time

## How it works
PRs that modify `docs/OPERATION-GUIDE.md`, `docs/Data.md`, `docs/THEME-PACK-AUTHORING.html`, or `docs/build-guide.mjs` without regenerating `docs/guide.html` will fail CI with:
> docs/guide.html is stale — run 'pnpm run doc:guide' and commit the result.

Since GitHub Pages serves `/docs` from `main`, this guarantees Pages always reflects the latest source.

## Test plan
- [ ] CI passes on this PR (guide.html is already up to date)
- [ ] Modifying a source doc without rebuilding guide.html causes CI to fail