### PR TITLE
feat(ui): comparison baseline polish — caption, scope, modal, name tooltips

### DIFF
--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -93,7 +93,6 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
             </div>
 
             <div className="flex min-h-0 flex-col gap-1 overflow-y-auto p-4">
-              <p className="mb-1 text-xs text-content-muted">{t('editor.typingTest.compare.description')}</p>
               {COMPARISON_BASELINE_KINDS.map((kind) => (
                 <label
                   key={kind}

--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -65,8 +65,11 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
       <button
         type="button"
         data-testid="typing-test-comparison-toggle"
-        className={toggleClass(open)}
-        aria-pressed={open}
+        // Accent-highlight whenever comparison is active (any baseline but
+        // 'off'), mirroring the Show toggles, so the button reflects on/off
+        // state rather than just whether the modal is open.
+        className={toggleClass(baseline.kind !== 'off')}
+        aria-pressed={baseline.kind !== 'off'}
         onClick={openModal}
       >
         {t('editor.typingTest.compare.button')}
@@ -81,7 +84,7 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
           onClick={close}
         >
           <div
-            className="flex max-h-modal-80vh w-full max-w-2xl flex-col rounded-xl border border-edge bg-surface-alt shadow-lg"
+            className="flex max-h-modal-80vh w-full max-w-3xl flex-col rounded-xl border border-edge bg-surface-alt shadow-lg"
             data-testid="comparison-modal"
             onClick={(e) => e.stopPropagation()}
           >
@@ -120,8 +123,8 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
                         <thead className="sticky top-0 bg-surface-alt text-content-muted">
                           <tr>
                             <th className="px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colName')}</th>
-                            <th className="w-28 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colKeyboard')}</th>
-                            <th className="w-36 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colTime')}</th>
+                            <th className="w-36 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colKeyboard')}</th>
+                            <th className="w-44 px-2 py-1.5 text-left font-medium">{t('editor.typingTest.compare.colTime')}</th>
                             <th className="w-14 px-2 py-1.5 text-right font-medium">{t('editor.typingTest.wpm')}</th>
                           </tr>
                         </thead>
@@ -135,9 +138,9 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
                               onClick={() => setDraftPinnedDate(r.date)}
                             >
                               <td className="truncate px-2 py-1.5">{r.name || t('editor.typingTest.history.unnamed')}</td>
-                              <td className="truncate px-2 py-1.5">{r.keyboardName}</td>
-                              <td className="px-2 py-1.5 font-mono">{formatDate(r.date)}</td>
-                              <td className="px-2 py-1.5 text-right font-mono">{r.wpm}</td>
+                              <td className="whitespace-nowrap px-2 py-1.5">{r.keyboardName}</td>
+                              <td className="whitespace-nowrap px-2 py-1.5 font-mono">{formatDate(r.date)}</td>
+                              <td className="whitespace-nowrap px-2 py-1.5 text-right font-mono">{r.wpm}</td>
                             </tr>
                           ))}
                         </tbody>

--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -6,6 +6,7 @@ import { useEscapeClose } from '../../hooks/useEscapeClose'
 import { ModalCloseButton } from './ModalCloseButton'
 import { formatDate } from './store-modal-shared'
 import { BTN_PRIMARY, BTN_SECONDARY } from '../../constants/ui-tokens'
+import { Tooltip } from '../ui/Tooltip'
 import { COMPARISON_BASELINE_KINDS } from '../../../shared/types/pipette-settings'
 import type { PooledTypingTestResult, TypingTestComparisonBaseline, ComparisonBaselineKind } from '../../../shared/types/pipette-settings'
 
@@ -137,7 +138,11 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
                               className={`cursor-pointer border-t border-edge/50 transition-colors ${draftPinnedDate === r.date ? 'bg-accent/10 font-semibold text-accent' : 'text-content hover:bg-surface-dim'}`}
                               onClick={() => setDraftPinnedDate(r.date)}
                             >
