### PR TITLE
fix(build): set Wayland app-id and window icon for Linux dock

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,8 @@ import { secureHandle, secureOn } from './ipc-guard'
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL
 
+app.setDesktopName('pipette')
+
 // Linux: disable GPU sandbox only when chrome-sandbox lacks SUID root.
 // Packaged builds with correct permissions keep the GPU sandbox enabled.
 if (process.platform === 'linux') {
@@ -78,6 +80,7 @@ function createWindow(): void {
     height: saved.height,
     minWidth: 1320,
     minHeight: 960,
+    icon: join(__dirname, '../../build/icon.png'),
     webPreferences: {
       preload: join(__dirname, '../preload/index.cjs'),
       contextIsolation: true,


### PR DESCRIPTION
## Summary

- Add `app.setDesktopName('pipette')` to set the Wayland app-id matching `pipette.desktop`'s `StartupWMClass`, fixing the gear icon shown in the GNOME dock on Wayland sessions
- Add `icon` to `BrowserWindow` options for X11 fallback

## Test plan

- [ ] Run `pnpm dev` on Linux (Wayland session) and confirm the GNOME dock shows the Pipette icon instead of a gear
- [ ] Run `pnpm dev` on Linux (X11 session) and confirm the window icon is correct