### PR TITLE
feat(ui): add TypingTest filter to Analyze view

### DIFF
--- a/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
+++ b/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
@@ -541,6 +541,36 @@ describe('TypingAnalyticsDB', () => {
       expect(summaries[0].activeMs).toBe(1_500)
     })
 
+    it('lists distinct typing_test labels and filters queries by typingTestScopes', () => {
+      // Two extra minutes on 0xAABB tagged with different typing tests.
+      db.writeMinute(
+        { scopeId: 'scope-aabb-local', minuteTs: 180_000, ...baseStats, keystrokes: 5, typingTest: 'words (english)' },
+        [],
+        [{ scopeId: 'scope-aabb-local', minuteTs: 180_000, row: 1, col: 1, layer: 0, keycode: 0x05, count: 5, typingTest: 'words (english)' }],
+        2_000,
+      )
+      db.writeMinute(
+        { scopeId: 'scope-aabb-local', minuteTs: 240_000, ...baseStats, keystrokes: 9, typingTest: 'novel.txt' },
+        [],
+        [{ scopeId: 'scope-aabb-local', minuteTs: 240_000, row: 1, col: 1, layer: 0, keycode: 0x05, count: 9, typingTest: 'novel.txt' }],
+        2_000,
+      )
+
+      // Option source: both labels present, NULL (the untagged 60_000 minute) excluded.
+      const labels = db.listTypingTestsForUidInRange('0xAABB', MACHINE_HASH, 0, 300_000).map((r) => r.name).sort()
+      expect(labels).toEqual(['novel.txt', 'words (english)'])
+
+      // Filtering a cell query to one test returns only that test's count.
+      const cell = (rows: { count: number }[]): number => rows.reduce((s, r) => s + r.count, 0)
+      const novelOnly = db.listMatrixCellsForUid('0xAABB', 0, 300_000, [], ['novel.txt'])
+      expect(cell(novelOnly)).toBe(9)
+      const wordsOnly = db.listMatrixCellsForUid('0xAABB', 0, 300_000, [], ['words (english)'])
+      expect(cell(wordsOnly)).toBe(5)
+      // Empty filter = no filter: includes the untagged 60_000 cell (3) + 5 + 9.
+      const unfiltered = db.listMatrixCellsForUid('0xAABB', 0, 300_000)
+      expect(cell(unfiltered)).toBe(17)
+    })
+
     it('tombstoneRowsForUidInRange flips is_deleted on matching rows and bumps updated_at', () => {
       const result = db.tombstoneRowsForUidInRange('0xAABB', 0, 90_000, 5_000)
       expect(result.charMinutes).toBe(2) // aabb-local + aabb-remote at minute 60_000

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -224,6 +224,12 @@ function appFilterClause(column: string): string {
   return `AND (json_array_length(@appNamesJson) = 0 OR ${column} IN (SELECT value FROM json_each(@appNamesJson)))`
 }
 
+/** Same shape as {@link appFilterClause} for the typing_test dimension.
+ * `@typingTestsJson` is a JSON array; empty = no filter. */
+function typingTestFilterClause(column: string): string {
+  return `AND (json_array_length(@typingTestsJson) = 0 OR ${column} IN (SELECT value FROM json_each(@typingTestsJson)))`
+}
+
 export class TypingAnalyticsDB {
   private readonly db: DatabaseType
   private readonly upsertScopeStmt: Statement
@@ -305,6 +311,7 @@ export class TypingAnalyticsDB {
   // optional via the @machineHash IS NULL trick so a single statement
   // serves both "all devices" and "this device" scopes.
   private readonly selectAppsForUidInRangeStmt: Statement
+  private readonly selectTypingTestsForUidInRangeStmt: Statement
   private readonly selectAppUsageForUidInRangeStmt: Statement
   private readonly selectWpmByAppForUidInRangeStmt: Statement
 
@@ -752,7 +759,7 @@ export class TypingAnalyticsDB {
          AND m.layer = @layer
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.row, m.col
     `)
 
@@ -770,7 +777,7 @@ export class TypingAnalyticsDB {
          AND m.layer = @layer
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.row, m.col
     `)
 
@@ -810,7 +817,7 @@ export class TypingAnalyticsDB {
        WHERE s.keyboard_uid = @uid
          AND s.is_deleted = 0
          AND t.is_deleted = 0
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY date
        ORDER BY date DESC
     `)
@@ -828,7 +835,7 @@ export class TypingAnalyticsDB {
          AND s.machine_hash = @machineHash
          AND s.is_deleted = 0
          AND t.is_deleted = 0
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY date
        ORDER BY date DESC
     `)
@@ -887,7 +894,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY dow, hour
     `)
 
@@ -903,7 +910,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY dow, hour
     `)
 
@@ -922,7 +929,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.layer
        ORDER BY m.layer ASC
     `)
@@ -938,7 +945,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.layer
        ORDER BY m.layer ASC
     `)
@@ -964,7 +971,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.layer, m.row, m.col
     `)
 
@@ -983,7 +990,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY m.layer, m.row, m.col
     `)
 
@@ -1010,7 +1017,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY date, m.layer, m.row, m.col
        ORDER BY date ASC
     `)
@@ -1031,7 +1038,7 @@ export class TypingAnalyticsDB {
          AND m.is_deleted = 0
          AND m.minute_ts >= @sinceMs
          AND m.minute_ts < @untilMs
-         ${appFilterClause('m.app_name')}
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')}
        GROUP BY date, m.layer, m.row, m.col
        ORDER BY date ASC
     `)
@@ -1063,7 +1070,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        ORDER BY t.minute_ts ASC
     `)
@@ -1085,7 +1092,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        ORDER BY t.minute_ts ASC
     `)
@@ -1110,6 +1117,25 @@ export class TypingAnalyticsDB {
          AND t.minute_ts < @untilMs
          AND t.app_name IS NOT NULL
        GROUP BY t.app_name
+       ORDER BY keystrokes DESC
+    `)
+
+    // Distinct typing_test labels in range — the TypingTest filter's option
+    // source (mirrors selectAppsForUidInRange). NULL (REC / mixed) excluded.
+    this.selectTypingTestsForUidInRangeStmt = this.db.prepare(`
+      SELECT t.typing_test AS name,
+             SUM(t.keystrokes) AS keystrokes,
+             SUM(t.active_ms) AS activeMs
+        FROM typing_minute_stats t
+        JOIN typing_scopes s ON s.id = t.scope_id
+       WHERE s.keyboard_uid = @uid
+         AND (@machineHash IS NULL OR s.machine_hash = @machineHash)
+         AND s.is_deleted = 0
+         AND t.is_deleted = 0
+         AND t.minute_ts >= @sinceMs
+         AND t.minute_ts < @untilMs
+         AND t.typing_test IS NOT NULL
+       GROUP BY t.typing_test
        ORDER BY keystrokes DESC
     `)
 
@@ -1175,7 +1201,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        ORDER BY t.bigram_id ASC, t.minute_ts ASC
     `)
 
