### PR TITLE
fix(sync): pull cloud settings before applying local prefs (#190)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^8.54.0",
     "@typescript-eslint/parser": "^8.54.0",
     "@vitejs/plugin-react": "^5.2.0",
-    "electron": "~41.1.1",
+    "electron": "~41.7.1",
     "electron-builder": "^26.7.0",
     "electron-vite": "^5.0.0",
     "eslint": "^9.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2))
       electron:
-        specifier: ~41.1.1
-        version: 41.1.1
+        specifier: ~41.7.1
+        version: 41.7.1
       electron-builder:
         specifier: ^26.7.0
         version: 26.7.0(electron-builder-squirrel-windows@26.7.0)
@@ -1937,8 +1937,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.1.1:
-    resolution: {integrity: sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==}
+  electron@41.7.1:
+    resolution: {integrity: sha512-pdRvNNP99Qfvs1lyIxo/sfIGAwJP0CrJFNCE3goFKc7/fV+kjK3EPxx5Nt6sLTkzqTyeRYylpwPUfpeGojiyyw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5732,7 +5732,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.1.1:
+  electron@41.7.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.10.11

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,5 @@
-allowedBuiltDependencies: node-hid
+allowedBuiltDependencies:
+  - better-sqlite3
+  - electron
+  - esbuild
+  - node-hid

--- a/sample-packs/themes/morphous-abalone.json
+++ b/sample-packs/themes/morphous-abalone.json
@@ -1,0 +1,48 @@
+{
+  "name": "Morphous Abalone",
+  "version": "1.0.0",
+  "colorScheme": "light",
+  "colors": {
+    "surface":               "#F7F8FA",
+    "surface-alt":           "#FEFBF7",
+    "surface-dim":           "#E6E9EE",
+    "surface-raised":        "#FFFFFF",
+
+    "content":               "#0F1A1D",
+    "content-secondary":     "#45686D",
+    "content-muted":         "#9BA8AA",
+    "content-inverse":       "#FEFBF7",
+
+    "edge":                  "#C8CDD8",
+    "edge-subtle":           "#DDE2E8",
+    "edge-strong":           "#9BA8AA",
+
+    "accent":                "#0A7A78",
+    "accent-hover":          "#0EA5A3",
+    "accent-alt":            "#6ED1C5",
+    "success":               "#10B981",
+    "warning":               "#F59E0B",
+    "danger":                "#EF4444",
+    "pending":               "#EA580C",
+
+    "key-bg":                "#FEFBF7",
+    "key-bg-hover":          "#E6E9EE",
+    "key-bg-active":         "#0A7A78",
+    "key-border":            "#C8CDD8",
+    "key-shadow":            "rgba(7, 23, 25, 0.25)",
+    "key-label":             "#0F1A1D",
+    "key-sublabel":          "#9BA8AA",
+    "key-label-remap":       "#0A7A78",
+    "key-bg-multi-selected": "#6ED1C5",
+
+    "tab-bg-active":         "#0A7A78",
+    "tab-text":              "#9BA8AA",
+    "tab-text-active":       "#FEFBF7",
+
+    "picker-bg":             "#EEF2F3",
+    "picker-item-bg":        "#F7F8FA",
+    "picker-item-hover":     "#DDE2E8",
+    "picker-item-text":      "#0F1A1D",
+    "picker-item-border":    "#C8CDD8"
+  }
+}

--- a/src/main/__tests__/electron-stub.ts
+++ b/src/main/__tests__/electron-stub.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Vitest-only replacement for the `electron` module.
+//
+// The real `electron` npm package's `index.js` calls `getElectronPath()` at
+// module-init time and throws "Electron failed to install correctly" when
+// `path.txt` is missing — which it can be in CI when the postinstall script
+// silently short-circuits. Tests that transitively import any main-process
+// module (logger, ipc-guard, ...) hit this throw before any `vi.mock` runs.
+//
+// This stub is wired in via `vitest.config.ts#resolve.alias` so the throw is
+// avoided in vitest. Tests that need specific electron behavior continue to
+// override individual APIs through `vi.mock('electron', factory)`.
+
+import { vi } from 'vitest'
+
+export const app = {
+  getPath: vi.fn((_name: string) => '/tmp/pipette-test'),
+  getName: vi.fn(() => 'pipette-desktop-test'),
+  getVersion: vi.fn(() => '0.0.0-test'),
+  getAppPath: vi.fn(() => '/tmp/pipette-test/app'),
+  isPackaged: false,
+  on: vi.fn(),
+  once: vi.fn(),
+  off: vi.fn(),
+  removeListener: vi.fn(),
+  whenReady: vi.fn(() => Promise.resolve()),
+  quit: vi.fn(),
+  setPath: vi.fn(),
+}
+
+export const ipcMain = {
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+  on: vi.fn(),
+  off: vi.fn(),
+  once: vi.fn(),
+  removeListener: vi.fn(),
+  removeAllListeners: vi.fn(),
+  emit: vi.fn(),
+}
+
+export const BrowserWindow = vi.fn().mockImplementation(() => ({
+  loadURL: vi.fn(),
+  loadFile: vi.fn(),
+  on: vi.fn(),
+  webContents: { send: vi.fn(), on: vi.fn() },
+  close: vi.fn(),
+  destroy: vi.fn(),
+})) as unknown as {
+  getAllWindows: () => unknown[]
+  getFocusedWindow: () => unknown | null
+  fromWebContents: (wc: unknown) => unknown | null
+} & (new () => unknown)
+
+;(BrowserWindow as unknown as { getAllWindows: () => unknown[] }).getAllWindows = vi.fn(() => [])
+;(BrowserWindow as unknown as { getFocusedWindow: () => unknown | null }).getFocusedWindow = vi.fn(() => null)
+;(BrowserWindow as unknown as { fromWebContents: (wc: unknown) => unknown | null }).fromWebContents = vi.fn(() => null)
+
+export const dialog = {
+  showOpenDialog: vi.fn(() => Promise.resolve({ canceled: true, filePaths: [] })),
+  showSaveDialog: vi.fn(() => Promise.resolve({ canceled: true })),
+  showMessageBox: vi.fn(() => Promise.resolve({ response: 0 })),
+  showErrorBox: vi.fn(),
+}
+
+export const Menu = {
+  setApplicationMenu: vi.fn(),
+  buildFromTemplate: vi.fn(() => ({ popup: vi.fn() })),
+}
+
+export const net = {
+  request: vi.fn(),
+  fetch: vi.fn(() => Promise.resolve(new Response())),
+}
+
+export const safeStorage = {
+  isEncryptionAvailable: vi.fn(() => false),
+  encryptString: vi.fn((s: string) => Buffer.from(s)),
+  decryptString: vi.fn((b: Buffer) => b.toString('utf-8')),
+}
+
+export const screen = {
+  getPrimaryDisplay: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1080 } })),
+  getAllDisplays: vi.fn(() => []),
+}
+
+export const session = {
+  defaultSession: { webRequest: { onBeforeRequest: vi.fn() } },
+  fromPartition: vi.fn(),
+}
+
+export const shell = {
+  openExternal: vi.fn(() => Promise.resolve()),
+  openPath: vi.fn(() => Promise.resolve('')),
+  showItemInFolder: vi.fn(),
+}

