### PR TITLE
fix(build): remove top-level productName to restore userData path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "pipette-desktop",
-  "productName": "Pipette",
   "version": "0.4.5",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
## Summary

- Remove `productName` from the top-level `package.json` to restore userData path to `~/.config/pipette-desktop`
- The previous top-level `productName: "Pipette"` caused Electron to use `~/.config/Pipette` instead

## Test plan

- [ ] Confirm userData is stored at `~/.config/pipette-desktop` after this change