### PR TITLE
feat(ui): record typing tests into the analytics pipeline

### DIFF
--- a/src/main/typing-analytics/db/schema.ts
+++ b/src/main/typing-analytics/db/schema.ts
@@ -2,7 +2,7 @@
 // SQLite schema for the typing analytics database. See
 // .claude/plans/typing-analytics.md for the design rationale.
 
-export const SCHEMA_VERSION = 4
+export const SCHEMA_VERSION = 5
 
 /** User-data tables in the order a rebuild should truncate them. Listed
  * child-before-parent so any future FK_ON delete won't trip itself. */
@@ -54,6 +54,10 @@ CREATE TABLE IF NOT EXISTS typing_char_minute (
   -- when the lookup failed. App-filtered analytics queries compare
   -- against this column directly.
   app_name TEXT,
+  -- Typing test label captured per-event. NULL for ordinary REC input and
+  -- for minutes that mixed multiple tests. TypingTest-filtered analytics
+  -- queries compare against this column directly (see app_name).
+  typing_test TEXT,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (scope_id, minute_ts, char),
@@ -62,6 +66,8 @@ CREATE TABLE IF NOT EXISTS typing_char_minute (
 CREATE INDEX IF NOT EXISTS idx_char_minute_ts ON typing_char_minute(minute_ts);
 CREATE INDEX IF NOT EXISTS idx_char_minute_scope_app_ts
   ON typing_char_minute(scope_id, app_name, minute_ts);
+CREATE INDEX IF NOT EXISTS idx_char_minute_scope_test_ts
+  ON typing_char_minute(scope_id, typing_test, minute_ts);
 
 CREATE TABLE IF NOT EXISTS typing_matrix_minute (
   scope_id TEXT NOT NULL,
@@ -78,12 +84,16 @@ CREATE TABLE IF NOT EXISTS typing_matrix_minute (
   hold_count INTEGER NOT NULL DEFAULT 0,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
+  -- See typing_char_minute.typing_test comment.
+  typing_test TEXT,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (scope_id, minute_ts, row, col, layer),
   FOREIGN KEY (scope_id) REFERENCES typing_scopes(id)
 );
 CREATE INDEX IF NOT EXISTS idx_matrix_minute_ts ON typing_matrix_minute(minute_ts);
+CREATE INDEX IF NOT EXISTS idx_matrix_minute_scope_test_ts
+  ON typing_matrix_minute(scope_id, typing_test, minute_ts);
 -- Supports the typing-view heatmap (scope_id + layer + minute_ts range scan
 -- polled every few seconds). Without it the heatmap query falls back to the
 -- minute_ts-only index and re-filters every scope/layer row in memory.
@@ -104,6 +114,8 @@ CREATE TABLE IF NOT EXISTS typing_minute_stats (
   interval_max_ms INTEGER,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
+  -- See typing_char_minute.typing_test comment.
+  typing_test TEXT,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (scope_id, minute_ts),
@@ -111,6 +123,8 @@ CREATE TABLE IF NOT EXISTS typing_minute_stats (
 );
 CREATE INDEX IF NOT EXISTS idx_minute_stats_scope_app_ts
   ON typing_minute_stats(scope_id, app_name, minute_ts);
+CREATE INDEX IF NOT EXISTS idx_minute_stats_scope_test_ts
+  ON typing_minute_stats(scope_id, typing_test, minute_ts);
 
 CREATE TABLE IF NOT EXISTS typing_bigram_minute (
   scope_id TEXT NOT NULL,
@@ -126,6 +140,8 @@ CREATE TABLE IF NOT EXISTS typing_bigram_minute (
   hist BLOB NOT NULL,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
+  -- See typing_char_minute.typing_test comment.
+  typing_test TEXT,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (scope_id, minute_ts, bigram_id),
@@ -135,6 +151,8 @@ CREATE INDEX IF NOT EXISTS idx_bigram_minute_scope_minute
   ON typing_bigram_minute(scope_id, minute_ts);
 CREATE INDEX IF NOT EXISTS idx_bigram_minute_scope_app_ts
   ON typing_bigram_minute(scope_id, app_name, minute_ts);
+CREATE INDEX IF NOT EXISTS idx_bigram_minute_scope_test_ts
+  ON typing_bigram_minute(scope_id, typing_test, minute_ts);
 
 CREATE TABLE IF NOT EXISTS typing_sessions (
   id TEXT PRIMARY KEY,

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -38,6 +38,10 @@ export interface CharMinuteRow {
    * shape to keep older callers / fixtures terse; the DB layer
    * normalizes missing to null on insert. */
   appName?: string | null
+  /** Typing test label captured per-event (custom = text name, normal =
+   * `mode (language)`). Missing/null = ordinary REC input or a mixed
+   * minute. Normalized to null on insert. */
+  typingTest?: string | null
 }
 
 export interface MatrixMinuteRow {
@@ -57,6 +61,8 @@ export interface MatrixMinuteRow {
   holdCount?: number
   /** See {@link CharMinuteRow.appName}. */
   appName?: string | null
+  /** See {@link CharMinuteRow.typingTest}. */
+  typingTest?: string | null
 }
 
 export interface MinuteStatsRow {
@@ -72,6 +78,8 @@ export interface MinuteStatsRow {
   intervalMaxMs: number | null
   /** See {@link CharMinuteRow.appName}. */
   appName?: string | null
+  /** See {@link CharMinuteRow.typingTest}. */
+  typingTest?: string | null
 }
 
 export interface SessionRow {
@@ -359,12 +367,16 @@ export class TypingAnalyticsDB {
     // as mixed. This matches the aggregator's "size>1 set => null"
     // payload contract on the read side.
     this.upsertCharMinuteStmt = this.db.prepare(`
-      INSERT INTO typing_char_minute (scope_id, minute_ts, char, count, app_name, updated_at, is_deleted)
-      VALUES (@scopeId, @minuteTs, @char, @count, @appName, @updatedAt, 0)
+      INSERT INTO typing_char_minute (scope_id, minute_ts, char, count, app_name, typing_test, updated_at, is_deleted)
+      VALUES (@scopeId, @minuteTs, @char, @count, @appName, @typingTest, @updatedAt, 0)
       ON CONFLICT(scope_id, minute_ts, char) DO UPDATE SET
         count = typing_char_minute.count + excluded.count,
         app_name = CASE
           WHEN typing_char_minute.app_name IS excluded.app_name THEN typing_char_minute.app_name
+          ELSE NULL
+        END,
+        typing_test = CASE
+          WHEN typing_char_minute.typing_test IS excluded.typing_test THEN typing_char_minute.typing_test
           ELSE NULL
         END,
         updated_at = excluded.updated_at,
@@ -375,13 +387,13 @@ export class TypingAnalyticsDB {
       INSERT INTO typing_matrix_minute (
         scope_id, minute_ts, row, col, layer, keycode, count,
         tap_count, hold_count,
-        app_name,
+        app_name, typing_test,
         updated_at, is_deleted
       )
       VALUES (
         @scopeId, @minuteTs, @row, @col, @layer, @keycode, @count,
         @tapCount, @holdCount,
-        @appName,
+        @appName, @typingTest,
         @updatedAt, 0
       )
       ON CONFLICT(scope_id, minute_ts, row, col, layer) DO UPDATE SET
@@ -393,6 +405,10 @@ export class TypingAnalyticsDB {
           WHEN typing_matrix_minute.app_name IS excluded.app_name THEN typing_matrix_minute.app_name
           ELSE NULL
         END,
+        typing_test = CASE
+          WHEN typing_matrix_minute.typing_test IS excluded.typing_test THEN typing_matrix_minute.typing_test
+          ELSE NULL
+        END,
         updated_at = excluded.updated_at,
         is_deleted = 0
     `)
@@ -402,14 +418,14 @@ export class TypingAnalyticsDB {
         scope_id, minute_ts, keystrokes, active_ms,
         interval_avg_ms, interval_min_ms,
         interval_p25_ms, interval_p50_ms, interval_p75_ms, interval_max_ms,
-        app_name,
+        app_name, typing_test,
         updated_at, is_deleted
       )
       VALUES (
         @scopeId, @minuteTs, @keystrokes, @activeMs,
         @intervalAvgMs, @intervalMinMs,
         @intervalP25Ms, @intervalP50Ms, @intervalP75Ms, @intervalMaxMs,
-        @appName,
+        @appName, @typingTest,
         @updatedAt, 0
       )
       ON CONFLICT(scope_id, minute_ts) DO UPDATE SET
@@ -423,6 +439,10 @@ export class TypingAnalyticsDB {
         interval_max_ms = MAX(typing_minute_stats.interval_max_ms, excluded.interval_max_ms),
         app_name = CASE
           WHEN typing_minute_stats.app_name IS excluded.app_name THEN typing_minute_stats.app_name
+          ELSE NULL
+        END,
+        typing_test = CASE
+          WHEN typing_minute_stats.typing_test IS excluded.typing_test THEN typing_minute_stats.typing_test
           ELSE NULL
         END,
         updated_at = excluded.updated_at,
@@ -498,14 +518,15 @@ export class TypingAnalyticsDB {
     // parameter is always defined.
     this.mergeCharMinuteStmt = this.db.prepare(`
       INSERT INTO typing_char_minute (
-        scope_id, minute_ts, char, count, app_name, updated_at, is_deleted
+        scope_id, minute_ts, char, count, app_name, typing_test, updated_at, is_deleted
       )
       VALUES (
-        @scopeId, @minuteTs, @char, @count, @appName, @updatedAt, @isDeleted
+        @scopeId, @minuteTs, @char, @count, @appName, @typingTest, @updatedAt, @isDeleted
       )
       ON CONFLICT(scope_id, minute_ts, char) DO UPDATE SET
         count = excluded.count,
         app_name = excluded.app_name,
+        typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
         is_deleted = excluded.is_deleted
       WHERE excluded.updated_at > typing_char_minute.updated_at
@@ -515,13 +536,13 @@ export class TypingAnalyticsDB {
       INSERT INTO typing_matrix_minute (
         scope_id, minute_ts, row, col, layer, keycode, count,
         tap_count, hold_count,
-        app_name,
+        app_name, typing_test,
         updated_at, is_deleted
       )
       VALUES (
         @scopeId, @minuteTs, @row, @col, @layer, @keycode, @count,
         @tapCount, @holdCount,
-        @appName,
+        @appName, @typingTest,
         @updatedAt, @isDeleted
       )
       ON CONFLICT(scope_id, minute_ts, row, col, layer) DO UPDATE SET
@@ -530,6 +551,7 @@ export class TypingAnalyticsDB {
         tap_count = excluded.tap_count,
         hold_count = excluded.hold_count,
         app_name = excluded.app_name,
+        typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
         is_deleted = excluded.is_deleted
       WHERE excluded.updated_at > typing_matrix_minute.updated_at
@@ -540,14 +562,14 @@ export class TypingAnalyticsDB {
         scope_id, minute_ts, keystrokes, active_ms,
         interval_avg_ms, interval_min_ms,
         interval_p25_ms, interval_p50_ms, interval_p75_ms, interval_max_ms,
-        app_name,
+        app_name, typing_test,
         updated_at, is_deleted
       )
       VALUES (
         @scopeId, @minuteTs, @keystrokes, @activeMs,
         @intervalAvgMs, @intervalMinMs,
         @intervalP25Ms, @intervalP50Ms, @intervalP75Ms, @intervalMaxMs,
-        @appName,
+        @appName, @typingTest,
         @updatedAt, @isDeleted
       )
       ON CONFLICT(scope_id, minute_ts) DO UPDATE SET
@@ -560,6 +582,7 @@ export class TypingAnalyticsDB {
         interval_p75_ms = excluded.interval_p75_ms,
         interval_max_ms = excluded.interval_max_ms,
         app_name = excluded.app_name,
+        typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
         is_deleted = excluded.is_deleted
       WHERE excluded.updated_at > typing_minute_stats.updated_at
@@ -583,15 +606,16 @@ export class TypingAnalyticsDB {
 
     this.mergeBigramMinuteStmt = this.db.prepare(`
       INSERT INTO typing_bigram_minute (
-        scope_id, minute_ts, bigram_id, count, hist, app_name, updated_at, is_deleted
+        scope_id, minute_ts, bigram_id, count, hist, app_name, typing_test, updated_at, is_deleted
       )
       VALUES (
-        @scopeId, @minuteTs, @bigramId, @count, @hist, @appName, @updatedAt, @isDeleted
+        @scopeId, @minuteTs, @bigramId, @count, @hist, @appName, @typingTest, @updatedAt, @isDeleted
       )
       ON CONFLICT(scope_id, minute_ts, bigram_id) DO UPDATE SET
         count = excluded.count,
         hist = excluded.hist,
         app_name = excluded.app_name,
+        typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
         is_deleted = excluded.is_deleted
       WHERE excluded.updated_at > typing_bigram_minute.updated_at
@@ -1673,6 +1697,9 @@ export class TypingAnalyticsDB {
     // fixtures that hand-build mixed rows still work; live ingestion
     // sets stats.appName once and lets the rows inherit.
     const minuteAppName = stats.appName ?? null
+    // typing_test flows the same way as app_name (uniform per minute, with
+    // a per-row override accepted for hand-built fixtures).
+    const minuteTypingTest = stats.typingTest ?? null
     const upsertTx = this.db.transaction(() => {
       this.upsertMinuteStatsStmt.run({
         scopeId: stats.scopeId,
@@ -1686,6 +1713,7 @@ export class TypingAnalyticsDB {
         intervalP75Ms: stats.intervalP75Ms,
         intervalMaxMs: stats.intervalMaxMs,
         appName: minuteAppName,
+        typingTest: minuteTypingTest,
         updatedAt,
       })
       for (const c of charCounts) {
@@ -1695,6 +1723,7 @@ export class TypingAnalyticsDB {
           char: c.char,
           count: c.count,
           appName: c.appName ?? minuteAppName,
+          typingTest: c.typingTest ?? minuteTypingTest,
           updatedAt,
         })
       }
@@ -1710,6 +1739,7 @@ export class TypingAnalyticsDB {
           tapCount: m.tapCount ?? 0,
           holdCount: m.holdCount ?? 0,
           appName: m.appName ?? minuteAppName,
+          typingTest: m.typingTest ?? minuteTypingTest,
           updatedAt,
         })
       }
@@ -2364,6 +2394,7 @@ export class TypingAnalyticsDB {
       char: row.char,
       count: row.count,
       appName: row.appName ?? null,
+      typingTest: row.typingTest ?? null,
       updatedAt: row.updatedAt,
       isDeleted: row.isDeleted ? 1 : 0,
     })
@@ -2381,6 +2412,7 @@ export class TypingAnalyticsDB {
       tapCount: row.tapCount ?? 0,
       holdCount: row.holdCount ?? 0,
       appName: row.appName ?? null,
+      typingTest: row.typingTest ?? null,
       updatedAt: row.updatedAt,
       isDeleted: row.isDeleted ? 1 : 0,
     })
@@ -2399,6 +2431,7 @@ export class TypingAnalyticsDB {
       intervalP75Ms: row.intervalP75Ms,
       intervalMaxMs: row.intervalMaxMs,
       appName: row.appName ?? null,
+      typingTest: row.typingTest ?? null,
       updatedAt: row.updatedAt,
       isDeleted: row.isDeleted ? 1 : 0,
     })
@@ -2421,6 +2454,7 @@ export class TypingAnalyticsDB {
   mergeBigramMinute(row: BigramMinuteExportRow): void {
     const isDeleted = row.isDeleted ? 1 : 0
     const appName = row.appName ?? null
+    const typingTest = row.typingTest ?? null
     for (const bigramId of Object.keys(row.bigrams)) {
       const entry = row.bigrams[bigramId]
       this.mergeBigramMinuteStmt.run({
@@ -2430,6 +2464,7 @@ export class TypingAnalyticsDB {
         count: entry.c,
         hist: encodeHistBuffer(entry.h),
         appName,
+        typingTest,
         updatedAt: row.updatedAt,
         isDeleted,
       })
@@ -2470,6 +2505,18 @@ export class TypingAnalyticsDB {
         ALTER TABLE typing_matrix_minute ADD COLUMN app_name TEXT;
         ALTER TABLE typing_minute_stats ADD COLUMN app_name TEXT;
         ALTER TABLE typing_bigram_minute ADD COLUMN app_name TEXT;
+      `)
+    }
+    // v4 -> v5: Add typing_test to the four minute rollups so
+    // TypingTest-filtered analytics can restrict to one test's keystrokes.
+    // NULL means ordinary REC input or a mixed minute. Indices are created
+    // in CREATE_SCHEMA_SQL's second-phase exec (see app_name note above).
+    if (fromVersion < 5) {
+      this.db.exec(`
+        ALTER TABLE typing_char_minute ADD COLUMN typing_test TEXT;
+        ALTER TABLE typing_matrix_minute ADD COLUMN typing_test TEXT;
+        ALTER TABLE typing_minute_stats ADD COLUMN typing_test TEXT;
+        ALTER TABLE typing_bigram_minute ADD COLUMN typing_test TEXT;
       `)
     }
   }

--- a/src/main/typing-analytics/jsonl/jsonl-row.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-row.ts
@@ -15,6 +15,12 @@ export const JSONL_SCHEMA_VERSION = 1
  * existed. */
 export type AppNameField = string | null
 
+/** Typing test label attached to per-minute payloads (custom = text name,
+ * normal = `mode (language)`). null / absent for ordinary REC input or a
+ * minute that mixed multiple tests. Optional on the wire for backward
+ * compatibility with master files written before this field existed. */
+export type TypingTestField = string | null
+
 export type JsonlRowKind =
   | 'scope'
   | 'char-minute'
@@ -41,6 +47,7 @@ export interface JsonlCharMinutePayload {
   char: string
   count: number
   appName?: AppNameField
+  typingTest?: TypingTestField
 }
 
 export interface JsonlMatrixMinutePayload {
@@ -54,6 +61,7 @@ export interface JsonlMatrixMinutePayload {
   tapCount: number
   holdCount: number
   appName?: AppNameField
+  typingTest?: TypingTestField
 }
 
 export interface JsonlMinuteStatsPayload {
@@ -68,6 +76,7 @@ export interface JsonlMinuteStatsPayload {
   intervalP75Ms: number | null
   intervalMaxMs: number | null
   appName?: AppNameField
+  typingTest?: TypingTestField
 }
 
 export interface JsonlSessionPayload {
@@ -92,6 +101,7 @@ export interface JsonlBigramMinutePayload {
    * joined by underscore). One row per minute aggregates all bigrams. */
   bigrams: Record<string, JsonlBigramMinuteEntry>
   appName?: AppNameField
+  typingTest?: TypingTestField
 }
 
 /** Number of buckets in the bigram IKI histogram. Kept as a constant so
@@ -222,7 +232,8 @@ function isCharMinutePayload(p: Record<string, unknown>): boolean {
     hasNumberField(p, 'minuteTs') &&
     hasStringField(p, 'char') &&
     hasNumberField(p, 'count') &&
-    isOptionalAppName(p)
+    isOptionalAppName(p) &&
+    isOptionalTypingTest(p)
   )
 }
 
@@ -237,7 +248,8 @@ function isMatrixMinutePayload(p: Record<string, unknown>): boolean {
     hasNumberField(p, 'count') &&
     hasNumberField(p, 'tapCount') &&
     hasNumberField(p, 'holdCount') &&
-    isOptionalAppName(p)
+    isOptionalAppName(p) &&
+    isOptionalTypingTest(p)
   )
 }
 
@@ -256,6 +268,14 @@ function isOptionalAppName(p: Record<string, unknown>): boolean {
   return v === null || typeof v === 'string'
 }
 
+/** Same optional string|null contract as {@link isOptionalAppName}, for the
+ * typing-test dimension. Missing reads as null. */
+function isOptionalTypingTest(p: Record<string, unknown>): boolean {
+  if (!('typingTest' in p)) return true
+  const v = p.typingTest
+  return v === null || typeof v === 'string'
+}
+
 function isMinuteStatsPayload(p: Record<string, unknown>): boolean {
   return (
     hasStringField(p, 'scopeId') &&
@@ -268,7 +288,8 @@ function isMinuteStatsPayload(p: Record<string, unknown>): boolean {
     isNumericOrNull(p, 'intervalP50Ms') &&
     isNumericOrNull(p, 'intervalP75Ms') &&
     isNumericOrNull(p, 'intervalMaxMs') &&
-    isOptionalAppName(p)
+    isOptionalAppName(p) &&
+    isOptionalTypingTest(p)
   )
 }
 
@@ -298,6 +319,7 @@ function isBigramMinuteEntry(value: unknown): boolean {
 function isBigramMinutePayload(p: Record<string, unknown>): boolean {
   if (!hasStringField(p, 'scopeId') || !hasNumberField(p, 'minuteTs')) return false
   if (!isOptionalAppName(p)) return false
+  if (!isOptionalTypingTest(p)) return false
   const bigrams = p.bigrams
   if (typeof bigrams !== 'object' || bigrams === null) return false
   for (const value of Object.values(bigrams as Record<string, unknown>)) {

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -54,6 +54,11 @@ export interface MinuteSnapshot {
    * Computed from the entry's app-set on finalize so the consumer sees
    * a flat string|null and never has to reason about set semantics. */
   appName: string | null
+  /** Typing test label observed during this minute, or null when no test
+   *  input (ordinary REC) or the minute mixed multiple tests. Same
+   *  single-or-null semantics as {@link appName}, but sourced per-event
+   *  (each keystroke carries its own `typingTest`) rather than at flush. */
+  typingTest: string | null
 }
 
 interface Entry {
@@ -72,6 +77,10 @@ interface Entry {
    * just before each flush). Size>1 collapses to null on finalize so
    * downstream consumers only see "single app" or "mixed/unknown". */
   appSet: Set<string>
+  /** Distinct typing-test labels observed across this minute, populated
+   * per-event in {@link MinuteBuffer.addEvent}. Same size→value/null
+   * collapse as {@link appSet} on finalize. */
+  typingTestSet: Set<string>
 }
 
 function floorMinute(ts: number): number {
@@ -101,6 +110,10 @@ function finalize(entry: Entry): MinuteSnapshot {
     // Iterator is the only way to peek a Set without copying.
     appName = entry.appSet.values().next().value ?? null
   }
+  let typingTest: string | null = null
+  if (entry.typingTestSet.size === 1) {
+    typingTest = entry.typingTestSet.values().next().value ?? null
+  }
   return {
     scopeId: entry.scopeId,
     fingerprint: entry.fingerprint,
@@ -117,6 +130,7 @@ function finalize(entry: Entry): MinuteSnapshot {
     matrixCounts: entry.matrixCounts,
     bigrams: entry.bigrams,
     appName,
+    typingTest,
   }
 }
 
@@ -147,9 +161,12 @@ export class MinuteBuffer {
         firstEventMs: event.ts,
         lastEventMs: event.ts,
         appSet: new Set<string>(),
+        typingTestSet: new Set<string>(),
       }
       this.buffers.set(key, entry)
     }
+
+    if (event.typingTest) entry.typingTestSet.add(event.typingTest)
 
     if (entry.keystrokes > 0) {
       const gap = event.ts - entry.lastEventMs

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -1409,6 +1409,9 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
   // Older master files predate this field; the readers fall back to
   // null on missing.
   const appName = snapshot.appName
+  // typing_test carries through identically to appName so the JSONL master
+  // stays the source of truth for TypingTest filtering after a rebuild.
+  const typingTest = snapshot.typingTest
   const rows: JsonlRow[] = [
     {
       id: minuteStatsRowId(snapshot.scopeId, snapshot.minuteTs),
@@ -1426,6 +1429,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
         intervalP75Ms: snapshot.intervalP75Ms,
         intervalMaxMs: snapshot.intervalMaxMs,
         appName,
+        typingTest,
       },
     },
   ]
@@ -1434,7 +1438,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
       id: charMinuteRowId(snapshot.scopeId, snapshot.minuteTs, char),
       kind: 'char-minute',
       updated_at: updatedAt,
-      payload: { scopeId: snapshot.scopeId, minuteTs: snapshot.minuteTs, char, count, appName },
+      payload: { scopeId: snapshot.scopeId, minuteTs: snapshot.minuteTs, char, count, appName, typingTest },
     })
   }
   for (const cell of snapshot.matrixCounts.values()) {
@@ -1453,6 +1457,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
         tapCount: cell.tapCount,
         holdCount: cell.holdCount,
         appName,
+        typingTest,
       },
     })
   }
@@ -1470,6 +1475,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
         minuteTs: snapshot.minuteTs,
         bigrams,
         appName,
+        typingTest,
       },
     })
   }

--- a/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
@@ -77,9 +77,11 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
   })
 
-  it('does not dispatch analytics events in regular typing-test mode (not view-only)', () => {
+  it('dispatches a typingTest-tagged event in regular typing-test mode, even with REC off', () => {
+    // The editor test path is independent of the REC toggle: a running test
+    // always feeds analytics, tagged with its typing_test label.
     const { result } = renderUseInputModes({
-      typingRecordEnabled: true,
+      typingRecordEnabled: false,
       typingTestViewOnly: false,
     })
 
@@ -87,7 +89,10 @@ describe('useInputModes — typing analytics dispatch', () => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
 
-    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'matrix', keyboard: sampleKeyboard, typingTest: expect.any(String) }),
+    )
   })
 
   it('does not dispatch when the active keyboard is unknown', () => {

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { useTypingTest } from '../../typing-test/useTypingTest'
 import { buildTypingTestResult, isPbForConfig } from '../../typing-test/result-builder'
 import type { TypingTestConfig } from '../../typing-test/types'
@@ -9,6 +9,18 @@ import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/p
 import type { TypingAnalyticsEventPayload, TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
 import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
 import { PROCESS_CODE_TO_KEY } from './keymap-editor-types'
+
+/** Analytics `typing_test` dimension label for the running test: the
+ *  imported text's name for custom, else `mode (language)` (e.g.
+ *  `words (english)`) so Analyze can slice normal runs by language too. */
+function typingTestAnalyticsLabel(
+  config: TypingTestConfig,
+  language: string,
+  currentQuote: { source: string } | null,
+): string {
+  if (config.mode === 'custom') return currentQuote?.source ?? 'custom'
+  return `${config.mode} (${language})`
+}
 
 export interface UseInputModesOptions {
   rows?: number
@@ -162,29 +174,26 @@ export function useInputModes({
   // --- Typing test ---
   const keyboardRef = useRef(typingRecordKeyboard)
   keyboardRef.current = typingRecordKeyboard
-  const analyticsSink = useMemo<((event: TypingAnalyticsEventPayload) => void) | undefined>(() => {
-    // Recording lifecycle — see .claude/plans/typing-analytics.md.
-    //
-    // Events only flow to the main process when all three conditions hold:
-    //   1. typing-view compact window is open (typingTestViewOnly)
-    //   2. user has Start pressed on the record toggle (typingRecordEnabled)
-    //   3. useTypingTest's processMatrixFrame / processKeyEvent actually
-    //      fires, which is gated to typingTestMode by useInputModes below
-    //
-    // typingRecordEnabled is the user's explicit Start/Stop choice —
-    // persisted in PipetteSettings + synced across devices. Leaving
-    // the typing view (Exit, analytics navigation, disconnect) stops
-    // the sink via typingTestViewOnly=false without touching the
-    // toggle, so the next re-entry resumes recording automatically.
-    if (!typingRecordEnabled || !typingTestViewOnly) return undefined
-    return (payload) => {
-      const keyboard = keyboardRef.current
-      if (!keyboard) return
-      window.vialAPI
-        .typingAnalyticsEvent({ ...payload, keyboard })
-        .catch(() => { /* fire-and-forget */ })
-    }
-  }, [typingRecordEnabled, typingTestViewOnly])
+  // Analytics event sink — two independent sources feed the same pipeline:
+  //   1. Typing View REC ambient typing — gated by recordingActiveRef
+  //      (record toggle ON + compact window open), emitted untagged.
+  //   2. A typing test running in the editor — gated by testLabelRef
+  //      (non-null while a test is the active input source), emitted with
+  //      a `typingTest` dimension tag so Analyze can slice by which test.
+  // Both refs are updated below from render so this stays a stable callback
+  // (useTypingTest captures it once).
+  const recordingActiveRef = useRef(false)
+  const testLabelRef = useRef<string | null>(null)
+  const analyticsSink = useCallback((payload: TypingAnalyticsEventPayload) => {
+    const keyboard = keyboardRef.current
+    if (!keyboard) return
+    const label = testLabelRef.current
+    if (!recordingActiveRef.current && !label) return
+    const event = label
+      ? { ...payload, keyboard, typingTest: label }
+      : { ...payload, keyboard }
+    window.vialAPI.typingAnalyticsEvent(event).catch(() => { /* fire-and-forget */ })
+  }, [])
   const typingTest = useTypingTest(savedTypingTestConfig, savedTypingTestLanguage, {
     onAnalyticsEvent: analyticsSink,
     tappingTermMs,
@@ -266,6 +275,12 @@ export function useInputModes({
   // Effective recording condition: view-only + record toggle on. Anything
   // else leaves the analytics pipeline idle.
   const recordingActive = (typingRecordEnabled ?? false) && (typingTestViewOnly ?? false)
+  // Keep the sink's refs current (the sink itself is a stable callback).
+  recordingActiveRef.current = recordingActive
+  // A test in the editor (not the REC view) is the tagged input source.
+  testLabelRef.current = typingTestMode && !typingTestViewOnly
+    ? typingTestAnalyticsLabel(typingTest.config, typingTest.language, typingTest.state.currentQuote)
+    : null
 
   // Reset matrix press-edge tracking when keymap changes or recording toggles
   // so the next frame doesn't emit stale press events against an old state.
@@ -336,6 +351,11 @@ export function useInputModes({
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       onSaveTypingTestResult(result)
+      // Flush the test's analytics so the just-finished minute/session
+      // lands in the cache promptly (Analyze can show it without waiting
+      // for the minute-close / before-quit flush).
+      const uid = keyboardRef.current?.uid
+      if (uid) window.vialAPI.typingAnalyticsFlush(uid).catch(() => { /* fire-and-forget */ })
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -69,9 +69,17 @@ export type TypingMatrixAction = 'tap' | 'hold'
 /** Partial event emitted by `useTypingTest` before the active keyboard is
  * attached. `useInputModes` wraps it into a full {@link TypingAnalyticsEvent}
  * before dispatching to the main process. */
+interface TypingAnalyticsEventCommon {
+  /** Identifies the typing test producing this keystroke (custom = text
+   *  name, normal = `mode (language)`). Absent for ordinary Typing View REC
+   *  input. Resolved per-minute into the `typing_test` dimension (like the
+   *  active-app tag), so Analyze can slice by which test it was. */
+  typingTest?: string
+}
+
 export type TypingAnalyticsEventPayload =
-  | { kind: 'char'; key: string; ts: number }
-  | {
+  | (TypingAnalyticsEventCommon & { kind: 'char'; key: string; ts: number })
+  | (TypingAnalyticsEventCommon & {
       kind: 'matrix'
       row: number
       col: number
@@ -83,7 +91,7 @@ export type TypingAnalyticsEventPayload =
        * and presses that have not yet seen a release leave this
        * undefined; the count still lands in the `count` total column. */
       action?: TypingMatrixAction
-    }
+    })
 
 /** Normalized analytics event carried over the IPC to the main process. */
 export type TypingAnalyticsEvent = TypingAnalyticsEventPayload & {


### PR DESCRIPTION
## Summary
First of two parts integrating the Typing Test with the Typing View REC analytics system. This PR is the **recording infrastructure**: typing test keystrokes now feed the typing-analytics pipeline, tagged with a `typing_test` dimension. The existing Typing Test UX/History is unchanged — only the aggregation path is extended.

(The Analyze `TypingTest []` filter UI is the follow-up PR.)

## What's in this PR
- **New `typing_test` dimension** threaded alongside `app_name` through the whole pipeline:
  - event payload → `MinuteBuffer` (per-event, single-value/mixed→null like app_name) → JSONL rows (optional, backward-compatible) → SQLite (`typing_test` column on the 4 minute tables, indexes, `SCHEMA_VERSION 4→5` + ALTER migration) → ingestion & merge upserts → JSONL master rows
- **Emit from every typing test run** (editor included, independent of the REC toggle): tagged `custom` = imported text name, `normal` = `mode (language)` (e.g. `words (english)`). Flush on finish so data lands promptly.
- Existing Typing View REC behaviour and the Typing Test History (`PipetteSettings.typingTestResults`) are untouched.
- `typing_test` is local-only in sync (matches `app_name`); cache rebuilds from JSONL.
- Design doc: `.claude/plans/Plan-typing-test-analytics-integration.md`.

## Testing
- `pnpm run lint` ✅
- `npx tsc --noEmit` ✅
- `pnpm test` ✅ (4213 passed; typing-analytics DB upsert/merge/migrate covered)
- `pnpm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)