### PR TITLE
ci(release): set up MSBuild on Windows for native module rebuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,12 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      # node-gyp / electron-rebuild needs MSBuild to compile native
+      # modules (node-hid, better-sqlite3) on Windows runners.
+      - name: Set up MSBuild (Windows)
+        if: matrix.platform == 'win'
+        uses: microsoft/setup-msbuild@v2
+
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev


### PR DESCRIPTION
The v0.4.8 release run failed: on `windows-latest`, `electron-rebuild` (postinstall) could not rebuild native modules (node-hid, better-sqlite3) — node-gyp reported "Could not find any Visual Studio installation to use".

Adds `microsoft/setup-msbuild@v2` (Windows only) before `pnpm install` so node-gyp can locate the toolchain. Node stays on 24.

After merge: re-tag v0.4.8 on the updated main and push to re-trigger the Release workflow. If node-gyp still can't find the VC++ workload, the next step is pinning `windows-2022`.