### PR TITLE
feat(ui): add Typing Test custom text import

### DIFF
--- a/src/main/__tests__/typing-test-text-store.test.ts
+++ b/src/main/__tests__/typing-test-text-store.test.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+// --- Mock electron ---
+
+let mockUserDataPath = ''
+const showOpenDialog = vi.fn()
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+  dialog: {
+    showOpenDialog: (...args: unknown[]) => showOpenDialog(...args),
+  },
+  BrowserWindow: {},
+}))
+
+vi.mock('../sync/sync-service', () => ({
+  notifyChange: vi.fn(),
+}))
+
+// --- Import after mocking ---
+
+import { notifyChange } from '../sync/sync-service'
+import {
+  saveRecord,
+  listMetas,
+  listAllMetas,
+  getRecord,
+  renameRecord,
+  deleteRecord,
+  hasActiveName,
+  importFromDialog,
+  confirmImportOverwrite,
+  TYPING_TEST_TEXT_SYNC_UNIT,
+} from '../typing-test-text-store'
+import { parseCustomText, normalizeCustomText, TYPING_TEST_TEXT_MAX_WORDS } from '../../shared/types/typing-test-text-store'
+
+const fakeWin = {} as Electron.BrowserWindow
+
+describe('typing-test-text-store', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'tt-text-store-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  describe('parseCustomText', () => {
+    it('collapses intra-line whitespace and keeps single-line as no breaks', () => {
+      expect(parseCustomText('  the  quick\t fox ')).toEqual({ words: ['the', 'quick', 'fox'], lineBreaks: [], indents: ['  '] })
+    })
+
+    it('treats newline as a line break distinct from space', () => {
+      // "the quick" / "brown fox": break after index 1, none after the last word.
+      expect(parseCustomText('the quick\nbrown fox')).toEqual({ words: ['the', 'quick', 'brown', 'fox'], lineBreaks: [1], indents: ['', ''] })
+    })
+
+    it('normalizes CRLF/CR and drops empty lines', () => {
+      expect(parseCustomText('a\r\n\r\nb\rc')).toEqual({ words: ['a', 'b', 'c'], lineBreaks: [0, 1], indents: ['', '', ''] })
+    })
+
+    it('caps at the word limit', () => {
+      const many = Array.from({ length: TYPING_TEST_TEXT_MAX_WORDS + 50 }, (_, i) => `w${i}`).join(' ')
+      expect(parseCustomText(many).words).toHaveLength(TYPING_TEST_TEXT_MAX_WORDS)
+    })
+  })
+
+  describe('normalizeCustomText', () => {
+    it('canonicalizes with single spaces in a line and newline at breaks', () => {
+      expect(normalizeCustomText('the  quick\nbrown   fox')).toEqual({ text: 'the quick\nbrown fox', wordCount: 4 })
+    })
+
+    it('preserves leading indentation per line (code structure)', () => {
+      expect(normalizeCustomText('def f() {\n  val x = 1\n}')).toEqual({ text: 'def f() {\n  val x = 1\n}', wordCount: 8 })
+    })
+
+    it('round-trips through parseCustomText', () => {
+      const { text } = normalizeCustomText('a b\nc\n\nd e f')
+      expect(parseCustomText(text)).toEqual(parseCustomText('a b\nc\n\nd e f'))
+    })
+  })
+
+  describe('saveRecord', () => {
+    it('saves text + meta with wordCount and notifies sync', async () => {
+      const result = await saveRecord({ name: 'My Novel', text: 'the quick brown fox' })
+      expect(result.success).toBe(true)
+      expect(result.data?.wordCount).toBe(4)
+      expect(result.data?.id).toBeTruthy()
+      expect(notifyChange).toHaveBeenCalledWith(TYPING_TEST_TEXT_SYNC_UNIT)
+
+      const metas = await listMetas()
+      expect(metas).toHaveLength(1)
+      expect(metas[0].name).toBe('My Novel')
+    })
+
+    it('rejects empty / whitespace-only text', async () => {
+      const result = await saveRecord({ name: 'Empty', text: '   \n\t  ' })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('EMPTY_TEXT')
+    })
+
+    it('rejects an empty name', async () => {
+      const result = await saveRecord({ name: '   ', text: 'hello world' })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('INVALID_NAME')
+    })
+
+    it('rejects a duplicate active name', async () => {
+      await saveRecord({ name: 'Dup', text: 'one two' })
+      const result = await saveRecord({ name: 'dup', text: 'three four' })
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('DUPLICATE_NAME')
+    })
+
+    it('overwrites in place when the same id is passed', async () => {
+      const first = await saveRecord({ name: 'Doc', text: 'a b c' })
+      const id = first.data!.id
+      const second = await saveRecord({ id, name: 'Doc', text: 'a b c d e' })
+      expect(second.success).toBe(true)
+      const metas = await listMetas()
+      expect(metas).toHaveLength(1)
+      expect(metas[0].wordCount).toBe(5)
+    })
+  })
+
+  describe('getRecord', () => {
+    it('returns stored text joined back from words, keeping leading indentation', async () => {
+      const saved = await saveRecord({ name: 'Read', text: '  hello   world  ' })
+      const rec = await getRecord(saved.data!.id)
+      expect(rec.success).toBe(true)
+      // Intra-line whitespace collapses, trailing drops, leading indent stays.
+      expect(rec.data?.data.text).toBe('  hello world')
+    })
+
+    it('NOT_FOUND for unknown id', async () => {
+      const rec = await getRecord('nope')
+      expect(rec.success).toBe(false)
+      expect(rec.errorCode).toBe('NOT_FOUND')
+    })
+
+    it('preserves line breaks: stored text keeps newlines distinct from spaces', async () => {
+      const saved = await saveRecord({ name: 'Multi', text: 'the quick brown\nfox jumps\n\nover' })
+      expect(saved.data?.wordCount).toBe(6)
+      const rec = await getRecord(saved.data!.id)
+      // Single spaces within a line, a newline at each line break, blank line dropped.
+      expect(rec.data?.data.text).toBe('the quick brown\nfox jumps\nover')
+    })
+  })
+
+  describe('renameRecord', () => {
+    it('renames and bumps updatedAt', async () => {
+      const saved = await saveRecord({ name: 'Old', text: 'x y z' })
+      const renamed = await renameRecord(saved.data!.id, 'New')
+      expect(renamed.success).toBe(true)
+      expect(renamed.data?.name).toBe('New')
+      const rec = await getRecord(saved.data!.id)
+      expect(rec.data?.data.name).toBe('New')
+    })
+
+    it('rejects duplicate name on rename', async () => {
+      await saveRecord({ name: 'A', text: 'a' })
+      const b = await saveRecord({ name: 'B', text: 'b' })
+      const result = await renameRecord(b.data!.id, 'A')
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('DUPLICATE_NAME')
+    })
+  })
+
+  describe('deleteRecord', () => {
+    it('soft-deletes: hidden from listMetas, present in listAllMetas as tombstone', async () => {
+      const saved = await saveRecord({ name: 'Gone', text: 'bye' })
+      const del = await deleteRecord(saved.data!.id)
+      expect(del.success).toBe(true)
+      expect(await listMetas()).toHaveLength(0)
+      const all = await listAllMetas()
+      expect(all).toHaveLength(1)
+      expect(all[0].deletedAt).toBeTruthy()
+    })
+
+    it('frees the name for reuse after delete', async () => {
+      const saved = await saveRecord({ name: 'Reuse', text: 'one' })
+      await deleteRecord(saved.data!.id)
+      expect(await hasActiveName('Reuse')).toBe(false)
+      const again = await saveRecord({ name: 'Reuse', text: 'two' })
+      expect(again.success).toBe(true)
+    })
+  })
+
+  describe('importFromDialog', () => {
+    it('imports a .txt file using the base name as the entry name', async () => {
+      const filePath = join(mockUserDataPath, 'poem.txt')
+      await writeFile(filePath, 'roses are red', 'utf-8')
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [filePath] })
+
+      const result = await importFromDialog(fakeWin)
+      expect(result.success).toBe(true)
+      expect(result.data?.name).toBe('poem')
+      expect(result.data?.wordCount).toBe(3)
+    })
+
+    it('returns cancelled when the dialog is dismissed', async () => {
+      showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] })
+      const result = await importFromDialog(fakeWin)
+      expect(result.success).toBe(false)
+      expect(result.error).toBe('cancelled')
+    })
+
+    it('rejects a non-UTF-8 (e.g. Shift-JIS) file with NOT_UTF8', async () => {
+      const filePath = join(mockUserDataPath, 'sjis.txt')
+      // Shift-JIS bytes for "あい" — invalid as UTF-8.
+      await writeFile(filePath, Buffer.from([0x82, 0xA0, 0x82, 0xA2]))
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [filePath] })
+
+      const result = await importFromDialog(fakeWin)
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_UTF8')
+    })
+
+    it('accepts a UTF-8 file with a BOM (BOM stripped)', async () => {
+      const filePath = join(mockUserDataPath, 'bom.txt')
+      await writeFile(filePath, Buffer.concat([Buffer.from([0xEF, 0xBB, 0xBF]), Buffer.from('hello world', 'utf-8')]))
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [filePath] })
+
+      const result = await importFromDialog(fakeWin)
+      expect(result.success).toBe(true)
+      expect(result.data?.wordCount).toBe(2)
+      const rec = await getRecord(result.data!.id)
+      expect(rec.data?.data.text).toBe('hello world')
+    })
+
+    it('rejects files over the size limit', async () => {
+      const filePath = join(mockUserDataPath, 'big.txt')
+      // 5 MB + 1 byte of ASCII (over TYPING_TEST_TEXT_MAX_FILE_BYTES)
+      await writeFile(filePath, 'a'.repeat(5 * 1024 * 1024 + 1), 'utf-8')
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [filePath] })
+
+      const result = await importFromDialog(fakeWin)
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('TOO_LARGE')
+    })
+
+    it('re-import of an existing name asks to confirm, then overwrites in place', async () => {
+      const filePath = join(mockUserDataPath, 'doc.txt')
+      await writeFile(filePath, 'one two', 'utf-8')
+      showOpenDialog.mockResolvedValue({ canceled: false, filePaths: [filePath] })
+      const first = await importFromDialog(fakeWin)
+
+      await writeFile(filePath, 'one two three four', 'utf-8')
+      // Collision: held for confirmation, nothing saved yet.
+      const second = await importFromDialog(fakeWin)
+      expect(second.success).toBe(false)
+      expect(second.errorCode).toBe('DUPLICATE_NAME')
+      expect(second.error).toBe('doc')
+      expect((await listMetas())[0].wordCount).toBe(2)
+
+      // Confirm → overwrites the same entry in place.
+      const confirmed = await confirmImportOverwrite()
+      expect(confirmed.success).toBe(true)
+      expect(confirmed.data?.id).toBe(first.data?.id)
+      const metas = await listMetas()
+      expect(metas).toHaveLength(1)
+      expect(metas[0].wordCount).toBe(4)
+    })
+
+    it('confirmImportOverwrite without a pending import fails', async () => {
+      const result = await confirmImportOverwrite()
+      expect(result.success).toBe(false)
+      expect(result.errorCode).toBe('NOT_FOUND')
+    })
+  })
+
+  it('persists index.json under sync/typing-test-texts', async () => {
+    await saveRecord({ name: 'Persist', text: 'check disk' })
+    const raw = await readFile(join(mockUserDataPath, 'sync', TYPING_TEST_TEXT_SYNC_UNIT, 'index.json'), 'utf-8')
+    const parsed = JSON.parse(raw) as { entries: unknown[] }
+    expect(parsed.entries).toHaveLength(1)
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,6 +7,7 @@ import { setupSnapshotStore } from './snapshot-store'
 import { setupAnalyzeFilterStore } from './analyze-filter-store'
 import { setupFavoriteStore } from './favorite-store'
 import { setupKeyLabelStore } from './key-label-ipc'
+import { setupTypingTestTextStore } from './typing-test-text-ipc'
 import { setupI18nPackStore } from './i18n-pack-ipc'
 import { setupThemePackStore } from './theme-pack-ipc'
 import { setupHidIpc } from './hid-ipc'
@@ -312,6 +313,7 @@ app.whenReady().then(() => {
   setupAnalyzeFilterStore()
   setupFavoriteStore()
   setupKeyLabelStore()
+  setupTypingTestTextStore()
   setupI18nPackStore()
   setupThemePackStore()
   setupPipetteSettingsStore()

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -84,6 +84,9 @@ function isValidPrefs(value: unknown): value is PipetteSettings {
     if (typeof ws.width !== 'number' || typeof ws.height !== 'number') return false
   }
   if ('typingTestViewOnlyAlwaysOnTop' in obj && obj.typingTestViewOnlyAlwaysOnTop != null && typeof obj.typingTestViewOnlyAlwaysOnTop !== 'boolean') return false
+  if ('typingTestMemory' in obj && obj.typingTestMemory != null && (typeof obj.typingTestMemory !== 'object' || Array.isArray(obj.typingTestMemory))) return false
+  if ('typingTestDisplayLines' in obj && obj.typingTestDisplayLines != null && typeof obj.typingTestDisplayLines !== 'number') return false
+  if ('typingTestFontSize' in obj && obj.typingTestFontSize != null && typeof obj.typingTestFontSize !== 'number') return false
   if ('typingRecordEnabled' in obj && obj.typingRecordEnabled != null && typeof obj.typingRecordEnabled !== 'boolean') return false
   if ('typingSyncSpanDays' in obj && obj.typingSyncSpanDays != null && !isTypingSyncSpanDays(obj.typingSyncSpanDays)) return false
   if ('typingViewMenuTab' in obj && obj.typingViewMenuTab != null && !isTypingViewMenuTab(obj.typingViewMenuTab)) return false
@@ -130,6 +133,9 @@ async function readData(uid: string): Promise<PipetteSettings | null> {
       typingTestViewOnly: parsed.typingTestViewOnly,
       typingTestViewOnlyWindowSize: parsed.typingTestViewOnlyWindowSize,
       typingTestViewOnlyAlwaysOnTop: parsed.typingTestViewOnlyAlwaysOnTop,
+      typingTestMemory: parsed.typingTestMemory,
+      typingTestDisplayLines: parsed.typingTestDisplayLines,
+      typingTestFontSize: parsed.typingTestFontSize,
       typingRecordEnabled: parsed.typingRecordEnabled,
       typingSyncSpanDays: parsed.typingSyncSpanDays,
       typingViewMenuTab: parsed.typingViewMenuTab,

--- a/src/main/sync/merge.ts
+++ b/src/main/sync/merge.ts
@@ -4,8 +4,10 @@
 import type { SavedFavoriteMeta } from '../../shared/types/favorite-store'
 import type { SnapshotMeta } from '../../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from '../../shared/types/analyze-filter-store'
+import type { KeyLabelMeta } from '../../shared/types/key-label-store'
+import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 
-type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta
+type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta | KeyLabelMeta | TypingTestTextMeta
 
 const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 

--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -11,9 +11,11 @@ import type { FavoriteIndex } from '../../shared/types/favorite-store'
 import type { SnapshotIndex } from '../../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotIndex } from '../../shared/types/analyze-filter-store'
 import type { KeyLabelIndex } from '../../shared/types/key-label-store'
+import type { TypingTestTextIndex } from '../../shared/types/typing-test-text-store'
 import type { SyncBundle } from '../../shared/types/sync'
 import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
+import { TYPING_TEST_TEXT_SYNC_UNIT } from '../typing-test-text-store'
 import { I18N_INDEX_SYNC_UNIT, type I18nPackIndex } from '../../shared/types/i18n-store'
 import { THEME_INDEX_SYNC_UNIT, type ThemePackIndex } from '../../shared/types/theme-store'
 import {
@@ -28,10 +30,10 @@ import {
 } from '../typing-analytics/sync'
 import { log } from '../logger'
 
-export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex | null> {
+export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex | TypingTestTextIndex | null> {
   try {
     const raw = await readFile(join(dir, 'index.json'), 'utf-8')
-    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex
+    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex | TypingTestTextIndex
   } catch {
     return null
   }
@@ -175,6 +177,9 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
   if (syncUnit === KEY_LABEL_SYNC_UNIT) {
     type = 'key-label'
     key = KEY_LABEL_SYNC_UNIT
+  } else if (syncUnit === TYPING_TEST_TEXT_SYNC_UNIT) {
+    type = 'typing-test-text'
+    key = TYPING_TEST_TEXT_SYNC_UNIT
   } else if (parts[0] === 'favorites') {
     type = 'favorite'
     key = parts[1]
@@ -230,6 +235,11 @@ export async function collectAllSyncUnits(): Promise<string[]> {
     await access(join(userData, 'sync', KEY_LABEL_SYNC_UNIT, 'index.json'))
     units.push(KEY_LABEL_SYNC_UNIT)
   } catch { /* no key labels */ }
+
+  try {
+    await access(join(userData, 'sync', TYPING_TEST_TEXT_SYNC_UNIT, 'index.json'))
+    units.push(TYPING_TEST_TEXT_SYNC_UNIT)
+  } catch { /* no typing-test texts */ }
 
   // i18n: emit "i18n/index" plus one "i18n/packs/{packId}" per known
   // meta (including tombstones — the tombstone needs to propagate to

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -346,7 +346,12 @@ export function setupSyncIpc(): void {
         stopPolling()
       } else {
         if (targets.keyboards) cancelPendingChanges('keyboards/')
-        if (targets.favorites) cancelPendingChanges('favorites/')
+        if (targets.favorites) {
+          cancelPendingChanges('favorites/')
+          // Imported typing-test texts are global user content — reset
+          // them alongside favorites (the global-content reset bucket).
+          cancelPendingChanges('typing-test-texts')
+        }
         if (targets.i18nPacks) cancelPendingChanges(I18N_SYNC_UNIT_PREFIX)
         if (targets.themePacks) cancelPendingChanges(THEME_SYNC_UNIT_PREFIX)
         // Clearing appSettings resets autoSync config, so stop polling to match
@@ -357,6 +362,7 @@ export function setupSyncIpc(): void {
       }
       if (targets.favorites) {
         await rm(join(userData, 'sync', 'favorites'), { recursive: true, force: true })
+        await rm(join(userData, 'sync', 'typing-test-texts'), { recursive: true, force: true })
       }
       if (targets.i18nPacks) {
         await rm(join(userData, 'sync', 'i18n'), { recursive: true, force: true })

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -36,6 +36,7 @@ import {
 } from './keyboard-meta'
 import { KEYBOARD_META_SYNC_UNIT, type KeyboardMetaIndex } from '../../shared/types/keyboard-meta'
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
+import { TYPING_TEST_TEXT_SYNC_UNIT } from '../typing-test-text-store'
 import { I18N_SYNC_UNIT_PREFIX } from '../../shared/types/i18n-store'
 import { THEME_SYNC_UNIT_PREFIX } from '../../shared/types/theme-store'
 import {
@@ -142,6 +143,7 @@ export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean
   if (syncUnit === null) return false
   if (syncUnit === KEYBOARD_META_SYNC_UNIT) return true // meta follows every scope
   if (syncUnit === KEY_LABEL_SYNC_UNIT) return true // key-labels follow every scope (global, all-keyboard)
+  if (syncUnit === TYPING_TEST_TEXT_SYNC_UNIT) return true // imported typing-test texts follow every scope (global, all-keyboard)
   if (syncUnit.startsWith(I18N_SYNC_UNIT_PREFIX)) return false // i18n checked once at startup via i18n-startup-sync
   if (syncUnit.startsWith(THEME_SYNC_UNIT_PREFIX)) return false // themes follow i18n pattern — not in periodic polls
   if (scope === 'favorites') return syncUnit.startsWith('favorites/')

--- a/src/main/typing-test-text-ipc.ts
+++ b/src/main/typing-test-text-ipc.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// IPC handlers for the local Typing Test text store.
+
+import { BrowserWindow } from 'electron'
+import { IpcChannels } from '../shared/ipc/channels'
+import { secureHandle } from './ipc-guard'
+import {
+  listMetas,
+  getRecord,
+  renameRecord,
+  deleteRecord,
+  importFromDialog,
+  confirmImportOverwrite,
+} from './typing-test-text-store'
+import type {
+  TypingTestTextMeta,
+  TypingTestTextRecord,
+  TypingTestTextStoreResult,
+} from '../shared/types/typing-test-text-store'
+
+export function setupTypingTestTextStore(): void {
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_LIST,
+    async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta[]>> => {
+      try {
+        const entries = await listMetas()
+        return { success: true, data: entries }
+      } catch (err) {
+        return { success: false, errorCode: 'IO_ERROR', error: String(err) }
+      }
+    },
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_GET,
+    async (_event, id: unknown): Promise<TypingTestTextStoreResult<TypingTestTextRecord>> => {
+      if (typeof id !== 'string') {
+        return { success: false, errorCode: 'NOT_FOUND', error: 'Invalid id' }
+      }
+      return getRecord(id)
+    },
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_RENAME,
+    async (_event, id: unknown, newName: unknown): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
+      if (typeof id !== 'string') {
+        return { success: false, errorCode: 'NOT_FOUND', error: 'Invalid id' }
+      }
+      if (typeof newName !== 'string') {
+        return { success: false, errorCode: 'INVALID_NAME', error: 'Invalid name' }
+      }
+      return renameRecord(id, newName)
+    },
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_DELETE,
+    async (_event, id: unknown): Promise<TypingTestTextStoreResult<void>> => {
+      if (typeof id !== 'string') {
+        return { success: false, errorCode: 'NOT_FOUND', error: 'Invalid id' }
+      }
+      return deleteRecord(id)
+    },
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_IMPORT,
+    async (event): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
+      const win = BrowserWindow.fromWebContents(event.sender)
+      if (!win) return { success: false, errorCode: 'IO_ERROR', error: 'No window' }
+      return importFromDialog(win)
+    },
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_TEST_TEXT_IMPORT_CONFIRM,
+    async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => confirmImportOverwrite(),
+  )
+}

--- a/src/main/typing-test-text-store.ts
+++ b/src/main/typing-test-text-store.ts
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Local store for imported Typing Test texts — mirrors key-label-store's
+// index + per-entry layout. Cross-keyboard (global), entry-level LWW.
+
+import { app, dialog, BrowserWindow } from 'electron'
+import { join, basename } from 'node:path'
+import { mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { notifyChange } from './sync/sync-service'
+import type {
+  TypingTestTextMeta,
+  TypingTestTextIndex,
+  TypingTestTextEntryFile,
+  TypingTestTextRecord,
+  TypingTestTextStoreResult,
+  TypingTestTextStoreErrorCode,
+} from '../shared/types/typing-test-text-store'
+import {
+  TYPING_TEST_TEXT_MAX_FILE_BYTES,
+  normalizeCustomText,
+} from '../shared/types/typing-test-text-store'
+
+export const TYPING_TEST_TEXT_SYNC_UNIT = 'typing-test-texts'
+const MAX_NAME_LENGTH = 100
+
+// An import that collided with an existing name, parsed but not yet saved.
+// Held here so confirmImportOverwrite() can commit it without re-picking the
+// file. Single-slot: a newer import replaces any earlier pending one.
+let pendingImport: { name: string; text: string; existingId: string } | null = null
+
+function getStoreDir(): string {
+  return join(app.getPath('userData'), 'sync', TYPING_TEST_TEXT_SYNC_UNIT)
+}
+
+function getIndexPath(): string {
+  return join(getStoreDir(), 'index.json')
+}
+
+function isSafePathSegment(segment: string): boolean {
+  if (!segment || segment === '.' || segment === '..') return false
+  return !/[/\\]/.test(segment)
+}
+
+function getEntryPath(filename: string): string {
+  if (!isSafePathSegment(filename)) throw new Error('Invalid filename')
+  return join(getStoreDir(), filename)
+}
+
+function fail<T>(errorCode: TypingTestTextStoreErrorCode, error: string): TypingTestTextStoreResult<T> {
+  return { success: false, errorCode, error }
+}
+
+function ok<T>(data?: T): TypingTestTextStoreResult<T> {
+  return { success: true, data }
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function tsForFilename(now: Date = new Date()): string {
+  return now.toISOString().replace(/:/g, '-')
+}
+
+async function readIndex(): Promise<TypingTestTextIndex> {
+  try {
+    const raw = await readFile(getIndexPath(), 'utf-8')
+    const parsed = JSON.parse(raw) as TypingTestTextIndex
+    if (Array.isArray(parsed?.entries)) return parsed
+  } catch {
+    // missing / corrupt — return empty
+  }
+  return { entries: [] }
+}
+
+async function writeIndex(index: TypingTestTextIndex): Promise<void> {
+  await mkdir(getStoreDir(), { recursive: true })
+  await writeFile(getIndexPath(), JSON.stringify(index, null, 2), 'utf-8')
+}
+
+function findActiveByName(entries: TypingTestTextMeta[], name: string, excludeId?: string): TypingTestTextMeta | undefined {
+  const target = name.trim().toLowerCase()
+  return entries.find((e) => !e.deletedAt && e.id !== excludeId && e.name.trim().toLowerCase() === target)
+}
+
+function validateName(value: unknown): TypingTestTextStoreResult<string> {
+  if (typeof value !== 'string') return fail('INVALID_NAME', 'name must be a string')
+  const trimmed = value.trim()
+  if (!trimmed) return fail('INVALID_NAME', 'name must not be empty')
+  if (trimmed.length > MAX_NAME_LENGTH) {
+    return fail('INVALID_NAME', `name must be at most ${String(MAX_NAME_LENGTH)} characters`)
+  }
+  return ok(trimmed)
+}
+
+function normalizeFile(parsed: unknown): TypingTestTextEntryFile | null {
+  if (!parsed || typeof parsed !== 'object') return null
+  const obj = parsed as Record<string, unknown>
+  if (typeof obj.name !== 'string') return null
+  if (typeof obj.text !== 'string') return null
+  return { name: obj.name, text: obj.text }
+}
+
+async function listInternal(includeDeleted: boolean): Promise<TypingTestTextMeta[]> {
+  const { entries } = await readIndex()
+  return includeDeleted ? entries : entries.filter((e) => !e.deletedAt)
+}
+
+export async function listMetas(): Promise<TypingTestTextMeta[]> {
+  return listInternal(false)
+}
+
+export async function listAllMetas(): Promise<TypingTestTextMeta[]> {
+  return listInternal(true)
+}
+
+export async function getRecord(id: string): Promise<TypingTestTextStoreResult<TypingTestTextRecord>> {
+  try {
+    const index = await readIndex()
+    const meta = index.entries.find((e) => e.id === id)
+    if (!meta || meta.deletedAt) return fail('NOT_FOUND', 'Text not found')
+    const raw = await readFile(getEntryPath(meta.filename), 'utf-8')
+    const parsed = normalizeFile(JSON.parse(raw))
+    if (!parsed) return fail('INVALID_FILE', 'Stored file is malformed')
+    return ok({ meta, data: parsed })
+  } catch (err) {
+    return fail('IO_ERROR', String(err))
+  }
+}
+
+export interface SaveTextInput {
+  /** Carry an existing id to overwrite in place (re-import). */
+  id?: string
+  name: string
+  /** Raw text — normalized + word-capped here. */
+  text: string
+}
+
+async function writeRecord(meta: TypingTestTextMeta, data: TypingTestTextEntryFile): Promise<void> {
+  await mkdir(getStoreDir(), { recursive: true })
+  await writeFile(getEntryPath(meta.filename), JSON.stringify(data, null, 2), 'utf-8')
+}
+
+export async function saveRecord(input: SaveTextInput): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> {
+  const validated = validateName(input.name)
+  if (!validated.success || validated.data === undefined) return validated as TypingTestTextStoreResult<TypingTestTextMeta>
+  const name = validated.data
+
+  const { text, wordCount } = normalizeCustomText(typeof input.text === 'string' ? input.text : '')
+  if (wordCount === 0) return fail('EMPTY_TEXT', 'Text has no typeable words')
+
+  try {
+    const index = await readIndex()
+    if (findActiveByName(index.entries, name, input.id)) {
+      return fail('DUPLICATE_NAME', 'A text with the same name already exists')
+    }
+
+    const now = new Date()
+    const id = input.id ?? randomUUID()
+    const filename = `${id}_${tsForFilename(now)}.json`
+    const data: TypingTestTextEntryFile = { name, text }
+
+    const meta: TypingTestTextMeta = {
+      id,
+      name,
+      wordCount,
+      filename,
+      savedAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    }
+
+    await writeRecord(meta, data)
+
+    // Overwrite path: drop the previous JSON so the entry keeps a single
+    // file on disk. Best-effort — a missing file should not abort.
+    const previous = index.entries.find((e) => e.id === id)
+    if (previous && previous.filename !== filename) {
+      try { await unlink(getEntryPath(previous.filename)) } catch { /* swallow */ }
+    }
+
+    const existingIndex = index.entries.findIndex((e) => e.id === id)
+    let nextEntries: TypingTestTextMeta[]
+    if (existingIndex >= 0) {
+      nextEntries = index.entries.slice()
+      nextEntries[existingIndex] = meta
+    } else {
+      nextEntries = [...index.entries, meta]
+    }
+    await writeIndex({ entries: nextEntries })
+
+    notifyChange(TYPING_TEST_TEXT_SYNC_UNIT)
+    return ok(meta)
+  } catch (err) {
+    return fail('IO_ERROR', String(err))
+  }
+}
+
+export async function renameRecord(id: string, newName: string): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> {
+  const validated = validateName(newName)
+  if (!validated.success || validated.data === undefined) return validated as TypingTestTextStoreResult<TypingTestTextMeta>
+  const name = validated.data
+
+  try {
+    const index = await readIndex()
+    const meta = index.entries.find((e) => e.id === id && !e.deletedAt)
+    if (!meta) return fail('NOT_FOUND', 'Text not found')
+    if (findActiveByName(index.entries, name, id)) {
+      return fail('DUPLICATE_NAME', 'A text with the same name already exists')
+    }
+
+    const filePath = getEntryPath(meta.filename)
+    const raw = await readFile(filePath, 'utf-8')
+    const parsed = normalizeFile(JSON.parse(raw))
+    if (!parsed) return fail('INVALID_FILE', 'Stored file is malformed')
+
+    parsed.name = name
+    await writeFile(filePath, JSON.stringify(parsed, null, 2), 'utf-8')
+
+    meta.name = name
+    meta.updatedAt = nowIso()
+    await writeIndex(index)
+
+    notifyChange(TYPING_TEST_TEXT_SYNC_UNIT)
+    return ok(meta)
+  } catch (err) {
+    return fail('IO_ERROR', String(err))
+  }
+}
+
+export async function deleteRecord(id: string): Promise<TypingTestTextStoreResult<void>> {
+  try {
+    const index = await readIndex()
+    const meta = index.entries.find((e) => e.id === id)
+    if (!meta) return fail('NOT_FOUND', 'Text not found')
+
+    const now = nowIso()
+    meta.deletedAt = now
+    meta.updatedAt = now
+    await writeIndex(index)
+
+    notifyChange(TYPING_TEST_TEXT_SYNC_UNIT)
+    return ok()
+  } catch (err) {
+    return fail('IO_ERROR', String(err))
+  }
+}
+
+/** Returns true if an active entry with the given name (case-insensitive) exists. */
+export async function hasActiveName(name: string, excludeId?: string): Promise<boolean> {
+  const index = await readIndex()
+  return Boolean(findActiveByName(index.entries, name, excludeId))
+}
+
+export async function importFromDialog(
+  win: BrowserWindow,
+): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> {
+  try {
+    const result = await dialog.showOpenDialog(win, {
+      title: 'Import UTF-8 Text',
+      // No extension restriction — any file is allowed. Content is validated
+      // as UTF-8 below (non-UTF-8 is rejected), so the extension is irrelevant.
+      filters: [{ name: 'UTF-8 text', extensions: ['*'] }],
+      properties: ['openFile'],
+    })
+
+    if (result.canceled || result.filePaths.length === 0) {
+      return fail('IO_ERROR', 'cancelled')
+    }
+
+    const filePath = result.filePaths[0]
+    // Gate on the on-disk size first so an oversized file is never read
+    // into memory. (Measuring after decode would also balloon for
+    // non-UTF-8 input via U+FFFD replacement chars.)
+    const { size } = await stat(filePath)
+    if (size > TYPING_TEST_TEXT_MAX_FILE_BYTES) {
+      return fail('TOO_LARGE', 'File exceeds the size limit')
+    }
+    const buf = await readFile(filePath)
+    // UTF-8 only. `fatal: true` throws on any invalid byte sequence (e.g.
+    // a Shift-JIS / CP932 file) so we reject rather than import mojibake.
+    // A leading UTF-8 BOM is stripped by TextDecoder automatically.
+    let raw: string
+    try {
+      raw = new TextDecoder('utf-8', { fatal: true }).decode(buf)
+    } catch {
+      return fail('NOT_UTF8', 'File must be UTF-8 encoded')
+    }
+
+    // Default name from the file's base name (sans extension).
+    const name = basename(filePath).replace(/\.[^/.]+$/, '').trim() || 'Imported text'
+
+    // Re-import of an entry with an existing name overwrites it (the user
+    // opted in by picking the same name back).
+    const index = await readIndex()
+    const existing = findActiveByName(index.entries, name)
+    if (existing) {
+      // Don't overwrite silently — stash the parsed text and let the renderer
+      // confirm. confirmImportOverwrite() commits it. The error carries the
+      // colliding name so the prompt can show it.
+      pendingImport = { name, text: raw, existingId: existing.id }
+      return fail('DUPLICATE_NAME', name)
+    }
+    // No collision — drop any stale pending and save straight away.
+    pendingImport = null
+    return saveRecord({ name, text: raw })
+  } catch (err) {
+    return fail('IO_ERROR', String(err))
+  }
+}
+
+/** Commit the import stashed by importFromDialog when its name collided,
+ *  overwriting the existing entry in place. */
+export async function confirmImportOverwrite(): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> {
+  if (!pendingImport) return fail('NOT_FOUND', 'No pending import to confirm')
+  const { name, text, existingId } = pendingImport
+  pendingImport = null
+  return saveRecord({ id: existingId, name, text })
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,6 +13,7 @@ import type { SnapshotMeta } from '../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from '../shared/types/analyze-filter-store'
 import type { SavedFavoriteMeta, FavoriteImportResult } from '../shared/types/favorite-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from '../shared/types/key-label-store'
+import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from '../shared/types/typing-test-text-store'
 import type { HubKeyLabelItem, HubKeyLabelListResponse, HubKeyLabelListParams, HubKeyLabelTimestampsResponse } from '../shared/types/hub-key-label'
 import type {
   I18nPackMeta,
@@ -285,6 +286,20 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_SET_HUB_POST_ID, id, hubPostId),
   keyLabelStoreHasName: (name: string, excludeId?: string): Promise<KeyLabelStoreResult<boolean>> =>
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_HAS_NAME, name, excludeId),
+
+  // --- Typing Test Text Store (local) ---
+  typingTestTextStoreList: (): Promise<TypingTestTextStoreResult<TypingTestTextMeta[]>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_LIST),
+  typingTestTextStoreGet: (id: string): Promise<TypingTestTextStoreResult<TypingTestTextRecord>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_GET, id),
+  typingTestTextStoreRename: (id: string, newName: string): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_RENAME, id, newName),
+  typingTestTextStoreDelete: (id: string): Promise<TypingTestTextStoreResult<void>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_DELETE, id),
+  typingTestTextStoreImport: (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_IMPORT),
+  typingTestTextStoreImportConfirm: (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_TEST_TEXT_IMPORT_CONFIRM),
 
   // --- Key Label Hub ---
   keyLabelHubList: (params?: HubKeyLabelListParams): Promise<KeyLabelStoreResult<HubKeyLabelListResponse>> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -798,6 +798,8 @@ export function App() {
             typingTestMode={editorUI.typingTestMode}
             onTypingTestModeChange={editorUI.handleTypingTestModeChange}
             onSaveTypingTestResult={devicePrefs.addTypingTestResult}
+            onRenameTypingTestResult={devicePrefs.renameTypingTestResult}
+            onDeleteTypingTestResult={devicePrefs.deleteTypingTestResult}
             typingTestHistory={devicePrefs.typingTestResults}
             typingTestConfig={devicePrefs.typingTestConfig}
             typingTestLanguage={devicePrefs.typingTestLanguage}
@@ -819,6 +821,12 @@ export function App() {
             onTypingTestViewOnlyWindowSizeChange={devicePrefs.setTypingTestViewOnlyWindowSize}
             typingTestViewOnlyAlwaysOnTop={devicePrefs.typingTestViewOnlyAlwaysOnTop}
             onTypingTestViewOnlyAlwaysOnTopChange={devicePrefs.setTypingTestViewOnlyAlwaysOnTop}
+            typingTestMemory={devicePrefs.typingTestMemory}
+            onTypingTestMemoryChange={devicePrefs.setTypingTestMemory}
+            typingTestDisplayLines={devicePrefs.typingTestDisplayLines}
+            typingTestFontSize={devicePrefs.typingTestFontSize}
+            onTypingTestDisplayLinesChange={devicePrefs.setTypingTestDisplayLines}
+            onTypingTestFontSizeChange={devicePrefs.setTypingTestFontSize}
             typingRecordEnabled={devicePrefs.typingRecordEnabled}
             onTypingRecordEnabledChange={handleTypingRecordEnabledChange}
             typingHeatmapWindowMin={appConfig.config.typingHeatmapWindowMin}

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -16,9 +16,11 @@ function historyToggleClass(active: boolean): string {
 interface HistoryToggleProps {
   results: TypingTestResult[]
   deviceName?: string
+  onRename?: (date: string, name: string) => void
+  onDelete?: (date: string) => void
 }
 
-export function HistoryToggle({ results, deviceName }: HistoryToggleProps) {
+export function HistoryToggle({ results, deviceName, onRename, onDelete }: HistoryToggleProps) {
   const { t } = useTranslation()
   const [showHistory, setShowHistory] = useState(false)
 
@@ -59,7 +61,7 @@ export function HistoryToggle({ results, deviceName }: HistoryToggleProps) {
               <h3 id="history-modal-title" className="text-lg font-semibold">{t('editor.typingTest.history.title')}</h3>
               <ModalCloseButton testid="history-modal-close" onClick={() => setShowHistory(false)} />
             </div>
-            <TypingTestHistory results={results} onExportCsv={handleExportCsv} />
+            <TypingTestHistory results={results} onExportCsv={handleExportCsv} onRename={onRename} onDelete={onDelete} />
           </div>
         </div>
       )}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -106,12 +106,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   layerPanelOpen: layerPanelOpenProp, onLayerPanelOpenChange,
   scale: scaleProp = 1, onScaleChange,
   keyEditorZoom, onKeyEditorZoomChange,
-  typingTestMode, onTypingTestModeChange, onSaveTypingTestResult, typingTestHistory,
+  typingTestMode, onTypingTestModeChange, onSaveTypingTestResult, onRenameTypingTestResult, onDeleteTypingTestResult, typingTestHistory,
   typingTestConfig: savedTypingTestConfig, typingTestLanguage: savedTypingTestLanguage,
   onTypingTestConfigChange, onTypingTestLanguageChange,
   typingTestViewOnly, onTypingTestViewOnlyChange,
   typingTestViewOnlyWindowSize, onTypingTestViewOnlyWindowSizeChange,
   typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
+  typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
+  typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
   typingRecordEnabled, onTypingRecordEnabledChange,
   typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
   typingHeatmapWindowMin, onTypingHeatmapWindowMinChange,
@@ -162,10 +164,12 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     matrixMode, pressedKeys, everPressedKeys, hasMatrixTester,
     handleMatrixToggle, handleTypingTestToggle,
     typingTest, handleTypingTestConfigChange, handleTypingTestLanguageChange,
+    pauseTypingTest, resumeTypingTest, restartTypingTestFromStart,
   } = useInputModes({
     rows, cols, getMatrixState, unlocked, onUnlock, onMatrixModeChange, keymap,
     typingTestMode, onTypingTestModeChange, savedTypingTestConfig, savedTypingTestLanguage,
     onTypingTestConfigChange, onTypingTestLanguageChange, onSaveTypingTestResult, typingTestHistory,
+    savedTypingTestMemory, onTypingTestMemoryChange,
     typingTestViewOnly, typingRecordEnabled,
     typingRecordKeyboard: keyboardUid && connectedDevice
       ? {
@@ -932,6 +936,8 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               layers={layers}
               layerNames={layerNames}
               typingTestHistory={typingTestHistory}
+              onRenameTypingTestResult={onRenameTypingTestResult}
+              onDeleteTypingTestResult={onDeleteTypingTestResult}
               deviceName={deviceName}
               pressedKeys={pressedKeys}
               keycodes={typingTestKeycodes}
@@ -942,6 +948,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               keys={layout.keys}
               layerLabel={layerLabel(typingTest.effectiveLayer)}
               contentRef={keyboardContentRef}
+              hasSavedMemory={!!savedTypingTestMemory}
+              displayLines={typingTestDisplayLines}
+              fontSize={typingTestFontSize}
+              onDisplayLinesChange={onTypingTestDisplayLinesChange}
+              onFontSizeChange={onTypingTestFontSizeChange}
+              onPauseTest={pauseTypingTest}
+              onResumeTest={resumeTypingTest}
+              onRestartTestFromStart={restartTypingTestFromStart}
               viewOnly={typingTestViewOnly}
               onViewOnlyChange={onTypingTestViewOnlyChange}
               viewOnlyWindowSize={typingTestViewOnlyWindowSize}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -2,9 +2,10 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Globe } from 'lucide-react'
+import { Pause, Play } from 'lucide-react'
 import { ICON_SM } from '../../constants/ui-tokens'
 import { TypingTestView } from '../../typing-test/TypingTestView'
+import { PauseResumeModal } from '../../typing-test/PauseResumeModal'
 import { LanguageSelectorModal } from '../../typing-test/LanguageSelectorModal'
 import { TypingRecordingConsentModal } from '../../typing-test/TypingRecordingConsentModal'
 import { useTypingHeatmap } from '../../typing-test/useTypingHeatmap'
@@ -16,6 +17,10 @@ import { repositionLayoutKeys, filterVisibleKeys } from '../../../shared/kle/fil
 import type { KleKey } from '../../../shared/kle/types'
 import type { TypingTestResult, TypingViewMenuTab } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, DISPLAY_LINES_MIN, DISPLAY_LINES_MAX, FONT_SIZE_MIN, FONT_SIZE_MAX, FONT_SIZE_STEP } from '../../typing-test/types'
+
+const LINE_OPTIONS = Array.from({ length: DISPLAY_LINES_MAX - DISPLAY_LINES_MIN + 1 }, (_, i) => DISPLAY_LINES_MIN + i)
+const FONT_OPTIONS = Array.from({ length: (FONT_SIZE_MAX - FONT_SIZE_MIN) / FONT_SIZE_STEP + 1 }, (_, i) => FONT_SIZE_MIN + i * FONT_SIZE_STEP)
 import type { useTypingTest } from '../../typing-test/useTypingTest'
 import { BTN_TOGGLE_ACTIVE, BTN_TOGGLE_INACTIVE } from '../../constants/ui-tokens'
 
@@ -36,6 +41,20 @@ export interface TypingTestPaneProps {
   keys: KleKey[]
   layerLabel: string
   contentRef?: React.RefObject<HTMLDivElement | null>
+  /** Memory mode (imported custom text): a paused snapshot is saved. */
+  hasSavedMemory?: boolean
+  onPauseTest?: () => void
+  onResumeTest?: () => void
+  onRestartTestFromStart?: () => void
+  /** Imported-text display preferences (custom mode). */
+  displayLines?: number
+  fontSize?: number
+  onDisplayLinesChange?: (lines: number) => void
+  onFontSizeChange?: (px: number) => void
+  /** Label a saved result (by ISO date) from the History modal. */
+  onRenameTypingTestResult?: (date: string, name: string) => void
+  /** Delete a saved result (by ISO date) from the History modal. */
+  onDeleteTypingTestResult?: (date: string) => void
   viewOnly?: boolean
   onViewOnlyChange?: (enabled: boolean) => void
   viewOnlyWindowSize?: { width: number; height: number }
@@ -96,6 +115,16 @@ export function TypingTestPane({
   keys,
   layerLabel,
   contentRef,
+  hasSavedMemory,
+  onPauseTest,
+  onResumeTest,
+  onRestartTestFromStart,
+  displayLines,
+  fontSize,
+  onDisplayLinesChange,
+  onFontSizeChange,
+  onRenameTypingTestResult,
+  onDeleteTypingTestResult,
   viewOnly,
   onViewOnlyChange,
   viewOnlyWindowSize,
@@ -134,6 +163,7 @@ export function TypingTestPane({
   const heatmapActive = heatmapMaxTotal > 0
   const [showLanguageModal, setShowLanguageModal] = useState(false)
   const [showConsentModal, setShowConsentModal] = useState(false)
+  const [showResumeModal, setShowResumeModal] = useState(false)
 
   const handleRecordToggle = useCallback(() => {
     if (!onRecordEnabledChange) return
@@ -333,10 +363,20 @@ export function TypingTestPane({
           onCancel={handleConsentCancel}
         />
       )}
+      {showResumeModal && (
+        <PauseResumeModal
+          wordIndex={typingTest.state.currentWordIndex}
+          totalWords={typingTest.state.words.length}
+          onResume={() => { setShowResumeModal(false); onResumeTest?.() }}
+          onRestart={() => { setShowResumeModal(false); onRestartTestFromStart?.() }}
+          onCancel={() => setShowResumeModal(false)}
+        />
+      )}
       {!viewOnly && (
         <TypingTestView
           state={typingTest.state}
           wpm={typingTest.wpm}
+          kpm={typingTest.kpm}
           accuracy={typingTest.accuracy}
           elapsedSeconds={typingTest.elapsedSeconds}
           remainingSeconds={typingTest.remainingSeconds}
@@ -348,6 +388,13 @@ export function TypingTestPane({
           onCompositionUpdate={typingTest.processCompositionUpdate}
           onCompositionEnd={typingTest.processCompositionEnd}
           onImeSpaceKey={() => typingTest.processKeyEvent(' ', false, false, false)}
+          displayLines={displayLines}
+          fontSize={fontSize}
+          onNameResult={(name) => {
+            // The auto-save prepends the finished result, so history[0] is it.
+            const date = typingTestHistory?.[0]?.date
+            if (date) onRenameTypingTestResult?.(date, name)
+          }}
         />
       )}
       <div
@@ -361,7 +408,7 @@ export function TypingTestPane({
             style={viewOnly ? { transform: `scale(${cssScale})`, transformOrigin: 'top left' } : undefined}
           >
           {!viewOnly && (
-            <div className="mb-3 flex items-center justify-between px-5">
+            <div className="mb-3 flex items-center justify-between gap-4 px-5">
               <div className="flex items-center gap-4">
                 {layers > 1 && (
                   <div className="flex items-center gap-1.5">
@@ -380,38 +427,108 @@ export function TypingTestPane({
                   </div>
                 )}
                 {typingTest.config.mode !== 'quote' && (
-                  <button
-                    type="button"
-                    data-testid="language-selector"
-                    className="flex items-center gap-1.5 rounded-md border border-edge px-2.5 py-1 text-sm text-content-secondary transition-colors hover:text-content"
-                    onClick={() => setShowLanguageModal(true)}
-                    disabled={typingTest.isLanguageLoading}
-                  >
-                    {typingTest.isLanguageLoading ? (
-                      <span>{t('editor.typingTest.language.loadingLanguage')}</span>
-                    ) : (
-                      <>
-                        <Globe size={ICON_SM} aria-hidden="true" />
-                        <span>{typingTest.language.replace(/_/g, ' ')}</span>
-                      </>
-                    )}
-                  </button>
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-sm text-content-muted">{t('editor.typingTest.modeLabel')}:</span>
+                    <button
+                      type="button"
+                      data-testid="language-selector"
+                      className="rounded-md border border-edge px-2.5 py-1 text-sm text-content-secondary transition-colors hover:text-content"
+                      onClick={() => setShowLanguageModal(true)}
+                      disabled={typingTest.isLanguageLoading}
+                    >
+                      {typingTest.isLanguageLoading ? (
+                        t('editor.typingTest.language.loadingLanguage')
+                      ) : typingTest.config.mode === 'custom' ? (
+                        `${t('editor.typingTest.language.tabCustom')} - ${typingTest.state.currentQuote?.source ?? t('editor.typingTest.language.customText')}`
+                      ) : (
+                        `${t('editor.typingTest.language.tabNormal')} - ${typingTest.language.replace(/_/g, ' ')}`
+                      )}
+                    </button>
+                  </div>
                 )}
                 {showLanguageModal && (
                   <LanguageSelectorModal
                     currentLanguage={typingTest.language}
-                    onSelectLanguage={onLanguageChange}
+                    currentCustomTextId={typingTest.config.mode === 'custom' ? typingTest.config.textId : undefined}
+                    onSelectLanguage={(name) => {
+                      // Picking a language leaves custom mode — fall back to
+                      // a words config so the language source applies.
+                      if (typingTest.config.mode === 'custom') onConfigChange(DEFAULT_CONFIG)
+                      void onLanguageChange(name)
+                    }}
+                    onSelectImport={(textId) => onConfigChange({ mode: 'custom', textId })}
+                    onCurrentTextDeleted={() => {
+                      // The selected imported text was deleted — fall back to
+                      // the default (words mode, English).
+                      onConfigChange(DEFAULT_CONFIG)
+                      void onLanguageChange(DEFAULT_LANGUAGE)
+                    }}
                     onClose={() => setShowLanguageModal(false)}
                   />
+                )}
+                {/* Imported-text display: visible line count + font size. */}
+                {typingTest.config.mode === 'custom' && (
+                  <>
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm text-content-muted">{t('editor.typingTest.lines')}:</span>
+                      <select
+                        data-testid="display-lines-select"
+                        aria-label={t('editor.typingTest.lines')}
+                        value={displayLines ?? DEFAULT_DISPLAY_LINES}
+                        onChange={(e) => onDisplayLinesChange?.(Number(e.target.value))}
+                        className="rounded-md border border-edge bg-surface-alt px-2 py-1 text-sm text-content-secondary focus:border-accent focus:outline-none"
+                      >
+                        {LINE_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+                      </select>
+                    </div>
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-sm text-content-muted">{t('editor.typingTest.fontSize')}:</span>
+                      <select
+                        data-testid="font-size-select"
+                        aria-label={t('editor.typingTest.fontSize')}
+                        value={fontSize ?? DEFAULT_FONT_SIZE}
+                        onChange={(e) => onFontSizeChange?.(Number(e.target.value))}
+                        className="rounded-md border border-edge bg-surface-alt px-2 py-1 text-sm text-content-secondary focus:border-accent focus:outline-none"
+                      >
+                        {FONT_OPTIONS.map((n) => <option key={n} value={n}>{n}</option>)}
+                      </select>
+                    </div>
+                  </>
                 )}
               </div>
               <div className="flex items-center gap-3">
                 {typingTestHistory && typingTestHistory.length > 0 && (
-                  <HistoryToggle results={typingTestHistory} deviceName={deviceName} />
+                  <HistoryToggle results={typingTestHistory} deviceName={deviceName} onRename={onRenameTypingTestResult} onDelete={onDeleteTypingTestResult} />
+                )}
+                {/* Memory mode (imported custom text): pause while running, or
+                    resume a saved snapshot. */}
+                {typingTest.config.mode === 'custom' && (
+                  typingTest.state.status === 'running' ? (
+                    <button
+                      type="button"
+                      data-testid="typing-memory-pause"
+                      className="flex items-center gap-1.5 rounded-md border border-edge px-2.5 py-1 text-sm text-content-secondary transition-colors hover:text-content"
+                      onClick={() => onPauseTest?.()}
+                    >
+                      <Pause size={ICON_SM} aria-hidden="true" />
+                      <span>{t('editor.typingTest.memory.pause')}</span>
+                    </button>
+                  ) : (typingTest.state.status === 'paused' || hasSavedMemory) ? (
+                    <button
+                      type="button"
+                      data-testid="typing-memory-resume"
+                      className="flex items-center gap-1.5 rounded-md border border-edge px-2.5 py-1 text-sm text-accent transition-colors hover:text-accent/80"
+                      onClick={() => setShowResumeModal(true)}
+                    >
+                      <Play size={ICON_SM} aria-hidden="true" />
+                      <span>{t('editor.typingTest.memory.resumeButton')}</span>
+                    </button>
+                  ) : null
                 )}
               </div>
             </div>
           )}
+          <div className="flex justify-center">
           <KeyboardPane
             paneId="primary"
             isActive={false}
@@ -435,6 +552,7 @@ export function TypingTestPane({
             layerLabelTestId="layer-label"
             contentRef={contentRef}
           />
+          </div>
           {heatmapActive && (
             <p
               data-testid="typing-test-heatmap-legend"

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -6,7 +6,7 @@ import type { BulkKeyEntry } from '../../hooks/useKeyboard'
 import type { MacroAction } from '../../../preload/macro'
 import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry, DeviceInfo } from '../../../shared/types/protocol'
 import type { KeyboardLayoutId } from '../../hooks/useKeyboardLayout'
-import type { TypingTestResult, TypingViewMenuTab } from '../../../shared/types/pipette-settings'
+import type { TypingTestResult, TypingViewMenuTab, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 
@@ -118,6 +118,8 @@ export interface KeymapEditorProps {
   typingTestMode?: boolean
   onTypingTestModeChange?: (enabled: boolean) => void
   onSaveTypingTestResult?: (result: TypingTestResult) => void
+  onRenameTypingTestResult?: (date: string, name: string) => void
+  onDeleteTypingTestResult?: (date: string) => void
   typingTestHistory?: TypingTestResult[]
   typingTestConfig?: TypingTestConfig
   typingTestLanguage?: string
@@ -129,6 +131,12 @@ export interface KeymapEditorProps {
   onTypingTestViewOnlyWindowSizeChange?: (size: { width: number; height: number }) => void
   typingTestViewOnlyAlwaysOnTop?: boolean
   onTypingTestViewOnlyAlwaysOnTopChange?: (enabled: boolean) => void
+  typingTestMemory?: TypingTestMemory
+  onTypingTestMemoryChange?: (memory: TypingTestMemory | undefined) => void
+  typingTestDisplayLines?: number
+  typingTestFontSize?: number
+  onTypingTestDisplayLinesChange?: (lines: number) => void
+  onTypingTestFontSizeChange?: (px: number) => void
   typingRecordEnabled?: boolean
   onTypingRecordEnabledChange?: (enabled: boolean) => void
   /** AppConfig flag — true once the user has accepted the recording

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -5,7 +5,7 @@ import { useTypingTest } from '../../typing-test/useTypingTest'
 import { buildTypingTestResult, isPbForConfig } from '../../typing-test/result-builder'
 import type { TypingTestConfig } from '../../typing-test/types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../typing-test/types'
-import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingAnalyticsEventPayload, TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
 import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
 import { PROCESS_CODE_TO_KEY } from './keymap-editor-types'
@@ -25,6 +25,10 @@ export interface UseInputModesOptions {
   onTypingTestConfigChange?: (config: TypingTestConfig) => void
   onTypingTestLanguageChange?: (lang: string) => void
   onSaveTypingTestResult?: (result: TypingTestResult) => void
+  /** Persisted paused-test snapshot for the active keyboard (memory mode). */
+  savedTypingTestMemory?: TypingTestMemory
+  /** Persist or clear the paused-test snapshot. */
+  onTypingTestMemoryChange?: (memory: TypingTestMemory | undefined) => void
   typingTestHistory?: TypingTestResult[]
   typingTestViewOnly?: boolean
   typingRecordEnabled?: boolean
@@ -45,6 +49,11 @@ export interface UseInputModesReturn {
   typingTest: ReturnType<typeof useTypingTest>
   handleTypingTestConfigChange: (config: TypingTestConfig) => void
   handleTypingTestLanguageChange: (lang: string) => Promise<void>
+  /** Memory mode (imported custom text). */
+  savedTypingTestMemory?: TypingTestMemory
+  pauseTypingTest: () => void
+  resumeTypingTest: () => void
+  restartTypingTestFromStart: () => void
 }
 
 export function useInputModes({
@@ -62,6 +71,8 @@ export function useInputModes({
   onTypingTestConfigChange,
   onTypingTestLanguageChange,
   onSaveTypingTestResult,
+  savedTypingTestMemory,
+  onTypingTestMemoryChange,
   typingTestHistory,
   typingTestViewOnly,
   typingRecordEnabled,
@@ -186,16 +197,45 @@ export function useInputModes({
     processKeyEvent,
     setWindowFocused,
   } = typingTest
+
+  const savedMemoryRef = useRef(savedTypingTestMemory)
+  savedMemoryRef.current = savedTypingTestMemory
+  const savedConfigRef = useRef(savedTypingTestConfig)
+  savedConfigRef.current = savedTypingTestConfig
+  const onMemoryChangeRef = useRef(onTypingTestMemoryChange)
+  onMemoryChangeRef.current = onTypingTestMemoryChange
+  // Tracks the config JSON last pushed into useTypingTest so the config-sync
+  // effect below doesn't re-apply (and overwrite a restored snapshot).
+  const lastSyncedConfigRef = useRef('')
+
+  /** Enter the typing test. When a paused snapshot is saved for the active
+   *  custom text, restore it frozen ('paused') so the user must choose
+   *  resume / restart before typing; otherwise start a fresh test. */
+  const beginTypingTest = useCallback((withCountdown: boolean) => {
+    enterMatrixMode()
+    const mem = savedMemoryRef.current
+    const cfg = savedConfigRef.current
+    if (mem && cfg?.mode === 'custom' && cfg.textId === mem.textId) {
+      // Pre-mark the config as synced so the config-sync effect doesn't
+      // clobber the restored snapshot with a fresh test.
+      lastSyncedConfigRef.current = JSON.stringify(cfg)
+      void typingTest.restoreState(mem, false)
+    } else if (withCountdown) {
+      restartWithCountdown()
+    } else {
+      restartTypingTest()
+    }
+    onTypingTestModeChange?.(true)
+  }, [enterMatrixMode, typingTest, restartWithCountdown, restartTypingTest, onTypingTestModeChange])
+
   const [pendingTypingTest, setPendingTypingTest] = useState(false)
 
   useEffect(() => {
     if (pendingTypingTest && unlocked) {
       setPendingTypingTest(false)
-      enterMatrixMode()
-      restartWithCountdown()
-      onTypingTestModeChange?.(true)
+      beginTypingTest(true)
     }
-  }, [pendingTypingTest, unlocked, enterMatrixMode, restartWithCountdown, onTypingTestModeChange])
+  }, [pendingTypingTest, unlocked, beginTypingTest])
 
   // Exit typing test when the keyboard is locked
   useEffect(() => {
@@ -210,14 +250,12 @@ export function useInputModes({
       resetMatrixState()
       onTypingTestModeChange?.(false)
     } else if (unlocked) {
-      enterMatrixMode()
-      restartTypingTest()
-      onTypingTestModeChange?.(true)
+      beginTypingTest(false)
     } else {
       setPendingTypingTest(true)
       onUnlock?.()
     }
-  }, [typingTestMode, unlocked, resetMatrixState, enterMatrixMode, restartTypingTest, onTypingTestModeChange, onUnlock])
+  }, [typingTestMode, unlocked, resetMatrixState, beginTypingTest, onTypingTestModeChange, onUnlock])
 
   // Feed matrix frames to typing test
   useEffect(() => {
@@ -255,6 +293,9 @@ export function useInputModes({
     if (!typingTestMode || typingTestViewOnly) return
     function handler(e: KeyboardEvent) {
       if (document.querySelector('[role="dialog"]')) return
+      // Inline edit fields (e.g. naming a finished result) opt out of typing
+      // capture so their keystrokes reach the input instead of the test.
+      if (e.target instanceof HTMLElement && e.target.dataset.ttPassthrough != null) return
       if (e.isComposing) return
       let key = e.key
       if (key === 'Process') {
@@ -291,9 +332,12 @@ export function useInputModes({
         config: typingTest.config,
         language: typingTest.language,
         wpmHistory: typingTest.state.wpmHistory,
+        customTextName: typingTest.config.mode === 'custom' ? typingTest.state.currentQuote?.source : undefined,
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       onSaveTypingTestResult(result)
+      // A completed test makes any saved pause snapshot obsolete.
+      if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }
     if (typingTest.state.status !== 'finished') {
       savedResultRef.current = false
@@ -301,12 +345,12 @@ export function useInputModes({
   }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
     typingTest.state.correctChars, typingTest.state.incorrectChars,
     typingTest.state.currentWordIndex, typingTest.state.wpmHistory,
+    typingTest.state.currentQuote,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
     typingTestHistory, onSaveTypingTestResult])
 
   // Sync saved config/language from device prefs into useTypingTest
-  const lastSyncedConfigRef = useRef('')
   useEffect(() => {
     const target = savedTypingTestConfig
     const json = target ? JSON.stringify(target) : ''
@@ -325,6 +369,11 @@ export function useInputModes({
 
   // Wrapped setters that persist user-initiated changes to device prefs
   const handleTypingTestConfigChange = useCallback((newConfig: TypingTestConfig) => {
+    // Starting a different imported text discards the saved snapshot.
+    const mem = savedMemoryRef.current
+    if (mem && newConfig.mode === 'custom' && newConfig.textId !== mem.textId) {
+      onMemoryChangeRef.current?.(undefined)
+    }
     typingTest.setConfig(newConfig)
     lastSyncedConfigRef.current = JSON.stringify(newConfig)
     onTypingTestConfigChange?.(newConfig)
@@ -335,6 +384,30 @@ export function useInputModes({
     lastSyncedLanguageRef.current = resolved
     onTypingTestLanguageChange?.(resolved)
   }, [typingTest.setLanguage, onTypingTestLanguageChange])
+
+  // --- Memory mode handlers ---
+  const pauseTypingTest = useCallback(() => {
+    const mem = typingTest.captureMemory()
+    if (!mem) return
+    onMemoryChangeRef.current?.(mem)
+    typingTest.pause()
+  }, [typingTest])
+
+  const resumeTypingTest = useCallback(() => {
+    const mem = savedMemoryRef.current
+    if (!mem) return
+    void typingTest.restoreState(mem, true).then((ok) => {
+      if (!ok) {
+        onMemoryChangeRef.current?.(undefined)
+        restartTypingTest()
+      }
+    })
+  }, [typingTest, restartTypingTest])
+
+  const restartTypingTestFromStart = useCallback(() => {
+    onMemoryChangeRef.current?.(undefined)
+    restartTypingTest()
+  }, [restartTypingTest])
 
   // Window focus/blur listeners
   useEffect(() => {
@@ -363,5 +436,9 @@ export function useInputModes({
     typingTest,
     handleTypingTestConfigChange,
     handleTypingTestLanguageChange,
+    savedTypingTestMemory,
+    pauseTypingTest,
+    resumeTypingTest,
+    restartTypingTestFromStart,
   }
 }

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -5,10 +5,11 @@ import type { KeyboardLayoutId } from '../data/keyboard-layouts'
 import { useKeyLabelLookup } from './useKeyLabelLookup'
 import { useAppConfig } from './useAppConfig'
 import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
-import type { TypingTestResult, TypingViewMenuTab, ViewMode } from '../../shared/types/pipette-settings'
+import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestMemoryWord } from '../../shared/types/pipette-settings'
 import { VIEW_MODES, isTypingViewMenuTab } from '../../shared/types/pipette-settings'
 import { trimResults } from '../typing-test/result-builder'
 import type { TypingTestConfig } from '../typing-test/types'
+import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, clampDisplayLines, clampFontSize } from '../typing-test/types'
 import type { AutoLockMinutes, BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
 import { clampZoomFactor } from '../../shared/types/app-config'
 
@@ -37,6 +38,9 @@ function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
     case 'quote':
       if (typeof obj.quoteLength !== 'string' || !VALID_QUOTE_LENGTHS.has(obj.quoteLength)) return undefined
       return { mode: 'quote', quoteLength: obj.quoteLength as 'short' | 'medium' | 'long' | 'all' }
+    case 'custom':
+      if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
+      return { mode: 'custom', textId: obj.textId }
     default:
       return undefined
   }
@@ -45,6 +49,39 @@ function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
 function validateTypingTestLanguage(raw: unknown): string | undefined {
   if (typeof raw !== 'string' || raw.length === 0) return undefined
   return raw
+}
+
+function validateTypingTestMemory(raw: unknown): TypingTestMemory | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (typeof o.textId !== 'string' || o.textId.length === 0) return undefined
+  if (typeof o.currentWordIndex !== 'number' || !Number.isFinite(o.currentWordIndex) || o.currentWordIndex < 0) return undefined
+  if (typeof o.currentInput !== 'string') return undefined
+  if (typeof o.correctChars !== 'number' || typeof o.incorrectChars !== 'number') return undefined
+  if (typeof o.elapsedMs !== 'number' || !Number.isFinite(o.elapsedMs) || o.elapsedMs < 0) return undefined
+  if (!Array.isArray(o.wordResults)) return undefined
+  const rawResults = o.wordResults as unknown[]
+  const wordResults = rawResults.filter((w): w is TypingTestMemoryWord => {
+    if (typeof w !== 'object' || w === null) return false
+    const r = w as Record<string, unknown>
+    return typeof r.word === 'string' && typeof r.typed === 'string' && typeof r.correct === 'boolean'
+  })
+  // A malformed entry means the snapshot is untrustworthy — discard it.
+  if (wordResults.length !== rawResults.length) return undefined
+  const wpmHistory = Array.isArray(o.wpmHistory)
+    ? (o.wpmHistory as unknown[]).filter((n): n is number => typeof n === 'number')
+    : []
+  return {
+    textId: o.textId,
+    currentWordIndex: o.currentWordIndex,
+    currentInput: o.currentInput,
+    wordResults,
+    correctChars: o.correctChars,
+    incorrectChars: o.incorrectChars,
+    elapsedMs: o.elapsedMs,
+    wpmHistory,
+    savedAt: typeof o.savedAt === 'string' ? o.savedAt : new Date(0).toISOString(),
+  }
 }
 
 function isValidTypingTestResult(item: unknown): item is TypingTestResult {
@@ -73,6 +110,9 @@ interface ValidatedPrefs {
   typingTestViewOnly: boolean
   typingTestViewOnlyWindowSize?: { width: number; height: number }
   typingTestViewOnlyAlwaysOnTop: boolean
+  typingTestMemory?: TypingTestMemory
+  typingTestDisplayLines: number
+  typingTestFontSize: number
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
   viewMode: ViewMode
@@ -80,7 +120,7 @@ interface ValidatedPrefs {
 }
 
 function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
   defaultLayout: KeyboardLayoutId,
   defaultAutoAdvance: boolean,
   defaultLayerPanelOpen: boolean,
@@ -152,6 +192,9 @@ function validateIpcPrefs(
     typingTestViewOnly,
     typingTestViewOnlyWindowSize: validateWindowSize(data.typingTestViewOnlyWindowSize),
     typingTestViewOnlyAlwaysOnTop: typeof data.typingTestViewOnlyAlwaysOnTop === 'boolean' ? data.typingTestViewOnlyAlwaysOnTop : false,
+    typingTestMemory: validateTypingTestMemory(data.typingTestMemory),
+    typingTestDisplayLines: typeof data.typingTestDisplayLines === 'number' ? clampDisplayLines(data.typingTestDisplayLines) : DEFAULT_DISPLAY_LINES,
+    typingTestFontSize: typeof data.typingTestFontSize === 'number' ? clampFontSize(data.typingTestFontSize) : DEFAULT_FONT_SIZE,
     typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
     typingViewMenuTab: isTypingViewMenuTab(data.typingViewMenuTab) ? data.typingViewMenuTab : 'window',
     viewMode,
@@ -182,6 +225,9 @@ export interface UseDevicePrefsReturn {
   typingTestViewOnly: boolean
   typingTestViewOnlyWindowSize: { width: number; height: number } | undefined
   typingTestViewOnlyAlwaysOnTop: boolean
+  typingTestMemory: TypingTestMemory | undefined
+  typingTestDisplayLines: number
+  typingTestFontSize: number
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
   viewMode: ViewMode
@@ -195,11 +241,16 @@ export interface UseDevicePrefsReturn {
   setKeymapScale: (scale: number) => void
   setLayerNames: (names: string[]) => void
   addTypingTestResult: (result: TypingTestResult) => void
+  renameTypingTestResult: (date: string, name: string) => void
+  deleteTypingTestResult: (date: string) => void
   setTypingTestConfig: (config: TypingTestConfig) => void
   setTypingTestLanguage: (lang: string) => void
   setTypingTestViewOnly: (enabled: boolean) => void
   setTypingTestViewOnlyWindowSize: (size: { width: number; height: number }) => void
   setTypingTestViewOnlyAlwaysOnTop: (enabled: boolean) => void
+  setTypingTestMemory: (memory: TypingTestMemory | undefined) => void
+  setTypingTestDisplayLines: (lines: number) => void
+  setTypingTestFontSize: (px: number) => void
   setTypingRecordEnabled: (enabled: boolean) => void
   setTypingViewMenuTab: (tab: TypingViewMenuTab) => void
   setViewMode: (mode: ViewMode) => void
@@ -266,6 +317,9 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   const [typingTestViewOnly, updateTypingTestViewOnly, typingTestViewOnlyRef] = useStateRef<boolean>(false)
   const [typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize, typingTestViewOnlyWindowSizeRef] = useStateRef<{ width: number; height: number } | undefined>(undefined)
   const [typingTestViewOnlyAlwaysOnTop, updateTypingTestViewOnlyAlwaysOnTop, typingTestViewOnlyAlwaysOnTopRef] = useStateRef<boolean>(false)
+  const [typingTestMemory, updateTypingTestMemory, typingTestMemoryRef] = useStateRef<TypingTestMemory | undefined>(undefined)
+  const [typingTestDisplayLines, updateTypingTestDisplayLines, typingTestDisplayLinesRef] = useStateRef<number>(DEFAULT_DISPLAY_LINES)
+  const [typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef] = useStateRef<number>(DEFAULT_FONT_SIZE)
   const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
   const [typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef] = useStateRef<TypingViewMenuTab>('window')
   const [viewMode, updateViewMode, viewModeRef] = useStateRef<ViewMode>('editor')
@@ -295,6 +349,9 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestViewOnly: typingTestViewOnlyRef.current,
       typingTestViewOnlyWindowSize: typingTestViewOnlyWindowSizeRef.current,
       typingTestViewOnlyAlwaysOnTop: typingTestViewOnlyAlwaysOnTopRef.current || undefined,
+      typingTestMemory: typingTestMemoryRef.current,
+      typingTestDisplayLines: typingTestDisplayLinesRef.current,
+      typingTestFontSize: typingTestFontSizeRef.current,
       typingRecordEnabled: typingRecordEnabledRef.current || undefined,
       typingViewMenuTab: typingViewMenuTabRef.current,
       viewMode: viewModeRef.current,
@@ -352,6 +409,29 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestResults])
 
+  /** Label a saved result (keyed by its ISO date) for run comparison. An
+   *  empty name clears the label. No-op when nothing changed. */
+  const renameTypingTestResult = useCallback((date: string, name: string) => {
+    const nextName = name.trim() || undefined
+    let changed = false
+    const updated = typingTestResultsRef.current.map((r) => {
+      if (r.date !== date || (r.name ?? '') === (nextName ?? '')) return r
+      changed = true
+      return { ...r, name: nextName }
+    })
+    if (!changed) return
+    updateTypingTestResults(updated)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestResults])
+
+  /** Remove a single saved result (keyed by its ISO date). */
+  const deleteTypingTestResult = useCallback((date: string) => {
+    const updated = typingTestResultsRef.current.filter((r) => r.date !== date)
+    if (updated.length === typingTestResultsRef.current.length) return
+    updateTypingTestResults(updated)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestResults])
+
   const setTypingTestConfig = useCallback((cfg: TypingTestConfig) => {
     updateTypingTestConfig(cfg)
     saveCurrentPrefs()
@@ -377,6 +457,28 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateTypingTestViewOnlyAlwaysOnTop(enabled)
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestViewOnlyAlwaysOnTop])
+
+  const setTypingTestMemory = useCallback((memory: TypingTestMemory | undefined) => {
+    // Skip the full-prefs write when nothing changed — most commonly a
+    // clear (undefined) issued while already cleared (finish / restart).
+    if (typingTestMemoryRef.current === memory) return
+    updateTypingTestMemory(memory)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestMemory])
+
+  const setTypingTestDisplayLines = useCallback((lines: number) => {
+    const clamped = clampDisplayLines(lines)
+    if (typingTestDisplayLinesRef.current === clamped) return
+    updateTypingTestDisplayLines(clamped)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestDisplayLines])
+
+  const setTypingTestFontSize = useCallback((px: number) => {
+    const clamped = clampFontSize(px)
+    if (typingTestFontSizeRef.current === clamped) return
+    updateTypingTestFontSize(clamped)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestFontSize])
 
   const setTypingRecordEnabled = useCallback((enabled: boolean) => {
     if (typingRecordEnabledRef.current === enabled) return
@@ -458,6 +560,8 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestResults: [],
       typingTestViewOnly: false,
       typingTestViewOnlyAlwaysOnTop: false,
+      typingTestDisplayLines: DEFAULT_DISPLAY_LINES,
+      typingTestFontSize: DEFAULT_FONT_SIZE,
       typingRecordEnabled: false,
       typingViewMenuTab: 'window',
       viewMode: 'editor',
@@ -476,6 +580,9 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateTypingTestViewOnly(resolved.typingTestViewOnly)
     updateTypingTestViewOnlyWindowSize(resolved.typingTestViewOnlyWindowSize)
     updateTypingTestViewOnlyAlwaysOnTop(resolved.typingTestViewOnlyAlwaysOnTop)
+    updateTypingTestMemory(resolved.typingTestMemory)
+    updateTypingTestDisplayLines(resolved.typingTestDisplayLines)
+    updateTypingTestFontSize(resolved.typingTestFontSize)
     updateTypingRecordEnabled(resolved.typingRecordEnabled)
     updateTypingViewMenuTab(resolved.typingViewMenuTab)
     updateViewMode(resolved.viewMode)
@@ -531,6 +638,9 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     typingTestViewOnly,
     typingTestViewOnlyWindowSize,
     typingTestViewOnlyAlwaysOnTop,
+    typingTestMemory,
+    typingTestDisplayLines,
+    typingTestFontSize,
     typingRecordEnabled,
     typingViewMenuTab,
     viewMode,
@@ -545,11 +655,16 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     setKeymapScale,
     setLayerNames,
     addTypingTestResult,
+    renameTypingTestResult,
+    deleteTypingTestResult,
     setTypingTestConfig,
     setTypingTestLanguage,
     setTypingTestViewOnly,
     setTypingTestViewOnlyWindowSize,
     setTypingTestViewOnlyAlwaysOnTop,
+    setTypingTestMemory,
+    setTypingTestDisplayLines,
+    setTypingTestFontSize,
     setTypingRecordEnabled,
     setTypingViewMenuTab,
     setViewMode,

--- a/src/renderer/hooks/useTypingTestTexts.ts
+++ b/src/renderer/hooks/useTypingTestTexts.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Renderer-side state for imported Typing Test texts: list local
+// entries and CRUD against the store. Mirrors useKeyLabels' cross-
+// instance refresh signal so the modal and any other consumer stay in
+// lockstep. Also clears the word-generator custom-text cache on change
+// so freshly imported / renamed text plays back correctly.
+
+import { useCallback, useEffect, useState } from 'react'
+import type {
+  TypingTestTextMeta,
+  TypingTestTextStoreResult,
+} from '../../shared/types/typing-test-text-store'
+import { clearCustomTextCache } from '../typing-test/word-generator'
+
+const REFRESH_EVENT = 'pipette:typing-test-texts-changed'
+
+function emitTypingTestTextsChanged(): void {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(REFRESH_EVENT))
+  }
+}
+
+export interface UseTypingTestTextsReturn {
+  metas: TypingTestTextMeta[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  importFromFile: () => Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
+  /** Commit the import that collided on name (after the user confirms). */
+  confirmImport: () => Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
+  rename: (id: string, newName: string) => Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
+  remove: (id: string) => Promise<TypingTestTextStoreResult<void>>
+}
+
+export function useTypingTestTexts(): UseTypingTestTextsReturn {
+  const [metas, setMetas] = useState<TypingTestTextMeta[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const result = await window.vialAPI.typingTestTextStoreList()
+      if (!result.success || !result.data) {
+        setError(result.error ?? 'Failed to load texts')
+        return
+      }
+      setMetas(result.data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handler = (): void => {
+      void refresh()
+    }
+    window.addEventListener(REFRESH_EVENT, handler)
+    return () => window.removeEventListener(REFRESH_EVENT, handler)
+  }, [refresh])
+
+  const importFromFile = useCallback(async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
+    const result = await window.vialAPI.typingTestTextStoreImport()
+    if (result.success) {
+      if (result.data) clearCustomTextCache(result.data.id)
+      await refresh()
+      emitTypingTestTextsChanged()
+    }
+    return result
+  }, [refresh])
+
+  const confirmImport = useCallback(async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
+    const result = await window.vialAPI.typingTestTextStoreImportConfirm()
+    if (result.success) {
+      if (result.data) clearCustomTextCache(result.data.id)
+      await refresh()
+      emitTypingTestTextsChanged()
+    }
+    return result
+  }, [refresh])
+
+  const rename = useCallback(async (
+    id: string,
+    newName: string,
+  ): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
+    const result = await window.vialAPI.typingTestTextStoreRename(id, newName)
+    if (result.success) {
+      clearCustomTextCache(id)
+      await refresh()
+      emitTypingTestTextsChanged()
+    }
+    return result
+  }, [refresh])
+
+  const remove = useCallback(async (id: string): Promise<TypingTestTextStoreResult<void>> => {
+    const result = await window.vialAPI.typingTestTextStoreDelete(id)
+    if (result.success) {
+      clearCustomTextCache(id)
+      await refresh()
+      emitTypingTestTextsChanged()
+    }
+    return result
+  }, [refresh])
+
+  return { metas, loading, error, refresh, importFromFile, confirmImport, rename, remove }
+}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -250,9 +250,13 @@
       "exitTypingMode": "Exit Typing Test",
       "restart": "Restart",
       "wpm": "WPM",
+      "kpm": "KPM",
       "accuracy": "Accuracy",
       "time": "Time",
       "words": "Words",
+      "lines": "Lines",
+      "chars": "Chars",
+      "fontSize": "Font",
       "correct": "Correct",
       "incorrect": "Incorrect",
       "finished": "Complete",
@@ -261,7 +265,8 @@
       "mode": {
         "words": "words",
         "time": "time",
-        "quote": "quote"
+        "quote": "quote",
+        "custom": "text"
       },
       "punctuation": "punctuation",
       "numbers": "numbers",
@@ -272,6 +277,7 @@
         "all": "all"
       },
       "quoteSource": "-- {{source}}",
+      "nameResult": "Name this result",
       "viewOnly": "Typing View",
       "exitViewOnly": "Exit Typing View",
       "alwaysOnTop": "top",
@@ -293,6 +299,7 @@
       "resetSize": "Default Size",
       "fitSize": "Fit Size",
       "baseLayer": "Base Layer",
+      "modeLabel": "Mode",
       "baseLayerShort": "Base",
       "heatmapWindow": "Heatmap window (minutes)",
       "heatmapWindowShort": "HeatMap",
@@ -317,14 +324,33 @@
       "paused": "Window lost focus",
       "layerNote": "Only MO / LT / LM layer switches are tracked. Other layer keys and advanced features may not be reflected.",
       "language": {
-        "title": "Languages",
+        "title": "Mode",
         "searchPlaceholder": "Search languages...",
         "downloaded": "Downloaded",
         "available": "Available",
         "noResults": "No matching languages",
         "words": "{{count}} words",
         "loadingLanguage": "Loading language...",
-        "downloadFailed": "Download failed"
+        "downloadFailed": "Download failed",
+        "tabNormal": "Normal",
+        "tabCustom": "Custom",
+        "import": "Import UTF-8 text file",
+        "importEmpty": "No imported texts yet",
+        "importFailed": "Import failed",
+        "importErrorNotUtf8": "Only UTF-8 encoded text files are supported",
+        "importErrorTooLarge": "File is too large (max 5 MB)",
+        "importErrorEmpty": "The file has no typeable text",
+        "importOverwritePrompt": "\"{{name}}\" already exists. Overwrite?",
+        "confirmOverwrite": "Overwrite",
+        "customText": "Imported text"
+      },
+      "memory": {
+        "pause": "Pause",
+        "resumeButton": "Resume",
+        "resumeTitle": "Resume saved test?",
+        "resumeBody": "You paused at word {{current}} of {{total}}. Continue from there, or start over?",
+        "resume": "Resume",
+        "restart": "Start over"
       },
       "history": {
         "title": "History",
@@ -334,11 +360,17 @@
         "totalTests": "Tests",
         "avgAccuracy": "Avg Acc",
         "date": "Date",
+        "name": "Name",
+        "unnamed": "Unnamed",
         "mode": "Mode",
+        "tabNormal": "Normal",
+        "tabCustom": "Custom",
+        "tabText": "Text",
         "noResults": "No results yet",
         "pb": "PB",
         "allModes": "All",
-        "exportCsv": "Export CSV"
+        "exportCsv": "Export CSV",
+        "delete": "Delete"
       }
     }
   },

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -250,9 +250,13 @@
       "exitTypingMode": "タイピングテスト終了",
       "restart": "やり直す",
       "wpm": "WPM",
+      "kpm": "KPM",
       "accuracy": "正確性",
       "time": "時間",
       "words": "単語",
+      "lines": "行",
+      "chars": "文字数",
+      "fontSize": "Font",
       "correct": "正解",
       "incorrect": "ミス",
       "finished": "完了",
@@ -261,7 +265,8 @@
       "mode": {
         "words": "単語",
         "time": "時間",
-        "quote": "引用"
+        "quote": "引用",
+        "custom": "テキスト"
       },
       "punctuation": "句読点",
       "numbers": "数字",
@@ -272,6 +277,7 @@
         "all": "全て"
       },
       "quoteSource": "-- {{source}}",
+      "nameResult": "この結果に名前を付ける",
       "viewOnly": "タイピングビュー",
       "exitViewOnly": "タイピングビュー終了",
       "alwaysOnTop": "最前面",
@@ -293,6 +299,7 @@
       "resetSize": "初期サイズ",
       "fitSize": "フィット",
       "baseLayer": "Base Layer",
+      "modeLabel": "Mode",
       "baseLayerShort": "Base",
       "heatmapWindow": "ヒートマップの表示期間（分）",
       "heatmapWindowShort": "HeatMap",
@@ -317,14 +324,33 @@
       "paused": "ウィンドウがフォーカスを失いました",
       "layerNote": "レイヤー切替の追随は MO / LT / LM のみ対応しています。その他のレイヤーキーや特殊機能は反映されない場合があります。",
       "language": {
-        "title": "言語",
+        "title": "Mode",
         "searchPlaceholder": "言語を検索...",
         "downloaded": "ダウンロード済み",
         "available": "利用可能",
         "noResults": "一致する言語がありません",
         "words": "{{count}} 単語",
         "loadingLanguage": "言語を読み込み中...",
-        "downloadFailed": "ダウンロードに失敗しました"
+        "downloadFailed": "ダウンロードに失敗しました",
+        "tabNormal": "Normal",
+        "tabCustom": "カスタム",
+        "import": "UTF-8 テキストをインポート",
+        "importEmpty": "インポートされたテキストはありません",
+        "importFailed": "インポートに失敗しました",
+        "importErrorNotUtf8": "UTF-8 のテキストファイルのみ対応しています",
+        "importErrorTooLarge": "ファイルが大きすぎます（最大 5 MB）",
+        "importErrorEmpty": "打鍵できるテキストがありません",
+        "importOverwritePrompt": "「{{name}}」は既に存在します。上書きしますか？",
+        "confirmOverwrite": "上書き",
+        "customText": "インポートテキスト"
+      },
+      "memory": {
+        "pause": "一時停止",
+        "resumeButton": "再開",
+        "resumeTitle": "保存したテストを再開しますか？",
+        "resumeBody": "{{total}} 語中 {{current}} 語目で一時停止しました。続きから再開しますか？最初からやり直しますか？",
+        "resume": "続きから再開",
+        "restart": "最初から"
       },
       "history": {
         "title": "履歴",
@@ -334,11 +360,17 @@
         "totalTests": "テスト数",
         "avgAccuracy": "平均正確性",
         "date": "日時",
+        "name": "名前",
+        "unnamed": "名称未設定",
         "mode": "モード",
+        "tabNormal": "Normal",
+        "tabCustom": "カスタム",
+        "tabText": "テキスト",
         "noResults": "結果がありません",
         "pb": "PB",
         "allModes": "すべて",
-        "exportCsv": "CSV出力"
+        "exportCsv": "CSV出力",
+        "delete": "削除"
       }
     }
   },

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -61,6 +61,15 @@
   margin-left: 6px;
 }
 
+/* Imported-text typing display: font size + visible-line window driven by
+   --tt-font (px) and --tt-lines (count). Window height = font × 1.5 (the
+   leading-normal line box) × line count. Kept here (not inline styles) so
+   the sizing math stays in the stylesheet. */
+.typing-multiline-window {
+  font-size: calc(var(--tt-font) * 1px);
+  height: calc(var(--tt-font) * var(--tt-lines) * 1.5px);
+}
+
 /* Interactive elements use pointer cursor */
 button:not(:disabled),
 a,
@@ -320,7 +329,7 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --min-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
   --max-height-device-list: 340px;     /* DeviceSelector, KeymapEditor device list */
   --min-height-word-list: 100px;       /* TypingTestPane word list */
-  --height-typing-display: 7.25rem;    /* TypingTestView word display area */
+  --height-typing-display: 7.25rem;    /* TypingTestView word display area (word-flow modes) */
   --width-color-picker: 15rem;         /* HSVColorPicker container */
   --height-color-picker-sv: 180px;     /* HSVColorPicker saturation/value canvas */
   --spacing-scale-btn: 34px;           /* ScaleControl toolbar button (non-grid: between sm key and toolbar icon) */

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -3,14 +3,33 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
+import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
-import { Check, Download, Trash2, Loader2 } from 'lucide-react'
+import { Check, Download, Trash2, Loader2, FileUp } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import type { LanguageListEntry } from '../../shared/types/language-store'
+import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
+
+type Tab = 'existing' | 'import'
+
+/** Store error code → i18n key for the Import tab error line. Unlisted
+ *  codes fall back to the generic importFailed message. */
+const IMPORT_ERROR_KEYS: Record<string, string> = {
+  NOT_UTF8: 'editor.typingTest.language.importErrorNotUtf8',
+  TOO_LARGE: 'editor.typingTest.language.importErrorTooLarge',
+  EMPTY_TEXT: 'editor.typingTest.language.importErrorEmpty',
+}
 
 interface Props {
   currentLanguage: string
+  /** Active imported text id, when the current config is in custom mode. */
+  currentCustomTextId?: string
   onSelectLanguage: (name: string) => void
+  /** Called when an imported text is picked — switches to custom mode. */
+  onSelectImport: (textId: string) => void
+  /** Called on close when the currently-selected imported text was deleted
+   *  (and nothing else was picked) so the caller can reset to the default. */
+  onCurrentTextDeleted?: () => void
   onClose: () => void
 }
 
@@ -18,28 +37,47 @@ function formatName(name: string): string {
   return name.replace(/_/g, ' ')
 }
 
-export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClose }: Props) {
+export function LanguageSelectorModal({
+  currentLanguage,
+  currentCustomTextId,
+  onSelectLanguage,
+  onSelectImport,
+  onCurrentTextDeleted,
+  onClose,
+}: Props) {
   const { t } = useTranslation()
+  const [tab, setTab] = useState<Tab>(currentCustomTextId ? 'import' : 'existing')
   const [languages, setLanguages] = useState<LanguageListEntry[]>([])
   const [search, setSearch] = useState('')
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
   const backdropRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
+  // Flipped true when the currently-selected imported text is deleted, so a
+  // plain close (Esc / backdrop / X — not an explicit pick) resets to default.
+  const deletedCurrentRef = useRef(false)
 
-  useEscapeClose(onClose)
+  const handleClose = useCallback(() => {
+    if (deletedCurrentRef.current) onCurrentTextDeleted?.()
+    onClose()
+  }, [onClose, onCurrentTextDeleted])
+
+  useEscapeClose(handleClose)
 
   useEffect(() => {
     let alive = true
     window.vialAPI.langList().then((list) => {
       if (alive) setLanguages(list)
     }).catch(() => {})
-    searchRef.current?.focus()
     return () => { alive = false }
   }, [])
 
+  useEffect(() => {
+    if (tab === 'existing') searchRef.current?.focus()
+  }, [tab])
+
   const handleBackdropClick = useCallback((e: React.MouseEvent) => {
-    if (e.target === backdropRef.current) onClose()
-  }, [onClose])
+    if (e.target === backdropRef.current) handleClose()
+  }, [handleClose])
 
   const handleDownload = useCallback(async (name: string) => {
     setDownloading((s) => new Set(s).add(name))
@@ -73,6 +111,11 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
     onClose()
   }, [onSelectLanguage, onClose])
 
+  const handleSelectImport = useCallback((id: string) => {
+    onSelectImport(id)
+    onClose()
+  }, [onSelectImport, onClose])
+
   const filtered = useMemo(() => {
     if (!search) return languages
     const q = search.toLowerCase()
@@ -92,63 +135,252 @@ export function LanguageSelectorModal({ currentLanguage, onSelectLanguage, onClo
       <div className="flex h-modal-80vh w-modal-typing flex-col rounded-2xl border border-edge bg-surface shadow-xl">
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 className="text-lg font-semibold text-content">{t('editor.typingTest.language.title')}</h2>
-          <ModalCloseButton testid="language-modal-close" onClick={onClose} />
+          <ModalCloseButton testid="language-modal-close" onClick={handleClose} />
         </div>
 
-        <div className="border-b border-edge px-4 py-2">
-          <input
-            ref={searchRef}
-            type="text"
-            className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
-            placeholder={t('editor.typingTest.language.searchPlaceholder')}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            data-testid="language-search"
+        <div className="flex border-b border-edge" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'existing'}
+            data-testid="language-tab-existing"
+            className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'existing' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
+            onClick={() => setTab('existing')}
+          >
+            {t('editor.typingTest.language.tabNormal')}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === 'import'}
+            data-testid="language-tab-import"
+            className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'import' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
+            onClick={() => setTab('import')}
+          >
+            {t('editor.typingTest.language.tabCustom')}
+          </button>
+        </div>
+
+        {tab === 'existing' ? (
+          <>
+            <div className="border-b border-edge px-4 py-2">
+              <input
+                ref={searchRef}
+                type="text"
+                className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
+                placeholder={t('editor.typingTest.language.searchPlaceholder')}
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                data-testid="language-search"
+              />
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              {filtered.length === 0 && (
+                <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
+              )}
+
+              {downloaded.length > 0 && (
+                <div>
+                  <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+                    {t('editor.typingTest.language.downloaded')}
+                  </div>
+                  {downloaded.map((lang) => (
+                    <LanguageRow
+                      key={lang.name}
+                      lang={lang}
+                      isCurrent={!currentCustomTextId && lang.name === currentLanguage}
+                      isDownloading={downloading.has(lang.name)}
+                      onSelect={handleSelect}
+                      onDelete={handleDelete}
+                    />
+                  ))}
+                </div>
+              )}
+
+              {available.length > 0 && (
+                <div>
+                  <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+                    {t('editor.typingTest.language.available')}
+                  </div>
+                  {available.map((lang) => (
+                    <LanguageRow
+                      key={lang.name}
+                      lang={lang}
+                      isCurrent={false}
+                      isDownloading={downloading.has(lang.name)}
+                      onSelect={handleSelect}
+                      onDownload={handleDownload}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        ) : (
+          <ImportTab
+            currentCustomTextId={currentCustomTextId}
+            onSelect={handleSelectImport}
+            onDeleteCurrent={() => { deletedCurrentRef.current = true }}
           />
-        </div>
-
-        <div className="flex-1 overflow-y-auto">
-          {filtered.length === 0 && (
-            <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
-          )}
-
-          {downloaded.length > 0 && (
-            <div>
-              <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-                {t('editor.typingTest.language.downloaded')}
-              </div>
-              {downloaded.map((lang) => (
-                <LanguageRow
-                  key={lang.name}
-                  lang={lang}
-                  isCurrent={lang.name === currentLanguage}
-                  isDownloading={downloading.has(lang.name)}
-                  onSelect={handleSelect}
-                  onDelete={handleDelete}
-                />
-              ))}
-            </div>
-          )}
-
-          {available.length > 0 && (
-            <div>
-              <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-                {t('editor.typingTest.language.available')}
-              </div>
-              {available.map((lang) => (
-                <LanguageRow
-                  key={lang.name}
-                  lang={lang}
-                  isCurrent={false}
-                  isDownloading={downloading.has(lang.name)}
-                  onSelect={handleSelect}
-                  onDownload={handleDownload}
-                />
-              ))}
-            </div>
-          )}
-        </div>
+        )}
       </div>
+    </div>
+  )
+}
+
+interface ImportTabProps {
+  currentCustomTextId?: string
+  onSelect: (id: string) => void
+  /** Fired when the currently-selected imported text is deleted. */
+  onDeleteCurrent?: () => void
+}
+
+function ImportTab({ currentCustomTextId, onSelect, onDeleteCurrent }: ImportTabProps) {
+  const { t } = useTranslation()
+  const { metas, importFromFile, confirmImport, remove } = useTypingTestTexts()
+  const [importing, setImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  // Name of an import awaiting overwrite confirmation (null = none pending).
+  const [overwriteName, setOverwriteName] = useState<string | null>(null)
+
+  const handleRemove = useCallback(async (id: string) => {
+    const result = await remove(id)
+    if (result.success && id === currentCustomTextId) onDeleteCurrent?.()
+    return result
+  }, [remove, currentCustomTextId, onDeleteCurrent])
+
+  const handleImport = useCallback(async () => {
+    setImporting(true)
+    setError(null)
+    setOverwriteName(null)
+    try {
+      const result = await importFromFile()
+      // A name collision is held for confirmation, not surfaced as an error.
+      if (!result.success && result.errorCode === 'DUPLICATE_NAME') {
+        setOverwriteName(result.error ?? '')
+        return
+      }
+      // 'cancelled' is a user no-op, not an error worth surfacing.
+      if (!result.success && result.error !== 'cancelled') {
+        const key = IMPORT_ERROR_KEYS[result.errorCode ?? ''] ?? 'editor.typingTest.language.importFailed'
+        setError(t(key))
+      }
+    } finally {
+      setImporting(false)
+    }
+  }, [importFromFile, t])
+
+  const handleConfirmOverwrite = useCallback(async () => {
+    setOverwriteName(null)
+    const result = await confirmImport()
+    if (!result.success) {
+      const key = IMPORT_ERROR_KEYS[result.errorCode ?? ''] ?? 'editor.typingTest.language.importFailed'
+      setError(t(key))
+    }
+  }, [confirmImport, t])
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <div className="border-b border-edge px-4 py-2">
+        {overwriteName !== null ? (
+          <div className="flex flex-col items-center gap-2" data-testid="typing-text-import-overwrite">
+            <p className="text-center text-sm text-content-secondary">
+              {t('editor.typingTest.language.importOverwritePrompt', { name: overwriteName })}
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                data-testid="typing-text-import-overwrite-confirm"
+                className="rounded-md border border-danger px-3 py-1 text-sm text-danger transition-colors hover:bg-danger/10"
+                onClick={handleConfirmOverwrite}
+              >
+                {t('editor.typingTest.language.confirmOverwrite')}
+              </button>
+              <button
+                type="button"
+                data-testid="typing-text-import-overwrite-cancel"
+                className="rounded-md border border-edge px-3 py-1 text-sm text-content-secondary transition-colors hover:text-content"
+                onClick={() => setOverwriteName(null)}
+              >
+                {t('common.cancel')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            type="button"
+            data-testid="typing-text-import"
+            className="flex w-full items-center justify-center gap-2 rounded-md border border-edge px-3 py-1.5 text-sm text-content-secondary transition-colors hover:text-accent disabled:opacity-50"
+            onClick={handleImport}
+            disabled={importing}
+          >
+            {importing ? (
+              <Loader2 size={ICON_SM} className="animate-spin" aria-hidden="true" />
+            ) : (
+              <FileUp size={ICON_SM} aria-hidden="true" />
+            )}
+            <span>{t('editor.typingTest.language.import')}</span>
+          </button>
+        )}
+        {error && (
+          <p className="mt-1 text-center text-xs text-danger" data-testid="typing-text-import-error">{error}</p>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {metas.length === 0 ? (
+          <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.importEmpty')}</p>
+        ) : (
+          metas.map((meta) => (
+            <ImportRow
+              key={meta.id}
+              meta={meta}
+              isCurrent={meta.id === currentCustomTextId}
+              onSelect={onSelect}
+              onDelete={handleRemove}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface ImportRowProps {
+  meta: TypingTestTextMeta
+  isCurrent: boolean
+  onSelect: (id: string) => void
+  onDelete: (id: string) => Promise<unknown>
+}
+
+function ImportRow({ meta, isCurrent, onSelect, onDelete }: ImportRowProps) {
+  const { t } = useTranslation()
+  return (
+    <div
+      data-testid={`typing-text-row-${meta.id}`}
+      className={`flex items-center gap-2 px-4 py-2 text-sm transition-colors ${isCurrent ? 'bg-accent/10' : 'cursor-pointer hover:bg-surface-alt'}`}
+      onClick={() => onSelect(meta.id)}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {isCurrent && <Check size={ICON_SM} className="shrink-0 text-accent" aria-hidden="true" />}
+        <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>{meta.name}</span>
+      </div>
+      <span className="shrink-0 text-xs text-content-muted">
+        {t('editor.typingTest.language.words', { count: meta.wordCount })}
+      </span>
+      <button
+        type="button"
+        data-testid={`typing-text-delete-${meta.id}`}
+        aria-label={t('common.delete')}
+        className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
+        onClick={(e) => {
+          e.stopPropagation()
+          void onDelete(meta.id)
+        }}
+      >
+        <Trash2 size={ICON_SM} aria-hidden="true" />
+      </button>
     </div>
   )
 }

--- a/src/renderer/typing-test/PauseResumeModal.tsx
+++ b/src/renderer/typing-test/PauseResumeModal.tsx
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Confirmation shown when the user resumes a paused imported-text typing
+// test (memory mode): continue from where they left off, or start over.
+
+import { useCallback, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../hooks/useEscapeClose'
+import { ModalCloseButton } from '../components/editors/ModalCloseButton'
+import { BTN_SECONDARY, BTN_ACCENT_OUTLINE } from '../constants/ui-tokens'
+
+interface Props {
+  /** Word progress of the saved snapshot, shown for context. */
+  wordIndex: number
+  totalWords: number
+  /** Continue from the saved position. */
+  onResume: () => void
+  /** Discard the snapshot and start the text from the beginning. */
+  onRestart: () => void
+  /** Dismiss without choosing (Cancel / Esc / backdrop). */
+  onCancel: () => void
+}
+
+export function PauseResumeModal({ wordIndex, totalWords, onResume, onRestart, onCancel }: Props) {
+  const { t } = useTranslation()
+  const backdropRef = useRef<HTMLDivElement>(null)
+
+  useEscapeClose(onCancel)
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === backdropRef.current) onCancel()
+  }, [onCancel])
+
+  return (
+    <div
+      ref={backdropRef}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-labelledby="typing-resume-title"
+      onClick={handleBackdropClick}
+      data-testid="typing-resume-modal"
+    >
+      <div className="flex w-modal-typing flex-col rounded-2xl border border-edge bg-surface shadow-xl">
+        <div className="flex items-center justify-between border-b border-edge px-4 py-3">
+          <h2 id="typing-resume-title" className="text-lg font-semibold text-content">
+            {t('editor.typingTest.memory.resumeTitle')}
+          </h2>
+          <ModalCloseButton testid="typing-resume-close" onClick={onCancel} />
+        </div>
+
+        <div className="px-5 py-4 text-sm text-content-secondary">
+          {t('editor.typingTest.memory.resumeBody', { current: wordIndex, total: totalWords })}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-edge px-4 py-3">
+          <button
+            type="button"
+            data-testid="typing-resume-restart"
+            onClick={onRestart}
+            className={BTN_SECONDARY}
+          >
+            {t('editor.typingTest.memory.restart')}
+          </button>
+          <button
+            type="button"
+            data-testid="typing-resume-resume"
+            onClick={onResume}
+            className={BTN_ACCENT_OUTLINE}
+          >
+            {t('editor.typingTest.memory.resume')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -7,15 +7,22 @@ import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import { buildCsv } from '../../shared/csv-export'
 import { computeStats } from './history-stats'
 import { WpmSparkline } from './WpmSparkline'
-import { formatDate } from '../components/editors/store-modal-shared'
+import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN } from '../components/editors/store-modal-shared'
 
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
-type SortColumn = 'date' | 'wpm' | 'accuracy' | 'mode' | 'duration'
+type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
 type SortDirection = 'asc' | 'desc'
+/** Top-level split: Monkeytype (words/time/quote) vs imported Text (custom).
+ *  Their baselines aren't comparable, so stats / chart / export are separate. */
+type HistoryTab = 'monkeytype' | 'text'
 
 interface Props {
   results: TypingTestResult[]
   onExportCsv?: (csv: string) => void
+  /** Label a result (keyed by ISO date) for run comparison. */
+  onRename?: (date: string, name: string) => void
+  /** Delete a single result (keyed by ISO date). */
+  onDelete?: (date: string) => void
 }
 
 const MAX_TABLE_ROWS = 20
@@ -35,36 +42,60 @@ function formatDuration(seconds: number): string {
   return `${m}:${String(s).padStart(2, '0')}`
 }
 
+/** Mode-column detail. Custom (imported-text) runs show the snapshotted text
+ *  name (falling back to the stable textId for legacy rows saved before the
+ *  name was captured); every other mode shows its `mode2` value. */
+function modeDetail(r: TypingTestResult): string {
+  if (r.mode === 'custom') return r.customTextName ?? (r.mode2 != null ? String(r.mode2) : '')
+  return r.mode2 != null ? String(r.mode2) : ''
+}
+
+/** Keystrokes per minute, derived from the stored char count and duration so
+ *  it works for legacy rows too (no separate field needed). */
+function resultKpm(r: TypingTestResult): number {
+  return r.durationSeconds > 0 ? Math.round((r.correctChars * 60) / r.durationSeconds) : 0
+}
+
 const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
-const CSV_HEADERS = ['date', 'wpm', 'accuracy', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'language', 'punctuation', 'numbers', 'consistency', 'isPb'] as const
+const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'customTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb'] as const
 
 function buildResultsCsv(results: TypingTestResult[]): string {
   return buildCsv(
     CSV_HEADERS,
-    results.map((r) => CSV_HEADERS.map((key) => r[key])),
+    results.map((r) => CSV_HEADERS.map((key) => (key === 'kpm' ? resultKpm(r) : r[key as keyof TypingTestResult]))),
   )
 }
 
-export function TypingTestHistory({ results, onExportCsv }: Props) {
+export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: Props) {
   const { t } = useTranslation()
+  const [tab, setTab] = useState<HistoryTab>('monkeytype')
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
   const [sortColumn, setSortColumn] = useState<SortColumn>('date')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  const [confirmDeleteDate, setConfirmDeleteDate] = useState<string | null>(null)
+  const isText = tab === 'text'
 
   const handleSort = useCallback((column: SortColumn) => {
     setSortDirection((prev) => (sortColumn === column && prev === 'desc') ? 'asc' : 'desc')
     setSortColumn(column)
   }, [sortColumn])
 
-  const handleExport = useCallback(() => {
-    onExportCsv?.(buildResultsCsv(results))
-  }, [results, onExportCsv])
+  // Active tab's rows: custom for Text, everything else for Monkeytype.
+  const tabResults = useMemo(
+    () => results.filter((r) => isText ? r.mode === 'custom' : r.mode !== 'custom'),
+    [results, isText],
+  )
 
   const filtered = useMemo(() => {
-    if (modeFilter === 'all') return results
-    return results.filter((r) => (r.mode ?? 'words') === modeFilter)
-  }, [results, modeFilter])
+    if (isText || modeFilter === 'all') return tabResults
+    return tabResults.filter((r) => (r.mode ?? 'words') === modeFilter)
+  }, [tabResults, isText, modeFilter])
+
+  // Export is per-tab: only the rows currently shown.
+  const handleExport = useCallback(() => {
+    onExportCsv?.(buildResultsCsv(filtered))
+  }, [filtered, onExportCsv])
 
   const stats = useMemo(() => computeStats(filtered), [filtered])
   const sparklineResults = useMemo(
@@ -82,12 +113,17 @@ export function TypingTestHistory({ results, onExportCsv }: Props) {
         case 'wpm':
           cmp = a.wpm - b.wpm
           break
+        case 'kpm':
+          cmp = resultKpm(a) - resultKpm(b)
+          break
         case 'accuracy':
           cmp = a.accuracy - b.accuracy
           break
         case 'mode': {
-          const modeA = `${a.mode ?? ''}${a.mode2 ?? ''}`
-          const modeB = `${b.mode ?? ''}${b.mode2 ?? ''}`
+          // Sort by what the Mode column actually shows (text name for custom),
+          // so custom rows order by name rather than an opaque textId.
+          const modeA = `${a.mode ?? ''}${modeDetail(a)}`
+          const modeB = `${b.mode ?? ''}${modeDetail(b)}`
           cmp = modeA.localeCompare(modeB)
           break
         }
@@ -101,24 +137,44 @@ export function TypingTestHistory({ results, onExportCsv }: Props) {
 
   return (
     <div data-testid="typing-test-history" className="flex h-full max-w-4xl flex-col gap-3">
-      {/* Header: mode filter + export */}
+      {/* Top tabs: Monkeytype (words/time/quote) vs imported Text (custom). */}
+      <div className="flex items-center gap-4 border-b border-edge">
+        {(['monkeytype', 'text'] as HistoryTab[]).map((tb) => (
+          <button
+            key={tb}
+            type="button"
+            data-testid={`history-tab-${tb}`}
+            aria-selected={tab === tb}
+            className={tab === tb
+              ? 'border-b-2 border-accent px-1 pb-1.5 text-sm font-semibold text-accent'
+              : 'border-b-2 border-transparent px-1 pb-1.5 text-sm text-content-secondary hover:text-content'}
+            onClick={() => setTab(tb)}
+          >
+            {t(tb === 'text' ? 'editor.typingTest.history.tabCustom' : 'editor.typingTest.history.tabNormal')}
+          </button>
+        ))}
+      </div>
+
+      {/* Sub-filter (Monkeytype only) + per-tab export */}
       <div className="flex items-center gap-2">
-        <div className="flex gap-1.5">
-          {MODE_FILTERS.map((mode) => (
-            <button
-              key={mode}
-              type="button"
-              data-testid={`history-filter-${mode}`}
-              className={modeFilterButtonClass(modeFilter === mode)}
-              aria-pressed={modeFilter === mode}
-              onClick={() => setModeFilter(mode)}
-            >
-              {mode === 'all'
-                ? t('editor.typingTest.history.allModes')
-                : t(`editor.typingTest.mode.${mode}`)}
-            </button>
-          ))}
-        </div>
+        {!isText && (
+          <div className="flex gap-1.5">
+            {MODE_FILTERS.map((mode) => (
+              <button
+                key={mode}
+                type="button"
+                data-testid={`history-filter-${mode}`}
+                className={modeFilterButtonClass(modeFilter === mode)}
+                aria-pressed={modeFilter === mode}
+                onClick={() => setModeFilter(mode)}
+              >
+                {mode === 'all'
+                  ? t('editor.typingTest.history.allModes')
+                  : t(`editor.typingTest.mode.${mode}`)}
+              </button>
+            ))}
+          </div>
+        )}
         {onExportCsv && (
           <button
             type="button"
@@ -153,25 +209,32 @@ export function TypingTestHistory({ results, onExportCsv }: Props) {
           <table className="w-full text-left text-xs">
             <thead className="sticky top-0 bg-surface-alt text-content-muted">
               <tr>
+                <th className="px-3 py-1.5">{t('editor.typingTest.history.name')}</th>
                 <SortableHeader column="date" label={t('editor.typingTest.history.date')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
                 <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
                 <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="mode" label={t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
+                <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
                 <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
                 <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
+                {onDelete && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.delete')} />}
               </tr>
             </thead>
             <tbody>
-              {sorted.map((r, i) => (
+              {sorted.map((r) => (
                 <tr
-                  key={i}
+                  key={r.date}
                   className="border-t border-edge/50 transition-colors hover:bg-surface-alt/50"
                 >
+                  <NameCell result={r} onRename={onRename} />
                   <td className="px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
                   <td className="px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
+                  <td className="px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
                   <td className="px-3 py-1.5 font-mono">{r.accuracy}%</td>
                   <td className="px-3 py-1.5 text-content-muted">
-                    {t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}{r.mode2 != null ? ` ${r.mode2}` : ''}
+                    {isText
+                      ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
+                      : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`}
                   </td>
                   <td className="px-3 py-1.5 font-mono text-content-muted">
                     {formatDuration(r.durationSeconds)}
@@ -179,6 +242,39 @@ export function TypingTestHistory({ results, onExportCsv }: Props) {
                   <td className="px-3 py-1.5">
                     {r.isPb && <Trophy role="img" className="inline-block size-3.5 text-warning" aria-label={t('editor.typingTest.history.pb')} />}
                   </td>
+                  {onDelete && (
+                    <td className="px-3 py-1.5">
+                      {confirmDeleteDate === r.date ? (
+                        <div className="flex items-center gap-0.5">
+                          <button
+                            type="button"
+                            className={CONFIRM_DELETE_BTN}
+                            onClick={() => { onDelete(r.date); setConfirmDeleteDate(null) }}
+                            data-testid={`history-delete-confirm-${r.date}`}
+                          >
+                            {t('common.confirmDelete')}
+                          </button>
+                          <button
+                            type="button"
+                            className={ACTION_BTN}
+                            onClick={() => setConfirmDeleteDate(null)}
+                            data-testid={`history-delete-cancel-${r.date}`}
+                          >
+                            {t('common.cancel')}
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          className={DELETE_BTN}
+                          onClick={() => setConfirmDeleteDate(r.date)}
+                          data-testid={`history-delete-${r.date}`}
+                        >
+                          {t('common.delete')}
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))}
             </tbody>
@@ -238,9 +334,62 @@ interface StatItemProps {
 
 function StatItem({ label, value, highlight }: StatItemProps) {
   return (
-    <div className="flex items-center gap-1.5">
+    // Baseline-align so the mono value digits sit level with the sans label
+    // (their font metrics differ, so items-center looks vertically off).
+    <div className="flex items-baseline gap-1.5">
       <span className="text-content-muted">{label}:</span>
       <span className={`font-mono font-semibold ${highlight ? 'text-accent' : ''}`}>{value}</span>
     </div>
+  )
+}
+
+interface NameCellProps {
+  result: TypingTestResult
+  onRename?: (date: string, name: string) => void
+}
+
+/** Editable result label. Click to rename (commit on Enter / blur, cancel
+ *  on Escape). Read-only "—" when no rename handler is provided. */
+function NameCell({ result, onRename }: NameCellProps) {
+  const { t } = useTranslation()
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState(result.name ?? '')
+  const placeholder = t('editor.typingTest.history.unnamed')
+
+  if (!onRename) {
+    return <td className="px-3 py-1.5 text-content-muted">{result.name || placeholder}</td>
+  }
+
+  const commit = (): void => {
+    setEditing(false)
+    onRename(result.date, value)
+  }
+
+  return (
+    <td className="px-3 py-1.5">
+      {editing ? (
+        <input
+          autoFocus
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit()
+            else if (e.key === 'Escape') { setValue(result.name ?? ''); setEditing(false) }
+          }}
+          className="w-full rounded border border-edge bg-surface px-1.5 py-0.5 text-xs text-content focus:border-accent focus:outline-none"
+          data-testid={`history-name-input-${result.date}`}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={() => { setValue(result.name ?? ''); setEditing(true) }}
+          className="w-full cursor-text text-left text-content-secondary underline decoration-dotted underline-offset-4 hover:text-content"
+          data-testid={`history-name-${result.date}`}
+        >
+          {result.name || placeholder}
+        </button>
+      )}
+    </td>
   )
 }

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useRef, useEffect, useLayoutEffect, useCallback } from 'react'
+import { useRef, useEffect, useLayoutEffect, useCallback, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import { RotateCcw } from 'lucide-react'
 import { ICON_XL } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig, TypingTestMode, QuoteLength } from './types'
-import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS } from './types'
+import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS, DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
 import { WordDisplay } from './WordDisplay'
 import { Tooltip } from '../components/ui/Tooltip'
 
@@ -17,6 +18,8 @@ const QUOTE_LENGTHS: QuoteLength[] = ['short', 'medium', 'long', 'all']
 interface Props {
   state: TypingTestState
   wpm: number
+  /** Keystrokes per minute — shown instead of WPM in custom mode. */
+  kpm?: number
   accuracy: number
   elapsedSeconds: number
   remainingSeconds: number | null
@@ -29,6 +32,13 @@ interface Props {
   onCompositionEnd?: (data: string) => void
   /** Called when Space is input via IME (keydown swallowed by the IME layer). */
   onImeSpaceKey?: () => void
+  /** Imported-text display: visible line count + font size (px). Ignored
+   *  outside custom mode. */
+  displayLines?: number
+  fontSize?: number
+  /** Name the just-finished result inline from the completion screen
+   *  (imported custom text only). Keyed to the most recent saved result. */
+  onNameResult?: (name: string) => void
 }
 
 function formatTime(seconds: number): string {
@@ -44,9 +54,36 @@ function optionButtonClass(active: boolean, px: 'px-2.5' | 'px-3' = 'px-3'): str
     : `${base} border-edge text-content-secondary hover:text-content`
 }
 
+/** Group flat word indices into logical lines using the line-break set
+ *  (imported custom text). Each entry is the global word indices of one
+ *  line, in order. */
+function groupIntoLines(words: string[], lineBreaks: Set<number>): number[][] {
+  const lines: number[][] = []
+  let current: number[] = []
+  for (let i = 0; i < words.length; i++) {
+    current.push(i)
+    if (lineBreaks.has(i)) {
+      lines.push(current)
+      current = []
+    }
+  }
+  if (current.length > 0) lines.push(current)
+  return lines
+}
+
+/** Which logical line the word index sits on (= breaks before it). */
+function lineIndexOf(wordIndex: number, lineBreaks: Set<number>): number {
+  let line = 0
+  for (const b of lineBreaks) {
+    if (b < wordIndex) line++
+  }
+  return line
+}
+
 export function TypingTestView({
   state,
   wpm,
+  kpm = 0,
   accuracy,
   elapsedSeconds,
   remainingSeconds,
@@ -58,14 +95,46 @@ export function TypingTestView({
   onCompositionUpdate,
   onCompositionEnd,
   onImeSpaceKey,
+  displayLines = DEFAULT_DISPLAY_LINES,
+  fontSize = DEFAULT_FONT_SIZE,
+  onNameResult,
 }: Props) {
   const { t } = useTranslation()
-  const showStats = state.status === 'running' || state.status === 'finished'
+  const showStats = state.status === 'running' || state.status === 'finished' || state.status === 'paused'
   const wordsRef = useRef<HTMLDivElement>(null)
   const imeInputRef = useRef<HTMLTextAreaElement>(null)
   const isComposingRef = useRef(false)
   // Guard: prevent duplicate space submission when both keydown and input fire
   const lastSpaceTimeRef = useRef(0)
+
+  // Imported custom text (line breaks present) renders as explicit line
+  // rows; every other mode keeps the flat word-flow layout. `null` = flat.
+  const lines = useMemo(
+    () => (state.lineBreaks.size > 0 ? groupIntoLines(state.words, state.lineBreaks) : null),
+    [state.words, state.lineBreaks],
+  )
+  // Imported-text window: font size + line count drive the CSS calc in
+  // .typing-multiline-window. Memoized so the style object is stable.
+  const multilineStyle = useMemo(
+    () => (lines ? ({ '--tt-font': fontSize, '--tt-lines': displayLines } as CSSProperties) : undefined),
+    [lines, fontSize, displayLines],
+  )
+
+  // Imported custom text counts progress by character (spaces included): each
+  // word-gap is one separator char, so total = Σ word lengths + (words - 1).
+  // Gated on the mode (not `lines`) so single-line imports count chars too.
+  const isCustom = config.mode === 'custom'
+  const totalChars = useMemo(
+    () => (isCustom ? state.words.reduce((sum, w) => sum + w.length, 0) + Math.max(0, state.words.length - 1) : 0),
+    [isCustom, state.words],
+  )
+  const typedChars = useMemo(() => {
+    if (!isCustom) return 0
+    let sum = state.currentInput.length
+    for (let i = 0; i < state.currentWordIndex && i < state.words.length; i++) sum += state.words[i].length
+    sum += Math.min(state.currentWordIndex, Math.max(0, state.words.length - 1)) // separators passed
+    return Math.min(sum, totalChars)
+  }, [isCustom, state.words, state.currentWordIndex, state.currentInput, totalChars])
 
   function clearImeInput(): void {
     if (imeInputRef.current) imeInputRef.current.value = ''
@@ -98,6 +167,21 @@ export function TypingTestView({
     const container = wordsRef.current
     if (!container) return
 
+    // Imported custom text: snap so the previous line sits at the top, so
+    // the four visible lines read [previous, current, next, next-next].
+    // Aligning to a real line element's top means lines are never clipped.
+    if (lines) {
+      const currentLine = lineIndexOf(state.currentWordIndex, state.lineBreaks)
+      if (currentLine <= 0) {
+        container.scrollTop = 0
+        return
+      }
+      const prevRow = container.querySelectorAll<HTMLElement>('[data-line-row]')[currentLine - 1]
+      if (!prevRow) return
+      container.scrollTop += prevRow.getBoundingClientRect().top - container.getBoundingClientRect().top
+      return
+    }
+
     const activeWord = container.querySelector<HTMLElement>(
       `[data-testid="word-${state.currentWordIndex}"]`,
     )
@@ -111,11 +195,11 @@ export function TypingTestView({
     if (visibleLine >= 2) {
       container.scrollTop += (visibleLine - 1) * lineHeight
     }
-  }, [state.currentWordIndex])
+  }, [state.currentWordIndex, state.lineBreaks, lines])
 
-  // Remember toggle state so it persists through quote mode (which has no toggles)
+  // Remember toggle state so it persists through quote/custom modes (which have no toggles)
   const togglesRef = useRef({ punctuation: false, numbers: false })
-  if (config.mode !== 'quote') {
+  if (config.mode === 'words' || config.mode === 'time') {
     togglesRef.current = { punctuation: config.punctuation, numbers: config.numbers }
   }
 
@@ -154,9 +238,25 @@ export function TypingTestView({
     ? formatTime(remainingSeconds)
     : formatTime(elapsedSeconds)
 
+  // Shared by the line-row and flat layouts so the word props stay in one place.
+  const renderWord = (wordIdx: number) => (
+    <WordDisplay
+      key={wordIdx}
+      word={state.words[wordIdx]}
+      wordIndex={wordIdx}
+      currentWordIndex={state.currentWordIndex}
+      currentInput={state.currentInput}
+      wordResults={state.wordResults}
+      cursorBlink={state.status === 'waiting'}
+      compositionText={wordIdx === state.currentWordIndex ? state.compositionText : ''}
+    />
+  )
+
   return (
     <div data-testid="typing-test-view" className="flex flex-col items-center gap-6 px-6 py-8">
-      {/* Settings bar */}
+      {/* Settings bar — hidden for imported custom text: its words/time/quote
+          tabs don't apply, so dropping it frees space for the reading area. */}
+      {config.mode !== 'custom' && (
       <div className="flex flex-wrap items-center justify-center gap-4">
         {/* Mode tabs */}
         <div className="flex items-center gap-1 rounded-lg bg-surface-alt/50 px-1 py-0.5">
@@ -250,6 +350,7 @@ export function TypingTestView({
           </>
         )}
       </div>
+      )}
 
       {/* Stats bar — always rendered to reserve height and prevent layout shift */}
       <div className={`flex items-center gap-8 text-sm ${showStats ? '' : 'invisible'}`}>
@@ -257,6 +358,12 @@ export function TypingTestView({
           <span className="text-content-muted">{t('editor.typingTest.wpm')}:</span>
           <span data-testid="typing-test-wpm" className="font-mono text-lg font-semibold text-accent">
             {wpm}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="text-content-muted">{t('editor.typingTest.kpm')}:</span>
+          <span data-testid="typing-test-kpm" className="font-mono text-lg font-semibold text-accent">
+            {kpm}
           </span>
         </div>
         <div className="flex items-center gap-1.5">
@@ -272,20 +379,26 @@ export function TypingTestView({
           </span>
         </div>
         <div className="flex items-center gap-1.5">
-          <span className="text-content-muted">{t('editor.typingTest.words')}:</span>
+          {/* Imported custom text tracks character progress (spaces included);
+              everything else tracks words. */}
+          <span className="text-content-muted">{t(isCustom ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
           <span data-testid="typing-test-word-count" className="font-mono text-lg font-semibold">
-            {t('editor.typingTest.wordCount', {
-              current: state.currentWordIndex,
-              total: state.words.length,
-            })}
+            {isCustom
+              ? t('editor.typingTest.wordCount', { current: typedChars, total: totalChars })
+              : t('editor.typingTest.wordCount', {
+                  current: state.currentWordIndex,
+                  total: state.words.length,
+                })}
           </span>
         </div>
       </div>
 
-      {/* Word display — fixed 3-line window with scroll */}
+      {/* Word display — fixed window with scroll. Word-flow modes show a
+          3-line window; imported custom text shows 4 lines (line-row layout). */}
       <div
         data-testid="typing-test-words"
-        className="relative h-typing-display w-full max-w-4xl font-mono text-2xl leading-normal"
+        className={`relative w-full max-w-4xl font-mono leading-normal ${lines ? 'typing-multiline-window' : 'text-2xl h-typing-display'}`}
+        style={multilineStyle}
         onClick={() => imeInputRef.current?.focus()}
       >
         {/* Hidden textarea for IME composition input */}
@@ -335,20 +448,27 @@ export function TypingTestView({
         )}
         {state.status !== 'countdown' && state.words.length > 0 && (
           <div ref={wordsRef} className="h-full overflow-hidden">
-            <div className="flex flex-wrap gap-x-3 gap-y-1">
-              {state.words.map((word, wordIdx) => (
-                <WordDisplay
-                  key={wordIdx}
-                  word={word}
-                  wordIndex={wordIdx}
-                  currentWordIndex={state.currentWordIndex}
-                  currentInput={state.currentInput}
-                  wordResults={state.wordResults}
-                  cursorBlink={state.status === 'waiting'}
-                  compositionText={wordIdx === state.currentWordIndex ? state.compositionText : ''}
-                />
-              ))}
-            </div>
+            {lines ? (
+              // Imported custom text: one row per logical line, ⏎ marks the
+              // line ends where Enter (not Space) advances.
+              lines.map((lineWordIdxs, lineIdx) => (
+                <div key={lineIdx} data-line-row={lineIdx} className="flex flex-wrap gap-x-3">
+                  {state.lineIndents[lineIdx] && (
+                    // Code indentation, display only — not typed (Space submits
+                    // a word, so leading spaces can't be keyed).
+                    <span data-testid={`line-indent-${lineIdx}`} className="-mr-3 select-none whitespace-pre text-content-muted/40" aria-hidden="true">{state.lineIndents[lineIdx]}</span>
+                  )}
+                  {lineWordIdxs.map(renderWord)}
+                  {lineIdx < lines.length - 1 && (
+                    <span className="select-none text-content-muted/40" aria-hidden="true">⏎</span>
+                  )}
+                </div>
+              ))
+            ) : (
+              <div className="flex flex-wrap gap-x-3 gap-y-1">
+                {state.words.map((_, wordIdx) => renderWord(wordIdx))}
+              </div>
+            )}
           </div>
         )}
         {paused && state.status === 'running' && (
@@ -378,23 +498,82 @@ export function TypingTestView({
 
       {/* Finished results */}
       {state.status === 'finished' && (
-        <div data-testid="typing-test-results" className="flex flex-wrap items-center gap-6 border-t border-edge pt-4 text-lg">
-          <span className="font-semibold">{t('editor.typingTest.finished')}</span>
-          <span className="text-content-muted">
-            {t('editor.typingTest.wpm')}: <span className="font-semibold text-accent">{wpm}</span>
-          </span>
-          <span className="text-content-muted">
-            {t('editor.typingTest.accuracy')}: <span className="font-semibold">{accuracy}%</span>
-          </span>
-          {config.mode === 'quote' && state.currentQuote && (
-            <span data-testid="typing-test-quote-source" className="text-content-muted italic">
-              {t('editor.typingTest.quoteSource', { source: state.currentQuote.source })}
-            </span>
+        <div data-testid="typing-test-results" className="flex flex-col items-center gap-2 border-t border-edge pt-4 text-lg">
+          {/* Imported custom text: name the result on its own centered row. */}
+          {config.mode === 'custom' && (
+            <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} />
           )}
+          <div className="flex flex-wrap items-center justify-center gap-6">
+            <span className="font-semibold">{t('editor.typingTest.finished')}</span>
+            <span className="text-content-muted">
+              {t('editor.typingTest.wpm')}: <span className="font-semibold text-accent">{wpm}</span>
+            </span>
+            <span className="text-content-muted">
+              {t('editor.typingTest.kpm')}: <span className="font-semibold text-accent">{kpm}</span>
+            </span>
+            <span className="text-content-muted">
+              {t('editor.typingTest.accuracy')}: <span className="font-semibold">{accuracy}%</span>
+            </span>
+            {config.mode === 'quote' && state.currentQuote && (
+              <span data-testid="typing-test-quote-source" className="text-content-muted italic">
+                {t('editor.typingTest.quoteSource', { source: state.currentQuote.source })}
+              </span>
+            )}
+          </div>
         </div>
       )}
 
     </div>
+  )
+}
+
+/** Inline-editable name for the just-finished result, shown on the completion
+ *  screen for imported custom text. Empty renders the "Unnamed" placeholder;
+ *  a dotted underline hints the text is editable. Commit on Enter / blur,
+ *  cancel on Escape. Mounted with a per-test `key`, so the draft always
+ *  starts empty for a fresh result. */
+function ResultNameField({ onName }: { onName?: (name: string) => void }) {
+  const { t } = useTranslation()
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState('')
+  // Snapshot of the value when editing began, restored on Escape.
+  const editStartValueRef = useRef('')
+
+  const commit = (): void => {
+    setEditing(false)
+    onName?.(value)
+  }
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        data-tt-passthrough=""
+        value={value}
+        aria-label={t('editor.typingTest.nameResult')}
+        onChange={(e) => setValue(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') commit()
+          else if (e.key === 'Escape') { setValue(editStartValueRef.current); setEditing(false) }
+        }}
+        className="rounded border border-edge bg-surface px-1.5 py-0.5 text-base text-content focus:border-accent focus:outline-none"
+        data-testid="typing-test-result-name-input"
+      />
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => { editStartValueRef.current = value; setEditing(true) }}
+      title={t('editor.typingTest.nameResult')}
+      aria-label={t('editor.typingTest.nameResult')}
+      className={`cursor-text italic underline decoration-dotted underline-offset-4 transition-colors hover:text-content ${value ? 'text-content-secondary' : 'text-content-muted'}`}
+      data-testid="typing-test-result-name"
+    >
+      {value || t('editor.typingTest.history.unnamed')}
+    </button>
   )
 }
 

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -219,4 +219,55 @@ describe('LanguageSelectorModal', () => {
     const arabicRow = screen.getByTestId('language-row-arabic')
     expect(arabicRow.textContent).toContain('RTL')
   })
+
+  it('deleting the selected imported text then closing fires onCurrentTextDeleted', async () => {
+    window.vialAPI = {
+      ...window.vialAPI,
+      typingTestTextStoreList: vi.fn().mockResolvedValue({
+        success: true,
+        data: [{ id: 'x', name: 'My Text', wordCount: 3, filename: 'x.json', savedAt: '', updatedAt: '' }],
+      }),
+      typingTestTextStoreDelete: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as typeof window.vialAPI
+
+    const onCurrentTextDeleted = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        currentCustomTextId="x"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onCurrentTextDeleted={onCurrentTextDeleted}
+        onClose={onClose}
+      />,
+    )
+
+    // Modal opens on the Import tab because a custom text is selected.
+    await waitFor(() => expect(screen.getByTestId('typing-text-delete-x')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('typing-text-delete-x'))
+    await waitFor(() => expect(window.vialAPI.typingTestTextStoreDelete).toHaveBeenCalledWith('x'))
+
+    fireEvent.click(screen.getByTestId('language-modal-close'))
+    expect(onCurrentTextDeleted).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onCurrentTextDeleted when nothing was deleted', async () => {
+    const onCurrentTextDeleted = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onCurrentTextDeleted={onCurrentTextDeleted}
+        onClose={onClose}
+      />,
+    )
+    await waitFor(() => expect(screen.getByTestId('language-search')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('language-modal-close'))
+    expect(onCurrentTextDeleted).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -101,7 +101,8 @@ describe('TypingTestHistory', () => {
       const trs = history.querySelectorAll('tbody tr')
       return Array.from(trs).map((tr) => {
         const cells = tr.querySelectorAll('td')
-        return Number(cells[1].textContent)
+        // Columns: Name, Date, WPM, Accuracy, Mode, Duration, PB
+        return Number(cells[2].textContent)
       })
     }
 
@@ -131,7 +132,7 @@ describe('TypingTestHistory', () => {
 
     // Other sortable headers should be 'none'
     const noneHeaders = Array.from(headers).filter((h) => h.getAttribute('aria-sort') === 'none')
-    expect(noneHeaders.length).toBe(4) // wpm, accuracy, mode, duration
+    expect(noneHeaders.length).toBe(5) // wpm, kpm, accuracy, mode, duration
   })
 
   it('computes stats from filtered data', () => {
@@ -164,7 +165,7 @@ describe('TypingTestHistory', () => {
     expect(onExportCsv).toHaveBeenCalledTimes(1)
 
     const csv = onExportCsv.mock.calls[0][0] as string
-    expect(csv).toContain('date,wpm,accuracy')
+    expect(csv).toContain('date,name,wpm,kpm,accuracy')
     expect(csv).toContain('2025-01-01T00:00:00Z')
     expect(csv).toContain('80')
   })
@@ -172,5 +173,83 @@ describe('TypingTestHistory', () => {
   it('does not show export button when onExportCsv is not provided', () => {
     renderWithI18n(<TypingTestHistory results={[makeResult()]} />)
     expect(screen.queryByTestId('history-export-csv')).toBeNull()
+  })
+
+  it('renames a result inline and calls onRename', () => {
+    const date = '2025-02-02T03:04:05.000Z'
+    const onRename = vi.fn()
+    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onRename={onRename} />)
+    fireEvent.click(screen.getByTestId(`history-name-${date}`))
+    const input = screen.getByTestId(`history-name-input-${date}`)
+    fireEvent.change(input, { target: { value: 'QWERTY baseline' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onRename).toHaveBeenCalledWith(date, 'QWERTY baseline')
+  })
+
+  it('shows the imported-text name (not the textId) for custom-mode rows under the Text tab', () => {
+    const results = [makeResult({
+      mode: 'custom',
+      mode2: 'b286fff1-78d1-40d5-8ea0-6dd57561badf',
+      customTextName: 'my-novel.txt',
+    })]
+    renderWithI18n(<TypingTestHistory results={results} />)
+    // Custom rows live under the Text tab, not Monkeytype (the default).
+    fireEvent.click(screen.getByTestId('history-tab-text'))
+    expect(screen.getByText('my-novel.txt')).toBeTruthy()
+    expect(screen.queryByText(/b286fff1/)).toBeNull()
+  })
+
+  it('shows a KPM column derived from chars and duration', () => {
+    // correctChars 100 over 30s → 100 * 60 / 30 = 200 KPM.
+    renderWithI18n(<TypingTestHistory results={[makeResult({ correctChars: 100, durationSeconds: 30 })]} />)
+    expect(screen.getAllByText('200').length).toBeGreaterThan(0)
+  })
+
+  it('separates Monkeytype and Text results into tabs', () => {
+    const results = [
+      makeResult({ wpm: 81, mode: 'words', mode2: 30 }),
+      makeResult({ wpm: 82, mode: 'custom', mode2: 'id-1', customTextName: 'novel.txt' }),
+    ]
+    renderWithI18n(<TypingTestHistory results={results} />)
+    // Monkeytype tab (default): words result shown, custom hidden.
+    expect(screen.getAllByText('81').length).toBeGreaterThan(0)
+    expect(screen.queryByText('novel.txt')).toBeNull()
+    // Text tab: custom result shown, words hidden.
+    fireEvent.click(screen.getByTestId('history-tab-text'))
+    expect(screen.getByText('novel.txt')).toBeTruthy()
+    expect(screen.queryByText('81')).toBeNull()
+  })
+
+  it('deletes a result only after confirmation', () => {
+    const date = '2025-03-03T01:02:03.000Z'
+    const onDelete = vi.fn()
+    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
+    // First click asks for confirmation, does not delete yet.
+    fireEvent.click(screen.getByTestId(`history-delete-${date}`))
+    expect(onDelete).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByTestId(`history-delete-confirm-${date}`))
+    expect(onDelete).toHaveBeenCalledWith(date)
+  })
+
+  it('cancels deletion when cancel is clicked', () => {
+    const date = '2025-04-04T01:02:03.000Z'
+    const onDelete = vi.fn()
+    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
+    fireEvent.click(screen.getByTestId(`history-delete-${date}`))
+    fireEvent.click(screen.getByTestId(`history-delete-cancel-${date}`))
+    expect(onDelete).not.toHaveBeenCalled()
+    // Delete button is back.
+    expect(screen.getByTestId(`history-delete-${date}`)).toBeTruthy()
+  })
+
+  it('shows no delete button when no onDelete handler', () => {
+    renderWithI18n(<TypingTestHistory results={[makeResult({ date: 'd1' })]} />)
+    expect(screen.queryByTestId('history-delete-d1')).toBeNull()
+  })
+
+  it('renders the name read-only (no edit) when no onRename handler', () => {
+    renderWithI18n(<TypingTestHistory results={[makeResult({ date: 'x', name: 'kept' })]} />)
+    expect(screen.queryByTestId('history-name-x')).toBeNull()
+    expect(screen.getByText('kept')).toBeTruthy()
   })
 })

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -24,6 +24,8 @@ function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
     incorrectChars: 0,
     currentQuote: null,
     wpmHistory: [],
+    lineBreaks: new Set(),
+    lineIndents: [],
     ...overrides,
   }
 }
@@ -418,6 +420,77 @@ describe('TypingTestView quote mode display', () => {
   })
 })
 
+describe('TypingTestView custom mode result naming', () => {
+  const customConfig: TypingTestConfig = { mode: 'custom', textId: 'abc' }
+
+  it('shows an inline name field (placeholder Unnamed) instead of the quote source', () => {
+    renderView({
+      config: customConfig,
+      state: makeState({ status: 'finished', currentQuote: { id: 1, text: 'x', source: 'code', length: 1 } }),
+    })
+    expect(screen.queryByTestId('typing-test-quote-source')).toBeNull()
+    const field = screen.getByTestId('typing-test-result-name')
+    expect(field.textContent).toBe('Unnamed')
+  })
+
+  it('shows both WPM and KPM in custom mode', () => {
+    renderView({
+      config: customConfig,
+      state: makeState({ status: 'running' }),
+      wpm: 24,
+      kpm: 120,
+    })
+    expect(screen.getByTestId('typing-test-wpm').textContent).toBe('24')
+    expect(screen.getByTestId('typing-test-kpm').textContent).toBe('120')
+  })
+
+  it('preserves leading indentation per line (display only)', () => {
+    renderView({
+      config: customConfig,
+      state: makeState({
+        status: 'running',
+        words: ['def', 'x'],
+        lineBreaks: new Set([0]),
+        lineIndents: ['', '  '],
+      }),
+    })
+    // First line has no indent; second line keeps its two-space indent.
+    expect(screen.queryByTestId('line-indent-0')).toBeNull()
+    expect(screen.getByTestId('line-indent-1').textContent).toBe('  ')
+  })
+
+  it('counts custom progress by character, the word gap included', () => {
+    // "AAA AA" -> 3 + 2 + 1 separator = 6 characters total.
+    renderView({
+      config: customConfig,
+      state: makeState({ status: 'running', words: ['AAA', 'AA'], currentWordIndex: 1, currentInput: '' }),
+    })
+    // 1 word done (3 chars) + 1 separator passed = 4 / 6.
+    expect(screen.getByTestId('typing-test-word-count').textContent).toBe('4 / 6')
+  })
+
+  it('hides the words/time/quote settings bar in custom mode', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+    expect(screen.queryByTestId('mode-words')).toBeNull()
+    expect(screen.queryByTestId('mode-time')).toBeNull()
+    expect(screen.queryByTestId('mode-quote')).toBeNull()
+  })
+
+  it('names the finished result on commit', () => {
+    const onNameResult = vi.fn()
+    renderView({
+      config: customConfig,
+      state: makeState({ status: 'finished' }),
+      onNameResult,
+    })
+    fireEvent.click(screen.getByTestId('typing-test-result-name'))
+    const input = screen.getByTestId('typing-test-result-name-input')
+    fireEvent.change(input, { target: { value: 'QWERTY baseline' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onNameResult).toHaveBeenCalledWith('QWERTY baseline')
+  })
+})
+
 describe('TypingTestView IME space key', () => {
   it('calls onImeSpaceKey when textarea receives half-width space input while not composing', () => {
     const onImeSpaceKey = vi.fn()
@@ -495,5 +568,62 @@ describe('TypingTestView paused overlay', () => {
       paused: true,
     })
     expect(screen.queryByTestId('typing-test-paused')).not.toBeInTheDocument()
+  })
+})
+
+describe('TypingTestView — imported custom text (line breaks)', () => {
+  it('renders one row per logical line with ⏎ at line ends, and uses the 4-line window', () => {
+    const { container } = renderView({
+      state: makeState({
+        status: 'running',
+        words: ['a', 'b', 'c', 'd'],
+        currentInput: '',
+        lineBreaks: new Set([1]),
+      }),
+    })
+    // Two logical lines: [a b] / [c d].
+    const rows = container.querySelectorAll('[data-line-row]')
+    expect(rows).toHaveLength(2)
+    // ⏎ marker only after the non-final line.
+    expect(container.textContent).toContain('⏎')
+    expect(container.querySelectorAll('[data-line-row]')[0].textContent).toContain('⏎')
+    expect(container.querySelectorAll('[data-line-row]')[1].textContent).not.toContain('⏎')
+    // Imported text uses the var-driven multiline window.
+    expect(screen.getByTestId('typing-test-words').className).toContain('typing-multiline-window')
+  })
+
+  it('applies font size and line count as CSS vars on the custom window', () => {
+    renderView({
+      displayLines: 6,
+      fontSize: 32,
+      state: makeState({ status: 'running', words: ['a', 'b', 'c', 'd'], lineBreaks: new Set([1]) }),
+    })
+    const win = screen.getByTestId('typing-test-words')
+    expect(win.style.getPropertyValue('--tt-font')).toBe('32')
+    expect(win.style.getPropertyValue('--tt-lines')).toBe('6')
+  })
+
+  it('shows character progress (not word/line progress) in the stats bar', () => {
+    renderView({
+      config: { mode: 'custom', textId: 'x' },
+      state: makeState({
+        status: 'running',
+        words: ['a', 'b', 'c', 'd'],
+        currentWordIndex: 2,
+        lineBreaks: new Set([1]),
+      }),
+    })
+    // total = 4 word chars + 3 separators = 7. Done: 2 words (2 chars) + 2
+    // separators passed = 4 → "4 / 7".
+    expect(screen.getByTestId('typing-test-word-count').textContent).toBe('4 / 7')
+  })
+
+  it('keeps the flat word-flow layout (no line rows) when there are no line breaks', () => {
+    const { container } = renderView({
+      state: makeState({ status: 'running', words: ['a', 'b'], lineBreaks: new Set() }),
+    })
+    expect(container.querySelectorAll('[data-line-row]')).toHaveLength(0)
+    expect(screen.getByTestId('typing-test-words').className).toContain('h-typing-display')
+    expect(screen.getByTestId('typing-test-words').className).not.toContain('typing-multiline-window')
   })
 })

--- a/src/renderer/typing-test/__tests__/display-prefs.test.ts
+++ b/src/renderer/typing-test/__tests__/display-prefs.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import {
+  clampDisplayLines,
+  clampFontSize,
+  DEFAULT_DISPLAY_LINES,
+  DEFAULT_FONT_SIZE,
+  DISPLAY_LINES_MIN,
+  DISPLAY_LINES_MAX,
+  FONT_SIZE_MIN,
+  FONT_SIZE_MAX,
+} from '../types'
+
+describe('clampDisplayLines', () => {
+  it('keeps in-range integers', () => {
+    expect(clampDisplayLines(4)).toBe(4)
+    expect(clampDisplayLines(DEFAULT_DISPLAY_LINES)).toBe(DEFAULT_DISPLAY_LINES)
+  })
+  it('clamps below/above the range', () => {
+    expect(clampDisplayLines(0)).toBe(DISPLAY_LINES_MIN)
+    expect(clampDisplayLines(1)).toBe(DISPLAY_LINES_MIN)
+    expect(clampDisplayLines(99)).toBe(DISPLAY_LINES_MAX)
+  })
+  it('rounds fractional values', () => {
+    expect(clampDisplayLines(4.6)).toBe(5)
+  })
+})
+
+describe('clampFontSize', () => {
+  it('keeps in-range even sizes', () => {
+    expect(clampFontSize(24)).toBe(24)
+    expect(clampFontSize(DEFAULT_FONT_SIZE)).toBe(DEFAULT_FONT_SIZE)
+  })
+  it('snaps odd values to the nearest even step', () => {
+    expect(clampFontSize(25)).toBe(26)
+    expect(clampFontSize(23)).toBe(24)
+  })
+  it('clamps below/above the range', () => {
+    expect(clampFontSize(2)).toBe(FONT_SIZE_MIN)
+    expect(clampFontSize(100)).toBe(FONT_SIZE_MAX)
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.customText.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.customText.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTypingTest } from '../useTypingTest'
+import { getCustomTextData, clearCustomTextCache } from '../word-generator'
+
+const mockGet = vi.fn()
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearCustomTextCache()
+  window.vialAPI = {
+    ...(window.vialAPI ?? {}),
+    typingTestTextStoreGet: mockGet,
+  } as unknown as typeof window.vialAPI
+})
+
+afterEach(() => {
+  clearCustomTextCache()
+  window.vialAPI = originalVialAPI
+})
+
+const type = (result: { current: { processKeyEvent: (k: string, c: boolean, a: boolean, m: boolean) => void } }, key: string): void => {
+  act(() => result.current.processKeyEvent(key, false, false, false))
+}
+
+describe('useTypingTest — imported custom text (line breaks)', () => {
+  it('Enter advances at a line break, Space advances within a line; the wrong key is a no-op', async () => {
+    // "a b" / "c d" → words [a,b,c,d], line break after index 1 (the word "b").
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't' }, data: { name: 'T', text: 'a b\nc d' } },
+    })
+    // Warm the cache so the hook's synchronous initial state has the words.
+    await getCustomTextData('t')
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'custom', textId: 't' }, 'english'))
+    expect(result.current.state.words).toEqual(['a', 'b', 'c', 'd'])
+    expect([...result.current.state.lineBreaks]).toEqual([1])
+
+    // Word 0 ("a") is mid-line → Space advances, Enter would be a no-op.
+    type(result, 'a')
+    type(result, 'Enter') // mismatch at a non-line-end word → ignored
+    expect(result.current.state.currentWordIndex).toBe(0)
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(1)
+
+    // Word 1 ("b") ends a line → Enter advances, Space is a no-op.
+    type(result, 'b')
+    type(result, ' ') // mismatch at a line-end word → ignored
+    expect(result.current.state.currentWordIndex).toBe(1)
+    type(result, 'Enter')
+    expect(result.current.state.currentWordIndex).toBe(2)
+
+    // Word 2 ("c") mid-line → Space advances.
+    type(result, 'c')
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(3)
+
+    // Last word finishes on the final character (no separator needed).
+    type(result, 'd')
+    expect(result.current.state.status).toBe('finished')
+  })
+
+  it('words mode ignores Enter (line breaks empty) — existing behaviour unchanged', () => {
+    const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
+    expect([...result.current.state.lineBreaks]).toEqual([])
+
+    const firstWord = result.current.state.words[0]
+    for (const ch of firstWord) type(result, ch)
+    type(result, 'Enter') // ignored in words mode
+    expect(result.current.state.currentWordIndex).toBe(0)
+    type(result, ' ') // Space advances as usual
+    expect(result.current.state.currentWordIndex).toBe(1)
+  })
+})
+
+describe('useTypingTest — memory mode (pause / capture / restore)', () => {
+  const setupCustom = async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't' }, data: { name: 'T', text: 'a b\nc d' } },
+    })
+    await getCustomTextData('t')
+    return renderHook(() => useTypingTest({ mode: 'custom', textId: 't' }, 'english'))
+  }
+
+  it('captureMemory snapshots progress; pause freezes and blocks input', async () => {
+    const { result } = await setupCustom()
+    type(result, 'a')
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(1)
+
+    const mem = result.current.captureMemory()
+    expect(mem).not.toBeNull()
+    expect(mem?.textId).toBe('t')
+    expect(mem?.currentWordIndex).toBe(1)
+    expect(mem?.wordResults).toEqual([{ word: 'a', typed: 'a', correct: true }])
+    expect(typeof mem?.elapsedMs).toBe('number')
+
+    act(() => result.current.pause())
+    expect(result.current.state.status).toBe('paused')
+    // Input is ignored while paused.
+    type(result, 'c')
+    expect(result.current.state.currentInput).toBe('')
+  })
+
+  it('captureMemory returns null for non-custom modes', () => {
+    const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
+    expect(result.current.captureMemory()).toBeNull()
+  })
+
+  it('restoreState(resume=true) continues running at the saved position', async () => {
+    const { result } = await setupCustom()
+    const memory = {
+      textId: 't', currentWordIndex: 2, currentInput: 'c',
+      wordResults: [
+        { word: 'a', typed: 'a', correct: true },
+        { word: 'b', typed: 'b', correct: true },
+      ],
+      correctChars: 4, incorrectChars: 0, elapsedMs: 5000, wpmHistory: [10, 20],
+      savedAt: new Date(0).toISOString(),
+    }
+    let ok = false
+    await act(async () => { ok = await result.current.restoreState(memory, true) })
+    expect(ok).toBe(true)
+    expect(result.current.state.status).toBe('running')
+    expect(result.current.state.currentWordIndex).toBe(2)
+    expect(result.current.state.currentInput).toBe('c')
+    expect(result.current.state.wpmHistory).toEqual([10, 20])
+  })
+
+  it('restoreState(resume=false) restores the snapshot frozen as paused', async () => {
+    const { result } = await setupCustom()
+    const memory = {
+      textId: 't', currentWordIndex: 1, currentInput: '',
+      wordResults: [{ word: 'a', typed: 'a', correct: true }],
+      correctChars: 2, incorrectChars: 0, elapsedMs: 1000, wpmHistory: [],
+      savedAt: new Date(0).toISOString(),
+    }
+    await act(async () => { await result.current.restoreState(memory, false) })
+    expect(result.current.state.status).toBe('paused')
+    expect(result.current.state.currentWordIndex).toBe(1)
+  })
+})

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -44,6 +44,9 @@ export function deriveMode2(config: TypingTestConfig): number | string {
       return config.duration
     case 'quote':
       return config.quoteLength
+    case 'custom':
+      // Group PBs per imported text via its id.
+      return config.textId
   }
 }
 
@@ -57,14 +60,17 @@ export interface BuildTypingTestResultInput {
   config: TypingTestConfig
   language: string
   wpmHistory: number[]
+  /** Imported-text display name (custom mode); ignored for other modes. */
+  customTextName?: string
 }
 
 export function buildTypingTestResult(input: BuildTypingTestResultInput): TypingTestResult {
   const totalChars = input.correctChars + input.incorrectChars
   const rawWpm = computeRawWpm(totalChars, input.elapsedMs)
   const consistency = computeConsistency(input.wpmHistory)
-  const hasPunctuation = input.config.mode !== 'quote' ? input.config.punctuation : undefined
-  const hasNumbers = input.config.mode !== 'quote' ? input.config.numbers : undefined
+  const hasToggles = input.config.mode === 'words' || input.config.mode === 'time'
+  const hasPunctuation = hasToggles ? input.config.punctuation : undefined
+  const hasNumbers = hasToggles ? input.config.numbers : undefined
 
   return {
     date: new Date().toISOString(),
@@ -77,6 +83,7 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     rawWpm,
     mode: input.config.mode,
     mode2: deriveMode2(input.config),
+    customTextName: input.config.mode === 'custom' ? input.customTextName : undefined,
     language: input.language,
     punctuation: hasPunctuation,
     numbers: hasNumbers,

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-export type TypingTestMode = 'words' | 'time' | 'quote'
+export type TypingTestMode = 'words' | 'time' | 'quote' | 'custom'
 export type QuoteLength = 'short' | 'medium' | 'long' | 'all'
 
 export type TypingTestConfig =
   | { mode: 'words'; wordCount: number; punctuation: boolean; numbers: boolean }
   | { mode: 'time'; duration: number; punctuation: boolean; numbers: boolean }
   | { mode: 'quote'; quoteLength: QuoteLength }
+  // Imported user text, played verbatim in order via the quote rendering
+  // path. `textId` references an entry in the typing-test-texts store.
+  | { mode: 'custom'; textId: string }
 
 export interface Quote {
   id: number
@@ -18,6 +21,26 @@ export interface Quote {
 export const WORD_COUNT_OPTIONS = [15, 30, 60, 120] as const
 export const TIME_DURATION_OPTIONS = [15, 30, 60, 120] as const
 export const DEFAULT_LANGUAGE = 'english'
+
+// Imported custom-text display preferences (custom mode only).
+export const DISPLAY_LINES_MIN = 2
+export const DISPLAY_LINES_MAX = 10
+export const DEFAULT_DISPLAY_LINES = 4
+export const FONT_SIZE_MIN = 14
+export const FONT_SIZE_MAX = 48
+export const FONT_SIZE_STEP = 2
+export const DEFAULT_FONT_SIZE = 24
+
+/** Clamp + round a display-line-count to the supported range. */
+export function clampDisplayLines(n: number): number {
+  return Math.min(DISPLAY_LINES_MAX, Math.max(DISPLAY_LINES_MIN, Math.round(n)))
+}
+
+/** Clamp + snap a font size (px) to the supported even range. */
+export function clampFontSize(px: number): number {
+  const snapped = Math.round(px / FONT_SIZE_STEP) * FONT_SIZE_STEP
+  return Math.min(FONT_SIZE_MAX, Math.max(FONT_SIZE_MIN, snapped))
+}
 export const DEFAULT_CONFIG: TypingTestConfig = {
   mode: 'words',
   wordCount: 30,

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -2,10 +2,12 @@
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { extractMOLayer, extractLTLayer, extractLMLayer, isTapKeycode } from './keycode-char-map'
-import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords } from './word-generator'
+import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getCustomTextData, getCustomTextDataSync } from './word-generator'
+import type { CustomTextData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, Quote } from './types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from './types'
+import type { TypingTestMemory } from '../../shared/types/pipette-settings'
 import type { TypingAnalyticsEventPayload, TypingMatrixAction } from '../../shared/types/typing-analytics'
 
 export interface UseTypingTestOptions {
@@ -28,7 +30,7 @@ interface PressStartRecord {
   keycode: number
 }
 
-export type TypingTestStatus = 'countdown' | 'waiting' | 'running' | 'finished'
+export type TypingTestStatus = 'countdown' | 'waiting' | 'running' | 'finished' | 'paused'
 
 const COUNTDOWN_MS = 3000
 const TIME_MODE_BATCH_SIZE = 60
@@ -61,6 +63,13 @@ export interface TypingTestState {
   incorrectChars: number
   currentQuote: Quote | null
   wpmHistory: number[]
+  /** Word indices that end a line (imported custom text only). At these
+   *  words Enter advances; elsewhere Space advances. Empty for every other
+   *  mode, so their submit behaviour is unchanged. */
+  lineBreaks: Set<number>
+  /** Leading whitespace per logical line (imported custom text, display only).
+   *  Indexed by line order; empty for every other mode. */
+  lineIndents: string[]
 }
 
 export interface UseTypingTestReturn {
@@ -87,6 +96,9 @@ export interface UseTypingTestReturn {
   setLanguage: (language: string) => Promise<string>
   setBaseLayer: (layer: number) => void
   setWindowFocused: (focused: boolean) => void
+  captureMemory: () => TypingTestMemory | null
+  pause: () => void
+  restoreState: (memory: TypingTestMemory, resume: boolean) => Promise<boolean>
 }
 
 /** Return the word count and generation options for word-based modes (words/time). */
@@ -97,32 +109,63 @@ function wordGenParams(config: TypingTestConfig & { mode: 'words' | 'time' }): {
   }
 }
 
-function createWordsForConfigSync(config: TypingTestConfig, language: string): { words: string[]; quote: Quote | null } {
+interface WordsForConfig {
+  words: string[]
+  quote: Quote | null
+  /** Line-end word indices (custom mode only); empty otherwise. */
+  lineBreaks: number[]
+  /** Per-line leading whitespace (custom mode only); empty otherwise. */
+  lineIndents: string[]
+}
+
+/** Build the verbatim quote shell for an imported custom text so the
+ *  finished screen can show its name as the source. Carries the line-break
+ *  positions through so Enter can advance at line ends. */
+function customTextToWords(data: CustomTextData): WordsForConfig {
+  const text = data.words.join(' ')
+  return {
+    words: data.words,
+    quote: { id: 0, text, source: data.name, length: text.length },
+    lineBreaks: data.lineBreaks,
+    lineIndents: data.indents,
+  }
+}
+
+function createWordsForConfigSync(config: TypingTestConfig, language: string): WordsForConfig {
   if (config.mode === 'quote') {
     const quote = selectQuote(config.quoteLength)
-    return { words: quoteToWords(quote), quote }
+    return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
+  }
+  if (config.mode === 'custom') {
+    const data = getCustomTextDataSync(config.textId)
+    // Cache miss — the async setConfig path fills words once the store
+    // round-trip resolves. Return empty (never call sampleWords on []).
+    return data ? customTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
   }
   const { count, opts } = wordGenParams(config)
   const { words } = generateWordsSync(count, opts, language)
-  return { words, quote: null }
+  return { words, quote: null, lineBreaks: [], lineIndents: [] }
 }
 
-async function createWordsForConfig(config: TypingTestConfig, language: string): Promise<{ words: string[]; quote: Quote | null }> {
+async function createWordsForConfig(config: TypingTestConfig, language: string): Promise<WordsForConfig> {
   if (config.mode === 'quote') {
     const quote = selectQuote(config.quoteLength)
-    return { words: quoteToWords(quote), quote }
+    return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
+  }
+  if (config.mode === 'custom') {
+    const data = await getCustomTextData(config.textId)
+    return data ? customTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
   }
   const { count, opts } = wordGenParams(config)
   const { words } = await generateWords(count, opts, language)
-  return { words, quote: null }
+  return { words, quote: null, lineBreaks: [], lineIndents: [] }
 }
 
 function createInitialState(config: TypingTestConfig, language: string, status: TypingTestStatus = 'waiting'): TypingTestState {
-  const { words, quote } = createWordsForConfigSync(config, language)
-  return freshState(words, quote, status)
+  return freshState(createWordsForConfigSync(config, language), status)
 }
 
-function freshState(words: string[], quote: Quote | null, status: TypingTestStatus = 'waiting'): TypingTestState {
+function freshState({ words, quote, lineBreaks, lineIndents }: WordsForConfig, status: TypingTestStatus = 'waiting'): TypingTestState {
   return {
     status,
     words,
@@ -136,6 +179,8 @@ function freshState(words: string[], quote: Quote | null, status: TypingTestStat
     incorrectChars: 0,
     currentQuote: quote,
     wpmHistory: [],
+    lineBreaks: new Set(lineBreaks),
+    lineIndents,
   }
 }
 
@@ -202,6 +247,7 @@ export function useTypingTest(
   const [windowFocused, setWindowFocusedState] = useState(true)
   const [state, setState] = useState<TypingTestState>(() => createInitialState(initialConfig ?? DEFAULT_CONFIG, initialLanguage ?? DEFAULT_LANGUAGE))
   const configRef = useRef(config)
+  const stateRef = useRef(state)
   const languageRef = useRef(language)
   const baseLayerRef = useRef(baseLayer)
   const windowFocusedRef = useRef(windowFocused)
@@ -215,6 +261,7 @@ export function useTypingTest(
   const seqRef = useRef(0)
   const langLoadSeqRef = useRef(0)
   configRef.current = config
+  stateRef.current = state
   languageRef.current = language
   baseLayerRef.current = baseLayer
   windowFocusedRef.current = windowFocused
@@ -223,9 +270,9 @@ export function useTypingTest(
 
   const restartAsync = useCallback(async () => {
     const seq = ++seqRef.current
-    const { words, quote } = await createWordsForConfig(configRef.current, languageRef.current)
+    const result = await createWordsForConfig(configRef.current, languageRef.current)
     if (seqRef.current !== seq) return
-    setState(freshState(words, quote))
+    setState(freshState(result))
   }, [])
 
   const restart = useCallback(() => {
@@ -234,9 +281,9 @@ export function useTypingTest(
 
   const restartWithCountdown = useCallback(async () => {
     const seq = ++seqRef.current
-    const { words, quote } = await createWordsForConfig(configRef.current, languageRef.current)
+    const result = await createWordsForConfig(configRef.current, languageRef.current)
     if (seqRef.current !== seq) return
-    setState(freshState(words, quote, 'countdown'))
+    setState(freshState(result, 'countdown'))
   }, [])
 
   // Transition from countdown to waiting after delay
@@ -252,9 +299,9 @@ export function useTypingTest(
     setConfigState(newConfig)
     configRef.current = newConfig
     const seq = ++seqRef.current
-    const { words, quote } = await createWordsForConfig(newConfig, languageRef.current)
+    const result = await createWordsForConfig(newConfig, languageRef.current)
     if (seqRef.current !== seq) return
-    setState(freshState(words, quote))
+    setState(freshState(result))
   }, [])
 
   const setLanguage = useCallback(async (newLanguage: string): Promise<string> => {
@@ -266,9 +313,9 @@ export function useTypingTest(
     const langSeq = ++langLoadSeqRef.current
     try {
       await getLanguageData(newLanguage)
-      const { words, quote } = await createWordsForConfig(configRef.current, newLanguage)
+      const result = await createWordsForConfig(configRef.current, newLanguage)
       if (seqRef.current !== seq) return languageRef.current
-      setState(freshState(words, quote))
+      setState(freshState(result))
       return newLanguage
     } catch {
       if (seqRef.current !== seq) return languageRef.current
@@ -288,9 +335,72 @@ export function useTypingTest(
     baseLayerRef.current = layer
     setEffectiveLayer(layer)
     const seq = ++seqRef.current
-    const { words, quote } = await createWordsForConfig(configRef.current, languageRef.current)
+    const result = await createWordsForConfig(configRef.current, languageRef.current)
     if (seqRef.current !== seq) return
-    setState(freshState(words, quote))
+    setState(freshState(result))
+  }, [])
+
+  // --- Memory mode (imported custom text only): pause / capture / restore ---
+
+  /** Snapshot the in-progress test so it can be persisted and resumed.
+   *  Returns null unless an imported custom text is active. */
+  const captureMemory = useCallback((): TypingTestMemory | null => {
+    const s = stateRef.current
+    const cfg = configRef.current
+    if (cfg.mode !== 'custom') return null
+    return {
+      textId: cfg.textId,
+      currentWordIndex: s.currentWordIndex,
+      currentInput: s.currentInput,
+      wordResults: s.wordResults.map((w) => ({ word: w.word, typed: w.typed, correct: w.correct })),
+      correctChars: s.correctChars,
+      incorrectChars: s.incorrectChars,
+      // startTime already folds in any earlier paused/resumed segments.
+      elapsedMs: s.startTime ? Date.now() - s.startTime : 0,
+      wpmHistory: s.wpmHistory,
+      savedAt: new Date().toISOString(),
+    }
+  }, [])
+
+  /** Stop accepting input and freeze the timer (endTime pins elapsed/WPM)
+   *  without discarding progress. */
+  const pause = useCallback(() => {
+    setState((s) => (s.status === 'running' ? { ...s, status: 'paused', endTime: Date.now() } : s))
+  }, [])
+
+  /** Load a persisted snapshot's text and restore its progress.
+   *  `resume=true` continues the timer (status 'running'); `resume=false`
+   *  shows it frozen ('paused') — used on re-entry so the user must confirm
+   *  before continuing. Returns false when the text can no longer be loaded
+   *  (e.g. deleted) so the caller can fall back to a fresh test. */
+  const restoreState = useCallback(async (memory: TypingTestMemory, resume: boolean): Promise<boolean> => {
+    const cfg: TypingTestConfig = { mode: 'custom', textId: memory.textId }
+    setConfigState(cfg)
+    configRef.current = cfg
+    const seq = ++seqRef.current
+    const { words, quote, lineBreaks, lineIndents } = await createWordsForConfig(cfg, languageRef.current)
+    if (seqRef.current !== seq) return false
+    if (words.length === 0) return false
+    const idx = Math.min(Math.max(0, memory.currentWordIndex), words.length - 1)
+    const startTime = Date.now() - memory.elapsedMs
+    setState({
+      status: resume ? 'running' : 'paused',
+      words,
+      currentWordIndex: idx,
+      currentInput: memory.currentInput,
+      compositionText: '',
+      wordResults: memory.wordResults.map((w) => ({ word: w.word, typed: w.typed, correct: w.correct })),
+      startTime,
+      // Paused: pin endTime so elapsed/WPM display stays frozen at the saved time.
+      endTime: resume ? null : Date.now(),
+      correctChars: memory.correctChars,
+      incorrectChars: memory.incorrectChars,
+      currentQuote: quote,
+      wpmHistory: memory.wpmHistory,
+      lineBreaks: new Set(lineBreaks),
+      lineIndents,
+    })
+    return true
   }, [])
 
   const processMatrixFrame = useCallback((pressed: Set<string>, keymap: Map<string, number>) => {
@@ -431,10 +541,18 @@ export function useTypingTest(
     setState((s) => {
       if (s.status !== 'waiting' && s.status !== 'running') return s
 
-      if (isSubmitKey(key)) {
+      // Space and Enter both advance a word, but they are distinct: at a
+      // line-end word (imported custom text) Enter is expected, elsewhere
+      // Space. The non-matching key is a no-op. For every non-custom mode
+      // `lineBreaks` is empty, so Space always advances and Enter is always
+      // ignored — identical to the previous behaviour.
+      if (isSubmitKey(key) || key === 'Enter') {
         if (s.status === 'waiting') {
           return { ...s, status: 'running', startTime: Date.now() }
         }
+        const expectsEnter = s.lineBreaks.has(s.currentWordIndex)
+        const wrongSubmitKey = key === 'Enter' ? !expectsEnter : expectsEnter
+        if (wrongSubmitKey) return s
         return handleSpace(s, configRef.current, languageRef.current)
       }
 
@@ -537,6 +655,16 @@ export function useTypingTest(
     return Math.round((state.correctChars / 5) / minutes)
   }, [state.startTime, state.endTime, state.correctChars, tick])
 
+  // Keystrokes per minute (correct chars / minute). Custom mode shows this
+  // instead of WPM, since imported code / CJK text has no meaningful "words".
+  const kpm = useMemo(() => {
+    if (!state.startTime) return 0
+    const end = state.endTime ?? Date.now()
+    const minutes = (end - state.startTime) / 60000
+    if (minutes <= 0) return 0
+    return Math.round(state.correctChars / minutes)
+  }, [state.startTime, state.endTime, state.correctChars, tick])
+
   const accuracy = useMemo(() => {
     const total = state.correctChars + state.incorrectChars
     if (total === 0) return 100
@@ -560,6 +688,7 @@ export function useTypingTest(
   return {
     state,
     wpm,
+    kpm,
     accuracy,
     elapsedSeconds,
     remainingSeconds,
@@ -581,6 +710,9 @@ export function useTypingTest(
     setLanguage,
     setBaseLayer,
     setWindowFocused,
+    captureMemory,
+    pause,
+    restoreState,
   }
 }
 

--- a/src/renderer/typing-test/word-generator/__tests__/custom-text.test.ts
+++ b/src/renderer/typing-test/word-generator/__tests__/custom-text.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  getCustomTextData,
+  getCustomTextDataSync,
+  clearCustomTextCache,
+} from '../custom-text'
+
+const mockGet = vi.fn()
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  clearCustomTextCache()
+  window.vialAPI = {
+    ...(window.vialAPI ?? {}),
+    typingTestTextStoreGet: mockGet,
+  } as unknown as typeof window.vialAPI
+})
+
+afterEach(() => {
+  clearCustomTextCache()
+  window.vialAPI = originalVialAPI
+})
+
+describe('getCustomTextData', () => {
+  it('fetches via IPC, parses words + line breaks, and caches', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't1' }, data: { name: 'My Text', text: 'one two\nthree four' } },
+    })
+
+    const first = await getCustomTextData('t1')
+    // "one two" then a newline then "three four": break after word index 1.
+    expect(first).toEqual({ name: 'My Text', words: ['one', 'two', 'three', 'four'], lineBreaks: [1], indents: ['', ''] })
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    // Second call served from cache — no extra IPC.
+    const second = await getCustomTextData('t1')
+    expect(second).toBe(first)
+    expect(mockGet).toHaveBeenCalledTimes(1)
+
+    // Sync accessor now hits the warmed cache.
+    expect(getCustomTextDataSync('t1')).toBe(first)
+  })
+
+  it('single-line text has no line breaks', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't2' }, data: { name: 'Flat', text: 'one two three' } },
+    })
+    const data = await getCustomTextData('t2')
+    expect(data).toEqual({ name: 'Flat', words: ['one', 'two', 'three'], lineBreaks: [], indents: [''] })
+  })
+
+  it('returns undefined for a missing entry and does not cache', async () => {
+    mockGet.mockResolvedValue({ success: false, errorCode: 'NOT_FOUND' })
+    expect(await getCustomTextData('gone')).toBeUndefined()
+    expect(getCustomTextDataSync('gone')).toBeUndefined()
+  })
+
+  it('clearCustomTextCache(id) forces a re-fetch', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't1' }, data: { name: 'A', text: 'x y' } },
+    })
+    await getCustomTextData('t1')
+    clearCustomTextCache('t1')
+    expect(getCustomTextDataSync('t1')).toBeUndefined()
+    await getCustomTextData('t1')
+    expect(mockGet).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/typing-test/word-generator/custom-text.ts
+++ b/src/renderer/typing-test/word-generator/custom-text.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Imported custom-text source for the typing test. Mirrors the language
+// cache: fetched once per id from the typing-test-texts store, then
+// served synchronously. Played verbatim in order via the quote path.
+
+import { parseCustomText } from '../../../shared/types/typing-test-text-store'
+
+export interface CustomTextData {
+  name: string
+  /** Words in original order (space- and newline-separated, flattened). */
+  words: string[]
+  /** Indices of words that end a line — Enter advances past them; Space
+   *  advances the others. Empty for single-line texts. */
+  lineBreaks: number[]
+  /** Leading whitespace per line (display only, preserves code indentation). */
+  indents: string[]
+}
+
+const customTextCache = new Map<string, CustomTextData>()
+
+export function getCustomTextDataSync(textId: string): CustomTextData | undefined {
+  return customTextCache.get(textId)
+}
+
+export async function getCustomTextData(textId: string): Promise<CustomTextData | undefined> {
+  const cached = customTextCache.get(textId)
+  if (cached) return cached
+
+  const result = await window.vialAPI.typingTestTextStoreGet(textId)
+  if (!result.success || !result.data) return undefined
+
+  const { name, text } = result.data.data
+  // Shares parseCustomText with the main-process import path so playback
+  // and storage agree on word boundaries AND line breaks.
+  const { words, lineBreaks, indents } = parseCustomText(text)
+  const data: CustomTextData = { name, words, lineBreaks, indents }
+  customTextCache.set(textId, data)
+  return data
+}
+
+/** Drop cached entries so the next read re-fetches from the store. Called
+ *  by useTypingTestTexts after rename / delete / import / sync changes. */
+export function clearCustomTextCache(textId?: string): void {
+  if (textId) {
+    customTextCache.delete(textId)
+  } else {
+    customTextCache.clear()
+  }
+}

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -3,4 +3,6 @@
 
 export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync, injectPunctuation, injectNumbers } from './word-generator'
 export { selectQuote, quoteToWords } from './quote-generator'
+export { getCustomTextData, getCustomTextDataSync, clearCustomTextCache } from './custom-text'
+export type { CustomTextData } from './custom-text'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -155,6 +155,14 @@ export const IpcChannels = {
    * analyze range. Backs the "WPM by App" bar chart. */
   TYPING_ANALYTICS_GET_WPM_BY_APP_FOR_RANGE: 'typing-analytics:get-wpm-by-app-for-range',
 
+  // Typing Test Text Store (renderer → main → renderer)
+  TYPING_TEST_TEXT_LIST: 'typing-test-text:list',
+  TYPING_TEST_TEXT_GET: 'typing-test-text:get',
+  TYPING_TEST_TEXT_RENAME: 'typing-test-text:rename',
+  TYPING_TEST_TEXT_DELETE: 'typing-test-text:delete',
+  TYPING_TEST_TEXT_IMPORT: 'typing-test-text:import',
+  TYPING_TEST_TEXT_IMPORT_CONFIRM: 'typing-test-text:import-confirm',
+
   // Language Store (renderer → main → renderer)
   LANG_LIST: 'lang:list',
   LANG_GET: 'lang:get',

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -6,6 +6,8 @@ import { ALLOWED_TYPING_SYNC_SPAN_DAYS, type TypingSyncSpanDays } from './typing
 
 export interface TypingTestResult {
   date: string
+  /** User-assigned label for comparing runs (e.g. "QWERTY baseline"). */
+  name?: string
   wpm: number
   accuracy: number
   wordCount: number
@@ -13,8 +15,12 @@ export interface TypingTestResult {
   incorrectChars: number
   durationSeconds: number
   rawWpm?: number
-  mode?: 'words' | 'time' | 'quote'
+  mode?: 'words' | 'time' | 'quote' | 'custom'
   mode2?: number | string
+  /** Human-readable imported-text name, snapshotted at test time (custom
+   *  mode only). `mode2` keeps the stable textId for PB grouping; this is
+   *  what History shows so the row isn't an opaque id. */
+  customTextName?: string
   language?: string
   punctuation?: boolean
   numbers?: boolean
@@ -109,6 +115,31 @@ export const DEFAULT_PIPETTE_SETTINGS: PipetteSettings = {
   layerNames: [],
 }
 
+/** Serializable per-word result for resuming a paused custom typing test. */
+export interface TypingTestMemoryWord {
+  word: string
+  typed: string
+  correct: boolean
+}
+
+/** Snapshot of an in-progress imported (custom) typing test, persisted so
+ * the user can pause and resume later. One slot per keyboard. Words and
+ * line breaks are regenerated from `textId`, so only progress is stored. */
+export interface TypingTestMemory {
+  /** typing-test-texts store id of the imported text being typed. */
+  textId: string
+  currentWordIndex: number
+  currentInput: string
+  wordResults: TypingTestMemoryWord[]
+  correctChars: number
+  incorrectChars: number
+  /** Accumulated typing time in ms (excludes the paused interval). */
+  elapsedMs: number
+  wpmHistory: number[]
+  /** ISO 8601 save time. */
+  savedAt: string
+}
+
 export interface PipetteSettings {
   _rev: 1
   keyboardLayout: string
@@ -120,6 +151,13 @@ export interface PipetteSettings {
   typingTestViewOnly?: boolean
   typingTestViewOnlyWindowSize?: { width: number; height: number }
   typingTestViewOnlyAlwaysOnTop?: boolean
+  /** Paused custom typing-test snapshot (memory mode). Cleared on finish,
+   * "start over", text change, or device switch. */
+  typingTestMemory?: TypingTestMemory
+  /** Imported-text display: visible line count (2–10, default 4). */
+  typingTestDisplayLines?: number
+  /** Imported-text display: font size in px (14–48, default 24). */
+  typingTestFontSize?: number
   /** User-chosen record toggle. Persisted + synced so the setting
    * survives reloads and follows the keyboard across machines. Actual
    * recording is gated additionally on typingTestViewOnly at the

--- a/src/shared/types/sync.ts
+++ b/src/shared/types/sync.ts
@@ -6,6 +6,7 @@ import type { AnalyzeFilterSnapshotIndex } from './analyze-filter-store'
 import type { AppConfig } from './app-config'
 import type { KeyboardMetaIndex, KeyboardMetaSyncUnit } from './keyboard-meta'
 import type { KeyLabelIndex } from './key-label-store'
+import type { TypingTestTextIndex } from './typing-test-text-store'
 import type { I18nPackIndex, I18nIndexSyncUnit, I18nPackSyncUnit } from './i18n-store'
 
 export type { AppConfig }
@@ -21,9 +22,9 @@ export interface SyncEnvelope {
 }
 
 export interface SyncBundle {
-  type: 'favorite' | 'layout' | 'analyze-filter' | 'settings' | 'keyboard-meta' | 'typing-analytics-device' | 'key-label' | 'i18n-index' | 'i18n-pack' | 'theme-index' | 'theme-pack'
-  key: string // FavoriteType, UID, 'keyboard-names' for meta, `${uid}|${machineHash}` for device, 'key-labels', 'i18n-index', or packId for i18n-pack
-  index: FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyboardMetaIndex | KeyLabelIndex | I18nPackIndex
+  type: 'favorite' | 'layout' | 'analyze-filter' | 'settings' | 'keyboard-meta' | 'typing-analytics-device' | 'key-label' | 'typing-test-text' | 'i18n-index' | 'i18n-pack' | 'theme-index' | 'theme-pack'
+  key: string // FavoriteType, UID, 'keyboard-names' for meta, `${uid}|${machineHash}` for device, 'key-labels', 'typing-test-texts', 'i18n-index', or packId for i18n-pack
+  index: FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyboardMetaIndex | KeyLabelIndex | TypingTestTextIndex | I18nPackIndex
   files: Record<string, string> // filename -> content (empty for meta / i18n-index)
 }
 
@@ -63,6 +64,7 @@ export type KeyboardSnapshotsSyncUnit = `keyboards/${string}/snapshots`
 export type KeyboardAnalyzeFiltersSyncUnit = `keyboards/${string}/analyze_filters`
 export type KeyboardTypingAnalyticsDeviceSyncUnit = `keyboards/${string}/devices/${string}`
 export type KeyLabelSyncUnit = 'key-labels'
+export type TypingTestTextSyncUnit = 'typing-test-texts'
 export type SyncUnit =
   | FavoriteSyncUnit
   | KeyboardSettingsSyncUnit
@@ -71,6 +73,7 @@ export type SyncUnit =
   | KeyboardMetaSyncUnit
   | KeyboardTypingAnalyticsDeviceSyncUnit
   | KeyLabelSyncUnit
+  | TypingTestTextSyncUnit
   | I18nIndexSyncUnit
   | I18nPackSyncUnit
 

--- a/src/shared/types/typing-test-text-store.ts
+++ b/src/shared/types/typing-test-text-store.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Local store for imported Typing Test texts — mirrors key-label-store's
+// index + per-entry layout (entry-level LWW with soft tombstones).
+
+/**
+ * Per-entry metadata persisted in `userData/sync/typing-test-texts/index.json`.
+ * Cross-keyboard (global) user content, synced like Key Labels.
+ */
+export interface TypingTestTextMeta {
+  /** Local UUID v4. Stable across renames; used as the config `textId`. */
+  id: string
+  /** Display name (defaults to the imported file's base name). Unique
+   *  (case-insensitive) across active entries. */
+  name: string
+  /** Number of whitespace-separated words stored (post word-cap). Shown
+   *  in the Import list. */
+  wordCount: number
+  /** Internal filename (`{id}_{timestamp}.json`). */
+  filename: string
+  /** First save time (ISO 8601). */
+  savedAt: string
+  /** Last update time (ISO 8601) — LWW key. */
+  updatedAt: string
+  /** Soft delete tombstone (ISO 8601). 30-day GC matches favorites. */
+  deletedAt?: string
+}
+
+export interface TypingTestTextIndex {
+  entries: TypingTestTextMeta[]
+}
+
+/** On-disk content of `{filename}`. The raw verbatim text the user typed
+ *  against, normalized + capped on import. */
+export interface TypingTestTextEntryFile {
+  name: string
+  text: string
+}
+
+/** Combined meta + entry payload returned by `get`. */
+export interface TypingTestTextRecord {
+  meta: TypingTestTextMeta
+  data: TypingTestTextEntryFile
+}
+
+/** Specific error codes the renderer can branch on. */
+export type TypingTestTextStoreErrorCode =
+  | 'INVALID_NAME'
+  | 'DUPLICATE_NAME'
+  | 'NOT_FOUND'
+  | 'INVALID_FILE'
+  | 'EMPTY_TEXT'
+  | 'TOO_LARGE'
+  | 'NOT_UTF8'
+  | 'IO_ERROR'
+
+export interface TypingTestTextStoreResult<T> {
+  success: boolean
+  data?: T
+  errorCode?: TypingTestTextStoreErrorCode
+  error?: string
+}
+
+/** Max accepted `.txt` file size on import (bytes). */
+export const TYPING_TEST_TEXT_MAX_FILE_BYTES = 5 * 1024 * 1024 // 5 MB
+/** Max stored words per imported text. Excess is truncated on import. */
+export const TYPING_TEST_TEXT_MAX_WORDS = 5000
+
+export interface ParsedCustomText {
+  /** Words in original order (space- and newline-separated, flattened). */
+  words: string[]
+  /** Indices of words that END a line — a newline follows them, so the
+   *  typing engine expects Enter (not Space) to advance. The final word is
+   *  never included (no trailing newline). */
+  lineBreaks: number[]
+  /** Leading whitespace of each kept line, indexed by line order. Shown for
+   *  code structure (display only — not typed, since Space submits a word). */
+  indents: string[]
+}
+
+/**
+ * Parse imported text into words + line-break positions, preserving the
+ * line structure. Space and newline are treated separately: intra-line
+ * whitespace runs collapse to one word separator; a newline marks a line
+ * break. Empty lines are dropped. Capped at `maxWords` (excess truncated).
+ *
+ * Shared by the main store (canonicalize on import) and the renderer
+ * (verbatim playback) so the two never disagree on words or break points.
+ */
+export function parseCustomText(text: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): ParsedCustomText {
+  const lines = text
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => ({
+      // Leading whitespace kept for display; the rest splits into words.
+      indent: line.match(/^[^\S\n]*/)?.[0] ?? '',
+      words: line.split(/[^\S\n]+/).filter((w) => w.length > 0),
+    }))
+    .filter((line) => line.words.length > 0)
+
+  const words: string[] = []
+  const lineBreaks: number[] = []
+  const indents: string[] = []
+  for (const line of lines) {
+    if (words.length >= maxWords) break
+    indents.push(line.indent)
+    for (const w of line.words) {
+      if (words.length >= maxWords) break
+      words.push(w)
+    }
+    // Record a break after this line's last word. A truncated line (cap
+    // hit mid-line) gets no break.
+    if (words.length < maxWords) lineBreaks.push(words.length - 1)
+  }
+  // The last line's recorded break points at the final word, which has no
+  // newline after it — drop it.
+  if (lineBreaks.length > 0 && lineBreaks[lineBreaks.length - 1] === words.length - 1) {
+    lineBreaks.pop()
+  }
+  return { words, lineBreaks, indents }
+}
+
+/**
+ * Canonicalize raw imported text for storage: words joined by a single
+ * space within a line and a newline at each line break. Round-trips
+ * through `parseCustomText` so storage and playback agree exactly.
+ */
+export function normalizeCustomText(raw: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): { text: string; wordCount: number } {
+  const { words, lineBreaks, indents } = parseCustomText(raw, maxWords)
+  const breakSet = new Set(lineBreaks)
+  let text = ''
+  let lineIdx = 0
+  for (let i = 0; i < words.length; i++) {
+    // Start of a line (first word, or the previous word ended a line) →
+    // restore its leading indentation so code structure survives the round-trip.
+    if (i === 0 || breakSet.has(i - 1)) {
+      text += indents[lineIdx] ?? ''
+      lineIdx++
+    }
+    text += words[i]
+    if (i < words.length - 1) text += breakSet.has(i) ? '\n' : ' '
+  }
+  return { text, wordCount: words.length }
+}

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -17,6 +17,7 @@ import type { SnapshotMeta } from './snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from './analyze-filter-store'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteImportResult } from './favorite-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from './key-label-store'
+import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from './typing-test-text-store'
 import type { HubKeyLabelItem, HubKeyLabelListResponse, HubKeyLabelListParams, HubKeyLabelTimestampsResponse } from './hub-key-label'
 import type {
   I18nPackMeta,
@@ -182,6 +183,14 @@ export interface VialAPI {
   keyLabelStoreReorder(orderedIds: string[]): Promise<KeyLabelStoreResult<void>>
   keyLabelStoreSetHubPostId(id: string, hubPostId: string | null): Promise<KeyLabelStoreResult<KeyLabelMeta>>
   keyLabelStoreHasName(name: string, excludeId?: string): Promise<KeyLabelStoreResult<boolean>>
+
+  // Typing Test Text Store
+  typingTestTextStoreList(): Promise<TypingTestTextStoreResult<TypingTestTextMeta[]>>
+  typingTestTextStoreGet(id: string): Promise<TypingTestTextStoreResult<TypingTestTextRecord>>
+  typingTestTextStoreRename(id: string, newName: string): Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
+  typingTestTextStoreDelete(id: string): Promise<TypingTestTextStoreResult<void>>
+  typingTestTextStoreImport(): Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
+  typingTestTextStoreImportConfirm(): Promise<TypingTestTextStoreResult<TypingTestTextMeta>>
 
   // Key Label Hub
   keyLabelHubList(params?: HubKeyLabelListParams): Promise<KeyLabelStoreResult<HubKeyLabelListResponse>>


### PR DESCRIPTION
## Summary
Import arbitrary UTF-8 text (Aozora Bunko novels, source code, …) into the Typing Test and type it verbatim — to get used to a new keyboard / layout / keymap, practice, and compare the same text typed different ways.

## What's added
- **Imported-text store** — new cross-keyboard synced store `sync/typing-test-texts/` (entry-level LWW + tombstone). Any UTF-8 file is accepted (no extension restriction); non-UTF-8 is rejected.
- **Custom playback mode** — plays the text verbatim:
  - Line breaks: Space advances words within a line, Enter advances at line ends.
  - Leading indentation is preserved (display only — code keeps its shape).
  - Progress is counted by characters; the words/time/quote bar is hidden to widen the reading area.
- **WPM + KPM** shown together in every mode.
- **History** split into **Normal** and **Custom** tabs, each with its own stats, chart and CSV export. Inline result naming, a KPM column, and per-row delete with confirmation.
- **Per-keyboard settings** (synced): paused-test memory (resume / start over), display line count (2–10) and font size (14–48px) for imported text.
- **Import overwrite** is confirmed inline instead of silently replacing an existing same-named text.

## Testing
- `pnpm run lint` ✅
- `npx tsc --noEmit` ✅
- `pnpm test` ✅ (4213 passed)
- `pnpm run build` ✅

Docs updated: `.claude/docs/DATA-INVENTORY.md` (§3.3, §3.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)