### PR TITLE
fix(ui): keep tooltip bubbles inside the viewport near screen edges

### DIFF
--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -48,12 +48,22 @@ const BUBBLE_BASE =
 
 const WRAPPER_BASE = 'relative inline-block'
 
-function computeBubblePosition(
+const VIEWPORT_MARGIN = 8
+
+function clampAxis(value: number, size: number, viewport: number, margin: number): number {
+  // When the bubble is wider/taller than the available space, pin it to the
+  // near edge rather than producing a negative max (which would flip the clamp).
+  const max = Math.max(margin, viewport - size - margin)
+  return Math.min(Math.max(value, margin), max)
+}
+
+export function computeBubblePosition(
   trigger: DOMRect,
   bubble: DOMRect,
   side: TooltipSide,
   align: TooltipAlign,
   offset: number,
+  viewport: { width: number; height: number },
 ): { top: number; left: number } {
   let top = 0
   let left = 0
@@ -75,7 +85,12 @@ function computeBubblePosition(
     else if (align === 'end') top = trigger.bottom - bubble.height
     else top = trigger.top + trigger.height / 2 - bubble.height / 2
   }
-  return { top, left }
+  // Keep the whole bubble inside the viewport so triggers near a screen edge
+  // (e.g. the collapsed layer-panel toggle) don't render a clipped tooltip.
+  return {
+    top: clampAxis(top, bubble.height, viewport.height, VIEWPORT_MARGIN),
+    left: clampAxis(left, bubble.width, viewport.width, VIEWPORT_MARGIN),
+  }
 }
 
 export function Tooltip({
@@ -117,6 +132,7 @@ export function Tooltip({
       side,
       align,
       Math.max(0, offset),
+      { width: window.innerWidth, height: window.innerHeight },
     ))
   }, [side, align, offset])
 

--- a/src/renderer/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/renderer/components/ui/__tests__/Tooltip.test.tsx
@@ -3,7 +3,12 @@
 
 import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import { Tooltip } from '../Tooltip'
+import { Tooltip, computeBubblePosition } from '../Tooltip'
+
+const rect = (x: number, y: number, width: number, height: number): DOMRect => ({
+  x, y, width, height, top: y, left: x, right: x + width, bottom: y + height,
+  toJSON: () => ({}),
+})
 
 describe('Tooltip', () => {
   it('renders tooltip bubble (portaled to body) with role="tooltip" and auto-generated id', () => {
@@ -217,6 +222,32 @@ describe('Tooltip', () => {
     const bubble = screen.getByRole('tooltip')
     expect(bubble.className).toContain('whitespace-pre-line')
     expect(bubble.textContent).toBe('first line\nsecond line')
+  })
+
+  describe('computeBubblePosition viewport clamping', () => {
+    const viewport = { width: 1000, height: 800 }
+
+    it('clamps a top/center bubble back inside the left edge for a near-edge trigger', () => {
+      // Trigger hugging the left edge: centered bubble would land at left = -80.
+      const { left } = computeBubblePosition(rect(10, 700, 20, 20), rect(0, 0, 200, 30), 'top', 'center', 8, viewport)
+      expect(left).toBe(8)
+    })
+
+    it('clamps against the right edge so a wide bubble stays fully visible', () => {
+      const { left } = computeBubblePosition(rect(960, 400, 20, 20), rect(0, 0, 200, 30), 'top', 'center', 8, viewport)
+      expect(left).toBe(viewport.width - 200 - 8)
+    })
+
+    it('clamps the top so a bubble above an edge trigger is not pushed off-screen', () => {
+      const { top } = computeBubblePosition(rect(500, 2, 20, 20), rect(0, 0, 100, 40), 'top', 'center', 8, viewport)
+      expect(top).toBe(8)
+    })
+
+    it('leaves a comfortably-placed bubble untouched', () => {
+      const { top, left } = computeBubblePosition(rect(490, 400, 20, 20), rect(0, 0, 100, 30), 'top', 'center', 8, viewport)
+      expect(left).toBe(450)
+      expect(top).toBe(362)
+    })
   })
 
   it('lets wrapperClassName override wrapperProps.className on the wrapper', () => {


### PR DESCRIPTION
## What

Tooltips on triggers near a screen edge — most visibly the collapsed layer-panel toggle at the bottom-left corner — rendered clipped off the viewport, so the label text was cut off.

## Why

`computeBubblePosition` placed the bubble purely from `side`/`align` and never clamped to the viewport. A `side='top' align='center'` tooltip on a left-edge trigger lands at a negative `left`, pushing half the bubble off-screen.

## How

- Add viewport clamping in the shared `computeBubblePosition` helper (8px margin) so every tooltip consumer benefits — no per-call-site special-casing.
- Clamp both axes; the cross-axis clamp is what slides the bubble back on-screen. The main-axis clamp is a benign fallback (bubble is `pointer-events-none`, never blocks interaction).
- Export `computeBubblePosition` and add 4 unit tests for the near-edge cases.

## Test

- `Tooltip.test.tsx`: 22 passed (4 new clamping tests)
- `pnpm lint` / `tsc --noEmit`: clean