@@ -1192,7 +1218,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        ORDER BY t.bigram_id ASC, t.minute_ts ASC
     `)
 
@@ -1262,7 +1288,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        HAVING backspaceCount > 0
        ORDER BY t.minute_ts ASC
@@ -1285,7 +1311,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        HAVING backspaceCount > 0
        ORDER BY t.minute_ts ASC
@@ -1310,7 +1336,7 @@ export class TypingAnalyticsDB {
              AND t.is_deleted = 0
              AND t.minute_ts >= @sinceMs
              AND t.minute_ts < @untilMs
-             ${appFilterClause('t.app_name')}
+             ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
            GROUP BY t.minute_ts
         ) AS total
        WHERE total.active_ms > 0
@@ -1333,7 +1359,7 @@ export class TypingAnalyticsDB {
              AND t.is_deleted = 0
              AND t.minute_ts >= @sinceMs
              AND t.minute_ts < @untilMs
-             ${appFilterClause('t.app_name')}
+             ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
            GROUP BY t.minute_ts
         ) AS total
        WHERE total.active_ms > 0
@@ -1357,7 +1383,7 @@ export class TypingAnalyticsDB {
              AND t.is_deleted = 0
              AND t.minute_ts >= @sinceMs
              AND t.minute_ts < @untilMs
-             ${appFilterClause('t.app_name')}
+             ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
            GROUP BY t.minute_ts
         ) AS total
        WHERE total.active_ms > 0
@@ -1381,7 +1407,7 @@ export class TypingAnalyticsDB {
              AND t.is_deleted = 0
              AND t.minute_ts >= @sinceMs
              AND t.minute_ts < @untilMs
-             ${appFilterClause('t.app_name')}
+             ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
            GROUP BY t.minute_ts
         ) AS total
        WHERE total.active_ms > 0
@@ -1399,7 +1425,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        HAVING value > 0
        ORDER BY value DESC
@@ -1416,7 +1442,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY t.minute_ts
        HAVING value > 0
        ORDER BY value DESC
@@ -1433,7 +1459,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY day
        HAVING value > 0
        ORDER BY value DESC
@@ -1451,7 +1477,7 @@ export class TypingAnalyticsDB {
          AND t.is_deleted = 0
          AND t.minute_ts >= @sinceMs
          AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')}
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')}
        GROUP BY day
        HAVING value > 0
        ORDER BY value DESC
@@ -1838,14 +1864,14 @@ export class TypingAnalyticsDB {
     sinceMs: number,
     untilMs: number,
     machineHash?: string,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): Map<string, { total: number; tap: number; hold: number }> {
     const stmt = machineHash !== undefined
       ? this.selectMatrixHeatmapInRangeForHashStmt
       : this.selectMatrixHeatmapInRangeStmt
     const params = machineHash !== undefined
-      ? { uid, machineHash, layer, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }
-      : { uid, layer, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }
+      ? { uid, machineHash, layer, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }
+      : { uid, layer, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }
     const rows = stmt.all(params) as Array<{
       row: number
       col: number
@@ -1873,9 +1899,9 @@ export class TypingAnalyticsDB {
    * and ordered newest first. Live rows only. */
   listDailySummariesForUid(
     uid: string,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingDailySummary[] {
-    return this.selectDailySummariesForUidStmt.all({ uid, appNamesJson: JSON.stringify(appScopes) }) as TypingDailySummary[]
+    return this.selectDailySummariesForUidStmt.all({ uid, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingDailySummary[]
   }
 
   /** Daily summaries for a keyboard uid restricted to a single
@@ -1886,9 +1912,9 @@ export class TypingAnalyticsDB {
   listDailySummariesForUidAndHash(
     uid: string,
     machineHash: string,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingDailySummary[] {
-    return this.selectDailySummariesForUidAndHashStmt.all({ uid, machineHash, appNamesJson: JSON.stringify(appScopes) }) as TypingDailySummary[]
+    return this.selectDailySummariesForUidAndHashStmt.all({ uid, machineHash, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingDailySummary[]
   }
 
   /** Daily interval summaries (min/p25/p50/p75/max) for a keyboard uid,
@@ -1916,9 +1942,9 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingActivityCell[] {
-    return this.selectActivityGridForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingActivityCell[]
+    return this.selectActivityGridForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingActivityCell[]
   }
 
   /** Same as {@link listActivityGridForUid} but restricted to a single
@@ -1929,9 +1955,9 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingActivityCell[] {
-    return this.selectActivityGridForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingActivityCell[]
+    return this.selectActivityGridForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingActivityCell[]
   }
 
   /** Per-layer keystroke totals for the Analyze > Layer tab. Layers
@@ -1942,9 +1968,9 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingLayerUsageRow[] {
-    return this.selectLayerUsageForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingLayerUsageRow[]
+    return this.selectLayerUsageForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingLayerUsageRow[]
   }
 
   /** Same as {@link listLayerUsageForUid} but restricted to one
@@ -1954,9 +1980,9 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingLayerUsageRow[] {
-    return this.selectLayerUsageForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingLayerUsageRow[]
+    return this.selectLayerUsageForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingLayerUsageRow[]
   }
 
   /** Per-(layer, row, col) press totals for the Analyze > Layer
@@ -1967,9 +1993,9 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMatrixCellRow[] {
-    return this.selectMatrixCellsForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingMatrixCellRow[]
+    return this.selectMatrixCellsForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingMatrixCellRow[]
   }
 
   /** Same as {@link listMatrixCellsForUid} but restricted to one
@@ -1979,9 +2005,9 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMatrixCellRow[] {
-    return this.selectMatrixCellsForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingMatrixCellRow[]
+    return this.selectMatrixCellsForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingMatrixCellRow[]
   }
 
   /** Per-(localDay, layer, row, col) press totals for the Analyze
@@ -1993,9 +2019,9 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMatrixCellDailyRow[] {
-    const rows = this.selectMatrixCellsByDayForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as MatrixCellsByDayDbRow[]
+    const rows = this.selectMatrixCellsByDayForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as MatrixCellsByDayDbRow[]
     return rows.map(matrixCellsByDayDbRowToDailyRow)
   }
 
@@ -2006,9 +2032,9 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMatrixCellDailyRow[] {
-    const rows = this.selectMatrixCellsByDayForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as MatrixCellsByDayDbRow[]
+    const rows = this.selectMatrixCellsByDayForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as MatrixCellsByDayDbRow[]
     return rows.map(matrixCellsByDayDbRowToDailyRow)
   }
 
@@ -2022,13 +2048,13 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMinuteStatsRow[] {
     return this.selectMinuteStatsInRangeForUidStmt.all({
       uid,
       sinceMs,
       untilMs,
-      appNamesJson: JSON.stringify(appScopes),
+      appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes),
     }) as TypingMinuteStatsRow[]
   }
 
@@ -2039,14 +2065,14 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingMinuteStatsRow[] {
     return this.selectMinuteStatsInRangeForUidAndHashStmt.all({
       uid,
       machineHash,
       sinceMs,
       untilMs,
-      appNamesJson: JSON.stringify(appScopes),
+      appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes),
     }) as TypingMinuteStatsRow[]
   }
 
@@ -2061,6 +2087,21 @@ export class TypingAnalyticsDB {
     untilMs: number,
   ): { name: string; keystrokes: number; activeMs: number }[] {
     return this.selectAppsForUidInRangeStmt.all({ uid, machineHash, sinceMs, untilMs }) as {
+      name: string
+      keystrokes: number
+      activeMs: number
+    }[]
+  }
+
+  /** Distinct typing_test labels with activity in range — the TypingTest
+   * filter's option source. */
+  listTypingTestsForUidInRange(
+    uid: string,
+    machineHash: string | null,
+    sinceMs: number,
+    untilMs: number,
+  ): { name: string; keystrokes: number; activeMs: number }[] {
+    return this.selectTypingTestsForUidInRangeStmt.all({ uid, machineHash, sinceMs, untilMs }) as {
       name: string
       keystrokes: number
       activeMs: number
@@ -2110,10 +2151,10 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): BigramMinuteCellRow[] {
     return this.toBigramMinuteCellRows(
-      this.selectBigramMinutesInRangeForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }),
+      this.selectBigramMinutesInRangeForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }),
     )
   }
 
@@ -2124,7 +2165,7 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): BigramMinuteCellRow[] {
     return this.toBigramMinuteCellRows(
       this.selectBigramMinutesInRangeForUidAndHashStmt.all({
@@ -2132,7 +2173,7 @@ export class TypingAnalyticsDB {
         machineHash,
         sinceMs,
         untilMs,
-        appNamesJson: JSON.stringify(appScopes),
+        appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes),
       }),
     )
   }
@@ -2170,9 +2211,9 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingBksMinuteRow[] {
-    return this.selectBksMinuteInRangeForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingBksMinuteRow[]
+    return this.selectBksMinuteInRangeForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingBksMinuteRow[]
   }
 
   /** Same as {@link listBksMinuteInRangeForUid} but restricted to a
@@ -2182,9 +2223,9 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): TypingBksMinuteRow[] {
-    return this.selectBksMinuteInRangeForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes) }) as TypingBksMinuteRow[]
+    return this.selectBksMinuteInRangeForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }) as TypingBksMinuteRow[]
   }
 
   /** Peak records for the Analyze summary cards across every scope of
@@ -2194,7 +2235,7 @@ export class TypingAnalyticsDB {
     uid: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): PeakRecords {
     // typing_sessions has no app_name column — sessions span multiple
     // minutes and the app focus can change during one. We deliberately
@@ -2204,7 +2245,7 @@ export class TypingAnalyticsDB {
     // do honour the filter so the WPM / keystroke-per-minute peaks
     // match the rest of the per-app aggregates.
     const sessParams = { uid, sinceMs, untilMs }
-    const params = { ...sessParams, appNamesJson: JSON.stringify(appScopes) }
+    const params = { ...sessParams, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }
     const wpm = this.selectPeakWpmInRangeForUidStmt.get(params) as { value: number; atMs: number } | undefined
     const low = this.selectLowestWpmInRangeForUidStmt.get(params) as { value: number; atMs: number } | undefined
     const kpm = this.selectPeakKpmInRangeForUidStmt.get(params) as { value: number; atMs: number } | undefined
@@ -2226,10 +2267,10 @@ export class TypingAnalyticsDB {
     machineHash: string,
     sinceMs: number,
     untilMs: number,
-    appScopes: readonly string[] = [],
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [],
   ): PeakRecords {
     const sessParams = { uid, machineHash, sinceMs, untilMs }
-    const params = { ...sessParams, appNamesJson: JSON.stringify(appScopes) }
+    const params = { ...sessParams, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes) }
     const wpm = this.selectPeakWpmInRangeForUidAndHashStmt.get(params) as { value: number; atMs: number } | undefined
     const low = this.selectLowestWpmInRangeForUidAndHashStmt.get(params) as { value: number; atMs: number } | undefined
     const kpm = this.selectPeakKpmInRangeForUidAndHashStmt.get(params) as { value: number; atMs: number } | undefined

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -193,9 +193,9 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ITEMS,
-    async (_event, uid: unknown, appScopes: unknown): Promise<TypingDailySummary[]> => {
+    async (_event, uid: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingDailySummary[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
-      return listTypingDailySummaries(uid, normalizeAppScopes(appScopes))
+      return listTypingDailySummaries(uid, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -235,10 +235,10 @@ export function setupTypingAnalyticsIpc(): void {
   // wired into sync-service so they share the same credential check.
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_LOCAL,
-    async (_event, uid: unknown, appScopes: unknown): Promise<TypingDailySummary[]> => {
+    async (_event, uid: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingDailySummary[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const ownHash = await getMachineHash()
-      return listTypingDailySummariesForHash(uid, ownHash, normalizeAppScopes(appScopes))
+      return listTypingDailySummariesForHash(uid, ownHash, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -252,10 +252,10 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, appScopes: unknown): Promise<TypingDailySummary[]> => {
+    async (_event, uid: unknown, machineHash: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingDailySummary[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
-      return listTypingDailySummariesForHash(uid, machineHash, normalizeAppScopes(appScopes))
+      return listTypingDailySummariesForHash(uid, machineHash, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -270,45 +270,45 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingActivityCell[]> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingActivityCell[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingActivityGridForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingActivityGridForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingLayerUsageRow[]> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingLayerUsageRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingLayerUsageInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingLayerUsageInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellRow[]> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingMatrixCellsInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingMatrixCellsByDayInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsByDayInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -320,14 +320,15 @@ export function setupTypingAnalyticsIpc(): void {
       machineHash: unknown,
       sinceMs: unknown,
       untilMs: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<TypingMinuteStatsRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const apps = normalizeAppScopes(appScopes)
-      return listTypingMinuteStatsInRangeForHash(uid, machineHash, since, until, apps)
+      const typingTests = normalizeAppScopes(typingTestScopes)
+      return listTypingMinuteStatsInRangeForHash(uid, machineHash, since, until, apps, typingTests)
     },
   )
 
@@ -344,23 +345,23 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingBksMinuteRow[]> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingBksMinuteRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       if (typeof machineHash !== 'string' || machineHash.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingBksMinuteInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingBksMinuteInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_FOR_HASH,
-    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<PeakRecords> => {
+    async (_event, uid: unknown, machineHash: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<PeakRecords> => {
       if (typeof uid !== 'string' || uid.length === 0) return emptyPeakRecords()
       if (typeof machineHash !== 'string' || machineHash.length === 0) return emptyPeakRecords()
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return getTypingPeakRecordsInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes))
+      return getTypingPeakRecordsInRangeForHash(uid, machineHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -392,85 +393,85 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingActivityCell[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingActivityCell[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingActivityGrid(uid, since, until, normalizeAppScopes(appScopes))
+      return listTypingActivityGrid(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingActivityCell[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingActivityCell[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return listTypingActivityGridForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingActivityGridForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingLayerUsageRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingLayerUsageRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingLayerUsageInRange(uid, since, until, normalizeAppScopes(appScopes))
+      return listTypingLayerUsageInRange(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingLayerUsageRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingLayerUsageRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return listTypingLayerUsageInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingLayerUsageInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingMatrixCellsInRange(uid, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsInRange(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return listTypingMatrixCellsInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingMatrixCellsByDayInRange(uid, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsByDayInRange(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingMatrixCellDailyRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return listTypingMatrixCellsByDayInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingMatrixCellsByDayInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -481,13 +482,14 @@ export function setupTypingAnalyticsIpc(): void {
       uid: unknown,
       sinceMs: unknown,
       untilMs: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<TypingMinuteStatsRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const apps = normalizeAppScopes(appScopes)
-      return listTypingMinuteStatsInRange(uid, since, until, apps)
+      const typingTests = normalizeAppScopes(typingTestScopes)
+      return listTypingMinuteStatsInRange(uid, since, until, apps, typingTests)
     },
   )
 
@@ -498,14 +500,15 @@ export function setupTypingAnalyticsIpc(): void {
       uid: unknown,
       sinceMs: unknown,
       untilMs: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<TypingMinuteStatsRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
       const apps = normalizeAppScopes(appScopes)
-      return listTypingMinuteStatsInRangeForHash(uid, ownHash, since, until, apps)
+      const typingTests = normalizeAppScopes(typingTestScopes)
+      return listTypingMinuteStatsInRangeForHash(uid, ownHash, since, until, apps, typingTests)
     },
   )
 
@@ -532,43 +535,43 @@ export function setupTypingAnalyticsIpc(): void {
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingBksMinuteRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingBksMinuteRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return listTypingBksMinuteInRange(uid, since, until, normalizeAppScopes(appScopes))
+      return listTypingBksMinuteInRange(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<TypingBksMinuteRow[]> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<TypingBksMinuteRow[]> => {
       if (typeof uid !== 'string' || uid.length === 0) return []
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return listTypingBksMinuteInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return listTypingBksMinuteInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<PeakRecords> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<PeakRecords> => {
       if (typeof uid !== 'string' || uid.length === 0) return emptyPeakRecords()
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
-      return getTypingPeakRecordsInRange(uid, since, until, normalizeAppScopes(appScopes))
+      return getTypingPeakRecordsInRange(uid, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_LOCAL,
-    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown): Promise<PeakRecords> => {
+    async (_event, uid: unknown, sinceMs: unknown, untilMs: unknown, appScopes: unknown, typingTestScopes: unknown): Promise<PeakRecords> => {
       if (typeof uid !== 'string' || uid.length === 0) return emptyPeakRecords()
       const since = typeof sinceMs === 'number' && Number.isFinite(sinceMs) && sinceMs >= 0 ? sinceMs : 0
       const until = typeof untilMs === 'number' && Number.isFinite(untilMs) && untilMs > since ? untilMs : Number.MAX_SAFE_INTEGER
       const ownHash = await getMachineHash()
-      return getTypingPeakRecordsInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes))
+      return getTypingPeakRecordsInRangeForHash(uid, ownHash, since, until, normalizeAppScopes(appScopes), normalizeAppScopes(typingTestScopes))
     },
   )
 
@@ -608,7 +611,7 @@ export function setupTypingAnalyticsIpc(): void {
       sinceMs: unknown,
       untilMs: unknown,
       scope: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<TypingHeatmapByCell> => {
       if (typeof uid !== 'string' || uid.length === 0) return {}
       if (typeof layer !== 'number' || !Number.isFinite(layer) || layer < 0) return {}
@@ -628,7 +631,8 @@ export function setupTypingAnalyticsIpc(): void {
           ? parsedScope.machineHash
           : undefined
       const apps = normalizeAppScopes(appScopes)
-      const totals = db.aggregateMatrixCountsForUidInRange(uid, layer, sinceMinuteMs, untilMinuteMs, machineHash, apps)
+      const typingTests = normalizeAppScopes(typingTestScopes)
+      const totals = db.aggregateMatrixCountsForUidInRange(uid, layer, sinceMinuteMs, untilMinuteMs, machineHash, apps, typingTests)
       const out: TypingHeatmapByCell = {}
       for (const [key, cell] of totals) {
         out[key] = { total: cell.total, tap: cell.tap, hold: cell.hold }
@@ -676,6 +680,15 @@ export function setupTypingAnalyticsIpc(): void {
   )
 
   secureHandle(
+    IpcChannels.TYPING_ANALYTICS_LIST_TYPING_TESTS_FOR_RANGE,
+    async (_event, uid, sinceMs, untilMs, scope): Promise<{ name: string; keystrokes: number; activeMs: number }[]> => {
+      const args = await parseAppRangeArgs(uid, sinceMs, untilMs, scope)
+      if (!args) return []
+      return getTypingAnalyticsDB().listTypingTestsForUidInRange(args.uid, args.machineHash, args.sinceMs, args.untilMs)
+    },
+  )
+
+  secureHandle(
     IpcChannels.TYPING_ANALYTICS_GET_APP_USAGE_FOR_RANGE,
     async (_event, uid, sinceMs, untilMs, scope): Promise<{ name: string; keystrokes: number; activeMs: number }[]> => {
       const args = await parseAppRangeArgs(uid, sinceMs, untilMs, scope)
@@ -703,7 +716,7 @@ export function setupTypingAnalyticsIpc(): void {
       view: unknown,
       scope: unknown,
       options: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<TypingBigramAggregateResult> => {
       // Reject unknown views up front so parsedView is the trusted union
       // and downstream branches can return literal-typed empty results.
@@ -722,6 +735,7 @@ export function setupTypingAnalyticsIpc(): void {
       const limit = opts.limit ?? 30
       const minSample = opts.minSampleCount ?? 5
       const apps = normalizeAppScopes(appScopes)
+      const typingTests = normalizeAppScopes(typingTestScopes)
 
       const db = getTypingAnalyticsDB()
       const machineHash = isOwnScope(parsedScope)
@@ -730,8 +744,8 @@ export function setupTypingAnalyticsIpc(): void {
           ? parsedScope.machineHash
           : undefined
       const rows = machineHash === undefined
-        ? db.listBigramMinutesInRangeForUid(uid, sinceMs, untilMs, apps)
-        : db.listBigramMinutesInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, apps)
+        ? db.listBigramMinutesInRangeForUid(uid, sinceMs, untilMs, apps, typingTests)
+        : db.listBigramMinutesInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, apps, typingTests)
       const totals = aggregatePairTotals(rows)
       if (parsedView === 'slow') {
         return { view: 'slow', entries: rankBigramsBySlow(totals, minSample, limit) }
@@ -749,7 +763,7 @@ export function setupTypingAnalyticsIpc(): void {
       untilMs: unknown,
       scope: unknown,
       options: unknown,
-      appScopes: unknown,
+      appScopes: unknown, typingTestScopes: unknown,
     ): Promise<LayoutComparisonResult | null> => {
       if (typeof uid !== 'string' || uid.length === 0) return null
       if (typeof sinceMs !== 'number' || !Number.isFinite(sinceMs)) return null
@@ -759,6 +773,7 @@ export function setupTypingAnalyticsIpc(): void {
       const opts = parseLayoutComparisonOptions(options)
       if (!opts) return null
       const apps = normalizeAppScopes(appScopes)
+      const typingTests = normalizeAppScopes(typingTestScopes)
       // Snapshots are only stored for the own device, so we always
       // resolve the source layer + KleKey geometry against the local
       // machine hash regardless of which scope the metric counts use.
@@ -780,6 +795,7 @@ export function setupTypingAnalyticsIpc(): void {
         untilMinuteMs,
         matrixHash,
         apps,
+        typingTests,
       )
       return computeLayoutComparison({
         matrixCounts,
@@ -858,8 +874,9 @@ export function listTypingKeyboards(): TypingKeyboardSummary[] {
 export function listTypingDailySummaries(
   uid: string,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingDailySummary[] {
-  return getTypingAnalyticsDB().listDailySummariesForUid(uid, appScopes)
+  return getTypingAnalyticsDB().listDailySummariesForUid(uid, appScopes, typingTestScopes)
 }
 
 /** Pure-cache lookup for the Analyze > Interval chart. Returns every
@@ -887,8 +904,9 @@ export function listTypingActivityGrid(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingActivityCell[] {
-  return getTypingAnalyticsDB().listActivityGridForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listActivityGridForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingActivityGridForHash(
@@ -897,8 +915,9 @@ export function listTypingActivityGridForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingActivityCell[] {
-  return getTypingAnalyticsDB().listActivityGridForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listActivityGridForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Per-layer keystroke totals for the Analyze > Layer tab. Covers
@@ -908,8 +927,9 @@ export function listTypingLayerUsageInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingLayerUsageRow[] {
-  return getTypingAnalyticsDB().listLayerUsageForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listLayerUsageForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingLayerUsageInRangeForHash(
@@ -918,8 +938,9 @@ export function listTypingLayerUsageInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingLayerUsageRow[] {
-  return getTypingAnalyticsDB().listLayerUsageForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listLayerUsageForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Per-cell matrix totals for the Analyze > Layer activations mode.
@@ -929,8 +950,9 @@ export function listTypingMatrixCellsInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMatrixCellRow[] {
-  return getTypingAnalyticsDB().listMatrixCellsForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMatrixCellsForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingMatrixCellsInRangeForHash(
@@ -939,8 +961,9 @@ export function listTypingMatrixCellsInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMatrixCellRow[] {
-  return getTypingAnalyticsDB().listMatrixCellsForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMatrixCellsForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Per-(localDay, layer, row, col) totals for the Analyze Ergonomic
@@ -952,8 +975,9 @@ export function listTypingMatrixCellsByDayInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMatrixCellDailyRow[] {
-  return getTypingAnalyticsDB().listMatrixCellsByDayForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMatrixCellsByDayForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingMatrixCellsByDayInRangeForHash(
@@ -962,8 +986,9 @@ export function listTypingMatrixCellsByDayInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMatrixCellDailyRow[] {
-  return getTypingAnalyticsDB().listMatrixCellsByDayForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMatrixCellsByDayForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Minute-raw stats for the Analyze WPM / Interval charts over the
@@ -976,8 +1001,9 @@ export function listTypingMinuteStatsInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMinuteStatsRow[] {
-  return getTypingAnalyticsDB().listMinuteStatsInRangeForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMinuteStatsInRangeForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingMinuteStatsInRangeForHash(
@@ -986,8 +1012,9 @@ export function listTypingMinuteStatsInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingMinuteStatsRow[] {
-  return getTypingAnalyticsDB().listMinuteStatsInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listMinuteStatsInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Live sessions that intersect `[sinceMs, untilMs)`. Powers the
@@ -1015,8 +1042,9 @@ export function listTypingBksMinuteInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingBksMinuteRow[] {
-  return getTypingAnalyticsDB().listBksMinuteInRangeForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listBksMinuteInRangeForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function listTypingBksMinuteInRangeForHash(
@@ -1025,8 +1053,9 @@ export function listTypingBksMinuteInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingBksMinuteRow[] {
-  return getTypingAnalyticsDB().listBksMinuteInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().listBksMinuteInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function getTypingPeakRecordsInRange(
@@ -1034,8 +1063,9 @@ export function getTypingPeakRecordsInRange(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): PeakRecords {
-  return getTypingAnalyticsDB().getPeakRecordsInRangeForUid(uid, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().getPeakRecordsInRangeForUid(uid, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 export function getTypingPeakRecordsInRangeForHash(
@@ -1044,8 +1074,9 @@ export function getTypingPeakRecordsInRangeForHash(
   sinceMs: number,
   untilMs: number,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): PeakRecords {
-  return getTypingAnalyticsDB().getPeakRecordsInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes)
+  return getTypingAnalyticsDB().getPeakRecordsInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes)
 }
 
 /** Day-level summaries restricted to a single `machineHash`. When
@@ -1055,8 +1086,9 @@ export function listTypingDailySummariesForHash(
   uid: string,
   machineHash: string,
   appScopes: readonly string[] = [],
+  typingTestScopes: readonly string[] = [],
 ): TypingDailySummary[] {
-  return getTypingAnalyticsDB().listDailySummariesForUidAndHash(uid, machineHash, appScopes)
+  return getTypingAnalyticsDB().listDailySummariesForUidAndHash(uid, machineHash, appScopes, typingTestScopes)
 }
 
 /** Per-keyboard device infos for the Analyze > Device filter: own

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -417,6 +417,13 @@ const vialAPI = {
     scope: unknown,
   ): Promise<{ name: string; keystrokes: number; activeMs: number }[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_APPS_FOR_RANGE, uid, sinceMs, untilMs, scope),
+  typingAnalyticsListTypingTestsForRange: (
+    uid: string,
+    sinceMs: number,
+    untilMs: number,
+    scope: unknown,
+  ): Promise<{ name: string; keystrokes: number; activeMs: number }[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_TYPING_TESTS_FOR_RANGE, uid, sinceMs, untilMs, scope),
   typingAnalyticsGetAppUsageForRange: (
     uid: string,
     sinceMs: number,
@@ -433,8 +440,8 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_WPM_BY_APP_FOR_RANGE, uid, sinceMs, untilMs, scope),
   typingAnalyticsListKeyboards: (): Promise<TypingKeyboardSummary[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_KEYBOARDS),
-  typingAnalyticsListItems: (uid: string, appScopes: string[] = []): Promise<TypingDailySummary[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS, uid, appScopes),
+  typingAnalyticsListItems: (uid: string, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingDailySummary[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS, uid, appScopes, typingTestScopes),
   typingAnalyticsDeleteItems: (uid: string, dates: string[]): Promise<TypingTombstoneResult> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_DELETE_ITEMS, uid, dates),
   typingAnalyticsDeleteAll: (uid: string): Promise<TypingTombstoneResult> =>
@@ -445,74 +452,74 @@ const vialAPI = {
     sinceMs: number,
   ): Promise<TypingHeatmapByCell> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_MATRIX_HEATMAP, uid, layer, sinceMs),
-  typingAnalyticsListItemsLocal: (uid: string, appScopes: string[] = []): Promise<TypingDailySummary[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_LOCAL, uid, appScopes),
+  typingAnalyticsListItemsLocal: (uid: string, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingDailySummary[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_LOCAL, uid, appScopes, typingTestScopes),
   typingAnalyticsListDeviceInfos: (uid: string): Promise<TypingAnalyticsDeviceInfoBundle | null> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_DEVICE_INFOS, uid),
-  typingAnalyticsListItemsForHash: (uid: string, machineHash: string, appScopes: string[] = []): Promise<TypingDailySummary[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_FOR_HASH, uid, machineHash, appScopes),
+  typingAnalyticsListItemsForHash: (uid: string, machineHash: string, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingDailySummary[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ITEMS_FOR_HASH, uid, machineHash, appScopes, typingTestScopes),
   typingAnalyticsListIntervalItems: (uid: string): Promise<TypingIntervalDailySummary[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_INTERVAL_ITEMS, uid),
   typingAnalyticsListIntervalItemsLocal: (uid: string): Promise<TypingIntervalDailySummary[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_INTERVAL_ITEMS_LOCAL, uid),
   typingAnalyticsListIntervalItemsForHash: (uid: string, machineHash: string): Promise<TypingIntervalDailySummary[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_INTERVAL_ITEMS_FOR_HASH, uid, machineHash),
-  typingAnalyticsListActivityGrid: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingActivityCell[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListActivityGridLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingActivityCell[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListActivityGridForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingActivityCell[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
-  typingAnalyticsListLayerUsage: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListLayerUsageLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListLayerUsageForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCells: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCellsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCellsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCellsByDay: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCellsByDayLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMatrixCellsByDayForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMinuteStats: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMinuteStatsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListMinuteStatsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
+  typingAnalyticsListActivityGrid: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingActivityCell[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListActivityGridLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingActivityCell[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListActivityGridForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingActivityCell[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_ACTIVITY_GRID_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListLayerUsage: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListLayerUsageLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListLayerUsageForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingLayerUsageRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LAYER_USAGE_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCells: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCellsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCellsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCellsByDay: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCellsByDayLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMatrixCellsByDayForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMatrixCellDailyRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MATRIX_CELLS_BY_DAY_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMinuteStats: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMinuteStatsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListMinuteStatsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingMinuteStatsRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_MINUTE_STATS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
   typingAnalyticsListSessions: (uid: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_SESSIONS, uid, sinceMs, untilMs),
   typingAnalyticsListSessionsLocal: (uid: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_SESSIONS_LOCAL, uid, sinceMs, untilMs),
   typingAnalyticsListSessionsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_SESSIONS_FOR_HASH, uid, machineHash, sinceMs, untilMs),
-  typingAnalyticsListBksMinute: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListBksMinuteLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsListBksMinuteForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
-  typingAnalyticsGetPeakRecords: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<PeakRecords> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsGetPeakRecordsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<PeakRecords> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_LOCAL, uid, sinceMs, untilMs, appScopes),
-  typingAnalyticsGetPeakRecordsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = []): Promise<PeakRecords> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes),
+  typingAnalyticsListBksMinute: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListBksMinuteLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsListBksMinuteForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingBksMinuteRow[]> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_BKS_MINUTE_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsGetPeakRecords: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<PeakRecords> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsGetPeakRecordsLocal: (uid: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<PeakRecords> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_LOCAL, uid, sinceMs, untilMs, appScopes, typingTestScopes),
+  typingAnalyticsGetPeakRecordsForHash: (uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<PeakRecords> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_PEAK_RECORDS_FOR_HASH, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes),
   typingAnalyticsSaveKeymapSnapshot: (partial: Omit<TypingKeymapSnapshot, 'machineHash'>): Promise<{ saved: boolean; savedAt: number | null }> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_SAVE_KEYMAP_SNAPSHOT, partial),
   typingAnalyticsGetKeymapSnapshotForRange: (uid: string, fromMs: number, toMs: number): Promise<TypingKeymapSnapshot | null> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_KEYMAP_SNAPSHOT_FOR_RANGE, uid, fromMs, toMs),
   typingAnalyticsListKeymapSnapshots: (uid: string): Promise<TypingKeymapSnapshotSummary[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_KEYMAP_SNAPSHOTS, uid),
-  typingAnalyticsGetMatrixHeatmapForRange: (uid: string, layer: number, sinceMs: number, untilMs: number, scope: DeviceScope, appScopes: string[] = []): Promise<TypingHeatmapByCell> =>
-    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_MATRIX_HEATMAP_FOR_RANGE, uid, layer, sinceMs, untilMs, scope, appScopes),
+  typingAnalyticsGetMatrixHeatmapForRange: (uid: string, layer: number, sinceMs: number, untilMs: number, scope: DeviceScope, appScopes: string[] = [], typingTestScopes: string[] = []): Promise<TypingHeatmapByCell> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_GET_MATRIX_HEATMAP_FOR_RANGE, uid, layer, sinceMs, untilMs, scope, appScopes, typingTestScopes),
   typingAnalyticsGetBigramAggregateForRange: (
     uid: string,
     sinceMs: number,
@@ -520,7 +527,7 @@ const vialAPI = {
     view: TypingBigramAggregateView,
     scope: DeviceScope,
     options?: TypingBigramAggregateOptions,
-    appScopes: string[] = [],
+    appScopes: string[] = [], typingTestScopes: string[] = [],
   ): Promise<TypingBigramAggregateResult> =>
     ipcRenderer.invoke(
       IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE,
@@ -531,6 +538,7 @@ const vialAPI = {
       scope,
       options,
       appScopes,
+      typingTestScopes,
     ),
   typingAnalyticsGetLayoutComparisonForRange: (
     uid: string,
@@ -538,7 +546,7 @@ const vialAPI = {
     untilMs: number,
     scope: DeviceScope,
     options: LayoutComparisonOptions,
-    appScopes: string[] = [],
+    appScopes: string[] = [], typingTestScopes: string[] = [],
   ): Promise<LayoutComparisonResult | null> =>
     ipcRenderer.invoke(
       IpcChannels.TYPING_ANALYTICS_GET_LAYOUT_COMPARISON_FOR_RANGE,
@@ -548,6 +556,7 @@ const vialAPI = {
       scope,
       options,
       appScopes,
+      typingTestScopes,
     ),
   typingAnalyticsListLocalDeviceDays: (uid: string, machineHash: string): Promise<string[]> =>
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_LIST_LOCAL_DEVICE_DAYS, uid, machineHash),

--- a/src/renderer/components/analyze/ActivityCalendarChart.tsx
+++ b/src/renderer/components/analyze/ActivityCalendarChart.tsx
@@ -60,6 +60,7 @@ interface Props {
   deviceScope: DeviceScope
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   /** Outer Activity metric — drives both the cell value and (when
    * `'sessions'`) the dedicated sessions IPC fetch. */
   metric: ActivityMetric
@@ -80,6 +81,7 @@ export function ActivityCalendarChart({
   uid,
   deviceScope,
   appScopes,
+  typingTestScopes,
   metric,
   calendarFilter,
   nowMs,
@@ -98,7 +100,7 @@ export function ActivityCalendarChart({
     [monthsToShow, endMonthIso, nowMs],
   )
 
-  const { daily, loading: dailyLoading } = useDailySummary(uid, deviceScope, appScopes)
+  const { daily, loading: dailyLoading } = useDailySummary(uid, deviceScope, appScopes, typingTestScopes)
   const [sessions, setSessions] = useState<TypingSessionRow[]>([])
   const [sessionsLoading, setSessionsLoading] = useState(false)
 

--- a/src/renderer/components/analyze/ActivityChart.tsx
+++ b/src/renderer/components/analyze/ActivityChart.tsx
@@ -48,6 +48,7 @@ interface Props {
   deviceScope: DeviceScope
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   metric: ActivityMetric
   /** Chart geometry — `grid` keeps the existing 24×7 grid / sessions
    * histogram, `calendar` swaps to the year heatmap. */
@@ -100,7 +101,7 @@ export function ActivityChart(props: Props) {
   return <ActivityGridChart {...props} />
 }
 
-function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActiveMs }: Props) {
+function ActivityGridChart({ uid, range, deviceScope, appScopes, typingTestScopes, metric, minActiveMs }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingMinuteStatsRow[]>([])
   const [loading, setLoading] = useState(true)
@@ -112,10 +113,10 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
     const load = async () => {
       try {
         const data = isHashScope(deviceScope)
-          ? await window.vialAPI.typingAnalyticsListMinuteStatsForHash(uid, deviceScope.machineHash, range.fromMs, range.toMs, appScopes)
+          ? await window.vialAPI.typingAnalyticsListMinuteStatsForHash(uid, deviceScope.machineHash, range.fromMs, range.toMs, appScopes, typingTestScopes)
           : isOwnScope(deviceScope)
-            ? await window.vialAPI.typingAnalyticsListMinuteStatsLocal(uid, range.fromMs, range.toMs, appScopes)
-            : await window.vialAPI.typingAnalyticsListMinuteStats(uid, range.fromMs, range.toMs, appScopes)
+            ? await window.vialAPI.typingAnalyticsListMinuteStatsLocal(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
+            : await window.vialAPI.typingAnalyticsListMinuteStats(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
         if (!cancelled) setRows(data)
       } catch {
         if (!cancelled) setRows([])
@@ -125,7 +126,7 @@ function ActivityGridChart({ uid, range, deviceScope, appScopes, metric, minActi
     }
     void load()
     return () => { cancelled = true }
-  }, [uid, scopeKey, range, appScopes])
+  }, [uid, scopeKey, range, appScopes, typingTestScopes])
 
   const grid = useMemo(
     () => buildActivityGrid({ rows, range, minActiveMs }),

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -59,6 +59,7 @@ export interface AnalyzeExportContext {
    * the on-screen chart shows for the current selection. Empty array
    * = "All apps" — same row set as the pre-Monitor-App export. */
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot | null
   heatmap: Required<HeatmapFilters>
   wpm: { granularity: GranularityChoice; viewMode: WpmViewMode; minActiveMs: number }
@@ -273,6 +274,7 @@ function pickBuilders(
     range: ctx.range,
     deviceScope: ctx.deviceScope,
     appScopes: ctx.appScopes,
+    typingTestScopes: ctx.typingTestScopes,
   }
   if (selected.summary) {
     out.push(buildSummaryCsv(scope))

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -58,6 +58,7 @@ import { ConnectingOverlay } from '../ConnectingOverlay'
 import { ActivityChart } from './ActivityChart'
 import { DeviceMultiSelect } from './DeviceMultiSelect'
 import { AppSelect } from './AppSelect'
+import { TypingTestSelect } from './TypingTestSelect'
 import { RangeDayPicker } from './RangeDayPicker'
 import { clampRangeToBoundaries, getSnapshotBoundaries } from './clamp-range'
 import { resolveAnalyzeLoadingPhase } from './analyze-loading-phase'
@@ -248,6 +249,7 @@ export function AnalyzePane({
     filters: {
       deviceScopes,
       appScopes,
+      typingTestScopes,
       heatmap: heatmapFilter,
       wpm: wpmFilter,
       interval: intervalFilter,
@@ -260,6 +262,7 @@ export function AnalyzePane({
     ready: filtersReady,
     setDeviceScopes,
     setAppScopes,
+    setTypingTestScopes,
     setHeatmap,
     setWpm,
     setInterval: setIntervalFilter,
@@ -647,6 +650,7 @@ export function AnalyzePane({
       range,
       deviceScope: scope,
       appScopes,
+      typingTestScopes,
       snapshot: effectiveSnapshot,
       heatmap: heatmapFilter,
       wpm: {
@@ -668,7 +672,7 @@ export function AnalyzePane({
       conditions: { device: deviceLabel, app: appLabel, keymap: keymapLabel, range: rangeLabel },
     }
   }, [
-    selected, deviceScopes, appScopes, deviceInfos, range, effectiveSnapshot, selectedSnapshotSavedAt,
+    selected, deviceScopes, appScopes, typingTestScopes, deviceInfos, range, effectiveSnapshot, selectedSnapshotSavedAt,
     snapshotSummaries, heatmapFilter, wpmFilter, intervalFilter, activityFilter, layerFilter,
     layoutComparisonFilter, fingerAssignments, t,
   ])
@@ -696,6 +700,7 @@ export function AnalyzePane({
       filters: {
         deviceScopes,
         appScopes,
+        typingTestScopes,
         heatmap: heatmapFilter,
         wpm: wpmFilter,
         interval: intervalFilter,
@@ -722,7 +727,7 @@ export function AnalyzePane({
     return { payload, summary }
   }, [
     analysisTab, range,
-    deviceScopes, appScopes, heatmapFilter, wpmFilter, intervalFilter,
+    deviceScopes, appScopes, typingTestScopes, heatmapFilter, wpmFilter, intervalFilter,
     activityFilter, layerFilter, ergonomicsFilter, bigramsFilter,
     layoutComparisonFilter, exportCtx,
   ])
@@ -760,6 +765,7 @@ export function AnalyzePane({
       setRange(payload.range)
       setDeviceScopes(payload.filters.deviceScopes)
       setAppScopes(payload.filters.appScopes)
+      setTypingTestScopes(payload.filters.typingTestScopes)
       setHeatmap(payload.filters.heatmap)
       setWpm(payload.filters.wpm)
       setIntervalFilter(payload.filters.interval)
@@ -771,7 +777,7 @@ export function AnalyzePane({
       return true
     },
     [
-      filterStore, setAnalysisTab, setRange, setDeviceScopes, setAppScopes,
+      filterStore, setAnalysisTab, setRange, setDeviceScopes, setAppScopes, setTypingTestScopes,
       setHeatmap, setWpm, setIntervalFilter, setActivity, setLayer,
       setErgonomics, setBigrams, setLayoutComparison,
     ],
@@ -1163,6 +1169,17 @@ export function AnalyzePane({
                         />
                       </label>
                     )}
+                    <label className={FILTER_LABEL}>
+                      <span>{t('analyze.filters.typingTest')}</span>
+                      <TypingTestSelect
+                        uid={selected.uid}
+                        range={range}
+                        deviceScopes={deviceScopes}
+                        value={typingTestScopes}
+                        onChange={setTypingTestScopes}
+                        ariaLabel={t('analyze.filters.typingTest')}
+                      />
+                    </label>
                   </>
                 ) : (
                   <>
@@ -1358,6 +1375,7 @@ export function AnalyzePane({
                   uid={selected.uid}
                   deviceScope={deviceScopes[0]}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   snapshot={effectiveSnapshot}
                   fingerOverrides={fingerAssignments}
                 />
@@ -1367,6 +1385,7 @@ export function AnalyzePane({
                   range={range}
                   deviceScopes={deviceScopes}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   granularity={wpmFilter.granularity}
                   viewMode={wpmFilter.viewMode}
                   minActiveMs={wpmFilter.minActiveMs}
@@ -1377,6 +1396,7 @@ export function AnalyzePane({
                   range={range}
                   deviceScopes={deviceScopes}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   unit={intervalFilter.unit}
                   granularity={wpmFilter.granularity}
                   viewMode={intervalFilter.viewMode}
@@ -1387,6 +1407,7 @@ export function AnalyzePane({
                   range={range}
                   deviceScope={deviceScopes[0]}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   metric={activityFilter.metric}
                   view={activityFilter.view}
                   minActiveMs={wpmFilter.minActiveMs}
@@ -1401,6 +1422,7 @@ export function AnalyzePane({
                     range={range}
                     deviceScope={deviceScopes[0]}
                     appScopes={appScopes}
+                    typingTestScopes={typingTestScopes}
                     snapshot={effectiveSnapshot}
                     heatmap={heatmapFilter}
                     onHeatmapChange={setHeatmap}
@@ -1417,6 +1439,7 @@ export function AnalyzePane({
                     range={range}
                     deviceScopes={deviceScopes}
                     appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                     snapshot={effectiveSnapshot}
                     fingerOverrides={fingerAssignments}
                     viewMode={ergonomicsFilter.viewMode}
@@ -1435,6 +1458,7 @@ export function AnalyzePane({
                   range={range}
                   deviceScopes={deviceScopes}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   topLimit={bigramsFilter.topLimit}
                   slowLimit={bigramsFilter.slowLimit}
                   fingerLimit={bigramsFilter.fingerLimit}
@@ -1452,6 +1476,7 @@ export function AnalyzePane({
                   range={range}
                   deviceScopes={deviceScopes}
                   appScopes={appScopes}
+                  typingTestScopes={typingTestScopes}
                   snapshot={effectiveSnapshot}
                   filter={layoutComparisonFilter}
                   onSkipPercentChange={onSkipPercentChange}
@@ -1470,6 +1495,7 @@ export function AnalyzePane({
                       range={range}
                       deviceScopes={deviceScopes}
                       appScopes={appScopes}
+                      typingTestScopes={typingTestScopes}
                       snapshot={effectiveSnapshot}
                       viewMode="keystrokes"
                       baseLayer={layerFilter.baseLayer}
@@ -1481,6 +1507,7 @@ export function AnalyzePane({
                       range={range}
                       deviceScopes={deviceScopes}
                       appScopes={appScopes}
+                      typingTestScopes={typingTestScopes}
                       snapshot={effectiveSnapshot}
                       viewMode="activations"
                       baseLayer={layerFilter.baseLayer}

--- a/src/renderer/components/analyze/AppSelect.tsx
+++ b/src/renderer/components/analyze/AppSelect.tsx
@@ -1,21 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Multi-select App-name filter for the Analyze panel. Backed by
-// `typingAnalyticsListAppsForRange` for the current uid + device
-// scope + range, so the option list always reflects what's actually
-// available — picking an app that no longer has data is impossible.
-//
-// `value` is a `string[]`; the empty array is the "no filter" choice
-// (every minute including mixed/unknown). Stale persisted names that
-// disappear from the option list are silently dropped on the next
-// `onChange`. Renders as a button that opens a checkbox popover so
-// the filter row stays compact even with a long-tail app list.
+// Multi-select App-name filter for the Analyze panel — a thin binding of
+// the shared `ScopeMultiSelect` to `typingAnalyticsListAppsForRange`, so
+// the option list always reflects which apps actually have data in the
+// current uid + device scope + range.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import { scopeToSelectValue, type DeviceScope } from '../../../shared/types/analyze-filters'
-import { AnchoredPopover } from '../ui/AnchoredPopover'
+import { ScopeMultiSelect } from './ScopeMultiSelect'
+import type { DeviceScope } from '../../../shared/types/analyze-filters'
 import type { RangeMs } from './analyze-types'
-import { FILTER_SELECT } from './analyze-filter-styles'
 
 interface Props {
   uid: string
@@ -27,137 +18,18 @@ interface Props {
   testId?: string
 }
 
-interface AppOption {
-  name: string
-  keystrokes: number
-}
+// Module-level so the reference is stable across renders (ScopeMultiSelect
+// lists it in the fetch effect's dep array).
+const fetchApps = (uid: string, fromMs: number, toMs: number, scope: string) =>
+  window.vialAPI.typingAnalyticsListAppsForRange(uid, fromMs, toMs, scope)
 
-export function AppSelect({
-  uid,
-  range,
-  deviceScopes,
-  value,
-  onChange,
-  ariaLabel,
-  testId = 'analyze-filter-app',
-}: Props) {
-  const { t } = useTranslation()
-  const [options, setOptions] = useState<AppOption[]>([])
-  const [open, setOpen] = useState(false)
-  const triggerRef = useRef<HTMLButtonElement>(null)
-  const scope = scopeToSelectValue(deviceScopes[0] ?? 'own')
-
-  useEffect(() => {
-    // 150 ms debounce so range scrubbing (date-picker drag) doesn't
-    // fan out one IPC per intermediate value before the user lands on
-    // the final range.
-    let cancelled = false
-    const id = window.setTimeout(() => {
-      window.vialAPI
-        .typingAnalyticsListAppsForRange(uid, range.fromMs, range.toMs, scope)
-        .then((rows) => {
-          if (cancelled) return
-          setOptions(rows.map((r) => ({ name: r.name, keystrokes: r.keystrokes })))
-        })
-        .catch(() => {
-          if (!cancelled) setOptions([])
-        })
-    }, 150)
-    return () => {
-      cancelled = true
-      window.clearTimeout(id)
-    }
-  }, [uid, range.fromMs, range.toMs, scope])
-
-  // Drop stale persisted names silently — the parent's
-  // normalizeAppScopes already trims unknowns on load, but this
-  // catches the in-flight case where the option list refreshes after
-  // the user changed device scope.
-  useEffect(() => {
-    if (value.length === 0) return
-    if (options.length === 0) return
-    const known = new Set(options.map((o) => o.name))
-    const filtered = value.filter((v) => known.has(v))
-    if (filtered.length !== value.length) onChange(filtered)
-  }, [options, value, onChange])
-
-  const valueSet = useMemo(() => new Set(value), [value])
-
-  const buttonLabel = useMemo(() => {
-    if (value.length === 0) return t('analyze.filters.appOption.none')
-    if (value.length === 1) return value[0]
-    return t('analyze.filters.appOption.multi', { first: value[0], rest: value.length - 1 })
-  }, [value, t])
-
-  const toggleApp = (name: string) => {
-    if (valueSet.has(name)) onChange(value.filter((v) => v !== name))
-    else onChange([...value, name])
-  }
-
-  const clearAll = () => {
-    if (value.length === 0) return
-    onChange([])
-  }
-
-  // Memoised so AnchoredPopover's outside-click / Escape effect doesn't
-  // tear down + re-attach window listeners on every parent render.
-  const handleClose = useCallback(() => setOpen(false), [])
-
+export function AppSelect({ testId = 'analyze-filter-app', ...rest }: Props) {
   return (
-    <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`${FILTER_SELECT} text-left`}
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label={ariaLabel}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        data-testid={testId}
-      >
-        {buttonLabel}
-      </button>
-      <AnchoredPopover
-        anchorRef={triggerRef}
-        open={open}
-        onClose={handleClose}
-        className="z-20 max-h-72 min-w-dropdown overflow-y-auto rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
-        role="listbox"
-        aria-multiselectable
-      >
-        <button
-          type="button"
-          // "全アプリ" is the no-filter sentinel. Disable it once the
-          // user has picked anything specific so they have to clear
-          // the multi-select intentionally before re-entering the
-          // unfiltered view.
-          className="w-full rounded px-2 py-1 text-left text-content-secondary transition-colors hover:bg-surface-dim disabled:cursor-not-allowed disabled:opacity-40"
-          onClick={clearAll}
-          disabled={value.length === 0}
-          data-testid={`${testId}-option-none`}
-        >
-          {t('analyze.filters.appOption.none')}
-        </button>
-        {options.length > 0 && <div className="my-1 border-t border-edge" />}
-        {options.map((o) => {
-          const checked = valueSet.has(o.name)
-          return (
-            <label
-              key={o.name}
-              className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
-              data-testid={`${testId}-option-${o.name}`}
-            >
-              <input
-                type="checkbox"
-                className="cursor-pointer"
-                checked={checked}
-                onChange={() => toggleApp(o.name)}
-              />
-              <span className="flex-1 truncate">{o.name}</span>
-            </label>
-          )
-        })}
-      </AnchoredPopover>
-    </>
+    <ScopeMultiSelect
+      {...rest}
+      testId={testId}
+      fetchOptions={fetchApps}
+      i18nPrefix="analyze.filters.appOption"
+    />
   )
 }

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -45,6 +45,7 @@ interface BigramsChartProps {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   topLimit: number
   slowLimit: number
   fingerLimit: number
@@ -73,6 +74,7 @@ export function BigramsChart({
   range,
   deviceScopes,
   appScopes,
+  typingTestScopes,
   topLimit,
   slowLimit,
   fingerLimit,
@@ -102,7 +104,7 @@ export function BigramsChart({
     setError(false)
     fetchBigramAggregateForRange(uid, scope, range.fromMs, range.toMs, 'top', {
       limit: ALL_PAIRS_LIMIT,
-    }, appScopes)
+    }, appScopes, typingTestScopes)
       .then((next) => {
         if (cancelled) return
         setResult(next)

--- a/src/renderer/components/analyze/ErgonomicsChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsChart.tsx
@@ -43,6 +43,7 @@ interface Props {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot
   fingerOverrides?: Record<string, FingerType>
   /** Sub-view selector: `'snapshot'` keeps the four-pane summary,
@@ -270,6 +271,7 @@ export function ErgonomicsChart({
   range,
   deviceScopes,
   appScopes,
+  typingTestScopes,
   snapshot,
   fingerOverrides,
   viewMode = 'snapshot',
@@ -284,6 +286,7 @@ export function ErgonomicsChart({
         range={range}
         deviceScopes={deviceScopes}
         appScopes={appScopes}
+        typingTestScopes={typingTestScopes}
         snapshot={snapshot}
         period={period}
         minSampleKeystrokes={learningMinSampleKeystrokes}
@@ -296,6 +299,7 @@ export function ErgonomicsChart({
       range={range}
       deviceScopes={deviceScopes}
       appScopes={appScopes}
+      typingTestScopes={typingTestScopes}
       snapshot={snapshot}
       fingerOverrides={fingerOverrides}
       onOpenFingerAssignment={onOpenFingerAssignment}
@@ -308,6 +312,7 @@ interface SnapshotViewProps {
   range: RangeMs
   deviceScopes: readonly DeviceScope[]
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot
   fingerOverrides?: Record<string, FingerType>
   onOpenFingerAssignment?: () => void
@@ -318,6 +323,7 @@ function ErgonomicsSnapshotView({
   range,
   deviceScopes,
   appScopes,
+  typingTestScopes,
   snapshot,
   fingerOverrides,
   onOpenFingerAssignment,
@@ -332,7 +338,7 @@ function ErgonomicsSnapshotView({
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    void fetchMatrixHeatmapAllLayers(uid, snapshot, range.fromMs, range.toMs, deviceScope, appScopes)
+    void fetchMatrixHeatmapAllLayers(uid, snapshot, range.fromMs, range.toMs, deviceScope, appScopes, typingTestScopes)
       .then((next) => {
         if (cancelled) return
         setLayerCells(next)
@@ -340,7 +346,7 @@ function ErgonomicsSnapshotView({
       })
     return () => { cancelled = true }
     // `scopeKey` carries `deviceScope` identity.
-  }, [uid, range, scopeKey, snapshot, appScopes])
+  }, [uid, range, scopeKey, snapshot, appScopes, typingTestScopes])
 
   const mergedHeatmap = useMemo(
     () => mergeLayerHeatmaps(layerCells),

--- a/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
+++ b/src/renderer/components/analyze/ErgonomicsLearningCurveChart.tsx
@@ -49,6 +49,7 @@ interface Props {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot
   period: ErgonomicsLearningPeriod
   minSampleKeystrokes?: number
@@ -130,6 +131,7 @@ export function ErgonomicsLearningCurveChart({
   range,
   deviceScopes,
   appScopes,
+  typingTestScopes,
   snapshot,
   period,
   minSampleKeystrokes = DEFAULT_LEARNING_MIN_SAMPLE,
@@ -144,7 +146,7 @@ export function ErgonomicsLearningCurveChart({
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    void listMatrixCellsByDayForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
+    void listMatrixCellsByDayForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
       .then((next) => {
         if (cancelled) return
         setRows(next)
@@ -157,7 +159,7 @@ export function ErgonomicsLearningCurveChart({
       })
     return () => { cancelled = true }
     // `scopeKey` carries `deviceScope` identity.
-  }, [uid, range, scopeKey, appScopes])
+  }, [uid, range, scopeKey, appScopes, typingTestScopes])
 
   const layout = snapshot.layout as KeyboardLayout | null
   const layoutKeys = layout?.keys

--- a/src/renderer/components/analyze/IntervalChart.tsx
+++ b/src/renderer/components/analyze/IntervalChart.tsx
@@ -46,6 +46,7 @@ interface Props {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   unit: IntervalUnit
   granularity: GranularityChoice
   viewMode: IntervalViewMode
@@ -87,7 +88,7 @@ function formatShare(v: number): string {
   return `${formatSharePercent(v)}%`
 }
 
-export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granularity, viewMode }: Props) {
+export function IntervalChart({ uid, range, deviceScopes, appScopes, typingTestScopes, unit, granularity, viewMode }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingMinuteStatsRow[]>([])
   const [peakRecords, setPeakRecords] = useState<PeakRecords | null>(null)
@@ -111,14 +112,14 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    listMinuteStatsForScope(uid, effectiveDeviceScope, range.fromMs, range.toMs, appScopes)
+    listMinuteStatsForScope(uid, effectiveDeviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
       .then((data) => { if (!cancelled) setRows(data) })
       .catch(() => { if (!cancelled) setRows([]) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
     // `scopeKey` encodes `effectiveDeviceScope` identity; including the
     // object would refetch every parent rerender.
-  }, [uid, scopeKey, range, appScopes])
+  }, [uid, scopeKey, range, appScopes, typingTestScopes])
 
   // Longest session comes from a narrow aggregation IPC rather than
   // the minute-stats rows so it surfaces the run that straddles bucket
@@ -130,15 +131,15 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, unit, granu
     }
     let cancelled = false
     const peakPromise = isHashScope(effectiveDeviceScope)
-      ? window.vialAPI.typingAnalyticsGetPeakRecordsForHash(uid, effectiveDeviceScope.machineHash, range.fromMs, range.toMs, appScopes)
+      ? window.vialAPI.typingAnalyticsGetPeakRecordsForHash(uid, effectiveDeviceScope.machineHash, range.fromMs, range.toMs, appScopes, typingTestScopes)
       : isOwnScope(effectiveDeviceScope)
-        ? window.vialAPI.typingAnalyticsGetPeakRecordsLocal(uid, range.fromMs, range.toMs, appScopes)
-        : window.vialAPI.typingAnalyticsGetPeakRecords(uid, range.fromMs, range.toMs, appScopes)
+        ? window.vialAPI.typingAnalyticsGetPeakRecordsLocal(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
+        : window.vialAPI.typingAnalyticsGetPeakRecords(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
     void peakPromise
       .then((r) => { if (!cancelled) setPeakRecords(r) })
       .catch(() => { if (!cancelled) setPeakRecords(null) })
     return () => { cancelled = true }
-  }, [uid, scopeKey, range, appScopes])
+  }, [uid, scopeKey, range, appScopes, typingTestScopes])
 
   // Log-axis can't plot 0 ms, but min often legitimately rounds to 0
   // on fast adjacent keystrokes. Clamp the axis floor at 1 ms so the

--- a/src/renderer/components/analyze/KeyHeatmapChart.tsx
+++ b/src/renderer/components/analyze/KeyHeatmapChart.tsx
@@ -35,6 +35,7 @@ interface Props {
   deviceScope: DeviceScope
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot
   /** Persisted filter state for this tab — `selectedLayers` / `groups`
    * / ranking controls / normalization. Lifted to `TypingAnalyticsView`
@@ -263,7 +264,7 @@ function groupOf(groups: number[][], layer: number): number {
   return groups.findIndex((g) => g.includes(layer))
 }
 
-export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, heatmap, onHeatmapChange }: Props) {
+export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, typingTestScopes, snapshot, heatmap, onHeatmapChange }: Props) {
   const { t } = useTranslation()
   const { selectedLayers, groups, frequentUsedN, aggregateMode, normalization, keyGroupFilter } = heatmap
   const [layerCells, setLayerCells] = useState<Map<number, TypingHeatmapByCell>>(new Map())
@@ -290,7 +291,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
     setLoading(true)
     void Promise.all(selectedLayers.map((layer) =>
       window.vialAPI
-        .typingAnalyticsGetMatrixHeatmapForRange(uid, layer, range.fromMs, range.toMs, deviceScope, appScopes)
+        .typingAnalyticsGetMatrixHeatmapForRange(uid, layer, range.fromMs, range.toMs, deviceScope, appScopes, typingTestScopes)
         .catch(() => ({} as TypingHeatmapByCell)),
     )).then((results) => {
       if (cancelled) return
@@ -302,7 +303,7 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, snapshot, 
     return () => { cancelled = true }
     // selectedLayersKey carries the layer-set identity (joined string)
     // so an unchanged array doesn't refire on every render.
-  }, [uid, range, scopeKey, selectedLayersKey, appScopes])
+  }, [uid, range, scopeKey, selectedLayersKey, appScopes, typingTestScopes])
 
   const layout = snapshot.layout as KeyboardLayout | null
 

--- a/src/renderer/components/analyze/LayerUsageChart.tsx
+++ b/src/renderer/components/analyze/LayerUsageChart.tsx
@@ -94,6 +94,7 @@ interface Props {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   /** Optional snapshot. Keystrokes mode still works without one
    * (zero-fills against the max observed layer); activations mode
    * needs it to resolve layer-op keycodes. */
@@ -112,7 +113,7 @@ interface Props {
   onBaseLayerChange?: (baseLayer: number) => void
 }
 
-export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot, viewMode, baseLayer, onBaseLayerChange }: Props) {
+export function LayerUsageChart({ uid, range, deviceScopes, appScopes, typingTestScopes, snapshot, viewMode, baseLayer, onBaseLayerChange }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingLayerUsageRow[]>([])
   const [cells, setCells] = useState<TypingMatrixCellRow[]>([])
@@ -126,8 +127,8 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
     let cancelled = false
     setLoading(true)
     const promise = viewMode === 'activations'
-      ? listMatrixCellsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
-      : listLayerUsageForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
+      ? listMatrixCellsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
+      : listLayerUsageForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
     void promise
       .then((result) => {
         if (cancelled) return
@@ -143,7 +144,7 @@ export function LayerUsageChart({ uid, range, deviceScopes, appScopes, snapshot,
     return () => { cancelled = true }
     // `scopeKey` carries `deviceScope` identity — adding the object
     // would refetch on every parent rerender.
-  }, [uid, range, scopeKey, viewMode, appScopes])
+  }, [uid, range, scopeKey, viewMode, appScopes, typingTestScopes])
 
   // Settings tracks `uid` only — layer names don't change per range /
   // deviceScope / viewMode, so merging this with the rows fetch would

--- a/src/renderer/components/analyze/LayoutComparisonView.tsx
+++ b/src/renderer/components/analyze/LayoutComparisonView.tsx
@@ -36,6 +36,7 @@ interface Props {
   deviceScopes: readonly DeviceScope[]
   /** App filter — see WpmChart.Props.appScopes. */
   appScopes: string[]
+  typingTestScopes: string[]
   snapshot: TypingKeymapSnapshot | null
   /** Persisted source / target read from `useAnalyzeFilters`. The
    * AnalyzePane filter row owns the picker UI; this view stays
@@ -55,6 +56,7 @@ export function LayoutComparisonView({
   range,
   deviceScopes,
   appScopes,
+  typingTestScopes,
   snapshot,
   filter,
   onSkipPercentChange,
@@ -111,7 +113,7 @@ export function LayoutComparisonView({
       source,
       targets: [source, target],
       metrics: [...LAYOUT_COMPARISON_PHASE_1_METRICS],
-    }, appScopes)
+    }, appScopes, typingTestScopes)
       .then((next) => {
         if (cancelled) return
         setResult(next)

--- a/src/renderer/components/analyze/ScopeMultiSelect.tsx
+++ b/src/renderer/components/analyze/ScopeMultiSelect.tsx
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Shared multi-select filter for the Analyze panel, backing both the
+// App-name and TypingTest filters. The option list is fetched for the
+// current uid + device scope + range via the injected `fetchOptions`, so
+// it always reflects what actually has data — picking a value that no
+// longer exists is impossible.
+//
+// `value` is a `string[]`; the empty array is the "no filter" choice
+// (every minute, including mixed/unknown). Stale persisted names that
+// disappear from the option list are silently dropped on the next
+// `onChange`. Renders as a button that opens a checkbox popover so the
+// filter row stays compact even with a long-tail list.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { scopeToSelectValue, type DeviceScope } from '../../../shared/types/analyze-filters'
+import { AnchoredPopover } from '../ui/AnchoredPopover'
+import type { RangeMs } from './analyze-types'
+import { FILTER_SELECT } from './analyze-filter-styles'
+
+interface ScopeOption {
+  name: string
+  keystrokes: number
+}
+
+interface Props {
+  uid: string
+  range: RangeMs
+  deviceScopes: readonly DeviceScope[]
+  value: string[]
+  onChange: (next: string[]) => void
+  ariaLabel?: string
+  testId: string
+  // Fetches the available option names for the uid + range + device scope.
+  fetchOptions: (uid: string, fromMs: number, toMs: number, scope: string) => Promise<ScopeOption[]>
+  // i18n key prefix for the no-filter / multi-select labels, e.g.
+  // `analyze.filters.appOption` → `.none` / `.multi`.
+  i18nPrefix: string
+}
+
+export function ScopeMultiSelect({
+  uid,
+  range,
+  deviceScopes,
+  value,
+  onChange,
+  ariaLabel,
+  testId,
+  fetchOptions,
+  i18nPrefix,
+}: Props) {
+  const { t } = useTranslation()
+  const [options, setOptions] = useState<ScopeOption[]>([])
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const scope = scopeToSelectValue(deviceScopes[0] ?? 'own')
+
+  useEffect(() => {
+    // 150 ms debounce so range scrubbing (date-picker drag) doesn't fan
+    // out one IPC per intermediate value before the user lands on the
+    // final range.
+    let cancelled = false
+    const id = window.setTimeout(() => {
+      fetchOptions(uid, range.fromMs, range.toMs, scope)
+        .then((rows) => {
+          if (cancelled) return
+          setOptions(rows.map((r) => ({ name: r.name, keystrokes: r.keystrokes })))
+        })
+        .catch(() => {
+          if (!cancelled) setOptions([])
+        })
+    }, 150)
+    return () => {
+      cancelled = true
+      window.clearTimeout(id)
+    }
+  }, [uid, range.fromMs, range.toMs, scope, fetchOptions])
+
+  // Drop stale persisted names silently — the parent's normalize step
+  // already trims unknowns on load, but this catches the in-flight case
+  // where the option list refreshes after a device-scope change.
+  useEffect(() => {
+    if (value.length === 0) return
+    if (options.length === 0) return
+    const known = new Set(options.map((o) => o.name))
+    const filtered = value.filter((v) => known.has(v))
+    if (filtered.length !== value.length) onChange(filtered)
+  }, [options, value, onChange])
+
+  const valueSet = useMemo(() => new Set(value), [value])
+
+  const buttonLabel = useMemo(() => {
+    if (value.length === 0) return t(`${i18nPrefix}.none`)
+    if (value.length === 1) return value[0]
+    return t(`${i18nPrefix}.multi`, { first: value[0], rest: value.length - 1 })
+  }, [value, t, i18nPrefix])
+
+  const toggle = (name: string) => {
+    if (valueSet.has(name)) onChange(value.filter((v) => v !== name))
+    else onChange([...value, name])
+  }
+
+  const clearAll = () => {
+    if (value.length === 0) return
+    onChange([])
+  }
+
+  // Memoised so AnchoredPopover's outside-click / Escape effect doesn't
+  // tear down + re-attach window listeners on every parent render.
+  const handleClose = useCallback(() => setOpen(false), [])
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={`${FILTER_SELECT} text-left`}
+        onClick={() => setOpen((prev) => !prev)}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        data-testid={testId}
+      >
+        {buttonLabel}
+      </button>
+      <AnchoredPopover
+        anchorRef={triggerRef}
+        open={open}
+        onClose={handleClose}
+        className="z-20 max-h-72 min-w-dropdown overflow-y-auto rounded-md border border-edge bg-surface p-1 text-xs shadow-lg"
+        role="listbox"
+        aria-multiselectable
+      >
+        <button
+          type="button"
+          // The no-filter sentinel. Disable it once the user has picked
+          // anything specific so they have to clear the multi-select
+          // intentionally before re-entering the unfiltered view.
+          className="w-full rounded px-2 py-1 text-left text-content-secondary transition-colors hover:bg-surface-dim disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={clearAll}
+          disabled={value.length === 0}
+          data-testid={`${testId}-option-none`}
+        >
+          {t(`${i18nPrefix}.none`)}
+        </button>
+        {options.length > 0 && <div className="my-1 border-t border-edge" />}
+        {options.map((o) => {
+          const checked = valueSet.has(o.name)
+          return (
+            <label
+              key={o.name}
+              className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-content transition-colors hover:bg-surface-dim"
+              data-testid={`${testId}-option-${o.name}`}
+            >
+              <input
+                type="checkbox"
+                className="cursor-pointer"
+                checked={checked}
+                onChange={() => toggle(o.name)}
+              />
+              <span className="flex-1 truncate">{o.name}</span>
+            </label>
+          )
+        })}
+      </AnchoredPopover>
+    </>
+  )
+}

--- a/src/renderer/components/analyze/SummaryView.tsx
+++ b/src/renderer/components/analyze/SummaryView.tsx
@@ -22,6 +22,8 @@ interface Props {
    * daily-summary fetch and to TypingProfileCard so every per-app
    * subview re-aggregates from the same single-app minute set. */
   appScopes: string[]
+  /** TypingTest filter — same contract as appScopes, forwarded alongside. */
+  typingTestScopes: string[]
   /** Snapshot the parent already resolved for the current scope —
    * Profile uses it to map bigram keycodes to fingers / hands. */
   snapshot: TypingKeymapSnapshot | null
@@ -30,8 +32,8 @@ interface Props {
   fingerOverrides: Record<string, FingerType>
 }
 
-export function SummaryView({ uid, deviceScope, appScopes, snapshot, fingerOverrides }: Props) {
-  const { daily } = useDailySummary(uid, deviceScope, appScopes)
+export function SummaryView({ uid, deviceScope, appScopes, typingTestScopes, snapshot, fingerOverrides }: Props) {
+  const { daily } = useDailySummary(uid, deviceScope, appScopes, typingTestScopes)
   const today = useLocalToday()
   return (
     <div className="flex h-full w-full flex-col gap-3">
@@ -41,6 +43,7 @@ export function SummaryView({ uid, deviceScope, appScopes, snapshot, fingerOverr
         uid={uid}
         deviceScope={deviceScope}
         appScopes={appScopes}
+        typingTestScopes={typingTestScopes}
         daily={daily}
         today={today}
         snapshot={snapshot}

--- a/src/renderer/components/analyze/TypingProfileCard.tsx
+++ b/src/renderer/components/analyze/TypingProfileCard.tsx
@@ -43,6 +43,7 @@ interface Props {
    * bigram and minute-stats fetches so the per-app summary doesn't
    * blend across the whole 30-day window. */
   appScopes: string[]
+  typingTestScopes: string[]
   daily: ReadonlyArray<TypingDailySummary>
   today: string
   /** Required for the keycode → finger map. When `null`, hand
@@ -62,6 +63,7 @@ export function TypingProfileCard({
   uid,
   deviceScope,
   appScopes,
+  typingTestScopes,
   daily,
   today,
   snapshot,
@@ -80,7 +82,7 @@ export function TypingProfileCard({
 
   useEffect(() => {
     let cancelled = false
-    fetchBigramAggregateForRange(uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAM_FETCH_LIMIT }, appScopes)
+    fetchBigramAggregateForRange(uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAM_FETCH_LIMIT }, appScopes, typingTestScopes)
       .then((res) => {
         if (cancelled) return
         setBigrams(res.view === 'top' ? res.entries : [])
@@ -91,7 +93,7 @@ export function TypingProfileCard({
 
   useEffect(() => {
     let cancelled = false
-    listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
+    listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
       .then((rows) => { if (!cancelled) setMinuteStats(rows) })
       .catch(() => { if (!cancelled) setMinuteStats([]) })
     return () => { cancelled = true }

--- a/src/renderer/components/analyze/TypingTestSelect.tsx
+++ b/src/renderer/components/analyze/TypingTestSelect.tsx
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Multi-select TypingTest filter for the Analyze panel — a thin binding of
+// the shared `ScopeMultiSelect` to `typingAnalyticsListTypingTestsForRange`,
+// so the option list reflects which typing tests actually have data in the
+// current uid + device scope + range (custom = imported text name, normal =
+// `mode (language)`).
+
+import { ScopeMultiSelect } from './ScopeMultiSelect'
+import type { DeviceScope } from '../../../shared/types/analyze-filters'
+import type { RangeMs } from './analyze-types'
+
+interface Props {
+  uid: string
+  range: RangeMs
+  deviceScopes: readonly DeviceScope[]
+  value: string[]
+  onChange: (next: string[]) => void
+  ariaLabel?: string
+  testId?: string
+}
+
+// Module-level so the reference is stable across renders (ScopeMultiSelect
+// lists it in the fetch effect's dep array).
+const fetchTypingTests = (uid: string, fromMs: number, toMs: number, scope: string) =>
+  window.vialAPI.typingAnalyticsListTypingTestsForRange(uid, fromMs, toMs, scope)
+
+export function TypingTestSelect({ testId = 'analyze-filter-typing-test', ...rest }: Props) {
+  return (
+    <ScopeMultiSelect
+      {...rest}
+      testId={testId}
+      fetchOptions={fetchTypingTests}
+      i18nPrefix="analyze.filters.typingTestOption"
+    />
+  )
+}

--- a/src/renderer/components/analyze/WpmChart.tsx
+++ b/src/renderer/components/analyze/WpmChart.tsx
@@ -53,6 +53,7 @@ interface Props {
    * these names. Empty array = no app filter (all minutes including
    * mixed/unknown). */
   appScopes: string[]
+  typingTestScopes: string[]
   granularity: GranularityChoice
   viewMode: WpmViewMode
   /** Minimum `activeMs` (ms) a bucket / hour must clear to count
@@ -71,7 +72,7 @@ function formatHourWithWpm(hour: number, wpm: number): string {
 
 type WpmLineKey = 'wpm' | 'bksPercent'
 
-export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, viewMode, minActiveMs }: Props) {
+export function WpmChart({ uid, range, deviceScopes, appScopes, typingTestScopes, granularity, viewMode, minActiveMs }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingMinuteStatsRow[]>([])
   const [bksRows, setBksRows] = useState<TypingBksMinuteRow[]>([])
@@ -97,13 +98,13 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
+    listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
       .then((data) => { if (!cancelled) setRows(data) })
       .catch(() => { if (!cancelled) setRows([]) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
     // `scopeKey` is the canonical identity for `deviceScope`.
-  }, [uid, scopeKey, range, appScopes])
+  }, [uid, scopeKey, range, appScopes, typingTestScopes])
 
   // The Bksp% overlay is always available in timeSeries mode; users
   // who don't want it click the legend to hide the line instead of
@@ -115,11 +116,11 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
       return
     }
     let cancelled = false
-    listBksMinuteForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes)
+    listBksMinuteForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes)
       .then((data) => { if (!cancelled) setBksRows(data) })
       .catch(() => { if (!cancelled) setBksRows([]) })
     return () => { cancelled = true }
-  }, [uid, scopeKey, range, errorProxyActive, appScopes])
+  }, [uid, scopeKey, range, errorProxyActive, appScopes, typingTestScopes])
 
   // Peak / lowest WPM come from a narrow aggregation IPC rather than
   // the timeseries rows so they reflect the entire range (including
@@ -132,15 +133,15 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, granularity, vie
     }
     let cancelled = false
     const peakPromise = isHashScope(deviceScope)
-      ? window.vialAPI.typingAnalyticsGetPeakRecordsForHash(uid, deviceScope.machineHash, range.fromMs, range.toMs, appScopes)
+      ? window.vialAPI.typingAnalyticsGetPeakRecordsForHash(uid, deviceScope.machineHash, range.fromMs, range.toMs, appScopes, typingTestScopes)
       : isOwnScope(deviceScope)
-        ? window.vialAPI.typingAnalyticsGetPeakRecordsLocal(uid, range.fromMs, range.toMs, appScopes)
-        : window.vialAPI.typingAnalyticsGetPeakRecords(uid, range.fromMs, range.toMs, appScopes)
+        ? window.vialAPI.typingAnalyticsGetPeakRecordsLocal(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
+        : window.vialAPI.typingAnalyticsGetPeakRecords(uid, range.fromMs, range.toMs, appScopes, typingTestScopes)
     void peakPromise
       .then((r) => { if (!cancelled) setPeakRecords(r) })
       .catch(() => { if (!cancelled) setPeakRecords(null) })
     return () => { cancelled = true }
-  }, [uid, scopeKey, range, appScopes])
+  }, [uid, scopeKey, range, appScopes, typingTestScopes])
 
   const bucketMs = useMemo(
     () => (granularity === 'auto' ? pickBucketMs(range) : granularity),

--- a/src/renderer/components/analyze/analyze-csv-builders.ts
+++ b/src/renderer/components/analyze/analyze-csv-builders.ts
@@ -128,6 +128,8 @@ interface ScopeArgs {
    * matching this name. `null` (or absent) means "no app filter" so
    * the existing all-apps export shape is preserved. */
   appScopes?: string[]
+  /** TypingTest filter — same contract as appScopes. */
+  typingTestScopes?: string[]
 }
 
 // --- Heatmap ranking ---------------------------------------------
@@ -137,13 +139,13 @@ export async function buildHeatmapCsv(args: ScopeArgs & {
   heatmap: Required<HeatmapFilters>
   t: TFunction
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], snapshot, heatmap, t } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], snapshot, heatmap, t } = args
   const { selectedLayers, groups, frequentUsedN, aggregateMode, normalization, keyGroupFilter } = heatmap
 
   const layerCells = new Map<number, TypingHeatmapByCell>()
   await Promise.all(selectedLayers.map(async (layer) => {
     try {
-      const cells = await window.vialAPI.typingAnalyticsGetMatrixHeatmapForRange(uid, layer, range.fromMs, range.toMs, deviceScope, appScopes)
+      const cells = await window.vialAPI.typingAnalyticsGetMatrixHeatmapForRange(uid, layer, range.fromMs, range.toMs, deviceScope, appScopes, typingTestScopes)
       layerCells.set(layer, cells)
     } catch {
       layerCells.set(layer, {})
@@ -188,8 +190,8 @@ export async function buildWpmCsv(args: ScopeArgs & {
   viewMode: WpmViewMode
   minActiveMs: number
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], granularity, viewMode, minActiveMs } = args
-  const rows = await listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes).catch(() => [])
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], granularity, viewMode, minActiveMs } = args
+  const rows = await listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => [])
 
   if (viewMode === 'timeOfDay') {
     const hourOfDay = buildHourOfDayWpm({ rows, range, minActiveMs })
@@ -208,7 +210,7 @@ export async function buildWpmCsv(args: ScopeArgs & {
 
   const bucketMs = granularity === 'auto' ? pickBucketMs(range) : granularity
   const buckets = bucketMinuteStats(rows, range, bucketMs)
-  const bksRows = await listBksMinuteForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes).catch(() => [])
+  const bksRows = await listBksMinuteForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => [])
   const bksRate = buildBksRateBuckets({ bksRows, minuteRows: rows, range, bucketMs })
   const bksByBucket = new Map<number, number | null>()
   for (const b of bksRate.buckets) bksByBucket.set(b.bucketStartMs, b.bksPercent)
@@ -239,11 +241,11 @@ export async function buildIntervalCsv(args: ScopeArgs & {
   granularity: GranularityChoice
   viewMode: IntervalViewMode
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], granularity, viewMode } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], granularity, viewMode } = args
   // Distribution forces own scope to match the live chart's
   // anti-meta-aggregate rule (see IntervalChart.tsx).
   const effectiveScope: DeviceScope = viewMode === 'distribution' ? 'own' : deviceScope
-  const rows = await listMinuteStatsForScope(uid, effectiveScope, range.fromMs, range.toMs, appScopes).catch(() => [])
+  const rows = await listMinuteStatsForScope(uid, effectiveScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => [])
 
   if (viewMode === 'distribution') {
     const histogram = buildIntervalHistogram(rows, range)
@@ -280,7 +282,7 @@ export async function buildActivityCsv(args: ScopeArgs & {
   metric: ActivityMetric
   minActiveMs: number
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], metric, minActiveMs } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], metric, minActiveMs } = args
 
   if (metric === 'sessions') {
     // Sessions stay un-filtered by app: the typing_sessions table
@@ -301,7 +303,7 @@ export async function buildActivityCsv(args: ScopeArgs & {
     }
   }
 
-  const rows = await listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes).catch(() => [])
+  const rows = await listMinuteStatsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => [])
   const grid = buildActivityGrid({ rows, range, minActiveMs })
   const csvRows = grid.cells.map((c) => [c.dow, c.hour, c.keystrokes, c.activeMs, c.wpm, c.qualified ? 1 : 0])
   return {
@@ -317,11 +319,11 @@ export async function buildLayerCsv(args: ScopeArgs & {
   baseLayer: number
   t: TFunction
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], snapshot, baseLayer, t } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], snapshot, baseLayer, t } = args
 
   const [keystrokeRows, activationCells, prefs] = await Promise.all([
-    listLayerUsageForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes).catch(() => []),
-    listMatrixCellsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes).catch(() => []),
+    listLayerUsageForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => []),
+    listMatrixCellsForScope(uid, deviceScope, range.fromMs, range.toMs, appScopes, typingTestScopes).catch(() => []),
     window.vialAPI.pipetteSettingsGet(uid).catch(() => null),
   ])
   const layerNames = Array.isArray(prefs?.layerNames) ? prefs.layerNames : []
@@ -369,10 +371,10 @@ export async function buildErgonomicsCsv(args: ScopeArgs & {
   fingerOverrides: Record<string, FingerType>
   t: TFunction
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], snapshot, fingerOverrides, t } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], snapshot, fingerOverrides, t } = args
   const layout = snapshot.layout as KeyboardLayout | null
   const keys = layout?.keys ?? []
-  const layerCells = await fetchMatrixHeatmapAllLayers(uid, snapshot, range.fromMs, range.toMs, deviceScope, appScopes)
+  const layerCells = await fetchMatrixHeatmapAllLayers(uid, snapshot, range.fromMs, range.toMs, deviceScope, appScopes, typingTestScopes)
   const merged = mergeLayerHeatmaps(layerCells)
   const aggregation = aggregateErgonomics(merged, keys, fingerOverrides)
 
@@ -400,9 +402,9 @@ export async function buildErgonomicsCsv(args: ScopeArgs & {
 const BIGRAMS_EXPORT_LIMIT = 5000
 
 export async function buildBigramsCsv(args: ScopeArgs): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [] } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [] } = args
   const result = await fetchBigramAggregateForRange(
-    uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAMS_EXPORT_LIMIT }, appScopes,
+    uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAMS_EXPORT_LIMIT }, appScopes, typingTestScopes,
   ).catch(() => ({ view: 'top' as const, entries: [] }))
   const entries = result.view === 'top' ? result.entries : []
   const rows = entries.map((e) => [
@@ -423,7 +425,7 @@ export async function buildLayoutComparisonCsv(args: ScopeArgs & {
   targetLayoutId: string
   t: TFunction
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], sourceLayoutId, targetLayoutId, t } = args
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], sourceLayoutId, targetLayoutId, t } = args
   const header = ['layout_id', 'layout_label', 'metric', 'key', 'label', 'value']
   const [source, target] = await Promise.all([
     resolveComparisonInput(sourceLayoutId),
@@ -434,7 +436,7 @@ export async function buildLayoutComparisonCsv(args: ScopeArgs & {
   }
   const result = await fetchLayoutComparisonForRange(uid, deviceScope, range.fromMs, range.toMs, {
     source, targets: [source, target], metrics: [...LAYOUT_COMPARISON_PHASE_1_METRICS],
-  }, appScopes).catch(() => null)
+  }, appScopes, typingTestScopes).catch(() => null)
 
   const rows: unknown[][] = []
   // Resolve display labels up front; downloaded entries hit the
@@ -484,8 +486,8 @@ export async function buildLayoutComparisonCsv(args: ScopeArgs & {
 // --- Summary (daily summary within range) --------------------------
 
 export async function buildSummaryCsv(args: ScopeArgs): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [] } = args
-  const allDaily = await listDailyForScope(uid, deviceScope, appScopes).catch(() => [])
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [] } = args
+  const allDaily = await listDailyForScope(uid, deviceScope, appScopes, typingTestScopes).catch(() => [])
 
   const fromDate = toLocalDate(range.fromMs)
   const toDate = toLocalDate(range.toMs)

--- a/src/renderer/components/analyze/analyze-fetch.ts
+++ b/src/renderer/components/analyze/analyze-fetch.ts
@@ -29,10 +29,11 @@ export function listDailyForScope(
   uid: string,
   scope: DeviceScope,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingDailySummary[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListItemsForHash(uid, scope.machineHash, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListItemsLocal(uid, appScopes)
-  return window.vialAPI.typingAnalyticsListItems(uid, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListItemsForHash(uid, scope.machineHash, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListItemsLocal(uid, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListItems(uid, appScopes, typingTestScopes)
 }
 
 export function listMinuteStatsForScope(
@@ -41,10 +42,11 @@ export function listMinuteStatsForScope(
   fromMs: number,
   toMs: number,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingMinuteStatsRow[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMinuteStatsForHash(uid, scope.machineHash, fromMs, toMs, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMinuteStatsLocal(uid, fromMs, toMs, appScopes)
-  return window.vialAPI.typingAnalyticsListMinuteStats(uid, fromMs, toMs, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMinuteStatsForHash(uid, scope.machineHash, fromMs, toMs, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMinuteStatsLocal(uid, fromMs, toMs, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListMinuteStats(uid, fromMs, toMs, appScopes, typingTestScopes)
 }
 
 export function listBksMinuteForScope(
@@ -53,10 +55,11 @@ export function listBksMinuteForScope(
   fromMs: number,
   toMs: number,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingBksMinuteRow[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListBksMinuteForHash(uid, scope.machineHash, fromMs, toMs, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListBksMinuteLocal(uid, fromMs, toMs, appScopes)
-  return window.vialAPI.typingAnalyticsListBksMinute(uid, fromMs, toMs, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListBksMinuteForHash(uid, scope.machineHash, fromMs, toMs, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListBksMinuteLocal(uid, fromMs, toMs, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListBksMinute(uid, fromMs, toMs, appScopes, typingTestScopes)
 }
 
 export function listMatrixCellsForScope(
@@ -65,10 +68,11 @@ export function listMatrixCellsForScope(
   fromMs: number,
   toMs: number,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingMatrixCellRow[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsForHash(uid, scope.machineHash, fromMs, toMs, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsLocal(uid, fromMs, toMs, appScopes)
-  return window.vialAPI.typingAnalyticsListMatrixCells(uid, fromMs, toMs, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsForHash(uid, scope.machineHash, fromMs, toMs, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsLocal(uid, fromMs, toMs, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListMatrixCells(uid, fromMs, toMs, appScopes, typingTestScopes)
 }
 
 /** Per-(localDay, layer, row, col) totals for the Analyze Ergonomic
@@ -82,10 +86,11 @@ export function listMatrixCellsByDayForScope(
   fromMs: number,
   toMs: number,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingMatrixCellDailyRow[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsByDayForHash(uid, scope.machineHash, fromMs, toMs, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsByDayLocal(uid, fromMs, toMs, appScopes)
-  return window.vialAPI.typingAnalyticsListMatrixCellsByDay(uid, fromMs, toMs, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsByDayForHash(uid, scope.machineHash, fromMs, toMs, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListMatrixCellsByDayLocal(uid, fromMs, toMs, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListMatrixCellsByDay(uid, fromMs, toMs, appScopes, typingTestScopes)
 }
 
 export function listLayerUsageForScope(
@@ -94,10 +99,11 @@ export function listLayerUsageForScope(
   fromMs: number,
   toMs: number,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingLayerUsageRow[]> {
-  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListLayerUsageForHash(uid, scope.machineHash, fromMs, toMs, appScopes)
-  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListLayerUsageLocal(uid, fromMs, toMs, appScopes)
-  return window.vialAPI.typingAnalyticsListLayerUsage(uid, fromMs, toMs, appScopes)
+  if (isHashScope(scope)) return window.vialAPI.typingAnalyticsListLayerUsageForHash(uid, scope.machineHash, fromMs, toMs, appScopes, typingTestScopes)
+  if (isOwnScope(scope)) return window.vialAPI.typingAnalyticsListLayerUsageLocal(uid, fromMs, toMs, appScopes, typingTestScopes)
+  return window.vialAPI.typingAnalyticsListLayerUsage(uid, fromMs, toMs, appScopes, typingTestScopes)
 }
 
 /** Fetch the matrix heatmap for every layer in `snapshot.keymap`,
@@ -113,6 +119,7 @@ export async function fetchMatrixHeatmapAllLayers(
   toMs: number,
   scope: DeviceScope,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<Record<number, TypingHeatmapByCell>> {
   const layerCount = Array.isArray(snapshot.keymap) ? snapshot.keymap.length : 0
   if (layerCount === 0) return {}
@@ -120,7 +127,7 @@ export async function fetchMatrixHeatmapAllLayers(
   const results = await Promise.all(
     layerIdxs.map((l) =>
       window.vialAPI
-        .typingAnalyticsGetMatrixHeatmapForRange(uid, l, fromMs, toMs, scope, appScopes)
+        .typingAnalyticsGetMatrixHeatmapForRange(uid, l, fromMs, toMs, scope, appScopes, typingTestScopes)
         .catch(() => ({} as TypingHeatmapByCell)),
     ),
   )
@@ -140,8 +147,9 @@ export function fetchBigramAggregateForRange(
   view: TypingBigramAggregateView,
   options?: TypingBigramAggregateOptions,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<TypingBigramAggregateResult> {
-  return window.vialAPI.typingAnalyticsGetBigramAggregateForRange(uid, fromMs, toMs, view, scope, options, appScopes)
+  return window.vialAPI.typingAnalyticsGetBigramAggregateForRange(uid, fromMs, toMs, view, scope, options, appScopes, typingTestScopes)
 }
 
 /** Layout Comparison metrics fetch. Single channel; the main-side
@@ -155,6 +163,7 @@ export function fetchLayoutComparisonForRange(
   toMs: number,
   options: LayoutComparisonOptions,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): Promise<LayoutComparisonResult | null> {
-  return window.vialAPI.typingAnalyticsGetLayoutComparisonForRange(uid, fromMs, toMs, scope, options, appScopes)
+  return window.vialAPI.typingAnalyticsGetLayoutComparisonForRange(uid, fromMs, toMs, scope, options, appScopes, typingTestScopes)
 }

--- a/src/renderer/components/analyze/use-daily-summary.ts
+++ b/src/renderer/components/analyze/use-daily-summary.ts
@@ -31,6 +31,7 @@ export function useDailySummary(
   uid: string,
   deviceScope: DeviceScope,
   appScopes: string[] = [],
+  typingTestScopes: string[] = [],
 ): DailySummaryState {
   const [daily, setDaily] = useState<TypingDailySummary[]>([])
   const [loading, setLoading] = useState(true)
@@ -38,18 +39,19 @@ export function useDailySummary(
   // Stable string identity for the app filter so the effect doesn't
   // refire when the parent passes a fresh-but-equal array each render.
   const appScopesKey = appScopes.join('|')
+  const typingTestScopesKey = typingTestScopes.join('|')
 
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    void listDailyForScope(uid, deviceScope, appScopes)
+    void listDailyForScope(uid, deviceScope, appScopes, typingTestScopes)
       .then((rows) => { if (!cancelled) setDaily(rows) })
       .catch(() => { if (!cancelled) setDaily([]) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
     // appScopesKey carries the array's identity, so the raw array can
     // be omitted from deps.
-  }, [uid, scopeKey, appScopesKey])
+  }, [uid, scopeKey, appScopesKey, typingTestScopesKey])
 
   return { daily, loading }
 }

--- a/src/renderer/hooks/useAnalyzeFilters.ts
+++ b/src/renderer/hooks/useAnalyzeFilters.ts
@@ -44,6 +44,9 @@ export interface AnalyzeFiltersState {
    * list is fetched from the analyze range; stale persisted names
    * are silently dropped on next load via `normalizeAppScopes`. */
   appScopes: string[]
+  /** Selected typing-test labels (custom = text name, normal =
+   * `mode (language)`). Empty = no filter. Same semantics as appScopes. */
+  typingTestScopes: string[]
   heatmap: Required<HeatmapFilters>
   wpm: Required<WpmFilters>
   interval: Required<IntervalFilters>
@@ -61,6 +64,7 @@ export interface AnalyzeFiltersState {
 export const DEFAULT_ANALYZE_FILTERS: AnalyzeFiltersState = {
   deviceScopes: ['own'],
   appScopes: [],
+  typingTestScopes: [],
   heatmap: {
     selectedLayers: [0],
     groups: [[0]],
@@ -121,6 +125,7 @@ function restoreFilters(saved: AnalyzeFilterSettings | undefined): AnalyzeFilter
   return {
     deviceScopes: normalizeDeviceScopes(saved.deviceScopes),
     appScopes: normalizeAppScopes(saved.appScopes),
+    typingTestScopes: normalizeAppScopes(saved.typingTestScopes),
     heatmap: { ...DEFAULT_ANALYZE_FILTERS.heatmap, ...saved.heatmap },
     wpm: { ...DEFAULT_ANALYZE_FILTERS.wpm, ...saved.wpm },
     interval: { ...DEFAULT_ANALYZE_FILTERS.interval, ...saved.interval },
@@ -150,6 +155,7 @@ function serializeFilters(state: AnalyzeFiltersState): AnalyzeFilterSettings {
   return {
     deviceScopes: state.deviceScopes,
     appScopes: state.appScopes,
+    typingTestScopes: state.typingTestScopes,
     heatmap: state.heatmap,
     wpm: state.wpm,
     interval: state.interval,
@@ -316,6 +322,11 @@ export function useAnalyzeFilters(
     update((prev) => (appScopesEqual(prev.appScopes, next) ? prev : { ...prev, appScopes: next }))
   }, [update])
 
+  const setTypingTestScopes = useCallback((v: string[]) => {
+    const next = normalizeAppScopes(v)
+    update((prev) => (appScopesEqual(prev.typingTestScopes, next) ? prev : { ...prev, typingTestScopes: next }))
+  }, [update])
+
   const setHeatmap = useCallback((patch: Partial<HeatmapFilters>) => {
     update((prev) => ({ ...prev, heatmap: { ...prev.heatmap, ...patch } }))
   }, [update])
@@ -361,6 +372,7 @@ export function useAnalyzeFilters(
     ready,
     setDeviceScopes,
     setAppScopes,
+    setTypingTestScopes,
     setHeatmap,
     setWpm,
     setInterval,

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1199,6 +1199,11 @@
         "none": "All apps",
         "multi": "{{first}} +{{rest}}"
       },
+      "typingTest": "TypingTest",
+      "typingTestOption": {
+        "none": "All tests",
+        "multi": "{{first}} +{{rest}}"
+      },
       "unit": "Display",
       "unitOption": {
         "sec": "Seconds",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -1199,6 +1199,11 @@
         "none": "全アプリ合算",
         "multi": "{{first}} 他{{rest}}件"
       },
+      "typingTest": "TypingTest",
+      "typingTestOption": {
+        "none": "全テスト合算",
+        "multi": "{{first}} 他{{rest}}件"
+      },
       "unit": "表示",
       "unitOption": {
         "sec": "秒",

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -148,6 +148,7 @@ export const IpcChannels = {
    * collected into the `appScopes` array passed to every per-app-aware
    * range query. */
   TYPING_ANALYTICS_LIST_APPS_FOR_RANGE: 'typing-analytics:list-apps-for-range',
+  TYPING_ANALYTICS_LIST_TYPING_TESTS_FOR_RANGE: 'typing-analytics:list-typing-tests-for-range',
   /** Per-app keystroke / activeMs aggregate over the analyze range.
    * Backs the App Usage Distribution pie chart. */
   TYPING_ANALYTICS_GET_APP_USAGE_FOR_RANGE: 'typing-analytics:get-app-usage-for-range',

--- a/src/shared/types/analyze-filters.ts
+++ b/src/shared/types/analyze-filters.ts
@@ -300,6 +300,9 @@ export interface AnalyzeFilterSettings {
    * for an app that has no rows. Order is preserved; duplicates are
    * collapsed. */
   appScopes?: string[]
+  /** Selected typing-test labels; same persistence/normalization contract
+   * as appScopes. */
+  typingTestScopes?: string[]
   heatmap?: HeatmapFilters
   wpm?: WpmFilters
   interval?: IntervalFilters
@@ -505,6 +508,10 @@ export function isValidAnalyzeFilterSettings(value: unknown): boolean {
   if (o.appScopes !== undefined) {
     if (!Array.isArray(o.appScopes)) return false
     if (!o.appScopes.every((v) => typeof v === 'string')) return false
+  }
+  if (o.typingTestScopes !== undefined) {
+    if (!Array.isArray(o.typingTestScopes)) return false
+    if (!o.typingTestScopes.every((v) => typeof v === 'string')) return false
   }
   if (!isValidHeatmapFilters(o.heatmap)) return false
   if (!isValidWpmFilters(o.wpm)) return false

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -215,6 +215,12 @@ export interface VialAPI {
     untilMs: number,
     scope: unknown,
   ): Promise<{ name: string; keystrokes: number; activeMs: number }[]>
+  typingAnalyticsListTypingTestsForRange(
+    uid: string,
+    sinceMs: number,
+    untilMs: number,
+    scope: unknown,
+  ): Promise<{ name: string; keystrokes: number; activeMs: number }[]>
   typingAnalyticsGetAppUsageForRange(
     uid: string,
     sinceMs: number,
@@ -228,45 +234,45 @@ export interface VialAPI {
     scope: unknown,
   ): Promise<{ name: string; keystrokes: number; activeMs: number }[]>
   typingAnalyticsListKeyboards(): Promise<TypingKeyboardSummary[]>
-  typingAnalyticsListItems(uid: string, appScopes?: string[]): Promise<TypingDailySummary[]>
+  typingAnalyticsListItems(uid: string, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingDailySummary[]>
   typingAnalyticsDeleteItems(uid: string, dates: string[]): Promise<TypingTombstoneResult>
   typingAnalyticsDeleteAll(uid: string): Promise<TypingTombstoneResult>
   typingAnalyticsGetMatrixHeatmap(uid: string, layer: number, sinceMs: number): Promise<TypingHeatmapByCell>
-  typingAnalyticsListItemsLocal(uid: string, appScopes?: string[]): Promise<TypingDailySummary[]>
+  typingAnalyticsListItemsLocal(uid: string, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingDailySummary[]>
   typingAnalyticsListDeviceInfos(uid: string): Promise<TypingAnalyticsDeviceInfoBundle | null>
-  typingAnalyticsListItemsForHash(uid: string, machineHash: string, appScopes?: string[]): Promise<TypingDailySummary[]>
+  typingAnalyticsListItemsForHash(uid: string, machineHash: string, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingDailySummary[]>
   typingAnalyticsListIntervalItems(uid: string): Promise<TypingIntervalDailySummary[]>
   typingAnalyticsListIntervalItemsLocal(uid: string): Promise<TypingIntervalDailySummary[]>
   typingAnalyticsListIntervalItemsForHash(uid: string, machineHash: string): Promise<TypingIntervalDailySummary[]>
-  typingAnalyticsListActivityGrid(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingActivityCell[]>
-  typingAnalyticsListActivityGridLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingActivityCell[]>
-  typingAnalyticsListActivityGridForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingActivityCell[]>
-  typingAnalyticsListLayerUsage(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingLayerUsageRow[]>
-  typingAnalyticsListLayerUsageLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingLayerUsageRow[]>
-  typingAnalyticsListLayerUsageForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingLayerUsageRow[]>
-  typingAnalyticsListMatrixCells(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellRow[]>
-  typingAnalyticsListMatrixCellsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellRow[]>
-  typingAnalyticsListMatrixCellsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellRow[]>
-  typingAnalyticsListMatrixCellsByDay(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
-  typingAnalyticsListMatrixCellsByDayLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
-  typingAnalyticsListMatrixCellsByDayForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
-  typingAnalyticsListMinuteStats(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMinuteStatsRow[]>
-  typingAnalyticsListMinuteStatsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMinuteStatsRow[]>
-  typingAnalyticsListMinuteStatsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingMinuteStatsRow[]>
+  typingAnalyticsListActivityGrid(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingActivityCell[]>
+  typingAnalyticsListActivityGridLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingActivityCell[]>
+  typingAnalyticsListActivityGridForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingActivityCell[]>
+  typingAnalyticsListLayerUsage(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingLayerUsageRow[]>
+  typingAnalyticsListLayerUsageLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingLayerUsageRow[]>
+  typingAnalyticsListLayerUsageForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingLayerUsageRow[]>
+  typingAnalyticsListMatrixCells(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellRow[]>
+  typingAnalyticsListMatrixCellsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellRow[]>
+  typingAnalyticsListMatrixCellsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellRow[]>
+  typingAnalyticsListMatrixCellsByDay(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
+  typingAnalyticsListMatrixCellsByDayLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
+  typingAnalyticsListMatrixCellsByDayForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMatrixCellDailyRow[]>
+  typingAnalyticsListMinuteStats(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMinuteStatsRow[]>
+  typingAnalyticsListMinuteStatsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMinuteStatsRow[]>
+  typingAnalyticsListMinuteStatsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingMinuteStatsRow[]>
   typingAnalyticsListSessions(uid: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]>
   typingAnalyticsListSessionsLocal(uid: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]>
   typingAnalyticsListSessionsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number): Promise<TypingSessionRow[]>
-  typingAnalyticsListBksMinute(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingBksMinuteRow[]>
-  typingAnalyticsListBksMinuteLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingBksMinuteRow[]>
-  typingAnalyticsListBksMinuteForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<TypingBksMinuteRow[]>
-  typingAnalyticsGetPeakRecords(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<PeakRecords>
-  typingAnalyticsGetPeakRecordsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<PeakRecords>
-  typingAnalyticsGetPeakRecordsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[]): Promise<PeakRecords>
+  typingAnalyticsListBksMinute(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingBksMinuteRow[]>
+  typingAnalyticsListBksMinuteLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingBksMinuteRow[]>
+  typingAnalyticsListBksMinuteForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingBksMinuteRow[]>
+  typingAnalyticsGetPeakRecords(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<PeakRecords>
+  typingAnalyticsGetPeakRecordsLocal(uid: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<PeakRecords>
+  typingAnalyticsGetPeakRecordsForHash(uid: string, machineHash: string, sinceMs: number, untilMs: number, appScopes?: string[], typingTestScopes?: string[]): Promise<PeakRecords>
   typingAnalyticsSaveKeymapSnapshot(partial: Omit<TypingKeymapSnapshot, 'machineHash'>): Promise<{ saved: boolean; savedAt: number | null }>
   typingAnalyticsGetKeymapSnapshotForRange(uid: string, fromMs: number, toMs: number): Promise<TypingKeymapSnapshot | null>
   typingAnalyticsListKeymapSnapshots(uid: string): Promise<TypingKeymapSnapshotSummary[]>
-  typingAnalyticsGetMatrixHeatmapForRange(uid: string, layer: number, sinceMs: number, untilMs: number, scope: DeviceScope, appScopes?: string[]): Promise<TypingHeatmapByCell>
-  typingAnalyticsGetBigramAggregateForRange(uid: string, sinceMs: number, untilMs: number, view: TypingBigramAggregateView, scope: DeviceScope, options?: TypingBigramAggregateOptions, appScopes?: string[]): Promise<TypingBigramAggregateResult>
+  typingAnalyticsGetMatrixHeatmapForRange(uid: string, layer: number, sinceMs: number, untilMs: number, scope: DeviceScope, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingHeatmapByCell>
+  typingAnalyticsGetBigramAggregateForRange(uid: string, sinceMs: number, untilMs: number, view: TypingBigramAggregateView, scope: DeviceScope, options?: TypingBigramAggregateOptions, appScopes?: string[], typingTestScopes?: string[]): Promise<TypingBigramAggregateResult>
   typingAnalyticsListLocalDeviceDays(uid: string, machineHash: string): Promise<string[]>
   typingAnalyticsHasRemote(): Promise<boolean>
   typingAnalyticsListRemoteCloudHashes(uid: string): Promise<string[]>


### PR DESCRIPTION
## Summary

Adds a multi-select **TypingTest** filter to the Analyze panel, alongside the existing **Device** and **App** filters. Typing-test-sourced keystrokes (recorded automatically since #201) can now be sliced by which test produced them:

- custom material → imported text name
- normal material → `mode (language)` (e.g. `words (english)`)

This is **PR2 (分析UI)** of the typing-test × typing-analytics integration. PR1 (#201) landed the recording base that tags minute rows with `typing_test`.

## How it works

The `typing_test` dimension is threaded end-to-end as a parallel of the existing `app_name` dimension:

- **DB**: `typingTestFilterClause` SQL fragment on the minute queries (`json_array_length(@typingTestsJson) = 0 OR …`), served by the pre-existing `*_scope_test_ts` indexes. New `listTypingTestsForUidInRange` backs the option list so only tests with data in the current uid / device-scope / range are selectable.
- **service / IPC / preload**: `typingTestScopes` params + `TYPING_ANALYTICS_LIST_TYPING_TESTS_FOR_RANGE` channel.
- **renderer**: `typingTestScopes` prop down the Analyze charts, CSV builders, and the persisted `AnalyzeFilterSettings`.

Empty selection = no filter (every minute, including mixed/unknown), matching `appScopes` semantics. Local-only in sync (mirrors `app_name`).

## Refactor (via /simplify)

Extracted the shared `ScopeMultiSelect` component — `AppSelect` and `TypingTestSelect` become thin bindings differing only in the fetcher, i18n key prefix, and default `testId` (removes ~150 lines of duplicated popover/debounce/stale-drop logic).

## Test

- New DB unit test: distinct `typing_test` label listing + query filtering by `typingTestScopes`.
- lint ✅ / tsc ✅ / `pnpm test` 4214 passed ✅ / build ✅