### PR TITLE
feat: name keyboards on connect + sort Data modal lists A-Z

### DIFF
--- a/src/main/__tests__/keyboard-meta.test.ts
+++ b/src/main/__tests__/keyboard-meta.test.ts
@@ -31,6 +31,7 @@ import {
   mergeKeyboardMetaIndex,
   readKeyboardMetaIndex,
   upsertKeyboardMeta,
+  upsertKeyboardMetaIfMissing,
   tombstoneKeyboardMeta,
   tombstoneAllKeyboardMeta,
   applyRemoteKeyboardMetaIndex,
@@ -205,5 +206,33 @@ describe('getActiveKeyboardMetaMap', () => {
     expect(map.get('0xA')).toBe('A')
     expect(map.has('0xB')).toBe(false)
     expect(map.has('0xC')).toBe(false)
+  })
+})
+
+describe('upsertKeyboardMetaIfMissing', () => {
+  it('records the name when the keyboard has none', async () => {
+    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('upserted')
+    const map = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
+    expect(map.get('0xc5')).toBe('Ieneko54R')
+  })
+
+  it('does not overwrite an existing name (no churn on reconnect)', async () => {
+    await upsertKeyboardMeta('0xc5', 'My Custom Name')
+    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('unchanged')
+    const map = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
+    expect(map.get('0xc5')).toBe('My Custom Name')
+  })
+
+  it('is a no-op for an empty uid or name', async () => {
+    expect(await upsertKeyboardMetaIfMissing('', 'Name')).toBe('unchanged')
+    expect(await upsertKeyboardMetaIfMissing('0xc5', '   ')).toBe('unchanged')
+    expect(getActiveKeyboardMetaMap(await readKeyboardMetaIndex()).size).toBe(0)
+  })
+
+  it('does not revive a tombstoned entry the user deleted', async () => {
+    await upsertKeyboardMeta('0xc5', 'Ieneko54R')
+    await tombstoneKeyboardMeta('0xc5')
+    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('unchanged')
+    expect(getActiveKeyboardMetaMap(await readKeyboardMetaIndex()).has('0xc5')).toBe(false)
   })
 })

--- a/src/main/sync/keyboard-meta.ts
+++ b/src/main/sync/keyboard-meta.ts
@@ -101,6 +101,30 @@ export async function upsertKeyboardMeta(
   })
 }
 
+/** Record `deviceName` for `uid` only when the index has NO entry for it yet.
+ *  Used at connect time to name keyboards that never saved a keymap snapshot,
+ *  without overwriting a name the user set or reviving a tombstone they deleted
+ *  (and without churning the index on every reconnect). The presence check and
+ *  the write share one lock so a concurrent writer can't be clobbered. Same
+ *  'unchanged' | 'upserted' contract as {@link upsertKeyboardMeta}. */
+export async function upsertKeyboardMetaIfMissing(
+  uid: string,
+  deviceName: string,
+): Promise<'unchanged' | 'upserted'> {
+  const normalized = deviceName.trim()
+  if (!uid || !normalized) return 'unchanged'
+  return withMetaWriteLock(async () => {
+    const index = await readKeyboardMetaIndex()
+    // Any entry — active OR tombstoned — counts as "has a name decision";
+    // only a uid the index has never seen gets the connect-time name.
+    if (findEntry(index, uid)) return 'unchanged'
+    index.entries.push({ uid, deviceName: normalized, updatedAt: new Date().toISOString() })
+    index.entries = gcKeyboardMetaTombstones(index.entries)
+    await writeKeyboardMetaIndex(index)
+    return 'upserted'
+  })
+}
+
 export async function tombstoneKeyboardMeta(uid: string): Promise<'unchanged' | 'tombstoned'> {
   if (!uid) return 'unchanged'
   return withMetaWriteLock(async () => {

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -57,6 +57,7 @@ import {
   tombstoneAllKeyboardMeta,
   tombstoneKeyboardMeta,
   upsertKeyboardMeta,
+  upsertKeyboardMetaIfMissing,
 } from './keyboard-meta'
 import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import { I18N_SYNC_UNIT_PREFIX } from '../../shared/types/i18n-store'
@@ -267,6 +268,13 @@ export function setupSyncIpc(): void {
         }
       }),
   )
