### PR TITLE
feat(ui): typing-test editor — controls, history filters, Show toggles, comparison

### DIFF
--- a/src/main/__tests__/device-prefs-store.test.ts
+++ b/src/main/__tests__/device-prefs-store.test.ts
@@ -263,6 +263,22 @@ describe('pipette-settings-store', () => {
       expect(prefs.typingTestSettingsPanelOpen).toBe(false)
     })
 
+    it('round-trips typingTestNormalConfig field', async () => {
+      const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
+      const normalConfig = { mode: 'words', wordCount: 60, punctuation: true, numbers: false }
+      await setter(fakeEvent, 'uid-1', {
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestNormalConfig: normalConfig,
+      })
+
+      const getter = getHandler(IpcChannels.PIPETTE_SETTINGS_GET)
+      const prefs = await getter(fakeEvent, 'uid-1') as { typingTestNormalConfig: typeof normalConfig }
+      expect(prefs.typingTestNormalConfig).toEqual(normalConfig)
+    })
+
     it('defaults layerNames to [] when not present', async () => {
       const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
       await setter(fakeEvent, 'uid-1', {

--- a/src/main/__tests__/device-prefs-store.test.ts
+++ b/src/main/__tests__/device-prefs-store.test.ts
@@ -230,7 +230,7 @@ describe('pipette-settings-store', () => {
       expect(prefs.layerPanelOpen).toBe(false)
     })
 
-    it('round-trips typingTestHideKeymap / typingTestHideStatsRow fields', async () => {
+    it('round-trips typingTestHideKeymap / typingTestHideStatsRow / typingTestHideControls fields', async () => {
       const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
       await setter(fakeEvent, 'uid-1', {
         _rev: 1,
@@ -239,13 +239,15 @@ describe('pipette-settings-store', () => {
         layerNames: [],
         typingTestHideKeymap: true,
         typingTestHideStatsRow: true,
+        typingTestHideControls: true,
       })
 
       const getter = getHandler(IpcChannels.PIPETTE_SETTINGS_GET)
-      const prefs = await getter(fakeEvent, 'uid-1') as { typingTestHideKeymap: boolean; typingTestHideStatsRow: boolean }
-      // readData() must echo both back, else a later partial PATCH drops them.
+      const prefs = await getter(fakeEvent, 'uid-1') as { typingTestHideKeymap: boolean; typingTestHideStatsRow: boolean; typingTestHideControls: boolean }
+      // readData() must echo all back, else a later partial PATCH drops them.
       expect(prefs.typingTestHideKeymap).toBe(true)
       expect(prefs.typingTestHideStatsRow).toBe(true)
+      expect(prefs.typingTestHideControls).toBe(true)
     })
 
     it('round-trips typingTestSettingsPanelOpen field', async () => {

--- a/src/main/__tests__/device-prefs-store.test.ts
+++ b/src/main/__tests__/device-prefs-store.test.ts
@@ -265,6 +265,37 @@ describe('pipette-settings-store', () => {
       expect(prefs.typingTestSettingsPanelOpen).toBe(false)
     })
 
+    it('round-trips typingTestComparisonBaselines map', async () => {
+      const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
+      const baselines = {
+        'words|30|english|false|true': { kind: 'best' },
+        'custom|t2': { kind: 'pinned', pinnedDate: '2026-06-20T00:00:00.000Z' },
+      }
+      await setter(fakeEvent, 'uid-1', {
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestComparisonBaselines: baselines,
+      })
+
+      const getter = getHandler(IpcChannels.PIPETTE_SETTINGS_GET)
+      const prefs = await getter(fakeEvent, 'uid-1') as { typingTestComparisonBaselines: typeof baselines }
+      expect(prefs.typingTestComparisonBaselines).toEqual(baselines)
+    })
+
+    it('rejects a typingTestComparisonBaselines map with an invalid kind', async () => {
+      const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
+      const result = await setter(fakeEvent, 'uid-1', {
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestComparisonBaselines: { 'words|30': { kind: 'bogus' } },
+      })
+      expect(result.success).toBe(false)
+    })
+
     it('round-trips typingTestNormalConfig field', async () => {
       const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
       const normalConfig = { mode: 'words', wordCount: 60, punctuation: true, numbers: false }

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -93,6 +93,7 @@ function isValidPrefs(value: unknown): value is PipetteSettings {
   if ('typingTestFontSize' in obj && obj.typingTestFontSize != null && typeof obj.typingTestFontSize !== 'number') return false
   if ('typingTestHideKeymap' in obj && obj.typingTestHideKeymap != null && typeof obj.typingTestHideKeymap !== 'boolean') return false
   if ('typingTestHideStatsRow' in obj && obj.typingTestHideStatsRow != null && typeof obj.typingTestHideStatsRow !== 'boolean') return false
+  if ('typingTestHideControls' in obj && obj.typingTestHideControls != null && typeof obj.typingTestHideControls !== 'boolean') return false
   if ('typingTestSettingsPanelOpen' in obj && obj.typingTestSettingsPanelOpen != null && typeof obj.typingTestSettingsPanelOpen !== 'boolean') return false
   if ('typingRecordEnabled' in obj && obj.typingRecordEnabled != null && typeof obj.typingRecordEnabled !== 'boolean') return false
   if ('typingSyncSpanDays' in obj && obj.typingSyncSpanDays != null && !isTypingSyncSpanDays(obj.typingSyncSpanDays)) return false
@@ -146,6 +147,7 @@ async function readData(uid: string): Promise<PipetteSettings | null> {
       typingTestFontSize: parsed.typingTestFontSize,
       typingTestHideKeymap: parsed.typingTestHideKeymap,
       typingTestHideStatsRow: parsed.typingTestHideStatsRow,
+      typingTestHideControls: parsed.typingTestHideControls,
       typingTestSettingsPanelOpen: parsed.typingTestSettingsPanelOpen,
       typingRecordEnabled: parsed.typingRecordEnabled,
       typingSyncSpanDays: parsed.typingSyncSpanDays,

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -73,6 +73,7 @@ function isValidPrefs(value: unknown): value is PipetteSettings {
   if (Array.isArray(obj.layerNames) && (obj.layerNames as unknown[]).some((n) => typeof n !== 'string')) return false
   if ('typingTestResults' in obj && obj.typingTestResults != null && !Array.isArray(obj.typingTestResults)) return false
   if ('typingTestConfig' in obj && obj.typingTestConfig != null && (typeof obj.typingTestConfig !== 'object' || Array.isArray(obj.typingTestConfig))) return false
+  if ('typingTestNormalConfig' in obj && obj.typingTestNormalConfig != null && (typeof obj.typingTestNormalConfig !== 'object' || Array.isArray(obj.typingTestNormalConfig))) return false
   if ('typingTestLanguage' in obj && obj.typingTestLanguage != null && typeof obj.typingTestLanguage !== 'string') return false
   if ('layerPanelOpen' in obj && obj.layerPanelOpen != null && typeof obj.layerPanelOpen !== 'boolean') return false
   if ('basicViewType' in obj && obj.basicViewType != null && obj.basicViewType !== 'ansi' && obj.basicViewType !== 'iso' && obj.basicViewType !== 'jis' && obj.basicViewType !== 'list' && obj.basicViewType !== 'keyboard') return false
@@ -135,6 +136,7 @@ async function readData(uid: string): Promise<PipetteSettings | null> {
       layerNames: parsed.layerNames ?? [],
       typingTestResults: parsed.typingTestResults,
       typingTestConfig: parsed.typingTestConfig,
+      typingTestNormalConfig: parsed.typingTestNormalConfig,
       typingTestLanguage: parsed.typingTestLanguage,
       typingTestViewOnly: parsed.typingTestViewOnly,
       typingTestViewOnlyWindowSize: parsed.typingTestViewOnlyWindowSize,

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -3,14 +3,16 @@
 
 import { app } from 'electron'
 import { join } from 'node:path'
-import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile, readdir } from 'node:fs/promises'
 import { IpcChannels } from '../shared/ipc/channels'
 import { notifyChange } from './sync/sync-service'
 import { secureHandle } from './ipc-guard'
 import { withWriteLock } from './per-uid-write-lock'
 import { isRecord } from '../shared/vil-file'
-import type { PipetteSettings, PipetteSettingsPatch, ViewMode } from '../shared/types/pipette-settings'
-import { VIEW_MODES, DEFAULT_PIPETTE_SETTINGS, isTypingSyncSpanDays, isTypingViewMenuTab } from '../shared/types/pipette-settings'
+import { getActiveKeyboardMetaMap, readKeyboardMetaIndex, resolveKeyboardDisplayName } from './sync/keyboard-meta'
+import { getTypingAnalyticsDB } from './typing-analytics/db/typing-analytics-db'
+import type { PipetteSettings, PipetteSettingsPatch, ViewMode, PooledTypingTestResult } from '../shared/types/pipette-settings'
+import { VIEW_MODES, DEFAULT_PIPETTE_SETTINGS, isTypingSyncSpanDays, isTypingViewMenuTab, isTypingTestComparisonBaselines } from '../shared/types/pipette-settings'
 import { isPositiveInt, isValidAnalyzeFilterSettings } from '../shared/types/analyze-filters'
 import { FINGER_LIST, type FingerType } from '../shared/kle/kle-ergonomics'
 
@@ -94,6 +96,7 @@ function isValidPrefs(value: unknown): value is PipetteSettings {
   if ('typingTestHideKeymap' in obj && obj.typingTestHideKeymap != null && typeof obj.typingTestHideKeymap !== 'boolean') return false
   if ('typingTestHideStatsRow' in obj && obj.typingTestHideStatsRow != null && typeof obj.typingTestHideStatsRow !== 'boolean') return false
   if ('typingTestHideControls' in obj && obj.typingTestHideControls != null && typeof obj.typingTestHideControls !== 'boolean') return false
+  if ('typingTestComparisonBaselines' in obj && obj.typingTestComparisonBaselines != null && !isTypingTestComparisonBaselines(obj.typingTestComparisonBaselines)) return false
   if ('typingTestSettingsPanelOpen' in obj && obj.typingTestSettingsPanelOpen != null && typeof obj.typingTestSettingsPanelOpen !== 'boolean') return false
   if ('typingRecordEnabled' in obj && obj.typingRecordEnabled != null && typeof obj.typingRecordEnabled !== 'boolean') return false
   if ('typingSyncSpanDays' in obj && obj.typingSyncSpanDays != null && !isTypingSyncSpanDays(obj.typingSyncSpanDays)) return false
@@ -148,6 +151,7 @@ async function readData(uid: string): Promise<PipetteSettings | null> {
       typingTestHideKeymap: parsed.typingTestHideKeymap,
       typingTestHideStatsRow: parsed.typingTestHideStatsRow,
       typingTestHideControls: parsed.typingTestHideControls,
+      typingTestComparisonBaselines: parsed.typingTestComparisonBaselines,
       typingTestSettingsPanelOpen: parsed.typingTestSettingsPanelOpen,
       typingRecordEnabled: parsed.typingRecordEnabled,
       typingSyncSpanDays: parsed.typingSyncSpanDays,
@@ -221,6 +225,37 @@ export function setupPipetteSettingsStore(): void {
       } catch {
         return null
       }
+    },
+  )
+
+  // Pool every locally-stored keyboard's saved typing-test results into one
+  // flat list for the Measurement-row comparison baseline (keyboard-agnostic).
+  // Reads are best-effort: a missing / invalid keyboard dir is skipped.
+  secureHandle(
+    IpcChannels.PIPETTE_SETTINGS_LIST_ALL_TYPING_RESULTS,
+    async (): Promise<PooledTypingTestResult[]> => {
+      const keyboardsDir = join(app.getPath('userData'), 'sync', 'keyboards')
+      const metaMap = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
+      // Analytics carries a product name even for keyboards with no saved
+      // keymap (meta / snapshot), so it names otherwise-uid-only keyboards.
+      let analyticsNames: Map<string, string> | undefined
+      try {
+        analyticsNames = new Map(
+          getTypingAnalyticsDB().listKeyboardsWithTypingData().map((k) => [k.uid, k.productName]),
+        )
+      } catch { /* analytics db unavailable */ }
+      const all: PooledTypingTestResult[] = []
+      try {
+        const entries = await readdir(keyboardsDir, { withFileTypes: true })
+        for (const entry of entries) {
+          if (!entry.isDirectory() || !isSafePathSegment(entry.name)) continue
+          const prefs = await readData(entry.name)
+          if (!prefs?.typingTestResults?.length) continue
+          const keyboardName = await resolveKeyboardDisplayName(entry.name, metaMap, analyticsNames)
+          for (const r of prefs.typingTestResults) all.push({ ...r, keyboardName })
+        }
+      } catch { /* keyboards dir doesn't exist yet */ }
+      return all
     },
   )
 

--- a/src/main/sync/keyboard-meta.ts
+++ b/src/main/sync/keyboard-meta.ts
@@ -221,6 +221,23 @@ async function resolveDeviceNameFromLocalSnapshots(uid: string): Promise<string 
   }
 }
 
+/** Best-effort display name for a stored keyboard: its meta-index name, else
+ *  the device name from its local snapshot filename, else the analytics product
+ *  name (present even for keyboards with no saved keymap), else the uid.
+ *  No side effects (unlike the backfill path), so it's safe for read-only
+ *  lookups such as the comparison-result pool. */
+export async function resolveKeyboardDisplayName(
+  uid: string,
+  metaMap: Map<string, string>,
+  analyticsNames?: Map<string, string>,
+): Promise<string> {
+  const metaName = metaMap.get(uid)
+  if (metaName && metaName !== uid) return metaName
+  const snapshotName = await resolveDeviceNameFromLocalSnapshots(uid)
+  if (snapshotName) return snapshotName
+  return analyticsNames?.get(uid) || uid
+}
+
 async function resolveDeviceNameFromRemoteSnapshots(
   uid: string,
   password: string,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,7 +53,7 @@ import type { HubPrivateLink } from '../shared/types/hub-private'
 import type { AppConfig } from '../shared/types/app-config'
 import type { DeviceScope } from '../shared/types/analyze-filters'
 import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncDataScanResult, SyncScope, StoredKeyboardInfo, SyncOperationResult } from '../shared/types/sync'
-import type { PipetteSettings, PipetteSettingsPatch } from '../shared/types/pipette-settings'
+import type { PipetteSettings, PipetteSettingsPatch, PooledTypingTestResult } from '../shared/types/pipette-settings'
 import type {
   LayoutComparisonOptions,
   LayoutComparisonResult,
@@ -404,6 +404,8 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.PIPETTE_SETTINGS_GET, uid),
   pipetteSettingsPatch: (uid: string, partial: PipetteSettingsPatch): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.PIPETTE_SETTINGS_PATCH, uid, partial),
+  pipetteSettingsListAllTypingResults: (): Promise<PooledTypingTestResult[]> =>
+    ipcRenderer.invoke(IpcChannels.PIPETTE_SETTINGS_LIST_ALL_TYPING_RESULTS),
 
   // --- Typing Analytics (fire-and-forget event dispatch) ---
   typingAnalyticsEvent: (event: TypingAnalyticsEvent): Promise<void> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -868,8 +868,10 @@ export function App() {
             onTypingTestFontSizeChange={devicePrefs.setTypingTestFontSize}
             typingTestHideKeymap={devicePrefs.typingTestHideKeymap}
             typingTestHideStatsRow={devicePrefs.typingTestHideStatsRow}
+            typingTestHideControls={devicePrefs.typingTestHideControls}
             onTypingTestHideKeymapChange={devicePrefs.setTypingTestHideKeymap}
             onTypingTestHideStatsRowChange={devicePrefs.setTypingTestHideStatsRow}
+            onTypingTestHideControlsChange={devicePrefs.setTypingTestHideControls}
             typingTestSettingsPanelOpen={devicePrefs.typingTestSettingsPanelOpen}
             onTypingTestSettingsPanelOpenChange={devicePrefs.setTypingTestSettingsPanelOpen}
             typingRecordEnabled={devicePrefs.typingRecordEnabled}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -869,9 +869,11 @@ export function App() {
             typingTestHideKeymap={devicePrefs.typingTestHideKeymap}
             typingTestHideStatsRow={devicePrefs.typingTestHideStatsRow}
             typingTestHideControls={devicePrefs.typingTestHideControls}
+            typingTestComparisonBaselines={devicePrefs.typingTestComparisonBaselines}
             onTypingTestHideKeymapChange={devicePrefs.setTypingTestHideKeymap}
             onTypingTestHideStatsRowChange={devicePrefs.setTypingTestHideStatsRow}
             onTypingTestHideControlsChange={devicePrefs.setTypingTestHideControls}
+            onTypingTestComparisonBaselineChange={devicePrefs.setTypingTestComparisonBaseline}
             typingTestSettingsPanelOpen={devicePrefs.typingTestSettingsPanelOpen}
             onTypingTestSettingsPanelOpenChange={devicePrefs.setTypingTestSettingsPanelOpen}
             typingRecordEnabled={devicePrefs.typingRecordEnabled}

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -840,6 +840,7 @@ export function App() {
             onDeleteTypingTestResult={devicePrefs.deleteTypingTestResult}
             typingTestHistory={devicePrefs.typingTestResults}
             typingTestConfig={devicePrefs.typingTestConfig}
+            typingTestNormalConfig={devicePrefs.typingTestNormalConfig}
             typingTestLanguage={devicePrefs.typingTestLanguage}
             onTypingTestConfigChange={devicePrefs.setTypingTestConfig}
             onTypingTestLanguageChange={devicePrefs.setTypingTestLanguage}

--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -54,6 +54,8 @@ if (typeof window !== 'undefined') {
     keyLabelHubUpdate: noopOk,
     keyLabelHubDelete: noopOk,
     typingAnalyticsListAppsForRange: async () => [],
+    // Comparison baseline pool — TypingTestPane fetches this on mount.
+    pipetteSettingsListAllTypingResults: async () => [],
     // i18n pack store: every renderer that mounts SettingsModal pulls in
     // LanguagePacksModal → useI18nPackStore, which calls i18nPackList on
     // mount. Stub the read paths to an empty list and the change-notifier

--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useEscapeClose } from '../../hooks/useEscapeClose'
+import { ModalCloseButton } from './ModalCloseButton'
+import { formatDate } from './store-modal-shared'
+import { BTN_PRIMARY, BTN_SECONDARY } from '../../constants/ui-tokens'
+import { COMPARISON_BASELINE_KINDS } from '../../../shared/types/pipette-settings'
+import type { PooledTypingTestResult, TypingTestComparisonBaseline, ComparisonBaselineKind } from '../../../shared/types/pipette-settings'
+
+interface Props {
+  /** Same-condition results (across all keyboards) — the choices for a pinned
+   *  baseline. */
+  pool: PooledTypingTestResult[]
+  baseline: TypingTestComparisonBaseline
+  onChange?: (baseline: TypingTestComparisonBaseline) => void
+}
+
+const MAX_PINNABLE = 100
+
+function toggleClass(active: boolean): string {
+  const base = 'inline-flex h-8 items-center rounded-md border px-3 text-sm transition-colors'
+  if (active) return `${base} border-accent bg-accent/10 text-accent`
+  return `${base} border-edge text-content-secondary hover:text-content`
+}
+
+export function ComparisonToggle({ pool, baseline, onChange }: Props) {
+  const { t } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const [draftKind, setDraftKind] = useState<ComparisonBaselineKind>(baseline.kind)
+  const [draftPinnedDate, setDraftPinnedDate] = useState<string | undefined>(baseline.pinnedDate)
+
+  const close = useCallback(() => setOpen(false), [])
+  useEscapeClose(close, open)
+
+  // Sync the draft to the persisted value each time the modal opens.
+  const openModal = useCallback(() => {
+    setDraftKind(baseline.kind)
+    setDraftPinnedDate(baseline.pinnedDate)
+    setOpen(true)
+  }, [baseline])
+
+  // Most-recent first; capped so a huge history doesn't bloat the picker.
+  const pinnable = useMemo(
+    () => [...pool]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, MAX_PINNABLE),
+    [pool],
+  )
+
+  const save = useCallback(() => {
+    const next: TypingTestComparisonBaseline = draftKind === 'pinned'
+      ? { kind: 'pinned', pinnedDate: draftPinnedDate }
+      : { kind: draftKind }
+    onChange?.(next)
+    setOpen(false)
+  }, [draftKind, draftPinnedDate, onChange])
+
+  // A pinned baseline with no chosen result isn't a valid save.
+  const canSave = draftKind !== 'pinned' || !!draftPinnedDate
+
+  return (
+    <>
+      <button
+        type="button"
+        data-testid="typing-test-comparison-toggle"
+        className={toggleClass(open)}
+        aria-pressed={open}
+        onClick={openModal}
+      >
+        {t('editor.typingTest.compare.button')}
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+          data-testid="comparison-modal-backdrop"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="comparison-modal-title"
+          onClick={close}
+        >
+          <div
+            className="flex max-h-modal-80vh w-full max-w-2xl flex-col rounded-xl border border-edge bg-surface-alt shadow-lg"
+            data-testid="comparison-modal"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between border-b border-edge px-4 py-3">
+              <h2 id="comparison-modal-title" className="text-base font-semibold text-content">
+                {t('editor.typingTest.compare.title')}
+              </h2>
+              <ModalCloseButton testid="comparison-modal-close" onClick={close} />
+            </div>
+
+            <div className="flex min-h-0 flex-col gap-1 overflow-y-auto p-4">
+              <p className="mb-1 text-xs text-content-muted">{t('editor.typingTest.compare.description')}</p>
+              {COMPARISON_BASELINE_KINDS.map((kind) => (
+                <label
+                  key={kind}
+                  className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-surface-dim"
+                  data-testid={`comparison-kind-${kind}`}
+                >
+                  <input
+                    type="radio"
+                    name="comparison-kind"
+                    className="accent-accent"
+                    checked={draftKind === kind}
+                    onChange={() => setDraftKind(kind)}
+                  />
+                  <span className={draftKind === kind ? 'text-content' : 'text-content-secondary'}>
+                    {t(`editor.typingTest.compare.${kind}`)}
+                  </span>
+                </label>
+              ))}
+
+              {draftKind === 'pinned' && (
+                <div className="mt-1 min-h-0 rounded-md border border-edge">
+                  {pinnable.length > 0 ? (
+                    <div className="max-h-56 overflow-y-auto">
+                      <table className="w-full table-fixed text-xs">
+                        <thead className="sticky top-0 bg-surface-alt text-content-muted">
+                          <tr>
+                            <th className="px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colName')}</th>
+                            <th className="w-28 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colKeyboard')}</th>
+                            <th className="w-36 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colTime')}</th>
+                            <th className="w-14 px-2 py-1.5 text-right font-medium">{t('editor.typingTest.wpm')}</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {pinnable.map((r) => (
+                            <tr
+                              key={r.date}
+                              data-testid={`comparison-pin-${r.date}`}
+                              aria-pressed={draftPinnedDate === r.date}
+                              className={`cursor-pointer border-t border-edge/50 transition-colors ${draftPinnedDate === r.date ? 'bg-accent/10 font-semibold text-accent' : 'text-content hover:bg-surface-dim'}`}
+                              onClick={() => setDraftPinnedDate(r.date)}
+                            >
+                              <td className="truncate px-2 py-1.5">{r.name || t('editor.typingTest.history.unnamed')}</td>
+                              <td className="truncate px-2 py-1.5">{r.keyboardName}</td>
+                              <td className="px-2 py-1.5 font-mono">{formatDate(r.date)}</td>
+                              <td className="px-2 py-1.5 text-right font-mono">{r.wpm}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  ) : (
+                    <p className="px-2 py-2 text-xs text-content-muted">{t('editor.typingTest.compare.noResults')}</p>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 border-t border-edge px-4 py-3">
+              <button type="button" className={BTN_SECONDARY} onClick={close}>
+                {t('common.cancel')}
+              </button>
+              <button type="button" className={BTN_PRIMARY} disabled={!canSave} onClick={save} data-testid="comparison-modal-save">
+                {t('common.save')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -24,9 +24,9 @@ export function HistoryToggle({ results, deviceName, onRename, onDelete }: Histo
   const { t } = useTranslation()
   const [showHistory, setShowHistory] = useState(false)
 
-  const handleExportCsv = useCallback((csv: string) => {
-    const prefix = deviceName ? `${deviceName}_typing-test-history` : undefined
-    window.vialAPI.exportCsv(csv, prefix)
+  const handleExportCsv = useCallback((csv: string, filterSlug: string) => {
+    const base = deviceName ? `${deviceName}_typing-test-history` : 'typing-test-history'
+    window.vialAPI.exportCsv(csv, filterSlug ? `${base}_${filterSlug}` : base)
   }, [deviceName])
 
   const closeHistory = useCallback(() => setShowHistory(false), [])

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -114,7 +114,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
   typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
   typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
-  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange,
+  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestComparisonBaselines, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestComparisonBaselineChange,
   typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
   typingRecordEnabled, onTypingRecordEnabledChange,
   typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
@@ -966,9 +966,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               hideKeymap={typingTestHideKeymap}
               hideStatsRow={typingTestHideStatsRow}
               hideControls={typingTestHideControls}
+              comparisonBaselines={typingTestComparisonBaselines}
               onToggleHideKeymap={onTypingTestHideKeymapChange}
               onToggleHideStatsRow={onTypingTestHideStatsRowChange}
               onToggleHideControls={onTypingTestHideControlsChange}
+              onComparisonBaselineChange={onTypingTestComparisonBaselineChange}
               settingsPanelOpen={typingTestSettingsPanelOpen}
               onToggleSettingsPanel={onTypingTestSettingsPanelOpenChange}
               onPauseTest={pauseTypingTest}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -107,7 +107,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   scale: scaleProp = 1, onScaleChange,
   keyEditorZoom, onKeyEditorZoomChange,
   typingTestMode, onTypingTestModeChange, onSaveTypingTestResult, onRenameTypingTestResult, onDeleteTypingTestResult, typingTestHistory,
-  typingTestConfig: savedTypingTestConfig, typingTestLanguage: savedTypingTestLanguage,
+  typingTestConfig: savedTypingTestConfig, typingTestNormalConfig, typingTestLanguage: savedTypingTestLanguage,
   onTypingTestConfigChange, onTypingTestLanguageChange,
   typingTestViewOnly, onTypingTestViewOnlyChange,
   typingTestViewOnlyWindowSize, onTypingTestViewOnlyWindowSizeChange,
@@ -941,6 +941,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
             <TypingTestPane
               typingTest={typingTest}
               onConfigChange={handleTypingTestConfigChange}
+              normalConfig={typingTestNormalConfig}
               onLanguageChange={handleTypingTestLanguageChange}
               layers={layers}
               layerNames={layerNames}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -114,7 +114,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
   typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
   typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
-  typingTestHideKeymap, typingTestHideStatsRow, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange,
+  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange,
   typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
   typingRecordEnabled, onTypingRecordEnabledChange,
   typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
@@ -965,8 +965,10 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               onFontSizeChange={onTypingTestFontSizeChange}
               hideKeymap={typingTestHideKeymap}
               hideStatsRow={typingTestHideStatsRow}
+              hideControls={typingTestHideControls}
               onToggleHideKeymap={onTypingTestHideKeymapChange}
               onToggleHideStatsRow={onTypingTestHideStatsRowChange}
+              onToggleHideControls={onTypingTestHideControlsChange}
               settingsPanelOpen={typingTestSettingsPanelOpen}
               onToggleSettingsPanel={onTypingTestSettingsPanelOpenChange}
               onPauseTest={pauseTypingTest}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -74,8 +74,10 @@ export interface TypingTestPaneProps {
    *  Persisted per keyboard; only meaningful outside view-only mode. */
   hideKeymap?: boolean
   hideStatsRow?: boolean
+  hideControls?: boolean
   onToggleHideKeymap?: (hidden: boolean) => void
   onToggleHideStatsRow?: (hidden: boolean) => void
+  onToggleHideControls?: (hidden: boolean) => void
   /** Left Settings panel expanded state (persisted per keyboard). */
   settingsPanelOpen?: boolean
   onToggleSettingsPanel?: (open: boolean) => void
@@ -154,8 +156,10 @@ export function TypingTestPane({
   onFontSizeChange,
   hideKeymap,
   hideStatsRow,
+  hideControls,
   onToggleHideKeymap,
   onToggleHideStatsRow,
+  onToggleHideControls,
   settingsPanelOpen = true,
   onToggleSettingsPanel,
   onRenameTypingTestResult,
@@ -531,19 +535,20 @@ export function TypingTestPane({
         </PanelSection>
       )}
 
-      {/* Show — toggle the keymap and the live measurement display. Accent
-          highlight marks the hidden (active) state. */}
+      {/* Show — toggles ordered top-to-bottom to match the editor layout:
+          operation (controls row) → measurement (stats row) → keymap pane.
+          Accent highlight marks the visible (active) state. */}
       <PanelSection title={t('editor.typingTest.section.show')}>
         <button
           type="button"
-          data-testid="typing-test-toggle-keymap"
-          aria-pressed={!hideKeymap}
-          title={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
-          aria-label={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
-          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideKeymap ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
-          onClick={() => onToggleHideKeymap?.(!hideKeymap)}
+          data-testid="typing-test-toggle-controls"
+          aria-pressed={!hideControls}
+          title={t(hideControls ? 'editor.typingTest.showControls' : 'editor.typingTest.hideControls')}
+          aria-label={t(hideControls ? 'editor.typingTest.showControls' : 'editor.typingTest.hideControls')}
+          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideControls ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+          onClick={() => onToggleHideControls?.(!hideControls)}
         >
-          {t('editor.typingTest.keymapToggle')}
+          {t('editor.typingTest.controlsToggle')}
         </button>
         <button
           type="button"
@@ -555,6 +560,17 @@ export function TypingTestPane({
           onClick={() => onToggleHideStatsRow?.(!hideStatsRow)}
         >
           {t('editor.typingTest.statsToggle')}
+        </button>
+        <button
+          type="button"
+          data-testid="typing-test-toggle-keymap"
+          aria-pressed={!hideKeymap}
+          title={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
+          aria-label={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
+          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideKeymap ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+          onClick={() => onToggleHideKeymap?.(!hideKeymap)}
+        >
+          {t('editor.typingTest.keymapToggle')}
         </button>
       </PanelSection>
       </div>
@@ -604,6 +620,7 @@ export function TypingTestPane({
           // fall back to its own max width instead of collapsing.
           readingMaxWidth={hideKeymap ? undefined : keyboardWidth}
           hideStatsRow={hideStatsRow}
+          hideControls={hideControls}
           state={typingTest.state}
           wpm={typingTest.wpm}
           kpm={typingTest.kpm}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -44,6 +44,8 @@ import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export interface TypingTestPaneProps {
   typingTest: ReturnType<typeof useTypingTest>
   onConfigChange: (config: TypingTestConfig) => void
+  /** Last normal (words/time/quote) config, restored when leaving custom. */
+  normalConfig?: TypingTestConfig
   onLanguageChange: (lang: string) => Promise<void>
   layers: number
   layerNames?: string[]
@@ -127,6 +129,7 @@ export interface TypingTestPaneProps {
 export function TypingTestPane({
   typingTest,
   onConfigChange,
+  normalConfig,
   onLanguageChange,
   layers,
   layerNames,
@@ -431,29 +434,30 @@ export function TypingTestPane({
       <div className="flex min-h-0 w-60 flex-1 flex-col gap-4 overflow-y-auto p-3">
       {/* Settings — language/mode, base layer, pattern / units / options. */}
       <PanelSection title={t('editor.typingTest.section.settings')}>
-        {typingTest.config.mode !== 'quote' && (
-          <div className="flex w-full flex-col items-start gap-1">
-            <span className="text-sm text-content-muted">{t('editor.typingTest.modeLabel')}({modeType}):</span>
-            <button
-              type="button"
-              data-testid="language-selector"
-              title={modeLabel}
-              className="flex h-8 w-full items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-              onClick={() => setShowLanguageModal(true)}
-              disabled={typingTest.isLanguageLoading}
-            >
-              <span className="truncate">{modeLabel}</span>
-            </button>
-          </div>
-        )}
+        {/* Mode / language — shown for every mode (words / time / quote /
+            custom); quote uses it to pick the quote source language. */}
+        <div className="flex w-full flex-col items-start gap-1">
+          <span className="text-sm text-content-muted">{t('editor.typingTest.modeLabel')}({modeType}):</span>
+          <button
+            type="button"
+            data-testid="language-selector"
+            title={modeLabel}
+            className="flex h-8 w-full items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+            onClick={() => setShowLanguageModal(true)}
+            disabled={typingTest.isLanguageLoading}
+          >
+            <span className="truncate">{modeLabel}</span>
+          </button>
+        </div>
         {showLanguageModal && (
           <LanguageSelectorModal
             currentLanguage={typingTest.language}
             currentCustomTextId={typingTest.config.mode === 'custom' ? typingTest.config.textId : undefined}
             onSelectLanguage={(name) => {
-              // Picking a language leaves custom mode — fall back to
-              // a words config so the language source applies.
-              if (typingTest.config.mode === 'custom') onConfigChange(DEFAULT_CONFIG)
+              // Picking a language leaves custom mode — restore the last normal
+              // (words/time/quote) config so its Pattern/Units/Option settings
+              // survive the round trip; fall back to the default if none saved.
+              if (typingTest.config.mode === 'custom') onConfigChange(normalConfig ?? DEFAULT_CONFIG)
               void onLanguageChange(name)
             }}
             onSelectImport={(textId) => onConfigChange({ mode: 'custom', textId })}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ChevronsLeft, ChevronsRight } from 'lucide-react'
 import { ICON_SM } from '../../constants/ui-tokens'
@@ -14,10 +14,13 @@ import { useTypingHeatmap } from '../../typing-test/useTypingHeatmap'
 import { TYPING_HEATMAP_WINDOW_OPTIONS } from '../../../shared/types/app-config'
 import { KeyboardPane } from './KeyboardPane'
 import { HistoryToggle } from './HistoryToggle'
+import { ComparisonToggle } from './ComparisonToggle'
+import { computeComparison, matchingResults, conditionKey } from '../../typing-test/comparison'
 import { KEY_UNIT, KEYBOARD_PADDING } from '../keyboard/constants'
 import { repositionLayoutKeys, filterVisibleKeys } from '../../../shared/kle/filter-keys'
 import type { KleKey } from '../../../shared/kle/types'
-import type { TypingTestResult, TypingViewMenuTab } from '../../../shared/types/pipette-settings'
+import type { TypingTestResult, PooledTypingTestResult, TypingViewMenuTab, TypingTestComparisonBaseline, TypingTestComparisonBaselines } from '../../../shared/types/pipette-settings'
+import { DEFAULT_COMPARISON_BASELINE } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, DISPLAY_LINES_MIN, DISPLAY_LINES_MAX, FONT_SIZE_MIN, FONT_SIZE_MAX, FONT_SIZE_STEP } from '../../typing-test/types'
 
@@ -78,6 +81,11 @@ export interface TypingTestPaneProps {
   onToggleHideKeymap?: (hidden: boolean) => void
   onToggleHideStatsRow?: (hidden: boolean) => void
   onToggleHideControls?: (hidden: boolean) => void
+  /** Per-condition Measurement-row comparison baselines (persisted per
+   *  keyboard, synced). Keyed by condition; the current condition's baseline
+   *  is looked up and applied. */
+  comparisonBaselines?: TypingTestComparisonBaselines
+  onComparisonBaselineChange?: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
   /** Left Settings panel expanded state (persisted per keyboard). */
   settingsPanelOpen?: boolean
   onToggleSettingsPanel?: (open: boolean) => void
@@ -160,6 +168,8 @@ export function TypingTestPane({
   onToggleHideKeymap,
   onToggleHideStatsRow,
   onToggleHideControls,
+  comparisonBaselines,
+  onComparisonBaselineChange,
   settingsPanelOpen = true,
   onToggleSettingsPanel,
   onRenameTypingTestResult,
@@ -203,6 +213,38 @@ export function TypingTestPane({
   const [showLanguageModal, setShowLanguageModal] = useState(false)
   const [showConsentModal, setShowConsentModal] = useState(false)
   const [showResumeModal, setShowResumeModal] = useState(false)
+
+  // Measurement-row comparison: pool every keyboard's saved results, then pick
+  // the baseline for the current condition. Refetched when this keyboard's
+  // history changes so a just-saved run joins the pool. `state.startTime`
+  // excludes the in-flight run from previous/best/average.
+  const [comparisonPool, setComparisonPool] = useState<PooledTypingTestResult[]>([])
+  useEffect(() => {
+    let cancelled = false
+    window.vialAPI.pipetteSettingsListAllTypingResults()
+      .then((all) => { if (!cancelled) setComparisonPool(all) })
+      .catch(() => { /* best-effort: no comparison if unavailable */ })
+    return () => { cancelled = true }
+  }, [typingTestHistory])
+
+  // The baseline is remembered per condition: switching the typing-test
+  // condition recalls the baseline saved for it (default: previous).
+  const currentConditionKey = conditionKey(typingTest.config, typingTest.language)
+  const comparisonBaselineValue = comparisonBaselines?.[currentConditionKey] ?? DEFAULT_COMPARISON_BASELINE
+  const comparison = useMemo(
+    () => computeComparison(comparisonPool, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime),
+    [comparisonPool, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime],
+  )
+  // Same-condition results only — the choices for a pinned baseline. No
+  // `beforeMs`: the user is pinning a past result, not measuring a live run.
+  const sameConditionResults = useMemo(
+    () => matchingResults(comparisonPool, typingTest.config, typingTest.language),
+    [comparisonPool, typingTest.config, typingTest.language],
+  )
+  const handleComparisonChange = useCallback(
+    (baseline: TypingTestComparisonBaseline) => onComparisonBaselineChange?.(currentConditionKey, baseline),
+    [onComparisonBaselineChange, currentConditionKey],
+  )
 
   const handleRecordToggle = useCallback(() => {
     if (!onRecordEnabledChange) return
@@ -523,17 +565,22 @@ export function TypingTestPane({
         )}
       </PanelSection>
 
-      {/* Data — saved run history. */}
-      {typingTestHistory && typingTestHistory.length > 0 && (
-        <PanelSection title={t('editor.typingTest.section.data')}>
-          <HistoryToggle
-            results={typingTestHistory}
-            deviceName={deviceName}
-            onRename={onRenameTypingTestResult}
-            onDelete={onDeleteTypingTestResult}
-          />
-        </PanelSection>
-      )}
+      {/* Data — saved run history + comparison baseline settings. Always shown
+          (even with no saved results yet) so History stays reachable and the
+          comparison baseline can be set up before the first result. */}
+      <PanelSection title={t('editor.typingTest.section.data')}>
+        <HistoryToggle
+          results={typingTestHistory ?? []}
+          deviceName={deviceName}
+          onRename={onRenameTypingTestResult}
+          onDelete={onDeleteTypingTestResult}
+        />
+        <ComparisonToggle
+          pool={sameConditionResults}
+          baseline={comparisonBaselineValue}
+          onChange={handleComparisonChange}
+        />
+      </PanelSection>
 
       {/* Show — toggles ordered top-to-bottom to match the editor layout:
           operation (controls row) → measurement (stats row) → keymap pane.
@@ -621,6 +668,7 @@ export function TypingTestPane({
           readingMaxWidth={hideKeymap ? undefined : keyboardWidth}
           hideStatsRow={hideStatsRow}
           hideControls={hideControls}
+          comparison={comparison}
           state={typingTest.state}
           wpm={typingTest.wpm}
           kpm={typingTest.kpm}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pause, Play, ChevronsLeft, ChevronsRight } from 'lucide-react'
+import { ChevronsLeft, ChevronsRight } from 'lucide-react'
 import { ICON_SM } from '../../constants/ui-tokens'
 import { TypingTestView } from '../../typing-test/TypingTestView'
 import { TypingTestSettingsBar } from '../../typing-test/TypingTestSettingsBar'
@@ -527,41 +527,6 @@ export function TypingTestPane({
         </PanelSection>
       )}
 
-      {/* Operations — pause/resume (imported custom text) and restart. */}
-      <PanelSection title={t('editor.typingTest.section.operations')}>
-        {typingTest.config.mode === 'custom' && (
-          typingTest.state.status === 'running' ? (
-            <button
-              type="button"
-              data-testid="typing-memory-pause"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-              onClick={() => onPauseTest?.()}
-            >
-              <Pause size={ICON_SM} aria-hidden="true" />
-              <span>{t('editor.typingTest.memory.pause')}</span>
-            </button>
-          ) : (typingTest.state.status === 'paused' || hasSavedMemory) ? (
-            <button
-              type="button"
-              data-testid="typing-memory-resume"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-accent transition-colors hover:text-accent/80"
-              onClick={() => setShowResumeModal(true)}
-            >
-              <Play size={ICON_SM} aria-hidden="true" />
-              <span>{t('editor.typingTest.memory.resumeButton')}</span>
-            </button>
-          ) : null
-        )}
-        <button
-          type="button"
-          data-testid="typing-test-restart"
-          className="flex h-8 items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-          onClick={() => typingTest.restart()}
-        >
-          {t('editor.typingTest.restart')}
-        </button>
-      </PanelSection>
-
       {/* Show — toggle the keymap and the live measurement display. Accent
           highlight marks the hidden (active) state. */}
       <PanelSection title={t('editor.typingTest.section.show')}>
@@ -657,6 +622,9 @@ export function TypingTestPane({
           // Chips come from the just-finished result (history[0]).
           resultNameChips={typingTestHistory?.[0] ? buildResultNameChips(typingTestHistory[0], t) : []}
           onStart={() => typingTest.restart()}
+          onPause={() => onPauseTest?.()}
+          onResume={() => setShowResumeModal(true)}
+          hasSavedMemory={hasSavedMemory}
         />
       )}
       <div

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -126,6 +126,7 @@ export interface KeymapEditorProps {
   onDeleteTypingTestResult?: (date: string) => void
   typingTestHistory?: TypingTestResult[]
   typingTestConfig?: TypingTestConfig
+  typingTestNormalConfig?: TypingTestConfig
   typingTestLanguage?: string
   onTypingTestConfigChange?: (config: TypingTestConfig) => void
   onTypingTestLanguageChange?: (lang: string) => void

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -144,8 +144,10 @@ export interface KeymapEditorProps {
   onTypingTestFontSizeChange?: (px: number) => void
   typingTestHideKeymap?: boolean
   typingTestHideStatsRow?: boolean
+  typingTestHideControls?: boolean
   onTypingTestHideKeymapChange?: (hidden: boolean) => void
   onTypingTestHideStatsRowChange?: (hidden: boolean) => void
+  onTypingTestHideControlsChange?: (hidden: boolean) => void
   typingTestSettingsPanelOpen?: boolean
   onTypingTestSettingsPanelOpenChange?: (open: boolean) => void
   typingRecordEnabled?: boolean

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -6,7 +6,7 @@ import type { BulkKeyEntry } from '../../hooks/useKeyboard'
 import type { MacroAction } from '../../../preload/macro'
 import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry, DeviceInfo } from '../../../shared/types/protocol'
 import type { KeyboardLayoutId } from '../../hooks/useKeyboardLayout'
-import type { TypingTestResult, TypingViewMenuTab, TypingTestMemory } from '../../../shared/types/pipette-settings'
+import type { TypingTestResult, TypingViewMenuTab, TypingTestMemory, TypingTestComparisonBaseline, TypingTestComparisonBaselines } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 
@@ -145,9 +145,11 @@ export interface KeymapEditorProps {
   typingTestHideKeymap?: boolean
   typingTestHideStatsRow?: boolean
   typingTestHideControls?: boolean
+  typingTestComparisonBaselines?: TypingTestComparisonBaselines
   onTypingTestHideKeymapChange?: (hidden: boolean) => void
   onTypingTestHideStatsRowChange?: (hidden: boolean) => void
   onTypingTestHideControlsChange?: (hidden: boolean) => void
+  onTypingTestComparisonBaselineChange?: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
   typingTestSettingsPanelOpen?: boolean
   onTypingTestSettingsPanelOpenChange?: (open: boolean) => void
   typingRecordEnabled?: boolean

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -106,6 +106,7 @@ interface ValidatedPrefs {
   layerNames: string[]
   typingTestResults: TypingTestResult[]
   typingTestConfig?: TypingTestConfig
+  typingTestNormalConfig?: TypingTestConfig
   typingTestLanguage?: string
   typingTestViewOnly: boolean
   typingTestViewOnlyWindowSize?: { width: number; height: number }
@@ -123,7 +124,7 @@ interface ValidatedPrefs {
 }
 
 function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
   defaultLayout: KeyboardLayoutId,
   defaultAutoAdvance: boolean,
   defaultLayerPanelOpen: boolean,
@@ -191,6 +192,7 @@ function validateIpcPrefs(
     layerNames,
     typingTestResults,
     typingTestConfig,
+    typingTestNormalConfig: validateTypingTestConfig(data.typingTestNormalConfig),
     typingTestLanguage: validateTypingTestLanguage(data.typingTestLanguage),
     typingTestViewOnly,
     typingTestViewOnlyWindowSize: validateWindowSize(data.typingTestViewOnlyWindowSize),
@@ -227,6 +229,7 @@ export interface UseDevicePrefsReturn {
   layerNames: string[]
   typingTestResults: TypingTestResult[]
   typingTestConfig: TypingTestConfig | undefined
+  typingTestNormalConfig: TypingTestConfig | undefined
   typingTestLanguage: string | undefined
   typingTestViewOnly: boolean
   typingTestViewOnlyWindowSize: { width: number; height: number } | undefined
@@ -325,6 +328,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   const [layerNames, updateLayerNames, layerNamesRef] = useStateRef<string[]>([])
   const [typingTestResults, updateTypingTestResults, typingTestResultsRef] = useStateRef<TypingTestResult[]>([])
   const [typingTestConfig, updateTypingTestConfig, typingTestConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
+  const [typingTestNormalConfig, updateTypingTestNormalConfig, typingTestNormalConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
   const [typingTestLanguage, updateTypingTestLanguage, typingTestLanguageRef] = useStateRef<string | undefined>(undefined)
   const [typingTestViewOnly, updateTypingTestViewOnly, typingTestViewOnlyRef] = useStateRef<boolean>(false)
   const [typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize, typingTestViewOnlyWindowSizeRef] = useStateRef<{ width: number; height: number } | undefined>(undefined)
@@ -360,6 +364,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       layerNames: layerNamesRef.current,
       typingTestResults: typingTestResultsRef.current,
       typingTestConfig: typingTestConfigRef.current as Record<string, unknown> | undefined,
+      typingTestNormalConfig: typingTestNormalConfigRef.current as Record<string, unknown> | undefined,
       typingTestLanguage: typingTestLanguageRef.current,
       typingTestViewOnly: typingTestViewOnlyRef.current,
       typingTestViewOnlyWindowSize: typingTestViewOnlyWindowSizeRef.current,
@@ -454,9 +459,16 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   }, [saveCurrentPrefs, updateTypingTestResults])
 
   const setTypingTestConfig = useCallback((cfg: TypingTestConfig) => {
+    const prev = typingTestConfigRef.current
     updateTypingTestConfig(cfg)
+    // Remember the last normal (words/time/quote) config so it survives a
+    // switch into custom (imported text) and back. When entering custom,
+    // capture the outgoing normal config too — covers old prefs where
+    // typingTestNormalConfig was never saved.
+    if (cfg.mode !== 'custom') updateTypingTestNormalConfig(cfg)
+    else if (prev && prev.mode !== 'custom') updateTypingTestNormalConfig(prev)
     saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestConfig])
+  }, [saveCurrentPrefs, updateTypingTestConfig, updateTypingTestNormalConfig])
 
   const setTypingTestLanguage = useCallback((lang: string) => {
     updateTypingTestLanguage(lang)
@@ -618,6 +630,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateLayerNames(resolved.layerNames)
     updateTypingTestResults(resolved.typingTestResults)
     updateTypingTestConfig(resolved.typingTestConfig)
+    updateTypingTestNormalConfig(resolved.typingTestNormalConfig)
     updateTypingTestLanguage(resolved.typingTestLanguage)
     updateTypingTestViewOnly(resolved.typingTestViewOnly)
     updateTypingTestViewOnlyWindowSize(resolved.typingTestViewOnlyWindowSize)
@@ -679,6 +692,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     layerNames,
     typingTestResults,
     typingTestConfig,
+    typingTestNormalConfig,
     typingTestLanguage,
     typingTestViewOnly,
     typingTestViewOnlyWindowSize,

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -5,8 +5,8 @@ import type { KeyboardLayoutId } from '../data/keyboard-layouts'
 import { useKeyLabelLookup } from './useKeyLabelLookup'
 import { useAppConfig } from './useAppConfig'
 import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
-import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestMemoryWord } from '../../shared/types/pipette-settings'
-import { VIEW_MODES, isTypingViewMenuTab } from '../../shared/types/pipette-settings'
+import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestMemoryWord, TypingTestComparisonBaseline, TypingTestComparisonBaselines } from '../../shared/types/pipette-settings'
+import { VIEW_MODES, isTypingViewMenuTab, isTypingTestComparisonBaselines } from '../../shared/types/pipette-settings'
 import { trimResults } from '../typing-test/result-builder'
 import type { TypingTestConfig } from '../typing-test/types'
 import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, clampDisplayLines, clampFontSize } from '../typing-test/types'
@@ -117,6 +117,7 @@ interface ValidatedPrefs {
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
   typingTestHideControls: boolean
+  typingTestComparisonBaselines: TypingTestComparisonBaselines
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
@@ -125,7 +126,7 @@ interface ValidatedPrefs {
 }
 
 function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestComparisonBaselines?: unknown; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
   defaultLayout: KeyboardLayoutId,
   defaultAutoAdvance: boolean,
   defaultLayerPanelOpen: boolean,
@@ -204,6 +205,7 @@ function validateIpcPrefs(
     typingTestHideKeymap: data.typingTestHideKeymap === true,
     typingTestHideStatsRow: data.typingTestHideStatsRow === true,
     typingTestHideControls: data.typingTestHideControls === true,
+    typingTestComparisonBaselines: isTypingTestComparisonBaselines(data.typingTestComparisonBaselines) ? data.typingTestComparisonBaselines : {},
     typingTestSettingsPanelOpen: typeof data.typingTestSettingsPanelOpen === 'boolean' ? data.typingTestSettingsPanelOpen : true,
     typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
     typingViewMenuTab: isTypingViewMenuTab(data.typingViewMenuTab) ? data.typingViewMenuTab : 'window',
@@ -242,6 +244,7 @@ export interface UseDevicePrefsReturn {
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
   typingTestHideControls: boolean
+  typingTestComparisonBaselines: TypingTestComparisonBaselines
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
@@ -269,6 +272,7 @@ export interface UseDevicePrefsReturn {
   setTypingTestHideKeymap: (hidden: boolean) => void
   setTypingTestHideStatsRow: (hidden: boolean) => void
   setTypingTestHideControls: (hidden: boolean) => void
+  setTypingTestComparisonBaseline: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
   setTypingTestSettingsPanelOpen: (open: boolean) => void
   setTypingRecordEnabled: (enabled: boolean) => void
   setTypingViewMenuTab: (tab: TypingViewMenuTab) => void
@@ -343,6 +347,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   const [typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef] = useStateRef<boolean>(false)
   const [typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef] = useStateRef<boolean>(false)
   const [typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef] = useStateRef<boolean>(false)
+  const [typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef] = useStateRef<TypingTestComparisonBaselines>({})
   const [typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef] = useStateRef<boolean>(true)
   const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
   const [typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef] = useStateRef<TypingViewMenuTab>('window')
@@ -383,6 +388,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestHideKeymap: typingTestHideKeymapRef.current,
       typingTestHideStatsRow: typingTestHideStatsRowRef.current,
       typingTestHideControls: typingTestHideControlsRef.current,
+      typingTestComparisonBaselines: typingTestComparisonBaselinesRef.current,
       typingTestSettingsPanelOpen: typingTestSettingsPanelOpenRef.current,
       typingRecordEnabled: typingRecordEnabledRef.current,
       typingViewMenuTab: typingViewMenuTabRef.current,
@@ -537,6 +543,11 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestHideControls])
 
+  const setTypingTestComparisonBaseline = useCallback((conditionKey: string, baseline: TypingTestComparisonBaseline) => {
+    updateTypingTestComparisonBaselines({ ...typingTestComparisonBaselinesRef.current, [conditionKey]: baseline })
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef])
+
   const setTypingTestSettingsPanelOpen = useCallback((open: boolean) => {
     if (typingTestSettingsPanelOpenRef.current === open) return
     updateTypingTestSettingsPanelOpen(open)
@@ -628,6 +639,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestHideKeymap: false,
       typingTestHideStatsRow: false,
       typingTestHideControls: false,
+      typingTestComparisonBaselines: {},
       typingTestSettingsPanelOpen: true,
       typingRecordEnabled: false,
       typingViewMenuTab: 'window',
@@ -654,6 +666,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateTypingTestHideKeymap(resolved.typingTestHideKeymap)
     updateTypingTestHideStatsRow(resolved.typingTestHideStatsRow)
     updateTypingTestHideControls(resolved.typingTestHideControls)
+    updateTypingTestComparisonBaselines(resolved.typingTestComparisonBaselines)
     updateTypingTestSettingsPanelOpen(resolved.typingTestSettingsPanelOpen)
     updateTypingRecordEnabled(resolved.typingRecordEnabled)
     updateTypingViewMenuTab(resolved.typingViewMenuTab)
@@ -717,6 +730,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     typingTestHideKeymap,
     typingTestHideStatsRow,
     typingTestHideControls,
+    typingTestComparisonBaselines,
     typingTestSettingsPanelOpen,
     typingRecordEnabled,
     typingViewMenuTab,
@@ -745,6 +759,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     setTypingTestHideKeymap,
     setTypingTestHideStatsRow,
     setTypingTestHideControls,
+    setTypingTestComparisonBaseline,
     setTypingTestSettingsPanelOpen,
     setTypingRecordEnabled,
     setTypingViewMenuTab,

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -116,6 +116,7 @@ interface ValidatedPrefs {
   typingTestFontSize: number
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
+  typingTestHideControls: boolean
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
@@ -124,7 +125,7 @@ interface ValidatedPrefs {
 }
 
 function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
   defaultLayout: KeyboardLayoutId,
   defaultAutoAdvance: boolean,
   defaultLayerPanelOpen: boolean,
@@ -202,6 +203,7 @@ function validateIpcPrefs(
     typingTestFontSize: typeof data.typingTestFontSize === 'number' ? clampFontSize(data.typingTestFontSize) : DEFAULT_FONT_SIZE,
     typingTestHideKeymap: data.typingTestHideKeymap === true,
     typingTestHideStatsRow: data.typingTestHideStatsRow === true,
+    typingTestHideControls: data.typingTestHideControls === true,
     typingTestSettingsPanelOpen: typeof data.typingTestSettingsPanelOpen === 'boolean' ? data.typingTestSettingsPanelOpen : true,
     typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
     typingViewMenuTab: isTypingViewMenuTab(data.typingViewMenuTab) ? data.typingViewMenuTab : 'window',
@@ -239,6 +241,7 @@ export interface UseDevicePrefsReturn {
   typingTestFontSize: number
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
+  typingTestHideControls: boolean
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
   typingViewMenuTab: TypingViewMenuTab
@@ -265,6 +268,7 @@ export interface UseDevicePrefsReturn {
   setTypingTestFontSize: (px: number) => void
   setTypingTestHideKeymap: (hidden: boolean) => void
   setTypingTestHideStatsRow: (hidden: boolean) => void
+  setTypingTestHideControls: (hidden: boolean) => void
   setTypingTestSettingsPanelOpen: (open: boolean) => void
   setTypingRecordEnabled: (enabled: boolean) => void
   setTypingViewMenuTab: (tab: TypingViewMenuTab) => void
@@ -338,6 +342,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   const [typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef] = useStateRef<number>(DEFAULT_FONT_SIZE)
   const [typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef] = useStateRef<boolean>(false)
   const [typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef] = useStateRef<boolean>(false)
+  const [typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef] = useStateRef<boolean>(false)
   const [typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef] = useStateRef<boolean>(true)
   const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
   const [typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef] = useStateRef<TypingViewMenuTab>('window')
@@ -377,6 +382,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestFontSize: typingTestFontSizeRef.current,
       typingTestHideKeymap: typingTestHideKeymapRef.current,
       typingTestHideStatsRow: typingTestHideStatsRowRef.current,
+      typingTestHideControls: typingTestHideControlsRef.current,
       typingTestSettingsPanelOpen: typingTestSettingsPanelOpenRef.current,
       typingRecordEnabled: typingRecordEnabledRef.current,
       typingViewMenuTab: typingViewMenuTabRef.current,
@@ -525,6 +531,12 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestHideStatsRow])
 
+  const setTypingTestHideControls = useCallback((hidden: boolean) => {
+    if (typingTestHideControlsRef.current === hidden) return
+    updateTypingTestHideControls(hidden)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestHideControls])
+
   const setTypingTestSettingsPanelOpen = useCallback((open: boolean) => {
     if (typingTestSettingsPanelOpenRef.current === open) return
     updateTypingTestSettingsPanelOpen(open)
@@ -615,6 +627,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestFontSize: DEFAULT_FONT_SIZE,
       typingTestHideKeymap: false,
       typingTestHideStatsRow: false,
+      typingTestHideControls: false,
       typingTestSettingsPanelOpen: true,
       typingRecordEnabled: false,
       typingViewMenuTab: 'window',
@@ -640,6 +653,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateTypingTestFontSize(resolved.typingTestFontSize)
     updateTypingTestHideKeymap(resolved.typingTestHideKeymap)
     updateTypingTestHideStatsRow(resolved.typingTestHideStatsRow)
+    updateTypingTestHideControls(resolved.typingTestHideControls)
     updateTypingTestSettingsPanelOpen(resolved.typingTestSettingsPanelOpen)
     updateTypingRecordEnabled(resolved.typingRecordEnabled)
     updateTypingViewMenuTab(resolved.typingViewMenuTab)
@@ -702,6 +716,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     typingTestFontSize,
     typingTestHideKeymap,
     typingTestHideStatsRow,
+    typingTestHideControls,
     typingTestSettingsPanelOpen,
     typingRecordEnabled,
     typingViewMenuTab,
@@ -729,6 +744,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     setTypingTestFontSize,
     setTypingTestHideKeymap,
     setTypingTestHideStatsRow,
+    setTypingTestHideControls,
     setTypingTestSettingsPanelOpen,
     setTypingRecordEnabled,
     setTypingViewMenuTab,

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -255,10 +255,13 @@
       "expandSettings": "Expand settings",
       "keymapToggle": "Keymap",
       "statsToggle": "Measurement",
+      "controlsToggle": "Operation",
       "hideKeymap": "Hide keymap",
       "showKeymap": "Show keymap",
       "hideStats": "Hide measurement",
       "showStats": "Show measurement",
+      "hideControls": "Hide operation",
+      "showControls": "Show operation",
       "section": {
         "settings": "Settings",
         "data": "Data",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -391,6 +391,8 @@
         "noResults": "No results yet",
         "pb": "PB",
         "allModes": "All",
+        "filterMode": "Filter by mode",
+        "filterText": "Filter by text",
         "exportCsv": "Export CSV",
         "delete": "Delete"
       }

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -267,6 +267,20 @@
         "data": "Data",
         "show": "Show"
       },
+      "compare": {
+        "button": "Compare",
+        "title": "Comparison",
+        "description": "Compare the Measurement values against past results matching the same condition (across all keyboards).",
+        "previous": "Previous",
+        "best": "Best",
+        "average": "Average",
+        "pinned": "Specific result",
+        "off": "Off",
+        "noResults": "No results to pin yet",
+        "colName": "Name",
+        "colKeyboard": "Keyboard",
+        "colTime": "Time"
+      },
       "wpm": "WPM",
       "kpm": "KPM",
       "accuracy": "Accuracy",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -250,6 +250,7 @@
       "exitTypingMode": "Exit Typing Test",
       "restart": "Restart",
       "nextTest": "Next Test",
+      "complete": "Complete",
       "collapseSettings": "Collapse settings",
       "expandSettings": "Expand settings",
       "keymapToggle": "Keymap",
@@ -261,7 +262,6 @@
       "section": {
         "settings": "Settings",
         "data": "Data",
-        "operations": "Operations",
         "show": "Show"
       },
       "wpm": "WPM",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -391,6 +391,8 @@
         "noResults": "結果がありません",
         "pb": "PB",
         "allModes": "すべて",
+        "filterMode": "モードで絞り込み",
+        "filterText": "テキストで絞り込み",
         "exportCsv": "CSV出力",
         "delete": "削除"
       }

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -267,6 +267,20 @@
         "data": "データ",
         "show": "表示"
       },
+      "compare": {
+        "button": "比較",
+        "title": "比較",
+        "description": "計測値を同じ条件の過去の結果と比較します（全キーボード横断）。",
+        "previous": "前回",
+        "best": "ベスト",
+        "average": "平均",
+        "pinned": "特定の結果",
+        "off": "オフ",
+        "noResults": "ピンできる結果がありません",
+        "colName": "名前",
+        "colKeyboard": "キーボード",
+        "colTime": "時間"
+      },
       "wpm": "WPM",
       "kpm": "KPM",
       "accuracy": "正確性",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -255,10 +255,13 @@
       "expandSettings": "設定を開く",
       "keymapToggle": "キーマップ",
       "statsToggle": "計測",
+      "controlsToggle": "操作",
       "hideKeymap": "キーマップを隠す",
       "showKeymap": "キーマップを表示",
       "hideStats": "計測を隠す",
       "showStats": "計測を表示",
+      "hideControls": "操作を隠す",
+      "showControls": "操作を表示",
       "section": {
         "settings": "設定",
         "data": "データ",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -250,6 +250,7 @@
       "exitTypingMode": "タイピングテスト終了",
       "restart": "やり直す",
       "nextTest": "次のテスト",
+      "complete": "完了",
       "collapseSettings": "設定を閉じる",
       "expandSettings": "設定を開く",
       "keymapToggle": "キーマップ",
@@ -261,7 +262,6 @@
       "section": {
         "settings": "設定",
         "data": "データ",
-        "operations": "操作",
         "show": "表示"
       },
       "wpm": "WPM",

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -21,7 +21,9 @@ type HistoryTab = 'monkeytype' | 'text'
 
 interface Props {
   results: TypingTestResult[]
-  onExportCsv?: (csv: string) => void
+  /** Export the currently-filtered rows. `filterSlug` describes the active
+   *  tab + selection (e.g. `normal-words`, `text-Alpha`) for the filename. */
+  onExportCsv?: (csv: string, filterSlug: string) => void
   /** Label a result (keyed by ISO date) for run comparison. */
   onRename?: (date: string, name: string) => void
   /** Delete a single result (keyed by ISO date). */
@@ -30,11 +32,8 @@ interface Props {
 
 const MAX_TABLE_ROWS = 20
 
-function modeFilterButtonClass(active: boolean): string {
-  const base = 'rounded-md border px-2.5 py-1 text-xs transition-colors'
-  if (active) return `${base} border-accent bg-accent/10 text-accent`
-  return `${base} border-edge text-content-secondary hover:text-content`
-}
+const FILTER_SELECT_CLASS = 'h-8 rounded-md border border-edge bg-surface-alt px-2 text-sm text-content-secondary focus:border-accent focus:outline-none'
+const EXPORT_BTN_CLASS = 'rounded-md border border-edge px-2.5 py-1 text-xs text-content-secondary transition-colors hover:text-content'
 
 const MAX_SPARKLINE_RESULTS = 50
 
@@ -53,6 +52,29 @@ function modeDetail(r: TypingTestResult): string {
   return r.mode2 != null ? String(r.mode2) : ''
 }
 
+/** Stable filter key for an imported-text (custom) run; its textId is `mode2`. */
+function customTextId(r: TypingTestResult): string {
+  return String(r.mode2 ?? '')
+}
+
+/** Filename slug describing the active export selection (tab + filter), so each
+ *  filtered export lands in a distinct, self-describing file. Normal-all and
+ *  Text-all stay distinct via the tab prefix. */
+function exportFilterSlug(
+  isText: boolean,
+  modeFilter: ModeFilter,
+  textFilter: string,
+  customTexts: { id: string, name: string }[],
+): string {
+  if (isText) {
+    if (textFilter === 'all') return 'text'
+    // Fall back to the textId for an empty / missing name so the slug never
+    // ends in a bare `text-`.
+    return `text-${customTexts.find((c) => c.id === textFilter)?.name || textFilter}`
+  }
+  return modeFilter === 'all' ? 'normal' : `normal-${modeFilter}`
+}
+
 const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
 const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'customTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb'] as const
@@ -68,6 +90,8 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: 
   const { t } = useTranslation()
   const [tab, setTab] = useState<HistoryTab>('monkeytype')
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
+  // Text-tab filter, keyed by the stable textId (mode2). 'all' = no filter.
+  const [textFilter, setTextFilter] = useState<string>('all')
   const [sortColumn, setSortColumn] = useState<SortColumn>('date')
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   const [confirmDeleteDate, setConfirmDeleteDate] = useState<string | null>(null)
@@ -84,15 +108,38 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: 
     [results, isText],
   )
 
+  // Distinct imported texts (custom rows), keyed by stable textId, displayed by
+  // the snapshotted name. Drives the Text-tab filter dropdown.
+  const customTexts = useMemo(() => {
+    const seen = new Map<string, string>()
+    for (const r of results) {
+      if (r.mode !== 'custom') continue
+      const id = customTextId(r)
+      if (!seen.has(id)) seen.set(id, r.customTextName ?? id)
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name }))
+  }, [results])
+
+  // Fall back to 'all' when the selected text no longer exists (e.g. all its
+  // rows were deleted), so the dropdown stays controlled and the stats/chart
+  // never collapse to an empty selection.
+  const effectiveTextFilter = textFilter === 'all' || customTexts.some((c) => c.id === textFilter)
+    ? textFilter
+    : 'all'
+
   const filtered = useMemo(() => {
-    if (isText || modeFilter === 'all') return tabResults
+    if (isText) {
+      if (effectiveTextFilter === 'all') return tabResults
+      return tabResults.filter((r) => customTextId(r) === effectiveTextFilter)
+    }
+    if (modeFilter === 'all') return tabResults
     return tabResults.filter((r) => (r.mode ?? 'words') === modeFilter)
-  }, [tabResults, isText, modeFilter])
+  }, [tabResults, isText, modeFilter, effectiveTextFilter])
 
   // Export is per-tab: only the rows currently shown.
   const handleExport = useCallback(() => {
-    onExportCsv?.(buildResultsCsv(filtered))
-  }, [filtered, onExportCsv])
+    onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(isText, modeFilter, effectiveTextFilter, customTexts))
+  }, [filtered, onExportCsv, isText, modeFilter, effectiveTextFilter, customTexts])
 
   const stats = useMemo(() => computeStats(filtered), [filtered])
   const sparklineResults = useMemo(
@@ -152,31 +199,48 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: 
         ))}
       </div>
 
-      {/* Sub-filter (Monkeytype only) + per-tab export */}
+      {/* Sub-filter (mode dropdown for Monkeytype, text dropdown for Text) +
+          per-tab export. Both selects feed `filtered`, so the stats row and the
+          sparkline reflect the current selection too. */}
       <div className="flex items-center gap-2">
         {!isText && (
-          <div className="flex gap-1.5">
+          <select
+            data-testid="history-filter-mode"
+            aria-label={t('editor.typingTest.history.filterMode')}
+            className={FILTER_SELECT_CLASS}
+            value={modeFilter}
+            onChange={(e) => setModeFilter(e.target.value as ModeFilter)}
+          >
             {MODE_FILTERS.map((mode) => (
-              <button
-                key={mode}
-                type="button"
-                data-testid={`history-filter-${mode}`}
-                className={modeFilterButtonClass(modeFilter === mode)}
-                aria-pressed={modeFilter === mode}
-                onClick={() => setModeFilter(mode)}
-              >
+              <option key={mode} value={mode}>
                 {mode === 'all'
                   ? t('editor.typingTest.history.allModes')
                   : t(`editor.typingTest.mode.${mode}`)}
-              </button>
+              </option>
             ))}
-          </div>
+          </select>
+        )}
+        {isText && customTexts.length > 1 && (
+          <select
+            data-testid="history-filter-text"
+            aria-label={t('editor.typingTest.history.filterText')}
+            className={FILTER_SELECT_CLASS}
+            value={effectiveTextFilter}
+            onChange={(e) => setTextFilter(e.target.value)}
+          >
+            <option value="all">{t('editor.typingTest.history.allModes')}</option>
+            {customTexts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name || t('editor.typingTest.history.unnamed')}
+              </option>
+            ))}
+          </select>
         )}
         {onExportCsv && (
           <button
             type="button"
             data-testid="history-export-csv"
-            className={`ml-auto ${modeFilterButtonClass(false)}`}
+            className={`ml-auto ${EXPORT_BTN_CLASS}`}
             onClick={handleExport}
           >
             {t('editor.typingTest.history.exportCsv')}

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -27,6 +27,9 @@ interface Props {
   readingMaxWidth?: number
   /** Hide the stats / results (WPM) row. Persisted per keyboard. */
   hideStatsRow?: boolean
+  /** Hide the operation (Next Test button) controls row. Persisted per
+   *  keyboard. Force-shown once a test finishes. */
+  hideControls?: boolean
   onCompositionStart?: () => void
   onCompositionUpdate?: (data: string) => void
   onCompositionEnd?: (data: string) => void
@@ -95,6 +98,7 @@ export function TypingTestView({
   paused,
   readingMaxWidth,
   hideStatsRow,
+  hideControls,
   onCompositionStart,
   onCompositionUpdate,
   onCompositionEnd,
@@ -339,6 +343,9 @@ export function TypingTestView({
           {t('editor.typingTest.complete')}
         </p>
       )}
+      {/* The "operation" toggle hides this controls row, but a finished test
+          always shows it so the result can be named and the next test started. */}
+      {(!hideControls || state.status === 'finished') && (
       <div className="flex items-center gap-2">
         {config.mode === 'custom' && (
           state.status === 'running' ? (
@@ -375,6 +382,7 @@ export function TypingTestView({
           {t(state.status === 'running' || state.status === 'paused' ? 'editor.typingTest.restart' : 'editor.typingTest.nextTest')}
         </button>
       </div>
+      )}
 
       {/* Measurement / results row — below the reading window and the
           Unnamed / Next Test row. Live metrics during a run; before measuring

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -7,6 +7,7 @@ import { SquarePen, Pause, Play, CircleCheck } from 'lucide-react'
 import { ICON_SM, ICON_LG } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig } from './types'
+import type { ComparisonStats } from './comparison'
 import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
 import { WordDisplay } from './WordDisplay'
 import { ResultNameModal } from './ResultNameModal'
@@ -30,6 +31,9 @@ interface Props {
   /** Hide the operation (Next Test button) controls row. Persisted per
    *  keyboard. Force-shown once a test finishes. */
   hideControls?: boolean
+  /** Baseline metrics for the Measurement-row comparison delta, or null when
+   *  comparison is off / no matching history. */
+  comparison?: ComparisonStats | null
   onCompositionStart?: () => void
   onCompositionUpdate?: (data: string) => void
   onCompositionEnd?: (data: string) => void
@@ -99,6 +103,7 @@ export function TypingTestView({
   readingMaxWidth,
   hideStatsRow,
   hideControls,
+  comparison,
   onCompositionStart,
   onCompositionUpdate,
   onCompositionEnd,
@@ -401,18 +406,21 @@ export function TypingTestView({
             <span data-testid="typing-test-wpm" className="font-mono text-lg font-semibold text-accent">
               {showStats ? wpm : '-'}
             </span>
+            {showStats && comparison && <ComparisonDelta current={wpm} baseline={comparison.wpm} testid="wpm" />}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.kpm')}:</span>
             <span data-testid="typing-test-kpm" className="font-mono text-lg font-semibold text-accent">
               {showStats ? kpm : '-'}
             </span>
+            {showStats && comparison && <ComparisonDelta current={kpm} baseline={comparison.kpm} testid="kpm" />}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.accuracy')}:</span>
             <span data-testid="typing-test-accuracy" className="font-mono text-lg font-semibold">
               {showStats ? `${accuracy}%` : '-'}
             </span>
+            {showStats && comparison && <ComparisonDelta current={accuracy} baseline={comparison.accuracy} suffix="%" testid="accuracy" />}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.time')}:</span>
@@ -445,6 +453,19 @@ export function TypingTestView({
       )}
 
     </div>
+  )
+}
+
+/** Signed delta of the live metric against the comparison baseline: an arrow +
+ *  the difference, green when ahead, red when behind, muted when level. */
+function ComparisonDelta({ current, baseline, suffix, testid }: { current: number; baseline: number; suffix?: string; testid: string }) {
+  const diff = current - baseline
+  const arrow = diff > 0 ? '▲' : diff < 0 ? '▼' : ''
+  const color = diff > 0 ? 'text-success' : diff < 0 ? 'text-danger' : 'text-content-muted'
+  return (
+    <span data-testid={`typing-test-delta-${testid}`} className={`font-mono text-xs ${color}`}>
+      {arrow}{diff > 0 ? '+' : ''}{diff}{suffix ?? ''}
+    </span>
   )
 }
 

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -363,7 +363,7 @@ export function TypingTestView({
             </button>
           ) : null
         )}
-        {state.status === 'finished' && config.mode === 'custom' && (
+        {state.status === 'finished' && (
           <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} chips={resultNameChips} />
         )}
         <button

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -3,8 +3,8 @@
 import { useRef, useEffect, useLayoutEffect, useCallback, useMemo, useState } from 'react'
 import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquarePen } from 'lucide-react'
-import { ICON_SM } from '../constants/ui-tokens'
+import { SquarePen, Pause, Play, CircleCheck } from 'lucide-react'
+import { ICON_SM, ICON_LG } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig } from './types'
 import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
@@ -42,8 +42,14 @@ interface Props {
   /** Quick-insert chips for the result-name modal (material label, timestamp,
    *  WPM / KPM / Accuracy of the just-finished result). */
   resultNameChips?: string[]
-  /** Start a fresh run from the result screen (same as the Restart button). */
+  /** Start a fresh run (Next Test / Restart — both restart the test). */
   onStart?: () => void
+  /** Memory mode (imported custom text): pause the running run. */
+  onPause?: () => void
+  /** Memory mode: open the resume dialog for a paused / saved run. */
+  onResume?: () => void
+  /** A paused custom run is saved and can be resumed. */
+  hasSavedMemory?: boolean
 }
 
 function formatTime(seconds: number): string {
@@ -98,6 +104,9 @@ export function TypingTestView({
   onNameResult,
   resultNameChips = [],
   onStart,
+  onPause,
+  onResume,
+  hasSavedMemory,
 }: Props) {
   const { t } = useTranslation()
   const showStats = state.status === 'running' || state.status === 'finished' || state.status === 'paused'
@@ -318,22 +327,54 @@ export function TypingTestView({
         )}
       </div>
 
-      {/* Imported custom text: name the just-finished result, kept below the
-          reading window (its original spot) while the metrics row sits on top. */}
-      {state.status === 'finished' && config.mode === 'custom' && (
-        <div className="flex items-center gap-2">
-          <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} chips={resultNameChips} />
-          {/* Start a fresh run — same action as the Restart button. */}
-          <button
-            type="button"
-            data-testid="typing-test-start"
-            className="flex h-8 items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-            onClick={onStart}
-          >
-            {t('editor.typingTest.nextTest')}
-          </button>
-        </div>
+      {/* State-based controls row, below the reading window:
+          - not started (waiting / countdown): Next Test (+ Resume if a run is
+            saved for imported custom text)
+          - in progress (running / paused): Pause or Resume (custom) + Restart
+          - finished: result name (custom) + Next Test
+          Next Test and Restart share the same action; only the label differs. */}
+      {state.status === 'finished' && (
+        <p data-testid="typing-test-complete" className="flex items-center gap-1.5 text-lg font-semibold text-accent">
+          <CircleCheck size={ICON_LG} aria-hidden="true" />
+          {t('editor.typingTest.complete')}
+        </p>
       )}
+      <div className="flex items-center gap-2">
+        {config.mode === 'custom' && (
+          state.status === 'running' ? (
+            <button
+              type="button"
+              data-testid="typing-memory-pause"
+              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+              onClick={onPause}
+            >
+              <Pause size={ICON_SM} aria-hidden="true" />
+              <span>{t('editor.typingTest.memory.pause')}</span>
+            </button>
+          ) : (state.status === 'paused' || ((state.status === 'waiting' || state.status === 'countdown') && hasSavedMemory)) ? (
+            <button
+              type="button"
+              data-testid="typing-memory-resume"
+              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-accent transition-colors hover:text-accent/80"
+              onClick={onResume}
+            >
+              <Play size={ICON_SM} aria-hidden="true" />
+              <span>{t('editor.typingTest.memory.resumeButton')}</span>
+            </button>
+          ) : null
+        )}
+        {state.status === 'finished' && config.mode === 'custom' && (
+          <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} chips={resultNameChips} />
+        )}
+        <button
+          type="button"
+          data-testid={state.status === 'running' || state.status === 'paused' ? 'typing-test-restart' : 'typing-test-start'}
+          className="flex h-8 items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+          onClick={onStart}
+        >
+          {t(state.status === 'running' || state.status === 'paused' ? 'editor.typingTest.restart' : 'editor.typingTest.nextTest')}
+        </button>
+      </div>
 
       {/* Measurement / results row — below the reading window and the
           Unnamed / Next Test row. Live metrics during a run; before measuring

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -57,35 +57,54 @@ describe('TypingTestHistory', () => {
     expect(svgs.length).toBe(1) // cell trophy icon
   })
 
-  it('filters by mode when clicking filter buttons', () => {
+  it('filters by mode via the dropdown', () => {
     const results = [
       makeResult({ wpm: 80, mode: 'words', mode2: 30 }),
       makeResult({ wpm: 90, mode: 'time', mode2: 60 }),
       makeResult({ wpm: 70, mode: 'quote', mode2: 'short' }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
+    const select = screen.getByTestId('history-filter-mode')
 
     // Default is 'all', all three should show
     expect(screen.getAllByText('80').length).toBeGreaterThan(0)
     expect(screen.getAllByText('90').length).toBeGreaterThan(0)
     expect(screen.getAllByText('70').length).toBeGreaterThan(0)
 
-    // Click 'words' filter
-    fireEvent.click(screen.getByTestId('history-filter-words'))
+    // Select 'words'
+    fireEvent.change(select, { target: { value: 'words' } })
     expect(screen.getAllByText('80').length).toBeGreaterThan(0)
     expect(screen.queryByText('90')).toBeNull()
     expect(screen.queryByText('70')).toBeNull()
 
-    // Click 'time' filter
-    fireEvent.click(screen.getByTestId('history-filter-time'))
+    // Select 'time'
+    fireEvent.change(select, { target: { value: 'time' } })
     expect(screen.queryByText('80')).toBeNull()
     expect(screen.getAllByText('90').length).toBeGreaterThan(0)
 
-    // Click 'all' to reset
-    fireEvent.click(screen.getByTestId('history-filter-all'))
+    // Back to 'all'
+    fireEvent.change(select, { target: { value: 'all' } })
     expect(screen.getAllByText('80').length).toBeGreaterThan(0)
     expect(screen.getAllByText('90').length).toBeGreaterThan(0)
     expect(screen.getAllByText('70').length).toBeGreaterThan(0)
+  })
+
+  it('filters the Text tab by imported text via the dropdown', () => {
+    const results = [
+      makeResult({ wpm: 80, mode: 'custom', mode2: 't1', customTextName: 'Alpha' }),
+      makeResult({ wpm: 65, mode: 'custom', mode2: 't2', customTextName: 'Beta' }),
+    ]
+    renderWithI18n(<TypingTestHistory results={results} />)
+
+    // Switch to the Text tab
+    fireEvent.click(screen.getByTestId('history-tab-text'))
+    expect(screen.getAllByText('80').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('65').length).toBeGreaterThan(0)
+
+    // Filter to a single text → the other text's row drops out
+    fireEvent.change(screen.getByTestId('history-filter-text'), { target: { value: 't1' } })
+    expect(screen.getAllByText('80').length).toBeGreaterThan(0)
+    expect(screen.queryByText('65')).toBeNull()
   })
 
   it('sorts by WPM when clicking header', () => {
@@ -143,7 +162,7 @@ describe('TypingTestHistory', () => {
     renderWithI18n(<TypingTestHistory results={results} />)
 
     // Filter to words only
-    fireEvent.click(screen.getByTestId('history-filter-words'))
+    fireEvent.change(screen.getByTestId('history-filter-mode'), { target: { value: 'words' } })
 
     // Stats should reflect only words results (best=100, tests=1)
     expect(screen.getAllByText('100').length).toBeGreaterThan(0)
@@ -168,6 +187,27 @@ describe('TypingTestHistory', () => {
     expect(csv).toContain('date,name,wpm,kpm,accuracy')
     expect(csv).toContain('2025-01-01T00:00:00Z')
     expect(csv).toContain('80')
+    // Default (Normal tab, All) → 'normal' slug
+    expect(onExportCsv.mock.calls[0][1]).toBe('normal')
+  })
+
+  it('passes a filename slug reflecting the active filter selection', () => {
+    const onExportCsv = vi.fn()
+    const results = [
+      makeResult({ wpm: 80, mode: 'words', mode2: 30 }),
+      makeResult({ wpm: 70, mode: 'custom', mode2: 't1', customTextName: 'Alpha' }),
+    ]
+    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+
+    // Normal tab, filter to words → 'normal-words'
+    fireEvent.change(screen.getByTestId('history-filter-mode'), { target: { value: 'words' } })
+    fireEvent.click(screen.getByTestId('history-export-csv'))
+    expect(onExportCsv.mock.calls.at(-1)?.[1]).toBe('normal-words')
+
+    // Text tab, all → 'text'
+    fireEvent.click(screen.getByTestId('history-tab-text'))
+    fireEvent.click(screen.getByTestId('history-export-csv'))
+    expect(onExportCsv.mock.calls.at(-1)?.[1]).toBe('text')
   })
 
   it('does not show export button when onExportCsv is not provided', () => {

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -306,6 +306,12 @@ describe('TypingTestView controls row (state-based)', () => {
     expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
   })
 
+  it('shows the result name field on finish for normal modes too', () => {
+    const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    renderView({ config: wordsConfig, state: makeState({ status: 'finished' }) })
+    expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
+  })
+
   it('shows the Complete message on the finished screen', () => {
     renderView({ config: customConfig, state: makeState({ status: 'finished' }) })
     expect(screen.getByTestId('typing-test-complete')).toBeInTheDocument()

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -280,6 +280,50 @@ describe('TypingTestView quote mode display', () => {
   })
 })
 
+describe('TypingTestView controls row (state-based)', () => {
+  const customConfig: TypingTestConfig = { mode: 'custom', textId: 'abc' }
+
+  it('shows Next Test (not Restart) before a run starts', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'waiting' }) })
+    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+    expect(screen.queryByTestId('typing-test-restart')).toBeNull()
+  })
+
+  it('shows Pause + Restart while running (custom)', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+    expect(screen.getByTestId('typing-memory-pause')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
+  })
+
+  it('shows Resume + Restart while paused (custom)', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'paused' }) })
+    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
+  })
+
+  it('shows Resume in the waiting state when a custom run is saved', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'waiting' }), hasSavedMemory: true })
+    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
+  })
+
+  it('shows the Complete message on the finished screen', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'finished' }) })
+    expect(screen.getByTestId('typing-test-complete')).toBeInTheDocument()
+  })
+
+  it('hides the Complete message while running', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+    expect(screen.queryByTestId('typing-test-complete')).toBeNull()
+  })
+
+  it('never shows Resume on the finished screen, even with a saved memory', () => {
+    renderView({ config: customConfig, state: makeState({ status: 'finished' }), hasSavedMemory: true })
+    expect(screen.queryByTestId('typing-memory-resume')).toBeNull()
+    expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+  })
+})
+
 describe('TypingTestView custom mode result naming', () => {
   const customConfig: TypingTestConfig = { mode: 'custom', textId: 'abc' }
 

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { computeComparison, matchingResults, conditionKey } from '../comparison'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { TypingTestConfig } from '../types'
+
+function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+  return {
+    date: '2026-06-20T00:00:00.000Z',
+    wpm: 60,
+    accuracy: 95,
+    wordCount: 30,
+    correctChars: 300,
+    incorrectChars: 5,
+    durationSeconds: 30,
+    mode: 'words',
+    mode2: 30,
+    language: 'english',
+    punctuation: false,
+    numbers: false,
+    ...overrides,
+  }
+}
+
+const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false } as TypingTestConfig
+const customConfig: TypingTestConfig = { mode: 'custom', textId: 't1' } as TypingTestConfig
+
+describe('matchingResults', () => {
+  it('matches normal runs on mode + params + language + toggles', () => {
+    const pool = [
+      makeResult({ wpm: 70 }),                              // match
+      makeResult({ wpm: 80, mode2: 60 }),                   // different wordCount
+      makeResult({ wpm: 90, language: 'japanese' }),        // different language
+      makeResult({ wpm: 50, punctuation: true }),           // different toggle
+    ]
+    const out = matchingResults(pool, wordsConfig, 'english')
+    expect(out.map((r) => r.wpm)).toEqual([70])
+  })
+
+  it('matches custom runs on the imported text id only', () => {
+    const pool = [
+      makeResult({ wpm: 40, mode: 'custom', mode2: 't1', language: 'a' }),
+      makeResult({ wpm: 45, mode: 'custom', mode2: 't1', language: 'b' }), // same text, diff lang → still match
+      makeResult({ wpm: 99, mode: 'custom', mode2: 't2' }),                 // different text
+    ]
+    const out = matchingResults(pool, customConfig, 'english')
+    expect(out.map((r) => r.wpm).sort()).toEqual([40, 45])
+  })
+
+  it('excludes results at/after beforeMs (the in-flight run)', () => {
+    const pool = [
+      makeResult({ wpm: 70, date: '2026-06-20T00:00:00.000Z' }),
+      makeResult({ wpm: 99, date: '2026-06-21T00:00:00.000Z' }), // the current run
+    ]
+    const beforeMs = new Date('2026-06-21T00:00:00.000Z').getTime()
+    const out = matchingResults(pool, wordsConfig, 'english', beforeMs)
+    expect(out.map((r) => r.wpm)).toEqual([70])
+  })
+})
+
+describe('conditionKey', () => {
+  it('keys normal modes on mode + params + language + toggles', () => {
+    expect(conditionKey(wordsConfig, 'english')).toBe('words|30|english|false|false')
+    const timeConfig = { mode: 'time', duration: 10 } as TypingTestConfig
+    expect(conditionKey(timeConfig, 'english')).toBe('time|10|english|false|false')
+  })
+
+  it('keys custom on the imported text id only (language-independent)', () => {
+    expect(conditionKey(customConfig, 'english')).toBe('custom|t1')
+    expect(conditionKey(customConfig, 'japanese')).toBe('custom|t1')
+  })
+
+  it('distinguishes different conditions', () => {
+    const a = conditionKey(wordsConfig, 'english')
+    const b = conditionKey({ mode: 'time', duration: 10 } as TypingTestConfig, 'english')
+    const c = conditionKey(customConfig, 'english')
+    expect(new Set([a, b, c]).size).toBe(3)
+  })
+})
+
+describe('computeComparison', () => {
+  const pool = [
+    makeResult({ wpm: 60, accuracy: 90, date: '2026-06-18T00:00:00.000Z' }),
+    makeResult({ wpm: 80, accuracy: 96, date: '2026-06-19T00:00:00.000Z' }),
+    makeResult({ wpm: 70, accuracy: 92, date: '2026-06-20T00:00:00.000Z' }),
+  ]
+
+  it('off → null', () => {
+    expect(computeComparison(pool, wordsConfig, 'english', { kind: 'off' })).toBeNull()
+  })
+
+  it('previous → most recent matching run', () => {
+    const out = computeComparison(pool, wordsConfig, 'english', { kind: 'previous' })
+    expect(out?.wpm).toBe(70)
+  })
+
+  it('best → highest WPM', () => {
+    const out = computeComparison(pool, wordsConfig, 'english', { kind: 'best' })
+    expect(out?.wpm).toBe(80)
+  })
+
+  it('average → rounded mean of each metric', () => {
+    const out = computeComparison(pool, wordsConfig, 'english', { kind: 'average' })
+    expect(out?.wpm).toBe(70) // (60+80+70)/3
+    expect(out?.accuracy).toBe(93) // (90+96+92)/3 = 92.67 → 93
+  })
+
+  it('pinned → the result with the matching date, condition-independent', () => {
+    const out = computeComparison(pool, customConfig, 'english', { kind: 'pinned', pinnedDate: '2026-06-19T00:00:00.000Z' })
+    expect(out?.wpm).toBe(80)
+  })
+
+  it('pinned with a missing/unknown date → null', () => {
+    expect(computeComparison(pool, wordsConfig, 'english', { kind: 'pinned' })).toBeNull()
+    expect(computeComparison(pool, wordsConfig, 'english', { kind: 'pinned', pinnedDate: 'nope' })).toBeNull()
+  })
+
+  it('no matching history → null', () => {
+    const out = computeComparison([], wordsConfig, 'english', { kind: 'previous' })
+    expect(out).toBeNull()
+  })
+})

--- a/src/renderer/typing-test/comparison.ts
+++ b/src/renderer/typing-test/comparison.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { TypingTestResult, TypingTestComparisonBaseline } from '../../shared/types/pipette-settings'
+import type { TypingTestConfig } from './types'
+import { configKey, deriveMode2, resultKpm } from './result-builder'
+
+/** Headline metrics of the chosen baseline, compared against the live run. */
+export interface ComparisonStats {
+  wpm: number
+  kpm: number
+  accuracy: number
+}
+
+/** Stable key identifying the current test condition, used both to group
+ *  same-condition history and to remember the per-condition baseline:
+ *  - custom: the imported text id (`custom|textId`)
+ *  - normal: mode + params + language + toggles (mirrors `configKey`)
+ *  This must agree with {@link matchingResults} so the saved baseline and the
+ *  pinnable choices stay in lockstep. */
+export function conditionKey(config: TypingTestConfig, language: string): string {
+  if (config.mode === 'custom') return `custom|${String(deriveMode2(config) ?? '')}`
+  const hasToggles = config.mode === 'words' || config.mode === 'time'
+  return configKey({
+    mode: config.mode,
+    mode2: deriveMode2(config),
+    language,
+    punctuation: hasToggles ? config.punctuation : undefined,
+    numbers: hasToggles ? config.numbers : undefined,
+  } as TypingTestResult)
+}
+
+/** Results from the pool sharing the current test's condition:
+ *  - custom: the same imported text (matched on `mode2` = textId)
+ *  - normal: same mode + params + language + punctuation/numbers (`configKey`)
+ *  `beforeMs`, when given, drops results at/after that time so the in-flight
+ *  run (saved on finish) never compares against itself. */
+export function matchingResults<T extends TypingTestResult>(
+  pool: T[],
+  config: TypingTestConfig,
+  language: string,
+  beforeMs?: number,
+): T[] {
+  const isCustom = config.mode === 'custom'
+  const currentTextId = String(deriveMode2(config) ?? '')
+  const hasToggles = config.mode === 'words' || config.mode === 'time'
+  // configKey only reads these 5 fields, so a config-shaped partial is enough.
+  const currentKey = configKey({
+    mode: config.mode,
+    mode2: deriveMode2(config),
+    language,
+    punctuation: hasToggles ? config.punctuation : undefined,
+    numbers: hasToggles ? config.numbers : undefined,
+  } as TypingTestResult)
+
+  return pool.filter((r) => {
+    if (beforeMs != null && new Date(r.date).getTime() >= beforeMs) return false
+    if (isCustom) return r.mode === 'custom' && String(r.mode2 ?? '') === currentTextId
+    return configKey(r) === currentKey
+  })
+}
+
+function statsOf(r: TypingTestResult): ComparisonStats {
+  return { wpm: r.wpm, kpm: resultKpm(r), accuracy: r.accuracy }
+}
+
+/** The baseline metrics to compare the live run against, or `null` when the
+ *  baseline is off / unresolved (no matching history, pinned result gone). */
+export function computeComparison(
+  pool: TypingTestResult[],
+  config: TypingTestConfig,
+  language: string,
+  baseline: TypingTestComparisonBaseline,
+  beforeMs?: number,
+): ComparisonStats | null {
+  if (baseline.kind === 'off') return null
+
+  // A pinned result is a fixed, condition-independent baseline keyed by `date`.
+  if (baseline.kind === 'pinned') {
+    if (!baseline.pinnedDate) return null
+    const pinned = pool.find((r) => r.date === baseline.pinnedDate)
+    return pinned ? statsOf(pinned) : null
+  }
+
+  const matches = matchingResults(pool, config, language, beforeMs)
+  if (matches.length === 0) return null
+
+  if (baseline.kind === 'average') {
+    const n = matches.length
+    const sum = matches.reduce(
+      (acc, r) => ({ wpm: acc.wpm + r.wpm, kpm: acc.kpm + resultKpm(r), accuracy: acc.accuracy + r.accuracy }),
+      { wpm: 0, kpm: 0, accuracy: 0 },
+    )
+    return { wpm: Math.round(sum.wpm / n), kpm: Math.round(sum.kpm / n), accuracy: Math.round(sum.accuracy / n) }
+  }
+
+  // 'previous' = most recent matching run; 'best' = highest WPM.
+  const chosen = baseline.kind === 'best'
+    ? matches.reduce((a, b) => (b.wpm > a.wpm ? b : a))
+    : matches.reduce((a, b) => (new Date(b.date).getTime() > new Date(a.date).getTime() ? b : a))
+  return statsOf(chosen)
+}

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -86,6 +86,9 @@ export const IpcChannels = {
   // Pipette Settings Store (renderer → main → renderer)
   PIPETTE_SETTINGS_GET: 'pipette-settings:get',
   PIPETTE_SETTINGS_PATCH: 'pipette-settings:patch',
+  // Typing-test results pooled across every locally-stored keyboard, for the
+  // Measurement-row comparison baseline (keyboard-agnostic).
+  PIPETTE_SETTINGS_LIST_ALL_TYPING_RESULTS: 'pipette-settings:list-all-typing-results',
 
   // Typing Analytics (renderer ↔ main)
   TYPING_ANALYTICS_EVENT: 'typing-analytics:event',

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -154,6 +154,9 @@ export interface PipetteSettings {
   layerNames: string[]
   typingTestResults?: TypingTestResult[]
   typingTestConfig?: Record<string, unknown>
+  /** Last words/time/quote config, restored when switching back from custom
+   *  (imported text) so normal-mode Pattern/Units/Option settings survive. */
+  typingTestNormalConfig?: Record<string, unknown>
   typingTestLanguage?: string
   typingTestViewOnly?: boolean
   typingTestViewOnlyWindowSize?: { width: number; height: number }

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -33,8 +33,49 @@ export interface TypingTestResult {
   wpmHistory?: number[]
 }
 
+/** A saved result tagged with the keyboard it belongs to. Returned by the
+ *  cross-keyboard pool so the comparison picker can show a Keyboard column. */
+export interface PooledTypingTestResult extends TypingTestResult {
+  keyboardName: string
+}
+
 export const VIEW_MODES = ['editor', 'typingView', 'typingTest'] as const
 export type ViewMode = typeof VIEW_MODES[number]
+
+/** Measurement-row comparison baseline. Comparison is always within the same
+ *  condition: `previous` (default) / `best` / `average` compute from
+ *  same-condition results pooled across all local keyboards; `pinned` fixes the
+ *  baseline to one chosen same-condition result (by its History `date` key);
+ *  `off` hides the delta. The baseline is remembered per condition (see
+ *  `typingTestComparisonBaselines`), so switching the typing-test condition
+ *  recalls the baseline saved for it. */
+export const COMPARISON_BASELINE_KINDS = ['previous', 'best', 'average', 'pinned', 'off'] as const
+export type ComparisonBaselineKind = typeof COMPARISON_BASELINE_KINDS[number]
+
+export interface TypingTestComparisonBaseline {
+  kind: ComparisonBaselineKind
+  /** History key (`date`, ISO string) of the chosen result when kind === 'pinned'. */
+  pinnedDate?: string
+}
+
+export function isTypingTestComparisonBaseline(value: unknown): value is TypingTestComparisonBaseline {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  if (!(COMPARISON_BASELINE_KINDS as readonly string[]).includes(v.kind as string)) return false
+  if ('pinnedDate' in v && v.pinnedDate != null && typeof v.pinnedDate !== 'string') return false
+  return true
+}
+
+/** Map of condition key → baseline. Each typing-test condition (mode + params,
+ *  or imported text) keeps its own remembered baseline. */
+export type TypingTestComparisonBaselines = Record<string, TypingTestComparisonBaseline>
+
+export function isTypingTestComparisonBaselines(value: unknown): value is TypingTestComparisonBaselines {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  return Object.values(value).every((v) => isTypingTestComparisonBaseline(v))
+}
+
+export const DEFAULT_COMPARISON_BASELINE: TypingTestComparisonBaseline = { kind: 'previous' }
 
 /** Which tab of the typing-view menu is currently open. Persisted so
  * the next entry restores the user's last-chosen pane (Window controls
@@ -175,6 +216,9 @@ export interface PipetteSettings {
   /** Editor typing-test: hide the operation (Next Test button) controls row.
    *  Default false. Force-shown once a test finishes. */
   typingTestHideControls?: boolean
+  /** Editor typing-test: Measurement-row comparison baseline per condition
+   *  key. Unset conditions default to `{ kind: 'previous' }`. */
+  typingTestComparisonBaselines?: TypingTestComparisonBaselines
   /** Editor typing-test: the left Settings panel is expanded. Default true. */
   typingTestSettingsPanelOpen?: boolean
   /** User-chosen record toggle. Persisted + synced so the setting

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -172,6 +172,9 @@ export interface PipetteSettings {
   typingTestHideKeymap?: boolean
   /** Editor typing-test: hide the stats / results (WPM) row. Default false. */
   typingTestHideStatsRow?: boolean
+  /** Editor typing-test: hide the operation (Next Test button) controls row.
+   *  Default false. Force-shown once a test finishes. */
+  typingTestHideControls?: boolean
   /** Editor typing-test: the left Settings panel is expanded. Default true. */
   typingTestSettingsPanelOpen?: boolean
   /** User-chosen record toggle. Persisted + synced so the setting

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -36,7 +36,7 @@ import type {
 import type { AppConfig } from './app-config'
 import type { DeviceScope } from './analyze-filters'
 import type { SyncAuthStatus, SyncProgress, PasswordStrength, SyncResetTargets, LocalResetTargets, UndecryptableFile, SyncScope, SyncDataScanResult, StoredKeyboardInfo, SyncOperationResult } from './sync'
-import type { PipetteSettings, PipetteSettingsPatch } from './pipette-settings'
+import type { PipetteSettings, PipetteSettingsPatch, PooledTypingTestResult } from './pipette-settings'
 import type {
   TypingActivityCell,
   TypingAnalyticsDeviceInfoBundle,
@@ -207,6 +207,10 @@ export interface VialAPI {
   /** Field-level merge persist: only the defined keys of `partial` are
    * written, so concurrent writers never clobber each other's fields. */
   pipetteSettingsPatch(uid: string, partial: PipetteSettingsPatch): Promise<{ success: boolean; error?: string }>
+  /** Every locally-stored keyboard's saved typing-test results, pooled flat
+   * (each tagged with its keyboard name) for the keyboard-agnostic
+   * Measurement-row comparison baseline. */
+  pipetteSettingsListAllTypingResults(): Promise<PooledTypingTestResult[]>
 
   // Typing Analytics
   typingAnalyticsEvent(event: TypingAnalyticsEvent): Promise<void>


### PR DESCRIPTION
Typing-test editor refinements, building on #206.

## Changes
- **State-based controls row** with a completion message: Next Test / Pause-Resume / Restart shown by run state.
- **Per-mode result naming** and normal-config memory (custom ↔ normal switching restores the last normal config).
- **History filter dropdowns** (mode for Normal, imported-text for Text tab) driving the stats row, sparkline, and table; filtered CSV export with a filename slug.
- **Operation toggle** added to the Show panel (hides the controls row, force-shown once finished); Show toggles ordered Operation → Measurement → Keymap.
- **Measurement comparison baseline**: WPM/KPM/Accuracy deltas vs a baseline chosen per condition (previous / best / average / pinned result / off), computed from same-condition results pooled across all local keyboards. Compare button + settings modal in the Data section; the Data section is now always shown.

## Persistence
New per-keyboard (synced) PipetteSettings fields: hide-keymap / hide-stats / hide-controls toggles, settings-panel-open state, per-mode normal config, and per-condition comparison baselines. New cross-keyboard results IPC tags each result with its resolved keyboard name (meta → snapshot → analytics → uid).

## Tests
Unit tests for comparison logic, history filters, and prefs round-trips. lint / tsc / full vitest suite / build all pass.