--- a/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
+++ b/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDeviceLifecycle } from '../useDeviceLifecycle'
+import type { DeviceInfo, KeyboardDefinition, VilFile } from '../../../shared/types/protocol'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}))
+
+const mockDevice: DeviceInfo = {
+  vendorId: 0x1234,
+  productId: 0x5678,
+  productName: 'Test Keyboard',
+  serialNumber: 'SN001',
+  type: 'vial',
+}
+
+interface Mocks {
+  connectDevice: ReturnType<typeof vi.fn>
+  disconnectDevice: ReturnType<typeof vi.fn>
+  keyboardReload: ReturnType<typeof vi.fn>
+  applyDevicePrefs: ReturnType<typeof vi.fn>
+  syncNow: ReturnType<typeof vi.fn>
+}
+
+function makeOptions(overrides: Partial<{
+  authenticated: boolean
+  autoSync: boolean
+  hasPassword: boolean
+  reloadUid: string | undefined
+}> = {}, mocks?: Partial<Mocks>) {
+  const connectDevice = mocks?.connectDevice ?? vi.fn().mockResolvedValue(true)
+  const disconnectDevice = mocks?.disconnectDevice ?? vi.fn().mockResolvedValue(undefined)
+  const keyboardReload = mocks?.keyboardReload ??
+    vi.fn().mockResolvedValue(overrides.reloadUid ?? 'uid-1')
+  const applyDevicePrefs = mocks?.applyDevicePrefs ?? vi.fn().mockResolvedValue(undefined)
+  const syncNow = mocks?.syncNow ?? vi.fn().mockResolvedValue(undefined)
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).vialAPI = {
+    lock: vi.fn().mockResolvedValue(undefined),
+  }
+
+  return {
+    options: {
+      connectDevice,
+      disconnectDevice,
+      connectDummy: vi.fn(),
+      connectPipetteFile: vi.fn(),
+      isPipetteFile: false,
+      keyboardUid: undefined,
+      keyboardReload,
+      keyboardReset: vi.fn(),
+      keyboardLoadDummy: vi.fn() as (def: KeyboardDefinition) => void,
+      keyboardLoadPipetteFile: vi.fn() as (vil: VilFile) => void,
+      refreshUnlockStatus: vi.fn().mockResolvedValue(undefined),
+      unlocked: false,
+      activityCount: 0,
+      applyDevicePrefs,
+      autoLockTime: 0,
+      autoSync: overrides.autoSync ?? true,
+      authenticated: overrides.authenticated ?? true,
+      hasPassword: overrides.hasPassword ?? true,
+      syncNow,
+      deviceSyncing: false,
+      resetUIState: vi.fn(),
+      clearFileStatus: vi.fn(),
+      resetHubState: vi.fn(),
+      matrixMode: false,
+      typingTestMode: false,
+      typingTestViewOnly: false,
+    },
+    mocks: { connectDevice, disconnectDevice, keyboardReload, applyDevicePrefs, syncNow },
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useDeviceLifecycle.handleConnect — issue #190 regression', () => {
+  it('downloads cloud settings BEFORE applying device prefs when sync is ready', async () => {
+    const callOrder: string[] = []
+    const syncNow = vi.fn().mockImplementation(async () => {
+      callOrder.push('syncNow')
+    })
+    const applyDevicePrefs = vi.fn().mockImplementation(async () => {
+      callOrder.push('applyDevicePrefs')
+    })
+
+    const { options } = makeOptions({}, { syncNow, applyDevicePrefs })
+    const { result } = renderHook(() => useDeviceLifecycle(options))
+
+    await act(async () => {
+      await result.current.handleConnect(mockDevice)
+    })
+
+    expect(callOrder).toEqual(['syncNow', 'applyDevicePrefs'])
+    expect(syncNow).toHaveBeenCalledWith('download', { favorites: true, keyboard: 'uid-1' })
+  })
+
+  it('skips sync download when autoSync is disabled', async () => {
+    const { options, mocks } = makeOptions({ autoSync: false })
+    const { result } = renderHook(() => useDeviceLifecycle(options))
+
+    await act(async () => {
+      await result.current.handleConnect(mockDevice)
+    })
+
+    expect(mocks.syncNow).not.toHaveBeenCalled()
+    expect(mocks.applyDevicePrefs).toHaveBeenCalledWith('uid-1')
+  })
+
+  it('skips sync download when not authenticated', async () => {
+    const { options, mocks } = makeOptions({ authenticated: false })
+    const { result } = renderHook(() => useDeviceLifecycle(options))
+
+    await act(async () => {
+      await result.current.handleConnect(mockDevice)
+    })
+
+    expect(mocks.syncNow).not.toHaveBeenCalled()
+    expect(mocks.applyDevicePrefs).toHaveBeenCalledWith('uid-1')
+  })
+
+  it('still applies device prefs when sync download fails', async () => {
+    const syncNow = vi.fn().mockRejectedValue(new Error('network error'))
+    const { options, mocks } = makeOptions({}, { syncNow })
+    const { result } = renderHook(() => useDeviceLifecycle(options))
+
+    await act(async () => {
+      await result.current.handleConnect(mockDevice)
+    })
+
+    expect(syncNow).toHaveBeenCalled()
+    expect(mocks.applyDevicePrefs).toHaveBeenCalledWith('uid-1')
+  })
+})

