### PR TITLE
refactor(ui): enforce design token compliance across renderer

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -937,7 +937,7 @@ export function App() {
           onClick={() => editorUI.setShowLightingModal(false)}
         >
           <div
-            className="w-modal-app max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+            className="w-modal-app max-w-modal-vw max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/DeviceSelector.tsx
+++ b/src/renderer/components/DeviceSelector.tsx
@@ -110,7 +110,7 @@ export function DeviceSelector({
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-surface">
-      <div className="w-full max-w-sm rounded-2xl bg-surface-alt px-8 pb-7 pt-9 shadow-lg">
+      <div className="w-full max-w-sm rounded-2xl bg-surface-alt px-8 pb-7 pt-9 border border-edge">
         <div className="mb-7 flex items-center justify-between">
           <h1 className="text-xl font-bold text-content">
             {t('app.title')}

--- a/src/renderer/components/NotificationModal.tsx
+++ b/src/renderer/components/NotificationModal.tsx
@@ -20,7 +20,7 @@ export function NotificationModal({ notifications, onClose }: NotificationModalP
       onClick={onClose}
     >
       <div
-        className="w-modal-notify max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-notify max-w-modal-vw max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/UpwardSelect.tsx
+++ b/src/renderer/components/UpwardSelect.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { ChevronUp } from 'lucide-react'
 import { AnchoredPopover } from './ui/AnchoredPopover'
+import { ICON_XS } from '../constants/ui-tokens'
 
 export interface UpwardSelectOption {
   id: string
@@ -35,7 +36,7 @@ export function UpwardSelect({ value, onChange, options, 'aria-label': ariaLabel
         onClick={() => setOpen((v) => !v)}
       >
         <span>{currentName}</span>
-        <ChevronUp size={10} className={open ? 'opacity-100' : 'opacity-50'} />
+        <ChevronUp size={ICON_XS} className={open ? 'opacity-100' : 'opacity-50'} />
       </button>
       <AnchoredPopover
         anchorRef={triggerRef}

--- a/src/renderer/components/analyze/ActivityChart.tsx
+++ b/src/renderer/components/analyze/ActivityChart.tsx
@@ -40,6 +40,7 @@ import { isHashScope, isOwnScope, scopeToSelectValue } from '../../../shared/typ
 import type { ActivityCalendarFilters } from '../../../shared/types/analyze-filters'
 import type { ActivityMetric, ActivityView, DeviceScope, RangeMs } from './analyze-types'
 import { ActivityCalendarChart } from './ActivityCalendarChart'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 interface Props {
   uid: string
@@ -320,12 +321,12 @@ function SessionDistributionChart({ uid, range, deviceScope }: SessionChartProps
             <CartesianGrid strokeDasharray="3 3" stroke="var(--color-edge)" />
             <XAxis
               dataKey="label"
-              tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+              tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
               stroke="var(--color-edge)"
               interval={0}
             />
             <YAxis
-              tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+              tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
               stroke="var(--color-edge)"
               allowDecimals={false}
             />

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -608,6 +608,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
                           role="listbox"
                           aria-multiselectable
                         >
+                          {/* Exception: maxHeight is a runtime value computed from layout measurements; no static Tailwind class can express this. */}
                           <div className="overflow-y-auto" style={{ maxHeight: targetPopoverMaxH }}>
                             {layoutOptions.map((opt) => (
                               <label

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -533,7 +533,7 @@ export function AnalyzeExportModal({ isOpen, onClose, ctx, mode = 'export', uplo
         role="dialog"
         aria-modal="true"
         aria-label={t('analyze.export.categoriesLabel')}
-        className="w-modal-notify max-w-[95vw] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-notify max-w-modal-xl-vw flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-end px-3 pt-3 shrink-0">

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -222,7 +222,7 @@ export function AnalyzeFilterStorePanel({
               </form>
               <div className="mt-2 flex items-center gap-1">
                 {showSaved && (
-                  <span className="text-xs font-medium text-emerald-500" data-testid="analyze-filter-store-saved-flash">
+                  <span className="text-xs font-medium text-success" data-testid="analyze-filter-store-saved-flash">
                     {t('common.saved')}
                   </span>
                 )}

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -18,6 +18,7 @@ import {
   formatDate,
 } from '../editors/store-modal-shared'
 import { FORMAT_BTN } from '../editors/layout-store-types'
+import { BTN_PRIMARY_XS, BTN_DANGER_XS } from '../../constants/ui-tokens'
 import type { HubEntryResult } from '../editors/layout-store-types'
 import type { AnalyzeFilterSnapshotMeta } from '../../../shared/types/analyze-filter-store'
 import { AnalyzeFilterStoreHubRow } from './AnalyzeFilterStoreHubRow'
@@ -194,7 +195,7 @@ export function AnalyzeFilterStorePanel({
                     <button
                       type="submit"
                       disabled={saving}
-                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
+                      className={`shrink-0 ${BTN_DANGER_XS}`}
                       data-testid="analyze-filter-store-overwrite-confirm"
                     >
                       {t('analyzeFilterStore.confirmOverwrite')}
@@ -212,7 +213,7 @@ export function AnalyzeFilterStorePanel({
                   <button
                     type="submit"
                     disabled={saving || !saveLabel.trim()}
-                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+                    className={`shrink-0 ${BTN_PRIMARY_XS}`}
                     data-testid="analyze-filter-store-save-submit"
                   >
                     {t('common.save')}

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -269,7 +269,7 @@ export function AnalyzeFilterStorePanel({
                                 onKeyDown={(e) => { void handleRenameKeyDown(e, entry.id) }}
                                 onBlur={() => { void commitRename(entry.id) }}
                                 maxLength={200}
-                                className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content outline-none focus:border-accent"
+                                className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content focus:outline-none focus:border-accent"
                                 data-testid={`analyze-filter-store-rename-input-${entry.id}`}
                               />
                             ) : (

--- a/src/renderer/components/analyze/AppUsageChart.tsx
+++ b/src/renderer/components/analyze/AppUsageChart.tsx
@@ -148,7 +148,7 @@ export function AppUsageChart({ uid, range, deviceScopes }: Props) {
   // being visible on both themes (the surface-dim fill blended into
   // the panel background and made the slice unreadable).
   const colorFor = (datum: PieDatum, index: number): string => {
-    if (datum.isUnknown) return '#9ca3af'
+    if (datum.isUnknown) return 'var(--color-content-muted)'
     return chartSeriesColor(index, data.length, theme)
   }
 

--- a/src/renderer/components/analyze/AppUsageChart.tsx
+++ b/src/renderer/components/analyze/AppUsageChart.tsx
@@ -5,7 +5,7 @@
 // or two apps observed) collapse into a single "Unknown" slice so the
 // total still adds up to all keystrokes in the range.
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts'
 import {
@@ -147,10 +147,13 @@ export function AppUsageChart({ uid, range, deviceScopes }: Props) {
   // as the "missing data" bucket rather than a real app, while still
   // being visible on both themes (the surface-dim fill blended into
   // the panel background and made the slice unreadable).
-  const colorFor = (datum: PieDatum, index: number): string => {
-    if (datum.isUnknown) return 'var(--color-content-muted)'
-    return chartSeriesColor(index, data.length, theme)
-  }
+  const colorFor = useCallback(
+    (datum: PieDatum, index: number): string => {
+      if (datum.isUnknown) return 'var(--color-content-muted)'
+      return chartSeriesColor(index, data.length, theme)
+    },
+    [data.length, theme],
+  )
 
   if (loading) {
     return (

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -317,7 +317,7 @@ function PairIntervalThresholdInput({
         }}
         aria-label={t('analyze.bigrams.pairIntervalThreshold.ariaLabel')}
         data-testid={testId}
-        className="w-14 rounded border border-edge bg-surface px-1 py-0.5 text-right tabular-nums text-content"
+        className="w-14 rounded border border-edge bg-surface px-1 py-0.5 text-right tabular-nums text-content focus:border-accent focus:outline-none"
       />
       <span>{t('analyze.bigrams.pairIntervalThreshold.suffix')}</span>
     </span>

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -37,6 +37,7 @@ import {
 import { FILTER_SELECT, LIST_LIMIT_OPTIONS } from './analyze-filter-styles'
 import type { RangeMs } from './analyze-types'
 import { Stat, TooltipShell } from './analyze-tooltip'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 interface BigramsChartProps {
   uid: string
@@ -610,8 +611,8 @@ function BigramFingerBarChart({
   )
 }
 
-const BAR_LEFT = '#3b82f6'
-const BAR_RIGHT = '#ef4444'
+const BAR_LEFT = 'var(--color-accent-hover)'
+const BAR_RIGHT = 'var(--color-danger)'
 
 interface BarDatum {
   id: string
@@ -650,14 +651,14 @@ function BigramBarChart({ data, yAxisWidth, unit }: BigramBarChartProps): JSX.El
           <XAxis
             type="number"
             stroke="var(--color-content-muted)"
-            fontSize={11}
+            fontSize={CHART_TICK_FONT_SIZE}
             tickFormatter={(v) => `${Math.round(Number(v))}`}
           />
           <YAxis
             type="category"
             dataKey="label"
             stroke="var(--color-content-muted)"
-            fontSize={11}
+            fontSize={CHART_TICK_FONT_SIZE}
             width={yAxisWidth}
             interval={0}
           />
@@ -673,7 +674,7 @@ function BigramBarChart({ data, yAxisWidth, unit }: BigramBarChartProps): JSX.El
               dataKey="value"
               position="right"
               formatter={(v: unknown) => `${Math.round(Number(v))} ${unit}`}
-              style={{ fill: 'var(--color-content-muted)', fontSize: 11 }}
+              style={{ fill: 'var(--color-content-muted)', fontSize: CHART_TICK_FONT_SIZE }}
             />
           </Bar>
         </BarChart>

--- a/src/renderer/components/analyze/ErgonomicsChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsChart.tsx
@@ -33,6 +33,7 @@ import { aggregateErgonomics, ROW_ORDER } from './analyze-ergonomics'
 import { fetchMatrixHeatmapAllLayers } from './analyze-fetch'
 import { KeystrokeCountTooltip, Stat, TooltipShell } from './analyze-tooltip'
 import { ErgonomicsLearningCurveChart } from './ErgonomicsLearningCurveChart'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 interface Props {
   uid: string
@@ -65,8 +66,8 @@ type BarDatum = { label: string; value: number }
 type FingerKind = 'thumb' | 'index' | 'middle' | 'ring' | 'pinky'
 const FINGER_KINDS: readonly FingerKind[] = ['thumb', 'index', 'middle', 'ring', 'pinky']
 
-const PYRAMID_LEFT_COLOR = '#3b82f6'
-const PYRAMID_RIGHT_COLOR = '#ef4444'
+const PYRAMID_LEFT_COLOR = 'var(--color-accent-hover)'
+const PYRAMID_RIGHT_COLOR = 'var(--color-danger)'
 
 interface PyramidDatum {
   /** Localised category label (drives YAxis ticks). */
@@ -111,13 +112,13 @@ const Section = memo(function Section({
                 <XAxis
                   type="number"
                   stroke="var(--color-content-muted)"
-                  fontSize={11}
+                  fontSize={CHART_TICK_FONT_SIZE}
                 />
                 <YAxis
                   type="category"
                   dataKey="label"
                   stroke="var(--color-content-muted)"
-                  fontSize={11}
+                  fontSize={CHART_TICK_FONT_SIZE}
                   width={80}
                 />
               </>
@@ -127,9 +128,9 @@ const Section = memo(function Section({
                   type="category"
                   dataKey="label"
                   stroke="var(--color-content-muted)"
-                  fontSize={11}
+                  fontSize={CHART_TICK_FONT_SIZE}
                 />
-                <YAxis type="number" stroke="var(--color-content-muted)" fontSize={11} />
+                <YAxis type="number" stroke="var(--color-content-muted)" fontSize={CHART_TICK_FONT_SIZE} />
               </>
             )}
             <Tooltip
@@ -194,13 +195,13 @@ const HandPyramidChart = memo(function HandPyramidChart({
               domain={[-maxAbs, maxAbs]}
               tickFormatter={(v) => Math.abs(Number(v)).toLocaleString()}
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
             />
             <YAxis
               type="category"
               dataKey="category"
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
               width={yAxisWidth}
             />
             <Tooltip

--- a/src/renderer/components/analyze/ErgonomicsChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsChart.tsx
@@ -418,7 +418,7 @@ function ErgonomicsSnapshotView({
         * needs the wider column to keep the diverging axis legible.
         * `min-w-0` keeps recharts measurement from forcing either child
         * past its grid track. */}
-      <div className="grid grid-cols-[1fr_3fr] gap-4">
+      <div className="grid grid-cols-1-3 gap-4">
         <div className="min-w-0">
           <Section
             title={t('analyze.ergonomics.handBalance')}
@@ -453,7 +453,7 @@ function ErgonomicsSnapshotView({
       {/* Row 2: Row balance (sum across hands) sits next to its
         * left/right pyramid so the totals and the per-hand split
         * read together. */}
-      <div className="grid grid-cols-[1fr_3fr] gap-4">
+      <div className="grid grid-cols-1-3 gap-4">
         <div className="min-w-0">
           <Section
             title={t('analyze.ergonomics.rowUsage')}

--- a/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
@@ -38,6 +38,7 @@ import {
   type LearningCurveBucket,
   DEFAULT_LEARNING_MIN_SAMPLE,
 } from './analyze-ergonomics-curve'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 const pct = (v: number): string => `${Math.round(v * 100)}%`
 const signedPct = (v: number): string => `${v >= 0 ? '+' : ''}${pct(v)}`
@@ -59,9 +60,9 @@ interface Props {
 type ChartDatum = LearningCurveBucket
 
 const LINE_OVERALL = 'var(--color-accent)'
-const LINE_FINGER = '#3b82f6'
-const LINE_HAND = '#10b981'
-const LINE_HOME = '#f59e0b'
+const LINE_FINGER = 'var(--color-accent-hover)'
+const LINE_HAND = 'var(--color-success)'
+const LINE_HOME = 'var(--color-warning)'
 
 function formatDateAxis(ms: number, period: ErgonomicsLearningPeriod): string {
   const d = new Date(ms)
@@ -230,14 +231,14 @@ export function ErgonomicsLearningCurveChart({
               domain={['dataMin', 'dataMax']}
               tickFormatter={(v) => formatDateAxis(Number(v), period)}
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
             />
             <YAxis
               type="number"
               domain={[0, 1]}
               tickFormatter={(v) => pct(Number(v))}
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
               width={48}
             />
             <Tooltip content={(props) => <LearningCurveTooltip {...props} />} />

--- a/src/renderer/components/analyze/FingerAssignmentModal.tsx
+++ b/src/renderer/components/analyze/FingerAssignmentModal.tsx
@@ -181,7 +181,7 @@ export function FingerAssignmentModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="finger-assignment-title"
-        className="w-modal-xl max-w-[95vw] max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-xl max-w-modal-xl-vw max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-0 shrink-0">

--- a/src/renderer/components/analyze/FingerAssignmentModal.tsx
+++ b/src/renderer/components/analyze/FingerAssignmentModal.tsx
@@ -224,7 +224,7 @@ export function FingerAssignmentModal({
           </button>
           <button
             type="button"
-            className="rounded-md border border-accent bg-accent px-4 py-1.5 text-sm font-medium text-surface hover:bg-accent/90"
+            className="rounded border border-accent bg-accent px-4 py-1.5 text-sm font-medium text-content-inverse hover:bg-accent/90"
             onClick={handleSave}
             data-testid="finger-assignment-save"
           >

--- a/src/renderer/components/analyze/GoalAchievementsModal.tsx
+++ b/src/renderer/components/analyze/GoalAchievementsModal.tsx
@@ -40,7 +40,7 @@ export function GoalAchievementsModal({ isOpen, onClose, achievements }: Props) 
         role="dialog"
         aria-modal="true"
         aria-labelledby="goal-achievements-title"
-        className="w-modal-goal max-w-[95vw] max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-goal max-w-modal-xl-vw max-h-modal-90vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-2 shrink-0">

--- a/src/renderer/components/analyze/IntervalChart.tsx
+++ b/src/renderer/components/analyze/IntervalChart.tsx
@@ -33,6 +33,7 @@ import {
 import type { AnalyzeSummaryItem } from './analyze-summary-table'
 import { AnalyzeStatGrid } from './stat-card'
 import { Tooltip as UITooltip } from '../ui/Tooltip'
+import { CHART_TICK_FONT_SIZE, CHART_LEGEND_FONT_SIZE } from '../../utils/chart-palette'
 
 interface Props {
   uid: string
@@ -57,20 +58,20 @@ type SeriesKey = (typeof SERIES_KEYS)[number]
 // central tendency lines visually. All series are drawn solid — the
 // old dashed whiskers were hard to tell apart at a glance.
 const SERIES_STYLE: Record<SeriesKey, string> = {
-  min: '#10b981',
-  p25: '#06b6d4',
-  p50: '#3b82f6',
-  p75: '#f59e0b',
-  max: '#ef4444',
+  min: 'var(--color-success)',
+  p25: '#06b6d4', // Exception: cyan-500, no design token — intentional 5th distinct hue
+  p50: 'var(--color-accent-hover)',
+  p75: 'var(--color-warning)',
+  max: 'var(--color-danger)',
 }
 
 // Band palette blended from the timeSeries quartile colours so the
 // histogram stays visually related to the line chart.
 const RHYTHM_BAND_COLORS: Record<RhythmBandId, string> = {
-  fast: '#10b981',
-  normal: '#3b82f6',
-  slow: '#f59e0b',
-  pause: '#ef4444',
+  fast: 'var(--color-success)',
+  normal: 'var(--color-accent-hover)',
+  slow: 'var(--color-warning)',
+  pause: 'var(--color-danger)',
 }
 
 function formatIntervalValue(ms: number, unit: IntervalUnit): string {
@@ -222,12 +223,12 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-edge)" />
               <XAxis
                 dataKey="label"
-                tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+                tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
                 stroke="var(--color-edge)"
                 interval={0}
               />
               <YAxis
-                tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+                tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
                 stroke="var(--color-edge)"
                 tickFormatter={(v: number) => Math.round(v).toLocaleString()}
               />
@@ -278,7 +279,7 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
             dataKey="bucketStartMs"
             type="number"
             domain={[range.fromMs, range.toMs]}
-            tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+            tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
             stroke="var(--color-edge)"
             tickFormatter={(v: number) => formatBucketAxisLabel(v, bucketMs)}
           />
@@ -286,14 +287,14 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
             scale="log"
             domain={['auto', 'auto']}
             allowDataOverflow={false}
-            tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+            tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
             stroke="var(--color-edge)"
             tickFormatter={(v: number) => unit === 'sec' ? (v / 1000).toString() : v.toString()}
             label={{
               value: unit === 'sec' ? 'sec (log)' : 'ms (log)',
               angle: -90,
               position: 'insideLeft',
-              style: { fontSize: 11, fill: 'var(--color-content-muted)' },
+              style: { fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' },
             }}
           />
           <Tooltip
@@ -306,7 +307,7 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
             }}
           />
           <Legend
-            wrapperStyle={{ fontSize: 12, cursor: 'pointer' }}
+            wrapperStyle={{ fontSize: CHART_LEGEND_FONT_SIZE, cursor: 'pointer' }}
             onClick={(entry) => toggleSeries(String(entry.dataKey ?? ''))}
             formatter={(value, entry) => {
               const key = String(entry.dataKey ?? '') as SeriesKey

--- a/src/renderer/components/analyze/IntervalChart.tsx
+++ b/src/renderer/components/analyze/IntervalChart.tsx
@@ -33,7 +33,7 @@ import {
 import type { AnalyzeSummaryItem } from './analyze-summary-table'
 import { AnalyzeStatGrid } from './stat-card'
 import { Tooltip as UITooltip } from '../ui/Tooltip'
-import { CHART_TICK_FONT_SIZE, CHART_LEGEND_FONT_SIZE } from '../../utils/chart-palette'
+import { CHART_TICK_FONT_SIZE, CHART_LEGEND_FONT_SIZE, CHART_CYAN_SERIES_COLOR } from '../../utils/chart-palette'
 
 interface Props {
   uid: string
@@ -59,7 +59,7 @@ type SeriesKey = (typeof SERIES_KEYS)[number]
 // old dashed whiskers were hard to tell apart at a glance.
 const SERIES_STYLE: Record<SeriesKey, string> = {
   min: 'var(--color-success)',
-  p25: '#06b6d4', // Exception: cyan-500, no design token — intentional 5th distinct hue
+  p25: CHART_CYAN_SERIES_COLOR,
   p50: 'var(--color-accent-hover)',
   p75: 'var(--color-warning)',
   max: 'var(--color-danger)',

--- a/src/renderer/components/analyze/LayerUsageChart.tsx
+++ b/src/renderer/components/analyze/LayerUsageChart.tsx
@@ -37,6 +37,7 @@ import {
 } from './analyze-layer-usage'
 import { KeystrokeCountTooltip } from './analyze-tooltip'
 import { FILTER_SELECT } from './analyze-filter-styles'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 interface AxisTickProps {
   x?: number
@@ -286,12 +287,12 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
             margin={{ top: 4, right: 16, bottom: 4, left: 8 }}
           >
             <CartesianGrid strokeDasharray="3 3" stroke="var(--color-edge)" />
-            <XAxis type="number" stroke="var(--color-content-muted)" fontSize={11} />
+            <XAxis type="number" stroke="var(--color-content-muted)" fontSize={CHART_TICK_FONT_SIZE} />
             <YAxis
               type="category"
               dataKey="axisLabel"
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
               width={120}
               tick={<MultiLineYAxisTick />}
             />

--- a/src/renderer/components/analyze/LayoutComparisonFingerDiff.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonFingerDiff.tsx
@@ -23,6 +23,7 @@ import { FINGER_LIST } from '../../../shared/kle/kle-ergonomics'
 import type { LayoutComparisonTargetResult } from '../../../shared/types/typing-analytics'
 import { formatSignedPercent } from './analyze-format'
 import { Stat, TooltipShell } from './analyze-tooltip'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
 
 interface Props {
   current: LayoutComparisonTargetResult
@@ -98,12 +99,12 @@ export function LayoutComparisonFingerDiff({ current, target, targetLabel }: Pro
               type="category"
               dataKey="label"
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
             />
             <YAxis
               type="number"
               stroke="var(--color-content-muted)"
-              fontSize={11}
+              fontSize={CHART_TICK_FONT_SIZE}
               tickFormatter={(value: number) => `${value >= 0 ? '+' : ''}${(value * 100).toFixed(0)}%`}
             />
             <ReferenceLine y={0} stroke="var(--color-content-muted)" />

--- a/src/renderer/components/analyze/LayoutComparisonView.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonView.tsx
@@ -192,7 +192,7 @@ export function LayoutComparisonView({
               // position vs. finger shifts together, and the metric
               // table spans both rows on the right so the numeric
               // baseline stays visible alongside either chart.
-              <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-[3fr_2fr] lg:grid-rows-2">
+              <div className="grid min-h-0 flex-1 gap-4 lg:grid-cols-3-2 lg:grid-rows-2">
                 <div className="min-w-0 min-h-0 overflow-auto lg:col-start-1 lg:row-start-1">
                   <LayoutComparisonHeatmapDiff
                     current={result.targets[0]}

--- a/src/renderer/components/analyze/StreakGoalCard.tsx
+++ b/src/renderer/components/analyze/StreakGoalCard.tsx
@@ -345,7 +345,7 @@ function InlineNumberField({
         }}
         aria-label={ariaLabel}
         data-testid={testid}
-        className="w-20 border-b border-edge bg-transparent p-0 text-lg font-bold text-content outline-none focus:border-accent"
+        className="w-20 border-b border-edge bg-transparent p-0 text-lg font-bold text-content focus:outline-none focus:border-accent"
       />
       {confirmPending && (
         <button

--- a/src/renderer/components/analyze/WpmChart.tsx
+++ b/src/renderer/components/analyze/WpmChart.tsx
@@ -42,6 +42,7 @@ import {
 import type { AnalyzeSummaryItem } from './analyze-summary-table'
 import { AnalyzeStatGrid } from './stat-card'
 import { Tooltip as UITooltip } from '../ui/Tooltip'
+import { CHART_TICK_FONT_SIZE, CHART_LEGEND_FONT_SIZE } from '../../utils/chart-palette'
 
 interface Props {
   uid: string
@@ -60,7 +61,7 @@ interface Props {
   minActiveMs: number
 }
 
-const ERROR_PROXY_COLOR = '#ef4444'
+const ERROR_PROXY_COLOR = 'var(--color-danger)'
 
 const INACTIVE_BAR_COLOR = 'var(--color-surface-dim)'
 
@@ -235,12 +236,12 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
               <CartesianGrid strokeDasharray="3 3" stroke="var(--color-edge)" />
               <XAxis
                 dataKey="label"
-                tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+                tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
                 stroke="var(--color-edge)"
                 interval={1}
               />
               <YAxis
-                tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+                tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
                 stroke="var(--color-edge)"
                 allowDecimals
               />
@@ -296,17 +297,17 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
               dataKey="bucketStartMs"
               type="number"
               domain={[range.fromMs, range.toMs]}
-              tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+              tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
               stroke="var(--color-edge)"
               tickFormatter={(v: number) => formatBucketAxisLabel(v, bucketMs)}
             />
-            <YAxis yAxisId="wpm" tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }} stroke="var(--color-edge)" allowDecimals />
+            <YAxis yAxisId="wpm" tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }} stroke="var(--color-edge)" allowDecimals />
             {errorProxyActive && (
               <YAxis
                 yAxisId="bks"
                 orientation="right"
                 domain={[0, 'auto']}
-                tick={{ fontSize: 11, fill: 'var(--color-content-muted)' }}
+                tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
                 stroke="var(--color-edge)"
                 tickFormatter={(v: number) => `${v}%`}
                 width={40}
@@ -325,7 +326,7 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
               }}
             />
             <Legend
-              wrapperStyle={{ fontSize: 12, cursor: 'pointer' }}
+              wrapperStyle={{ fontSize: CHART_LEGEND_FONT_SIZE, cursor: 'pointer' }}
               onClick={(entry) => toggleSeries(String(entry.dataKey ?? ''))}
               formatter={(value, entry) => {
                 const key = String(entry.dataKey ?? '') as WpmLineKey

--- a/src/renderer/components/analyze/analyze-summary-table.tsx
+++ b/src/renderer/components/analyze/analyze-summary-table.tsx
@@ -43,7 +43,7 @@ export function AnalyzeSummaryTable({ items, ariaLabelKey, testId = 'analyze-sum
   const { t } = useTranslation()
   return (
     <div
-      className="grid shrink-0 grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-x-4 gap-y-1 border-t border-edge pt-2 text-xs"
+      className="grid shrink-0 grid-cols-auto-fit-160 gap-x-4 gap-y-1 border-t border-edge pt-2 text-xs"
       data-testid={testId}
       aria-label={t(ariaLabelKey)}
     >

--- a/src/renderer/components/analyze/analyze-thumbnail.ts
+++ b/src/renderer/components/analyze/analyze-thumbnail.ts
@@ -38,6 +38,10 @@ export function generateAnalyzeThumbnail(input: AnalyzeThumbnailInput): string {
   const ctx = canvas.getContext('2d')
   if (!ctx) throw new Error('Canvas 2D context unavailable')
 
+  // Exception: Canvas API requires literal color strings — CSS custom properties
+  // (var(--color-*)) are not supported in CanvasRenderingContext2D fillStyle.
+  // This thumbnail is always rendered in dark-theme style (slate palette).
+  //
   // Background — slate gradient gives a recognisable Pipette look
   // without needing a logo asset bundled.
   const grad = ctx.createLinearGradient(0, 0, 0, CANVAS_HEIGHT)

--- a/src/renderer/components/analyze/analyze-tooltip.tsx
+++ b/src/renderer/components/analyze/analyze-tooltip.tsx
@@ -16,12 +16,13 @@
 
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { CHART_LEGEND_FONT_SIZE } from '../../utils/chart-palette'
 
 const SHELL_STYLE = {
   backgroundColor: 'var(--color-surface)',
   border: '1px solid var(--color-edge)',
   color: 'var(--color-content)',
-  fontSize: 12,
+  fontSize: CHART_LEGEND_FONT_SIZE,
   padding: '4px 8px',
   borderRadius: 4,
 } as const
@@ -36,7 +37,7 @@ const VALUE_STYLE = { fontWeight: 600 } as const
  * rendering; reach for `TooltipShell` instead when supplying a custom
  * `content` renderer. */
 export const ANALYZE_TOOLTIP_DEFAULTS = {
-  contentStyle: { backgroundColor: 'var(--color-surface)', border: '1px solid var(--color-edge)', fontSize: 12 },
+  contentStyle: { backgroundColor: 'var(--color-surface)', border: '1px solid var(--color-edge)', fontSize: CHART_LEGEND_FONT_SIZE },
   labelStyle: { color: 'var(--color-content-secondary)' },
   itemStyle: { color: 'var(--color-content)' },
 } as const

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -271,7 +271,7 @@ export function DataModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="data-modal-title"
-        className="w-modal-data max-w-[95vw] h-modal-data flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-data max-w-modal-xl-vw h-modal-data flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         data-testid="data-modal"
       >

--- a/src/renderer/components/data-modal/DataModal.tsx
+++ b/src/renderer/components/data-modal/DataModal.tsx
@@ -271,7 +271,7 @@ export function DataModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="data-modal-title"
-        className="w-[860px] max-w-[95vw] h-[min(720px,80vh)] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-data max-w-[95vw] h-modal-data flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         data-testid="data-modal"
       >

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { Fragment } from 'react'
+import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DataNavPath } from './data-modal-types'
 import type { StoredKeyboardInfo, SyncDataScanResult } from '../../../shared/types/sync'
@@ -25,6 +26,8 @@ interface Props {
   remoteTypingHashes: Record<string, string[]>
   ensureRemoteTypingHashes: (uid: string) => void
 }
+
+const treeIndentStyle = (depth: number): CSSProperties => ({ paddingLeft: `${depth * 14 + 8}px` })
 
 function deviceLabelFromHash(hash: string): string {
   return `Device ${hash.slice(0, 8)}`
@@ -85,7 +88,7 @@ function Leaf({ label, depth, active, onClick, testId }: LeafProps) {
     <button
       type="button"
       className={active ? LEAF_ACTIVE : LEAF_IDLE}
-      style={{ paddingLeft: `${depth * 14 + 8}px` }}
+      style={treeIndentStyle(depth)}
       onClick={onClick}
       data-testid={testId}
     >
@@ -110,7 +113,7 @@ function Branch({ label, depth, open, onToggle, testId, children }: BranchProps)
       <button
         type="button"
         className={`${BRANCH_BASE} text-content-secondary hover:text-content`}
-        style={{ paddingLeft: `${depth * 14 + 8}px` }}
+        style={treeIndentStyle(depth)}
         onClick={onToggle}
         data-testid={testId}
         aria-expanded={open}
@@ -155,7 +158,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
           {storedKeyboards.length === 0 ? (
             <div
               className="text-xs text-content-muted py-1"
-              style={{ paddingLeft: '50px' }}
+              style={treeIndentStyle(3)}
               data-testid="nav-no-keyboards"
             >
               {t('dataModal.noKeyboards')}
@@ -205,7 +208,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
           {typingKeyboards.length === 0 ? (
             <div
               className="text-xs text-content-muted py-1"
-              style={{ paddingLeft: '50px' }}
+              style={treeIndentStyle(3)}
               data-testid="nav-no-typing"
             >
               {t('dataModal.typing.noKeyboards')}
@@ -243,19 +246,19 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
         testId="nav-sync"
       >
         {syncScanning ? (
-          <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }}>
+          <div className="text-xs text-content-muted py-1" style={treeIndentStyle(2)}>
             {t('sync.scanning')}
           </div>
         ) : (
           <>
             {!syncScanResult ? (
-              <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }}>
+              <div className="text-xs text-content-muted py-1" style={treeIndentStyle(2)}>
                 {t('sync.noRemoteData')}
               </div>
             ) : syncScanResult.keyboards.length === 0 ? (
               <div
                 className="text-xs text-content-muted py-1"
-                style={{ paddingLeft: '36px' }}
+                style={treeIndentStyle(2)}
                 data-testid="nav-sync-empty"
               >
                 {t('dataModal.syncNoOrphans')}
@@ -285,7 +288,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
                       {error && (
                         <div
                           className="text-xs text-danger py-1"
-                          style={{ paddingLeft: `${2 * 14 + 8}px` }}
+                          style={treeIndentStyle(2)}
                           data-testid={`nav-sync-kb-${uid}-error`}
                         >
                           {error}
@@ -311,7 +314,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
               {typingKeyboards.length === 0 ? (
                 <div
                   className="text-xs text-content-muted py-1"
-                  style={{ paddingLeft: '50px' }}
+                  style={treeIndentStyle(3)}
                   data-testid="nav-sync-typing-empty"
                 >
                   {t('dataModal.typing.noKeyboards')}
@@ -336,7 +339,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
                       {hashes.length === 0 ? (
                         <div
                           className="text-xs text-content-muted py-1"
-                          style={{ paddingLeft: '64px' }}
+                          style={treeIndentStyle(4)}
                           data-testid={`nav-sync-typing-${kb.uid}-empty`}
                         >
                           {t('dataModal.typing.noRemoteDevices')}
@@ -390,7 +393,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
           testId="nav-cloud-hub"
         >
           {hubKeyboardNames.length === 0 ? (
-            <div className="text-xs text-content-muted py-1" style={{ paddingLeft: '36px' }} data-testid="nav-hub-empty">
+            <div className="text-xs text-content-muted py-1" style={treeIndentStyle(2)} data-testid="nav-hub-empty">
               {t('hub.noPosts')}
             </div>
           ) : (

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -80,6 +80,8 @@ interface LeafProps {
 
 function Leaf({ label, depth, active, onClick, testId }: LeafProps) {
   return (
+    // Exception: paddingLeft is runtime-computed from `depth` using a 14px-per-level
+    // step (not on the 4px grid); Tailwind cannot express a prop-driven indentation.
     <button
       type="button"
       className={active ? LEAF_ACTIVE : LEAF_IDLE}
@@ -104,6 +106,7 @@ interface BranchProps {
 function Branch({ label, depth, open, onToggle, testId, children }: BranchProps) {
   return (
     <>
+      {/* Exception: same as Leaf — runtime depth-based indentation, off-grid 14px step */}
       <button
         type="button"
         className={`${BRANCH_BASE} text-content-secondary hover:text-content`}

--- a/src/renderer/components/data-modal/FavoriteTabContent.tsx
+++ b/src/renderer/components/data-modal/FavoriteTabContent.tsx
@@ -99,7 +99,7 @@ export function FavoriteTabContent({
                         onBlur={() => void commitRename(entry.id)}
                         onKeyDown={(e) => handleRenameKeyDown(e, entry.id)}
                         maxLength={200}
-                        className="flex-1 w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content outline-none focus:border-accent"
+                        className="flex-1 w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content focus:outline-none focus:border-accent"
                         data-testid="data-modal-fav-rename-input"
                         autoFocus
                       />

--- a/src/renderer/components/data-modal/TypingAnalyticsContent.tsx
+++ b/src/renderer/components/data-modal/TypingAnalyticsContent.tsx
@@ -306,7 +306,7 @@ export function TypingAnalyticsContent({ uid, onDeleted, mode = 'local', machine
     if (importStatus.phase === 'import-done' && importStatus.rejections.length > 0) {
       return 'border-warning/40 bg-warning/10 text-warning'
     }
-    return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-400'
+    return 'border-success/40 bg-success/10 text-success'
   })()
   const inProgress = importStatus?.phase === 'importing' || importStatus?.phase === 'exporting'
   const importBanner = importStatus ? (

--- a/src/renderer/components/editors/EditorSettingsModal.tsx
+++ b/src/renderer/components/editors/EditorSettingsModal.tsx
@@ -6,7 +6,7 @@ import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { LayoutStoreContent, type LayoutStoreContentProps } from './LayoutStoreModal'
 import { ModalCloseButton } from './ModalCloseButton'
 
-const PANEL_BASE = 'absolute top-0 h-full w-modal-sm max-w-[90vw] flex flex-col border-edge bg-surface-alt shadow-xl transition-transform duration-300 ease-out'
+const PANEL_BASE = 'absolute top-0 h-full w-modal-sm max-w-modal-vw flex flex-col border-edge bg-surface-alt shadow-xl transition-transform duration-300 ease-out'
 
 function panelPositionClass(open: boolean): string {
   return `${PANEL_BASE} left-0 border-r ${open ? 'translate-x-0' : '-translate-x-full'}`

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { ACTION_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, SectionHeader, formatDate } from './store-modal-shared'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 import { FavoriteHubActions } from './FavoriteHubActions'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import type { FavoriteType, SavedFavoriteMeta } from '../../../shared/types/favorite-store'
@@ -168,7 +169,7 @@ export function FavoriteStoreContent({
             <button
               type="submit"
               disabled={!canSubmitSave}
-              className="shrink-0 rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+              className={`shrink-0 ${BTN_PRIMARY}`}
               data-testid="favorite-store-save-submit"
             >
               {t('common.save')}

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -178,12 +178,12 @@ export function FavoriteStoreContent({
           {(onExportCurrent || onImportCurrent || showExported || showImported) && (
             <div className="flex items-center gap-1 mt-2">
               {showImported && (
-                <span className="text-xs font-medium text-emerald-500" data-testid="favorite-store-imported">
+                <span className="text-xs font-medium text-success" data-testid="favorite-store-imported">
                   {t('common.imported')}
                 </span>
               )}
               {showExported && (
-                <span className="text-xs font-medium text-emerald-500" data-testid="favorite-store-exported">
+                <span className="text-xs font-medium text-success" data-testid="favorite-store-exported">
                   {t('common.exported')}
                 </span>
               )}

--- a/src/renderer/components/editors/FavoriteStoreContent.tsx
+++ b/src/renderer/components/editors/FavoriteStoreContent.tsx
@@ -239,7 +239,7 @@ export function FavoriteStoreContent({
                         onBlur={() => void commitRename(entry.id)}
                         onKeyDown={(e) => handleRenameKeyDown(e, entry.id)}
                         maxLength={200}
-                        className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content outline-none focus:border-accent"
+                        className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content focus:outline-none focus:border-accent"
                         data-testid="favorite-store-rename-input"
                         autoFocus
                       />

--- a/src/renderer/components/editors/FavoriteStoreModal.tsx
+++ b/src/renderer/components/editors/FavoriteStoreModal.tsx
@@ -26,7 +26,7 @@ export function FavoriteStoreModal({
       onClick={onClose}
     >
       <div
-        className="w-modal-sm max-w-[90vw] h-modal-70vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-sm max-w-modal-vw h-modal-70vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -287,7 +287,7 @@ export function HSVColorPicker({
           {/* 10x10 Palette grid */}
           <div
             data-testid="palette-grid"
-            className="grid grid-cols-[repeat(10,1.5rem)] gap-0"
+            className="grid grid-cols-swatches gap-0"
           >
             {PALETTE.map((entry, i) => {
               const selected = i === nearestIdx

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -317,6 +317,9 @@ export function HSVColorPicker({
       ) : (
         <>
           {/* Saturation-Value picker area */}
+          {/* Exception: HSV gradient requires absolute #000/#fff as algorithm-level
+              canvas colors for the saturation/value axes; these are not theme
+              colors and must not be replaced with CSS variables. */}
           <div
             ref={svRef}
             data-testid="sv-picker"
@@ -329,6 +332,9 @@ export function HSVColorPicker({
             }}
             {...svHandlers}
           >
+            {/* Exception: border-white keeps the cursor thumb visible across the
+                full gradient (dark→light); border-content-inverse flips to near-black
+                in dark mode, making it invisible against dark gradient areas. */}
             <div
               className="pointer-events-none absolute h-3.5 w-3.5 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow"
               style={{
@@ -346,6 +352,8 @@ export function HSVColorPicker({
             style={{ background: HUE_GRADIENT, touchAction: 'none' }}
             {...hueHandlers}
           >
+            {/* Exception: border-white keeps the hue thumb visible across all
+                hue colors; same rationale as the SV picker cursor above. */}
             <div
               className="pointer-events-none absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white shadow"
               style={{

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -177,6 +177,9 @@ function clampNormalized(value: number, origin: number, size: number): number {
   return clamp((value - origin) / size, 0, 1)
 }
 
+// Exception: uses rounded-md (not rounded) to match the picker panel's
+// larger radius tier, and hover:text-content instead of hover:bg-surface-dim.
+// Cannot use BTN_TOGGLE_ACTIVE/INACTIVE from ui-tokens (those use rounded + px-2 py-1).
 function toggleButtonClass(active: boolean): string {
   const base = 'rounded-md border px-3 py-1.5 text-sm transition-colors'
   if (active) return `${base} border-accent bg-accent/10 text-accent`

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -300,7 +300,7 @@ export function HSVColorPicker({
                   data-selected={selected || undefined}
                   className={
                     selected
-                      ? 'relative z-10 h-6 w-6 rounded-none border-0 p-0 ring-2 ring-content-inverse shadow-[0_0_0_1px_rgba(0,0,0,0.3)]'
+                      ? 'relative z-10 h-6 w-6 rounded-none border-0 p-0 ring-2 ring-content-inverse shadow-color-swatch'
                       : 'h-6 w-6 rounded-none border-0 p-0'
                   }
                   style={{ backgroundColor: entry.hex }}

--- a/src/renderer/components/editors/HSVColorPicker.tsx
+++ b/src/renderer/components/editors/HSVColorPicker.tsx
@@ -297,7 +297,7 @@ export function HSVColorPicker({
                   data-selected={selected || undefined}
                   className={
                     selected
-                      ? 'relative z-10 h-6 w-6 rounded-none border-0 p-0 ring-2 ring-white shadow-[0_0_0_1px_rgba(0,0,0,0.3)]'
+                      ? 'relative z-10 h-6 w-6 rounded-none border-0 p-0 ring-2 ring-content-inverse shadow-[0_0_0_1px_rgba(0,0,0,0.3)]'
                       : 'h-6 w-6 rounded-none border-0 p-0'
                   }
                   style={{ backgroundColor: entry.hex }}

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -51,7 +51,7 @@ export function HistoryToggle({ results, deviceName }: HistoryToggleProps) {
           onClick={() => setShowHistory(false)}
         >
           <div
-            className="flex h-modal-80vh w-modal-wide max-w-[90vw] flex-col rounded-lg bg-surface-alt p-6 shadow-xl"
+            className="flex h-modal-80vh w-modal-wide max-w-modal-vw flex-col rounded-lg bg-surface-alt p-6 shadow-xl"
             data-testid="history-modal"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/renderer/components/editors/JsonEditorModal.tsx
+++ b/src/renderer/components/editors/JsonEditorModal.tsx
@@ -85,7 +85,7 @@ export function JsonEditorModal<T>({
       <div
         role="dialog"
         aria-modal="true"
-        className="w-modal-md max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-md max-w-modal-vw max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/editors/JsonEditorModal.tsx
+++ b/src/renderer/components/editors/JsonEditorModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ModalCloseButton } from './ModalCloseButton'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 export interface JsonEditorModalProps<T> {
   title: string
@@ -130,7 +131,7 @@ export function JsonEditorModal<T>({
               type="button"
               onClick={handleApply}
               disabled={!!error || applying}
-              className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+              className={BTN_PRIMARY}
               data-testid={`${testIdPrefix}-apply`}
             >
               {t('common.save')}

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -12,6 +12,7 @@ import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
 import { KeyPopover } from '../keycodes/KeyPopover'
 import { FavoriteStoreContent } from './FavoriteStoreContent'
 import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 // ---------------------------------------------------------------------------
 // Hub props (forwarded to FavoriteStoreContent)
@@ -191,7 +192,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
         <button
           type="button"
           data-testid={`${prefix}-modal-save`}
-          className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+          className={BTN_PRIMARY}
           disabled={!hasChanges}
           onClick={handleEntrySave}
         >

--- a/src/renderer/components/editors/KeycodeEntryModalShell.tsx
+++ b/src/renderer/components/editors/KeycodeEntryModalShell.tsx
@@ -247,7 +247,7 @@ export function KeycodeEntryModalShell<TEntry extends Record<string, unknown>>({
       onClick={handleClose}
     >
       <div
-        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] h-modal-80vh flex flex-col`}
+        className={`overflow-hidden rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-modal-xl-vw h-modal-80vh flex flex-col`}
         data-testid={`${prefix}-modal`}
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/renderer/components/editors/LayerListPanel.tsx
+++ b/src/renderer/components/editors/LayerListPanel.tsx
@@ -105,7 +105,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
                     {isEditing && onSetLayerName ? (
                       <input
                         data-testid={`layer-panel-layer-name-input-${i}`}
-                        className="w-full border-b border-edge bg-transparent text-xs text-content outline-none focus:border-accent"
+                        className="w-full border-b border-edge bg-transparent text-xs text-content focus:outline-none focus:border-accent"
                         value={layerRename.editLabel}
                         onChange={(e) => layerRename.setEditLabel(e.target.value)}
                         placeholder={defaultLabel}

--- a/src/renderer/components/editors/LayerListPanel.tsx
+++ b/src/renderer/components/editors/LayerListPanel.tsx
@@ -77,7 +77,7 @@ export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames
   // visible area so names slide out horizontally.
   return (
     <div
-      className="shrink-0 overflow-hidden rounded-xl border border-edge bg-picker-bg transition-[width] duration-200 ease-out"
+      className="shrink-0 overflow-hidden rounded-xl border border-edge bg-picker-bg transition-width duration-200 ease-out"
       style={{ width: collapsed ? PANEL_COLLAPSED_WIDTH : '11rem' }}
       data-testid={collapsed ? 'layer-list-panel-collapsed' : 'layer-list-panel'}
     >

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -6,6 +6,7 @@ import { useInlineRename } from '../../hooks/useInlineRename'
 import { SectionHeader } from './store-modal-shared'
 import { ROW_CLASS } from './modal-controls'
 import { FORMAT_BTN, EXPORT_BTN, IMPORT_BTN } from './layout-store-types'
+import { BTN_PRIMARY_XS, BTN_DANGER_XS } from '../../constants/ui-tokens'
 import type { FileStatus, LayoutStoreContentProps } from './layout-store-types'
 import { FormatButtons } from './LayoutStoreEntry'
 import { LayoutStoreEntry } from './LayoutStoreEntry'
@@ -184,7 +185,7 @@ export function LayoutStoreContent({
                       <button
                         type="submit"
                         disabled={saving}
-                        className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
+                        className={`shrink-0 ${BTN_DANGER_XS}`}
                         data-testid="layout-store-overwrite-confirm"
                       >
                         {t('layoutStore.confirmOverwrite')}
@@ -202,7 +203,7 @@ export function LayoutStoreContent({
                     <button
                       type="submit"
                       disabled={saving || !saveLabel.trim()}
-                      className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+                      className={`shrink-0 ${BTN_PRIMARY_XS}`}
                       data-testid="layout-store-save-submit"
                     >
                       {t('common.save')}
@@ -253,7 +254,7 @@ export function LayoutStoreContent({
                     <button
                       type="submit"
                       disabled={saving}
-                      className="shrink-0 rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50"
+                      className={`shrink-0 ${BTN_DANGER_XS}`}
                       data-testid="layout-store-overwrite-confirm"
                     >
                       {t('layoutStore.confirmOverwrite')}
@@ -271,7 +272,7 @@ export function LayoutStoreContent({
                   <button
                     type="submit"
                     disabled={saving || !saveLabel.trim()}
-                    className="shrink-0 rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+                    className={`shrink-0 ${BTN_PRIMARY_XS}`}
                     data-testid="layout-store-save-submit"
                   >
                     {t('common.save')}

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -214,10 +214,10 @@ export function LayoutStoreContent({
               {(hasCurrentExport || showSaved || showExported) && (
                 <div className={`flex items-center gap-1${!isDummy ? ' mt-2' : ''}`}>
                   {showSaved && (
-                    <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                    <span className="text-xs font-medium text-success" data-testid="layout-store-saved">{t('common.saved')}</span>
                   )}
                   {showExported && (
-                    <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
+                    <span className="text-xs font-medium text-success" data-testid="layout-store-exported">{t('common.exported')}</span>
                   )}
                   <div className="ml-auto flex gap-1">
                     <FormatButtons
@@ -288,10 +288,10 @@ export function LayoutStoreContent({
               <SectionHeader label={t('layoutStore.export')} />
               <div className="flex items-center gap-2">
                 {showSaved && (
-                  <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-saved">{t('common.saved')}</span>
+                  <span className="text-xs font-medium text-success" data-testid="layout-store-saved">{t('common.saved')}</span>
                 )}
                 {showExported && (
-                  <span className="text-xs font-medium text-emerald-500" data-testid="layout-store-exported">{t('common.exported')}</span>
+                  <span className="text-xs font-medium text-success" data-testid="layout-store-exported">{t('common.exported')}</span>
                 )}
                 <div className="ml-auto flex gap-2">
                   <FormatButtons

--- a/src/renderer/components/editors/LayoutStoreEntry.tsx
+++ b/src/renderer/components/editors/LayoutStoreEntry.tsx
@@ -147,7 +147,7 @@ export function LayoutStoreEntry({
               onBlur={() => onCommitRename?.(entry.id)}
               onKeyDown={(e) => onHandleRenameKeyDown?.(e, entry.id)}
               maxLength={200}
-              className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content outline-none focus:border-accent"
+              className="w-full border-b border-edge bg-transparent px-1 text-sm font-semibold text-content focus:outline-none focus:border-accent"
               data-testid="layout-store-rename-input"
               autoFocus
             />

--- a/src/renderer/components/editors/LayoutStoreModal.tsx
+++ b/src/renderer/components/editors/LayoutStoreModal.tsx
@@ -25,7 +25,7 @@ export function LayoutStoreModal({ onClose, ...contentProps }: Props) {
       onClick={onClose}
     >
       <div
-        className="w-modal-sm max-w-[90vw] max-h-modal-85vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-sm max-w-modal-vw max-h-modal-85vh flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { GripVertical, X } from 'lucide-react'
 import { ICON_SM, ICON_LG } from '../../constants/ui-tokens'
 import { isValidMacroText, type MacroAction } from '../../../preload/macro'
+import { INPUT_BASE } from './store-modal-shared'
 import { KeycodeField, KEYCODE_FIELD_SIZE } from './KeycodeField'
 import { Tooltip } from '../ui/Tooltip'
 
@@ -91,7 +92,7 @@ export function MacroActionItem({
               onChange={(e) => onChange(index, { type: 'text', text: e.target.value })}
               placeholder={t('editor.macro.text')}
               disabled={disabled}
-              className={`w-full rounded border px-2 py-1 text-sm disabled:opacity-50 ${valid ? 'border-edge' : 'border-danger'}`}
+              className={`w-full rounded border px-2 py-1 text-sm focus:border-accent focus:outline-none disabled:opacity-50 ${valid ? 'border-edge' : 'border-danger'}`}
             />
             {!valid && (
               <p className="mt-0.5 text-xs text-danger">{t('editor.macro.asciiOnly')}</p>
@@ -144,7 +145,7 @@ export function MacroActionItem({
                 })
               }
               disabled={disabled}
-              className="w-24 rounded border border-edge px-2 py-1 text-sm disabled:opacity-50"
+              className={`w-24 ${INPUT_BASE}`}
             />
             <span className="text-sm text-content-secondary">ms</span>
           </div>

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -345,7 +345,7 @@ export function MacroEditor({
             <div className="flex-1" />
             <select
               data-testid="macro-add-action"
-              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50"
+              className="rounded border border-transparent bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50 focus:border-accent focus:outline-none"
               value=""
               disabled={isRecording}
               onChange={(e) => {
@@ -364,7 +364,7 @@ export function MacroEditor({
             <button
               type="button"
               data-testid="macro-text-editor-btn"
-              className="rounded bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50"
+              className="rounded border border-transparent bg-surface-dim px-2.5 py-1 text-xs hover:bg-surface-raised disabled:opacity-50 focus:border-accent focus:outline-none"
               disabled={isRecording}
               onClick={() => setShowTextEditor(true)}
             >

--- a/src/renderer/components/editors/MacroEditor.tsx
+++ b/src/renderer/components/editors/MacroEditor.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../preload/macro'
 import type { TapDanceEntry } from '../../../shared/types/protocol'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 import { useConfirmAction } from '../../hooks/useConfirmAction'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { useFavoriteStore } from '../../hooks/useFavoriteStore'
@@ -458,7 +459,7 @@ export function MacroEditor({
               <button
                 type="button"
                 data-testid="macro-save"
-                className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+                className={BTN_PRIMARY}
                 onClick={isEditing ? commitAndDeselect : handleSave}
                 disabled={isEditing
                   ? (isRecording || !hasPendingEdit)

--- a/src/renderer/components/editors/MacroModal.tsx
+++ b/src/renderer/components/editors/MacroModal.tsx
@@ -83,7 +83,7 @@ export function MacroModal({
       onClick={isRecording ? undefined : onClose}
     >
       <div
-        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-[95vw] ${modalHeight} flex flex-col overflow-hidden`}
+        className={`rounded-lg bg-surface-alt shadow-xl ${modalWidth} max-w-modal-xl-vw ${modalHeight} flex flex-col overflow-hidden`}
         data-testid="macro-modal"
         onClick={(e) => e.stopPropagation()}
       >

--- a/src/renderer/components/editors/MacroTextEditor.tsx
+++ b/src/renderer/components/editors/MacroTextEditor.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { MacroAction } from '../../../preload/macro'
 import { jsonToMacroActions } from '../../../preload/macro'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 interface Props {
   initialJson: string
@@ -93,7 +94,7 @@ export function MacroTextEditor({ initialJson, onApply, onClose }: Props) {
             type="button"
             onClick={handleApply}
             disabled={error}
-            className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+            className={BTN_PRIMARY}
             data-testid="macro-text-editor-apply"
           >
             {t('common.save')}

--- a/src/renderer/components/editors/QmkSettings.tsx
+++ b/src/renderer/components/editors/QmkSettings.tsx
@@ -6,6 +6,7 @@ import type { QmkSettingsTab, QmkSettingsField } from '../../../shared/types/pro
 import { useConfirmAction } from '../../hooks/useConfirmAction'
 import { ConfirmButton } from './ConfirmButton'
 import settingsDefs from '../../../shared/qmk-settings-defs.json'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 interface Props {
   tabName: string
@@ -221,7 +222,7 @@ export function QmkSettings({
         <button
           type="button"
           data-testid="qmk-save"
-          className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+          className={BTN_PRIMARY}
           onClick={handleSave}
           disabled={!hasChanges}
         >

--- a/src/renderer/components/editors/QmkSettings.tsx
+++ b/src/renderer/components/editors/QmkSettings.tsx
@@ -197,7 +197,7 @@ export function QmkSettings({
                   onChange={(e) =>
                     handleIntegerChange(field, parseInt(e.target.value, 10) || 0)
                   }
-                  className="w-28 rounded border border-edge px-2 py-1 text-sm"
+                  className="w-28 rounded border border-edge px-2 py-1 text-sm focus:border-accent focus:outline-none"
                 />
               )}
             </div>

--- a/src/renderer/components/editors/QmkSettingsModal.tsx
+++ b/src/renderer/components/editors/QmkSettingsModal.tsx
@@ -36,7 +36,7 @@ function SettingsModal({
       onClick={onClose}
     >
       <div
-        className="w-modal-md max-w-[90vw] max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
+        className="w-modal-md max-w-modal-vw max-h-modal-80vh overflow-y-auto rounded-lg bg-surface-alt p-6 shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-4 flex items-center justify-between">

--- a/src/renderer/components/editors/RGBConfigurator.tsx
+++ b/src/renderer/components/editors/RGBConfigurator.tsx
@@ -6,6 +6,7 @@ import { HSVColorPicker, hsvToRgb, rgbToHsv, rgbToHex, hexToRgb } from './HSVCol
 import { useConfirmAction } from '../../hooks/useConfirmAction'
 import { ConfirmButton } from './ConfirmButton'
 import { QMK_RGBLIGHT_EFFECTS, VIALRGB_EFFECTS } from '../../../shared/constants/lighting'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 interface Props {
   lightingType: string | undefined
@@ -486,7 +487,7 @@ export function RGBConfigurator({
             }
           }}
           disabled={!isDirty}
-          className="rounded bg-accent px-4 py-2 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+          className={BTN_PRIMARY}
         >
           {t('common.save')}
         </button>

--- a/src/renderer/components/editors/TapDanceModal.tsx
+++ b/src/renderer/components/editors/TapDanceModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
+import { INPUT_BASE } from './store-modal-shared'
 import type { TapDanceEntry } from '../../../shared/types/protocol'
 import type { MacroAction } from '../../../preload/macro'
 import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
@@ -110,7 +111,7 @@ export function TapDanceModal({
             max={TAPPING_TERM_MAX}
             value={editedEntry?.tappingTerm ?? 0}
             onChange={(e) => handleTappingTermChange(e.target.value)}
-            className="flex-1 rounded border border-edge px-2 py-1 text-sm"
+            className={`flex-1 ${INPUT_BASE}`}
           />
         </div>
       )}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -503,7 +503,7 @@ export function TypingTestPane({
                   type="button"
                   role="menuitem"
                   data-testid="reset-window-size"
-                  className="whitespace-nowrap rounded border border-edge px-2 py-1 text-content-secondary transition-colors hover:text-content"
+                  className={`whitespace-nowrap ${BTN_TOGGLE_INACTIVE}`}
                   onClick={() => {
                     const size = getDefaultCompactSize()
                     window.vialAPI.setWindowCompactMode(true, size).catch(() => {})
@@ -517,7 +517,7 @@ export function TypingTestPane({
                   type="button"
                   role="menuitem"
                   data-testid="fit-window-size"
-                  className="whitespace-nowrap rounded border border-edge px-2 py-1 text-content-secondary transition-colors hover:text-content"
+                  className={`whitespace-nowrap ${BTN_TOGGLE_INACTIVE}`}
                   onClick={() => {
                     const defaultSize = getDefaultCompactSize()
                     const ratio = defaultSize.height / defaultSize.width
@@ -590,7 +590,7 @@ export function TypingTestPane({
                     type="button"
                     role="menuitem"
                     data-testid="view-analytics"
-                    className="whitespace-nowrap rounded border border-edge px-2 py-1 text-content-secondary transition-colors hover:text-content"
+                    className={`whitespace-nowrap ${BTN_TOGGLE_INACTIVE}`}
                     onClick={() => {
                       setViewOnlyControlsOpen(false)
                       onViewAnalytics()

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -17,6 +17,7 @@ import type { KleKey } from '../../../shared/kle/types'
 import type { TypingTestResult, TypingViewMenuTab } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { useTypingTest } from '../../typing-test/useTypingTest'
+import { BTN_TOGGLE_ACTIVE, BTN_TOGGLE_INACTIVE } from '../../constants/ui-tokens'
 
 export interface TypingTestPaneProps {
   typingTest: ReturnType<typeof useTypingTest>
@@ -474,7 +475,7 @@ export function TypingTestPane({
                 role="tab"
                 aria-selected={menuTab === 'window'}
                 data-testid="menu-tab-window"
-                className={`flex-1 whitespace-nowrap rounded border px-2 py-1 transition-colors ${menuTab === 'window' ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+                className={`flex-1 whitespace-nowrap ${menuTab === 'window' ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`}
                 onClick={() => onMenuTabChange?.('window')}
               >
                 {t('editor.typingTest.tab.window')}
@@ -484,7 +485,7 @@ export function TypingTestPane({
                 role="tab"
                 aria-selected={menuTab === 'rec'}
                 data-testid="menu-tab-rec"
-                className={`flex-1 whitespace-nowrap rounded border px-2 py-1 transition-colors ${menuTab === 'rec' ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+                className={`flex-1 whitespace-nowrap ${menuTab === 'rec' ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`}
                 onClick={() => onMenuTabChange?.('rec')}
               >
                 {t('editor.typingTest.tab.rec')}
@@ -535,7 +536,7 @@ export function TypingTestPane({
                     type="button"
                     role="menuitem"
                     data-testid="always-on-top-toggle"
-                    className={`whitespace-nowrap rounded border px-2 py-1 transition-colors ${viewOnlyAlwaysOnTop ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+                    className={`whitespace-nowrap ${viewOnlyAlwaysOnTop ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`}
                     onClick={() => onViewOnlyAlwaysOnTopChange(!viewOnlyAlwaysOnTop)}
                   >
                     {t('editor.typingTest.alwaysOnTop')}
@@ -552,7 +553,7 @@ export function TypingTestPane({
                     role="menuitemcheckbox"
                     aria-checked={recordEnabled ?? false}
                     data-testid="typing-record-toggle"
-                    className={`whitespace-nowrap rounded border px-2 py-1 transition-colors ${recordEnabled ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+                    className={`whitespace-nowrap ${recordEnabled ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`}
                     onClick={handleRecordToggle}
                   >
                     {recordEnabled ? t('editor.typingTest.recordStop') : t('editor.typingTest.recordStart')}
@@ -574,7 +575,7 @@ export function TypingTestPane({
                     className={
                       !recordEnabled
                         ? 'whitespace-nowrap rounded border border-edge px-2 py-1 text-content-muted opacity-60 cursor-not-allowed'
-                        : `whitespace-nowrap rounded border px-2 py-1 transition-colors ${monitorAppEnabled ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`
+                        : `whitespace-nowrap ${monitorAppEnabled ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`
                     }
                     onClick={() => {
                       if (!recordEnabled) return

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -371,7 +371,7 @@ export function TypingTestPane({
                       aria-label={t('editor.typingTest.baseLayer')}
                       value={typingTest.baseLayer}
                       onChange={(e) => typingTest.setBaseLayer(Number(e.target.value))}
-                      className="rounded-md border border-edge bg-surface-alt px-2 py-1 text-sm text-content-secondary"
+                      className="rounded-md border border-edge bg-surface-alt px-2 py-1 text-sm text-content-secondary focus:border-accent focus:outline-none"
                     >
                       {Array.from({ length: layers }, (_, i) => (
                         <option key={i} value={i}>{layerNames?.[i] || i}</option>
@@ -607,7 +607,7 @@ export function TypingTestPane({
                       aria-label={t('editor.typingTest.heatmapWindow')}
                       value={heatmapWindowMin ?? 5}
                       onChange={(e) => onHeatmapWindowMinChange(Number(e.target.value))}
-                      className="rounded border border-edge bg-surface-alt px-1.5 py-0.5 text-xs text-content-secondary"
+                      className="rounded border border-edge bg-surface-alt px-1.5 py-0.5 text-xs text-content-secondary focus:border-accent focus:outline-none"
                     >
                       {TYPING_HEATMAP_WINDOW_OPTIONS.map((m) => (
                         <option key={m} value={m}>{t('editor.typingTest.heatmapWindowOption', { minutes: m })}</option>
@@ -629,7 +629,7 @@ export function TypingTestPane({
                   aria-label={t('editor.typingTest.baseLayer')}
                   value={typingTest.baseLayer}
                   onChange={(e) => typingTest.setBaseLayer(Number(e.target.value))}
-                  className="rounded border border-edge bg-surface-alt px-1.5 py-0.5 text-xs text-content-secondary"
+                  className="rounded border border-edge bg-surface-alt px-1.5 py-0.5 text-xs text-content-secondary focus:border-accent focus:outline-none"
                 >
                   {Array.from({ length: layers }, (_, i) => (
                     <option key={i} value={i}>{layerNames?.[i] || i}</option>

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -126,7 +126,7 @@ export function UnlockDialog({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-modal-md max-w-[90vw] rounded-lg bg-surface-alt p-6 shadow-xl">
+      <div className="w-modal-md max-w-modal-vw rounded-lg bg-surface-alt p-6 shadow-xl">
         <h2 className="mb-4 text-lg font-semibold">{t('unlock.title')}</h2>
         <p className="mb-4 text-sm text-content-secondary">{t('unlock.instructions')}</p>
 

--- a/src/renderer/components/editors/keymap-editor-toolbar.tsx
+++ b/src/renderer/components/editors/keymap-editor-toolbar.tsx
@@ -36,7 +36,7 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
     <input
       ref={inputRef}
       data-testid="scale-input"
-      className="size-scale-btn rounded-md border border-accent bg-transparent text-xs leading-none tabular-nums text-content text-center outline-none"
+      className="size-scale-btn rounded-md border border-accent bg-transparent text-xs leading-none tabular-nums text-content text-center focus:border-accent focus:outline-none"
       value={draft}
       autoFocus
       onFocus={() => inputRef.current?.select()}

--- a/src/renderer/components/editors/keymap-editor-toolbar.tsx
+++ b/src/renderer/components/editors/keymap-editor-toolbar.tsx
@@ -24,7 +24,7 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
       <button
         type="button"
         data-testid="scale-display"
-        className="size-[34px] rounded-md border border-edge text-xs leading-none tabular-nums text-content-secondary hover:text-content transition-colors flex items-center justify-center"
+        className="size-scale-btn rounded-md border border-edge text-xs leading-none tabular-nums text-content-secondary hover:text-content transition-colors flex items-center justify-center"
         onClick={() => { setDraft(String(Math.round(scale * 100))); setEditing(true) }}
       >
         {display}
@@ -36,7 +36,7 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
     <input
       ref={inputRef}
       data-testid="scale-input"
-      className="size-[34px] rounded-md border border-accent bg-transparent text-xs leading-none tabular-nums text-content text-center outline-none"
+      className="size-scale-btn rounded-md border border-accent bg-transparent text-xs leading-none tabular-nums text-content text-center outline-none"
       value={draft}
       autoFocus
       onFocus={() => inputRef.current?.select()}

--- a/src/renderer/components/editors/store-modal-shared.tsx
+++ b/src/renderer/components/editors/store-modal-shared.tsx
@@ -12,11 +12,11 @@ export const INPUT_COMPACT =
   'focus:border-accent focus:outline-none'
 
 // Modal width tiers — use these instead of inline w-[*px] values.
-export const MODAL_SM  = 'w-[440px]  max-w-[90vw]'
-export const MODAL_MD  = 'w-[600px]  max-w-[90vw]'
-export const MODAL_LG  = 'w-[760px]  max-w-[90vw]'
-export const MODAL_XL  = 'w-[960px]  max-w-[95vw]'
-export const MODAL_2XL = 'w-[1200px] max-w-[95vw]'
+export const MODAL_SM  = 'w-modal-sm  max-w-[90vw]'
+export const MODAL_MD  = 'w-modal-md  max-w-[90vw]'
+export const MODAL_LG  = 'w-modal-lg  max-w-[90vw]'
+export const MODAL_XL  = 'w-modal-xl  max-w-[95vw]'
+export const MODAL_2XL = 'w-modal-2xl max-w-[95vw]'
 
 export const ACTION_BTN =
   'text-xs font-medium text-content hover:text-content cursor-pointer bg-transparent border-none px-2 py-1 rounded'

--- a/src/renderer/components/editors/store-modal-shared.tsx
+++ b/src/renderer/components/editors/store-modal-shared.tsx
@@ -12,11 +12,11 @@ export const INPUT_COMPACT =
   'focus:border-accent focus:outline-none'
 
 // Modal width tiers — use these instead of inline w-[*px] values.
-export const MODAL_SM  = 'w-modal-sm  max-w-[90vw]'
-export const MODAL_MD  = 'w-modal-md  max-w-[90vw]'
-export const MODAL_LG  = 'w-modal-lg  max-w-[90vw]'
-export const MODAL_XL  = 'w-modal-xl  max-w-[95vw]'
-export const MODAL_2XL = 'w-modal-2xl max-w-[95vw]'
+export const MODAL_SM  = 'w-modal-sm  max-w-modal-vw'
+export const MODAL_MD  = 'w-modal-md  max-w-modal-vw'
+export const MODAL_LG  = 'w-modal-lg  max-w-modal-vw'
+export const MODAL_XL  = 'w-modal-xl  max-w-modal-xl-vw'
+export const MODAL_2XL = 'w-modal-2xl max-w-modal-xl-vw'
 
 export const ACTION_BTN =
   'text-xs font-medium text-content hover:text-content cursor-pointer bg-transparent border-none px-2 py-1 rounded'

--- a/src/renderer/components/hub-post-shared.tsx
+++ b/src/renderer/components/hub-post-shared.tsx
@@ -100,7 +100,7 @@ export function HubPostRow({ post, onRename, onDelete, hubOrigin }: HubPostRowPr
           {rename.editingId === post.id ? (
             <input
               type="text"
-              className="w-full border-b border-edge bg-transparent px-1 text-sm text-content outline-none focus:border-accent"
+              className="w-full border-b border-edge bg-transparent px-1 text-sm text-content focus:outline-none focus:border-accent"
               value={rename.editLabel}
               onChange={(e) => rename.setEditLabel(e.target.value)}
               onBlur={handleBlurCommit}

--- a/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
+++ b/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
@@ -9,6 +9,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 export function JaRemovedBanner(): JSX.Element | null {
   const { t } = useTranslation()
@@ -37,7 +38,7 @@ export function JaRemovedBanner(): JSX.Element | null {
         <div className="flex justify-end">
           <button
             type="button"
-            className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-accent/90"
+            className={BTN_PRIMARY}
             onClick={dismiss}
             data-testid="ja-removed-dismiss"
           >

--- a/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
+++ b/src/renderer/components/i18n-packs/JaRemovedBanner.tsx
@@ -28,7 +28,7 @@ export function JaRemovedBanner(): JSX.Element | null {
       role="dialog"
       aria-modal="true"
     >
-      <div className="max-w-md rounded-lg border border-edge bg-surface p-4 shadow-lg">
+      <div className="max-w-md rounded-lg border border-edge bg-surface p-4 shadow-xl">
         <h2 className="mb-2 text-lg font-semibold text-content">
           {t('i18n.jaRemoved.title')}
         </h2>

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -595,7 +595,7 @@ export function LanguagePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-modal-vw h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="language-packs-modal"
       >
@@ -805,7 +805,7 @@ function InstalledRowView({
           onBlur={() => void onRenameCommit(row.packId as string)}
           onKeyDown={(e) => onRenameKey(e, row.packId as string)}
           maxLength={64}
-          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content outline-none focus:border-accent"
+          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content focus:outline-none focus:border-accent"
           data-testid={`language-packs-rename-input-${row.reactKey}`}
         />
       )

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -1000,7 +1000,7 @@ function InstalledRowView({
             {hasUpdateAvailable && (
               <span
                 aria-hidden="true"
-                className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"
+                className="h-1.5 w-1.5 rounded-full bg-success animate-pulse"
                 data-testid={`language-packs-update-available-${row.reactKey}`}
               />
             )}

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2 } from 'lucide-react'
-import { ICON_XL } from '../../constants/ui-tokens'
+import { BTN_PRIMARY, ICON_XL } from '../../constants/ui-tokens'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -624,7 +624,7 @@ export function LanguagePacksModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void runSearch(search.trim())}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
+              className={BTN_PRIMARY}
               data-testid="language-packs-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('i18n.search')}

--- a/src/renderer/components/i18n-packs/MissingKeysModal.tsx
+++ b/src/renderer/components/i18n-packs/MissingKeysModal.tsx
@@ -58,7 +58,7 @@ export function MissingKeysModal({
       }}
     >
       <div
-        className="w-modal-md max-w-[90vw] h-modal-70vh flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-md max-w-modal-vw h-modal-70vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-keys-modal"
       >

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { GripVertical } from 'lucide-react'
-import { ICON_SM } from '../../constants/ui-tokens'
+import { BTN_PRIMARY, ICON_SM } from '../../constants/ui-tokens'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useKeyLabels } from '../../hooks/useKeyLabels'
@@ -397,7 +397,7 @@ export function KeyLabelsModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void triggerSearch()}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
+              className={BTN_PRIMARY}
               data-testid="key-labels-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('keyLabels.search')}

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -854,7 +854,7 @@ function HubLineActions({
           {hasUpdateAvailable && (
             <span
               aria-hidden="true"
-              className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"
+              className="h-1.5 w-1.5 rounded-full bg-success animate-pulse"
               data-testid={`key-labels-update-available-${localId}`}
             />
           )}

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -358,7 +358,7 @@ export function KeyLabelsModal({
       onClick={onClose}
     >
       <div
-        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-modal-vw h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="key-labels-modal"
       >
@@ -601,7 +601,7 @@ function InstalledRowView({
           onBlur={() => void onRenameCommit(row.localId)}
           onKeyDown={(e) => onRenameKey(e, row.localId)}
           maxLength={100}
-          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content outline-none focus:border-accent"
+          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content focus:outline-none focus:border-accent"
           data-testid={`key-labels-rename-input-${row.localId}`}
         />
       )

--- a/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
+++ b/src/renderer/components/key-labels/MissingKeyLabelDialog.tsx
@@ -37,7 +37,7 @@ export function MissingKeyLabelDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="missing-key-label-title"
-        className="w-modal-md max-w-[90vw] rounded-lg bg-surface p-5 shadow-xl"
+        className="w-modal-md max-w-modal-vw rounded-lg bg-surface p-5 shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="missing-key-label-dialog"
       >

--- a/src/renderer/components/keycodes/KeycodeButton.tsx
+++ b/src/renderer/components/keycodes/KeycodeButton.tsx
@@ -39,7 +39,7 @@ function KeycodeButtonInner({ keycode, onClick, onDoubleClick, onHover, onHoverE
   const layout = useQuadrant
     ? 'grid grid-cols-2 grid-rows-2 place-items-center'
     : 'flex flex-col items-center justify-center'
-  const base = `${layout} rounded border border-transparent p-1 text-xs outline-none cursor-pointer ${hover} active:bg-accent/20 ${size} transition-colors`
+  const base = `${layout} rounded border border-transparent p-1 text-xs focus:outline-none focus:border-accent cursor-pointer ${hover} active:bg-accent/20 ${size} transition-colors`
   let variant: string
   if (selected) {
     variant = 'bg-accent/20 text-accent'

--- a/src/renderer/components/keycodes/PopoverTabCode.tsx
+++ b/src/renderer/components/keycodes/PopoverTabCode.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { serialize, isLMKeycode, resolve } from '../../../shared/keycodes/keycodes'
+import { BTN_PRIMARY } from '../../constants/ui-tokens'
 
 interface Props {
   currentKeycode: number
@@ -96,7 +97,7 @@ export function PopoverTabCode({ currentKeycode, maskOnly, onRawKeycodeSelect }:
 
       <button
         type="button"
-        className="self-end rounded bg-accent px-3 py-1.5 text-sm text-content-inverse hover:bg-accent-hover disabled:opacity-50"
+        className={`self-end ${BTN_PRIMARY}`}
         disabled={!canApply}
         onClick={handleApply}
         data-testid="popover-code-apply"

--- a/src/renderer/components/keycodes/TileGrids.tsx
+++ b/src/renderer/components/keycodes/TileGrids.tsx
@@ -59,7 +59,7 @@ function SettingsTileGrid<T extends Record<string, unknown>>({ entries, fields, 
             >
               <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">{i}</span>
               {configured ? (
-                <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px overflow-hidden">
+                <span className="mt-2 inline-grid grid-cols-auto-1fr gap-x-1 gap-y-px overflow-hidden">
                   {fields.map(({ key, prefix }) => (
                     <Fragment key={key}>
                       <span className="text-left text-content-secondary/60">{prefix}</span>
@@ -150,7 +150,7 @@ export function TdTileGrid({ entries, onSelect, onDoubleClick }: TdTileGridProps
           >
             <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">TD({i})</span>
             {configured ? (
-              <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-px">
+              <span className="mt-2 inline-grid grid-cols-auto-1fr gap-x-1 gap-y-px">
                 {TD_FIELDS.map(({ key, prefix }) => (
                   <Fragment key={key}>
                     <span className="text-left text-content-secondary/60">{prefix}</span>
@@ -224,7 +224,7 @@ export function MacroTileGrid({ macros, onSelect, onDoubleClick }: MacroTileGrid
           >
             <span className="absolute top-0.5 left-1 text-4xs text-content-secondary/60">M{i}</span>
             {configured ? (
-              <span className="mt-2 inline-grid grid-cols-[auto_1fr] gap-x-1 gap-y-0 overflow-hidden">
+              <span className="mt-2 inline-grid grid-cols-auto-1fr gap-x-1 gap-y-0 overflow-hidden">
                 {actions.slice(0, maxVisible).map((action, j) => (
                   <Fragment key={j}>
                     <span className="text-left text-content-secondary/60">{MACRO_PREFIX[action.type]}</span>

--- a/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
+++ b/src/renderer/components/settings-modal/LocalDataResetGroup.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
-import { BTN_SECONDARY, BTN_DANGER_OUTLINE } from './settings-modal-shared'
+import { BTN_SECONDARY, BTN_DANGER_OUTLINE, BTN_DANGER } from './settings-modal-shared'
 import type { LocalResetTargets, StoredKeyboardInfo } from '../../../shared/types/sync'
 
 export interface LocalDataResetGroupProps {
@@ -121,7 +121,7 @@ export function LocalDataResetGroup({
             </button>
             <button
               type="button"
-              className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-danger/90 disabled:opacity-50"
+              className={BTN_DANGER}
               onClick={onConfirm}
               disabled={confirmDisabled || !anySelected}
               data-testid="reset-local-data-confirm"

--- a/src/renderer/components/settings-modal/PasswordSection.tsx
+++ b/src/renderer/components/settings-modal/PasswordSection.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useTranslation } from 'react-i18next'
-import { scoreColor, BTN_SECONDARY } from './settings-modal-shared'
+import { scoreColor, BTN_PRIMARY, BTN_SECONDARY } from './settings-modal-shared'
 import type { UseSyncReturn } from '../../hooks/useSync'
 
 export interface PasswordSectionProps {
@@ -112,7 +112,7 @@ export function PasswordSection({
         <div className="flex gap-2">
           <button
             type="button"
-            className="rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+            className={BTN_PRIMARY}
             onClick={onSetPassword}
             disabled={!password || (passwordScore !== null && passwordScore < 4) || sync.syncUnavailable}
             data-testid="sync-password-save"

--- a/src/renderer/components/settings-modal/SettingsDataTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsDataTab.tsx
@@ -108,7 +108,7 @@ export function SettingsDataTab({
           <div className="space-y-2">
             <button
               type="button"
-              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+              className={`w-full ${BTN_PRIMARY}`}
               onClick={handleSignIn}
               disabled={authenticating}
               data-testid="sync-sign-in"
@@ -243,7 +243,7 @@ export function SettingsDataTab({
           <div data-testid="hub-enable-row">
             <button
               type="button"
-              className="w-full rounded bg-accent px-4 py-2 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50"
+              className={`w-full ${BTN_PRIMARY}`}
               onClick={() => onHubEnabledChange(true)}
               disabled={!hubAuthenticated}
               data-testid="hub-enable-toggle"

--- a/src/renderer/components/settings-modal/SettingsModal.tsx
+++ b/src/renderer/components/settings-modal/SettingsModal.tsx
@@ -70,7 +70,7 @@ export function SettingsModal({
         aria-modal="true"
         aria-busy={syncState.busy}
         aria-labelledby="settings-title"
-        className="w-modal-lg max-w-[90vw] h-modal-settings flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-lg max-w-modal-vw h-modal-settings flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         data-testid="settings-modal"
       >

--- a/src/renderer/components/settings-modal/SettingsModal.tsx
+++ b/src/renderer/components/settings-modal/SettingsModal.tsx
@@ -70,7 +70,7 @@ export function SettingsModal({
         aria-modal="true"
         aria-busy={syncState.busy}
         aria-labelledby="settings-title"
-        className="w-[760px] max-w-[90vw] h-[min(840px,85vh)] flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
+        className="w-modal-lg max-w-[90vw] h-modal-settings flex flex-col rounded-2xl bg-surface-alt border border-edge shadow-xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
         data-testid="settings-modal"
       >

--- a/src/renderer/components/settings-modal/SyncDataResetSection.tsx
+++ b/src/renderer/components/settings-modal/SyncDataResetSection.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { BTN_SECONDARY, BTN_DANGER_OUTLINE, toggleSetItem } from './settings-modal-shared'
+import { BTN_SECONDARY, BTN_DANGER_OUTLINE, BTN_DANGER, toggleSetItem } from './settings-modal-shared'
 import type { UseSyncReturn } from '../../hooks/useSync'
 import type { SyncDataScanResult, StoredKeyboardInfo } from '../../../shared/types/sync'
 
@@ -282,7 +282,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
                 </button>
                 <button
                   type="button"
-                  className="rounded bg-danger px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-danger/90 disabled:opacity-50"
+                  className={BTN_DANGER}
                   onClick={handleDelete}
                   disabled={!anySelected || deleting}
                   data-testid="sync-reset-data-confirm"

--- a/src/renderer/components/settings-modal/settings-modal-shared.ts
+++ b/src/renderer/components/settings-modal/settings-modal-shared.ts
@@ -2,7 +2,7 @@
 
 import type { LucideIcon } from 'lucide-react'
 import { Monitor, Sun, Moon } from 'lucide-react'
-export { BTN_PRIMARY, BTN_SECONDARY, BTN_DANGER_OUTLINE } from '../../constants/ui-tokens'
+export { BTN_PRIMARY, BTN_SECONDARY, BTN_DANGER_OUTLINE, BTN_DANGER } from '../../constants/ui-tokens'
 import type { UseSyncReturn } from '../../hooks/useSync'
 import type { ThemeMode, ThemeSelection } from '../../hooks/useTheme'
 import type { KeyboardLayoutId, AutoLockMinutes } from '../../hooks/useDevicePrefs'

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -215,7 +215,7 @@ export function PackRow({
             {hasUpdateAvailable && (
               <span
                 aria-hidden="true"
-                className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse"
+                className="h-1.5 w-1.5 rounded-full bg-success animate-pulse"
                 data-testid={`theme-packs-update-available-${meta.id}`}
               />
             )}

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -81,7 +81,7 @@ export function PackRow({
           onBlur={() => void onRenameCommit(meta.id)}
           onKeyDown={(e) => onRenameKey(e, meta.id)}
           maxLength={64}
-          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content outline-none focus:border-accent"
+          className="w-full border-b border-edge bg-transparent px-1 text-sm text-content focus:outline-none focus:border-accent"
           data-testid={`theme-packs-rename-input-${meta.id}`}
         />
       )

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -442,7 +442,7 @@ export function ThemePacksModal({
       onClick={onClose}
     >
       <div
-        className="w-modal-lg max-w-[90vw] h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
+        className="w-modal-lg max-w-modal-vw h-modal-80vh flex flex-col rounded-lg bg-surface shadow-xl"
         onClick={(e) => e.stopPropagation()}
         data-testid="theme-packs-modal"
       >

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Trans, useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2, Monitor, Sun, Moon } from 'lucide-react'
-import { ICON_MD } from '../../constants/ui-tokens'
+import { BTN_PRIMARY, ICON_MD } from '../../constants/ui-tokens'
 import { ModalCloseButton } from '../editors/ModalCloseButton'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -471,7 +471,7 @@ export function ThemePacksModal({
               type="button"
               disabled={hubSearching || search.trim().length < 2}
               onClick={() => void runSearch(search.trim())}
-              className="rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:opacity-90 disabled:opacity-50"
+              className={BTN_PRIMARY}
               data-testid="theme-packs-search-button"
             >
               {hubSearching ? t('keyLabels.searching') : t('i18n.search')}

--- a/src/renderer/constants/ui-tokens.ts
+++ b/src/renderer/constants/ui-tokens.ts
@@ -14,6 +14,9 @@ export const ICON_BTN_BASE = 'rounded p-1 text-content-muted hover:text-content 
 export const BTN_PRIMARY = 'rounded bg-accent px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed'
 export const BTN_SECONDARY = 'rounded border border-edge px-3 py-1.5 text-sm text-content-secondary hover:bg-surface-dim disabled:opacity-50 disabled:cursor-not-allowed'
 export const BTN_DANGER_OUTLINE = 'rounded border border-danger px-3 py-1.5 text-sm text-danger hover:bg-danger/10 disabled:opacity-50 disabled:cursor-not-allowed'
+export const BTN_DANGER = 'rounded bg-danger px-3 py-1.5 text-sm font-medium text-content-inverse hover:bg-danger/90 disabled:opacity-50 disabled:cursor-not-allowed'
+export const BTN_PRIMARY_XS = 'rounded-lg bg-accent px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-accent/90 disabled:opacity-50 disabled:cursor-not-allowed'
+export const BTN_DANGER_XS = 'rounded-lg bg-danger px-3 py-1.5 text-xs font-semibold text-content-inverse hover:bg-danger/90 disabled:opacity-50 disabled:cursor-not-allowed'
 
 // Toolbar toggle buttons (rounded-md, p-2)
 export const TOOLBAR_BTN_BASE = 'rounded-md border p-2 transition-colors'

--- a/src/renderer/constants/ui-tokens.ts
+++ b/src/renderer/constants/ui-tokens.ts
@@ -22,3 +22,10 @@ export const BTN_DANGER_XS = 'rounded-lg bg-danger px-3 py-1.5 text-xs font-semi
 export const TOOLBAR_BTN_BASE = 'rounded-md border p-2 transition-colors'
 export const TOOLBAR_BTN_ACTIVE = `${TOOLBAR_BTN_BASE} border-accent bg-accent/10 text-accent`
 export const TOOLBAR_BTN_INACTIVE = `${TOOLBAR_BTN_BASE} border-edge text-content-secondary hover:text-content`
+
+// Compact text toggle buttons (px-2 py-1) — StatusBar / TypingTestPane tabs
+export const BTN_TOGGLE_ACTIVE = 'rounded border border-accent bg-accent/10 px-2 py-1 text-sm text-accent transition-colors'
+export const BTN_TOGGLE_INACTIVE = 'rounded border border-edge px-2 py-1 text-sm text-content-secondary transition-colors hover:text-content'
+
+// Accent-outline button — non-destructive secondary CTA on accent color
+export const BTN_ACCENT_OUTLINE = 'rounded border border-accent bg-accent/10 px-3 py-1.5 text-sm text-accent hover:bg-accent/20 disabled:opacity-50 disabled:cursor-not-allowed'

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -335,6 +335,16 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --bottom-cursor: 0.12em;
   --height-cursor: 1.1em;
 
+  /* Transition properties */
+  --transition-property-width: width;                       /* LayerListPanel collapse animation */
+
+  /* Grid template columns */
+  --grid-template-columns-auto-1fr: auto 1fr;               /* TileGrids field rows */
+  --grid-template-columns-1-3: 1fr 3fr;                     /* ErgonomicsChart section rows */
+  --grid-template-columns-3-2: 3fr 2fr;                     /* LayoutComparisonView main split */
+  --grid-template-columns-swatches: repeat(10, 1.5rem);     /* HSVColorPicker palette */
+  --grid-template-columns-auto-fit-160: repeat(auto-fit, minmax(160px, 1fr)); /* AnalyzeSummaryTable */
+
   /* Z-index */
   --z-60: 60; /* AnalyzeExportModal dropdown overlay */
 }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -27,7 +27,7 @@
 }
 .rdp-root .rdp-day_button {
   color: var(--content);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 400;
 }
 .rdp-root .rdp-selected .rdp-day_button {

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -315,6 +315,8 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --min-width-keyboard-pane: 280px;    /* KeyboardPane */
   --min-width-keycode-panel: 360px;    /* KeymapEditor layout overlay panel */
   --max-width-keycode-panel: 420px;    /* KeymapEditor layout overlay panel */
+  --max-width-modal-vw: 90vw;          /* SM/MD/LG modal viewport constraint */
+  --max-width-modal-xl-vw: 95vw;       /* XL/2XL modal viewport constraint */
   --min-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
   --max-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
   --min-height-word-list: 100px;       /* TypingTestPane word list */
@@ -322,6 +324,9 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --width-color-picker: 15rem;         /* HSVColorPicker container */
   --height-color-picker-sv: 180px;     /* HSVColorPicker saturation/value canvas */
   --spacing-scale-btn: 34px;           /* ScaleControl toolbar button (non-grid: between sm key and toolbar icon) */
+
+  /* Shadows - custom */
+  --shadow-color-swatch: 0 0 0 1px rgba(0,0,0,0.3); /* HSV/color swatch contrast ring */
 
   /* Border radius - custom */
   --radius-panel-connector: 10px; /* KeymapEditor layout panel right edge */

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -282,7 +282,8 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --width-modal-md: 600px;     /* MissingKeyLabelDialog, UnlockDialog, QmkSettings, JsonEditor */
   --width-modal-notify: 560px; /* NotificationModal, AnalyzeExportModal */
   --width-modal-typing: 480px; /* LanguageSelectorModal, TypingRecordingConsentModal */
-  --width-modal-lg: 760px;     /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal */
+  --width-modal-lg: 760px;     /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal, SettingsModal */
+  --width-modal-data: 860px;   /* DataModal */
   --width-modal-goal: 720px;   /* GoalAchievementsModal */
   --width-modal-app: 500px;    /* App toast, MacroTextEditor */
   --width-modal-xl: 960px;     /* FingerAssignmentModal */
@@ -297,6 +298,8 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --height-modal-80vh: 80vh; /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal */
   --height-modal-70vh: 70vh; /* MissingKeysModal, TypingAnalyticsView */
   --height-modal-90vh: 90vh; /* MacroModal */
+  --height-modal-data: min(720px, 80vh);     /* DataModal */
+  --height-modal-settings: min(840px, 85vh); /* SettingsModal */
 
   /* Modal max-heights */
   --max-height-modal-80vh: 80vh; /* Various modals */

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -321,6 +321,7 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --height-typing-display: 7.25rem;    /* TypingTestView word display area */
   --width-color-picker: 15rem;         /* HSVColorPicker container */
   --height-color-picker-sv: 180px;     /* HSVColorPicker saturation/value canvas */
+  --spacing-scale-btn: 34px;           /* ScaleControl toolbar button (non-grid: between sm key and toolbar icon) */
 
   /* Border radius - custom */
   --radius-panel-connector: 10px; /* KeymapEditor layout panel right edge */

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -89,7 +89,7 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
       role="dialog"
       onClick={handleBackdropClick}
     >
-      <div className="flex h-modal-80vh w-modal-typing flex-col rounded-xl border border-edge bg-surface shadow-2xl">
+      <div className="flex h-modal-80vh w-modal-typing flex-col rounded-2xl border border-edge bg-surface shadow-xl">
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 className="text-lg font-semibold text-content">{t('editor.typingTest.language.title')}</h2>
           <ModalCloseButton testid="language-modal-close" onClick={onClose} />

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -99,7 +99,7 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
           <input
             ref={searchRef}
             type="text"
-            className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted"
+            className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
             placeholder={t('editor.typingTest.language.searchPlaceholder')}
             value={search}
             onChange={(e) => setSearch(e.target.value)}

--- a/src/renderer/typing-test/TypingRecordingConsentModal.tsx
+++ b/src/renderer/typing-test/TypingRecordingConsentModal.tsx
@@ -10,6 +10,7 @@ import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
+import { BTN_SECONDARY } from '../constants/ui-tokens'
 
 interface Props {
   /** Called when the user clicks "Enable" — caller is expected to
@@ -47,7 +48,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
       onClick={handleBackdropClick}
       data-testid="typing-consent-modal"
     >
-      <div className="flex w-modal-typing flex-col rounded-xl border border-edge bg-surface shadow-2xl">
+      <div className="flex w-modal-typing flex-col rounded-2xl border border-edge bg-surface shadow-xl">
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 id="typing-consent-title" className="text-lg font-semibold text-content">
             {t('editor.typingTest.consent.title')}
@@ -83,7 +84,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
             type="button"
             data-testid="typing-consent-cancel"
             onClick={onCancel}
-            className="rounded border border-edge px-3 py-1.5 text-sm text-content-secondary hover:bg-surface-dim"
+            className={BTN_SECONDARY}
           >
             {t('common.cancel')}
           </button>

--- a/src/renderer/typing-test/TypingRecordingConsentModal.tsx
+++ b/src/renderer/typing-test/TypingRecordingConsentModal.tsx
@@ -10,7 +10,7 @@ import { useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
-import { BTN_SECONDARY } from '../constants/ui-tokens'
+import { BTN_SECONDARY, BTN_ACCENT_OUTLINE } from '../constants/ui-tokens'
 
 interface Props {
   /** Called when the user clicks "Enable" — caller is expected to
@@ -92,7 +92,7 @@ export function TypingRecordingConsentModal({ onAccept, onCancel }: Props) {
             type="button"
             data-testid="typing-consent-accept"
             onClick={onAccept}
-            className="rounded border border-accent bg-accent/10 px-3 py-1.5 text-sm text-accent hover:bg-accent/20"
+            className={BTN_ACCENT_OUTLINE}
           >
             {t('editor.typingTest.consent.accept')}
           </button>

--- a/src/renderer/typing-test/WordDisplay.tsx
+++ b/src/renderer/typing-test/WordDisplay.tsx
@@ -3,6 +3,7 @@
 import type { WordResult } from './useTypingTest'
 
 const COMPOSITION_CHAR_CLASS = 'text-accent/60 underline decoration-accent/30'
+const ERROR_CHAR_CLASS = 'text-danger underline decoration-danger/50 decoration-2 underline-offset-2'
 
 interface WordDisplayProps {
   word: string
@@ -110,7 +111,7 @@ export function WordDisplay({ word, wordIndex, currentWordIndex, currentInput, w
             .slice(word.length)
             .split('')
             .map((char, i) => (
-              <span key={`extra-${i}`} className="text-danger underline decoration-danger/50 decoration-2 underline-offset-[3px]">
+              <span key={`extra-${i}`} className={ERROR_CHAR_CLASS}>
                 {char}
               </span>
             ))}
@@ -135,7 +136,7 @@ export function WordDisplay({ word, wordIndex, currentWordIndex, currentInput, w
 function charClassName(expected: string, index: number, input: string): string {
   if (index >= input.length) return 'text-content-muted'
   if (input[index] === expected) return 'text-success'
-  return 'text-danger underline decoration-danger/50 decoration-2 underline-offset-[3px]'
+  return ERROR_CHAR_CLASS
 }
 
 function displayChar(expected: string, index: number, input: string): string {

--- a/src/renderer/utils/chart-palette.ts
+++ b/src/renderer/utils/chart-palette.ts
@@ -22,6 +22,11 @@ export const PALETTE_MIN_T = 0.05
 
 /** Recharts axis tick font size — matches `text-xs` (12px body, 11px tick). */
 export const CHART_TICK_FONT_SIZE = 11
+
+/** Cyan-500: intentional 5th series hue in IntervalChart.
+ * The wide-hue ramp doesn't yield a clean cyan at 4-series spacing. */
+export const CHART_CYAN_SERIES_COLOR = '#06b6d4'
+
 /** Recharts legend wrapper font size. */
 export const CHART_LEGEND_FONT_SIZE = 12
 

--- a/src/renderer/utils/chart-palette.ts
+++ b/src/renderer/utils/chart-palette.ts
@@ -20,6 +20,11 @@ import type { EffectiveTheme } from '../hooks/useEffectiveTheme'
  * paints a visible tint. */
 export const PALETTE_MIN_T = 0.05
 
+/** Recharts axis tick font size — matches `text-xs` (12px body, 11px tick). */
+export const CHART_TICK_FONT_SIZE = 11
+/** Recharts legend wrapper font size. */
+export const CHART_LEGEND_FONT_SIZE = 12
+
 const HUE_START = 220
 const HUE_RANGE = 220
 


### PR DESCRIPTION
## Summary

- Fix arbitrary Tailwind bracket values (`underline-offset-[3px]`, `grid-cols-[...]`, `transition-[width]`) by registering named tokens in `@theme`
- Extract `ERROR_CHAR_CLASS` constant in `WordDisplay` to unify error character styling
- Add `treeIndentStyle(depth)` helper in `DataNavTree` to eliminate magic pixel strings
- Fix `font-size: 13px` → `12px` for react-day-picker calendar buttons (design scale compliance)

## Test plan

- [ ] Typing test: error characters underlined correctly
- [ ] Layer panel: collapse/expand animation works
- [ ] Ergonomics chart: grid layout renders correctly
- [ ] DataModal nav tree: indentation levels correct at all depths
- [ ] HSVColorPicker: palette grid renders correctly