### PR TITLE
fix(ui): align uploader column on Key Labels hub list

### DIFF
--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -986,7 +986,11 @@ function HubTable({ rows, hubSearched, pendingId, hubOrigin, onDownload }: HubTa
           >
             <span className="flex-1 min-w-0 truncate text-content">{row.name}</span>
             <span className="w-40 truncate text-content-secondary">{row.author}</span>
-            <span className="inline-flex items-center gap-3 whitespace-nowrap">
+            {/* Fixed-width slot keeps the Author column anchored across rows
+                — without it the "Open Download" vs "Open Installed" width
+                difference (different glyph widths + font-medium vs regular)
+                shifts the uploader name horizontally between rows. */}
+            <span className="inline-flex w-32 items-center justify-end gap-3 whitespace-nowrap">
               {openUrl && (
                 <a
                   href={openUrl}


### PR DESCRIPTION
## Summary
- Pin the Open/Download/Installed action slot in the Key Labels "Find on Hub" tab to a fixed width with `justify-end`, so the uploader name no longer shifts horizontally between rows where one action says "Download" (bold accent) and another says "Installed" (regular muted).

## Test plan
- [ ] Open Settings → Tools → Key Labels → Find on Hub.
- [ ] Confirm uploader names ("pipette", "Technofrikus", …) align vertically across rows regardless of whether the row shows Download or Installed.
- [ ] Confirm the Open link, Download button, and Installed label still right-align to the row's right edge.
- [ ] Verify no regression in the Installed tab and in narrow modal widths.