--- a/src/renderer/hooks/useDeviceLifecycle.ts
+++ b/src/renderer/hooks/useDeviceLifecycle.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useAutoLock } from './useAutoLock'
 import { isKeyboardDefinition, isVilFile, isVilFileV1, VILFILE_CURRENT_VERSION } from '../../shared/vil-file'
 import type { DeviceInfo, VilFile, KeyboardDefinition } from '../../shared/types/protocol'
+import type { SyncScope } from '../../shared/types/sync'
 import type { PipetteFileKeyboard, PipetteFileEntry } from '../app-types'
 
 interface Options {
@@ -30,7 +31,7 @@ interface Options {
   autoSync: boolean
   authenticated: boolean
   hasPassword: boolean
-  syncNow: (direction: string, target: string) => Promise<void>
+  syncNow: (direction: 'download' | 'upload', scope?: SyncScope) => Promise<void>
   deviceSyncing: boolean
   // Cross-cutting callbacks
   resetUIState: () => void
@@ -111,6 +112,21 @@ export function useDeviceLifecycle(options: Options) {
       if (success) {
         const uid = await keyboardReload()
         if (uid) {
+          // Pull the cloud copies of keyboards/{uid}/* (and favorites) BEFORE
+          // applying local prefs. Otherwise applyDevicePrefs sees a missing
+          // local file, writes defaults with a fresh _updatedAt, and the
+          // file-level LWW merge later overwrites the good remote copy with
+          // empty defaults (issue #190: layer names lost on PC switch).
+          // Covers favorites too because syncNow has a global `isSyncing`
+          // mutex — running the two scopes here as one call avoids a race
+          // with useDeviceAutoSync's parallel `syncNow` no-oping silently.
+          if (autoSync && authenticated && hasPassword) {
+            try {
+              await syncNow('download', { favorites: true, keyboard: uid })
+            } catch {
+              // Non-fatal — fall through to apply whatever local data we have.
+            }
+          }
           await applyDevicePrefs(uid)
         } else {
           try { await handleDisconnect() } catch { /* cleanup best-effort */ }
@@ -118,7 +134,8 @@ export function useDeviceLifecycle(options: Options) {
         }
       }
     },
-    [connectDevice, keyboardReload, applyDevicePrefs, handleDisconnect, t],
+    [connectDevice, keyboardReload, applyDevicePrefs, handleDisconnect, t,
+     autoSync, authenticated, hasPassword, syncNow],
   )
 
   const handleLock = useCallback(async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,12 @@ export default defineConfig({
       // depend on the Electron-ABI prebuilt binary. Production code path is
       // untouched — the alias only applies inside vitest's module graph.
       'better-sqlite3': resolve(__dirname, 'src/main/__tests__/better-sqlite3-adapter.ts'),
+      // Replace the real `electron` package with a stub. The real package's
+      // `index.js` throws "Electron failed to install correctly" at module
+      // load when `path.txt` is missing, which can happen on fresh CI
+      // installs where the postinstall script silently short-circuits.
+      // Tests that need specific behavior still override via `vi.mock`.
+      electron: resolve(__dirname, 'src/main/__tests__/electron-stub.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Fixes #190 — Layer names (and other `PipetteSettings` fields) silently reset when moving a keyboard between two synced computers
- Bundles a new theme pack (Morphous Abalone) and bumps version to v0.4.7

## Root cause

`useDeviceLifecycle.handleConnect` invoked `applyDevicePrefs(uid)` immediately after `keyboardReload()`, before the cloud copy of `keyboards/{uid}/settings` was downloaded. When the second machine had no local `pipette_settings.json` yet, `applyDevicePrefs` wrote defaults with a fresh `_updatedAt`. The file-level LWW merge then judged the empty local file newer than the remote good copy and overwrote the cloud — so the next sync wiped layer names.

Restoring a snapshot brought them back because snapshots live in a separate sync unit (`keyboards/{uid}/snapshots`, entry-level LWW) which was untouched by the race.

## Fix

`handleConnect` now `await`s `syncNow('download', { favorites: true, keyboard: uid })` before `applyDevicePrefs` when sync is ready (`autoSync && authenticated && hasPassword`). Failures are non-fatal — fall through to apply local data. Combining both scopes in one call dodges a race with `useDeviceAutoSync`'s parallel download (which would no-op silently against the global `isSyncing` mutex).

## Side benefit

The same race affected every other `PipetteSettings` field re-initialized on connect (`autoAdvance`, `typingTestConfig`, `typingViewMenuTab`, etc.). All of them are now safe.

## Test plan

- [x] Regression tests in `useDeviceLifecycle.test.ts` cover: call order (sync → apply), autoSync off skip, unauthenticated skip, sync failure falls through to apply
- [x] `pnpm test` — 4126 passed / 22 skipped
- [x] `pnpm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: connect a keyboard with layer names set on Machine A, then plug into Machine B and confirm layer names survive