-                              <td className="truncate px-2 py-1.5">{r.name || t('editor.typingTest.history.unnamed')}</td>
+                              <td className="px-2 py-1.5">
+                                <Tooltip content={r.name || t('editor.typingTest.history.unnamed')} wrapperClassName="block max-w-full">
+                                  <span className="block truncate">{r.name || t('editor.typingTest.history.unnamed')}</span>
+                                </Tooltip>
+                              </td>
                               <td className="whitespace-nowrap px-2 py-1.5">{r.keyboardName}</td>
                               <td className="whitespace-nowrap px-2 py-1.5 font-mono">{formatDate(r.date)}</td>
                               <td className="whitespace-nowrap px-2 py-1.5 text-right font-mono">{r.wpm}</td>

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -61,7 +61,7 @@ export function HistoryToggle({ results, deviceName, onRename, onDelete }: Histo
               <h3 id="history-modal-title" className="text-lg font-semibold">{t('editor.typingTest.history.title')}</h3>
               <ModalCloseButton testid="history-modal-close" onClick={() => setShowHistory(false)} />
             </div>
-            <TypingTestHistory results={results} onExportCsv={handleExportCsv} onRename={onRename} onDelete={onDelete} />
+            <TypingTestHistory results={results} onExportCsv={handleExportCsv} onRename={onRename} onDelete={onDelete} deviceName={deviceName} />
           </div>
         </div>
       )}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -705,7 +705,7 @@ export function TypingTestPane({
             if (date) onRenameTypingTestResult?.(date, name)
           }}
           // Chips come from the just-finished result (history[0]).
