### PR TITLE
feat(ui): add Save Unnamed toggle to typing test data settings

### DIFF
--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -96,6 +96,7 @@ function isValidPrefs(value: unknown): value is PipetteSettings {
   if ('typingTestHideKeymap' in obj && obj.typingTestHideKeymap != null && typeof obj.typingTestHideKeymap !== 'boolean') return false
   if ('typingTestHideStatsRow' in obj && obj.typingTestHideStatsRow != null && typeof obj.typingTestHideStatsRow !== 'boolean') return false
   if ('typingTestHideControls' in obj && obj.typingTestHideControls != null && typeof obj.typingTestHideControls !== 'boolean') return false
+  if ('typingTestSaveUnnamed' in obj && obj.typingTestSaveUnnamed != null && typeof obj.typingTestSaveUnnamed !== 'boolean') return false
   if ('typingTestComparisonBaselines' in obj && obj.typingTestComparisonBaselines != null && !isTypingTestComparisonBaselines(obj.typingTestComparisonBaselines)) return false
   if ('typingTestSettingsPanelOpen' in obj && obj.typingTestSettingsPanelOpen != null && typeof obj.typingTestSettingsPanelOpen !== 'boolean') return false
   if ('typingRecordEnabled' in obj && obj.typingRecordEnabled != null && typeof obj.typingRecordEnabled !== 'boolean') return false
@@ -151,6 +152,7 @@ async function readData(uid: string): Promise<PipetteSettings | null> {
       typingTestHideKeymap: parsed.typingTestHideKeymap,
       typingTestHideStatsRow: parsed.typingTestHideStatsRow,
       typingTestHideControls: parsed.typingTestHideControls,
+      typingTestSaveUnnamed: parsed.typingTestSaveUnnamed,
       typingTestComparisonBaselines: parsed.typingTestComparisonBaselines,
       typingTestSettingsPanelOpen: parsed.typingTestSettingsPanelOpen,
       typingRecordEnabled: parsed.typingRecordEnabled,

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -869,10 +869,12 @@ export function App() {
             typingTestHideKeymap={devicePrefs.typingTestHideKeymap}
             typingTestHideStatsRow={devicePrefs.typingTestHideStatsRow}
             typingTestHideControls={devicePrefs.typingTestHideControls}
+            typingTestSaveUnnamed={devicePrefs.typingTestSaveUnnamed}
             typingTestComparisonBaselines={devicePrefs.typingTestComparisonBaselines}
             onTypingTestHideKeymapChange={devicePrefs.setTypingTestHideKeymap}
             onTypingTestHideStatsRowChange={devicePrefs.setTypingTestHideStatsRow}
             onTypingTestHideControlsChange={devicePrefs.setTypingTestHideControls}
+            onTypingTestSaveUnnamedChange={devicePrefs.setTypingTestSaveUnnamed}
             onTypingTestComparisonBaselineChange={devicePrefs.setTypingTestComparisonBaseline}
             typingTestSettingsPanelOpen={devicePrefs.typingTestSettingsPanelOpen}
             onTypingTestSettingsPanelOpenChange={devicePrefs.setTypingTestSettingsPanelOpen}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -114,7 +114,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
   typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
   typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
-  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestComparisonBaselines, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestComparisonBaselineChange,
+  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestSaveUnnamed = true, typingTestComparisonBaselines, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestSaveUnnamedChange, onTypingTestComparisonBaselineChange,
   typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
   typingRecordEnabled, onTypingRecordEnabledChange,
   typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
@@ -166,11 +166,12 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     matrixMode, pressedKeys, everPressedKeys, hasMatrixTester,
     handleMatrixToggle, handleTypingTestToggle,
     typingTest, handleTypingTestConfigChange, handleTypingTestLanguageChange,
+    finishedResult, nameFinishedResult,
     pauseTypingTest, resumeTypingTest, restartTypingTestFromStart,
   } = useInputModes({
     rows, cols, getMatrixState, unlocked, onUnlock, onMatrixModeChange, keymap,
     typingTestMode, onTypingTestModeChange, savedTypingTestConfig, savedTypingTestLanguage,
-    onTypingTestConfigChange, onTypingTestLanguageChange, onSaveTypingTestResult, typingTestHistory,
+    onTypingTestConfigChange, onTypingTestLanguageChange, onSaveTypingTestResult, onRenameTypingTestResult, saveUnnamed: typingTestSaveUnnamed, typingTestHistory,
     savedTypingTestMemory, onTypingTestMemoryChange,
     typingTestViewOnly, typingRecordEnabled,
     typingRecordKeyboard: keyboardUid && connectedDevice
@@ -966,10 +967,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               hideKeymap={typingTestHideKeymap}
               hideStatsRow={typingTestHideStatsRow}
               hideControls={typingTestHideControls}
+              saveUnnamed={typingTestSaveUnnamed}
+              finishedResult={finishedResult}
+              onNameFinishedResult={nameFinishedResult}
               comparisonBaselines={typingTestComparisonBaselines}
               onToggleHideKeymap={onTypingTestHideKeymapChange}
               onToggleHideStatsRow={onTypingTestHideStatsRowChange}
               onToggleHideControls={onTypingTestHideControlsChange}
+              onToggleSaveUnnamed={onTypingTestSaveUnnamedChange}
               onComparisonBaselineChange={onTypingTestComparisonBaselineChange}
               settingsPanelOpen={typingTestSettingsPanelOpen}
               onToggleSettingsPanel={onTypingTestSettingsPanelOpenChange}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -81,6 +81,14 @@ export interface TypingTestPaneProps {
   onToggleHideKeymap?: (hidden: boolean) => void
   onToggleHideStatsRow?: (hidden: boolean) => void
   onToggleHideControls?: (hidden: boolean) => void
+  /** Auto-save finished results without a name (default true). Drives only the
+   *  toggle button — the save/name behavior lives in `useInputModes`. */
+  saveUnnamed?: boolean
+  onToggleSaveUnnamed?: (enabled: boolean) => void
+  /** The just-finished result (held unsaved or saved latest), for name chips. */
+  finishedResult?: TypingTestResult | null
+  /** Name the just-finished result (save under name when held, else rename). */
+  onNameFinishedResult?: (name: string) => void
   /** Per-condition Measurement-row comparison baselines (persisted per
    *  keyboard, synced). Keyed by condition; the current condition's baseline
    *  is looked up and applied. */
@@ -168,6 +176,10 @@ export function TypingTestPane({
   onToggleHideKeymap,
   onToggleHideStatsRow,
   onToggleHideControls,
+  saveUnnamed = true,
+  onToggleSaveUnnamed,
+  finishedResult,
+  onNameFinishedResult,
   comparisonBaselines,
   onComparisonBaselineChange,
   settingsPanelOpen = true,
@@ -595,6 +607,19 @@ export function TypingTestPane({
           baseline={comparisonBaselineValue}
           onChange={handleComparisonChange}
         />
+        {/* Save Unnamed — when on (default), a finished result is auto-saved
+            even without a name; when off, only named results are kept. */}
+        <button
+          type="button"
+          data-testid="typing-test-toggle-save-unnamed"
+          aria-pressed={saveUnnamed}
+          title={t(saveUnnamed ? 'editor.typingTest.disableSaveUnnamed' : 'editor.typingTest.enableSaveUnnamed')}
+          aria-label={t(saveUnnamed ? 'editor.typingTest.disableSaveUnnamed' : 'editor.typingTest.enableSaveUnnamed')}
+          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${saveUnnamed ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
+          onClick={() => onToggleSaveUnnamed?.(!saveUnnamed)}
+        >
+          {t('editor.typingTest.saveUnnamedToggle')}
+        </button>
       </PanelSection>
 
       {/* Show — toggles ordered top-to-bottom to match the editor layout:
@@ -699,13 +724,9 @@ export function TypingTestPane({
           onImeSpaceKey={() => typingTest.processKeyEvent(' ', false, false, false)}
           displayLines={displayLines}
           fontSize={fontSize}
-          onNameResult={(name) => {
-            // The auto-save prepends the finished result, so history[0] is it.
-            const date = typingTestHistory?.[0]?.date
-            if (date) onRenameTypingTestResult?.(date, name)
-          }}
-          // Chips come from the just-finished result (history[0]).
-          resultNameChips={typingTestHistory?.[0] ? buildResultNameChips(typingTestHistory[0], t, deviceName) : []}
+          onNameResult={onNameFinishedResult}
+          // Chips come from the just-finished result (held unsaved or saved).
+          resultNameChips={finishedResult ? buildResultNameChips(finishedResult, t, deviceName) : []}
           onStart={() => typingTest.restart()}
           onPause={() => onPauseTest?.()}
           onResume={() => setShowResumeModal(true)}

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -145,10 +145,12 @@ export interface KeymapEditorProps {
   typingTestHideKeymap?: boolean
   typingTestHideStatsRow?: boolean
   typingTestHideControls?: boolean
+  typingTestSaveUnnamed?: boolean
   typingTestComparisonBaselines?: TypingTestComparisonBaselines
   onTypingTestHideKeymapChange?: (hidden: boolean) => void
   onTypingTestHideStatsRowChange?: (hidden: boolean) => void
   onTypingTestHideControlsChange?: (hidden: boolean) => void
+  onTypingTestSaveUnnamedChange?: (enabled: boolean) => void
   onTypingTestComparisonBaselineChange?: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
   typingTestSettingsPanelOpen?: boolean
   onTypingTestSettingsPanelOpenChange?: (open: boolean) => void

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -38,6 +38,13 @@ export interface UseInputModesOptions {
   onTypingTestConfigChange?: (config: TypingTestConfig) => void
   onTypingTestLanguageChange?: (lang: string) => void
   onSaveTypingTestResult?: (result: TypingTestResult) => void
+  /** Label the latest saved result by its ISO date — used to name a finished
+   *  result when save-unnamed is on (the result is already in History). */
+  onRenameTypingTestResult?: (date: string, name: string) => void
+  /** When true (default), a finished result is auto-saved immediately, even
+   *  without a name. When false, the result is held unsaved until the user
+   *  names it (via `nameFinishedResult`); leaving it unnamed discards it. */
+  saveUnnamed?: boolean
   /** Persisted paused-test snapshot for the active keyboard (memory mode). */
   savedTypingTestMemory?: TypingTestMemory
   /** Persist or clear the paused-test snapshot. */
@@ -62,6 +69,12 @@ export interface UseInputModesReturn {
   typingTest: ReturnType<typeof useTypingTest>
   handleTypingTestConfigChange: (config: TypingTestConfig) => void
   handleTypingTestLanguageChange: (lang: string) => Promise<void>
+  /** The just-finished result — the held unsaved one when save-unnamed is off,
+   *  else the saved latest; null until a test finishes. For result-name chips. */
+  finishedResult: TypingTestResult | null
+  /** Name the just-finished result: persists a held unsaved result under the
+   *  name (save-unnamed off; blank → discarded) or renames the saved latest. */
+  nameFinishedResult: (name: string) => void
   /** Memory mode (imported custom text). */
   savedTypingTestMemory?: TypingTestMemory
   pauseTypingTest: () => void
@@ -84,6 +97,8 @@ export function useInputModes({
   onTypingTestConfigChange,
   onTypingTestLanguageChange,
   onSaveTypingTestResult,
+  onRenameTypingTestResult,
+  saveUnnamed = true,
   savedTypingTestMemory,
   onTypingTestMemoryChange,
   typingTestHistory,
@@ -345,8 +360,12 @@ export function useInputModes({
     return () => document.removeEventListener('keydown', handler, true)
   }, [typingTestMode, typingTestViewOnly, processKeyEvent])
 
-  // Auto-save typing test result when test finishes
+  // Auto-save typing test result when test finishes. With save-unnamed on
+  // (default) the result is persisted immediately; with it off the built
+  // result is held in `pendingUnnamedResult` and only saved once the user
+  // names it (commitPendingResult), so an unnamed run is discarded.
   const savedResultRef = useRef(false)
+  const [pendingUnnamedResult, setPendingUnnamedResult] = useState<TypingTestResult | null>(null)
   useEffect(() => {
     if (typingTestViewOnly) return
     if (typingTest.state.status === 'finished' && !savedResultRef.current && onSaveTypingTestResult) {
@@ -368,10 +387,15 @@ export function useInputModes({
         runId: typingTest.state.runId,
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
-      onSaveTypingTestResult(result)
+      if (saveUnnamed) {
+        onSaveTypingTestResult(result)
+      } else {
+        setPendingUnnamedResult(result)
+      }
       // Flush the test's analytics so the just-finished minute/session
       // lands in the cache promptly (Analyze can show it without waiting
-      // for the minute-close / before-quit flush).
+      // for the minute-close / before-quit flush). Keystrokes are recorded
+      // regardless of whether the result row is saved.
       const uid = keyboardRef.current?.uid
       if (uid) window.vialAPI.typingAnalyticsFlush(uid).catch(() => { /* fire-and-forget */ })
       // A completed test makes any saved pause snapshot obsolete.
@@ -379,6 +403,9 @@ export function useInputModes({
     }
     if (typingTest.state.status !== 'finished') {
       savedResultRef.current = false
+      // Leaving the finished state (next test / restart) drops an unsaved,
+      // still-unnamed result.
+      if (pendingUnnamedResult) setPendingUnnamedResult(null)
     }
   }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
     typingTest.state.correctChars, typingTest.state.incorrectChars,
@@ -386,7 +413,28 @@ export function useInputModes({
     typingTest.state.currentQuote, typingTest.state.runId,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
-    typingTestHistory, onSaveTypingTestResult])
+    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult])
+
+  // The just-finished result, exposed so the pane can build name chips: the
+  // held unsaved one (save-unnamed off) until named, else the saved latest.
+  const finishedResult = typingTest.state.status === 'finished'
+    ? (pendingUnnamedResult ?? typingTestHistory?.[0] ?? null)
+    : null
+
+  // Name the just-finished result. A held unsaved result (save-unnamed off) is
+  // persisted under the name — blank keeps it discarded; otherwise the already
+  // saved latest result is renamed (save-unnamed on; blank clears its name).
+  const nameFinishedResult = useCallback((name: string) => {
+    if (pendingUnnamedResult) {
+      const trimmed = name.trim()
+      if (!trimmed) return
+      onSaveTypingTestResult?.({ ...pendingUnnamedResult, name: trimmed })
+      setPendingUnnamedResult(null)
+      return
+    }
+    const date = typingTestHistory?.[0]?.date
+    if (date) onRenameTypingTestResult?.(date, name)
+  }, [pendingUnnamedResult, onSaveTypingTestResult, onRenameTypingTestResult, typingTestHistory])
 
   // Sync saved config/language from device prefs into useTypingTest
   useEffect(() => {
@@ -474,6 +522,8 @@ export function useInputModes({
     typingTest,
     handleTypingTestConfigChange,
     handleTypingTestLanguageChange,
+    finishedResult,
+    nameFinishedResult,
     savedTypingTestMemory,
     pauseTypingTest,
     resumeTypingTest,

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -117,6 +117,7 @@ interface ValidatedPrefs {
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
   typingTestHideControls: boolean
+  typingTestSaveUnnamed: boolean
   typingTestComparisonBaselines: TypingTestComparisonBaselines
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
@@ -126,7 +127,7 @@ interface ValidatedPrefs {
 }
 
 function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestComparisonBaselines?: unknown; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestNormalConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestSaveUnnamed?: boolean; typingTestComparisonBaselines?: unknown; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown } | null,
   defaultLayout: KeyboardLayoutId,
   defaultAutoAdvance: boolean,
   defaultLayerPanelOpen: boolean,
@@ -205,6 +206,8 @@ function validateIpcPrefs(
     typingTestHideKeymap: data.typingTestHideKeymap === true,
     typingTestHideStatsRow: data.typingTestHideStatsRow === true,
     typingTestHideControls: data.typingTestHideControls === true,
+    // Default true: a finished result is auto-saved unless the user opts out.
+    typingTestSaveUnnamed: data.typingTestSaveUnnamed !== false,
     typingTestComparisonBaselines: isTypingTestComparisonBaselines(data.typingTestComparisonBaselines) ? data.typingTestComparisonBaselines : {},
     typingTestSettingsPanelOpen: typeof data.typingTestSettingsPanelOpen === 'boolean' ? data.typingTestSettingsPanelOpen : true,
     typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
@@ -244,6 +247,7 @@ export interface UseDevicePrefsReturn {
   typingTestHideKeymap: boolean
   typingTestHideStatsRow: boolean
   typingTestHideControls: boolean
+  typingTestSaveUnnamed: boolean
   typingTestComparisonBaselines: TypingTestComparisonBaselines
   typingTestSettingsPanelOpen: boolean
   typingRecordEnabled: boolean
@@ -272,6 +276,7 @@ export interface UseDevicePrefsReturn {
   setTypingTestHideKeymap: (hidden: boolean) => void
   setTypingTestHideStatsRow: (hidden: boolean) => void
   setTypingTestHideControls: (hidden: boolean) => void
+  setTypingTestSaveUnnamed: (enabled: boolean) => void
   setTypingTestComparisonBaseline: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
   setTypingTestSettingsPanelOpen: (open: boolean) => void
   setTypingRecordEnabled: (enabled: boolean) => void
@@ -347,6 +352,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
   const [typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef] = useStateRef<boolean>(false)
   const [typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef] = useStateRef<boolean>(false)
   const [typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef] = useStateRef<boolean>(false)
+  const [typingTestSaveUnnamed, updateTypingTestSaveUnnamed, typingTestSaveUnnamedRef] = useStateRef<boolean>(true)
   const [typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef] = useStateRef<TypingTestComparisonBaselines>({})
   const [typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef] = useStateRef<boolean>(true)
   const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
@@ -388,6 +394,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestHideKeymap: typingTestHideKeymapRef.current,
       typingTestHideStatsRow: typingTestHideStatsRowRef.current,
       typingTestHideControls: typingTestHideControlsRef.current,
+      typingTestSaveUnnamed: typingTestSaveUnnamedRef.current,
       typingTestComparisonBaselines: typingTestComparisonBaselinesRef.current,
       typingTestSettingsPanelOpen: typingTestSettingsPanelOpenRef.current,
       typingRecordEnabled: typingRecordEnabledRef.current,
@@ -543,6 +550,12 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestHideControls])
 
+  const setTypingTestSaveUnnamed = useCallback((enabled: boolean) => {
+    if (typingTestSaveUnnamedRef.current === enabled) return
+    updateTypingTestSaveUnnamed(enabled)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestSaveUnnamed])
+
   const setTypingTestComparisonBaseline = useCallback((conditionKey: string, baseline: TypingTestComparisonBaseline) => {
     updateTypingTestComparisonBaselines({ ...typingTestComparisonBaselinesRef.current, [conditionKey]: baseline })
     saveCurrentPrefs()
@@ -639,6 +652,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingTestHideKeymap: false,
       typingTestHideStatsRow: false,
       typingTestHideControls: false,
+      typingTestSaveUnnamed: true,
       typingTestComparisonBaselines: {},
       typingTestSettingsPanelOpen: true,
       typingRecordEnabled: false,
@@ -666,6 +680,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateTypingTestHideKeymap(resolved.typingTestHideKeymap)
     updateTypingTestHideStatsRow(resolved.typingTestHideStatsRow)
     updateTypingTestHideControls(resolved.typingTestHideControls)
+    updateTypingTestSaveUnnamed(resolved.typingTestSaveUnnamed)
     updateTypingTestComparisonBaselines(resolved.typingTestComparisonBaselines)
     updateTypingTestSettingsPanelOpen(resolved.typingTestSettingsPanelOpen)
     updateTypingRecordEnabled(resolved.typingRecordEnabled)
@@ -730,6 +745,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     typingTestHideKeymap,
     typingTestHideStatsRow,
     typingTestHideControls,
+    typingTestSaveUnnamed,
     typingTestComparisonBaselines,
     typingTestSettingsPanelOpen,
     typingRecordEnabled,
@@ -759,6 +775,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     setTypingTestHideKeymap,
     setTypingTestHideStatsRow,
     setTypingTestHideControls,
+    setTypingTestSaveUnnamed,
     setTypingTestComparisonBaseline,
     setTypingTestSettingsPanelOpen,
     setTypingRecordEnabled,

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -262,6 +262,9 @@
       "showStats": "Show measurement",
       "hideControls": "Hide operation",
       "showControls": "Show operation",
+      "saveUnnamedToggle": "Save Unnamed",
+      "enableSaveUnnamed": "Auto-save results without a name",
+      "disableSaveUnnamed": "Require a name to save results",
       "section": {
         "settings": "Settings",
         "data": "Data",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -262,6 +262,9 @@
       "showStats": "計測を表示",
       "hideControls": "操作を隠す",
       "showControls": "操作を表示",
+      "saveUnnamedToggle": "名称未設定も保存",
+      "enableSaveUnnamed": "名前なしでも結果を保存",
+      "disableSaveUnnamed": "保存には名前を必須にする",
       "section": {
         "settings": "設定",
         "data": "データ",

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -216,6 +216,11 @@ export interface PipetteSettings {
   /** Editor typing-test: hide the operation (Next Test button) controls row.
    *  Default false. Force-shown once a test finishes. */
   typingTestHideControls?: boolean
+  /** Editor typing-test: auto-save finished results even without a name.
+   *  Default true (every result is saved, the user may name it after).
+   *  When false a finished result is held unsaved until the user gives it a
+   *  name — leaving it unnamed discards it. */
+  typingTestSaveUnnamed?: boolean
   /** Editor typing-test: Measurement-row comparison baseline per condition
    *  key. Unset conditions default to `{ kind: 'previous' }`. */
   typingTestComparisonBaselines?: TypingTestComparisonBaselines


### PR DESCRIPTION
## Summary

Adds a per-keyboard **Save Unnamed** toggle (default **on**) to the Typing Test **Data** settings panel.

- **On (default, unchanged behavior):** a finished result is auto-saved immediately; the user may name it afterward.
- **Off:** the finished result is held unsaved until the user gives it a non-blank name. Leaving it unnamed and starting the next test discards it.

## Changes

- New `typingTestSaveUnnamed?: boolean` (default true) persisted in `PipetteSettings`, threaded through the store / `useDevicePrefs` / `App` / `KeymapEditor` / `TypingTestPane` following the existing `typingTestHideControls` pattern.
- `useInputModes` now owns the save/name behavior: a held `pendingUnnamedResult` plus a unified `finishedResult` selector and `nameFinishedResult` handler, so both save modes flow through one path (no per-call-site branching in the pane).
- New `Save Unnamed` toggle button in the Data section; i18n keys added to both `english.json` and `japanese.json`.

## Test plan

- `npx tsc --noEmit` — clean
- `npx eslint` (changed files) — clean
- `pnpm test` — 2067 passed
- `pnpm run build` — success