### PR TITLE
fix(protocol): emit QMK function-macro form for LT/LM in C export

### DIFF
--- a/src/shared/keycodes/__tests__/keycodes.test.ts
+++ b/src/shared/keycodes/__tests__/keycodes.test.ts
@@ -1495,9 +1495,14 @@ describe('serializeForCExport', () => {
       kc = proto === 6 ? keycodesV6.kc : keycodesV5.kc
     })
 
-    it('LM keycodes return hex', () => {
-      const lmCode = kc.QK_LAYER_MOD | (0 << kc.QMK_LM_SHIFT) | kc.MOD_LSFT
-      expect(serializeForCExport(lmCode)).toMatch(/^0x[0-9a-f]+$/)
+    it('LM exports the QMK function-macro form LM(layer, mod), not the packed LM1(mod)', () => {
+      const lm0 = kc.QK_LAYER_MOD | (0 << kc.QMK_LM_SHIFT) | kc.MOD_LSFT
+      const lm2 = kc.QK_LAYER_MOD | (2 << kc.QMK_LM_SHIFT) | kc.MOD_LSFT
+      // keymap.c only defines LM(layer, mod); the packed LM1(...) form does not compile.
+      expect(serializeForCExport(lm0)).toBe('LM(0, MOD_LSFT)')
+      expect(serializeForCExport(lm2)).toBe('LM(2, MOD_LSFT)')
+      // display / .vil serialization keeps the packed form.
+      expect(serialize(lm0)).toBe('LM0(MOD_LSFT)')
     })
 
     it('vial-qmk undefined Modifier Mask keycodes return hex', () => {
@@ -1711,11 +1716,17 @@ describe('serializeForCExport', () => {
       expect(serializeForCExport(lsftBspace)).toBe('LSFT(KC_BSPC)')
     })
 
-    it('MO/TG/LT layer keycodes match serialize()', () => {
+    it('MO/TG layer keycodes match serialize()', () => {
       expect(serializeForCExport(kc['MO(1)'])).toBe(serialize(kc['MO(1)']))
       expect(serializeForCExport(kc['TG(2)'])).toBe(serialize(kc['TG(2)']))
+    })
+
+    it('LT exports the QMK function-macro form LT(layer, kc), not the packed LT1(kc)', () => {
       const lt1a = kc['LT1(kc)'] | kc.KC_A
-      expect(serializeForCExport(lt1a)).toBe(serialize(lt1a))
+      // keymap.c only defines LT(layer, kc); the packed LT1(...) form does not compile.
+      expect(serializeForCExport(lt1a)).toBe('LT(1, KC_A)')
+      // display / .vil serialization keeps the packed form.
+      expect(serialize(lt1a)).toBe('LT1(KC_A)')
     })
   })
 

--- a/src/shared/keycodes/keycodes-utils.ts
+++ b/src/shared/keycodes/keycodes-utils.ts
@@ -209,9 +209,21 @@ function cExportName(kc: Keycode): string {
   return kc.cExportId ?? kc.qmkId
 }
 
-export function serializeForCExport(code: number): string {
-  if (isLMKeycode(code)) return toHex(code)
+// The GUI packs the layer index into layer-tap / layer-mod ops (`LT1(kc)`,
+// `LM1(MOD_LSFT)`), but QMK keymap.c only defines the function-macro forms
+// `LT(layer, kc)` / `LM(layer, mod)` — the packed spelling does not compile.
+// Rewrite them to the QMK form on C export only; the display and `.vil`
+// serializers keep the packed form. The inner argument is a basic keycode or a
+// `MOD_*` constant, so it never contains parentheses.
+const C_EXPORT_LAYER_OP_RE = /^(LT|LM)(\d+)\((.+)\)$/
 
+function toQmkCExportForm(name: string): string {
+  const m = C_EXPORT_LAYER_OP_RE.exec(name)
+  if (m) return `${m[1]}(${m[2]}, ${m[3]})`
+  return name
+}
+
+export function serializeForCExport(code: number): string {
   const protocol = getProtocolValue()
   const masked = protocol === 6 ? keycodesV6.masked : keycodesV5.masked
 
@@ -222,7 +234,7 @@ export function serializeForCExport(code: number): string {
     }
   }
 
-  return serializeInternal(code, cExportName)
+  return toQmkCExportForm(serializeInternal(code, cExportName))
 }
 
 export function deserialize(val: string | number): number {


### PR DESCRIPTION
## Problem

The `keymap.c` export produced keycode spellings that do **not compile** against QMK:

- **LT (layer-tap)** exported as the GUI's packed form `LT1(KC_SPC)` — `LT1` is not a defined macro. Valid QMK is `LT(1, KC_SPC)`.
- **LM (layer-mod)** short-circuited to a raw hex literal (e.g. `0x5921`) — compiles, but opaque and not symbolic.

## Fix

Add a single post-process step in `serializeForCExport` that rewrites the packed layer ops to the QMK function-macro form:

| Family | Before | After |
|---|---|---|
| LT | `LT1(KC_SPC)` ❌ | `LT(1, KC_SPC)` ✅ |
| LM | `0x5921` (hex) | `LM(1, MOD_LSFT)` ✅ |

- Rewrites `LT<n>(kc)` → `LT(n, kc)` and `LM<n>(mod)` → `LM(n, mod)` at one choke point, covering both the dynamic (`RAWCODES_MAP`) and static (`maskedTemplates` fallback) serialization paths.
- Drops the `isLMKeycode → toHex` short-circuit so layer-mod keys export symbolically.
- **C-export only**: `serialize` / `.vil` keep the packed `LT1(...)` / `LM0(...)` form (display unchanged).
- MO/TO/TG/TT/DF/OSL/PDF (`MO(1)`), mod-tap (`LCTL_T(kc)`), OSM, TD, and the vial-qmk-undefined mod-masks (already hex) were verified to compile as-is and are left untouched.

## Verification

- QMK macro forms verified against vial-qmk: `LT(layer, kc)` and `LM(layer, mod)` (`#define LM(layer, mod) (QK_LAYER_MOD | (((layer)&0xF) << 5) | ((mod)&0x1F))`, `MOD_LSFT` accepted).
- `keycodes.test.ts`: new LT/LM C-export tests assert the function-macro form and that display/.vil keep the packed form.
- `pnpm lint` / `tsc --noEmit` / full `vitest` (4306 passed) / `pnpm build`: all clean.

Reported via the `.c` export of `LT1(KC_SPC)`.