### PR TITLE
ci(release): pin Windows runner to windows-2022 for node-gyp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,9 @@ jobs:
           - os: macos-latest
             platform: mac
             arch: arm64
-          - os: windows-latest
+          # Pin to windows-2022 (VS 2022 / v17): node-gyp 11 cannot yet
+          # detect the VS 18 toolchain that windows-latest now ships.
+          - os: windows-2022
             platform: win
             arch: x64
           - os: ubuntu-latest
@@ -70,12 +72,6 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-
-      # node-gyp / electron-rebuild needs MSBuild to compile native
-      # modules (node-hid, better-sqlite3) on Windows runners.
-      - name: Set up MSBuild (Windows)
-        if: matrix.platform == 'win'
-        uses: microsoft/setup-msbuild@v2
 
       - name: Install Linux dependencies
         if: matrix.platform == 'linux'


### PR DESCRIPTION
The v0.4.8 Release run still failed on Windows after adding setup-msbuild: `windows-latest` now ships **Visual Studio 18**, which **node-gyp 11.5.0 cannot detect** (`Could not find any Visual Studio installation to use"`), so the node-hid / better-sqlite3 native rebuild fails.

Pins the Windows build matrix to **windows-2022** (VS 2022 / v17), which node-gyp recognises — the same image that built v0.4.7 successfully. Also removes the now-unnecessary `microsoft/setup-msbuild` step.

After merge: re-point the v0.4.8 tag to the updated main and push to re-run Release.