### PR TITLE
chore(build): add explicit read-only permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` at workflow level in `ci.yml`
- Closes the minimal-permission gap identified during Pwn Request audit
- `pull_request` trigger already isolates fork PRs from secrets; this makes the intent explicit

## Test plan
- [ ] CI passes on this PR