-          resultNameChips={typingTestHistory?.[0] ? buildResultNameChips(typingTestHistory[0], t) : []}
+          resultNameChips={typingTestHistory?.[0] ? buildResultNameChips(typingTestHistory[0], t, deviceName) : []}
           onStart={() => typingTest.restart()}
           onPause={() => onPauseTest?.()}
           onResume={() => setShowResumeModal(true)}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -231,10 +231,13 @@ export function TypingTestPane({
   // condition recalls the baseline saved for it (default: previous).
   const currentConditionKey = conditionKey(typingTest.config, typingTest.language)
   const comparisonBaselineValue = comparisonBaselines?.[currentConditionKey] ?? DEFAULT_COMPARISON_BASELINE
-  const comparison = useMemo(
-    () => computeComparison(comparisonPool, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime),
-    [comparisonPool, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime],
-  )
+  // Scope: previous/best/average compare against THIS keyboard's same-condition
+  // history only; a pinned baseline can be any keyboard's result (cross-keyboard
+  // pool), so the picked result resolves from the full pool.
+  const comparison = useMemo(() => {
+    const pool = comparisonBaselineValue.kind === 'pinned' ? comparisonPool : (typingTestHistory ?? [])
+    return computeComparison(pool, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime)
+  }, [comparisonPool, typingTestHistory, typingTest.config, typingTest.language, comparisonBaselineValue, typingTest.state.startTime])
   // Same-condition results only — the choices for a pinned baseline. No
   // `beforeMs`: the user is pinning a past result, not measuring a live run.
   const sameConditionResults = useMemo(
@@ -245,6 +248,18 @@ export function TypingTestPane({
     (baseline: TypingTestComparisonBaseline) => onComparisonBaselineChange?.(currentConditionKey, baseline),
     [onComparisonBaselineChange, currentConditionKey],
   )
+  // "Compare With <target>" caption shown under the delta row, so the deltas
+  // aren't ambiguous about what they measure against. Null when no comparison
+  // is active (off / no matching history).
+  const comparisonLabel = useMemo(() => {
+    if (!comparison) return null
+    if (comparisonBaselineValue.kind === 'pinned') {
+      const pinned = comparisonPool.find((r) => r.date === comparisonBaselineValue.pinnedDate)
+      const target = pinned?.name || t('editor.typingTest.history.unnamed')
+      return t('editor.typingTest.compare.comparedWith', { target })
+    }
+    return t('editor.typingTest.compare.comparedWith', { target: t(`editor.typingTest.compare.${comparisonBaselineValue.kind}`) })
+  }, [comparison, comparisonBaselineValue, comparisonPool, t])
 
   const handleRecordToggle = useCallback(() => {
     if (!onRecordEnabledChange) return
@@ -669,6 +684,7 @@ export function TypingTestPane({
           hideStatsRow={hideStatsRow}
           hideControls={hideControls}
           comparison={comparison}
+          comparisonLabel={comparisonLabel}
           state={typingTest.state}
           wpm={typingTest.wpm}
           kpm={typingTest.kpm}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -270,12 +270,12 @@
       "compare": {
         "button": "Compare",
         "title": "Comparison",
-        "description": "Compare the Measurement values against past results matching the same condition (across all keyboards).",
         "previous": "Previous",
         "best": "Best",
         "average": "Average",
         "pinned": "Specific result",
         "off": "Off",
+        "comparedWith": "Compare With {{target}}",
         "noResults": "No results to pin yet",
         "colName": "Name",
         "colKeyboard": "Keyboard",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -270,12 +270,12 @@
       "compare": {
         "button": "比較",
         "title": "比較",
-        "description": "計測値を同じ条件の過去の結果と比較します（全キーボード横断）。",
         "previous": "前回",
         "best": "ベスト",
         "average": "平均",
         "pinned": "特定の結果",
         "off": "オフ",
+        "comparedWith": "{{target}}と比較",
         "noResults": "ピンできる結果がありません",
         "colName": "名前",
         "colKeyboard": "キーボード",

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -11,6 +11,7 @@ import { WpmSparkline } from './WpmSparkline'
 import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN } from '../components/editors/store-modal-shared'
 import { resultKpm, buildResultNameChips } from './result-builder'
 import { ResultNameModal } from './ResultNameModal'
+import { Tooltip } from '../components/ui/Tooltip'
 
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
 type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
@@ -290,16 +291,16 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
                   className="border-t border-edge/50 transition-colors hover:bg-surface-alt/50"
                 >
                   <NameCell result={r} onRename={onRename} deviceName={deviceName} />
-                  <td className="px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
-                  <td className="px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
-                  <td className="px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
-                  <td className="px-3 py-1.5 font-mono">{r.accuracy}%</td>
-                  <td className="px-3 py-1.5 text-content-muted">
+                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono">{r.accuracy}%</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
                     {isText
                       ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
                       : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`}
                   </td>
-                  <td className="px-3 py-1.5 font-mono text-content-muted">
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">
                     {formatDuration(r.durationSeconds)}
                   </td>
                   <td className="px-3 py-1.5">
@@ -420,22 +421,31 @@ function NameCell({ result, onRename, deviceName }: NameCellProps) {
   const [modalOpen, setModalOpen] = useState(false)
   const placeholder = t('editor.typingTest.history.unnamed')
 
+  const display = result.name || placeholder
+
   if (!onRename) {
-    return <td className="px-3 py-1.5 text-content-muted">{result.name || placeholder}</td>
+    return (
+      <td className="max-w-[14rem] px-3 py-1.5 text-content-muted">
+        <Tooltip content={display} wrapperClassName="block max-w-full">
+          <span className="block truncate">{display}</span>
+        </Tooltip>
+      </td>
+    )
   }
 
   return (
-    <td className="px-3 py-1.5">
-      <button
-        type="button"
-        onClick={() => setModalOpen(true)}
-        title={t('editor.typingTest.nameResult')}
-        className={`flex items-center gap-1.5 text-left transition-colors hover:text-content ${result.name ? 'text-content-secondary' : 'text-content-muted'}`}
-        data-testid={`history-name-${result.date}`}
-      >
-        <SquarePen size={ICON_SM} aria-hidden="true" />
-        <span className="truncate">{result.name || placeholder}</span>
-      </button>
+    <td className="max-w-[14rem] px-3 py-1.5">
+      <Tooltip content={display} wrapperClassName="block max-w-full">
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className={`flex w-full items-center gap-1.5 text-left transition-colors hover:text-content ${result.name ? 'text-content-secondary' : 'text-content-muted'}`}
+          data-testid={`history-name-${result.date}`}
+        >
+          <SquarePen size={ICON_SM} aria-hidden="true" className="shrink-0" />
+          <span className="min-w-0 truncate">{display}</span>
+        </button>
+      </Tooltip>
       {modalOpen && (
         <ResultNameModal
           initialName={result.name ?? ''}

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -28,6 +28,8 @@ interface Props {
   onRename?: (date: string, name: string) => void
   /** Delete a single result (keyed by ISO date). */
   onDelete?: (date: string) => void
+  /** Current keyboard name, offered as a quick-insert chip when renaming. */
+  deviceName?: string
 }
 
 const MAX_TABLE_ROWS = 20
@@ -86,7 +88,7 @@ function buildResultsCsv(results: TypingTestResult[]): string {
   )
 }
 
-export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: Props) {
+export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, deviceName }: Props) {
   const { t } = useTranslation()
   const [tab, setTab] = useState<HistoryTab>('monkeytype')
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
@@ -287,7 +289,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete }: 
                   key={r.date}
                   className="border-t border-edge/50 transition-colors hover:bg-surface-alt/50"
                 >
-                  <NameCell result={r} onRename={onRename} />
+                  <NameCell result={r} onRename={onRename} deviceName={deviceName} />
                   <td className="px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
                   <td className="px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
                   <td className="px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
@@ -407,12 +409,13 @@ function StatItem({ label, value, highlight }: StatItemProps) {
 interface NameCellProps {
   result: TypingTestResult
   onRename?: (date: string, name: string) => void
+  deviceName?: string
 }
 
 /** Result label cell. A button (edit icon + current name / "Unnamed") that
  *  opens the naming modal with quick-insert chips. Read-only when no rename
  *  handler is provided. */
-function NameCell({ result, onRename }: NameCellProps) {
+function NameCell({ result, onRename, deviceName }: NameCellProps) {
   const { t } = useTranslation()
   const [modalOpen, setModalOpen] = useState(false)
   const placeholder = t('editor.typingTest.history.unnamed')
@@ -436,7 +439,7 @@ function NameCell({ result, onRename }: NameCellProps) {
       {modalOpen && (
         <ResultNameModal
           initialName={result.name ?? ''}
-          chips={buildResultNameChips(result, t)}
+          chips={buildResultNameChips(result, t, deviceName)}
           onSave={(name) => onRename(result.date, name)}
           onClose={() => setModalOpen(false)}
         />

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -251,7 +251,7 @@ export function TypingTestView({
   )
 
   return (
-    <div data-testid="typing-test-view" className="flex flex-col items-center gap-4 px-4 py-4">
+    <div data-testid="typing-test-view" className="flex w-full min-w-0 flex-col items-center gap-4 px-4 py-4">
       {/* Word display — fixed window with scroll. Word-flow modes show a
           3-line window; imported custom text shows 4 lines (line-row layout). */}
       <div
@@ -407,28 +407,40 @@ export function TypingTestView({
         <div className="flex flex-wrap items-center justify-center gap-8 text-sm">
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.wpm')}:</span>
-            <span data-testid="typing-test-wpm" className="font-mono text-lg font-semibold text-accent">
+            <span data-testid="typing-test-wpm" className="font-mono text-lg font-semibold text-accent tabular-nums">
               {showStats ? wpm : '-'}
             </span>
-            {showStats && comparison && <ComparisonDelta current={wpm} baseline={comparison.wpm} testid="wpm" />}
+            {comparison && (
+              <span className="inline-flex min-w-12 justify-start">
+                {showStats && <ComparisonDelta current={wpm} baseline={comparison.wpm} testid="wpm" />}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.kpm')}:</span>
-            <span data-testid="typing-test-kpm" className="font-mono text-lg font-semibold text-accent">
+            <span data-testid="typing-test-kpm" className="font-mono text-lg font-semibold text-accent tabular-nums">
               {showStats ? kpm : '-'}
             </span>
-            {showStats && comparison && <ComparisonDelta current={kpm} baseline={comparison.kpm} testid="kpm" />}
+            {comparison && (
+              <span className="inline-flex min-w-12 justify-start">
+                {showStats && <ComparisonDelta current={kpm} baseline={comparison.kpm} testid="kpm" />}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.accuracy')}:</span>
-            <span data-testid="typing-test-accuracy" className="font-mono text-lg font-semibold">
+            <span data-testid="typing-test-accuracy" className="font-mono text-lg font-semibold tabular-nums">
               {showStats ? `${accuracy}%` : '-'}
             </span>
-            {showStats && comparison && <ComparisonDelta current={accuracy} baseline={comparison.accuracy} suffix="%" testid="accuracy" />}
+            {comparison && (
+              <span className="inline-flex min-w-12 justify-start">
+                {showStats && <ComparisonDelta current={accuracy} baseline={comparison.accuracy} suffix="%" testid="accuracy" />}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.time')}:</span>
-            <span data-testid="typing-test-time" className="font-mono text-lg font-semibold">
+            <span data-testid="typing-test-time" className="font-mono text-lg font-semibold tabular-nums">
               {showStats ? displayTime : '-'}
             </span>
           </div>
@@ -436,7 +448,7 @@ export function TypingTestView({
             {/* Imported custom text tracks character progress (spaces included);
                 everything else tracks words. */}
             <span className="text-content-muted">{t(isCustom ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
-            <span data-testid="typing-test-word-count" className="font-mono text-lg font-semibold">
+            <span data-testid="typing-test-word-count" className="font-mono text-lg font-semibold tabular-nums">
               {!showStats
                 ? '-'
                 : isCustom
@@ -453,7 +465,7 @@ export function TypingTestView({
             </span>
           )}
         </div>
-        {showStats && comparison && comparisonLabel && (
+        {comparison && comparisonLabel && (
           <p data-testid="typing-test-comparison-label" className="text-xs text-content-muted">
             {comparisonLabel}
           </p>

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -34,6 +34,9 @@ interface Props {
   /** Baseline metrics for the Measurement-row comparison delta, or null when
    *  comparison is off / no matching history. */
   comparison?: ComparisonStats | null
+  /** "Compare With <target>" caption describing what the deltas measure
+   *  against, or null when no comparison is active. */
+  comparisonLabel?: string | null
   onCompositionStart?: () => void
   onCompositionUpdate?: (data: string) => void
   onCompositionEnd?: (data: string) => void
@@ -104,6 +107,7 @@ export function TypingTestView({
   hideStatsRow,
   hideControls,
   comparison,
+  comparisonLabel,
   onCompositionStart,
   onCompositionUpdate,
   onCompositionEnd,
@@ -449,6 +453,11 @@ export function TypingTestView({
             </span>
           )}
         </div>
+        {showStats && comparison && comparisonLabel && (
+          <p data-testid="typing-test-comparison-label" className="text-xs text-content-muted">
+            {comparisonLabel}
+          </p>
+        )}
       </div>
       )}
 

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -291,6 +291,7 @@ describe('TypingTestHistory', () => {
   it('renders the name read-only (no edit) when no onRename handler', () => {
     renderWithI18n(<TypingTestHistory results={[makeResult({ date: 'x', name: 'kept' })]} />)
     expect(screen.queryByTestId('history-name-x')).toBeNull()
-    expect(screen.getByText('kept')).toBeTruthy()
+    // The name shows in the cell (and again in its hover tooltip bubble).
+    expect(screen.getAllByText('kept').length).toBeGreaterThan(0)
   })
 })

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -261,4 +261,9 @@ describe('buildResultNameChips', () => {
     const chips = buildResultNameChips({ ...base, mode: 'words', language: 'english' }, tStub)
     expect(chips[0]).toBe('words (english)')
   })
+  it('prepends the keyboard name when provided', () => {
+    const chips = buildResultNameChips({ ...base, mode: 'words', language: 'english' }, tStub, 'Ieneko54R')
+    expect(chips[0]).toBe('Ieneko54R')
+    expect(chips[1]).toBe('words (english)')
+  })
 })

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -50,12 +50,13 @@ function compactTimestamp(iso: string): string {
   return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`
 }
 
-/** Quick-insert chips for the result-name modal: material label, a compact
- *  timestamp, then the headline metrics. Each string is inserted verbatim.
- *  `t` translates the metric labels (WPM / KPM / Accuracy) so the chips honour
- *  the i18n locale. */
-export function buildResultNameChips(result: TypingTestResult, t: (key: string) => string): string[] {
+/** Quick-insert chips for the result-name modal: the keyboard name (when
+ *  known), the material label, a compact timestamp, then the headline metrics.
+ *  Each string is inserted verbatim. `t` translates the metric labels
+ *  (WPM / KPM / Accuracy) so the chips honour the i18n locale. */
+export function buildResultNameChips(result: TypingTestResult, t: (key: string) => string, deviceName?: string): string[] {
   const chips: string[] = []
+  if (deviceName) chips.push(deviceName)
   const label = typingTestResultMaterialLabel(result)
   if (label) chips.push(label)
   const ts = compactTimestamp(result.date)


### PR DESCRIPTION
Follow-up polish for the Measurement-row comparison feature (#207).

## Changes
- **Compare-with caption** under the Measurement deltas naming the baseline (previous / best / average / pinned result name); the Compare button now reflects on/off state.
- **Scoped baselines**: previous / best / average compare against this keyboard's same-condition history only; only a pinned result reaches across all keyboards. Removed the now-inaccurate modal description line.
- **Comparison modal**: wider, with a Name / Keyboard / Time / WPM table — Time/Keyboard/WPM shown in full, Name truncates.
- **Keyboard-name chip** in the result-naming modal (post-test field and History rename).
- **Stable reading window**: pinned the typing-test view to full width and reserved the delta slots + caption so starting a run no longer shifts the test text.
- **Name truncation + tooltip**: History Name column truncates (other columns stay full); History and Comparison name cells show the complete name in a shared hover/focus tooltip.

## Tests
Unit tests for `conditionKey`, the keyboard-name chip, and updated History/Comparison rendering. lint / tsc / full vitest suite / build all pass.