### PR TITLE
feat(ui): switch typing-test View/Data toggles to switch rows

### DIFF
--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -21,7 +21,7 @@ interface Props {
 const MAX_PINNABLE = 100
 
 function toggleClass(active: boolean): string {
-  const base = 'inline-flex h-8 items-center rounded-md border px-3 text-sm transition-colors'
+  const base = 'flex h-8 w-full items-center justify-center rounded-md border px-3 text-sm transition-colors'
   if (active) return `${base} border-accent bg-accent/10 text-accent`
   return `${base} border-edge text-content-secondary hover:text-content`
 }
@@ -67,7 +67,7 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
         type="button"
         data-testid="typing-test-comparison-toggle"
         // Accent-highlight whenever comparison is active (any baseline but
-        // 'off'), mirroring the Show toggles, so the button reflects on/off
+        // 'off'), mirroring the View toggles, so the button reflects on/off
         // state rather than just whether the modal is open.
         className={toggleClass(baseline.kind !== 'off')}
         aria-pressed={baseline.kind !== 'off'}

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -8,7 +8,7 @@ import { ModalCloseButton } from './ModalCloseButton'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 
 function historyToggleClass(active: boolean): string {
-  const base = 'inline-flex h-8 items-center rounded-md border px-3 text-sm transition-colors'
+  const base = 'flex h-8 w-full items-center justify-center rounded-md border px-3 text-sm transition-colors'
   if (active) return `${base} border-accent bg-accent/10 text-accent`
   return `${base} border-edge text-content-secondary hover:text-content`
 }

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -7,11 +7,10 @@ import { TypingTestHistory } from '../../typing-test/TypingTestHistory'
 import { ModalCloseButton } from './ModalCloseButton'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 
-function historyToggleClass(active: boolean): string {
-  const base = 'flex h-8 w-full items-center justify-center rounded-md border px-3 text-sm transition-colors'
-  if (active) return `${base} border-accent bg-accent/10 text-accent`
-  return `${base} border-edge text-content-secondary hover:text-content`
-}
+// History opens a modal — it is a dialog trigger, not a stateful toggle, so the
+// button keeps a single static style whether the modal is open or closed.
+const HISTORY_BUTTON_CLASS =
+  'flex h-8 w-full items-center justify-center rounded-md border border-edge px-3 text-sm text-content-secondary transition-colors hover:text-content'
 
 interface HistoryToggleProps {
   results: TypingTestResult[]
@@ -37,9 +36,10 @@ export function HistoryToggle({ results, deviceName, onRename, onDelete }: Histo
       <button
         type="button"
         data-testid="typing-test-history-toggle"
-        className={historyToggleClass(showHistory)}
+        className={HISTORY_BUTTON_CLASS}
         onClick={() => setShowHistory((v) => !v)}
-        aria-pressed={showHistory}
+        aria-haspopup="dialog"
+        aria-expanded={showHistory}
       >
         {t('editor.typingTest.history.title')}
       </button>

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -39,8 +39,40 @@ function PanelSection({ title, children }: { title: string; children: ReactNode 
     </section>
   )
 }
+
+// Full-width switch row: label on the left, a track/knob toggle on the right —
+// reused by the View visibility toggles and the Data "Save Unnamed" setting.
+// The accessible name is the fixed label; `title` carries the state-dependent
+// show/hide hint for the hover tooltip (the on/off state is read from
+// `aria-checked`, so it must not be baked into the accessible name).
+function ToggleRow({ label, on, onToggle, title, testid }: {
+  label: string
+  on: boolean
+  onToggle: () => void
+  title: string
+  testid: string
+}) {
+  return (
+    <div className={`${ROW_CLASS} w-full`} data-testid={`${testid}-row`}>
+      <span className="min-w-0 truncate text-sm font-medium text-content">{label}</span>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        aria-label={label}
+        title={title}
+        className={`${toggleTrackClass(on)} shrink-0`}
+        onClick={onToggle}
+        data-testid={testid}
+      >
+        <span className={toggleKnobClass(on)} />
+      </button>
+    </div>
+  )
+}
 import type { useTypingTest } from '../../typing-test/useTypingTest'
 import { BTN_TOGGLE_ACTIVE, BTN_TOGGLE_INACTIVE } from '../../constants/ui-tokens'
+import { ROW_CLASS, toggleTrackClass, toggleKnobClass } from './modal-controls'
 import type { AnalyticsOrigin } from './keymap-editor-types'
 import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 
@@ -609,56 +641,40 @@ export function TypingTestPane({
         />
         {/* Save Unnamed — when on (default), a finished result is auto-saved
             even without a name; when off, only named results are kept. */}
-        <button
-          type="button"
-          data-testid="typing-test-toggle-save-unnamed"
-          aria-pressed={saveUnnamed}
+        <ToggleRow
+          testid="typing-test-toggle-save-unnamed"
+          label={t('editor.typingTest.saveUnnamedToggle')}
+          on={saveUnnamed}
+          onToggle={() => onToggleSaveUnnamed?.(!saveUnnamed)}
           title={t(saveUnnamed ? 'editor.typingTest.disableSaveUnnamed' : 'editor.typingTest.enableSaveUnnamed')}
-          aria-label={t(saveUnnamed ? 'editor.typingTest.disableSaveUnnamed' : 'editor.typingTest.enableSaveUnnamed')}
-          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${saveUnnamed ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
-          onClick={() => onToggleSaveUnnamed?.(!saveUnnamed)}
-        >
-          {t('editor.typingTest.saveUnnamedToggle')}
-        </button>
+        />
       </PanelSection>
 
-      {/* Show — toggles ordered top-to-bottom to match the editor layout:
+      {/* View — toggles ordered top-to-bottom to match the editor layout:
           operation (controls row) → measurement (stats row) → keymap pane.
-          Accent highlight marks the visible (active) state. */}
-      <PanelSection title={t('editor.typingTest.section.show')}>
-        <button
-          type="button"
-          data-testid="typing-test-toggle-controls"
-          aria-pressed={!hideControls}
+          The switch is on when the section is visible. */}
+      <PanelSection title={t('editor.typingTest.section.view')}>
+        <ToggleRow
+          testid="typing-test-toggle-controls"
+          label={t('editor.typingTest.controlsToggle')}
+          on={!hideControls}
+          onToggle={() => onToggleHideControls?.(!hideControls)}
           title={t(hideControls ? 'editor.typingTest.showControls' : 'editor.typingTest.hideControls')}
-          aria-label={t(hideControls ? 'editor.typingTest.showControls' : 'editor.typingTest.hideControls')}
-          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideControls ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
-          onClick={() => onToggleHideControls?.(!hideControls)}
-        >
-          {t('editor.typingTest.controlsToggle')}
-        </button>
-        <button
-          type="button"
-          data-testid="typing-test-toggle-stats"
-          aria-pressed={!hideStatsRow}
+        />
+        <ToggleRow
+          testid="typing-test-toggle-stats"
+          label={t('editor.typingTest.statsToggle')}
+          on={!hideStatsRow}
+          onToggle={() => onToggleHideStatsRow?.(!hideStatsRow)}
           title={t(hideStatsRow ? 'editor.typingTest.showStats' : 'editor.typingTest.hideStats')}
-          aria-label={t(hideStatsRow ? 'editor.typingTest.showStats' : 'editor.typingTest.hideStats')}
-          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideStatsRow ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
-          onClick={() => onToggleHideStatsRow?.(!hideStatsRow)}
-        >
-          {t('editor.typingTest.statsToggle')}
-        </button>
-        <button
-          type="button"
-          data-testid="typing-test-toggle-keymap"
-          aria-pressed={!hideKeymap}
+        />
+        <ToggleRow
+          testid="typing-test-toggle-keymap"
+          label={t('editor.typingTest.keymapToggle')}
+          on={!hideKeymap}
+          onToggle={() => onToggleHideKeymap?.(!hideKeymap)}
           title={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
-          aria-label={t(hideKeymap ? 'editor.typingTest.showKeymap' : 'editor.typingTest.hideKeymap')}
-          className={`flex h-8 items-center rounded-md border px-2.5 text-sm transition-colors ${!hideKeymap ? 'border-accent bg-accent/10 text-accent' : 'border-edge text-content-secondary hover:text-content'}`}
-          onClick={() => onToggleHideKeymap?.(!hideKeymap)}
-        >
-          {t('editor.typingTest.keymapToggle')}
-        </button>
+        />
       </PanelSection>
       </div>
       )}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -268,7 +268,7 @@
       "section": {
         "settings": "Settings",
         "data": "Data",
-        "show": "Show"
+        "view": "View"
       },
       "compare": {
         "button": "Compare",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -268,7 +268,7 @@
       "section": {
         "settings": "設定",
         "data": "データ",
-        "show": "表示"
+        "view": "表示"
       },
       "compare": {
         "button": "比較",


### PR DESCRIPTION
## Summary
- Convert the typing-test config sidebar's on/off settings (Operation, Measurement, Keymap visibility and Save Unnamed) from bordered buttons to full-width label+switch rows using the shared `ROW_CLASS`/`toggleTrackClass` helpers.
- Stretch the History and Compare buttons to full width so the sidebar controls line up.
- Rename the **Show** section to **View** (i18n key `section.show` → `section.view`).
- Keep the History button static while its modal is open (it is a dialog trigger, not a stateful toggle); expose `aria-haspopup`/`aria-expanded` instead of `aria-pressed`.

## Notes
- Toggle switch accessible name is the fixed label; the show/hide hint moves to the `title` tooltip so screen readers read state from `aria-checked`.

## Test plan
- [x] lint / build / 4306 tests pass