+
+  // --- Name a keyboard on connect (only if it has no name yet) ---
+  secureHandle(IpcChannels.KEYBOARD_META_NAME_IF_MISSING, async (_event, uid: string, name: string): Promise<void> => {
+    if (typeof uid !== 'string' || !isSafeKey(uid) || typeof name !== 'string') return
+    const result = await upsertKeyboardMetaIfMissing(uid, name)
+    if (result === 'upserted') notifyChange(KEYBOARD_META_SYNC_UNIT)
+  })
 
   // --- List stored keyboards ---
   secureHandle(IpcChannels.LIST_STORED_KEYBOARDS, async (): Promise<StoredKeyboardInfo[]> => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -724,6 +724,8 @@ const vialAPI = {
   // --- Data Management ---
   listStoredKeyboards: (): Promise<StoredKeyboardInfo[]> =>
     ipcRenderer.invoke(IpcChannels.LIST_STORED_KEYBOARDS),
+  keyboardMetaNameIfMissing: (uid: string, name: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.KEYBOARD_META_NAME_IF_MISSING, uid, name),
   resetKeyboardData: (uid: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.RESET_KEYBOARD_DATA, uid),
   resetLocalTargets: (targets: LocalResetTargets): Promise<{ success: boolean; error?: string }> =>

--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -56,6 +56,8 @@ if (typeof window !== 'undefined') {
     typingAnalyticsListAppsForRange: async () => [],
     // Comparison baseline pool — TypingTestPane fetches this on mount.
     pipetteSettingsListAllTypingResults: async () => [],
+    // Connect-time keyboard naming — fire-and-forget in useDeviceLifecycle.
+    keyboardMetaNameIfMissing: async () => undefined,
     // i18n pack store: every renderer that mounts SettingsModal pulls in
     // LanguagePacksModal → useI18nPackStore, which calls i18nPackList on
     // mount. Stub the read paths to an empty list and the change-notifier

--- a/src/renderer/components/data-modal/DataNavTree.tsx
+++ b/src/renderer/components/data-modal/DataNavTree.tsx
@@ -8,6 +8,9 @@ import type { StoredKeyboardInfo, SyncDataScanResult } from '../../../shared/typ
 import type { FavoriteType } from '../../../shared/types/favorite-store'
 import type { TypingKeyboardSummary } from '../../../shared/types/typing-analytics'
 
+/** Case-insensitive A-Z compare for keyboard display names. */
+const byDisplayName = (a: string, b: string): number => a.localeCompare(b, undefined, { sensitivity: 'base' })
+
 interface Props {
   storedKeyboards: StoredKeyboardInfo[]
   typingKeyboards: TypingKeyboardSummary[]
@@ -164,7 +167,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
               {t('dataModal.noKeyboards')}
             </div>
           ) : (
-            storedKeyboards.map((kb) => (
+            [...storedKeyboards].sort((a, b) => byDisplayName(a.name, b.name)).map((kb) => (
               <Leaf
                 key={kb.uid}
                 label={kb.name}
@@ -214,7 +217,7 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
               {t('dataModal.typing.noKeyboards')}
             </div>
           ) : (
-            typingKeyboards.map((kb) => (
+            [...typingKeyboards].sort((a, b) => byDisplayName(a.productName || a.uid, b.productName || b.uid)).map((kb) => (
               <Leaf
                 key={kb.uid}
                 label={kb.productName || kb.uid}
@@ -271,7 +274,9 @@ export function DataNavTree({ storedKeyboards, typingKeyboards, hasRemoteTyping,
                 onToggle={() => onToggle('sync-keyboards')}
                 testId="nav-sync-keyboards"
               >
-                {syncScanResult.keyboards.map((uid) => {
+                {[...syncScanResult.keyboards]
+                  .sort((a, b) => byDisplayName(resolveSyncKeyboardName(a), resolveSyncKeyboardName(b)))
+                  .map((uid) => {
                   const name = resolveSyncKeyboardName(uid)
                   const isDownloading = downloadingUid === uid
                   const error = downloadErrorByUid[uid]

--- a/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
+++ b/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
@@ -42,6 +42,7 @@ function makeOptions(overrides: Partial<{
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).vialAPI = {
     lock: vi.fn().mockResolvedValue(undefined),
+    keyboardMetaNameIfMissing: vi.fn().mockResolvedValue(undefined),
   }
 
   return {
@@ -100,6 +101,17 @@ describe('useDeviceLifecycle.handleConnect — issue #190 regression', () => {
 
     expect(callOrder).toEqual(['syncNow', 'applyDevicePrefs'])
     expect(syncNow).toHaveBeenCalledWith('download', { favorites: true, keyboard: 'uid-1' })
+  })
+
+  it('names the keyboard from its product name on connect', async () => {
+    const { options } = makeOptions()
+    const { result } = renderHook(() => useDeviceLifecycle(options))
+
+    await act(async () => {
+      await result.current.handleConnect(mockDevice)
+    })
+
+    expect((window as any).vialAPI.keyboardMetaNameIfMissing).toHaveBeenCalledWith('uid-1', 'Test Keyboard')
   })
 
   it('skips sync download when autoSync is disabled', async () => {

--- a/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
+++ b/src/renderer/hooks/__tests__/useDeviceLifecycle.test.ts
@@ -111,7 +111,7 @@ describe('useDeviceLifecycle.handleConnect — issue #190 regression', () => {
       await result.current.handleConnect(mockDevice)
     })
 
-    expect((window as any).vialAPI.keyboardMetaNameIfMissing).toHaveBeenCalledWith('uid-1', 'Test Keyboard')
+    expect(window.vialAPI.keyboardMetaNameIfMissing).toHaveBeenCalledWith('uid-1', 'Test Keyboard')
   })
 
   it('skips sync download when autoSync is disabled', async () => {

--- a/src/renderer/hooks/useDeviceLifecycle.ts
+++ b/src/renderer/hooks/useDeviceLifecycle.ts
@@ -112,6 +112,10 @@ export function useDeviceLifecycle(options: Options) {
       if (success) {
         const uid = await keyboardReload()
         if (uid) {
+          // Name the keyboard from its USB product name on connect, so a board
+          // that never saves a keymap still shows a name instead of its uid.
+          // Fire-and-forget; the handler no-ops when a name already exists.
+          void window.vialAPI.keyboardMetaNameIfMissing(uid, dev.productName).catch(() => { /* best-effort */ })
           // Pull the cloud copies of keyboards/{uid}/* (and favorites) BEFORE
           // applying local prefs. Otherwise applyDevicePrefs sees a missing
           // local file, writes defaults with a fresh _updatedAt, and the

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -176,6 +176,8 @@ export const IpcChannels = {
 
   // Data management (renderer → main → renderer)
   LIST_STORED_KEYBOARDS: 'data:list-stored-keyboards',
+  // Record a keyboard's display name on connect, only when it has none yet.
+  KEYBOARD_META_NAME_IF_MISSING: 'data:keyboard-meta-name-if-missing',
   RESET_KEYBOARD_DATA: 'data:reset-keyboard',
   RESET_LOCAL_TARGETS: 'data:reset-local-targets',
   EXPORT_LOCAL_DATA: 'data:export-local',

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -331,6 +331,9 @@ export interface VialAPI {
 
   // Data management
   listStoredKeyboards(): Promise<StoredKeyboardInfo[]>
+  /** Record a keyboard's display name on connect, only when it has none yet
+   * (never overwrites a user-set name). No-op for empty uid/name. */
+  keyboardMetaNameIfMissing(uid: string, name: string): Promise<void>
   resetKeyboardData(uid: string): Promise<{ success: boolean; error?: string }>
   resetLocalTargets(targets: LocalResetTargets): Promise<{ success: boolean; error?: string }>
   exportLocalData(): Promise<{ success: boolean; error?: string }>


### PR DESCRIPTION
## Changes
- **Name keyboards on connect** — keyboards that never save a keymap snapshot showed their uid wherever the keyboard-meta index is used (e.g. the Data modal). On connect, record the USB product name when the meta index has no entry for that uid yet. Never overwrites a user-set name or revives a deleted (tombstoned) entry, and skips the write when a name already exists so reconnects don't churn the synced index (presence check + write share the meta write lock).
- **Sort the Data modal keyboard lists A-Z** — Local Keyboards, Local Typing, and Sync Keyboards were shown in backing-store order; now sorted by display name (case-insensitive) at render so every populate path stays ordered.

## Tests
New unit tests for `upsertKeyboardMetaIfMissing` (records when missing, never overwrites an existing name, never revives a tombstone, no-op on empty) and a connect-time naming assertion. lint / tsc / full vitest suite / build all pass.