### PR TITLE
fix(ui): baseline-align typing-test stat labels and values

### DIFF
--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -404,7 +404,7 @@ export function TypingTestView({
         className="flex w-full flex-col items-center gap-2"
       >
         <div className="flex flex-wrap items-center justify-center gap-8 text-sm">
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-baseline gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.wpm')}:</span>
             <span data-testid="typing-test-wpm" className="font-mono text-lg font-semibold text-accent tabular-nums">
               {showStats ? wpm : '-'}
@@ -415,7 +415,7 @@ export function TypingTestView({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-baseline gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.kpm')}:</span>
             <span data-testid="typing-test-kpm" className="font-mono text-lg font-semibold text-accent tabular-nums">
               {showStats ? kpm : '-'}
@@ -426,7 +426,7 @@ export function TypingTestView({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-baseline gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.accuracy')}:</span>
             <span data-testid="typing-test-accuracy" className="font-mono text-lg font-semibold tabular-nums">
               {showStats ? `${accuracy}%` : '-'}
@@ -437,13 +437,13 @@ export function TypingTestView({
               </span>
             )}
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-baseline gap-1.5">
             <span className="text-content-muted">{t('editor.typingTest.time')}:</span>
             <span data-testid="typing-test-time" className="font-mono text-lg font-semibold tabular-nums">
               {showStats ? displayTime : '-'}
             </span>
           </div>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-baseline gap-1.5">
             {/* Imported custom text tracks character progress (spaces included);
                 everything else tracks words. */}
             <span className="text-content-muted">{t(isCustom ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>


### PR DESCRIPTION
## Summary
- Each stat paired a `text-sm` label with a `text-lg` mono value under `items-center`, so the larger number sat visually high relative to the label.
- Switch the five stat rows to `items-baseline` (matching the History summary) so the digits line up with the label baseline.

## Test plan
- [x] lint / build / 4307 tests pass