### PR TITLE
docs(ui): improve sample themes link in theme authoring guide

### DIFF
--- a/docs/THEME-PACK-AUTHORING.html
+++ b/docs/THEME-PACK-AUTHORING.html
@@ -877,12 +877,9 @@ function copyTemplate() {
     <li>Iterate: re-import with the same <code>"name"</code> to overwrite in place</li>
     <li>Share on Pipette Hub via the <strong>Upload</strong> action</li>
   </ol>
-</div>
-
-<div class="tip" style="margin-top:32px;">
-  <strong>Example themes.</strong> Ready-made theme packs are available in the
-  <a href="https://github.com/darakuneko/pipette-desktop/tree/main/sample-packs/themes" target="_blank" rel="noopener noreferrer" style="color:#1e40af;">sample-packs/themes</a>
-  directory of the repository. Use them as real-world references when building your own palette.
+  <p style="font-size:13px;color:var(--doc-text2);margin-top:12px;padding-left:20px;">
+    Check out the sample theme packs on <a href="https://github.com/darakuneko/pipette-desktop/tree/main/sample-packs/themes" target="_blank" rel="noopener noreferrer" style="color:#2563eb;">GitHub</a>.
+  </p>
 </div>
 
 <p style="text-align:center;color:var(--doc-text3);font-size:12px;margin-top:40px;">

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -2686,12 +2686,9 @@ function copyTemplate() {
     <li>Iterate: re-import with the same <code>"name"</code> to overwrite in place</li>
     <li>Share on Pipette Hub via the <strong>Upload</strong> action</li>
   </ol>
-</div>
-
-<div class="tip" style="margin-top:32px;">
-  <strong>Example themes.</strong> Ready-made theme packs are available in the
-  <a href="https://github.com/darakuneko/pipette-desktop/tree/main/sample-packs/themes" target="_blank" rel="noopener noreferrer" style="color:#1e40af;">sample-packs/themes</a>
-  directory of the repository. Use them as real-world references when building your own palette.
+  <p style="font-size:13px;color:var(--doc-text2);margin-top:12px;padding-left:20px;">
+    Check out the sample theme packs on <a href="https://github.com/darakuneko/pipette-desktop/tree/main/sample-packs/themes" target="_blank" rel="noopener noreferrer" style="color:#2563eb;">GitHub</a>.
+  </p>
 </div>
 
 <p style="text-align:center;color:var(--doc-text3);font-size:12px;margin-top:40px;">


### PR DESCRIPTION
## Summary

- Move sample themes reference link into Quick Start Workflow section (below step 8)
- Simplify text to "Check out the sample theme packs on GitHub."
- Fix link color and background for readability

## Test plan

- [ ] Open `docs/guide.html` in browser and verify link appears correctly below step 8
- [ ] Confirm link color is blue and text is black