### PR TITLE
chore(release): bump version to 0.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
Release v0.4.8. Bumps `package.json` to 0.4.8 ahead of tagging.

Includes the Private (Unlisted) Uploads feature (#194) and its screenshot/docs follow-up (#195) merged since v0.4.7.