### PR TITLE
fix(ui): show comparison baseline as text and drop the Compare With caption

### DIFF
--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -20,11 +20,11 @@ interface Props {
 
 const MAX_PINNABLE = 100
 
-function toggleClass(active: boolean): string {
-  const base = 'flex h-8 w-full items-center justify-center rounded-md border px-3 text-sm transition-colors'
-  if (active) return `${base} border-accent bg-accent/10 text-accent`
-  return `${base} border-edge text-content-secondary hover:text-content`
-}
+// Compare opens a modal — a dialog trigger, not a stateful toggle — so it keeps
+// a single static style; the active baseline is conveyed by the button text
+// ("Compare - <baseline>") rather than an accent highlight.
+const COMPARE_BUTTON_CLASS =
+  'flex h-8 w-full items-center justify-center rounded-md border border-edge px-3 text-sm text-content-secondary transition-colors hover:text-content'
 
 export function ComparisonToggle({ pool, baseline, onChange }: Props) {
   const { t } = useTranslation()
@@ -66,14 +66,12 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
       <button
         type="button"
         data-testid="typing-test-comparison-toggle"
-        // Accent-highlight whenever comparison is active (any baseline but
-        // 'off'), mirroring the View toggles, so the button reflects on/off
-        // state rather than just whether the modal is open.
-        className={toggleClass(baseline.kind !== 'off')}
-        aria-pressed={baseline.kind !== 'off'}
+        className={COMPARE_BUTTON_CLASS}
+        aria-haspopup="dialog"
+        aria-expanded={open}
         onClick={openModal}
       >
-        {t('editor.typingTest.compare.button')}
+        {`${t('editor.typingTest.compare.button')} - ${t(`editor.typingTest.compare.${baseline.kind}`)}`}
       </button>
       {open && (
         <div

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -292,19 +292,6 @@ export function TypingTestPane({
     (baseline: TypingTestComparisonBaseline) => onComparisonBaselineChange?.(currentConditionKey, baseline),
     [onComparisonBaselineChange, currentConditionKey],
   )
-  // "Compare With <target>" caption shown under the delta row, so the deltas
-  // aren't ambiguous about what they measure against. Null when no comparison
-  // is active (off / no matching history).
-  const comparisonLabel = useMemo(() => {
-    if (!comparison) return null
-    if (comparisonBaselineValue.kind === 'pinned') {
-      const pinned = comparisonPool.find((r) => r.date === comparisonBaselineValue.pinnedDate)
-      const target = pinned?.name || t('editor.typingTest.history.unnamed')
-      return t('editor.typingTest.compare.comparedWith', { target })
-    }
-    return t('editor.typingTest.compare.comparedWith', { target: t(`editor.typingTest.compare.${comparisonBaselineValue.kind}`) })
-  }, [comparison, comparisonBaselineValue, comparisonPool, t])
-
   const handleRecordToggle = useCallback(() => {
     if (!onRecordEnabledChange) return
     // Stopping is always allowed without re-prompting; only the
@@ -725,7 +712,6 @@ export function TypingTestPane({
           hideStatsRow={hideStatsRow}
           hideControls={hideControls}
           comparison={comparison}
-          comparisonLabel={comparisonLabel}
           state={typingTest.state}
           wpm={typingTest.wpm}
           kpm={typingTest.kpm}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -276,7 +276,7 @@
         "previous": "Previous",
         "best": "Best",
         "average": "Average",
-        "pinned": "Specific result",
+        "pinned": "Result",
         "off": "Off",
         "comparedWith": "Compare With {{target}}",
         "noResults": "No results to pin yet",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -278,7 +278,6 @@
         "average": "Average",
         "pinned": "Result",
         "off": "Off",
-        "comparedWith": "Compare With {{target}}",
         "noResults": "No results to pin yet",
         "colName": "Name",
         "colKeyboard": "Keyboard",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -278,7 +278,6 @@
         "average": "平均",
         "pinned": "結果",
         "off": "オフ",
-        "comparedWith": "{{target}}と比較",
         "noResults": "ピンできる結果がありません",
         "colName": "名前",
         "colKeyboard": "キーボード",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -276,7 +276,7 @@
         "previous": "前回",
         "best": "ベスト",
         "average": "平均",
-        "pinned": "特定の結果",
+        "pinned": "結果",
         "off": "オフ",
         "comparedWith": "{{target}}と比較",
         "noResults": "ピンできる結果がありません",

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -34,9 +34,6 @@ interface Props {
   /** Baseline metrics for the Measurement-row comparison delta, or null when
    *  comparison is off / no matching history. */
   comparison?: ComparisonStats | null
-  /** "Compare With <target>" caption describing what the deltas measure
-   *  against, or null when no comparison is active. */
-  comparisonLabel?: string | null
   onCompositionStart?: () => void
   onCompositionUpdate?: (data: string) => void
   onCompositionEnd?: (data: string) => void
@@ -107,7 +104,6 @@ export function TypingTestView({
   hideStatsRow,
   hideControls,
   comparison,
-  comparisonLabel,
   onCompositionStart,
   onCompositionUpdate,
   onCompositionEnd,
@@ -468,11 +464,6 @@ export function TypingTestView({
             </span>
           )}
         </div>
-        {comparison && comparisonLabel && (
-          <p data-testid="typing-test-comparison-label" className="text-xs text-content-muted">
-            {comparisonLabel}
-          </p>
-        )}
       </div>
       )}
 


### PR DESCRIPTION
## Summary
- Stop accent-highlighting the **Compare** button. It opens a modal (a dialog trigger, not a stateful toggle), so it now uses a single static style and exposes `aria-haspopup`/`aria-expanded` like the History button.
- Show the active baseline as text on the button: **Compare - Previous / Best / Average / Result / Off**.
- Rename the pinned baseline label from "Specific result" to **Result** (EN) / "特定の結果" → "結果" (JA). This also updates the modal radio and the (now-removed) caption.
- Remove the redundant **Compare With <target>** caption row under the metrics, plus the now-dead `comparisonLabel` prop/computation and the unused `compare.comparedWith` strings.

## Notes
- Comparison deltas (▲+32 etc.) are unchanged; `comparisonPool` is retained for pinned-baseline resolution and same-condition matching.

## Test plan
- [x] lint / build / 4307 tests pass