### PR TITLE
refactor(ui): standardize design tokens across renderer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -578,7 +578,7 @@ export function App() {
     <>
       {(fileHandlers.handleImportVil || (!device.isDummy && sideload.sideloadJson)) && (
         <div className={ROW_CLASS} data-testid="overlay-import-row">
-          <span className="text-[13px] font-medium text-content">{t('layoutStore.import')}</span>
+          <span className="text-sm font-medium text-content">{t('layoutStore.import')}</span>
           <div className="flex gap-2">
             <button
               type="button"

--- a/src/renderer/components/ConnectingOverlay.tsx
+++ b/src/renderer/components/ConnectingOverlay.tsx
@@ -68,7 +68,7 @@ export function ConnectingOverlay({
             </p>
           )}
           {deviceId && (
-            <p className="font-mono text-[11px] tracking-wide text-content-muted">
+            <p className="font-mono text-xs tracking-wide text-content-muted">
               {deviceId}
             </p>
           )}

--- a/src/renderer/components/DeviceSelector.tsx
+++ b/src/renderer/components/DeviceSelector.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Settings, Database, ChevronRight, ChevronLeft } from 'lucide-react'
+import { ICON_XS, ICON_SM, ICON_MD } from '../constants/ui-tokens'
 import { SYNC_STATUS_CLASS } from './sync-ui'
 import type { DeviceInfo } from '../../shared/types/protocol'
 import type { SyncStatusType } from '../../shared/types/sync'
@@ -13,10 +14,10 @@ const DEVICE_ENTRY_CLASS =
   'flex w-full items-center gap-3.5 rounded-lg border border-edge p-3.5 text-left transition-colors hover:border-accent hover:bg-accent/10 disabled:opacity-50'
 
 const HEADER_BTN =
-  'flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5 text-[13px] font-medium text-content-muted transition-colors hover:border-edge hover:bg-surface-dim hover:text-content-secondary disabled:opacity-50'
+  'flex items-center gap-1.5 rounded-lg border border-transparent px-2.5 py-1.5 text-sm font-medium text-content-muted transition-colors hover:border-edge hover:bg-surface-dim hover:text-content-secondary disabled:opacity-50'
 
 const TAB_CLASS =
-  'flex-1 rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors'
+  'flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors'
 
 const TAB_ACTIVE =
   'bg-surface text-content shadow-sm'
@@ -123,7 +124,7 @@ export function DeviceSelector({
                 data-testid="data-button"
                 className={HEADER_BTN}
               >
-                <Database size={14} aria-hidden="true" />
+                <Database size={ICON_SM} aria-hidden="true" />
                 {t('dataModal.title')}
               </button>
             )}
@@ -135,7 +136,7 @@ export function DeviceSelector({
                 data-testid="settings-button"
                 className={HEADER_BTN}
               >
-                <Settings size={14} aria-hidden="true" />
+                <Settings size={ICON_SM} aria-hidden="true" />
                 {t('settings.title')}
               </button>
             )}
@@ -179,7 +180,7 @@ export function DeviceSelector({
         {tab === 'keyboard' && (
           <>
             <div className="mb-5">
-              <p className="mb-2.5 pl-0.5 text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+              <p className="mb-2.5 pl-0.5 text-2xs font-semibold uppercase tracking-widest text-content-muted">
                 {t('app.selectDevices')}
               </p>
 
@@ -197,13 +198,13 @@ export function DeviceSelector({
                       <div className="font-semibold text-content">
                         {device.productName || 'Unknown Device'}
                       </div>
-                      <div className="mt-0.5 font-mono text-[11px] tracking-wide text-content-muted" data-testid="device-id">
+                      <div className="mt-0.5 font-mono text-xs tracking-wide text-content-muted" data-testid="device-id">
                         {device.vendorId.toString(16).padStart(4, '0')}:
                         {device.productId.toString(16).padStart(4, '0')}
                         {device.type !== 'vial' && ` (${device.type})`}
                       </div>
                     </div>
-                    <ChevronRight size={16} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
+                    <ChevronRight size={ICON_MD} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
                   </button>
                 ))}
 
@@ -232,7 +233,7 @@ export function DeviceSelector({
         {tab === 'file' && !selectedFileUid && (
           <div data-testid="file-tab-content">
             <div className="mb-5">
-              <p className="mb-2.5 pl-0.5 text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+              <p className="mb-2.5 pl-0.5 text-2xs font-semibold uppercase tracking-widest text-content-muted">
                 {t('app.selectKeyboard')}
               </p>
 
@@ -249,11 +250,11 @@ export function DeviceSelector({
                       <div className="font-semibold text-content">
                         {kb.name}
                       </div>
-                      <div className="mt-0.5 text-[11px] text-content-muted">
+                      <div className="mt-0.5 text-xs text-content-muted">
                         {t('app.fileCount', { count: kb.entryCount })}
                       </div>
                     </div>
-                    <ChevronRight size={16} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
+                    <ChevronRight size={ICON_MD} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
                   </button>
                 ))}
 
@@ -286,13 +287,13 @@ export function DeviceSelector({
                 <button
                   type="button"
                   data-testid="file-back-button"
-                  className="flex items-center gap-0.5 text-[10px] font-semibold uppercase tracking-widest text-content-muted transition-colors hover:text-content-secondary"
+                  className="flex items-center gap-0.5 text-2xs font-semibold uppercase tracking-widest text-content-muted transition-colors hover:text-content-secondary"
                   onClick={() => { setSelectedFileUid(null); onClearError?.() }}
                 >
-                  <ChevronLeft size={12} aria-hidden="true" />
+                  <ChevronLeft size={ICON_XS} aria-hidden="true" />
                   {t('common.back')}
                 </button>
-                <span className="text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+                <span className="text-2xs font-semibold uppercase tracking-widest text-content-muted">
                   {selectedKeyboardName}
                 </span>
               </div>
@@ -311,11 +312,11 @@ export function DeviceSelector({
                       <div className="font-semibold text-content">
                         {entry.label || entry.keyboardName}
                       </div>
-                      <div className="mt-0.5 font-mono text-[11px] tracking-wide text-content-muted">
+                      <div className="mt-0.5 font-mono text-xs tracking-wide text-content-muted">
                         {formatDate(entry.savedAt)}
                       </div>
                     </div>
-                    <ChevronRight size={16} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
+                    <ChevronRight size={ICON_MD} aria-hidden="true" className="text-content-muted opacity-20 transition-opacity group-hover:opacity-60" />
                   </button>
                 ))}
               </div>

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -152,7 +152,7 @@ export function StatusBar({
           <button
             type="button"
             data-testid="disconnect-button"
-            className="flex items-center justify-center gap-1 rounded border border-edge px-2.5 py-1 text-xs leading-none text-red-500 transition-colors hover:text-red-600"
+            className="flex items-center justify-center gap-1 rounded border border-edge px-2.5 py-1 text-xs leading-none text-danger transition-colors hover:text-danger/80"
             onClick={onDisconnect}
           >
             {t('common.disconnect')}

--- a/src/renderer/components/analyze/ActivityCalendarChart.tsx
+++ b/src/renderer/components/analyze/ActivityCalendarChart.tsx
@@ -148,7 +148,7 @@ export function ActivityCalendarChart({
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-activity-calendar-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-activity-calendar-loading">
         {t('common.loading')}
       </div>
     )
@@ -189,7 +189,7 @@ export function ActivityCalendarChart({
         </button>
         <div className="flex min-w-0 flex-1 flex-col gap-1">
         <div
-          className="grid h-4 text-[10px] leading-none text-content-muted"
+          className="grid h-4 text-2xs leading-none text-content-muted"
           style={{ gridTemplateColumns, columnGap: CELL_GAP_PX }}
           aria-hidden="true"
         >
@@ -230,7 +230,7 @@ export function ActivityCalendarChart({
             <div key={`row-${dow}`} className="contents" role="row">
               <div
                 role="rowheader"
-                className="pr-1 text-right text-[10px] leading-none text-content-muted"
+                className="pr-1 text-right text-2xs leading-none text-content-muted"
                 style={{ alignSelf: 'center' }}
               >
                 {t(`analyze.activity.dow.${dow}`)}
@@ -265,7 +265,7 @@ export function ActivityCalendarChart({
           ›
         </button>
       </div>
-      <div className="flex items-center gap-2 pt-1 text-[11px] text-content-muted">
+      <div className="flex items-center gap-2 pt-1 text-xs text-content-muted">
         <span>{t('analyze.activity.legendLow')}</span>
         <div
           className="h-2 flex-1 rounded-sm"
@@ -320,7 +320,7 @@ function CalendarCellView({
       wrapperProps={{ role: 'gridcell', 'aria-label': tooltip }}
     >
       <div
-        className="h-full w-full rounded-[2px]"
+        className="h-full w-full rounded-sm"
         style={{
           backgroundColor: !cell.qualified ? 'var(--color-surface-dim)' : 'var(--color-accent)',
           opacity: !cell.qualified ? undefined : opacity,

--- a/src/renderer/components/analyze/ActivityChart.tsx
+++ b/src/renderer/components/analyze/ActivityChart.tsx
@@ -149,7 +149,7 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-activity-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-activity-loading">
         {t('common.loading')}
       </div>
     )
@@ -158,14 +158,14 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
   const isEmpty = metric === 'wpm' ? grid.maxWpm <= 0 : grid.maxKeystrokes <= 0
   if (isEmpty || grid.cells.length !== ACTIVITY_CELL_COUNT) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-activity-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-activity-empty">
         {t('analyze.noData')}
       </div>
     )
   }
 
   return (
-    <div className="flex flex-col gap-2 text-[11px]" data-testid="analyze-activity-chart">
+    <div className="flex flex-col gap-2 text-xs" data-testid="analyze-activity-chart">
       <div
         className="grid gap-[2px]"
         style={{ gridTemplateColumns: 'auto repeat(24, minmax(0, 1fr))' }}
@@ -225,7 +225,7 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
           </div>
         ))}
       </div>
-      <div className="flex items-center gap-2 pt-1 text-[11px] text-content-muted">
+      <div className="flex items-center gap-2 pt-1 text-xs text-content-muted">
         <span>{t('analyze.activity.legendLow')}</span>
         <div
           className="h-2 flex-1 rounded-sm"
@@ -298,7 +298,7 @@ function SessionDistributionChart({ uid, range, deviceScope }: SessionChartProps
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-activity-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-activity-loading">
         {t('common.loading')}
       </div>
     )
@@ -306,7 +306,7 @@ function SessionDistributionChart({ uid, range, deviceScope }: SessionChartProps
 
   if (histogram.summary.sessionCount === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-activity-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-activity-empty">
         {t('analyze.noData')}
       </div>
     )

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -542,7 +542,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
         <div className="flex flex-col gap-3 px-5 pb-3">
           {ctx !== null && (
             <div
-              className="flex flex-col gap-0.5 rounded-md border border-edge bg-surface px-3 py-2 text-[11px] text-content-secondary"
+              className="flex flex-col gap-0.5 rounded-md border border-edge bg-surface px-3 py-2 text-xs text-content-secondary"
               data-testid="analyze-export-common"
             >
               <div><span className="text-content-muted">{t('analyze.export.conditionLabel.device')}: </span>{ctx.conditions.device}</div>
@@ -571,11 +571,11 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                     onClick={() => handleToggle(c)}
                     data-testid={`analyze-export-toggle-${c}`}
                   >
-                    <span className="text-[13px] font-semibold">
+                    <span className="text-sm font-semibold">
                       {t(`analyze.export.category.${c}`)}
                     </span>
                     {specifics.length > 0 && !showTargetPicker && (
-                      <span className="text-[11px] text-content-muted">
+                      <span className="text-xs text-content-muted">
                         {specifics.map((s, i) => (
                           <span key={i} className={i === 0 ? '' : 'ml-3'}>{s}</span>
                         ))}
@@ -583,7 +583,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                     )}
                   </button>
                   {showTargetPicker && ctx !== null && (
-                    <div className="mt-1 flex flex-col gap-1 text-[11px]">
+                    <div className="mt-1 flex flex-col gap-1 text-xs">
                       <div className="text-content-muted">
                         {t('analyze.layoutComparison.sourceLabel')}: {LAYOUT_BY_ID.get(ctx.layoutComparison.sourceLayoutId)?.name ?? ctx.layoutComparison.sourceLayoutId}
                       </div>
@@ -604,7 +604,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                           open={targetPickerOpen}
                           onClose={handleTargetClose}
                           placement="top"
-                          className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+                          className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
                           role="listbox"
                           aria-multiselectable
                         >
@@ -634,12 +634,12 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
           </div>
           {mode === 'upload' && appDataOptions.length >= 2 && (
             <div className="flex flex-col gap-1 rounded-md border border-edge px-3 py-2">
-              <div className="flex items-center gap-2 text-[12px]">
-                <span className="text-[13px] font-semibold text-content">{t('analyze.export.appDataApps.label')}</span>
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-sm font-semibold text-content">{t('analyze.export.appDataApps.label')}</span>
                 <button
                   ref={appTriggerRef}
                   type="button"
-                  className="rounded border border-edge bg-surface px-2 py-0.5 text-left text-[12px] text-content-secondary transition-colors hover:bg-surface-dim"
+                  className="rounded border border-edge bg-surface px-2 py-0.5 text-left text-xs text-content-secondary transition-colors hover:bg-surface-dim"
                   onClick={() => setAppPickerOpen((prev) => !prev)}
                   aria-haspopup="listbox"
                   aria-expanded={appPickerOpen}
@@ -651,14 +651,14 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                   open={appPickerOpen}
                   onClose={handleAppClose}
                   placement="top"
-                  className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+                  className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
                   role="listbox"
                   aria-multiselectable
                 >
                   <div className="flex gap-1 px-2 py-1">
                     <button
                       type="button"
-                      className="text-accent text-[11px] hover:underline"
+                      className="text-accent text-xs hover:underline"
                       onClick={handleAppSelectAll}
                     >
                       {t('analyze.export.appDataApps.selectAll')}
@@ -666,7 +666,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                     <span className="text-content-muted">/</span>
                     <button
                       type="button"
-                      className="text-accent text-[11px] hover:underline"
+                      className="text-accent text-xs hover:underline"
                       onClick={handleAppDeselectAll}
                     >
                       {t('analyze.export.appDataApps.deselectAll')}
@@ -691,22 +691,22 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                   </div>
                 </AnchoredPopover>
               </div>
-              <p className="text-[11px] text-content-muted">{t('analyze.export.appDataApps.hint')}</p>
+              <p className="text-xs text-content-muted">{t('analyze.export.appDataApps.hint')}</p>
             </div>
           )}
           {snapshotMissing && (
-            <p className="text-[11px] text-content-muted" data-testid="analyze-export-snapshot-warning">
+            <p className="text-xs text-content-muted" data-testid="analyze-export-snapshot-warning">
               {t('analyze.export.snapshotMissing')}
             </p>
           )}
           {error !== null && (
-            <p className="text-[12px] text-error" role="alert" data-testid="analyze-export-error">
+            <p className="text-xs text-error" role="alert" data-testid="analyze-export-error">
               {error}
             </p>
           )}
           {mode === 'upload' && upload?.uploadResult && (
             <p
-              className={`text-[12px] font-medium ${upload.uploadResult.kind === 'success' ? 'text-accent' : 'text-danger'}`}
+              className={`text-xs font-medium ${upload.uploadResult.kind === 'success' ? 'text-accent' : 'text-danger'}`}
               data-testid="analyze-export-upload-result"
               role={upload.uploadResult.kind === 'error' ? 'alert' : undefined}
             >

--- a/src/renderer/components/analyze/AnalyzeFilterStoreHubRow.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStoreHubRow.tsx
@@ -79,7 +79,7 @@ export function AnalyzeFilterStoreHubRow({
       data-testid={`analyze-filter-store-hub-row-${entry.id}`}
     >
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-medium text-accent">
+        <span className="text-xs font-medium text-accent">
           {t('hub.pipetteHub')}
         </span>
         <div className="flex gap-1">
@@ -147,7 +147,7 @@ export function AnalyzeFilterStoreHubRow({
       </div>
       {hubNeedsDisplayName && (hubPostId ? !onUpdateOnHub : !onUploadToHub) && (
         <div
-          className="mt-1 text-[11px] text-content-muted"
+          className="mt-1 text-xs text-content-muted"
           data-testid={`analyze-filter-store-hub-needs-display-name-${entry.id}`}
         >
           {t('hub.needsDisplayName')}
@@ -155,7 +155,7 @@ export function AnalyzeFilterStoreHubRow({
       )}
       {resultMatches && hubUploadResult && (
         <div
-          className={`mt-1 flex items-center text-[11px] font-medium ${
+          className={`mt-1 flex items-center text-xs font-medium ${
             hubUploadResult.kind === 'success' ? 'text-accent' : 'text-danger'
           }`}
           data-testid={`analyze-filter-store-hub-result-${entry.id}`}

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -25,7 +25,7 @@ import { AnalyzeFilterStoreHubRow } from './AnalyzeFilterStoreHubRow'
 // Only one tab today — kept as a single-element tab bar for visual
 // parity with the keymap editor's overlay and so the structure is
 // ready when a Settings tab gets a real surface to render.
-const TAB_BASE = 'flex-1 py-1.5 text-[11px] font-medium transition-colors border-b-2 border-b-accent text-content'
+const TAB_BASE = 'flex-1 py-1.5 text-xs font-medium transition-colors border-b-2 border-b-accent text-content'
 
 interface Props {
   /** Render the save body only when the user has picked a keyboard.
@@ -221,7 +221,7 @@ export function AnalyzeFilterStorePanel({
               </form>
               <div className="mt-2 flex items-center gap-1">
                 {showSaved && (
-                  <span className="text-[11px] font-medium text-emerald-500" data-testid="analyze-filter-store-saved-flash">
+                  <span className="text-xs font-medium text-emerald-500" data-testid="analyze-filter-store-saved-flash">
                     {t('common.saved')}
                   </span>
                 )}
@@ -332,7 +332,7 @@ export function AnalyzeFilterStorePanel({
 
                         {entry.summary && (
                           <div
-                            className="mb-1 truncate text-[11px] text-content-muted"
+                            className="mb-1 truncate text-xs text-content-muted"
                             title={entry.summary}
                             data-testid={`analyze-filter-store-entry-summary-${entry.id}`}
                           >
@@ -342,7 +342,7 @@ export function AnalyzeFilterStorePanel({
 
                         {/* Row 2: date + .csv export */}
                         <div className="flex items-center justify-between">
-                          <span className="font-mono text-[11px] text-content-muted">
+                          <span className="font-mono text-xs text-content-muted">
                             {formatDate(entry.savedAt)}
                           </span>
                           {onExportEntryCsv && (

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -49,6 +49,7 @@ import type {
 } from './analyze-types'
 import type { SyncProgress } from '../../../shared/types/sync'
 import { SlidersHorizontal } from 'lucide-react'
+import { ICON_MD } from '../../constants/ui-tokens'
 import { useAnalyzeFilters } from '../../hooks/useAnalyzeFilters'
 import { useAnalyzeFilterStore, type AnalyzeFilterSnapshotPayload } from '../../hooks/useAnalyzeFilterStore'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
@@ -115,7 +116,7 @@ function resolveLayoutComparisonInputs(
 }
 
 const TAB_BTN_BASE =
-  'rounded-md px-3 py-1.5 text-[13px] font-medium transition-colors'
+  'rounded-md px-3 py-1.5 text-sm font-medium transition-colors'
 const TAB_BTN_IDLE = 'text-content-muted hover:text-content-secondary'
 const TAB_BTN_ACTIVE = 'bg-surface text-content shadow-sm'
 
@@ -1070,7 +1071,7 @@ export function AnalyzePane({
               onClick={handleToggleStorePanel}
               data-testid={tid("analyze-filter-store-toggle")}
             >
-              <SlidersHorizontal size={16} aria-hidden="true" />
+              <SlidersHorizontal size={ICON_MD} aria-hidden="true" />
             </button>
           </div>
         )}
@@ -1405,7 +1406,7 @@ export function AnalyzePane({
                     onHeatmapChange={setHeatmap}
                   />
                 ) : (
-                  <div className="py-4 text-center text-[13px] text-content-muted" data-testid={tid("analyze-keyheatmap-empty")}>
+                  <div className="py-4 text-center text-sm text-content-muted" data-testid={tid("analyze-keyheatmap-empty")}>
                     {t('analyze.keyHeatmap.noSnapshot')}
                   </div>
                 )
@@ -1424,7 +1425,7 @@ export function AnalyzePane({
                     onOpenFingerAssignment={() => setFingerModalOpen(true)}
                   />
                 ) : (
-                  <div className="py-4 text-center text-[13px] text-content-muted" data-testid={tid("analyze-ergonomics-no-snapshot")}>
+                  <div className="py-4 text-center text-sm text-content-muted" data-testid={tid("analyze-ergonomics-no-snapshot")}>
                     {t('analyze.ergonomics.noSnapshot')}
                   </div>
                 )

--- a/src/renderer/components/analyze/AppSelect.tsx
+++ b/src/renderer/components/analyze/AppSelect.tsx
@@ -121,7 +121,7 @@ export function AppSelect({
         anchorRef={triggerRef}
         open={open}
         onClose={handleClose}
-        className="z-20 max-h-72 min-w-[200px] overflow-y-auto rounded-md border border-edge bg-surface p-1 text-[12px] shadow-lg"
+        className="z-20 max-h-72 min-w-[200px] overflow-y-auto rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
         role="listbox"
         aria-multiselectable
       >

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -124,21 +124,21 @@ export function BigramsChart({
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-bigrams-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-loading">
         {t('analyze.bigrams.loading')}
       </div>
     )
   }
   if (error) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-bigrams-error">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-error">
         {t('analyze.bigrams.error')}
       </div>
     )
   }
   if (entries.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-bigrams-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-empty">
         {t('analyze.bigrams.empty')}
       </div>
     )
@@ -234,7 +234,7 @@ function Quadrant({ title, controls, children }: QuadrantProps): JSX.Element {
   return (
     <div className="flex min-h-0 min-w-0 flex-col gap-2 rounded border border-edge p-2">
       <div className="flex flex-wrap items-center gap-2">
-        <div className="text-[12px] font-medium text-content">{title}</div>
+        <div className="text-xs font-medium text-content">{title}</div>
         {controls}
       </div>
       <div className="min-h-0 flex-1 overflow-auto pr-1">{children}</div>
@@ -300,7 +300,7 @@ function PairIntervalThresholdInput({
   }
 
   return (
-    <span className="inline-flex items-center gap-1 text-[12px] text-content-muted">
+    <span className="inline-flex items-center gap-1 text-xs text-content-muted">
       <span>{t('analyze.bigrams.pairIntervalThreshold.label')}</span>
       <input
         type="number"
@@ -363,7 +363,7 @@ function TopRanking({ entries, listLimit }: TopRankingProps): JSX.Element {
     return <EmptyQuadrant text={t('analyze.bigrams.empty')} />
   }
   return (
-    <table className="w-full text-[12px]">
+    <table className="w-full text-xs">
       <thead className="text-content-muted">
         <tr>
           <th className="px-1 py-1 text-right font-medium">#</th>
@@ -458,7 +458,7 @@ function SlowRanking({ entries, listLimit, minAvgIkiMs }: SlowRankingProps): JSX
     return <EmptyQuadrant text={t('analyze.bigrams.empty')} />
   }
   return (
-    <table className="w-full text-[12px]" data-testid="analyze-bigrams-slow-ranking">
+    <table className="w-full text-xs" data-testid="analyze-bigrams-slow-ranking">
       <thead className="text-content-muted">
         <tr>
           <th className="px-1 py-1 text-right font-medium">#</th>
@@ -546,7 +546,7 @@ function SortHeader({ label, indicator, align, active, onClick }: SortHeaderProp
 }
 
 function EmptyQuadrant({ text }: { text: string }): JSX.Element {
-  return <div className="py-4 text-center text-[12px] text-content-muted">{text}</div>
+  return <div className="py-4 text-center text-xs text-content-muted">{text}</div>
 }
 
 interface FingerBarChartProps {
@@ -595,7 +595,7 @@ function BigramFingerBarChart({
 
   if (snapshot === null) {
     return (
-      <div className="py-4 text-center text-[12px] text-content-muted" data-testid="analyze-bigrams-finger-no-snapshot">
+      <div className="py-4 text-center text-xs text-content-muted" data-testid="analyze-bigrams-finger-no-snapshot">
         {t('analyze.bigrams.fingerIki.noSnapshot')}
       </div>
     )

--- a/src/renderer/components/analyze/ErgonomicsChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsChart.tsx
@@ -95,7 +95,7 @@ const Section = memo(function Section({
 }: SectionProps) {
   return (
     <div data-testid={testId}>
-      <h4 className="mb-1 text-[13px] font-semibold text-content-secondary">
+      <h4 className="mb-1 text-sm font-semibold text-content-secondary">
         {title}
       </h4>
       <div style={{ height }}>
@@ -177,7 +177,7 @@ const HandPyramidChart = memo(function HandPyramidChart({
   return (
     <div data-testid={testId}>
       <div className="mb-1 flex items-center justify-between gap-2">
-        <h4 className="text-[13px] font-semibold text-content-secondary">{title}</h4>
+        <h4 className="text-sm font-semibold text-content-secondary">{title}</h4>
         {titleAction}
       </div>
       <div style={{ height }}>
@@ -389,21 +389,21 @@ function ErgonomicsSnapshotView({
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-loading">
         {t('common.loading')}
       </div>
     )
   }
   if (!layout || keys.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-no-layout">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-no-layout">
         {t('analyze.ergonomics.noLayout')}
       </div>
     )
   }
   if (aggregation.total === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-empty">
         {t('analyze.ergonomics.noData')}
       </div>
     )
@@ -438,7 +438,7 @@ function ErgonomicsSnapshotView({
               onOpenFingerAssignment ? (
                 <button
                   type="button"
-                  className="rounded-md border border-edge bg-surface px-3 py-1 text-[12px] text-content-secondary transition-colors hover:border-accent hover:text-content"
+                  className="rounded-md border border-edge bg-surface px-3 py-1 text-xs text-content-secondary transition-colors hover:border-accent hover:text-content"
                   onClick={onOpenFingerAssignment}
                   data-testid="analyze-finger-assignment-open"
                 >

--- a/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
@@ -114,9 +114,9 @@ const TrendCard = memo(function TrendCard({
   delta?: string
 }) {
   return (
-    <div className="flex flex-col rounded border border-edge bg-surface px-3 py-2 text-[12px]">
+    <div className="flex flex-col rounded border border-edge bg-surface px-3 py-2 text-xs">
       <span className="text-content-muted">{label}</span>
-      <span className="text-[16px] font-semibold text-content">{value}</span>
+      <span className="text-base font-semibold text-content">{value}</span>
       {delta !== undefined && (
         <span className="text-content-secondary">{delta}</span>
       )}
@@ -188,21 +188,21 @@ export function ErgonomicsLearningCurveChart({
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-learning-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-learning-loading">
         {t('common.loading')}
       </div>
     )
   }
   if (!layout || !layoutKeys || layoutKeys.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-learning-no-layout">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-learning-no-layout">
         {t('analyze.ergonomics.noLayout')}
       </div>
     )
   }
   if (data.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-ergonomics-learning-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-ergonomics-learning-empty">
         {t('analyze.ergonomics.learning.noData')}
       </div>
     )
@@ -308,7 +308,7 @@ export function ErgonomicsLearningCurveChart({
           value={String(qualifiedCount)}
         />
       </div>
-      <p className="text-[11px] text-content-muted">
+      <p className="text-xs text-content-muted">
         {t('analyze.ergonomics.learning.relativeTrendNote')}
       </p>
     </div>

--- a/src/renderer/components/analyze/FingerAssignmentModal.tsx
+++ b/src/renderer/components/analyze/FingerAssignmentModal.tsx
@@ -191,11 +191,11 @@ export function FingerAssignmentModal({
           <ModalCloseButton testid="finger-assignment-close" onClick={onClose} />
         </div>
         <div className="flex-1 min-h-0 overflow-auto px-5 py-4">
-          <p className="mb-3 text-[12px] text-content-muted">
+          <p className="mb-3 text-xs text-content-muted">
             {t('analyze.fingerAssignment.subtitle')}
           </p>
           {keys.length === 0 ? (
-            <div className="py-4 text-center text-[13px] text-content-muted" data-testid="finger-assignment-empty">
+            <div className="py-4 text-center text-sm text-content-muted" data-testid="finger-assignment-empty">
               {t('analyze.fingerAssignment.noSnapshot')}
             </div>
           ) : (
@@ -215,7 +215,7 @@ export function FingerAssignmentModal({
         <div className="flex items-center justify-between gap-2 border-t border-edge px-5 py-3 shrink-0">
           <button
             type="button"
-            className="rounded-md border border-edge px-3 py-1.5 text-[13px] text-content-muted hover:border-accent hover:text-content disabled:opacity-50 disabled:hover:border-edge disabled:hover:text-content-muted"
+            className="rounded-md border border-edge px-3 py-1.5 text-sm text-content-muted hover:border-accent hover:text-content disabled:opacity-50 disabled:hover:border-edge disabled:hover:text-content-muted"
             onClick={handleResetAll}
             disabled={Object.keys(draft).length === 0}
             data-testid="finger-assignment-reset-all"
@@ -224,7 +224,7 @@ export function FingerAssignmentModal({
           </button>
           <button
             type="button"
-            className="rounded-md border border-accent bg-accent px-4 py-1.5 text-[13px] font-medium text-surface hover:bg-accent/90"
+            className="rounded-md border border-accent bg-accent px-4 py-1.5 text-sm font-medium text-surface hover:bg-accent/90"
             onClick={handleSave}
             data-testid="finger-assignment-save"
           >

--- a/src/renderer/components/analyze/FingerSelectPopover.tsx
+++ b/src/renderer/components/analyze/FingerSelectPopover.tsx
@@ -89,7 +89,7 @@ export function FingerSelectPopover({
       <button
         key={finger}
         type="button"
-        className={`flex w-full items-center justify-between px-3 py-1 text-left text-[12px] transition-colors ${
+        className={`flex w-full items-center justify-between px-3 py-1 text-left text-xs transition-colors ${
           isCurrent
             ? 'bg-accent/15 font-semibold text-content'
             : 'text-content-secondary hover:bg-surface-dim'
@@ -125,18 +125,18 @@ export function FingerSelectPopover({
       onClick={(e) => e.stopPropagation()}
       onMouseDown={(e) => e.stopPropagation()}
     >
-      <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+      <div className="px-3 pb-1 pt-2 text-2xs font-semibold uppercase tracking-widest text-content-muted">
         {t('analyze.fingerAssignment.leftHand')}
       </div>
       {LEFT_ORDER.map(renderOption)}
-      <div className="px-3 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+      <div className="px-3 pb-1 pt-2 text-2xs font-semibold uppercase tracking-widest text-content-muted">
         {t('analyze.fingerAssignment.rightHand')}
       </div>
       {RIGHT_ORDER.map(renderOption)}
       <div className="border-t border-edge">
         <button
           type="button"
-          className="w-full px-3 py-1.5 text-left text-[12px] text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-content-muted"
+          className="w-full px-3 py-1.5 text-left text-xs text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-content-muted"
           onClick={onReset}
           disabled={!isOverride}
           data-testid="finger-select-reset"

--- a/src/renderer/components/analyze/GoalAchievementsModal.tsx
+++ b/src/renderer/components/analyze/GoalAchievementsModal.tsx
@@ -52,15 +52,15 @@ export function GoalAchievementsModal({ isOpen, onClose, achievements }: Props) 
         <div className="flex-1 min-h-0 overflow-auto px-5 py-3">
           {rows.length === 0 ? (
             <div
-              className="py-8 text-center text-[13px] text-content-muted"
+              className="py-8 text-center text-sm text-content-muted"
               data-testid="analyze-goal-achievements-empty"
             >
               {t('analyze.streakGoal.historyEmpty')}
             </div>
           ) : (
-            <table className="w-full text-left text-[12px]" data-testid="analyze-goal-achievements-table">
+            <table className="w-full text-left text-xs" data-testid="analyze-goal-achievements-table">
               <thead>
-                <tr className="border-b border-edge text-[11px] uppercase tracking-wider text-content-muted">
+                <tr className="border-b border-edge text-xs uppercase tracking-wider text-content-muted">
                   <th className="py-2 pr-3 font-semibold">{t('analyze.streakGoal.historyColumn.period')}</th>
                   <th className="py-2 pr-3 font-semibold">{t('analyze.streakGoal.historyColumn.goal')}</th>
                   <th className="py-2 pr-3 text-right font-semibold">{t('analyze.streakGoal.historyColumn.days')}</th>

--- a/src/renderer/components/analyze/IntervalChart.tsx
+++ b/src/renderer/components/analyze/IntervalChart.tsx
@@ -200,7 +200,7 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-interval-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-interval-loading">
         {t('common.loading')}
       </div>
     )
@@ -209,7 +209,7 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
   if (viewMode === 'distribution') {
     if (histogram === null || histogram.totalWeight <= 0) {
       return (
-        <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-interval-empty">
+        <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-interval-empty">
           {t('analyze.noData')}
         </div>
       )
@@ -262,7 +262,7 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
 
   if (chartData.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-interval-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-interval-empty">
         {t('analyze.noData')}
       </div>
     )

--- a/src/renderer/components/analyze/KeyHeatmapChart.tsx
+++ b/src/renderer/components/analyze/KeyHeatmapChart.tsx
@@ -133,7 +133,7 @@ const LayerKeyboard = memo(function LayerKeyboard({
         readOnly
         scale={scale}
       />
-      <span className="text-[11px] font-semibold uppercase tracking-widest text-content-muted">
+      <span className="text-xs font-semibold uppercase tracking-widest text-content-muted">
         {t('analyze.keyHeatmap.layerOption', { i: layer })}
       </span>
     </button>
@@ -191,7 +191,7 @@ const RankingTable = memo(function RankingTable({
       <div className="flex min-h-0 flex-1 flex-col overflow-auto">
         <div className="sticky top-0 z-10 bg-surface">
           <div
-            className="grid text-[11px] font-semibold text-content-muted"
+            className="grid text-xs font-semibold text-content-muted"
             style={outerGrid}
           >
             <div />
@@ -202,7 +202,7 @@ const RankingTable = memo(function RankingTable({
             ))}
           </div>
           <div
-            className="grid border-b border-edge text-[10px] font-semibold uppercase tracking-wider text-content-muted"
+            className="grid border-b border-edge text-2xs font-semibold uppercase tracking-wider text-content-muted"
             style={outerGrid}
           >
             <div />
@@ -217,14 +217,14 @@ const RankingTable = memo(function RankingTable({
           </div>
         </div>
         {!anyEntry ? (
-          <div className="py-2 text-[12px] text-content-muted">
+          <div className="py-2 text-xs text-content-muted">
             {t('analyze.keyHeatmap.ranking.emptyFrequentUsed')}
           </div>
         ) : (
           Array.from({ length: rows }, (_, rankIdx) => (
             <div
               key={rankIdx}
-              className={`grid text-[12px] ${rankIdx % 2 === 1 ? 'bg-surface-dim/40' : ''}`}
+              className={`grid text-xs ${rankIdx % 2 === 1 ? 'bg-surface-dim/40' : ''}`}
               style={outerGrid}
             >
               <span className="px-2 py-1 text-right text-content-muted">{rankIdx + 1}</span>
@@ -244,9 +244,9 @@ const RankingTable = memo(function RankingTable({
                   >
                     <span className="min-w-0 truncate font-mono text-content">{entry.keyLabel}</span>
                     {showLayerCol && (
-                      <span className="font-mono text-[11px] text-content-muted">{entry.layerLabel}</span>
+                      <span className="font-mono text-xs text-content-muted">{entry.layerLabel}</span>
                     )}
-                    <span className="font-mono text-[11px] text-content-muted">{entry.matrixLabel}</span>
+                    <span className="font-mono text-xs text-content-muted">{entry.matrixLabel}</span>
                     <span className="text-right font-mono text-content-secondary">{formatCount(entry.count)}</span>
                   </div>
                 )
@@ -426,7 +426,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
 
   if (!layout || !Array.isArray(layout.keys)) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-keyheatmap-nolayout">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-keyheatmap-nolayout">
         {t('analyze.keyHeatmap.noLayout')}
       </div>
     )
@@ -434,7 +434,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
 
   if (loading && layerCells.size === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-keyheatmap-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-keyheatmap-loading">
         {t('common.loading')}
       </div>
     )
@@ -481,7 +481,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
         </div>
       </div>
       <div
-        className="flex shrink-0 flex-wrap items-center justify-end gap-1 text-[12px]"
+        className="flex shrink-0 flex-wrap items-center justify-end gap-1 text-xs"
         role="group"
         aria-label={t('analyze.keyHeatmap.layer')}
         data-testid="analyze-keyheatmap-layers"
@@ -497,7 +497,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
               aria-label={t('analyze.keyHeatmap.layerOption', { i })}
               onClick={() => toggleLayer(i)}
               disabled={isDisabled}
-              className={`flex w-8 shrink-0 items-center justify-center rounded-md border py-1.5 text-[12px] font-semibold tabular-nums transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
+              className={`flex w-8 shrink-0 items-center justify-center rounded-md border py-1.5 text-xs font-semibold tabular-nums transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                 isSelected
                   ? 'border-accent bg-accent text-content-inverse'
                   : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
@@ -510,12 +510,12 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
         })}
       </div>
       <div className="flex shrink-0 flex-wrap items-center gap-2">
-        <h3 className="text-[11px] font-semibold uppercase tracking-widest text-content-muted">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
           {t('analyze.keyHeatmap.ranking.frequentUsed')}
         </h3>
         <div className="flex flex-wrap items-center gap-2">
           <select
-            className="rounded-md border border-edge bg-surface px-2 py-1 text-[12px] text-content focus:border-accent focus:outline-none"
+            className="rounded-md border border-edge bg-surface px-2 py-1 text-xs text-content focus:border-accent focus:outline-none"
             value={normalization}
             onChange={(e) => onHeatmapChange({ normalization: e.target.value as HeatmapNormalization })}
             aria-label={t('analyze.filters.normalization')}
@@ -526,7 +526,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
             ))}
           </select>
           <select
-            className="rounded-md border border-edge bg-surface px-2 py-1 text-[12px] text-content focus:border-accent focus:outline-none"
+            className="rounded-md border border-edge bg-surface px-2 py-1 text-xs text-content focus:border-accent focus:outline-none"
             value={aggregateMode}
             onChange={(e) => onHeatmapChange({ aggregateMode: e.target.value as AggregateMode })}
             aria-label={t('analyze.keyHeatmap.ranking.aggregate')}
@@ -537,7 +537,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
             ))}
           </select>
           <select
-            className="rounded-md border border-edge bg-surface px-2 py-1 text-[12px] text-content focus:border-accent focus:outline-none"
+            className="rounded-md border border-edge bg-surface px-2 py-1 text-xs text-content focus:border-accent focus:outline-none"
             value={keyGroupFilter}
             onChange={(e) => onHeatmapChange({ keyGroupFilter: e.target.value as KeyGroupFilter })}
             aria-label={t('analyze.keyHeatmap.ranking.keyGroup')}
@@ -548,7 +548,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
             ))}
           </select>
           <select
-            className="rounded-md border border-edge bg-surface px-2 py-1 text-[12px] text-content focus:border-accent focus:outline-none"
+            className="rounded-md border border-edge bg-surface px-2 py-1 text-xs text-content focus:border-accent focus:outline-none"
             value={frequentUsedN}
             onChange={(e) => onHeatmapChange({ frequentUsedN: Number.parseInt(e.target.value, 10) })}
             aria-label={t('analyze.keyHeatmap.ranking.frequentUsedN')}

--- a/src/renderer/components/analyze/LayerUsageChart.tsx
+++ b/src/renderer/components/analyze/LayerUsageChart.tsx
@@ -201,7 +201,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
     snapshot !== null &&
     snapshot.layers > 1 &&
     onBaseLayerChange !== undefined ? (
-      <span className="ml-3 inline-flex items-center gap-1.5 text-[12px] font-normal text-content-muted">
+      <span className="ml-3 inline-flex items-center gap-1.5 text-xs font-normal text-content-muted">
         <span>{t('analyze.filters.layerBaseLayer')}</span>
         <select
           className={FILTER_SELECT}
@@ -218,7 +218,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
       </span>
     ) : null
   const titleRow = (
-    <h4 className="mb-1 flex items-center text-[13px] font-semibold text-content-secondary">
+    <h4 className="mb-1 flex items-center text-sm font-semibold text-content-secondary">
       <span>{title}</span>
       {inlineBaseLayerSelect}
     </h4>
@@ -233,7 +233,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
   if (viewMode === 'activations' && snapshot === null) {
     return sectionWrap(
       <div
-        className="py-4 text-center text-[13px] text-content-muted"
+        className="py-4 text-center text-sm text-content-muted"
         data-testid="analyze-layer-no-snapshot"
       >
         {t('analyze.layer.requiresSnapshot')}
@@ -243,7 +243,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
   if (loading) {
     return sectionWrap(
       <div
-        className="py-4 text-center text-[13px] text-content-muted"
+        className="py-4 text-center text-sm text-content-muted"
         data-testid="analyze-layer-loading"
       >
         {t('common.loading')}
@@ -254,7 +254,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
   if (bars.length === 0 || totalValue === 0) {
     return sectionWrap(
       <div
-        className="py-4 text-center text-[13px] text-content-muted"
+        className="py-4 text-center text-sm text-content-muted"
         data-testid="analyze-layer-empty"
       >
         {t(viewMode === 'activations' ? 'analyze.layer.noActivations' : 'analyze.layer.noData')}

--- a/src/renderer/components/analyze/LayoutComparisonFingerDiff.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonFingerDiff.tsx
@@ -80,7 +80,7 @@ export function LayoutComparisonFingerDiff({ current, target, targetLabel }: Pro
 
   return (
     <div className="flex h-full w-full min-h-0 min-w-0 flex-col gap-1" data-testid="analyze-layout-comparison-finger-diff">
-      <h4 className="text-[13px] font-semibold text-content-secondary">
+      <h4 className="text-sm font-semibold text-content-secondary">
         {t('analyze.layoutComparison.fingerDiffTitle', { target: targetLabel })}
       </h4>
       {/* flex-1 + min-h-0 lets the chart absorb whatever vertical

--- a/src/renderer/components/analyze/LayoutComparisonHeatmapDiff.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonHeatmapDiff.tsx
@@ -104,10 +104,10 @@ export function LayoutComparisonHeatmapDiff({
 
   return (
     <div className="flex w-full flex-col gap-1" data-testid="analyze-layout-comparison-heatmap-diff">
-      <h4 className="text-[13px] font-semibold text-content-secondary">
+      <h4 className="text-sm font-semibold text-content-secondary">
         {t('analyze.layoutComparison.heatmapDiffTitle', { target: targetLabel })}
       </h4>
-      <div className="flex items-center gap-3 text-[11px] text-content-muted" aria-hidden="true">
+      <div className="flex items-center gap-3 text-xs text-content-muted" aria-hidden="true">
         <Swatch color={`rgba(${DECREASE_RGB}, ${LEGEND_ALPHA})`} label={t('analyze.layoutComparison.heatmapDiffLegend.decrease')} />
         <Swatch color={`rgba(${INCREASE_RGB}, ${LEGEND_ALPHA})`} label={t('analyze.layoutComparison.heatmapDiffLegend.increase')} />
       </div>

--- a/src/renderer/components/analyze/LayoutComparisonMetricTable.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonMetricTable.tsx
@@ -24,7 +24,7 @@ export function LayoutComparisonMetricTable({ columnLabels, targets }: Props): J
   const columnCount = targets.length
   return (
     <table
-      className="w-full table-fixed border-collapse text-[12px]"
+      className="w-full table-fixed border-collapse text-xs"
       data-testid="analyze-layout-comparison-metric-table"
     >
       <thead>
@@ -88,7 +88,7 @@ function SectionHeader({ colSpan, label }: { colSpan: number; label: string }): 
       <th
         scope="row"
         colSpan={colSpan}
-        className="py-1 pr-3 text-left text-[11px] font-semibold uppercase tracking-wide text-content-secondary"
+        className="py-1 pr-3 text-left text-xs font-semibold uppercase tracking-wide text-content-secondary"
       >
         {label}
       </th>

--- a/src/renderer/components/analyze/LayoutComparisonView.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonView.tsx
@@ -229,7 +229,7 @@ export function LayoutComparisonView({
 function Empty({ message, testid }: { message: string; testid: string }): JSX.Element {
   return (
     <div
-      className="py-4 text-center text-[13px] text-content-muted"
+      className="py-4 text-center text-sm text-content-muted"
       data-testid={testid}
     >
       {message}

--- a/src/renderer/components/analyze/RangeDayPicker.tsx
+++ b/src/renderer/components/analyze/RangeDayPicker.tsx
@@ -180,7 +180,7 @@ export function RangeDayPicker({
           navLayout="around"
           showOutsideDays
         />
-        <div className="mt-2 flex items-center gap-2 border-t border-edge pt-2 text-[12px] text-content-secondary">
+        <div className="mt-2 flex items-center gap-2 border-t border-edge pt-2 text-xs text-content-secondary">
           <span className="whitespace-nowrap">{format(range.fromMs, 'yyyy/MM/dd')}</span>
           <input
             type="time"

--- a/src/renderer/components/analyze/StreakGoalCard.tsx
+++ b/src/renderer/components/analyze/StreakGoalCard.tsx
@@ -155,13 +155,13 @@ export function StreakGoalCard({ uid, daily, today }: Props) {
   return (
     <section className="flex flex-col gap-2" data-testid="analyze-streak-goal-section">
       <div className="flex items-center gap-3">
-        <h3 className="text-[13px] font-semibold text-content">
+        <h3 className="text-sm font-semibold text-content">
           {t('analyze.streakGoal.sectionTitle')}
         </h3>
         <button
           type="button"
           onClick={() => setHistoryOpen(true)}
-          className="rounded border border-edge bg-surface px-3 py-1 text-[11px] text-content-secondary transition-colors hover:border-accent hover:text-content"
+          className="rounded border border-edge bg-surface px-3 py-1 text-xs text-content-secondary transition-colors hover:border-accent hover:text-content"
           data-testid="analyze-streak-goal-history-open"
         >
           {t('analyze.streakGoal.historyButton')}
@@ -230,7 +230,7 @@ function InlineGoalSettings({ goalDays, goalKeystrokes, onSave }: InlineGoalSett
             ariaLabel={t('analyze.streakGoal.goalKeystrokesAria')}
             testid="analyze-streak-goal-keystrokes"
           />
-          <span className="text-[11px] text-content-muted">{t('analyze.streakGoal.keystrokesUnit')}</span>
+          <span className="text-xs text-content-muted">{t('analyze.streakGoal.keystrokesUnit')}</span>
         </span>
         <span className="inline-flex items-baseline gap-1">
           <InlineNumberField
@@ -244,12 +244,12 @@ function InlineGoalSettings({ goalDays, goalKeystrokes, onSave }: InlineGoalSett
             ariaLabel={t('analyze.streakGoal.goalDaysAria')}
             testid="analyze-streak-goal-days"
           />
-          <span className="text-[11px] text-content-muted">{t('analyze.streakGoal.daysUnit')}</span>
+          <span className="text-xs text-content-muted">{t('analyze.streakGoal.daysUnit')}</span>
         </span>
       </div>
       {hasPending && (
         <div
-          className="mt-1 rounded border border-accent/40 bg-accent/5 px-1.5 py-1 text-[10px] leading-tight text-content-secondary"
+          className="mt-1 rounded border border-accent/40 bg-accent/5 px-1.5 py-1 text-2xs leading-tight text-content-secondary"
           data-testid="analyze-streak-goal-warning"
         >
           {t('analyze.streakGoal.changeWarning')}
@@ -345,7 +345,7 @@ function InlineNumberField({
         }}
         aria-label={ariaLabel}
         data-testid={testid}
-        className="w-20 border-b border-edge bg-transparent p-0 text-[18px] font-bold text-content outline-none focus:border-accent"
+        className="w-20 border-b border-edge bg-transparent p-0 text-lg font-bold text-content outline-none focus:border-accent"
       />
       {confirmPending && (
         <button
@@ -354,7 +354,7 @@ function InlineNumberField({
           // commit never triggers a stale stageChange that would
           // unmount this button mid-click.
           onMouseDown={(e) => { e.preventDefault(); handleConfirm() }}
-          className="rounded border border-accent bg-accent/10 px-1.5 py-0.5 text-[10px] text-content hover:bg-accent/20"
+          className="rounded border border-accent bg-accent/10 px-1.5 py-0.5 text-2xs text-content hover:bg-accent/20"
           data-testid={`${testid}-confirm`}
         >
           {t('analyze.streakGoal.confirm')}

--- a/src/renderer/components/analyze/TodaySummaryCard.tsx
+++ b/src/renderer/components/analyze/TodaySummaryCard.tsx
@@ -54,7 +54,7 @@ export function TodaySummaryCard({ daily, today }: Props) {
 
   return (
     <section className="flex flex-col gap-2" data-testid="analyze-today-summary-section">
-      <h3 className="text-[13px] font-semibold text-content">
+      <h3 className="text-sm font-semibold text-content">
         {t('analyze.summary.today.sectionTitle')}
       </h3>
       <AnalyzeStatGrid

--- a/src/renderer/components/analyze/TypingAnalyticsView.tsx
+++ b/src/renderer/components/analyze/TypingAnalyticsView.tsx
@@ -157,7 +157,7 @@ export function TypingAnalyticsView({ initialUid, onBack }: TypingAnalyticsViewP
       </div>
       <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-edge pt-2">
         <div
-          className="min-w-0 flex-1 truncate text-left text-[12px] text-content-muted"
+          className="min-w-0 flex-1 truncate text-left text-xs text-content-muted"
           data-testid="analyze-skip-warning"
         >
           {skipWarningMessage}
@@ -181,7 +181,7 @@ export function TypingAnalyticsView({ initialUid, onBack }: TypingAnalyticsViewP
         {onBack && (
           <button
             type="button"
-            className={`${FOOTER_BUTTON_BASE} border-edge text-red-500 hover:text-red-600`}
+            className={`${FOOTER_BUTTON_BASE} border-edge text-danger hover:text-danger/80`}
             onClick={onBack}
             data-testid="analyze-back"
           >

--- a/src/renderer/components/analyze/TypingProfileCard.tsx
+++ b/src/renderer/components/analyze/TypingProfileCard.tsx
@@ -176,7 +176,7 @@ export function TypingProfileCard({
 
   return (
     <section className="flex flex-col gap-2" data-testid="analyze-typing-profile-section">
-      <h3 className="text-[13px] font-semibold text-content">
+      <h3 className="text-sm font-semibold text-content">
         {t('analyze.summary.profile.sectionTitle', { days: PROFILE_WINDOW_DAYS })}
       </h3>
       <AnalyzeStatGrid

--- a/src/renderer/components/analyze/WeeklyReportCard.tsx
+++ b/src/renderer/components/analyze/WeeklyReportCard.tsx
@@ -68,7 +68,7 @@ export function WeeklyReportCard({ daily, today }: Props) {
 
   return (
     <section className="flex flex-col gap-2" data-testid="analyze-weekly-report-section">
-      <h3 className="text-[13px] font-semibold text-content">
+      <h3 className="text-sm font-semibold text-content">
         {t('analyze.summary.weeklyReport.sectionTitle')}
       </h3>
       <AnalyzeStatGrid

--- a/src/renderer/components/analyze/WpmChart.tsx
+++ b/src/renderer/components/analyze/WpmChart.tsx
@@ -205,7 +205,7 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
 
   if (loading) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-wpm-loading">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-wpm-loading">
         {t('common.loading')}
       </div>
     )
@@ -214,7 +214,7 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
   if (viewMode === 'timeOfDay') {
     if (hourOfDay === null || hourOfDay.summary.totalKeystrokes <= 0) {
       return (
-        <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-wpm-empty">
+        <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-wpm-empty">
           {t('analyze.noData')}
         </div>
       )
@@ -280,7 +280,7 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
 
   if (chartData.length === 0) {
     return (
-      <div className="py-4 text-center text-[13px] text-content-muted" data-testid="analyze-wpm-empty">
+      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-wpm-empty">
         {t('analyze.noData')}
       </div>
     )

--- a/src/renderer/components/analyze/analyze-filter-styles.ts
+++ b/src/renderer/components/analyze/analyze-filter-styles.ts
@@ -9,10 +9,10 @@
 // column and every control column line-aligned across rows even as
 // per-tab filters wrap onto new rows.
 
-export const FILTER_LABEL = 'contents text-[12px] text-content-muted'
+export const FILTER_LABEL = 'contents text-xs text-content-muted'
 
 export const FILTER_SELECT =
-  'rounded-md border border-edge bg-surface px-2 py-1 text-[12px] text-content focus:border-accent focus:outline-none'
+  'rounded-md border border-edge bg-surface px-2 py-1 text-xs text-content focus:border-accent focus:outline-none'
 
 // Buttons that sit alongside FILTER_SELECT (export CSV etc). Mirrors the
 // select frame so the row reads as a single visual group, with hover /

--- a/src/renderer/components/analyze/analyze-summary-table.tsx
+++ b/src/renderer/components/analyze/analyze-summary-table.tsx
@@ -43,7 +43,7 @@ export function AnalyzeSummaryTable({ items, ariaLabelKey, testId = 'analyze-sum
   const { t } = useTranslation()
   return (
     <div
-      className="grid shrink-0 grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-x-4 gap-y-1 border-t border-edge pt-2 text-[12px]"
+      className="grid shrink-0 grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-x-4 gap-y-1 border-t border-edge pt-2 text-xs"
       data-testid={testId}
       aria-label={t(ariaLabelKey)}
     >

--- a/src/renderer/components/analyze/stat-card.tsx
+++ b/src/renderer/components/analyze/stat-card.tsx
@@ -42,15 +42,15 @@ export function StatCard({ label, value, unit, context, testid, description, too
       className="flex h-full flex-col gap-0.5 rounded-md border border-edge bg-surface px-3 py-2"
       data-testid={testid}
     >
-      <span className="text-[10px] font-semibold uppercase tracking-widest text-content-muted">
+      <span className="text-2xs font-semibold uppercase tracking-widest text-content-muted">
         {label}
       </span>
       <div className="flex items-baseline gap-1">
-        <span className="text-[18px] font-bold text-content">{value}</span>
-        {unit && <span className="text-[11px] text-content-muted">{unit}</span>}
+        <span className="text-lg font-bold text-content">{value}</span>
+        {unit && <span className="text-xs text-content-muted">{unit}</span>}
       </div>
       {/* Non-breaking space keeps heights aligned when context is empty */}
-      <span className="text-[10px] text-content-muted">{context || ' '}</span>
+      <span className="text-2xs text-content-muted">{context || ' '}</span>
     </div>
   )
 

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useTroubleshooting } from '../../hooks/useTroubleshooting'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
-import { BTN_SECONDARY as SETTINGS_BTN_SECONDARY } from '../settings-modal/settings-modal-shared'
+import { BTN_SECONDARY, BTN_DANGER_OUTLINE } from '../../constants/ui-tokens'
 import { HubPostRow, DEFAULT_PER_PAGE } from '../hub-post-shared'
 import { DataNavTree } from './DataNavTree'
 import { DataNavBreadcrumb } from './DataNavBreadcrumb'
@@ -203,7 +203,7 @@ export function DataModal({
 
     if (path.page === 'sync-favorite') {
       return (
-        <div className="py-4 text-center text-[13px] text-content-muted">
+        <div className="py-4 text-center text-sm text-content-muted">
           {t(`editor.${path.favoriteType}.title`)}
         </div>
       )
@@ -348,7 +348,7 @@ function LocalApplicationContent({
           <div className="flex items-center gap-2">
             <button
               type="button"
-              className={SETTINGS_BTN_SECONDARY}
+              className={BTN_SECONDARY}
               onClick={troubleshoot.handleImport}
               disabled={troubleshoot.busy}
               data-testid="local-data-import"
@@ -357,7 +357,7 @@ function LocalApplicationContent({
             </button>
             <button
               type="button"
-              className={SETTINGS_BTN_SECONDARY}
+              className={BTN_SECONDARY}
               onClick={troubleshoot.handleExport}
               disabled={troubleshoot.busy}
               data-testid="local-data-export"
@@ -371,8 +371,6 @@ function LocalApplicationContent({
     </div>
   )
 }
-
-const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1 text-sm text-danger hover:bg-danger/10 disabled:opacity-50'
 
 /** Simple application settings reset with confirm */
 function AppSettingsReset({
@@ -397,7 +395,7 @@ function AppSettingsReset({
           <button type="button" className={BTN_DANGER_OUTLINE} onClick={() => void handleReset()} disabled={troubleshoot.busy} data-testid="app-reset-confirm">
             {t('common.confirmReset')}
           </button>
-          <button type="button" className={SETTINGS_BTN_SECONDARY} onClick={() => setConfirming(false)} data-testid="app-reset-cancel">
+          <button type="button" className={BTN_SECONDARY} onClick={() => setConfirming(false)} data-testid="app-reset-cancel">
             {t('common.cancel')}
           </button>
         </div>

--- a/src/renderer/components/data-modal/DataNavBreadcrumb.tsx
+++ b/src/renderer/components/data-modal/DataNavBreadcrumb.tsx
@@ -26,7 +26,7 @@ export function DataNavBreadcrumb({ path }: Props) {
           </span>
         ))}
       </div>
-      {uid && <span className="shrink-0 font-mono text-[11px]">{uid}</span>}
+      {uid && <span className="shrink-0 font-mono text-xs">{uid}</span>}
     </nav>
   )
 }

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -53,11 +53,11 @@ function isActivePath(a: DataNavPath | null, b: DataNavPath): boolean {
   return true
 }
 
-const LEAF_BASE = 'w-full text-left text-[13px] py-1 rounded cursor-pointer truncate'
+const LEAF_BASE = 'w-full text-left text-sm py-1 rounded cursor-pointer truncate'
 const LEAF_ACTIVE = `${LEAF_BASE} bg-surface-dim text-content font-medium`
 const LEAF_IDLE = `${LEAF_BASE} text-content-secondary hover:text-content hover:bg-surface-dim/50`
 
-const BRANCH_BASE = 'w-full text-left text-[13px] py-1 flex items-center gap-1 cursor-pointer truncate'
+const BRANCH_BASE = 'w-full text-left text-sm py-1 flex items-center gap-1 cursor-pointer truncate'
 
 function Chevron({ open }: { open: boolean }) {
   return (
@@ -151,7 +151,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
         >
           {storedKeyboards.length === 0 ? (
             <div
-              className="text-[11px] text-content-muted py-1"
+              className="text-xs text-content-muted py-1"
               style={{ paddingLeft: '50px' }}
               data-testid="nav-no-keyboards"
             >
@@ -201,7 +201,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
         >
           {typingKeyboards.length === 0 ? (
             <div
-              className="text-[11px] text-content-muted py-1"
+              className="text-xs text-content-muted py-1"
               style={{ paddingLeft: '50px' }}
               data-testid="nav-no-typing"
             >
@@ -240,18 +240,18 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
         testId="nav-sync"
       >
         {syncScanning ? (
-          <div className="text-[11px] text-content-muted py-1" style={{ paddingLeft: '36px' }}>
+          <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }}>
             {t('sync.scanning')}
           </div>
         ) : (
           <>
             {!syncScanResult ? (
-              <div className="text-[11px] text-content-muted py-1" style={{ paddingLeft: '36px' }}>
+              <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }}>
                 {t('sync.noRemoteData')}
               </div>
             ) : syncScanResult.keyboards.length === 0 ? (
               <div
-                className="text-[11px] text-content-muted py-1"
+                className="text-xs text-content-muted py-1"
                 style={{ paddingLeft: '36px' }}
                 data-testid="nav-sync-empty"
               >
@@ -281,7 +281,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
                       />
                       {error && (
                         <div
-                          className="text-[11px] text-danger py-1"
+                          className="text-xs text-danger py-1"
                           style={{ paddingLeft: `${2 * 14 + 8}px` }}
                           data-testid={`nav-sync-kb-${uid}-error`}
                         >
@@ -307,7 +307,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
             >
               {typingKeyboards.length === 0 ? (
                 <div
-                  className="text-[11px] text-content-muted py-1"
+                  className="text-xs text-content-muted py-1"
                   style={{ paddingLeft: '50px' }}
                   data-testid="nav-sync-typing-empty"
                 >
@@ -332,7 +332,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
                     >
                       {hashes.length === 0 ? (
                         <div
-                          className="text-[11px] text-content-muted py-1"
+                          className="text-xs text-content-muted py-1"
                           style={{ paddingLeft: '64px' }}
                           data-testid={`nav-sync-typing-${kb.uid}-empty`}
                         >
@@ -387,7 +387,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
           testId="nav-cloud-hub"
         >
           {hubKeyboardNames.length === 0 ? (
-            <div className="text-[11px] text-content-muted py-1" style={{ paddingLeft: '36px' }} data-testid="nav-hub-empty">
+            <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }} data-testid="nav-hub-empty">
               {t('hub.noPosts')}
             </div>
           ) : (

--- a/src/renderer/components/data-modal/FavoriteTabContent.tsx
+++ b/src/renderer/components/data-modal/FavoriteTabContent.tsx
@@ -78,7 +78,7 @@ export function FavoriteTabContent({
     <div className="flex flex-col h-full">
       <div className="flex-1 min-h-0 overflow-y-auto">
         {manage.entries.length === 0 ? (
-          <div className="py-4 text-center text-[13px] text-content-muted" data-testid="data-modal-fav-empty">
+          <div className="py-4 text-center text-sm text-content-muted" data-testid="data-modal-fav-empty">
             {t('favoriteStore.noSaved')}
           </div>
         ) : (
@@ -146,7 +146,7 @@ export function FavoriteTabContent({
                   </div>
                 </div>
                 <div className="flex items-center justify-between">
-                  <span className="text-[11px] text-content-muted font-mono">
+                  <span className="text-xs text-content-muted font-mono">
                     {formatDate(entry.savedAt)}
                   </span>
                   <button

--- a/src/renderer/components/data-modal/KeyboardSavesContent.tsx
+++ b/src/renderer/components/data-modal/KeyboardSavesContent.tsx
@@ -7,6 +7,7 @@ import { LayoutStoreEntry } from '../editors/LayoutStoreEntry'
 import { useSnapshotActions } from './useSnapshotActions'
 import type { SnapshotMeta, SnapshotIndex } from '../../../shared/types/snapshot-store'
 import type { UseSyncReturn } from '../../hooks/useSync'
+import { BTN_DANGER_OUTLINE, BTN_SECONDARY } from '../../constants/ui-tokens'
 
 interface BaseProps {
   uid: string
@@ -28,9 +29,6 @@ interface SyncProps extends BaseProps {
 }
 
 type Props = LocalProps | SyncProps
-
-const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1 text-sm text-danger hover:bg-danger/10 disabled:opacity-50'
-const BTN_SECONDARY = 'rounded border border-edge px-3 py-1 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50'
 
 export function KeyboardSavesContent(props: Props) {
   const { uid, name, source } = props
@@ -152,13 +150,13 @@ export function KeyboardSavesContent(props: Props) {
   )
 
   if (loading) {
-    return <div className="py-4 text-center text-[13px] text-content-muted">{t('common.loading')}</div>
+    return <div className="py-4 text-center text-sm text-content-muted">{t('common.loading')}</div>
   }
 
   if (entries.length === 0) {
     return (
       <div className="flex flex-col h-full" data-testid="kb-saves-empty">
-        <div className="flex-1 py-4 text-center text-[13px] text-content-muted">
+        <div className="flex-1 py-4 text-center text-sm text-content-muted">
           {t('dataModal.noSaves')}
         </div>
         {deleteAllFooter}

--- a/src/renderer/components/data-modal/TypingAnalyticsContent.tsx
+++ b/src/renderer/components/data-modal/TypingAnalyticsContent.tsx
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingDailySummary } from '../../../shared/types/typing-analytics'
+import { BTN_DANGER_OUTLINE, BTN_SECONDARY } from '../../constants/ui-tokens'
 
 interface Props {
   uid: string
@@ -17,9 +18,6 @@ interface Props {
    * days are being shown and acted on. */
   machineHash?: string
 }
-
-const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1 text-sm text-danger hover:bg-danger/10 disabled:opacity-50 disabled:cursor-not-allowed'
-const BTN_SECONDARY = 'rounded border border-edge px-3 py-1 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50'
 
 /** Local-time label for the next UTC midnight — used to tell the user
  * when a `live-day-locked` import target will stop being the live day.
@@ -313,7 +311,7 @@ export function TypingAnalyticsContent({ uid, onDeleted, mode = 'local', machine
   const inProgress = importStatus?.phase === 'importing' || importStatus?.phase === 'exporting'
   const importBanner = importStatus ? (
     <div
-      className={`mb-2 flex items-start gap-2 rounded border px-3 py-2 text-[13px] shrink-0 ${bannerTone}`}
+      className={`mb-2 flex items-start gap-2 rounded border px-3 py-2 text-sm shrink-0 ${bannerTone}`}
       data-testid="typing-import-status"
     >
       <div className="flex-1 space-y-1 min-w-0">
@@ -362,14 +360,14 @@ export function TypingAnalyticsContent({ uid, onDeleted, mode = 'local', machine
   ) : null
 
   if (loading) {
-    return <div className="py-4 text-center text-[13px] text-content-muted">{t('common.loading')}</div>
+    return <div className="py-4 text-center text-sm text-content-muted">{t('common.loading')}</div>
   }
 
   if (summaries.length === 0) {
     return (
       <div className="flex flex-col h-full" data-testid="typing-empty">
         {importBanner}
-        <div className="flex-1 py-4 text-center text-[13px] text-content-muted">
+        <div className="flex-1 py-4 text-center text-sm text-content-muted">
           {t('dataModal.typing.noItems')}
         </div>
         {footer}
@@ -380,14 +378,14 @@ export function TypingAnalyticsContent({ uid, onDeleted, mode = 'local', machine
   return (
     <div className="flex flex-col h-full" data-testid="typing-list">
       {importBanner}
-      <div className="py-2 text-[13px] text-content-muted shrink-0">
+      <div className="py-2 text-sm text-content-muted shrink-0">
         {t('dataModal.typing.summaryLine', {
           days: summaries.length,
           keystrokes: totalKeystrokes.toLocaleString(),
         })}
       </div>
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <table className="w-full text-[13px]">
+        <table className="w-full text-sm">
           <thead className="sticky top-0 bg-surface">
             <tr className="border-b border-edge text-content-secondary">
               <th className="w-8 py-1.5 px-2 text-left">

--- a/src/renderer/components/editors/FavoriteHubActions.tsx
+++ b/src/renderer/components/editors/FavoriteHubActions.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SavedFavoriteMeta } from '../../../shared/types/favorite-store'
 
-const HUB_BTN_BASE = 'text-[11px] font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50'
+const HUB_BTN_BASE = 'text-xs font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50'
 const HUB_BTN = `${HUB_BTN_BASE} disabled:opacity-50`
 
 export interface FavHubEntryResult {
@@ -50,7 +50,7 @@ export function FavoriteHubActions({
   return (
     <div className="mt-1.5 border-t border-edge pt-1.5" data-testid="fav-hub-actions">
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-medium text-accent">{t('hub.pipetteHub')}</span>
+        <span className="text-xs font-medium text-accent">{t('hub.pipetteHub')}</span>
         <div className="flex gap-1">
           {!isUploading && hasHubPost && (
             <>
@@ -130,20 +130,20 @@ export function FavoriteHubActions({
       </div>
       {hubNeedsDisplayName && (hasHubPost ? !onUpdateOnHub : !onUploadToHub) && (
         <div
-          className="mt-1 text-[11px] text-content-muted"
+          className="mt-1 text-xs text-content-muted"
           data-testid="fav-hub-needs-display-name"
         >
           {t('hub.needsDisplayName')}
         </div>
       )}
       {isUploading && (
-        <div className="mt-1 text-[11px] text-accent" data-testid="fav-hub-uploading">
+        <div className="mt-1 text-xs text-accent" data-testid="fav-hub-uploading">
           {t('hub.uploading')}
         </div>
       )}
       {result && (
         <div
-          className={`mt-1 text-[11px] font-medium ${result.kind === 'success' ? 'text-accent' : 'text-danger'}`}
+          className={`mt-1 text-xs font-medium ${result.kind === 'success' ? 'text-accent' : 'text-danger'}`}
           data-testid="fav-hub-result"
         >
           {result.message}

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -162,7 +162,7 @@ export function FavoriteStoreContent({
               onChange={(e) => setSaveLabel(e.target.value)}
               placeholder={t('common.labelPlaceholder')}
               maxLength={200}
-              className="flex-1 rounded-lg border border-edge bg-surface px-3.5 py-2 text-[13px] text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
+              className="flex-1 rounded-lg border border-edge bg-surface px-3.5 py-2 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
               data-testid="favorite-store-save-input"
             />
             <button
@@ -177,12 +177,12 @@ export function FavoriteStoreContent({
           {(onExportCurrent || onImportCurrent || showExported || showImported) && (
             <div className="flex items-center gap-1 mt-2">
               {showImported && (
-                <span className="text-[11px] font-medium text-emerald-500" data-testid="favorite-store-imported">
+                <span className="text-xs font-medium text-emerald-500" data-testid="favorite-store-imported">
                   {t('common.imported')}
                 </span>
               )}
               {showExported && (
-                <span className="text-[11px] font-medium text-emerald-500" data-testid="favorite-store-exported">
+                <span className="text-xs font-medium text-emerald-500" data-testid="favorite-store-exported">
                   {t('common.exported')}
                 </span>
               )}
@@ -211,11 +211,11 @@ export function FavoriteStoreContent({
       {/* Scrollable Synced Data list */}
       <div className="flex-1 min-h-0 overflow-y-auto border-l border-edge px-5 pb-5">
         {loading && (
-          <div className="py-4 text-center text-[13px] text-content-muted">{t('common.loading')}</div>
+          <div className="py-4 text-center text-sm text-content-muted">{t('common.loading')}</div>
         )}
 
         {!loading && entries.length === 0 && (
-          <div className="py-4 text-center text-[13px] text-content-muted" data-testid="favorite-store-empty">
+          <div className="py-4 text-center text-sm text-content-muted" data-testid="favorite-store-empty">
             {t('favoriteStore.noSaved')}
           </div>
         )}
@@ -297,7 +297,7 @@ export function FavoriteStoreContent({
                 </div>
 
                 <div className="flex items-center justify-between">
-                  <span className="text-[11px] text-content-muted font-mono">
+                  <span className="text-xs text-content-muted font-mono">
                     {formatDate(entry.savedAt)}
                   </span>
                   <button

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -178,7 +178,7 @@ function clampNormalized(value: number, origin: number, size: number): number {
 }
 
 function toggleButtonClass(active: boolean): string {
-  const base = 'rounded-md border px-3 py-1.5 text-[13px] transition-colors'
+  const base = 'rounded-md border px-3 py-1.5 text-sm transition-colors'
   if (active) return `${base} border-accent bg-accent/10 text-accent`
   return `${base} border-edge text-content-secondary hover:text-content`
 }

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -8,7 +8,7 @@ import { ModalCloseButton } from './ModalCloseButton'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 
 function historyToggleClass(active: boolean): string {
-  const base = 'rounded-md border px-3 py-1 text-sm transition-colors'
+  const base = 'rounded-md border px-3 py-1.5 text-sm transition-colors'
   if (active) return `${base} border-accent bg-accent/10 text-accent`
   return `${base} border-edge text-content-secondary hover:text-content`
 }

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -3,6 +3,7 @@
 import { useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
+import { ICON_SM } from '../../constants/ui-tokens'
 import { serialize, keycodeTooltip, isMask } from '../../../shared/keycodes/keycodes'
 import { KeyWidget } from '../keyboard/KeyWidget'
 import type { KleKey } from '../../../shared/kle/types'
@@ -145,7 +146,7 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
         className="absolute -top-2 -right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-danger text-white opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
         onClick={(e) => { e.stopPropagation(); onDelete() }}
       >
-        <X size={14} aria-hidden="true" />
+        <X size={ICON_SM} aria-hidden="true" />
       </button>
     </div>
   )

--- a/src/renderer/components/editors/KeycodesOverlayPanel.tsx
+++ b/src/renderer/components/editors/KeycodesOverlayPanel.tsx
@@ -10,8 +10,8 @@ import { ROW_CLASS, toggleTrackClass, toggleKnobClass } from './modal-controls'
 
 type OverlayTab = 'layout' | 'tools' | 'data'
 
-const TAB_BASE = 'flex-1 py-1.5 text-[11px] font-medium transition-colors border-b-2'
-const FOOTER_BTN = 'rounded border border-edge px-2.5 py-1 text-[11px] text-content-secondary hover:text-content hover:bg-surface-dim transition-colors'
+const TAB_BASE = 'flex-1 py-1.5 text-xs font-medium transition-colors border-b-2'
+const FOOTER_BTN = 'rounded border border-edge px-2.5 py-1 text-xs text-content-secondary hover:text-content hover:bg-surface-dim transition-colors'
 
 function tabClass(active: boolean): string {
   if (active) return `${TAB_BASE} border-b-accent text-content`
@@ -154,7 +154,7 @@ export function KeycodesOverlayPanel({
             </div>
             {(onExportLayoutPdfAll || onExportLayoutPdfCurrent) && (
               <div className="shrink-0 border-t border-edge px-4 py-2 flex items-center gap-2" data-testid="layout-pdf-footer">
-                <span className="text-[11px] text-content-muted">{t('layout.pdfFooterLabel')}</span>
+                <span className="text-xs text-content-muted">{t('layout.pdfFooterLabel')}</span>
                 {onExportLayoutPdfAll && (
                   <button
                     type="button"
@@ -189,7 +189,7 @@ export function KeycodesOverlayPanel({
             {onKeyEditorZoomChange && (
               <div className={ROW_CLASS} data-testid="overlay-key-editor-zoom-row">
                 <div className="flex flex-col gap-0.5 flex-1 min-w-0">
-                  <span className="text-[13px] font-medium text-content">
+                  <span className="text-sm font-medium text-content">
                     {t('editorSettings.keyEditorZoom')}
                   </span>
                   <span className="text-xs text-content-muted">
@@ -205,7 +205,7 @@ export function KeycodesOverlayPanel({
                     onChange={(e) => handleZoomChange(e.target.value)}
                     onBlur={() => commitZoom()}
                     onKeyDown={(e) => e.key === 'Enter' && commitZoom()}
-                    className="zoom-factor-input w-16 rounded border border-edge bg-surface pl-2 pr-1 py-0.5 text-xs text-content text-right"
+                    className="zoom-factor-input w-16 rounded border border-edge bg-surface pl-2 pr-1 py-0.5 text-xs text-content text-right focus:border-accent focus:outline-none"
                     aria-label={t('editorSettings.keyEditorZoom')}
                     data-testid="overlay-key-editor-zoom-input"
                   />
@@ -216,7 +216,7 @@ export function KeycodesOverlayPanel({
 
             {/* Auto-advance toggle */}
             <div className={ROW_CLASS} data-testid="overlay-auto-advance-row">
-              <span className="text-[13px] font-medium text-content">
+              <span className="text-sm font-medium text-content">
                 {t('editor.autoAdvance')}
               </span>
               <button
@@ -235,7 +235,7 @@ export function KeycodesOverlayPanel({
             {/* Split key toggle */}
             {splitKeyMode != null && onSplitKeyModeChange && (
               <div className={ROW_CLASS} data-testid="overlay-split-key-mode-row">
-                <span className="text-[13px] font-medium text-content">
+                <span className="text-sm font-medium text-content">
                   {t('editorSettings.splitKeyMode')}
                 </span>
                 <button
@@ -255,7 +255,7 @@ export function KeycodesOverlayPanel({
             {/* Quick select toggle */}
             {quickSelect != null && onQuickSelectChange && (
               <div className={ROW_CLASS} data-testid="overlay-quick-select-row">
-                <span className="text-[13px] font-medium text-content">
+                <span className="text-sm font-medium text-content">
                   {t('editorSettings.quickSelect')}
                 </span>
                 <button
@@ -275,7 +275,7 @@ export function KeycodesOverlayPanel({
             {/* Key tester toggle */}
             {(hasMatrixTester || matrixMode) && onToggleMatrix && (
               <div className={ROW_CLASS} data-testid="overlay-matrix-row">
-                <span className="text-[13px] font-medium text-content">
+                <span className="text-sm font-medium text-content">
                   {t('editor.keyTester.title')}
                 </span>
                 <button
@@ -296,7 +296,7 @@ export function KeycodesOverlayPanel({
             {!isDummy && (
               <div className={ROW_CLASS} data-testid="overlay-lock-row">
                 <div className="flex items-center gap-1.5">
-                  <span className="text-[13px] font-medium text-content">
+                  <span className="text-sm font-medium text-content">
                     {t('settings.security')}
                   </span>
                   <span
@@ -309,7 +309,7 @@ export function KeycodesOverlayPanel({
                 <button
                   type="button"
                   disabled={!unlocked}
-                  className={`rounded border border-edge px-3 py-1 text-sm ${unlocked ? 'text-content-secondary hover:bg-surface-dim' : 'text-content-muted opacity-50'}`}
+                  className={`rounded border border-edge px-3 py-1.5 text-sm ${unlocked ? 'text-content-secondary hover:bg-surface-dim' : 'text-content-muted opacity-50'}`}
                   onClick={onLock}
                   data-testid="overlay-lock-button"
                 >

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -17,6 +17,7 @@ import { JsonEditorModal } from './JsonEditorModal'
 import { comboToJson, parseCombo, keyOverrideToJson, parseKeyOverride, altRepeatKeyToJson, parseAltRepeatKey, macroToJson, parseMacro } from './json-entry-serializers'
 import { KeycodesOverlayPanel } from './KeycodesOverlayPanel'
 import { ZoomIn, ZoomOut, SlidersHorizontal, Undo2, Redo2 } from 'lucide-react'
+import { ICON_SM, ICON_MD } from '../../constants/ui-tokens'
 import { parseKle } from '../../../shared/kle/kle-parser'
 import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
 import { posKey } from '../../../shared/kle/pos-key'
@@ -714,7 +715,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   const activPickerKeycodes = pickerFileData ? filePickerKeycodes : pickerKeycodes
 
   const layerBtnClass = (active: boolean) =>
-    `min-w-7 max-w-20 shrink-0 truncate rounded-md border px-1.5 py-1 text-center text-[12px] font-semibold tabular-nums transition-colors ${
+    `min-w-7 max-w-20 shrink-0 truncate rounded-md border px-1.5 py-1 text-center text-xs font-semibold tabular-nums transition-colors ${
       active ? 'border-accent bg-accent text-content-inverse' : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
     }`
   const sourceBtnClass = (active: boolean) =>
@@ -784,7 +785,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
                   className="flex flex-col rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
                   onClick={() => handleLoadSnapshotEntry(selectedFileUid!, entry.id)}>
                   <span className="font-medium text-content">{entry.label || entry.filename}</span>
-                  <span className="text-[11px] text-content-muted">{new Date(entry.savedAt).toLocaleString()}</span>
+                  <span className="text-xs text-content-muted">{new Date(entry.savedAt).toLocaleString()}</span>
                 </button>
               )) : (
                 <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoEntries')}</p>
@@ -816,7 +817,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
                 className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
                 style={{ top: pickerTooltip.top - 4, left: pickerTooltip.left, transform: 'translate(-50%, -100%)' }}
               >
-                <div className="text-[10px] leading-snug text-content-muted whitespace-nowrap">{pickerTooltip.keycode}</div>
+                <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">{pickerTooltip.keycode}</div>
               </div>
             )}
           </div>
@@ -843,7 +844,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               className="rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none"
               disabled={pickerEffectiveScale <= MIN_SCALE}
               onClick={() => { if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, +(pickerEffectiveScale - 0.1).toFixed(1))); else onScaleChange?.(-0.1) }}>
-              <ZoomOut size={14} aria-hidden="true" />
+              <ZoomOut size={ICON_SM} aria-hidden="true" />
             </button>
           </Tooltip>
           <ScaleInput scale={pickerEffectiveScale} onScaleChange={(delta) => {
@@ -855,7 +856,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               className="rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none"
               disabled={pickerEffectiveScale >= MAX_SCALE}
               onClick={() => { if (pickerFileData) setPickerScale(Math.min(MAX_SCALE, +(pickerEffectiveScale + 0.1).toFixed(1))); else onScaleChange?.(0.1) }}>
-              <ZoomIn size={14} aria-hidden="true" />
+              <ZoomIn size={ICON_SM} aria-hidden="true" />
             </button>
           </Tooltip>
         </div>
@@ -884,12 +885,12 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         <>
           <Tooltip content={t('editor.keymap.undo')} side="right">
             <button type="button" data-testid="undo-button" aria-label={t('editor.keymap.undo')} className={zoomButtonClass} disabled={!history.canUndo} onClick={() => void handleUndo()}>
-              <Undo2 size={16} aria-hidden="true" />
+              <Undo2 size={ICON_MD} aria-hidden="true" />
             </button>
           </Tooltip>
           <Tooltip content={t('editor.keymap.redo')} side="right">
             <button type="button" data-testid="redo-button" aria-label={t('editor.keymap.redo')} className={zoomButtonClass} disabled={!history.canRedo} onClick={() => void handleRedo()}>
-              <Redo2 size={16} aria-hidden="true" />
+              <Redo2 size={ICON_MD} aria-hidden="true" />
             </button>
           </Tooltip>
         </>
@@ -899,13 +900,13 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         <>
           <Tooltip content={t('editor.keymap.zoomIn')} side="right">
             <button type="button" data-testid="zoom-in-button" aria-label={t('editor.keymap.zoomIn')} className={zoomButtonClass} disabled={scaleProp >= MAX_SCALE} onClick={() => onScaleChange(0.1)}>
-              <ZoomIn size={16} aria-hidden="true" />
+              <ZoomIn size={ICON_MD} aria-hidden="true" />
             </button>
           </Tooltip>
           <ScaleInput scale={scaleProp} onScaleChange={onScaleChange} />
           <Tooltip content={t('editor.keymap.zoomOut')} side="right">
             <button type="button" data-testid="zoom-out-button" aria-label={t('editor.keymap.zoomOut')} className={zoomButtonClass} disabled={scaleProp <= MIN_SCALE} onClick={() => onScaleChange(-0.1)}>
-              <ZoomOut size={16} aria-hidden="true" />
+              <ZoomOut size={ICON_MD} aria-hidden="true" />
             </button>
           </Tooltip>
         </>
@@ -1013,7 +1014,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
                   className={`rounded p-1 transition-colors ${layoutPanelOpen ? 'bg-surface-dim text-accent' : 'text-content-secondary hover:bg-surface-dim hover:text-content'}`}
                   onClick={() => { setLayoutPanelOpen((prev) => { if (!prev) onOverlayOpen?.(); return !prev }) }}
                 >
-                  <SlidersHorizontal size={16} aria-hidden="true" />
+                  <SlidersHorizontal size={ICON_MD} aria-hidden="true" />
                 </button>
               </Tooltip>
             }

--- a/src/renderer/components/editors/LayerListPanel.tsx
+++ b/src/renderer/components/editors/LayerListPanel.tsx
@@ -2,11 +2,12 @@
 
 import { useTranslation } from 'react-i18next'
 import { ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { ICON_SM } from '../../constants/ui-tokens'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 import { Tooltip } from '../ui/Tooltip'
 
-const LAYER_NUM_BASE = 'w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 cursor-pointer text-[12px] font-semibold tabular-nums transition-colors'
+const LAYER_NUM_BASE = 'w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 cursor-pointer text-xs font-semibold tabular-nums transition-colors'
 const LAYER_NAME_BASE = 'flex-1 min-w-0 rounded-md border px-3 py-1.5 transition-colors'
 
 function layerNumClass(active: boolean): string {
@@ -76,7 +77,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
   // visible area so names slide out horizontally.
   return (
     <div
-      className="shrink-0 overflow-hidden rounded-[10px] border border-edge bg-picker-bg transition-[width] duration-200 ease-out"
+      className="shrink-0 overflow-hidden rounded-xl border border-edge bg-picker-bg transition-[width] duration-200 ease-out"
       style={{ width: collapsed ? PANEL_COLLAPSED_WIDTH : '11rem' }}
       data-testid={collapsed ? 'layer-list-panel-collapsed' : 'layer-list-panel'}
     >
@@ -104,7 +105,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
                     {isEditing && onSetLayerName ? (
                       <input
                         data-testid={`layer-panel-layer-name-input-${i}`}
-                        className="w-full border-b border-edge bg-transparent text-[12px] text-content outline-none focus:border-accent"
+                        className="w-full border-b border-edge bg-transparent text-xs text-content outline-none focus:border-accent"
                         value={layerRename.editLabel}
                         onChange={(e) => layerRename.setEditLabel(e.target.value)}
                         placeholder={defaultLabel}
@@ -115,7 +116,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
                       />
                     ) : (
                       <span
-                        className={`block truncate text-[12px] ${isActive ? 'text-content' : 'text-content-secondary'}`}
+                        className={`block truncate text-xs ${isActive ? 'text-content' : 'text-content-secondary'}`}
                         data-testid={`layer-panel-layer-name-${i}`}
                       >
                         {name || defaultLabel}
@@ -138,7 +139,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
                 aria-label={collapsed ? t('editor.keymap.expandLayers') : t('editor.keymap.collapseLayers')}
                 data-testid={collapsed ? 'layer-panel-expand-btn' : 'layer-panel-collapse-btn'}
               >
-                {collapsed ? <ChevronsRight size={14} aria-hidden="true" /> : <ChevronsLeft size={14} aria-hidden="true" />}
+                {collapsed ? <ChevronsRight size={ICON_SM} aria-hidden="true" /> : <ChevronsLeft size={ICON_SM} aria-hidden="true" />}
               </button>
             </Tooltip>
           </div>

--- a/src/renderer/components/editors/LayoutEditor.tsx
+++ b/src/renderer/components/editors/LayoutEditor.tsx
@@ -77,7 +77,7 @@ export function LayoutEditor({
                 onChange={(e) =>
                   handleChange(opt.index, Number(e.target.value))
                 }
-                className="rounded border border-edge bg-surface px-2 py-1 text-sm"
+                className="rounded border border-edge bg-surface px-2 py-1 text-sm focus:border-accent focus:outline-none"
               >
                 {opt.labels.slice(1).map((label, i) => (
                   <option key={i} value={i}>

--- a/src/renderer/components/editors/LayoutOptionsPanel.tsx
+++ b/src/renderer/components/editors/LayoutOptionsPanel.tsx
@@ -34,7 +34,7 @@ export function LayoutOptionsPanel({ options, values, onChange }: LayoutOptionsP
       {hasSelect && (
         <select
           ref={selectRef}
-          className="invisible absolute rounded border border-edge px-2.5 py-1.5 text-[13px]"
+          className="invisible absolute rounded border border-edge px-2.5 py-1.5 text-sm"
           tabIndex={-1}
           aria-hidden="true"
         >
@@ -48,7 +48,7 @@ export function LayoutOptionsPanel({ options, values, onChange }: LayoutOptionsP
         const isBoolean = opt.labels.length <= 2
         return (
           <label key={opt.index} className={`${ROW_CLASS} cursor-pointer`}>
-            <span className="text-[13px] font-medium text-content">{opt.labels[0]}</span>
+            <span className="text-sm font-medium text-content">{opt.labels[0]}</span>
             {isBoolean ? (
               <input
                 type="checkbox"
@@ -59,7 +59,7 @@ export function LayoutOptionsPanel({ options, values, onChange }: LayoutOptionsP
               <select
                 value={val}
                 onChange={(e) => onChange(opt.index, Number(e.target.value))}
-                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content focus:border-accent focus:outline-none"
+                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content focus:border-accent focus:outline-none"
                 style={selectWidth ? { width: selectWidth } : undefined}
               >
                 {opt.labels.slice(1).map((label, i) => (

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -32,7 +32,7 @@ function FileStatusDisplay({ fileStatus }: { fileStatus: Exclude<FileStatus, 'id
 
   return (
     <div
-      className={`pt-3 text-[13px] font-medium ${fileStatusColorClass(fileStatus)}`}
+      className={`pt-3 text-sm font-medium ${fileStatusColorClass(fileStatus)}`}
       data-testid="layout-store-file-status"
     >
       {statusText()}
@@ -213,10 +213,10 @@ export function LayoutStoreContent({
               {(hasCurrentExport || showSaved || showExported) && (
                 <div className={`flex items-center gap-1${!isDummy ? ' mt-2' : ''}`}>
                   {showSaved && (
-                    <span className="text-[11px] font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                    <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
                   )}
                   {showExported && (
-                    <span className="text-[11px] font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
+                    <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
                   )}
                   <div className="ml-auto flex gap-1">
                     <FormatButtons
@@ -314,11 +314,11 @@ export function LayoutStoreContent({
           <SectionHeader label={t('common.synced')} count={entries.length} />
 
           {loading && (
-            <div className="py-4 text-center text-[13px] text-content-muted">{t('common.loading')}</div>
+            <div className="py-4 text-center text-sm text-content-muted">{t('common.loading')}</div>
           )}
 
           {!loading && entries.length === 0 && (
-            <div className="py-4 text-center text-[13px] text-content-muted" data-testid="layout-store-empty">
+            <div className="py-4 text-center text-sm text-content-muted" data-testid="layout-store-empty">
               {t('layoutStore.noSavedLayouts')}
             </div>
           )}
@@ -371,7 +371,7 @@ export function LayoutStoreContent({
         <div className={`${importGap}${fixedSection}`} data-testid="layout-store-import-section">
           {isPanel ? (
             <div className={ROW_CLASS}>
-              <span className="text-[13px] font-medium text-content">{t('layoutStore.import')}</span>
+              <span className="text-sm font-medium text-content">{t('layoutStore.import')}</span>
               <div className="flex gap-2">
                 {onImportVil && (
                   <button

--- a/src/renderer/components/editors/LayoutStoreEntry.tsx
+++ b/src/renderer/components/editors/LayoutStoreEntry.tsx
@@ -209,7 +209,7 @@ export function LayoutStoreEntry({
 
       {/* Row 2: date + format tags */}
       <div className="flex items-center justify-between">
-        <span className="text-[11px] text-content-muted font-mono">
+        <span className="text-xs text-content-muted font-mono">
           {entry.vilVersion != null && t('layoutStore.versionPrefix', { version: entry.vilVersion })}{formatDate(entry.savedAt)}
         </span>
         {hasEntryExport && (

--- a/src/renderer/components/editors/LayoutStoreHubActions.tsx
+++ b/src/renderer/components/editors/LayoutStoreHubActions.tsx
@@ -138,7 +138,7 @@ export function LayoutStoreHubRow({
   return (
     <div className="mt-1.5 border-t border-edge pt-1.5" data-testid="layout-store-hub-row">
       <div className="flex items-center justify-between">
-        <span className="text-[11px] font-medium text-accent">{t('hub.pipetteHub')}</span>
+        <span className="text-xs font-medium text-accent">{t('hub.pipetteHub')}</span>
         <div className="flex gap-1">
           {entryHubPostId && hubOrigin && (
             <ShareLink url={`${hubOrigin}/post/${encodeURIComponent(entryHubPostId)}`} />
@@ -205,7 +205,7 @@ export function LayoutStoreHubRow({
       </div>
       {hubNeedsDisplayName && (entryHubPostId ? !onUpdateOnHub : !onUploadToHub) && (
         <div
-          className="mt-1 text-[11px] text-content-muted"
+          className="mt-1 text-xs text-content-muted"
           data-testid="layout-store-hub-needs-display-name"
         >
           {t('hub.needsDisplayName')}
@@ -213,7 +213,7 @@ export function LayoutStoreHubRow({
       )}
       {hubUploadResult && (hubUploadResult.entryId === entry.id || hubUploadResult.entryIds?.includes(entry.id)) && (
         <div
-          className={`mt-1 flex items-center text-[11px] font-medium ${hubUploadResult.kind === 'success' ? 'text-accent' : 'text-danger'}`}
+          className={`mt-1 flex items-center text-xs font-medium ${hubUploadResult.kind === 'success' ? 'text-accent' : 'text-danger'}`}
           data-testid="layout-store-hub-result"
         >
           {hubUploadResult.message}

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { GripVertical, X } from 'lucide-react'
+import { ICON_SM, ICON_LG } from '../../constants/ui-tokens'
 import { isValidMacroText, type MacroAction } from '../../../preload/macro'
 import { KeycodeField, KEYCODE_FIELD_SIZE } from './KeycodeField'
 import { Tooltip } from '../ui/Tooltip'
@@ -200,7 +201,7 @@ export function MacroActionItem({
             disabled={disabled}
             aria-label={t('common.close')}
           >
-            <X size={20} aria-hidden="true" />
+            <X size={ICON_LG} aria-hidden="true" />
           </button>
         )}
       </div>
@@ -220,7 +221,7 @@ export function MacroActionItem({
         onDragEnd={disabled ? undefined : onDragEnd}
         className={`flex items-center gap-1.5 border-r border-edge py-1 pl-1 pr-3 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       >
-        <GripVertical className="shrink-0 text-content-muted" size={14} />
+        <GripVertical className="shrink-0 text-content-muted" size={ICON_SM} />
         <span className="min-w-[36px] text-center text-sm text-content-secondary">
           {typeLabels[action.type]}
         </span>
@@ -236,7 +237,7 @@ export function MacroActionItem({
           className="rounded p-1 text-content-muted hover:text-danger disabled:opacity-50"
           aria-label={t('common.delete')}
         >
-          <X size={20} aria-hidden="true" />
+          <X size={ICON_LG} aria-hidden="true" />
         </button>
       </Tooltip>
     </div>

--- a/src/renderer/components/editors/ModalCloseButton.tsx
+++ b/src/renderer/components/editors/ModalCloseButton.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
+import { ICON_LG } from '../../constants/ui-tokens'
 
 interface Props {
   testid: string
@@ -19,7 +20,7 @@ export function ModalCloseButton({ testid, onClick }: Props) {
       onClick={onClick}
       aria-label={t('common.close')}
     >
-      <X size={20} aria-hidden="true" />
+      <X size={ICON_LG} aria-hidden="true" />
     </button>
   )
 }

--- a/src/renderer/components/editors/RGBConfigurator.tsx
+++ b/src/renderer/components/editors/RGBConfigurator.tsx
@@ -42,7 +42,7 @@ interface Props {
   onSave: () => Promise<void>
 }
 
-const INPUT_CLASS = 'rounded border border-edge bg-transparent px-1.5 py-0.5 font-mono text-xs'
+const INPUT_CLASS = 'rounded border border-edge bg-transparent px-1.5 py-0.5 font-mono text-xs focus:border-accent focus:outline-none'
 
 function ColorCodeFields({
   hue,
@@ -299,7 +299,7 @@ export function RGBConfigurator({
               onChange={async (e) => {
                 await onSetRgblightEffect(Number(e.target.value))
               }}
-              className="flex-1 rounded border border-edge bg-surface px-2 py-1 text-sm"
+              className="flex-1 rounded border border-edge bg-surface px-2 py-1 text-sm focus:border-accent focus:outline-none"
             >
               {QMK_RGBLIGHT_EFFECTS.map((fx) => (
                 <option key={fx.index} value={fx.index}>
@@ -389,7 +389,7 @@ export function RGBConfigurator({
               onChange={async (e) => {
                 await onSetVialRGBMode(Number(e.target.value))
               }}
-              className="flex-1 rounded border border-edge bg-surface px-2 py-1 text-sm"
+              className="flex-1 rounded border border-edge bg-surface px-2 py-1 text-sm focus:border-accent focus:outline-none"
             >
               {filteredVialRGBEffects.map((fx) => (
                 <option key={fx.index} value={fx.index}>

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Globe } from 'lucide-react'
+import { ICON_SM } from '../../constants/ui-tokens'
 import { TypingTestView } from '../../typing-test/TypingTestView'
 import { LanguageSelectorModal } from '../../typing-test/LanguageSelectorModal'
 import { TypingRecordingConsentModal } from '../../typing-test/TypingRecordingConsentModal'
@@ -389,7 +390,7 @@ export function TypingTestPane({
                       <span>{t('editor.typingTest.language.loadingLanguage')}</span>
                     ) : (
                       <>
-                        <Globe size={14} aria-hidden="true" />
+                        <Globe size={ICON_SM} aria-hidden="true" />
                         <span>{typingTest.language.replace(/_/g, ' ')}</span>
                       </>
                     )}
@@ -436,7 +437,7 @@ export function TypingTestPane({
           {heatmapActive && (
             <p
               data-testid="typing-test-heatmap-legend"
-              className="mt-1 text-center text-[11px] text-content-muted"
+              className="mt-1 text-center text-xs text-content-muted"
             >
               {t('editor.typingTest.heatmap.legend')}
             </p>
@@ -449,7 +450,7 @@ export function TypingTestPane({
         <div
           className={`pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center py-1 transition-opacity duration-200 ${viewOnlyControlsOpen || (!mouseOver && !recordEnabled) ? 'opacity-0' : 'opacity-100'}`}
         >
-          <span className={`text-[10px] ${!mouseOver && recordEnabled ? 'text-accent' : 'text-content-muted'}`}>
+          <span className={`text-2xs ${!mouseOver && recordEnabled ? 'text-accent' : 'text-content-muted'}`}>
             {mouseOver
               ? t('editor.typingTest.closeHint')
               : t('editor.typingTest.recordingIndicator')}
@@ -645,7 +646,7 @@ export function TypingTestPane({
                 // a default-edge border so "exit" reads as the
                 // destructive / out-of-mode action rather than the
                 // accent-coloured primary path.
-                className="whitespace-nowrap rounded border border-edge px-2 py-1 text-red-500 transition-colors hover:text-red-600"
+                className="whitespace-nowrap rounded border border-edge px-2 py-1 text-danger transition-colors hover:text-danger/80"
                 onClick={handleViewOnlyToggle}
               >
                 {t('editor.typingTest.exitViewOnly')}

--- a/src/renderer/components/editors/keymap-editor-toolbar.tsx
+++ b/src/renderer/components/editors/keymap-editor-toolbar.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef } from 'react'
 import { MIN_SCALE, MAX_SCALE } from './keymap-editor-types'
+import { TOOLBAR_BTN_ACTIVE, TOOLBAR_BTN_INACTIVE } from '../../constants/ui-tokens'
 
 export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleChange: (delta: number) => void }) {
   const display = `${Math.round(scale * 100)}`
@@ -23,7 +24,7 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
       <button
         type="button"
         data-testid="scale-display"
-        className="size-[34px] rounded-md border border-edge text-[11px] leading-none tabular-nums text-content-secondary hover:text-content transition-colors flex items-center justify-center"
+        className="size-[34px] rounded-md border border-edge text-xs leading-none tabular-nums text-content-secondary hover:text-content transition-colors flex items-center justify-center"
         onClick={() => { setDraft(String(Math.round(scale * 100))); setEditing(true) }}
       >
         {display}
@@ -35,7 +36,7 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
     <input
       ref={inputRef}
       data-testid="scale-input"
-      className="size-[34px] rounded-md border border-accent bg-transparent text-[11px] leading-none tabular-nums text-content text-center outline-none"
+      className="size-[34px] rounded-md border border-accent bg-transparent text-xs leading-none tabular-nums text-content text-center outline-none"
       value={draft}
       autoFocus
       onFocus={() => inputRef.current?.select()}
@@ -46,10 +47,6 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
   )
 }
 
-export const CONTROL_BASE = 'rounded-md border p-2'
-
 export function toggleButtonClass(active: boolean): string {
-  const base = `${CONTROL_BASE} transition-colors`
-  if (active) return `${base} border-accent bg-accent/10 text-accent`
-  return `${base} border-edge text-content-secondary hover:text-content`
+  return active ? TOOLBAR_BTN_ACTIVE : TOOLBAR_BTN_INACTIVE
 }

--- a/src/renderer/components/editors/layout-store-types.ts
+++ b/src/renderer/components/editors/layout-store-types.ts
@@ -55,8 +55,8 @@ export interface LayoutStoreContentProps {
   footer?: React.ReactNode
 }
 
-export const FORMAT_BTN = 'text-[11px] font-medium text-content-muted bg-surface/50 border border-edge px-2 py-0.5 rounded hover:text-content hover:border-content-muted disabled:opacity-50'
+export const FORMAT_BTN = 'text-xs font-medium text-content-muted bg-surface/50 border border-edge px-2 py-0.5 rounded hover:text-content hover:border-content-muted disabled:opacity-50'
 export const IMPORT_BTN = 'rounded-lg border border-edge bg-surface/30 px-3 py-1.5 text-xs font-semibold text-content-muted hover:text-content hover:border-content-muted'
 export const EXPORT_BTN = 'rounded-lg border border-edge bg-surface/30 px-3 py-1.5 text-xs font-semibold text-content-muted hover:text-content hover:border-content-muted disabled:opacity-50'
-export const HUB_BTN = 'text-[11px] font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50 disabled:opacity-50'
-export const SHARE_LINK_BTN = 'text-[11px] font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50'
+export const HUB_BTN = 'text-xs font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50 disabled:opacity-50'
+export const SHARE_LINK_BTN = 'text-xs font-medium text-accent bg-accent/10 border border-accent/30 px-2 py-0.5 rounded hover:bg-accent/20 hover:border-accent/50'

--- a/src/renderer/components/editors/modal-tabs.tsx
+++ b/src/renderer/components/editors/modal-tabs.tsx
@@ -6,7 +6,7 @@ export type ModalTabId = 'tools' | 'data' | 'notification' | 'about'
 
 export type DataModalTabId = 'tapDance' | 'macro' | 'combo' | 'keyOverride' | 'altRepeatKey' | 'hubPost' | 'local' | 'sync'
 
-const TAB_BASE = 'px-4 py-2 text-[13px] font-medium transition-colors border-b-2'
+const TAB_BASE = 'px-4 py-2 text-sm font-medium transition-colors border-b-2'
 
 function tabClass(active: boolean): string {
   if (active) return `${TAB_BASE} border-b-accent text-content`

--- a/src/renderer/components/editors/store-modal-shared.tsx
+++ b/src/renderer/components/editors/store-modal-shared.tsx
@@ -1,5 +1,23 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+// Form element base classes — use these for input/select elements.
+export const INPUT_BASE =
+  'rounded border border-edge bg-surface px-2.5 py-1 text-sm text-content ' +
+  'focus:border-accent focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed'
+export const SELECT_BASE =
+  'rounded border border-edge bg-surface px-2 py-1 text-sm text-content ' +
+  'focus:border-accent focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed'
+export const INPUT_COMPACT =
+  'rounded border border-edge bg-transparent px-1.5 py-0.5 text-xs text-content ' +
+  'focus:border-accent focus:outline-none'
+
+// Modal width tiers — use these instead of inline w-[*px] values.
+export const MODAL_SM  = 'w-[440px]  max-w-[90vw]'
+export const MODAL_MD  = 'w-[600px]  max-w-[90vw]'
+export const MODAL_LG  = 'w-[760px]  max-w-[90vw]'
+export const MODAL_XL  = 'w-[960px]  max-w-[95vw]'
+export const MODAL_2XL = 'w-[1200px] max-w-[95vw]'
+
 export const ACTION_BTN =
   'text-xs font-medium text-content hover:text-content cursor-pointer bg-transparent border-none px-2 py-1 rounded'
 export const DELETE_BTN =
@@ -41,11 +59,11 @@ interface SectionHeaderProps {
 export function SectionHeader({ label, count }: SectionHeaderProps) {
   return (
     <div className="mb-2.5 flex items-center gap-2">
-      <span className="text-[10px] font-bold uppercase tracking-widest text-content-muted">
+      <span className="text-2xs font-bold uppercase tracking-widest text-content-muted">
         {label}
       </span>
       {count !== undefined && (
-        <span className="text-[10px] font-semibold text-content-muted bg-surface-dim px-1.5 py-px rounded-full">
+        <span className="text-2xs font-semibold text-content-muted bg-surface-dim px-1.5 py-px rounded-full">
           {count}
         </span>
       )}

--- a/src/renderer/components/hub-post-shared.tsx
+++ b/src/renderer/components/hub-post-shared.tsx
@@ -8,9 +8,6 @@ import type { HubMyPost } from '../../shared/types/hub'
 
 export const DEFAULT_PER_PAGE = 10
 
-export const BTN_PRIMARY = 'rounded bg-accent px-3 py-1 text-sm font-medium text-white hover:bg-accent/90 disabled:opacity-50'
-export const BTN_SECONDARY = 'rounded border border-edge px-3 py-1 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50'
-
 interface HubPostRowProps {
   post: HubMyPost
   onRename: (postId: string, newTitle: string) => Promise<void>
@@ -122,7 +119,7 @@ export function HubPostRow({ post, onRename, onDelete, hubOrigin }: HubPostRowPr
               {post.title}
             </span>
           )}
-          <span className="text-[11px] text-content-muted truncate">
+          <span className="text-xs text-content-muted truncate">
             {post.keyboard_name} · {formatDate(post.created_at)}
           </span>
         </div>

--- a/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
+++ b/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
@@ -37,7 +37,7 @@ export function JaRemovedBanner(): JSX.Element | null {
         <div className="flex justify-end">
           <button
             type="button"
-            className="rounded bg-accent px-3 py-1 text-sm font-medium text-white hover:bg-accent/90"
+            className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent/90"
             onClick={dismiss}
             data-testid="ja-removed-dismiss"
           >

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2 } from 'lucide-react'
+import { ICON_XL } from '../../constants/ui-tokens'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -594,7 +595,7 @@ export function LanguagePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="language-packs-modal"
       >
@@ -847,9 +848,9 @@ function InstalledRowView({
           data-testid={`language-packs-select-${row.reactKey}`}
         >
           {row.active ? (
-            <CheckCircle2 size={18} className="text-accent" aria-hidden="true" />
+            <CheckCircle2 size={ICON_XL} className="text-accent" aria-hidden="true" />
           ) : (
-            <Circle size={18} aria-hidden="true" />
+            <Circle size={ICON_XL} aria-hidden="true" />
           )}
         </button>
         <div className="flex-1 min-w-0 text-sm font-medium">{renderName()}</div>
@@ -959,7 +960,7 @@ function InstalledRowView({
         <span className="flex-1 min-w-0">
           {lastResult && (lastResult.id === row.packId || lastResult.id === row.hubPostId) && (
             <span
-              className={`text-[11px] font-medium ${lastResult.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
+              className={`text-xs font-medium ${lastResult.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
               data-testid={`language-packs-result-${row.reactKey}`}
             >
               {lastResult.message}

--- a/src/renderer/components/i18n-packs/MissingKeysModal.tsx
+++ b/src/renderer/components/i18n-packs/MissingKeysModal.tsx
@@ -58,7 +58,7 @@ export function MissingKeysModal({
       }}
     >
       <div
-        className="w-full max-w-xl h-[70vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-[600px] max-w-[90vw] h-[70vh] flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-keys-modal"
       >

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { GripVertical } from 'lucide-react'
+import { ICON_SM } from '../../constants/ui-tokens'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useKeyLabels } from '../../hooks/useKeyLabels'
@@ -357,7 +358,7 @@ export function KeyLabelsModal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="key-labels-modal"
       >
@@ -657,7 +658,7 @@ function InstalledRowView({
         aria-hidden="true"
       >
         {isDraggable
-          ? <GripVertical className="text-content-muted" size={14} />
+          ? <GripVertical className="text-content-muted" size={ICON_SM} />
           : null}
       </span>
       <div className="flex-1 min-w-0 px-1 py-2">
@@ -753,7 +754,7 @@ function ResultBadge({ result, rowId }: ResultBadgeProps): JSX.Element | null {
   if (!result || result.id !== rowId) return null
   return (
     <span
-      className={`text-[11px] font-medium ${result.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
+      className={`text-xs font-medium ${result.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
       data-testid={`key-labels-result-${rowId}`}
     >
       {result.message}

--- a/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
+++ b/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
@@ -37,7 +37,7 @@ export function MissingKeyLabelDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="missing-key-label-title"
-        className="w-full max-w-xl rounded-lg bg-surface p-5 shadow-xl"
+        className="w-[600px] max-w-[90vw] rounded-lg bg-surface p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-key-label-dialog"
       >

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -369,7 +369,7 @@ export function KeyPopover({
               key={i}
               type="button"
               onClick={() => handleLayerSidebarClick(i)}
-              className={`w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 text-[12px] font-semibold tabular-nums transition-colors ${
+              className={`w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 text-xs font-semibold tabular-nums transition-colors ${
                 currentLayer === i
                   ? 'border-accent bg-accent text-content-inverse'
                   : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'

--- a/src/renderer/components/keycodes/KeycodeButton.tsx
+++ b/src/renderer/components/keycodes/KeycodeButton.tsx
@@ -32,7 +32,7 @@ function KeycodeButtonInner({ keycode, onClick, onDoubleClick, onHover, onHoverE
     [keycode, onHover],
   )
 
-  const size = sizeClass ?? 'w-[44px] h-[44px]'
+  const size = sizeClass ?? 'w-key h-key'
   const hover = selected ? '' : 'hover:bg-picker-item-hover'
   // Switch to a 2 × 2 grid for 4-part labels so the picker matches
   // KeyWidget. 1/2/3 parts keep the existing flex-col stack.
@@ -61,7 +61,7 @@ function KeycodeButtonInner({ keycode, onClick, onDoubleClick, onHover, onHoverE
       onMouseLeave={onHoverEnd}
     >
       {lines.map((line, i) => (
-        <span key={i} className="leading-tight whitespace-nowrap text-[10px]">
+        <span key={i} className="leading-tight whitespace-nowrap text-2xs">
           {line}
         </span>
       ))}

--- a/src/renderer/components/keycodes/KeycodeGrid.tsx
+++ b/src/renderer/components/keycodes/KeycodeGrid.tsx
@@ -88,7 +88,7 @@ export function KeycodeGrid({
         if (shifted && shiftedIdx != null) {
           const splitRemap = getSplitRemapProps(kc.qmkId, remapLabel)
           return (
-            <div key={`${baseIdx}-${kc.qmkId}`} className="w-[44px] h-[44px]">
+            <div key={`${baseIdx}-${kc.qmkId}`} className="w-key h-key">
               <SplitKey
                 base={kc}
                 shifted={shifted}

--- a/src/renderer/components/keycodes/SplitKey.tsx
+++ b/src/renderer/components/keycodes/SplitKey.tsx
@@ -73,7 +73,7 @@ function splitHalfClass(highlighted?: boolean, selected?: boolean, remapped?: bo
   return `${text} ${bg}`
 }
 
-const SPLIT_HALF_BASE = 'flex-1 cursor-pointer flex items-center justify-center text-[10px] leading-tight whitespace-nowrap transition-colors hover:bg-picker-item-hover'
+const SPLIT_HALF_BASE = 'flex-1 cursor-pointer flex items-center justify-center text-2xs leading-tight whitespace-nowrap transition-colors hover:bg-picker-item-hover'
 
 function SplitKeyInner({
   base,

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -9,6 +9,7 @@ import { useAppConfig } from '../../hooks/useAppConfig'
 import { KEYCODE_CATEGORIES, groupByLayoutRow, type KeycodeCategory, type KeycodeGroup } from './categories'
 import { getLayoutsForViewType } from './display-keyboard-defs'
 import { X } from 'lucide-react'
+import { ICON_MD } from '../../constants/ui-tokens'
 import { UpwardSelect } from '../UpwardSelect'
 import { KeycodeGrid } from './KeycodeGrid'
 import { BasicKeyboardView } from './BasicKeyboardView'
@@ -447,7 +448,7 @@ export function TabbedKeycodes({
   return (
     <div
       ref={containerRef}
-      className="relative flex flex-col rounded-[10px] border border-edge bg-picker-bg min-h-0 flex-1"
+      className="relative flex flex-col rounded-xl border border-edge bg-picker-bg min-h-0 flex-1"
       data-testid="tabbed-keycodes-root"
       onClick={handleBackgroundClick}
     >
@@ -494,7 +495,7 @@ export function TabbedKeycodes({
                 onClick={onClose}
                 aria-label={t('common.close')}
               >
-                <X size={16} aria-hidden="true" />
+                <X size={ICON_MD} aria-hidden="true" />
               </button>
             )}
           </div>
@@ -534,7 +535,7 @@ export function TabbedKeycodes({
         {(showHint || (activeTab === 'basic' && onBasicViewTypeChange)) && (
           <div className="flex items-center justify-between px-3 pb-1.5">
             {showHint && (
-              <p className="text-[11px] text-content-muted">{t('editor.keymap.pickerHint')}</p>
+              <p className="text-xs text-content-muted">{t('editor.keymap.pickerHint')}</p>
             )}
             {activeTab === 'basic' && onBasicViewTypeChange && (
               <UpwardSelect
@@ -561,7 +562,7 @@ export function TabbedKeycodes({
             transform: 'translateY(-100%)',
           }}
         >
-          <div className="text-[10px] leading-snug text-content-muted whitespace-nowrap">
+          <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">
             {tooltip.keycode.qmkId}
           </div>
           {tooltip.keycode.tooltip && (

--- a/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
+++ b/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
@@ -121,7 +121,7 @@ export function LocalDataResetGroup({
             </button>
             <button
               type="button"
-              className="rounded bg-danger px-3 py-1 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+              className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
               onClick={onConfirm}
               disabled={confirmDisabled || !anySelected}
               data-testid="reset-local-data-confirm"

--- a/src/renderer/components/settings-modal/PasswordSection.tsx
+++ b/src/renderer/components/settings-modal/PasswordSection.tsx
@@ -81,7 +81,7 @@ export function PasswordSection({
       )}
       <input
         type="password"
-        className="w-full rounded border border-edge bg-surface px-3 py-2 text-sm text-content disabled:opacity-50"
+        className="w-full rounded border border-edge bg-surface px-3 py-2 text-sm text-content focus:border-accent focus:outline-none disabled:opacity-50"
         placeholder={t('sync.passwordPlaceholder')}
         value={password}
         onChange={(e) => onPasswordChange(e.target.value)}

--- a/src/renderer/components/settings-modal/SettingsDataTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsDataTab.tsx
@@ -169,7 +169,7 @@ export function SettingsDataTab({
       {/* Sync Controls */}
       <div className="mb-2 grid grid-cols-2 gap-3">
         <div className={ROW_CLASS} data-testid="sync-auto-row">
-          <span className="text-[13px] font-medium text-content">
+          <span className="text-sm font-medium text-content">
             {t('sync.autoSync')}
           </span>
           <button
@@ -184,7 +184,7 @@ export function SettingsDataTab({
         </div>
 
         <div className={ROW_CLASS} data-testid="sync-manual-row">
-          <span className="text-[13px] font-medium text-content">
+          <span className="text-sm font-medium text-content">
             {t('sync.manualSync')}
           </span>
           <button

--- a/src/renderer/components/settings-modal/SettingsToolsTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsToolsTab.tsx
@@ -141,7 +141,7 @@ export function SettingsToolsTab({
             </span>
             <div className="flex items-center gap-2">
               <span
-                className="text-[13px] text-content"
+                className="text-sm text-content"
                 data-testid="settings-language-active-name"
               >
                 {(() => {
@@ -152,7 +152,7 @@ export function SettingsToolsTab({
               <button
                 type="button"
                 onClick={() => setLanguagePacksOpen(true)}
-                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
+                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
                 data-testid="settings-language-packs-button"
               >
                 {t('i18n.edit')}
@@ -167,7 +167,7 @@ export function SettingsToolsTab({
             <button
               type="button"
               onClick={() => setKeyLabelsOpen(true)}
-              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
+              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
               data-testid="settings-key-labels-button"
             >
               {t('keyLabels.edit')}
@@ -180,7 +180,7 @@ export function SettingsToolsTab({
             </span>
             <div className="flex items-center gap-2">
               <span
-                className="text-[13px] text-content"
+                className="text-sm text-content"
                 data-testid="settings-theme-pack-active-name"
               >
                 {activeThemeName}
@@ -188,7 +188,7 @@ export function SettingsToolsTab({
               <button
                 type="button"
                 onClick={() => setThemePacksOpen(true)}
-                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
+                className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content hover:bg-surface-hover focus:border-accent focus:outline-none"
                 data-testid="settings-theme-packs-button"
               >
                 {t('i18n.edit')}
@@ -220,10 +220,10 @@ export function SettingsToolsTab({
                 }}
                 onBlur={commitZoom}
                 onKeyDown={(e) => { if (e.key === 'Enter') commitZoom() }}
-                className="zoom-factor-input w-20 rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content text-right tabular-nums hover:bg-surface-hover focus:border-accent focus:outline-none"
+                className="zoom-factor-input w-20 rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content text-right tabular-nums hover:bg-surface-hover focus:border-accent focus:outline-none"
                 data-testid="settings-zoom-factor-input"
               />
-              <span className="text-[13px] text-content-muted">%</span>
+              <span className="text-sm text-content-muted">%</span>
             </div>
           </div>
         </div>
@@ -235,14 +235,14 @@ export function SettingsToolsTab({
         </h4>
         <div className="grid grid-cols-2 gap-3">
           <div className={ROW_CLASS} data-testid="settings-default-basic-view-type-row">
-            <label htmlFor="settings-default-basic-view-type-selector" className="text-[13px] font-medium text-content">
+            <label htmlFor="settings-default-basic-view-type-selector" className="text-sm font-medium text-content">
               {t('settings.defaultBasicViewType')}
             </label>
             <select
               id="settings-default-basic-view-type-selector"
               value={defaultBasicViewType}
               onChange={(e) => onDefaultBasicViewTypeChange(e.target.value as BasicViewType)}
-              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content focus:border-accent focus:outline-none"
+              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content focus:border-accent focus:outline-none"
               data-testid="settings-default-basic-view-type-selector"
             >
               <option value="ansi">{t('settings.basicViewTypeAnsi')}</option>
@@ -253,14 +253,14 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-default-layout-row">
-            <label htmlFor="settings-default-layout-selector" className="text-[13px] font-medium text-content">
+            <label htmlFor="settings-default-layout-selector" className="text-sm font-medium text-content">
               {t('settings.defaultLayout')}
             </label>
             <select
               id="settings-default-layout-selector"
               value={defaultLayout}
               onChange={(e) => onDefaultLayoutChange(e.target.value as KeyboardLayoutId)}
-              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content focus:border-accent focus:outline-none"
+              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content focus:border-accent focus:outline-none"
               data-testid="settings-default-layout-selector"
             >
               {layoutOptions.map((layoutDef) => (
@@ -272,7 +272,7 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-default-auto-advance-row">
-            <span className="text-[13px] font-medium text-content">
+            <span className="text-sm font-medium text-content">
               {t('settings.defaultAutoAdvance')}
             </span>
             <button
@@ -289,7 +289,7 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-default-split-key-mode-row">
-            <span className="text-[13px] font-medium text-content">
+            <span className="text-sm font-medium text-content">
               {t('settings.defaultSplitKeyMode')}
             </span>
             <button
@@ -306,7 +306,7 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-default-quick-select-row">
-            <span className="text-[13px] font-medium text-content">
+            <span className="text-sm font-medium text-content">
               {t('settings.defaultQuickSelect')}
             </span>
             <button
@@ -323,7 +323,7 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-default-layer-panel-open-row">
-            <span className="text-[13px] font-medium text-content">
+            <span className="text-sm font-medium text-content">
               {t('settings.defaultLayerPanelOpen')}
             </span>
             <button
@@ -340,14 +340,14 @@ export function SettingsToolsTab({
           </div>
 
           <div className={ROW_CLASS} data-testid="settings-max-keymap-history-row">
-            <label htmlFor="settings-max-keymap-history-selector" className="text-[13px] font-medium text-content">
+            <label htmlFor="settings-max-keymap-history-selector" className="text-sm font-medium text-content">
               {t('settings.maxKeymapHistory')}
             </label>
             <select
               id="settings-max-keymap-history-selector"
               value={maxKeymapHistory}
               onChange={(e) => onMaxKeymapHistoryChange(Number(e.target.value))}
-              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content focus:border-accent focus:outline-none"
+              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content focus:border-accent focus:outline-none"
               data-testid="settings-max-keymap-history-selector"
             >
               {[10, 25, 50, 100, 200, 500].map((n) => (
@@ -365,7 +365,7 @@ export function SettingsToolsTab({
         <div className="flex flex-col gap-3">
           <div className={ROW_CLASS} data-testid="settings-auto-lock-time-row">
             <div className="flex flex-col gap-0.5">
-              <label htmlFor="settings-auto-lock-time-selector" className="text-[13px] font-medium text-content">
+              <label htmlFor="settings-auto-lock-time-selector" className="text-sm font-medium text-content">
                 {t('settings.autoLockTime')}
               </label>
               <span className="text-xs text-content-muted">
@@ -376,7 +376,7 @@ export function SettingsToolsTab({
               id="settings-auto-lock-time-selector"
               value={autoLockTime}
               onChange={(e) => onAutoLockTimeChange(Number(e.target.value) as AutoLockMinutes)}
-              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-[13px] text-content focus:border-accent focus:outline-none"
+              className="rounded border border-edge bg-surface px-2.5 py-1.5 text-sm text-content focus:border-accent focus:outline-none"
               data-testid="settings-auto-lock-time-selector"
             >
               {TIME_STEPS.map((m) => (

--- a/src/renderer/components/settings-modal/SyncDataResetSection.tsx
+++ b/src/renderer/components/settings-modal/SyncDataResetSection.tsx
@@ -282,7 +282,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
                 </button>
                 <button
                   type="button"
-                  className="rounded bg-danger px-3 py-1 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+                  className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
                   onClick={handleDelete}
                   disabled={!anySelected || deleting}
                   data-testid="sync-reset-data-confirm"

--- a/src/renderer/components/settings-modal/settings-modal-shared.ts
+++ b/src/renderer/components/settings-modal/settings-modal-shared.ts
@@ -2,6 +2,7 @@
 
 import type { LucideIcon } from 'lucide-react'
 import { Monitor, Sun, Moon } from 'lucide-react'
+export { BTN_PRIMARY, BTN_SECONDARY, BTN_DANGER_OUTLINE } from '../../constants/ui-tokens'
 import type { UseSyncReturn } from '../../hooks/useSync'
 import type { ThemeMode, ThemeSelection } from '../../hooks/useTheme'
 import type { KeyboardLayoutId, AutoLockMinutes } from '../../hooks/useDevicePrefs'
@@ -20,10 +21,6 @@ export function toggleSetItem<T>(prev: Set<T>, item: T, selected: boolean): Set<
   else next.delete(item)
   return next
 }
-
-export const BTN_PRIMARY = 'rounded bg-accent px-3 py-1 text-sm font-medium text-white hover:bg-accent/90 disabled:opacity-50'
-export const BTN_SECONDARY = 'rounded border border-edge px-3 py-1 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50'
-export const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1 text-sm text-danger hover:bg-danger/10 disabled:opacity-50'
 
 export interface ThemeOption {
   mode: ThemeMode

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2 } from 'lucide-react'
+import { ICON_XL } from '../../constants/ui-tokens'
 import type { useInlineRename } from '../../hooks/useInlineRename'
 import type { ThemePackMeta } from '../../../shared/types/theme-store'
 import { formatTimestamp } from '../../utils/format-timestamp'
@@ -110,9 +111,9 @@ export function PackRow({
           data-testid={`theme-packs-select-${meta.id}`}
         >
           {isActive ? (
-            <CheckCircle2 size={18} className="text-accent" aria-hidden="true" />
+            <CheckCircle2 size={ICON_XL} className="text-accent" aria-hidden="true" />
           ) : (
-            <Circle size={18} aria-hidden="true" />
+            <Circle size={ICON_XL} aria-hidden="true" />
           )}
         </button>
         <div className="flex-1 min-w-0 text-sm font-medium">{renderName()}</div>
@@ -174,7 +175,7 @@ export function PackRow({
         <span className="flex-1 min-w-0">
           {lastResult && lastResult.id === meta.id && (
             <span
-              className={`text-[11px] font-medium ${lastResult.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
+              className={`text-xs font-medium ${lastResult.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
               data-testid={`theme-packs-result-${meta.id}`}
             >
               {lastResult.message}

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2, Monitor, Sun, Moon } from 'lucide-react'
+import { ICON_MD } from '../../constants/ui-tokens'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -441,7 +442,7 @@ export function ThemePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-full max-w-2xl h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="theme-packs-modal"
       >
@@ -517,11 +518,11 @@ export function ThemePacksModal({
                       data-testid={`theme-packs-builtin-${mode}`}
                     >
                       {isActive ? (
-                        <CheckCircle2 size={16} className="text-accent" aria-hidden="true" />
+                        <CheckCircle2 size={ICON_MD} className="text-accent" aria-hidden="true" />
                       ) : (
-                        <Circle size={16} aria-hidden="true" />
+                        <Circle size={ICON_MD} aria-hidden="true" />
                       )}
-                      <Icon size={16} aria-hidden="true" />
+                      <Icon size={ICON_MD} aria-hidden="true" />
                       {t(`theme.${mode}`)}
                     </button>
                   )

--- a/src/renderer/constants/ui-tokens.ts
+++ b/src/renderer/constants/ui-tokens.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Icon sizes (px) for lucide-react `size` prop.
+export const ICON_XS = 12 // Tiny indicators (chevrons in selects)
+export const ICON_SM = 14 // Inline icons in buttons, list rows
+export const ICON_MD = 16 // Standard toolbar / modal icons
+export const ICON_LG = 20 // Close buttons, prominent actions
+export const ICON_XL = 18 // Checkbox/radio-style status icons
+
+// Icon button (rounded icon-only button)
+export const ICON_BTN_BASE = 'rounded p-1 text-content-muted hover:text-content transition-colors'
+
+// Standard modal / form buttons (text-sm, py-1.5)
+export const BTN_PRIMARY = 'rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed'
+export const BTN_SECONDARY = 'rounded border border-edge px-3 py-1.5 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50 disabled:cursor-not-allowed'
+export const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1.5 text-sm text-danger hover:bg-danger/10 disabled:opacity-50 disabled:cursor-not-allowed'
+
+// Toolbar toggle buttons (rounded-md, p-2)
+export const TOOLBAR_BTN_BASE = 'rounded-md border p-2 transition-colors'
+export const TOOLBAR_BTN_ACTIVE = `${TOOLBAR_BTN_BASE} border-accent bg-accent/10 text-accent`
+export const TOOLBAR_BTN_INACTIVE = `${TOOLBAR_BTN_BASE} border-edge text-content-secondary hover:text-content`

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -84,6 +84,7 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --surface: #f5f6f8;
   --surface-alt: #ffffff;
   --surface-dim: #ebedf2;
+  --surface-hover: #ebedf2;
   --surface-raised: #ffffff;
 
   --content: #1a1d27;
@@ -131,6 +132,7 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --surface: #0f1117;
   --surface-alt: #1a1d27;
   --surface-dim: #242836;
+  --surface-hover: #242836;
   --surface-raised: #2e3347;
 
   --content: #e8eaf0;
@@ -219,6 +221,7 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --color-surface: var(--surface);
   --color-surface-alt: var(--surface-alt);
   --color-surface-dim: var(--surface-dim);
+  --color-surface-hover: var(--surface-hover);
   --color-surface-raised: var(--surface-raised);
 
   /* Text */
@@ -263,6 +266,12 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --color-picker-item-hover: var(--picker-item-hover);
   --color-picker-item-text: var(--picker-item-text);
   --color-picker-item-border: var(--picker-item-border);
+
+  /* Typography */
+  --text-2xs: 10px; /* micro labels: badges, section headers */
+
+  /* Spacing */
+  --spacing-key: 44px; /* KeycodeButton / KeycodeGrid cell size */
 }
 
 @keyframes confirm-flash {

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
 import { Check, Download, Trash2, Loader2 } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
 import type { LanguageListEntry } from '../../shared/types/language-store'
 
 interface Props {
@@ -179,12 +180,12 @@ function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onD
       onClick={canSelect ? () => onSelect(lang.name) : undefined}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2">
-        {isCurrent && <Check size={14} className="shrink-0 text-accent" aria-hidden="true" />}
+        {isCurrent && <Check size={ICON_SM} className="shrink-0 text-accent" aria-hidden="true" />}
         <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>
           {formatName(lang.name)}
         </span>
         {lang.rightToLeft && (
-          <span className="shrink-0 rounded bg-surface-alt px-1 py-0.5 text-[10px] text-content-muted">RTL</span>
+          <span className="shrink-0 rounded bg-surface-alt px-1 py-0.5 text-2xs text-content-muted">RTL</span>
         )}
       </div>
 
@@ -204,9 +205,9 @@ function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onD
           disabled={isDownloading}
         >
           {isDownloading ? (
-            <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+            <Loader2 size={ICON_SM} className="animate-spin" aria-hidden="true" />
           ) : (
-            <Download size={14} aria-hidden="true" />
+            <Download size={ICON_SM} aria-hidden="true" />
           )}
         </button>
       )}
@@ -215,13 +216,13 @@ function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onD
         <button
           type="button"
           data-testid={`language-delete-${lang.name}`}
-          className="shrink-0 rounded p-1 text-content-muted hover:text-red-500"
+          className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
           onClick={(e) => {
             e.stopPropagation()
             onDelete(lang.name)
           }}
         >
-          <Trash2 size={14} aria-hidden="true" />
+          <Trash2 size={ICON_SM} aria-hidden="true" />
         </button>
       )}
     </div>

--- a/src/renderer/typing-test/TypingRecordingConsentModal.tsx
+++ b/src/renderer/typing-test/TypingRecordingConsentModal.tsx
@@ -55,7 +55,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
           <ModalCloseButton testid="typing-consent-close" onClick={onCancel} />
         </div>
 
-        <div className="flex flex-col gap-4 px-5 py-4 text-[13px] text-content">
+        <div className="flex flex-col gap-4 px-5 py-4 text-sm text-content">
           <section>
             <h3 className="mb-2 text-sm font-semibold text-content">
               {t('editor.typingTest.consent.collectedHeading')}
@@ -83,7 +83,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
             type="button"
             data-testid="typing-consent-cancel"
             onClick={onCancel}
-            className="rounded border border-edge px-3 py-1 text-sm text-content-secondary hover:bg-surface-dim"
+            className="rounded border border-edge px-3 py-1.5 text-sm text-content-secondary hover:bg-surface-dim"
           >
             {t('common.cancel')}
           </button>
@@ -91,7 +91,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
             type="button"
             data-testid="typing-consent-accept"
             onClick={onAccept}
-            className="rounded border border-accent bg-accent/10 px-3 py-1 text-sm text-accent hover:bg-accent/20"
+            className="rounded border border-accent bg-accent/10 px-3 py-1.5 text-sm text-accent hover:bg-accent/20"
           >
             {t('editor.typingTest.consent.accept')}
           </button>

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -3,6 +3,7 @@
 import { useRef, useEffect, useLayoutEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RotateCcw } from 'lucide-react'
+import { ICON_XL } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig, TypingTestMode, QuoteLength } from './types'
 import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS } from './types'
@@ -370,7 +371,7 @@ export function TypingTestView({
             onClick={onRestart}
             aria-label={t('editor.typingTest.restart')}
           >
-            <RotateCcw size={18} aria-hidden="true" />
+            <RotateCcw size={ICON_XL} aria-hidden="true" />
           </button>
         </Tooltip>
       </div>


### PR DESCRIPTION
## Summary

- Add `src/renderer/constants/ui-tokens.ts` as single source of truth for icon sizes (`ICON_XS/SM/MD/LG/XL`), button classes (`BTN_PRIMARY/SECONDARY/BTN_DANGER_OUTLINE`), and toolbar toggle classes (`TOOLBAR_BTN_BASE/ACTIVE/INACTIVE`)
- Replace all arbitrary Tailwind values (`text-[Npx]`, `w-[44px] h-[44px]`, `rounded-[10px]`) with semantic scale tokens across 85 files
- Consolidate duplicate button constants from `data-modal` and `settings-modal` into `ui-tokens.ts`
- Fix `BTN_PRIMARY` to use `text-content-inverse` instead of `text-white` for WCAG-compliant dark mode contrast
- Add `disabled:cursor-not-allowed` to all button constants
- Add `--text-2xs: 10px` and `--spacing-key: 44px` to Tailwind `@theme` block in `style.css`
- Update `.claude/DESIGN.md` to reflect all consolidated token definitions

## Test plan

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] `pnpm run lint` passes (0 errors)
- [ ] CI `check` job passes (lint → test → build)
- [ ] Verify button styles render correctly in light/dark mode