### PR TITLE
docs(build): remove index.html redirect

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<meta charset="UTF-8">
-<meta http-equiv="refresh" content="0; url=guide.html">
-<link rel="canonical" href="guide.html">
-<title>Pipette Docs</title>


### PR DESCRIPTION
## Summary
- Remove `docs/index.html` — users access `https://darakuneko.github.io/pipette-desktop/guide.html` directly