### PR TITLE
refactor(ui): replace arbitrary Tailwind values with design tokens

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -937,7 +937,7 @@ export function App() {
           onClick={() => editorUI.setShowLightingModal(false)}
         >
           <div
-            className="w-[500px] max-w-[90vw] max-h-[80vh] overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+            className="w-modal-app max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/ConnectingOverlay.tsx
+++ b/src/renderer/components/ConnectingOverlay.tsx
@@ -48,7 +48,7 @@ export function ConnectingOverlay({
           </svg>
         </div>
 
-        <div className="flex min-h-[7rem] max-w-xs flex-col items-center justify-center gap-2">
+        <div className="flex min-h-28 max-w-xs flex-col items-center justify-center gap-2">
           <p className="text-sm text-content-secondary">
             {syncOnly
               ? t('sync.syncing')

--- a/src/renderer/components/DeviceSelector.tsx
+++ b/src/renderer/components/DeviceSelector.tsx
@@ -20,13 +20,13 @@ const TAB_CLASS =
   'flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors'
 
 const TAB_ACTIVE =
-  'bg-surface text-content shadow-sm'
+  'bg-surface text-content'
 
 const TAB_INACTIVE =
   'text-content-muted hover:text-content-secondary'
 
 const LIST_CLASS =
-  'min-h-[340px] max-h-[340px] space-y-2 overflow-y-auto pb-2 pr-1'
+  'min-h-device-list max-h-device-list space-y-2 overflow-y-auto pb-2 pr-1'
 
 function formatDate(iso: string): string {
   const d = new Date(iso)

--- a/src/renderer/components/NotificationModal.tsx
+++ b/src/renderer/components/NotificationModal.tsx
@@ -20,7 +20,7 @@ export function NotificationModal({ notifications, onClose }: NotificationModalP
       onClick={onClose}
     >
       <div
-        className="w-[560px] max-w-[90vw] max-h-[80vh] overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-notify max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/analyze/ActivityChart.tsx
+++ b/src/renderer/components/analyze/ActivityChart.tsx
@@ -167,7 +167,7 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
   return (
     <div className="flex flex-col gap-2 text-xs" data-testid="analyze-activity-chart">
       <div
-        className="grid gap-[2px]"
+        className="grid gap-0.5"
         style={{ gridTemplateColumns: 'auto repeat(24, minmax(0, 1fr))' }}
         role="table"
         aria-label={t(metric === 'wpm' ? 'analyze.activity.tableLabelWpm' : 'analyze.activity.tableLabel')}

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -533,7 +533,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
         role="dialog"
         aria-modal="true"
         aria-label={t('analyze.export.categoriesLabel')}
-        className="w-[560px] max-w-[95vw] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-notify max-w-[95vw] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end px-3 pt-3 shrink-0">
@@ -604,7 +604,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                           open={targetPickerOpen}
                           onClose={handleTargetClose}
                           placement="top"
-                          className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
+                          className="z-60 min-w-dropdown rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
                           role="listbox"
                           aria-multiselectable
                         >
@@ -651,7 +651,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                   open={appPickerOpen}
                   onClose={handleAppClose}
                   placement="top"
-                  className="z-[60] min-w-[200px] rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
+                  className="z-60 min-w-dropdown rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
                   role="listbox"
                   aria-multiselectable
                 >

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -194,7 +194,7 @@ export function AnalyzeFilterStorePanel({
                     <button
                       type="submit"
                       disabled={saving}
-                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-white hover:bg-danger/90 disabled:opacity-50"
+                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
                       data-testid="analyze-filter-store-overwrite-confirm"
                     >
                       {t('analyzeFilterStore.confirmOverwrite')}
@@ -212,7 +212,7 @@ export function AnalyzeFilterStorePanel({
                   <button
                     type="submit"
                     disabled={saving || !saveLabel.trim()}
-                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent/90 disabled:opacity-50"
+                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
                     data-testid="analyze-filter-store-save-submit"
                   >
                     {t('common.save')}

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -118,7 +118,7 @@ function resolveLayoutComparisonInputs(
 const TAB_BTN_BASE =
   'rounded-md px-3 py-1.5 text-sm font-medium transition-colors'
 const TAB_BTN_IDLE = 'text-content-muted hover:text-content-secondary'
-const TAB_BTN_ACTIVE = 'bg-surface text-content shadow-sm'
+const TAB_BTN_ACTIVE = 'bg-surface text-content'
 
 // Grouped left → right: 全体像 (summary) / パフォーマンス (wpm,
 // interval) / 行動分析 (activity, byApp) / 負荷分析 (keyHeatmap,
@@ -1067,7 +1067,7 @@ export function AnalyzePane({
               aria-label={t('analyzeFilterStore.title')}
               aria-expanded={storePanelOpen}
               aria-controls={tid("analyze-filter-store-panel-overlay")}
-              className={`rounded p-1.5 transition-colors ${storePanelOpen ? 'bg-surface text-accent shadow-sm' : 'text-content-muted hover:bg-surface hover:text-content'}`}
+              className={`rounded p-1.5 transition-colors ${storePanelOpen ? 'bg-surface text-accent' : 'text-content-muted hover:bg-surface hover:text-content'}`}
               onClick={handleToggleStorePanel}
               data-testid={tid("analyze-filter-store-toggle")}
             >
@@ -1523,7 +1523,7 @@ export function AnalyzePane({
             // the panel is open. `shadow-lg` only when open — when
             // translated off-screen the shadow's left bleed lands inside
             // the visible area and reads as a stray gradient.
-            className={`absolute inset-y-0 right-0 z-10 w-fit min-w-[320px] rounded-l-lg border-l border-edge-subtle bg-surface-alt transition-transform duration-200 ease-out ${storePanelOpen ? 'translate-x-0 shadow-lg' : 'translate-x-full'}`}
+            className={`absolute inset-y-0 right-0 z-10 w-fit min-w-80 rounded-l-lg border-l border-edge-subtle bg-surface-alt transition-transform duration-200 ease-out ${storePanelOpen ? 'translate-x-0 shadow-lg' : 'translate-x-full'}`}
             inert={!storePanelOpen || undefined}
             data-testid={tid("analyze-filter-store-panel-container")}
           >

--- a/src/renderer/components/analyze/AppSelect.tsx
+++ b/src/renderer/components/analyze/AppSelect.tsx
@@ -121,7 +121,7 @@ export function AppSelect({
         anchorRef={triggerRef}
         open={open}
         onClose={handleClose}
-        className="z-20 max-h-72 min-w-[200px] overflow-y-auto rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
+        className="z-20 max-h-72 min-w-dropdown overflow-y-auto rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
         role="listbox"
         aria-multiselectable
       >

--- a/src/renderer/components/analyze/FingerAssignmentModal.tsx
+++ b/src/renderer/components/analyze/FingerAssignmentModal.tsx
@@ -181,7 +181,7 @@ export function FingerAssignmentModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="finger-assignment-title"
-        className="w-[960px] max-w-[95vw] max-h-[90vh] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-xl max-w-[95vw] max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-0 shrink-0">

--- a/src/renderer/components/analyze/GoalAchievementsModal.tsx
+++ b/src/renderer/components/analyze/GoalAchievementsModal.tsx
@@ -40,7 +40,7 @@ export function GoalAchievementsModal({ isOpen, onClose, achievements }: Props) 
         role="dialog"
         aria-modal="true"
         aria-labelledby="goal-achievements-title"
-        className="w-[720px] max-w-[95vw] max-h-[90vh] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-goal max-w-[95vw] max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-2 shrink-0">

--- a/src/renderer/components/analyze/TypingAnalyticsView.tsx
+++ b/src/renderer/components/analyze/TypingAnalyticsView.tsx
@@ -130,7 +130,7 @@ export function TypingAnalyticsView({ initialUid, onBack }: TypingAnalyticsViewP
 
   return (
     <div
-      className="flex h-full min-h-[70vh] flex-col"
+      className="flex h-full min-h-modal-70vh flex-col"
       data-testid="analyze-view"
     >
       <div className="flex flex-1 min-h-0 min-w-0 gap-4">

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -284,7 +284,7 @@ export function DataModal({
         {/* Body: sidebar + content */}
         <div className="flex flex-1 min-h-0">
           {/* Sidebar */}
-          <div className="w-[220px] shrink-0 border-r border-edge overflow-y-auto">
+          <div className="w-data-sidebar shrink-0 border-r border-edge overflow-y-auto">
             <DataNavTree
               storedKeyboards={nav.storedKeyboards}
               typingKeyboards={nav.typingKeyboards}

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -62,7 +62,7 @@ const BRANCH_BASE = 'w-full text-left text-sm py-1 flex items-center gap-1 curso
 function Chevron({ open }: { open: boolean }) {
   return (
     <span
-      className={`inline-block text-[9px] text-content-muted transition-transform ${open ? 'rotate-90' : ''}`}
+      className={`inline-block text-3xs text-content-muted transition-transform ${open ? 'rotate-90' : ''}`}
       aria-hidden="true"
     >
       &#9654;

--- a/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
+++ b/src/renderer/components/editors/AltRepeatKeyPanelModal.tsx
@@ -105,7 +105,7 @@ export function AltRepeatKeyPanelModal({
       hubProps={hubProps}
       renderBeforeFields={() => (
         <div className="flex items-center gap-3">
-          <label className="min-w-[140px] text-sm text-content">
+          <label className="min-w-modifier text-sm text-content">
             {t('editor.altRepeatKey.enabled')}
           </label>
           <input
@@ -127,7 +127,7 @@ export function AltRepeatKeyPanelModal({
             horizontal
           />
           <div className="flex items-start gap-3">
-            <label className="min-w-[140px] pt-0.5 text-sm font-medium">
+            <label className="min-w-modifier pt-0.5 text-sm font-medium">
               {t('editor.altRepeatKey.options')}
             </label>
             <div className="space-y-1">

--- a/src/renderer/components/editors/EditorSettingsModal.tsx
+++ b/src/renderer/components/editors/EditorSettingsModal.tsx
@@ -6,7 +6,7 @@ import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { LayoutStoreContent, type LayoutStoreContentProps } from './LayoutStoreModal'
 import { ModalCloseButton } from './ModalCloseButton'
 
-const PANEL_BASE = 'absolute top-0 h-full w-[440px] max-w-[90vw] flex flex-col border-edge bg-surface-alt shadow-xl transition-transform duration-300 ease-out'
+const PANEL_BASE = 'absolute top-0 h-full w-modal-sm max-w-[90vw] flex flex-col border-edge bg-surface-alt shadow-xl transition-transform duration-300 ease-out'
 
 function panelPositionClass(open: boolean): string {
   return `${PANEL_BASE} left-0 border-r ${open ? 'translate-x-0' : '-translate-x-full'}`

--- a/src/renderer/components/editors/FavoriteStoreModal.tsx
+++ b/src/renderer/components/editors/FavoriteStoreModal.tsx
@@ -21,12 +21,12 @@ export function FavoriteStoreModal({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
       data-testid="favorite-store-modal-backdrop"
       onClick={onClose}
     >
       <div
-        className="w-[440px] max-w-[90vw] h-[70vh] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-sm max-w-[90vw] h-modal-70vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -260,7 +260,7 @@ export function HSVColorPicker({
   }
 
   return (
-    <div className="flex w-[15rem] flex-col gap-3">
+    <div className="flex w-color-picker flex-col gap-3">
       {/* Mode toggle */}
       <div className="flex gap-1.5">
         <button
@@ -320,7 +320,7 @@ export function HSVColorPicker({
           <div
             ref={svRef}
             data-testid="sv-picker"
-            className="relative h-[180px] cursor-crosshair rounded-lg"
+            className="relative h-color-picker-sv cursor-crosshair rounded-lg"
             style={{
               background:
                 'linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent)',

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -51,7 +51,7 @@ export function HistoryToggle({ results, deviceName }: HistoryToggleProps) {
           onClick={() => setShowHistory(false)}
         >
           <div
-            className="flex h-[80vh] w-[900px] max-w-[90vw] flex-col rounded-lg bg-surface-alt p-6 shadow-xl"
+            className="flex h-modal-80vh w-modal-wide max-w-[90vw] flex-col rounded-lg bg-surface-alt p-6 shadow-xl"
             data-testid="history-modal"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/renderer/components/editors/JsonEditorModal.tsx
+++ b/src/renderer/components/editors/JsonEditorModal.tsx
@@ -84,7 +84,7 @@ export function JsonEditorModal<T>({
       <div
         role="dialog"
         aria-modal="true"
-        className="w-[600px] max-w-[90vw] max-h-[80vh] overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-md max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/editors/KeyOverridePanelModal.tsx
+++ b/src/renderer/components/editors/KeyOverridePanelModal.tsx
@@ -116,7 +116,7 @@ export function KeyOverridePanelModal({
       hubProps={hubProps}
       renderBeforeFields={() => (
         <div className="flex items-center gap-3">
-          <label className="min-w-[140px] text-sm text-content">
+          <label className="min-w-modifier text-sm text-content">
             {t('editor.keyOverride.enabled')}
           </label>
           <input
@@ -147,7 +147,7 @@ export function KeyOverridePanelModal({
             />
           ))}
           <div className="flex items-start gap-3">
-            <label className="min-w-[140px] pt-0.5 text-sm font-medium">
+            <label className="min-w-modifier pt-0.5 text-sm font-medium">
               {t('editor.keyOverride.options')}
             </label>
             <div className="space-y-1">

--- a/src/renderer/components/editors/KeyboardPane.tsx
+++ b/src/renderer/components/editors/KeyboardPane.tsx
@@ -4,7 +4,7 @@ import { KeyboardWidget } from '../keyboard/KeyboardWidget'
 import type { KleKey } from '../../../shared/kle/types'
 import type { TypingHeatmapCell } from '../../../shared/types/typing-analytics'
 
-const PANE_CLASS = 'relative inline-block min-w-[280px] rounded-xl bg-surface-alt px-5 pt-3 pb-2 border-2 border-edge-subtle'
+const PANE_CLASS = 'relative inline-block min-w-keyboard-pane rounded-xl bg-surface-alt px-5 pt-3 pb-2 border-2 border-edge-subtle'
 
 /** Returns true when any selection-modifier key (Ctrl/Meta/Shift) is held. */
 export function hasModifierKey(e: React.MouseEvent): boolean {
@@ -110,7 +110,7 @@ export function KeyboardPane({
           onKeyHoverEnd={onKeyHoverEnd}
         />
       </div>
-      <div className="flex items-center justify-between px-[5px] text-xs leading-none text-content-muted">
+      <div className="flex items-center justify-between px-keyboard-px text-xs leading-none text-content-muted">
         <span data-testid={layerLabelTestId} className="text-content-muted">
           {layerLabel}
         </span>

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -119,7 +119,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
     const value = editedEntry[key] as number
     return (
       <div key={key} className="flex items-center gap-3">
-        <label className="min-w-[140px] text-sm text-content">{t(labelKey, labelOpts)}</label>
+        <label className="min-w-modifier text-sm text-content">{t(labelKey, labelOpts)}</label>
         <KeycodeField
           value={value}
           selected={selectedField === key}
@@ -205,7 +205,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
     if (!showFavorites) return null
     return (
       <div
-        className={`w-[456px] shrink-0 flex flex-col ${selectedField ? 'hidden' : ''}`}
+        className={`w-macro-editor shrink-0 flex flex-col ${selectedField ? 'hidden' : ''}`}
         data-testid={`${prefix}-favorites-panel`}
       >
         <FavoriteStoreContent
@@ -246,7 +246,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
       onClick={handleClose}
     >
       <div
-        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-[80vh] flex flex-col`}
+        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-modal-80vh flex flex-col`}
         data-testid={`${prefix}-modal`}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -111,7 +111,7 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
       title={tooltip}
       data-testid="keycode-field"
       disabled={disabled}
-      className={`flex shrink-0 rounded-sm ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
+      className={`flex shrink-0 rounded ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
       onClick={handleClick}
       onDoubleClick={isMasked ? undefined : handleDoubleClick}
     >
@@ -143,7 +143,7 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
         type="button"
         data-testid="keycode-delete"
         aria-label={t('editor.macro.deleteKeycode')}
-        className="absolute -top-2 -right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-danger text-white opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
+        className="absolute -top-2 -right-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-danger text-content-inverse opacity-0 transition-opacity group-hover:opacity-100 focus:opacity-100"
         onClick={(e) => { e.stopPropagation(); onDelete() }}
       >
         <X size={ICON_SM} aria-hidden="true" />

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -731,7 +731,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         {pickerSource === 'device' && deviceBrowsing ? (
           /* --- Device browse view --- */
           <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
-            <div className="flex min-h-[340px] max-h-[340px] flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
+            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
               <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerCurrentState')}</span>
               {probeStatus === 'probing' ? (
                 <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerProbing')}</p>
@@ -753,7 +753,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         ) : pickerSource === 'file' && !pickerFileData ? (
           /* --- File browse view --- */
           <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
-            <div className="flex min-h-[340px] max-h-[340px] flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
+            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
             {pickerLoadError && (
               <div className="rounded-lg bg-danger/10 px-3 py-2 text-xs text-danger">
                 {pickerLoadError}
@@ -1020,7 +1020,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
             }
             panelOverlay={
               <div id="keycodes-overlay-panel" ref={layoutPanelRef}
-                className={`absolute inset-y-0 right-0 z-10 w-fit min-w-[360px] max-w-[420px] rounded-l-lg rounded-r-[10px] border-l border-edge-subtle bg-surface-alt shadow-lg transition-transform duration-200 ease-out ${layoutPanelOpen ? 'translate-x-0' : 'translate-x-full'}`}
+                className={`absolute inset-y-0 right-0 z-10 w-fit min-w-keycode-panel max-w-keycode-panel rounded-l-lg rounded-r-panel-connector border-l border-edge-subtle bg-surface-alt shadow-lg transition-transform duration-200 ease-out ${layoutPanelOpen ? 'translate-x-0' : 'translate-x-full'}`}
                 inert={!layoutPanelOpen || undefined}
               >
                 <KeycodesOverlayPanel

--- a/src/renderer/components/editors/LayerPicker.tsx
+++ b/src/renderer/components/editors/LayerPicker.tsx
@@ -64,7 +64,7 @@ export function LayerPicker({ value, onChange, label, horizontal }: Props) {
   if (horizontal) {
     return (
       <div className="flex items-start gap-3">
-        <span className="min-w-[140px] pt-0.5 text-sm font-medium">{label}</span>
+        <span className="min-w-modifier pt-0.5 text-sm font-medium">{label}</span>
         <div className="space-y-1">
           {grid}
           {buttons}

--- a/src/renderer/components/editors/LayoutEditor.tsx
+++ b/src/renderer/components/editors/LayoutEditor.tsx
@@ -59,7 +59,7 @@ export function LayoutEditor({
       <div className="space-y-3">
         {options.map((opt) => (
           <div key={opt.index} className="flex items-center gap-3">
-            <span className="min-w-[120px] text-sm text-content">
+            <span className="min-w-layout-label text-sm text-content">
               {opt.labels[0]}
             </span>
             {opt.labels.length <= 2 ? (

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -184,7 +184,7 @@ export function LayoutStoreContent({
                       <button
                         type="submit"
                         disabled={saving}
-                        className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-white hover:bg-danger/90 disabled:opacity-50"
+                        className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
                         data-testid="layout-store-overwrite-confirm"
                       >
                         {t('layoutStore.confirmOverwrite')}
@@ -202,7 +202,7 @@ export function LayoutStoreContent({
                     <button
                       type="submit"
                       disabled={saving || !saveLabel.trim()}
-                      className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent/90 disabled:opacity-50"
+                      className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
                       data-testid="layout-store-save-submit"
                     >
                       {t('common.save')}
@@ -253,7 +253,7 @@ export function LayoutStoreContent({
                     <button
                       type="submit"
                       disabled={saving}
-                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-white hover:bg-danger/90 disabled:opacity-50"
+                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
                       data-testid="layout-store-overwrite-confirm"
                     >
                       {t('layoutStore.confirmOverwrite')}
@@ -271,7 +271,7 @@ export function LayoutStoreContent({
                   <button
                     type="submit"
                     disabled={saving || !saveLabel.trim()}
-                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-white hover:bg-accent/90 disabled:opacity-50"
+                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
                     data-testid="layout-store-save-submit"
                   >
                     {t('common.save')}

--- a/src/renderer/components/editors/LayoutStoreModal.tsx
+++ b/src/renderer/components/editors/LayoutStoreModal.tsx
@@ -25,7 +25,7 @@ export function LayoutStoreModal({ onClose, ...contentProps }: Props) {
       onClick={onClose}
     >
       <div
-        className="w-[440px] max-w-[90vw] max-h-[85vh] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-sm max-w-[90vw] max-h-modal-85vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -120,7 +120,7 @@ export function MacroActionItem({
                   type="button"
                   data-testid="macro-edit-action"
                   style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
-                  className="flex shrink-0 rounded-sm outline outline-1 outline-dashed outline-edge hover:outline-accent disabled:opacity-50"
+                  className="flex shrink-0 rounded outline outline-1 outline-dashed outline-edge hover:outline-accent disabled:opacity-50"
                   onClick={() => onEditClick(action.keycodes.length)}
                   disabled={disabled}
                   aria-label={t('editor.macro.addKeycode')}
@@ -157,7 +157,7 @@ export function MacroActionItem({
   if (focusMode && isKeycodeType) {
     return (
       <div className="flex items-center gap-3">
-        <label className="min-w-[60px] text-sm text-content">{typeLabels[action.type]}</label>
+        <label className="min-w-keycode text-sm text-content">{typeLabels[action.type]}</label>
         <div className="flex flex-wrap items-center gap-1 flex-1">
           {action.keycodes.map((kc, ki) => {
             const isSelected = selectedKeycodeIndex === ki
@@ -180,7 +180,7 @@ export function MacroActionItem({
               type="button"
               data-testid="macro-add-keycode"
               style={{ width: KEYCODE_FIELD_SIZE, height: KEYCODE_FIELD_SIZE }}
-              className={`flex shrink-0 rounded-sm outline outline-1 outline-dashed disabled:opacity-50 ${
+              className={`flex shrink-0 rounded outline outline-1 outline-dashed disabled:opacity-50 ${
                 selectedKeycodeIndex === action.keycodes.length
                   ? 'outline-accent'
                   : 'outline-edge hover:outline-accent'
@@ -222,7 +222,7 @@ export function MacroActionItem({
         className={`flex items-center gap-1.5 border-r border-edge py-1 pl-1 pr-3 ${disabled ? '' : 'cursor-grab active:cursor-grabbing'}`}
       >
         <GripVertical className="shrink-0 text-content-muted" size={ICON_SM} />
-        <span className="min-w-[36px] text-center text-sm text-content-secondary">
+        <span className="min-w-9 text-center text-sm text-content-secondary">
           {typeLabels[action.type]}
         </span>
       </div>

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -498,7 +498,7 @@ export function MacroEditor({
 
       {!isDummy && (
         <div
-          className={`w-[456px] shrink-0 flex flex-col ${isEditing ? 'hidden' : isRecording ? 'invisible' : ''}`}
+          className={`w-macro-editor shrink-0 flex flex-col ${isEditing ? 'hidden' : isRecording ? 'invisible' : ''}`}
           data-testid="macro-favorites-panel"
         >
           <FavoriteStoreContent

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -71,8 +71,8 @@ export function MacroModal({
   const { t } = useTranslation()
   const [isEditing, setIsEditing] = useState(false)
   const [isRecording, setIsRecording] = useState(false)
-  const modalWidth = isDummy ? 'w-[1200px]' : 'w-[1300px]'
-  const modalHeight = isEditing ? 'max-h-[90vh]' : 'h-[90vh]'
+  const modalWidth = isDummy ? 'w-modal-2xl' : 'w-modal-3xl'
+  const modalHeight = isEditing ? 'max-h-modal-90vh' : 'h-modal-90vh'
 
   useEscapeClose(onClose, !isRecording && !isEditing)
 

--- a/src/renderer/components/editors/MacroTextEditor.tsx
+++ b/src/renderer/components/editors/MacroTextEditor.tsx
@@ -64,7 +64,7 @@ export function MacroTextEditor({ initialJson, onApply, onClose }: Props) {
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        className="w-[500px] rounded-lg border border-edge bg-surface p-4 shadow-xl"
+        className="w-modal-app rounded-lg border border-edge bg-surface p-4 shadow-xl"
       >
         <h3 id={titleId} className="mb-3 text-sm font-medium">{t('editor.macro.textEditorTitle')}</h3>
         <textarea

--- a/src/renderer/components/editors/ModifierPicker.tsx
+++ b/src/renderer/components/editors/ModifierPicker.tsx
@@ -42,7 +42,7 @@ export function ModifierPicker({ value, onChange, label, horizontal }: Props) {
   if (horizontal) {
     return (
       <div className="flex items-start gap-3">
-        <label className="min-w-[140px] pt-0.5 text-sm font-medium">{label}</label>
+        <label className="min-w-modifier pt-0.5 text-sm font-medium">{label}</label>
         {grid}
       </div>
     )

--- a/src/renderer/components/editors/QmkSettingsModal.tsx
+++ b/src/renderer/components/editors/QmkSettingsModal.tsx
@@ -36,7 +36,7 @@ function SettingsModal({
       onClick={onClose}
     >
       <div
-        className="w-[600px] max-w-[90vw] max-h-[80vh] overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-md max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/editors/RGBConfigurator.tsx
+++ b/src/renderer/components/editors/RGBConfigurator.tsx
@@ -69,12 +69,12 @@ function ColorCodeFields({
 
   return (
     <div className="flex items-center gap-3">
-      <label className="min-w-[100px] text-sm">{t('editor.lighting.hex')}</label>
+      <label className="min-w-rgb-label text-sm">{t('editor.lighting.hex')}</label>
       <div className="flex items-center gap-1 text-xs">
         <span className="text-content-muted">#</span>
         <input
           data-testid="hex-input"
-          className={`${INPUT_CLASS} w-[4.5rem]`}
+          className={`${INPUT_CLASS} w-18`}
           value={localHex ?? hexStr.slice(1)}
           maxLength={6}
           onFocus={() => setLocalHex(hexStr.slice(1))}
@@ -257,7 +257,7 @@ export function RGBConfigurator({
           )}
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.brightness')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.brightness')}</label>
             <input
               type="range"
               min={0}
@@ -272,7 +272,7 @@ export function RGBConfigurator({
           </div>
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.breathing')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.breathing')}</label>
             <input
               type="checkbox"
               checked={backlightEffect === 1}
@@ -293,7 +293,7 @@ export function RGBConfigurator({
           )}
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.effect')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.effect')}</label>
             <select
               value={rgblightEffect}
               onChange={async (e) => {
@@ -310,7 +310,7 @@ export function RGBConfigurator({
           </div>
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.speed')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.speed')}</label>
             <input
               type="range"
               min={0}
@@ -327,7 +327,7 @@ export function RGBConfigurator({
           {selectedRgblightEffect?.hasColorPicker && (
             <>
               <div className="flex items-start gap-3">
-                <label className="min-w-[100px] pt-1 text-sm">
+                <label className="min-w-rgb-label pt-1 text-sm">
                   {t('editor.lighting.colorPicker.label')}
                 </label>
                 <HSVColorPicker
@@ -351,7 +351,7 @@ export function RGBConfigurator({
               </div>
 
               <div className="flex items-center gap-3">
-                <label className="min-w-[100px] text-sm">
+                <label className="min-w-rgb-label text-sm">
                   {t('editor.lighting.brightness')}
                 </label>
                 <input
@@ -383,7 +383,7 @@ export function RGBConfigurator({
       {hasVialRGB && (
         <section className="flex flex-col gap-3">
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.effect')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.effect')}</label>
             <select
               value={vialRGBMode}
               onChange={async (e) => {
@@ -400,7 +400,7 @@ export function RGBConfigurator({
           </div>
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">{t('editor.lighting.speed')}</label>
+            <label className="min-w-rgb-label text-sm">{t('editor.lighting.speed')}</label>
             <input
               type="range"
               min={0}
@@ -415,7 +415,7 @@ export function RGBConfigurator({
           </div>
 
           <div className="flex items-start gap-3">
-            <label className="min-w-[100px] pt-1 text-sm">
+            <label className="min-w-rgb-label pt-1 text-sm">
               {t('editor.lighting.colorPicker.label')}
             </label>
             <HSVColorPicker
@@ -438,7 +438,7 @@ export function RGBConfigurator({
           </div>
 
           <div className="flex items-center gap-3">
-            <label className="min-w-[100px] text-sm">
+            <label className="min-w-rgb-label text-sm">
               {t('editor.lighting.brightness')}
             </label>
             <input

--- a/src/renderer/components/editors/TapDanceModal.tsx
+++ b/src/renderer/components/editors/TapDanceModal.tsx
@@ -50,7 +50,7 @@ const tdAdapter: KeycodeEntryModalAdapter<TapDanceEntry> = {
   guardCodes: () => [], // TapDance has no unlock guard
   closeOnSave: false,
   showFavorites: ({ isDummy }) => !isDummy,
-  modalWidth: ({ isDummy }) => isDummy ? 'w-[900px]' : 'w-[1050px]',
+  modalWidth: ({ isDummy }) => isDummy ? 'w-modal-wide' : 'w-modal-editor',
 }
 
 export function TapDanceModal({
@@ -101,7 +101,7 @@ export function TapDanceModal({
       hubProps={hubProps}
       renderAfterFields={() => (
         <div className="flex items-center gap-3">
-          <label className="min-w-[140px] text-sm text-content">
+          <label className="min-w-modifier text-sm text-content">
             {t('editor.tapDance.tappingTerm')}
           </label>
           <input

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -497,7 +497,7 @@ export function TypingTestPane({
                 other tabs match its natural height. Keep this in sync
                 if any tab grows/shrinks meaningfully. */}
             {menuTab === 'window' && (
-              <div className="flex min-h-[100px] flex-col gap-1.5">
+              <div className="flex min-h-word-list flex-col gap-1.5">
                 <button
                   type="button"
                   role="menuitem"
@@ -545,7 +545,7 @@ export function TypingTestPane({
             )}
 
             {menuTab === 'rec' && (
-              <div className="flex min-h-[100px] flex-col gap-1.5">
+              <div className="flex min-h-word-list flex-col gap-1.5">
                 {onRecordEnabledChange && (
                   <button
                     type="button"

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -126,7 +126,7 @@ export function UnlockDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-[600px] max-w-[90vw] rounded-lg bg-surface-alt p-6 shadow-xl">
+      <div className="w-modal-md max-w-[90vw] rounded-lg bg-surface-alt p-6 shadow-xl">
         <h2 className="mb-4 text-lg font-semibold">{t('unlock.title')}</h2>
         <p className="mb-4 text-sm text-content-secondary">{t('unlock.instructions')}</p>
 

--- a/src/renderer/components/editors/__tests__/KeycodeEntryModalShell.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeycodeEntryModalShell.test.tsx
@@ -129,7 +129,7 @@ function createMockHook(overrides?: Partial<KeycodeEntryModalReturn<TestEntry>>)
     },
     preEditValueRef: { current: 0 },
     showFavorites: true,
-    modalWidth: 'w-[1050px]',
+    modalWidth: 'w-modal-editor',
     ...overrides,
   }
 }

--- a/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
+++ b/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
@@ -22,7 +22,7 @@ export function JaRemovedBanner(): JSX.Element | null {
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/40 backdrop-blur-sm"
+      className="fixed inset-0 z-60 flex items-center justify-center bg-black/40 backdrop-blur-sm"
       data-testid="ja-removed-banner"
       role="dialog"
       aria-modal="true"
@@ -37,7 +37,7 @@ export function JaRemovedBanner(): JSX.Element | null {
         <div className="flex justify-end">
           <button
             type="button"
-            className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent/90"
+            className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-accent/90"
             onClick={dismiss}
             data-testid="ja-removed-dismiss"
           >

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -595,7 +595,7 @@ export function LanguagePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="language-packs-modal"
       >
@@ -624,7 +624,7 @@ export function LanguagePacksModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void runSearch(search.trim())}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
               data-testid="language-packs-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('i18n.search')}

--- a/src/renderer/components/i18n-packs/MissingKeysModal.tsx
+++ b/src/renderer/components/i18n-packs/MissingKeysModal.tsx
@@ -48,7 +48,7 @@ export function MissingKeysModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
       data-testid="missing-keys-modal-backdrop"
       onClick={(e) => {
         // Stop the click bubbling into the parent Languages modal —
@@ -58,7 +58,7 @@ export function MissingKeysModal({
       }}
     >
       <div
-        className="w-[600px] max-w-[90vw] h-[70vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-md max-w-[90vw] h-modal-70vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-keys-modal"
       >

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -358,7 +358,7 @@ export function KeyLabelsModal({
       onClick={onClose}
     >
       <div
-        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="key-labels-modal"
       >
@@ -397,7 +397,7 @@ export function KeyLabelsModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void triggerSearch()}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
               data-testid="key-labels-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('keyLabels.search')}
@@ -680,7 +680,7 @@ function InstalledRowView({
               every row — without it the QWERTY row's empty actions
               area collapses to 0 px and the "pipette" label drifts
               right relative to the other rows. */}
-          <span className="min-w-[6rem] text-right whitespace-nowrap">
+          <span className="min-w-24 text-right whitespace-nowrap">
             {row.isQwerty ? null : (
               <InstalledActions
                 localId={row.localId}
@@ -730,7 +730,7 @@ function InstalledRowView({
           // QWERTY (and any other no-action rows): keep the spacer so
           // the card height matches Hub-aware rows, and surface the
           // result badge on the left edge when one applies.
-          <div className="mt-2 flex h-[18px] items-center pr-1">
+          <div className="mt-2 flex h-4.5 items-center pr-1">
             <ResultBadge result={lastResult} rowId={row.localId} />
           </div>
         )}

--- a/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
+++ b/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
@@ -29,7 +29,7 @@ export function MissingKeyLabelDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50"
+      className="fixed inset-0 z-60 flex items-center justify-center bg-black/50"
       data-testid="missing-key-label-backdrop"
       onClick={onClose}
     >
@@ -37,7 +37,7 @@ export function MissingKeyLabelDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="missing-key-label-title"
-        className="w-[600px] max-w-[90vw] rounded-lg bg-surface p-5 shadow-xl"
+        className="w-modal-md max-w-[90vw] rounded-lg bg-surface p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-key-label-dialog"
       >

--- a/src/renderer/components/keycodes/PopoverTabKey.tsx
+++ b/src/renderer/components/keycodes/PopoverTabKey.tsx
@@ -208,7 +208,7 @@ export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask 
             onClick={() => { setTooltip(null); onKeycodeSelect(entry.keycode); setSuppressResults(true); setQuery(entry.keycode.label || stripPrefix(entry.keycode.qmkId)) }}
             data-testid={`popover-result-${entry.keycode.qmkId}`}
           >
-            <span className="min-w-[60px] font-mono text-xs font-medium">
+            <span className="min-w-keycode font-mono text-xs font-medium">
               {entry.keycode.label}
             </span>
             <span

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -54,10 +54,10 @@ function SettingsTileGrid<T extends Record<string, unknown>>({ entries, fields, 
               type="button"
               data-testid={`${testIdPrefix}-tile-${i}`}
               data-configured={configured || undefined}
-              className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${tileStyle(configured, enabled)}`}
+              className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-3xs leading-snug transition-colors ${tileStyle(configured, enabled)}`}
               onClick={() => onOpen(i)}
             >
-              <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">{i}</span>
+              <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">{i}</span>
               {configured ? (
                 <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px overflow-hidden">
                   {fields.map(({ key, prefix }) => (
@@ -144,11 +144,11 @@ export function TdTileGrid({ entries, onSelect, onDoubleClick }: TdTileGridProps
             type="button"
             data-testid={`td-tile-${i}`}
             data-configured={configured || undefined}
-            className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
+            className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-3xs leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
             onClick={select}
             onDoubleClick={commit}
           >
-            <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">TD({i})</span>
+            <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">TD({i})</span>
             {configured ? (
               <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px">
                 {TD_FIELDS.map(({ key, prefix }) => (
@@ -218,11 +218,11 @@ export function MacroTileGrid({ macros, onSelect, onDoubleClick }: MacroTileGrid
             type="button"
             data-testid={`macro-tile-${i}`}
             data-configured={configured || undefined}
-            className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-[9px] leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
+            className={`relative flex aspect-square min-h-0 flex-col items-start rounded-md border p-1 pl-1.5 text-3xs leading-snug transition-colors ${configured ? TILE_ENABLED : TILE_EMPTY}`}
             onClick={select}
             onDoubleClick={commit}
           >
-            <span className="absolute top-0.5 left-1 text-[8px] text-content-secondary/60">M{i}</span>
+            <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">M{i}</span>
             {configured ? (
               <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0 overflow-hidden">
                 {actions.slice(0, maxVisible).map((action, j) => (

--- a/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
+++ b/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
@@ -121,7 +121,7 @@ export function LocalDataResetGroup({
             </button>
             <button
               type="button"
-              className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+              className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-danger/90 disabled:opacity-50"
               onClick={onConfirm}
               disabled={confirmDisabled || !anySelected}
               data-testid="reset-local-data-confirm"

--- a/src/renderer/components/settings-modal/PasswordSection.tsx
+++ b/src/renderer/components/settings-modal/PasswordSection.tsx
@@ -112,7 +112,7 @@ export function PasswordSection({
         <div className="flex gap-2">
           <button
             type="button"
-            className="rounded bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+            className="rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
             onClick={onSetPassword}
             disabled={!password || (passwordScore !== null && passwordScore < 4) || sync.syncUnavailable}
             data-testid="sync-password-save"

--- a/src/renderer/components/settings-modal/SettingsDataTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsDataTab.tsx
@@ -82,7 +82,7 @@ export function SettingsDataTab({
     <div className="pt-4">
       {/* Google Account */}
       <section className="mb-4">
-        <h3 className="mb-3 text-[15px] font-bold text-content">
+        <h3 className="mb-3 text-heading-md font-bold text-content">
           {t('sync.googleAccount')}
         </h3>
         {sync.authStatus.authenticated ? (
@@ -108,7 +108,7 @@ export function SettingsDataTab({
           <div className="space-y-2">
             <button
               type="button"
-              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
               onClick={handleSignIn}
               disabled={authenticating}
               data-testid="sync-sign-in"
@@ -127,7 +127,7 @@ export function SettingsDataTab({
       <hr className="my-4 border-edge" />
 
       {/* Data Sync */}
-      <h3 className="mb-3 text-[15px] font-bold text-content" data-testid="data-sync-title">
+      <h3 className="mb-3 text-heading-md font-bold text-content" data-testid="data-sync-title">
         {t('settings.dataSync')}
       </h3>
 
@@ -210,7 +210,7 @@ export function SettingsDataTab({
       <hr className="my-4 border-edge" />
 
       {/* Pipette Hub */}
-      <h3 className="mb-3 text-[15px] font-bold text-content" data-testid="pipette-hub-title">
+      <h3 className="mb-3 text-heading-md font-bold text-content" data-testid="pipette-hub-title">
         {t('hub.pipetteHub')}
       </h3>
 
@@ -243,7 +243,7 @@ export function SettingsDataTab({
           <div data-testid="hub-enable-row">
             <button
               type="button"
-              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent/90 disabled:opacity-50"
+              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
               onClick={() => onHubEnabledChange(true)}
               disabled={!hubAuthenticated}
               data-testid="hub-enable-toggle"

--- a/src/renderer/components/settings-modal/SyncDataResetSection.tsx
+++ b/src/renderer/components/settings-modal/SyncDataResetSection.tsx
@@ -282,7 +282,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
                 </button>
                 <button
                   type="button"
-                  className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-white hover:bg-danger/90 disabled:opacity-50"
+                  className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-danger/90 disabled:opacity-50"
                   onClick={handleDelete}
                   disabled={!anySelected || deleting}
                   data-testid="sync-reset-data-confirm"

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -442,7 +442,7 @@ export function ThemePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-[760px] max-w-[90vw] h-[80vh] flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="theme-packs-modal"
       >
@@ -471,7 +471,7 @@ export function ThemePacksModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void runSearch(search.trim())}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:opacity-90 disabled:opacity-50"
+              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
               data-testid="theme-packs-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('i18n.search')}

--- a/src/renderer/hooks/__tests__/useKeycodeEntryModal.test.ts
+++ b/src/renderer/hooks/__tests__/useKeycodeEntryModal.test.ts
@@ -160,11 +160,11 @@ describe('useKeycodeEntryModal', () => {
   it('modalWidth supports function form', () => {
     const widthAdapter: KeycodeEntryModalAdapter<TestEntry> = {
       ...testAdapter,
-      modalWidth: ({ isDummy }) => isDummy ? 'w-[900px]' : 'w-[1050px]',
+      modalWidth: ({ isDummy }) => isDummy ? 'w-modal-wide' : 'w-modal-editor',
     }
     const opts = makeOptions({ isDummy: true })
     const { result } = renderHook(() => useKeycodeEntryModal(widthAdapter, opts))
-    expect(result.current.modalWidth).toBe('w-[900px]')
+    expect(result.current.modalWidth).toBe('w-modal-wide')
   })
 
   it('handleFieldSelect sets selectedField and stores preEditValue', () => {

--- a/src/renderer/hooks/useKeycodeEntryModal.ts
+++ b/src/renderer/hooks/useKeycodeEntryModal.ts
@@ -52,7 +52,7 @@ export interface KeycodeEntryModalAdapter<TEntry extends Record<string, unknown>
   closeOnSave: boolean
   /** Whether to show favorites panel. Default: () => true */
   showFavorites?: (opts: { isDummy?: boolean }) => boolean
-  /** Modal width class. Default: 'w-[1050px]' */
+  /** Modal width class. Default: 'w-modal-editor' */
   modalWidth?: string | ((opts: { isDummy?: boolean }) => string)
 }
 
@@ -319,7 +319,7 @@ export function useKeycodeEntryModal<TEntry extends Record<string, unknown>>(
 
   const modalWidth = typeof adapter.modalWidth === 'function'
     ? adapter.modalWidth({ isDummy })
-    : adapter.modalWidth ?? 'w-[1050px]'
+    : adapter.modalWidth ?? 'w-modal-editor'
 
   return {
     editedEntry,

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -268,10 +268,66 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --color-picker-item-border: var(--picker-item-border);
 
   /* Typography */
-  --text-2xs: 10px; /* micro labels: badges, section headers */
+  --text-2xs: 10px;      /* micro labels: badges, section headers */
+  --text-3xs: 9px;       /* tile grid keycode text */
+  --text-4xs: 8px;       /* tile grid index labels */
+  --text-heading-md: 15px; /* settings section headings */
 
   /* Spacing */
   --spacing-key: 44px; /* KeycodeButton / KeycodeGrid cell size */
+  --spacing-keyboard-px: 5px; /* KeyboardPane horizontal label padding */
+
+  /* Modal widths */
+  --width-modal-sm: 440px;     /* EditorSettingsModal, FavoriteStoreModal, LayoutStoreModal */
+  --width-modal-md: 600px;     /* MissingKeyLabelDialog, UnlockDialog, QmkSettings, JsonEditor */
+  --width-modal-notify: 560px; /* NotificationModal, AnalyzeExportModal */
+  --width-modal-typing: 480px; /* LanguageSelectorModal, TypingRecordingConsentModal */
+  --width-modal-lg: 760px;     /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal */
+  --width-modal-goal: 720px;   /* GoalAchievementsModal */
+  --width-modal-app: 500px;    /* App toast, MacroTextEditor */
+  --width-modal-xl: 960px;     /* FingerAssignmentModal */
+  --width-modal-wide: 900px;   /* HistoryToggle, TapDanceModal (dummy) */
+  --width-modal-editor: 1050px; /* KeycodeEntryModalShell, TapDanceModal */
+  --width-modal-2xl: 1200px;   /* MacroModal large */
+  --width-modal-3xl: 1300px;   /* MacroModal recording */
+  --width-macro-editor: 456px; /* MacroEditor / KeycodeEntryModalShell list panel */
+  --width-data-sidebar: 220px; /* DataModal tree sidebar */
+
+  /* Modal heights */
+  --height-modal-80vh: 80vh; /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal */
+  --height-modal-70vh: 70vh; /* MissingKeysModal, TypingAnalyticsView */
+  --height-modal-90vh: 90vh; /* MacroModal */
+
+  /* Modal max-heights */
+  --max-height-modal-80vh: 80vh; /* Various modals */
+  --max-height-modal-85vh: 85vh; /* LayoutStoreModal */
+  --max-height-modal-90vh: 90vh; /* GoalAchievements, FingerAssignment, MacroModal */
+
+  /* Component sizing */
+  --min-width-keycode: 60px;           /* PopoverTabKey, MacroActionItem */
+  --min-width-dropdown: 200px;         /* AppSelect, AnalyzeExportModal dropdowns */
+  --min-width-modifier: 140px;         /* AltRepeatKeyPanelModal, ModifierPicker, LayerPicker, TapDanceModal */
+  --min-width-rgb-label: 100px;        /* RGBConfigurator form labels */
+  --min-width-layout-label: 120px;     /* LayoutEditor form label */
+  --min-width-keyboard-pane: 280px;    /* KeyboardPane */
+  --min-width-keycode-panel: 360px;    /* KeymapEditor layout overlay panel */
+  --max-width-keycode-panel: 420px;    /* KeymapEditor layout overlay panel */
+  --min-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
+  --max-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
+  --min-height-word-list: 100px;       /* TypingTestPane word list */
+  --height-typing-display: 7.25rem;    /* TypingTestView word display area */
+  --width-color-picker: 15rem;         /* HSVColorPicker container */
+  --height-color-picker-sv: 180px;     /* HSVColorPicker saturation/value canvas */
+
+  /* Border radius - custom */
+  --radius-panel-connector: 10px; /* KeymapEditor layout panel right edge */
+
+  /* Cursor positioning (em-relative, typing test) */
+  --bottom-cursor: 0.12em;
+  --height-cursor: 1.1em;
+
+  /* Z-index */
+  --z-60: 60; /* AnalyzeExportModal dropdown overlay */
 }
 
 @keyframes confirm-flash {

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -89,7 +89,7 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
       role="dialog"
       onClick={handleBackdropClick}
     >
-      <div className="flex h-[80vh] w-[480px] flex-col rounded-xl border border-edge bg-surface shadow-2xl">
+      <div className="flex h-modal-80vh w-modal-typing flex-col rounded-xl border border-edge bg-surface shadow-2xl">
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 className="text-lg font-semibold text-content">{t('editor.typingTest.language.title')}</h2>
           <ModalCloseButton testid="language-modal-close" onClick={onClose} />

--- a/src/renderer/typing-test/TypingRecordingConsentModal.tsx
+++ b/src/renderer/typing-test/TypingRecordingConsentModal.tsx
@@ -47,7 +47,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
       onClick={handleBackdropClick}
       data-testid="typing-consent-modal"
     >
-      <div className="flex w-[480px] flex-col rounded-xl border border-edge bg-surface shadow-2xl">
+      <div className="flex w-modal-typing flex-col rounded-xl border border-edge bg-surface shadow-2xl">
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 id="typing-consent-title" className="text-lg font-semibold text-content">
             {t('editor.typingTest.consent.title')}

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -285,7 +285,7 @@ export function TypingTestView({
       {/* Word display — fixed 3-line window with scroll */}
       <div
         data-testid="typing-test-words"
-        className="relative h-[7.25rem] w-full max-w-4xl font-mono text-2xl leading-normal"
+        className="relative h-typing-display w-full max-w-4xl font-mono text-2xl leading-normal"
         onClick={() => imeInputRef.current?.focus()}
       >
         {/* Hidden textarea for IME composition input */}

--- a/src/renderer/typing-test/WordDisplay.tsx
+++ b/src/renderer/typing-test/WordDisplay.tsx
@@ -146,7 +146,7 @@ function displayChar(expected: string, index: number, input: string): string {
 function Cursor({ blink }: { blink: boolean }) {
   return (
     <span
-      className={`absolute left-0 bottom-[0.12em] h-[1.1em] w-0.5 rounded-full bg-accent${blink ? ' animate-blink' : ''}`}
+      className={`absolute left-0 bottom-cursor h-cursor w-0.5 rounded-full bg-accent${blink ? ' animate-blink' : ''}`}
       aria-hidden="true"
     />
   )

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -72,7 +72,7 @@ describe('TypingTestView', () => {
   it('word container has fixed height to prevent layout shift', () => {
     renderView({ state: makeState({ status: 'waiting' }) })
     const wordsContainer = screen.getByTestId('typing-test-words')
-    expect(wordsContainer.className).toContain('h-[7.25rem]')
+    expect(wordsContainer.className).toContain('h-typing-display')
   })
 
   it('displays word elements when running', () => {


### PR DESCRIPTION
## Summary

- Audit and fix all DESIGN.md violations across the renderer codebase
- Replace hardcoded arbitrary Tailwind values (`w-[Npx]`, `text-white`, `z-[60]`, `rounded-sm` on controls, `shadow-sm` on panels) with semantic `@theme` tokens
- Expand `style.css` with missing width/height/spacing/z-index tokens to cover all 60 affected files

## Test plan

- [x] `pnpm run lint` — no errors
- [x] `npx tsc --noEmit` — no errors
- [x] `pnpm test` — 206 files, 4122 tests passed