### PR TITLE
fix(ui): pack modal hub props, auto-fetch, and userData path restore

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
   },
   "build": {
     "appId": "app.pipette.desktop",
-    "productName": "Pipette",
     "npmRebuild": false,
     "directories": {
       "output": "dist"

--- a/src/renderer/components/QuickSettingsSelects.tsx
+++ b/src/renderer/components/QuickSettingsSelects.tsx
@@ -129,11 +129,17 @@ export function QuickSettingsSelects({
           {editMode ? t('common.done') : t('common.edit')}
         </button>
       </div>
-      <LanguagePacksModal open={activeModal === 'language'} onClose={closeModal} />
+      <LanguagePacksModal
+        open={activeModal === 'language'}
+        onClose={closeModal}
+        currentDisplayName={hubDisplayName}
+        hubCanWrite={hubCanWrite}
+      />
       <ThemePacksModal
         open={activeModal === 'theme'}
         onClose={closeModal}
         onThemeChange={onThemeChange}
+        hubCanWrite={hubCanWrite}
       />
       <KeyLabelsModal
         open={activeModal === 'keyLabels'}

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -89,6 +89,7 @@ export function LanguagePacksModal({
   const [activeTab, setActiveTab] = useState<TabId>('installed')
   const [search, setSearch] = useState('')
   const [hubResults, setHubResults] = useState<HubI18nPostListItem[]>([])
+  const [hubDefaultResults, setHubDefaultResults] = useState<HubI18nPostListItem[]>([])
   const [hubSearched, setHubSearched] = useState(false)
   const [hubSearching, setHubSearching] = useState(false)
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -227,6 +228,7 @@ export function LanguagePacksModal({
       if (result.success && result.data) {
         setHubResults(result.data.items)
         setHubSearched(true)
+        if (!query.trim()) setHubDefaultResults(result.data.items)
       } else {
         setActionError(result.error ?? t('i18n.errorGeneric'))
       }
@@ -235,22 +237,25 @@ export function LanguagePacksModal({
     }
   }, [t])
 
-  // Debounced auto-search: only fire once the user has typed 2+
-  // characters. Below the threshold we clear the previous results
-  // (and reset the "have searched" flag) so the empty hint comes back
-  // instead of leaving stale rows visible. Mirrors the KeyLabelsModal
-  // contract so the two manage modals stay predictable.
+  // Auto-fetch Hub list when the hub tab becomes active (no query = latest items).
+  // Re-fetches each time the modal is opened so results stay fresh.
+  useEffect(() => {
+    if (!open || activeTab !== 'hub' || hubSearched) return
+    void runSearch('')
+  }, [open, activeTab, hubSearched, runSearch])
+
+  // Debounced search: fire once the user has typed 2+ characters.
+  // Below the threshold restore the initial results instead of clearing.
   useEffect(() => {
     if (!open || activeTab !== 'hub') return
     const query = search.trim()
     if (query.length < 2) {
-      setHubResults((prev) => (prev.length === 0 ? prev : []))
-      setHubSearched((prev) => (prev ? false : prev))
+      if (hubDefaultResults.length > 0) setHubResults(hubDefaultResults)
       return
     }
     const handle = window.setTimeout(() => { void runSearch(query) }, 300)
     return () => { window.clearTimeout(handle) }
-  }, [open, activeTab, search, runSearch])
+  }, [open, activeTab, search, runSearch, hubDefaultResults])
 
   useEffect(() => {
     if (!open) {
@@ -258,6 +263,10 @@ export function LanguagePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
+      setHubSearched(false)
+      setHubResults([])
+      setHubDefaultResults([])
+      setSearch('')
     }
   }, [open])
 

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -546,6 +546,7 @@ describe('LanguagePacksModal', () => {
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
     await act(async () => { fireEvent.click(screen.getByTestId('language-packs-tab-hub')) })
+    vialAPI.hubListI18nPosts.mockClear()
     await act(async () => {
       fireEvent.change(screen.getByTestId('language-packs-search-input'), { target: { value: 'french' } })
     })
@@ -654,13 +655,16 @@ describe('LanguagePacksModal', () => {
     })
   })
 
-  it('hub initial hint when no search has been performed', async () => {
+  it('hub initial hint: auto-fetches hub list on tab open', async () => {
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
     await switchToHubTab()
-    expect(screen.getByTestId('language-packs-hub-empty')).toBeTruthy()
-    expect(screen.getByText('common.findOnHubHint')).toBeTruthy()
+    expect(vialAPI.hubListI18nPosts).toHaveBeenCalledWith({ q: '' })
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-hub-empty')).toBeTruthy()
+      expect(screen.getByText('i18n.hubEmpty')).toBeTruthy()
+    })
   })
 
   it('hub search error is displayed', async () => {

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -72,6 +72,7 @@ export function KeyLabelsModal({
   const [activeTab, setActiveTab] = useState<TabId>('installed')
   const [search, setSearch] = useState('')
   const [hubResults, setHubResults] = useState<HubKeyLabelItem[]>([])
+  const [hubDefaultResults, setHubDefaultResults] = useState<HubKeyLabelItem[]>([])
   const [hubSearched, setHubSearched] = useState(false)
   const [hubSearching, setHubSearching] = useState(false)
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -156,7 +157,6 @@ export function KeyLabelsModal({
   useEffect(() => { tRef.current = t }, [t])
 
   const runSearch = useCallback(async (query: string): Promise<void> => {
-    if (query.length < 2) return
     setHubSearching(true)
     setActionError(null)
     const res = await labelsRef.current.hubSearch({ q: query, perPage: 50 })
@@ -167,29 +167,44 @@ export function KeyLabelsModal({
       setHubResults([])
       return
     }
-    setHubResults((res.data as HubKeyLabelListResponse).items)
+    const items = (res.data as HubKeyLabelListResponse).items
+    setHubResults(items)
+    if (!query.trim()) setHubDefaultResults(items)
   }, [])
 
   const triggerSearch = useCallback((): void => {
     void runSearch(search.trim())
   }, [runSearch, search])
 
-  // Debounced auto-search: once the user has typed 2+ characters,
-  // queue a search 300ms after the last keystroke. Below the
-  // threshold we reset the result panel back to the initial hint
-  // (only when there is something to clear, to avoid setState ↔
-  // effect feedback loops).
+  // Auto-fetch Hub list when the hub tab becomes active.
+  // Re-fetches each time the modal is opened so results stay fresh.
+  useEffect(() => {
+    if (!open || activeTab !== 'hub' || hubSearched) return
+    void runSearch('')
+  }, [open, activeTab, hubSearched, runSearch])
+
+  // Reset hub state when modal closes so next open re-fetches fresh data.
+  useEffect(() => {
+    if (!open) {
+      setHubSearched(false)
+      setHubResults([])
+      setHubDefaultResults([])
+      setSearch('')
+    }
+  }, [open])
+
+  // Debounced search: fire once the user has typed 2+ characters.
+  // Below the threshold restore the initial results instead of clearing.
   useEffect(() => {
     if (activeTab !== 'hub') return
     const query = search.trim()
     if (query.length < 2) {
-      setHubResults((prev) => (prev.length === 0 ? prev : []))
-      setHubSearched((prev) => (prev ? false : prev))
+      if (hubDefaultResults.length > 0) setHubResults(hubDefaultResults)
       return
     }
     const handle = window.setTimeout(() => { void runSearch(query) }, 300)
     return () => { window.clearTimeout(handle) }
-  }, [activeTab, search, runSearch])
+  }, [activeTab, search, runSearch, hubDefaultResults])
 
   const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
     if (event.key === 'Enter') {

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -223,11 +223,11 @@ describe('KeyLabelsModal', () => {
   it('triggers hub search when Search button clicked', async () => {
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-tab-hub'))
+    await waitFor(() => expect(hubSearch).toHaveBeenCalledWith({ q: '', perPage: 50 }))
+    hubSearch.mockClear()
     fireEvent.change(screen.getByTestId('key-labels-search-input'), { target: { value: 'french' } })
     fireEvent.click(screen.getByTestId('key-labels-search-button'))
-
-    await waitFor(() => expect(hubSearch).toHaveBeenCalled())
-    expect(hubSearch).toHaveBeenCalledWith({ q: 'french', perPage: 50 })
+    await waitFor(() => expect(hubSearch).toHaveBeenCalledWith({ q: 'french', perPage: 50 }))
   })
 
   it('shows hub-only rows after a search returns items', async () => {

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -55,6 +55,7 @@ export function ThemePacksModal({
   const [lastResult, setLastResult] = useState<{ id: string; kind: 'success' | 'error'; message: string } | null>(null)
   const [search, setSearch] = useState('')
   const [hubResults, setHubResults] = useState<HubThemePostListItem[]>([])
+  const [hubDefaultResults, setHubDefaultResults] = useState<HubThemePostListItem[]>([])
   const [hubSearched, setHubSearched] = useState(false)
   const [hubSearching, setHubSearching] = useState(false)
   const [hubOrigin, setHubOrigin] = useState('')
@@ -109,6 +110,7 @@ export function ThemePacksModal({
       if (result.success && result.data) {
         setHubResults(result.data.items)
         setHubSearched(true)
+        if (!query.trim()) setHubDefaultResults(result.data.items)
       } else {
         setActionError(result.error ?? t('themePacks.hubEmpty'))
       }
@@ -117,17 +119,25 @@ export function ThemePacksModal({
     }
   }, [t])
 
+  // Auto-fetch Hub list when the hub tab becomes active.
+  // Re-fetches each time the modal is opened so results stay fresh.
+  useEffect(() => {
+    if (!open || activeTab !== 'hub' || hubSearched) return
+    void runSearch('')
+  }, [open, activeTab, hubSearched, runSearch])
+
+  // Debounced search: fire once the user has typed 2+ characters.
+  // Below the threshold restore the initial results instead of clearing.
   useEffect(() => {
     if (!open || activeTab !== 'hub') return
     const query = search.trim()
     if (query.length < 2) {
-      setHubResults((prev) => (prev.length === 0 ? prev : []))
-      setHubSearched((prev) => (prev ? false : prev))
+      if (hubDefaultResults.length > 0) setHubResults(hubDefaultResults)
       return
     }
     const handle = window.setTimeout(() => { void runSearch(query) }, 300)
     return () => { window.clearTimeout(handle) }
-  }, [open, activeTab, search, runSearch])
+  }, [open, activeTab, search, runSearch, hubDefaultResults])
 
   const restoreActiveTheme = useCallback(() => {
     clearPackColors()
@@ -181,6 +191,10 @@ export function ThemePacksModal({
       setConfirmRemoveId(null)
       hubPreviewCacheRef.current.clear()
       activePackCacheRef.current = null
+      setHubSearched(false)
+      setHubResults([])
+      setHubDefaultResults([])
+      setSearch('')
     }
   }, [open, previewPostId, restoreActiveTheme])
 

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -351,8 +351,11 @@ describe('ThemePacksModal', () => {
     render(
       <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
     )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
-    fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'neon' } })
+    await act(async () => { fireEvent.click(screen.getByTestId('theme-packs-tab-hub')) })
+    vialAPI.hubListThemePosts.mockClear()
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'neon' } })
+    })
     expect(vialAPI.hubListThemePosts).not.toHaveBeenCalled()
     await act(async () => { vi.advanceTimersByTime(300) })
     vi.useRealTimers()
@@ -360,6 +363,11 @@ describe('ThemePacksModal', () => {
   })
 
   it('shows hub results after search returns items', async () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: '' }))
     vialAPI.hubListThemePosts.mockResolvedValueOnce({
       success: true,
       data: {
@@ -368,10 +376,6 @@ describe('ThemePacksModal', () => {
         ],
       },
     })
-    render(
-      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
-    )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
     fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'retro' } })
     fireEvent.click(screen.getByTestId('theme-packs-search-button'))
     await waitFor(() => {
@@ -381,6 +385,11 @@ describe('ThemePacksModal', () => {
   })
 
   it('hub download action calls hubDownloadThemePost and applyImport', async () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: '' }))
     vialAPI.hubListThemePosts.mockResolvedValueOnce({
       success: true,
       data: {
@@ -389,10 +398,6 @@ describe('ThemePacksModal', () => {
         ],
       },
     })
-    render(
-      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
-    )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
     fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'dark' } })
     fireEvent.click(screen.getByTestId('theme-packs-search-button'))
     await waitFor(() => expect(screen.getByTestId('theme-packs-hub-download-hub-2')).toBeTruthy())
@@ -403,6 +408,11 @@ describe('ThemePacksModal', () => {
 
   it('hub row shows installed label when pack is already installed', async () => {
     metas = [meta({ id: 'local1', name: 'Existing', hubPostId: 'hub-3' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: '' }))
     vialAPI.hubListThemePosts.mockResolvedValueOnce({
       success: true,
       data: {
@@ -411,10 +421,6 @@ describe('ThemePacksModal', () => {
         ],
       },
     })
-    render(
-      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
-    )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
     fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'exist' } })
     fireEvent.click(screen.getByTestId('theme-packs-search-button'))
     await waitFor(() => expect(screen.getByTestId('theme-packs-hub-row-hub-3')).toBeTruthy())
@@ -450,6 +456,11 @@ describe('ThemePacksModal', () => {
   })
 
   it('preview button calls hubDownloadThemePost', async () => {
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: '' }))
     vialAPI.hubListThemePosts.mockResolvedValueOnce({
       success: true,
       data: {
@@ -458,10 +469,6 @@ describe('ThemePacksModal', () => {
         ],
       },
     })
-    render(
-      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
-    )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
     fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'preview' } })
     fireEvent.click(screen.getByTestId('theme-packs-search-button'))
     await waitFor(() => expect(screen.getByTestId('theme-packs-hub-preview-hub-p')).toBeTruthy())
@@ -643,6 +650,11 @@ describe('ThemePacksModal', () => {
 
   it('does not treat deleted (tombstoned) metas as installed in hub rows', async () => {
     metas = [meta({ id: 'del1', name: 'Deleted', hubPostId: 'hp-del1', deletedAt: '2026-01-01' })]
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
+    await waitFor(() => expect(vialAPI.hubListThemePosts).toHaveBeenCalledWith({ q: '' }))
     vialAPI.hubListThemePosts.mockResolvedValueOnce({
       success: true,
       data: {
@@ -651,10 +663,6 @@ describe('ThemePacksModal', () => {
         ],
       },
     })
-    render(
-      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
-    )
-    fireEvent.click(screen.getByTestId('theme-packs-tab-hub'))
     fireEvent.change(screen.getByTestId('theme-packs-search-input'), { target: { value: 'deleted' } })
     fireEvent.click(screen.getByTestId('theme-packs-search-button'))
     await waitFor(() => expect(screen.getByTestId('theme-packs-hub-row-hp-del1')).toBeTruthy())


### PR DESCRIPTION
## Summary

- Pass missing `hubCanWrite` and `currentDisplayName` props to `LanguagePacksModal` and `ThemePacksModal` in `QuickSettingsSelects` — Hub upload/update/remove actions were hidden due to props defaulting to `false`/`undefined`
- Auto-fetch Hub list when Language Packs, Theme Packs, and Key Labels modals open the Find on Hub tab; clearing search restores initial results without a network round-trip; closing and reopening re-fetches fresh data
- Remove `"productName": "Pipette"` from `build` config in `package.json` to restore correct userData path

## Test plan

- [ ] Open Language Packs / Theme Packs / Key Labels from the key picker bottom bar
- [ ] Verify Hub upload/update/remove buttons appear when signed in
- [ ] Switch to Find on Hub tab — list loads automatically without typing
- [ ] Type 2+ chars — search results appear; clear field — initial list restores
- [ ] Close and reopen modal — Hub list re-fetches fresh data
- [ ] Verify settings are saved to `~/.config/Pipette/` (not `~/.config/pipette-desktop/`)