### PR TITLE
refactor(ui): rename typing-test Custom mode to File Import

### DIFF
--- a/src/main/__tests__/device-prefs-store.test.ts
+++ b/src/main/__tests__/device-prefs-store.test.ts
@@ -269,7 +269,7 @@ describe('pipette-settings-store', () => {
       const setter = getHandler(IpcChannels.PIPETTE_SETTINGS_PATCH)
       const baselines = {
         'words|30|english|false|true': { kind: 'best' },
-        'custom|t2': { kind: 'pinned', pinnedDate: '2026-06-20T00:00:00.000Z' },
+        'fileImport|t2': { kind: 'pinned', pinnedDate: '2026-06-20T00:00:00.000Z' },
       }
       await setter(fakeEvent, 'uid-1', {
         _rev: 1,

--- a/src/main/__tests__/typing-test-text-store.test.ts
+++ b/src/main/__tests__/typing-test-text-store.test.ts
@@ -42,7 +42,7 @@ import {
   confirmImportOverwrite,
   TYPING_TEST_TEXT_SYNC_UNIT,
 } from '../typing-test-text-store'
-import { parseCustomText, normalizeCustomText, TYPING_TEST_TEXT_MAX_WORDS } from '../../shared/types/typing-test-text-store'
+import { parseFileImportText, normalizeFileImportText, TYPING_TEST_TEXT_MAX_WORDS } from '../../shared/types/typing-test-text-store'
 
 const fakeWin = {} as Electron.BrowserWindow
 
@@ -56,38 +56,38 @@ describe('typing-test-text-store', () => {
     await rm(mockUserDataPath, { recursive: true, force: true })
   })
 
-  describe('parseCustomText', () => {
+  describe('parseFileImportText', () => {
     it('collapses intra-line whitespace and keeps single-line as no breaks', () => {
-      expect(parseCustomText('  the  quick\t fox ')).toEqual({ words: ['the', 'quick', 'fox'], lineBreaks: [], indents: ['  '] })
+      expect(parseFileImportText('  the  quick\t fox ')).toEqual({ words: ['the', 'quick', 'fox'], lineBreaks: [], indents: ['  '] })
     })
 
     it('treats newline as a line break distinct from space', () => {
       // "the quick" / "brown fox": break after index 1, none after the last word.
-      expect(parseCustomText('the quick\nbrown fox')).toEqual({ words: ['the', 'quick', 'brown', 'fox'], lineBreaks: [1], indents: ['', ''] })
+      expect(parseFileImportText('the quick\nbrown fox')).toEqual({ words: ['the', 'quick', 'brown', 'fox'], lineBreaks: [1], indents: ['', ''] })
     })
 
     it('normalizes CRLF/CR and drops empty lines', () => {
-      expect(parseCustomText('a\r\n\r\nb\rc')).toEqual({ words: ['a', 'b', 'c'], lineBreaks: [0, 1], indents: ['', '', ''] })
+      expect(parseFileImportText('a\r\n\r\nb\rc')).toEqual({ words: ['a', 'b', 'c'], lineBreaks: [0, 1], indents: ['', '', ''] })
     })
 
     it('caps at the word limit', () => {
       const many = Array.from({ length: TYPING_TEST_TEXT_MAX_WORDS + 50 }, (_, i) => `w${i}`).join(' ')
-      expect(parseCustomText(many).words).toHaveLength(TYPING_TEST_TEXT_MAX_WORDS)
+      expect(parseFileImportText(many).words).toHaveLength(TYPING_TEST_TEXT_MAX_WORDS)
     })
   })
 
-  describe('normalizeCustomText', () => {
+  describe('normalizeFileImportText', () => {
     it('canonicalizes with single spaces in a line and newline at breaks', () => {
-      expect(normalizeCustomText('the  quick\nbrown   fox')).toEqual({ text: 'the quick\nbrown fox', wordCount: 4 })
+      expect(normalizeFileImportText('the  quick\nbrown   fox')).toEqual({ text: 'the quick\nbrown fox', wordCount: 4 })
     })
 
     it('preserves leading indentation per line (code structure)', () => {
-      expect(normalizeCustomText('def f() {\n  val x = 1\n}')).toEqual({ text: 'def f() {\n  val x = 1\n}', wordCount: 8 })
+      expect(normalizeFileImportText('def f() {\n  val x = 1\n}')).toEqual({ text: 'def f() {\n  val x = 1\n}', wordCount: 8 })
     })
 
-    it('round-trips through parseCustomText', () => {
-      const { text } = normalizeCustomText('a b\nc\n\nd e f')
-      expect(parseCustomText(text)).toEqual(parseCustomText('a b\nc\n\nd e f'))
+    it('round-trips through parseFileImportText', () => {
+      const { text } = normalizeFileImportText('a b\nc\n\nd e f')
+      expect(parseFileImportText(text)).toEqual(parseFileImportText('a b\nc\n\nd e f'))
     })
   })
 

--- a/src/main/typing-test-text-store.ts
+++ b/src/main/typing-test-text-store.ts
@@ -17,7 +17,7 @@ import type {
 } from '../shared/types/typing-test-text-store'
 import {
   TYPING_TEST_TEXT_MAX_FILE_BYTES,
-  normalizeCustomText,
+  normalizeFileImportText,
 } from '../shared/types/typing-test-text-store'
 
 export const TYPING_TEST_TEXT_SYNC_UNIT = 'typing-test-texts'
@@ -146,7 +146,7 @@ export async function saveRecord(input: SaveTextInput): Promise<TypingTestTextSt
   if (!validated.success || validated.data === undefined) return validated as TypingTestTextStoreResult<TypingTestTextMeta>
   const name = validated.data
 
-  const { text, wordCount } = normalizeCustomText(typeof input.text === 'string' ? input.text : '')
+  const { text, wordCount } = normalizeFileImportText(typeof input.text === 'string' ? input.text : '')
   if (wordCount === 0) return fail('EMPTY_TEXT', 'Text has no typeable words')
 
   try {

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -79,7 +79,7 @@ import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export interface TypingTestPaneProps {
   typingTest: ReturnType<typeof useTypingTest>
   onConfigChange: (config: TypingTestConfig) => void
-  /** Last normal (words/time/quote) config, restored when leaving custom. */
+  /** Last normal (words/time/quote) config, restored when leaving fileImport. */
   normalConfig?: TypingTestConfig
   onLanguageChange: (lang: string) => Promise<void>
   layers: number
@@ -95,12 +95,12 @@ export interface TypingTestPaneProps {
   keys: KleKey[]
   layerLabel: string
   contentRef?: React.RefObject<HTMLDivElement | null>
-  /** Memory mode (imported custom text): a paused snapshot is saved. */
+  /** Memory mode (imported fileImport text): a paused snapshot is saved. */
   hasSavedMemory?: boolean
   onPauseTest?: () => void
   onResumeTest?: () => void
   onRestartTestFromStart?: () => void
-  /** Imported-text display preferences (custom mode). */
+  /** Imported-text display preferences (fileImport mode). */
   displayLines?: number
   fontSize?: number
   onDisplayLinesChange?: (lines: number) => void
@@ -497,16 +497,16 @@ export function TypingTestPane({
     }
   }, [viewOnly, viewOnlyWindowSize, getDefaultCompactSize, onViewOnlyChange, typingTest])
 
-  // Mode / language. The mode kind (Custom / Normal) goes in the label —
-  // "Mode(Custom):" — and the button shows just the source (file name or
+  // Mode / language. The mode kind (FileImport / Normal) goes in the label —
+  // "Mode(FileImport):" — and the button shows just the source (file name or
   // language), truncated to one line; the full text is on the title.
-  const modeType = typingTest.config.mode === 'custom'
-    ? t('editor.typingTest.language.tabCustom')
+  const modeType = typingTest.config.mode === 'fileImport'
+    ? t('editor.typingTest.language.tabFileImport')
     : t('editor.typingTest.language.tabNormal')
   const modeLabel = typingTest.isLanguageLoading
     ? t('editor.typingTest.language.loadingLanguage')
-    : typingTest.config.mode === 'custom'
-    ? (typingTest.state.currentQuote?.source ?? t('editor.typingTest.language.customText'))
+    : typingTest.config.mode === 'fileImport'
+    ? (typingTest.state.currentQuote?.source ?? t('editor.typingTest.language.fileImportText'))
     : typingTest.language.replace(/_/g, ' ')
 
   // Config controls, pinned to the window's top-left as a sidebar in editor
@@ -527,7 +527,7 @@ export function TypingTestPane({
       {/* Settings — language/mode, base layer, pattern / units / options. */}
       <PanelSection title={t('editor.typingTest.section.settings')}>
         {/* Mode / language — shown for every mode (words / time / quote /
-            custom); quote uses it to pick the quote source language. */}
+            fileImport); quote uses it to pick the quote source language. */}
         <div className="flex w-full flex-col items-start gap-1">
           <span className="text-sm text-content-muted">{t('editor.typingTest.modeLabel')}({modeType}):</span>
           <button
@@ -544,15 +544,15 @@ export function TypingTestPane({
         {showLanguageModal && (
           <LanguageSelectorModal
             currentLanguage={typingTest.language}
-            currentCustomTextId={typingTest.config.mode === 'custom' ? typingTest.config.textId : undefined}
+            currentFileImportTextId={typingTest.config.mode === 'fileImport' ? typingTest.config.textId : undefined}
             onSelectLanguage={(name) => {
-              // Picking a language leaves custom mode — restore the last normal
+              // Picking a language leaves fileImport mode — restore the last normal
               // (words/time/quote) config so its Pattern/Units/Option settings
               // survive the round trip; fall back to the default if none saved.
-              if (typingTest.config.mode === 'custom') onConfigChange(normalConfig ?? DEFAULT_CONFIG)
+              if (typingTest.config.mode === 'fileImport') onConfigChange(normalConfig ?? DEFAULT_CONFIG)
               void onLanguageChange(name)
             }}
-            onSelectImport={(textId) => onConfigChange({ mode: 'custom', textId })}
+            onSelectImport={(textId) => onConfigChange({ mode: 'fileImport', textId })}
             onCurrentTextDeleted={() => {
               // The selected imported text was deleted — fall back to
               // the default (words mode, English).
@@ -606,7 +606,7 @@ export function TypingTestPane({
             </select>
           </div>
         </div>
-        {typingTest.config.mode !== 'custom' && (
+        {typingTest.config.mode !== 'fileImport' && (
           <TypingTestSettingsBar config={typingTest.config} onConfigChange={onConfigChange} />
         )}
       </PanelSection>

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -11,7 +11,7 @@ import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
 import { PROCESS_CODE_TO_KEY } from './keymap-editor-types'
 
 /** Analytics `typing_test` dimension label for the running test: the
- *  imported text's name for custom, else `mode (language)` (e.g.
+ *  imported text's name for fileImport, else `mode (language)` (e.g.
  *  `words (english)`) so Analyze can slice normal runs by language too.
  *  Delegates to `materialLabel` so the recording side and the Analyze run
  *  filter produce the identical join key. */
@@ -75,7 +75,7 @@ export interface UseInputModesReturn {
   /** Name the just-finished result: persists a held unsaved result under the
    *  name (save-unnamed off; blank → discarded) or renames the saved latest. */
   nameFinishedResult: (name: string) => void
-  /** Memory mode (imported custom text). */
+  /** Memory mode (imported fileImport text). */
   savedTypingTestMemory?: TypingTestMemory
   pauseTypingTest: () => void
   resumeTypingTest: () => void
@@ -237,13 +237,13 @@ export function useInputModes({
   const lastSyncedConfigRef = useRef('')
 
   /** Enter the typing test. When a paused snapshot is saved for the active
-   *  custom text, restore it frozen ('paused') so the user must choose
+   *  fileImport text, restore it frozen ('paused') so the user must choose
    *  resume / restart before typing; otherwise start a fresh test. */
   const beginTypingTest = useCallback((withCountdown: boolean) => {
     enterMatrixMode()
     const mem = savedMemoryRef.current
     const cfg = savedConfigRef.current
-    if (mem && cfg?.mode === 'custom' && cfg.textId === mem.textId) {
+    if (mem && cfg?.mode === 'fileImport' && cfg.textId === mem.textId) {
       // Pre-mark the config as synced so the config-sync effect doesn't
       // clobber the restored snapshot with a fresh test.
       lastSyncedConfigRef.current = JSON.stringify(cfg)
@@ -300,7 +300,7 @@ export function useInputModes({
   // only while it is actually running. Entering the test view auto-starts a
   // countdown on the default ('words') config; tagging keystrokes before the
   // run starts would record a phantom material (e.g. `words (english)`) for
-  // presses made during countdown / waiting or before the user picks a custom
+  // presses made during countdown / waiting or before the user picks a fileImport
   // text. Gating on 'running' guarantees the config has settled to the chosen
   // material before anything is recorded. Trade-off: the keystroke that starts
   // the run (waiting -> running) and the matrix edge of the key that ends it
@@ -383,7 +383,7 @@ export function useInputModes({
         config: typingTest.config,
         language: typingTest.language,
         wpmHistory: typingTest.state.wpmHistory,
-        customTextName: typingTest.config.mode === 'custom' ? typingTest.state.currentQuote?.source : undefined,
+        fileImportTextName: typingTest.config.mode === 'fileImport' ? typingTest.state.currentQuote?.source : undefined,
         runId: typingTest.state.runId,
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
@@ -457,7 +457,7 @@ export function useInputModes({
   const handleTypingTestConfigChange = useCallback((newConfig: TypingTestConfig) => {
     // Starting a different imported text discards the saved snapshot.
     const mem = savedMemoryRef.current
-    if (mem && newConfig.mode === 'custom' && newConfig.textId !== mem.textId) {
+    if (mem && newConfig.mode === 'fileImport' && newConfig.textId !== mem.textId) {
       onMemoryChangeRef.current?.(undefined)
     }
     typingTest.setConfig(newConfig)

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -38,9 +38,9 @@ function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
     case 'quote':
       if (typeof obj.quoteLength !== 'string' || !VALID_QUOTE_LENGTHS.has(obj.quoteLength)) return undefined
       return { mode: 'quote', quoteLength: obj.quoteLength as 'short' | 'medium' | 'long' | 'all' }
-    case 'custom':
+    case 'fileImport':
       if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
-      return { mode: 'custom', textId: obj.textId }
+      return { mode: 'fileImport', textId: obj.textId }
     default:
       return undefined
   }
@@ -481,11 +481,11 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     const prev = typingTestConfigRef.current
     updateTypingTestConfig(cfg)
     // Remember the last normal (words/time/quote) config so it survives a
-    // switch into custom (imported text) and back. When entering custom,
+    // switch into fileImport (imported text) and back. When entering fileImport,
     // capture the outgoing normal config too — covers old prefs where
     // typingTestNormalConfig was never saved.
-    if (cfg.mode !== 'custom') updateTypingTestNormalConfig(cfg)
-    else if (prev && prev.mode !== 'custom') updateTypingTestNormalConfig(prev)
+    if (cfg.mode !== 'fileImport') updateTypingTestNormalConfig(cfg)
+    else if (prev && prev.mode !== 'fileImport') updateTypingTestNormalConfig(prev)
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestConfig, updateTypingTestNormalConfig])
 

--- a/src/renderer/hooks/useTypingTestTexts.ts
+++ b/src/renderer/hooks/useTypingTestTexts.ts
@@ -3,7 +3,7 @@
 // Renderer-side state for imported Typing Test texts: list local
 // entries and CRUD against the store. Mirrors useKeyLabels' cross-
 // instance refresh signal so the modal and any other consumer stay in
-// lockstep. Also clears the word-generator custom-text cache on change
+// lockstep. Also clears the word-generator file-import-text cache on change
 // so freshly imported / renamed text plays back correctly.
 
 import { useCallback, useEffect, useState } from 'react'
@@ -11,7 +11,7 @@ import type {
   TypingTestTextMeta,
   TypingTestTextStoreResult,
 } from '../../shared/types/typing-test-text-store'
-import { clearCustomTextCache } from '../typing-test/word-generator'
+import { clearFileImportTextCache } from '../typing-test/word-generator'
 
 const REFRESH_EVENT = 'pipette:typing-test-texts-changed'
 
@@ -71,7 +71,7 @@ export function useTypingTestTexts(): UseTypingTestTextsReturn {
   const importFromFile = useCallback(async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
     const result = await window.vialAPI.typingTestTextStoreImport()
     if (result.success) {
-      if (result.data) clearCustomTextCache(result.data.id)
+      if (result.data) clearFileImportTextCache(result.data.id)
       await refresh()
       emitTypingTestTextsChanged()
     }
@@ -81,7 +81,7 @@ export function useTypingTestTexts(): UseTypingTestTextsReturn {
   const confirmImport = useCallback(async (): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
     const result = await window.vialAPI.typingTestTextStoreImportConfirm()
     if (result.success) {
-      if (result.data) clearCustomTextCache(result.data.id)
+      if (result.data) clearFileImportTextCache(result.data.id)
       await refresh()
       emitTypingTestTextsChanged()
     }
@@ -94,7 +94,7 @@ export function useTypingTestTexts(): UseTypingTestTextsReturn {
   ): Promise<TypingTestTextStoreResult<TypingTestTextMeta>> => {
     const result = await window.vialAPI.typingTestTextStoreRename(id, newName)
     if (result.success) {
-      clearCustomTextCache(id)
+      clearFileImportTextCache(id)
       await refresh()
       emitTypingTestTextsChanged()
     }
@@ -104,7 +104,7 @@ export function useTypingTestTexts(): UseTypingTestTextsReturn {
   const remove = useCallback(async (id: string): Promise<TypingTestTextStoreResult<void>> => {
     const result = await window.vialAPI.typingTestTextStoreDelete(id)
     if (result.success) {
-      clearCustomTextCache(id)
+      clearFileImportTextCache(id)
       await refresh()
       emitTypingTestTextsChanged()
     }

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -299,7 +299,7 @@
         "words": "words",
         "time": "time",
         "quote": "quote",
-        "custom": "text"
+        "fileImport": "text"
       },
       "punctuation": "punctuation",
       "numbers": "numbers",
@@ -374,7 +374,7 @@
         "loadingLanguage": "Loading language...",
         "downloadFailed": "Download failed",
         "tabNormal": "Normal",
-        "tabCustom": "Custom",
+        "tabFileImport": "File Import",
         "import": "Import UTF-8 text file",
         "importEmpty": "No imported texts yet",
         "importFailed": "Import failed",
@@ -383,7 +383,7 @@
         "importErrorEmpty": "The file has no typeable text",
         "importOverwritePrompt": "\"{{name}}\" already exists. Overwrite?",
         "confirmOverwrite": "Overwrite",
-        "customText": "Imported text"
+        "fileImportText": "Imported text"
       },
       "memory": {
         "pause": "Pause",
@@ -405,7 +405,7 @@
         "unnamed": "Unnamed",
         "mode": "Mode",
         "tabNormal": "Normal",
-        "tabCustom": "Custom",
+        "tabFileImport": "File Import",
         "tabText": "Text",
         "noResults": "No results yet",
         "pb": "PB",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -299,7 +299,7 @@
         "words": "単語",
         "time": "時間",
         "quote": "引用",
-        "custom": "テキスト"
+        "fileImport": "テキスト"
       },
       "punctuation": "句読点",
       "numbers": "数字",
@@ -374,7 +374,7 @@
         "loadingLanguage": "言語を読み込み中...",
         "downloadFailed": "ダウンロードに失敗しました",
         "tabNormal": "Normal",
-        "tabCustom": "カスタム",
+        "tabFileImport": "ファイル取込",
         "import": "UTF-8 テキストをインポート",
         "importEmpty": "インポートされたテキストはありません",
         "importFailed": "インポートに失敗しました",
@@ -383,7 +383,7 @@
         "importErrorEmpty": "打鍵できるテキストがありません",
         "importOverwritePrompt": "「{{name}}」は既に存在します。上書きしますか？",
         "confirmOverwrite": "上書き",
-        "customText": "インポートテキスト"
+        "fileImportText": "インポートテキスト"
       },
       "memory": {
         "pause": "一時停止",
@@ -405,7 +405,7 @@
         "unnamed": "名称未設定",
         "mode": "モード",
         "tabNormal": "Normal",
-        "tabCustom": "カスタム",
+        "tabFileImport": "ファイル取込",
         "tabText": "テキスト",
         "noResults": "結果がありません",
         "pb": "PB",

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -22,10 +22,10 @@ const IMPORT_ERROR_KEYS: Record<string, string> = {
 
 interface Props {
   currentLanguage: string
-  /** Active imported text id, when the current config is in custom mode. */
-  currentCustomTextId?: string
+  /** Active imported text id, when the current config is in fileImport mode. */
+  currentFileImportTextId?: string
   onSelectLanguage: (name: string) => void
-  /** Called when an imported text is picked — switches to custom mode. */
+  /** Called when an imported text is picked — switches to fileImport mode. */
   onSelectImport: (textId: string) => void
   /** Called on close when the currently-selected imported text was deleted
    *  (and nothing else was picked) so the caller can reset to the default. */
@@ -39,14 +39,14 @@ function formatName(name: string): string {
 
 export function LanguageSelectorModal({
   currentLanguage,
-  currentCustomTextId,
+  currentFileImportTextId,
   onSelectLanguage,
   onSelectImport,
   onCurrentTextDeleted,
   onClose,
 }: Props) {
   const { t } = useTranslation()
-  const [tab, setTab] = useState<Tab>(currentCustomTextId ? 'import' : 'existing')
+  const [tab, setTab] = useState<Tab>(currentFileImportTextId ? 'import' : 'existing')
   const [languages, setLanguages] = useState<LanguageListEntry[]>([])
   const [search, setSearch] = useState('')
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
@@ -157,7 +157,7 @@ export function LanguageSelectorModal({
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'import' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
             onClick={() => setTab('import')}
           >
-            {t('editor.typingTest.language.tabCustom')}
+            {t('editor.typingTest.language.tabFileImport')}
           </button>
         </div>
 
@@ -189,7 +189,7 @@ export function LanguageSelectorModal({
                     <LanguageRow
                       key={lang.name}
                       lang={lang}
-                      isCurrent={!currentCustomTextId && lang.name === currentLanguage}
+                      isCurrent={!currentFileImportTextId && lang.name === currentLanguage}
                       isDownloading={downloading.has(lang.name)}
                       onSelect={handleSelect}
                       onDelete={handleDelete}
@@ -219,7 +219,7 @@ export function LanguageSelectorModal({
           </>
         ) : (
           <ImportTab
-            currentCustomTextId={currentCustomTextId}
+            currentFileImportTextId={currentFileImportTextId}
             onSelect={handleSelectImport}
             onDeleteCurrent={() => { deletedCurrentRef.current = true }}
           />
@@ -230,13 +230,13 @@ export function LanguageSelectorModal({
 }
 
 interface ImportTabProps {
-  currentCustomTextId?: string
+  currentFileImportTextId?: string
   onSelect: (id: string) => void
   /** Fired when the currently-selected imported text is deleted. */
   onDeleteCurrent?: () => void
 }
 
-function ImportTab({ currentCustomTextId, onSelect, onDeleteCurrent }: ImportTabProps) {
+function ImportTab({ currentFileImportTextId, onSelect, onDeleteCurrent }: ImportTabProps) {
   const { t } = useTranslation()
   const { metas, importFromFile, confirmImport, remove } = useTypingTestTexts()
   const [importing, setImporting] = useState(false)
@@ -246,9 +246,9 @@ function ImportTab({ currentCustomTextId, onSelect, onDeleteCurrent }: ImportTab
 
   const handleRemove = useCallback(async (id: string) => {
     const result = await remove(id)
-    if (result.success && id === currentCustomTextId) onDeleteCurrent?.()
+    if (result.success && id === currentFileImportTextId) onDeleteCurrent?.()
     return result
-  }, [remove, currentCustomTextId, onDeleteCurrent])
+  }, [remove, currentFileImportTextId, onDeleteCurrent])
 
   const handleImport = useCallback(async () => {
     setImporting(true)
@@ -336,7 +336,7 @@ function ImportTab({ currentCustomTextId, onSelect, onDeleteCurrent }: ImportTab
             <ImportRow
               key={meta.id}
               meta={meta}
-              isCurrent={meta.id === currentCustomTextId}
+              isCurrent={meta.id === currentFileImportTextId}
               onSelect={onSelect}
               onDelete={handleRemove}
             />

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from '../components/ui/Tooltip'
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
 type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
 type SortDirection = 'asc' | 'desc'
-/** Top-level split: Monkeytype (words/time/quote) vs imported Text (custom).
+/** Top-level split: Monkeytype (words/time/quote) vs imported Text (fileImport).
  *  Their baselines aren't comparable, so stats / chart / export are separate. */
 type HistoryTab = 'monkeytype' | 'text'
 
@@ -47,16 +47,16 @@ function formatDuration(seconds: number): string {
   return `${m}:${String(s).padStart(2, '0')}`
 }
 
-/** Mode-column detail. Custom (imported-text) runs show the snapshotted text
+/** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
  *  name (falling back to the stable textId for legacy rows saved before the
  *  name was captured); every other mode shows its `mode2` value. */
 function modeDetail(r: TypingTestResult): string {
-  if (r.mode === 'custom') return r.customTextName ?? (r.mode2 != null ? String(r.mode2) : '')
+  if (r.mode === 'fileImport') return r.fileImportTextName ?? (r.mode2 != null ? String(r.mode2) : '')
   return r.mode2 != null ? String(r.mode2) : ''
 }
 
-/** Stable filter key for an imported-text (custom) run; its textId is `mode2`. */
-function customTextId(r: TypingTestResult): string {
+/** Stable filter key for an imported-text (fileImport) run; its textId is `mode2`. */
+function fileImportTextId(r: TypingTestResult): string {
   return String(r.mode2 ?? '')
 }
 
@@ -67,20 +67,20 @@ function exportFilterSlug(
   isText: boolean,
   modeFilter: ModeFilter,
   textFilter: string,
-  customTexts: { id: string, name: string }[],
+  fileImportTexts: { id: string, name: string }[],
 ): string {
   if (isText) {
     if (textFilter === 'all') return 'text'
     // Fall back to the textId for an empty / missing name so the slug never
     // ends in a bare `text-`.
-    return `text-${customTexts.find((c) => c.id === textFilter)?.name || textFilter}`
+    return `text-${fileImportTexts.find((c) => c.id === textFilter)?.name || textFilter}`
   }
   return modeFilter === 'all' ? 'normal' : `normal-${modeFilter}`
 }
 
 const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
-const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'customTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb'] as const
+const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'fileImportTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb'] as const
 
 function buildResultsCsv(results: TypingTestResult[]): string {
   return buildCsv(
@@ -105,20 +105,20 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
     setSortColumn(column)
   }, [sortColumn])
 
-  // Active tab's rows: custom for Text, everything else for Monkeytype.
+  // Active tab's rows: fileImport for Text, everything else for Monkeytype.
   const tabResults = useMemo(
-    () => results.filter((r) => isText ? r.mode === 'custom' : r.mode !== 'custom'),
+    () => results.filter((r) => isText ? r.mode === 'fileImport' : r.mode !== 'fileImport'),
     [results, isText],
   )
 
-  // Distinct imported texts (custom rows), keyed by stable textId, displayed by
+  // Distinct imported texts (fileImport rows), keyed by stable textId, displayed by
   // the snapshotted name. Drives the Text-tab filter dropdown.
-  const customTexts = useMemo(() => {
+  const fileImportTexts = useMemo(() => {
     const seen = new Map<string, string>()
     for (const r of results) {
-      if (r.mode !== 'custom') continue
-      const id = customTextId(r)
-      if (!seen.has(id)) seen.set(id, r.customTextName ?? id)
+      if (r.mode !== 'fileImport') continue
+      const id = fileImportTextId(r)
+      if (!seen.has(id)) seen.set(id, r.fileImportTextName ?? id)
     }
     return Array.from(seen, ([id, name]) => ({ id, name }))
   }, [results])
@@ -126,14 +126,14 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
   // Fall back to 'all' when the selected text no longer exists (e.g. all its
   // rows were deleted), so the dropdown stays controlled and the stats/chart
   // never collapse to an empty selection.
-  const effectiveTextFilter = textFilter === 'all' || customTexts.some((c) => c.id === textFilter)
+  const effectiveTextFilter = textFilter === 'all' || fileImportTexts.some((c) => c.id === textFilter)
     ? textFilter
     : 'all'
 
   const filtered = useMemo(() => {
     if (isText) {
       if (effectiveTextFilter === 'all') return tabResults
-      return tabResults.filter((r) => customTextId(r) === effectiveTextFilter)
+      return tabResults.filter((r) => fileImportTextId(r) === effectiveTextFilter)
     }
     if (modeFilter === 'all') return tabResults
     return tabResults.filter((r) => (r.mode ?? 'words') === modeFilter)
@@ -141,8 +141,8 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
 
   // Export is per-tab: only the rows currently shown.
   const handleExport = useCallback(() => {
-    onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(isText, modeFilter, effectiveTextFilter, customTexts))
-  }, [filtered, onExportCsv, isText, modeFilter, effectiveTextFilter, customTexts])
+    onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(isText, modeFilter, effectiveTextFilter, fileImportTexts))
+  }, [filtered, onExportCsv, isText, modeFilter, effectiveTextFilter, fileImportTexts])
 
   const stats = useMemo(() => computeStats(filtered), [filtered])
   const sparklineResults = useMemo(
@@ -167,8 +167,8 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
           cmp = a.accuracy - b.accuracy
           break
         case 'mode': {
-          // Sort by what the Mode column actually shows (text name for custom),
-          // so custom rows order by name rather than an opaque textId.
+          // Sort by what the Mode column actually shows (text name for fileImport),
+          // so fileImport rows order by name rather than an opaque textId.
           const modeA = `${a.mode ?? ''}${modeDetail(a)}`
           const modeB = `${b.mode ?? ''}${modeDetail(b)}`
           cmp = modeA.localeCompare(modeB)
@@ -184,7 +184,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
 
   return (
     <div data-testid="typing-test-history" className="flex h-full max-w-4xl flex-col gap-3">
-      {/* Top tabs: Monkeytype (words/time/quote) vs imported Text (custom). */}
+      {/* Top tabs: Monkeytype (words/time/quote) vs imported Text (fileImport). */}
       <div className="flex items-center gap-4 border-b border-edge">
         {(['monkeytype', 'text'] as HistoryTab[]).map((tb) => (
           <button
@@ -197,7 +197,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
               : 'border-b-2 border-transparent px-1 pb-1.5 text-sm text-content-secondary hover:text-content'}
             onClick={() => setTab(tb)}
           >
-            {t(tb === 'text' ? 'editor.typingTest.history.tabCustom' : 'editor.typingTest.history.tabNormal')}
+            {t(tb === 'text' ? 'editor.typingTest.history.tabFileImport' : 'editor.typingTest.history.tabNormal')}
           </button>
         ))}
       </div>
@@ -223,7 +223,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
             ))}
           </select>
         )}
-        {isText && customTexts.length > 0 && (
+        {isText && fileImportTexts.length > 0 && (
           <select
             data-testid="history-filter-text"
             aria-label={t('editor.typingTest.history.filterText')}
@@ -232,7 +232,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
             onChange={(e) => setTextFilter(e.target.value)}
           >
             <option value="all">{t('editor.typingTest.history.allModes')}</option>
-            {customTexts.map((c) => (
+            {fileImportTexts.map((c) => (
               <option key={c.id} value={c.id}>
                 {c.name || t('editor.typingTest.history.unnamed')}
               </option>

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -16,7 +16,7 @@ import { ResultNameModal } from './ResultNameModal'
 interface Props {
   state: TypingTestState
   wpm: number
-  /** Keystrokes per minute — shown instead of WPM in custom mode. */
+  /** Keystrokes per minute — shown instead of WPM in fileImport mode. */
   kpm?: number
   accuracy: number
   elapsedSeconds: number
@@ -40,22 +40,22 @@ interface Props {
   /** Called when Space is input via IME (keydown swallowed by the IME layer). */
   onImeSpaceKey?: () => void
   /** Imported-text display: visible line count + font size (px). Ignored
-   *  outside custom mode. */
+   *  outside fileImport mode. */
   displayLines?: number
   fontSize?: number
   /** Name the just-finished result inline from the completion screen
-   *  (imported custom text only). Keyed to the most recent saved result. */
+   *  (imported fileImport text only). Keyed to the most recent saved result. */
   onNameResult?: (name: string) => void
   /** Quick-insert chips for the result-name modal (material label, timestamp,
    *  WPM / KPM / Accuracy of the just-finished result). */
   resultNameChips?: string[]
   /** Start a fresh run (Next Test / Restart — both restart the test). */
   onStart?: () => void
-  /** Memory mode (imported custom text): pause the running run. */
+  /** Memory mode (imported fileImport text): pause the running run. */
   onPause?: () => void
   /** Memory mode: open the resume dialog for a paused / saved run. */
   onResume?: () => void
-  /** A paused custom run is saved and can be resumed. */
+  /** A paused fileImport run is saved and can be resumed. */
   hasSavedMemory?: boolean
 }
 
@@ -66,7 +66,7 @@ function formatTime(seconds: number): string {
 }
 
 /** Group flat word indices into logical lines using the line-break set
- *  (imported custom text). Each entry is the global word indices of one
+ *  (imported fileImport text). Each entry is the global word indices of one
  *  line, in order. */
 function groupIntoLines(words: string[], lineBreaks: Set<number>): number[][] {
   const lines: number[][] = []
@@ -125,7 +125,7 @@ export function TypingTestView({
   // Guard: prevent duplicate space submission when both keydown and input fire
   const lastSpaceTimeRef = useRef(0)
 
-  // Imported custom text (line breaks present) renders as explicit line
+  // Imported fileImport text (line breaks present) renders as explicit line
   // rows; every other mode keeps the flat word-flow layout. `null` = flat.
   const lines = useMemo(
     () => (state.lineBreaks.size > 0 ? groupIntoLines(state.words, state.lineBreaks) : null),
@@ -133,28 +133,28 @@ export function TypingTestView({
   )
   // Reading window: font size + line count drive the CSS calc in
   // .typing-multiline-window. Applied to every mode (normal word-flow and
-  // imported custom text share the same Font/Line settings). Memoized so the
+  // imported fileImport text share the same Font/Line settings). Memoized so the
   // style object is stable.
   const multilineStyle = useMemo(
     () => ({ '--tt-font': fontSize, '--tt-lines': displayLines } as CSSProperties),
     [fontSize, displayLines],
   )
 
-  // Imported custom text counts progress by character (spaces included): each
+  // Imported fileImport text counts progress by character (spaces included): each
   // word-gap is one separator char, so total = Σ word lengths + (words - 1).
   // Gated on the mode (not `lines`) so single-line imports count chars too.
-  const isCustom = config.mode === 'custom'
+  const isFileImport = config.mode === 'fileImport'
   const totalChars = useMemo(
-    () => (isCustom ? state.words.reduce((sum, w) => sum + w.length, 0) + Math.max(0, state.words.length - 1) : 0),
-    [isCustom, state.words],
+    () => (isFileImport ? state.words.reduce((sum, w) => sum + w.length, 0) + Math.max(0, state.words.length - 1) : 0),
+    [isFileImport, state.words],
   )
   const typedChars = useMemo(() => {
-    if (!isCustom) return 0
+    if (!isFileImport) return 0
     let sum = state.currentInput.length
     for (let i = 0; i < state.currentWordIndex && i < state.words.length; i++) sum += state.words[i].length
     sum += Math.min(state.currentWordIndex, Math.max(0, state.words.length - 1)) // separators passed
     return Math.min(sum, totalChars)
-  }, [isCustom, state.words, state.currentWordIndex, state.currentInput, totalChars])
+  }, [isFileImport, state.words, state.currentWordIndex, state.currentInput, totalChars])
 
   function clearImeInput(): void {
     if (imeInputRef.current) imeInputRef.current.value = ''
@@ -187,7 +187,7 @@ export function TypingTestView({
     const container = wordsRef.current
     if (!container) return
 
-    // Imported custom text: align to real line-row elements (never clipped).
+    // Imported fileImport text: align to real line-row elements (never clipped).
     // Prefer the previous line at the top for context — but if a wrapped line
     // (one logical line spanning several visual rows) would push the current
     // line out of view, snap the current line to the top so what's being typed
@@ -249,7 +249,7 @@ export function TypingTestView({
   return (
     <div data-testid="typing-test-view" className="flex w-full min-w-0 flex-col items-center gap-4 px-4 py-4">
       {/* Word display — fixed window with scroll. Word-flow modes show a
-          3-line window; imported custom text shows 4 lines (line-row layout). */}
+          3-line window; imported fileImport text shows 4 lines (line-row layout). */}
       <div
         data-testid="typing-test-words"
         className="relative w-full max-w-4xl font-mono leading-normal typing-multiline-window"
@@ -304,7 +304,7 @@ export function TypingTestView({
         {state.status !== 'countdown' && state.words.length > 0 && (
           <div ref={wordsRef} className="h-full overflow-hidden">
             {lines ? (
-              // Imported custom text: one row per logical line, ⏎ marks the
+              // Imported fileImport text: one row per logical line, ⏎ marks the
               // line ends where Enter (not Space) advances.
               lines.map((lineWordIdxs, lineIdx) => (
                 <div key={lineIdx} data-line-row={lineIdx} className="flex flex-wrap gap-x-3">
@@ -338,9 +338,9 @@ export function TypingTestView({
 
       {/* State-based controls row, below the reading window:
           - not started (waiting / countdown): Next Test (+ Resume if a run is
-            saved for imported custom text)
-          - in progress (running / paused): Pause or Resume (custom) + Restart
-          - finished: result name (custom) + Next Test
+            saved for imported fileImport text)
+          - in progress (running / paused): Pause or Resume (fileImport) + Restart
+          - finished: result name (fileImport) + Next Test
           Next Test and Restart share the same action; only the label differs. */}
       {state.status === 'finished' && (
         <p data-testid="typing-test-complete" className="flex items-center gap-1.5 text-lg font-semibold text-accent">
@@ -352,7 +352,7 @@ export function TypingTestView({
           always shows it so the result can be named and the next test started. */}
       {(!hideControls || state.status === 'finished') && (
       <div className="flex items-center gap-2">
-        {config.mode === 'custom' && (
+        {config.mode === 'fileImport' && (
           state.status === 'running' ? (
             <button
               type="button"
@@ -444,13 +444,13 @@ export function TypingTestView({
             </span>
           </div>
           <div className="flex items-baseline gap-1.5">
-            {/* Imported custom text tracks character progress (spaces included);
+            {/* Imported fileImport text tracks character progress (spaces included);
                 everything else tracks words. */}
-            <span className="text-content-muted">{t(isCustom ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
+            <span className="text-content-muted">{t(isFileImport ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
             <span data-testid="typing-test-word-count" className="font-mono text-lg font-semibold tabular-nums">
               {!showStats
                 ? '-'
-                : isCustom
+                : isFileImport
                 ? t('editor.typingTest.wordCount', { current: typedChars, total: totalChars })
                 : t('editor.typingTest.wordCount', {
                     current: state.currentWordIndex,
@@ -484,7 +484,7 @@ function ComparisonDelta({ current, baseline, suffix, testid }: { current: numbe
   )
 }
 
-/** Name for the just-finished result (imported custom text). A button showing
+/** Name for the just-finished result (imported fileImport text). A button showing
  *  the current name (or the "Unnamed" placeholder) with an edit icon; clicking
  *  opens the naming modal with quick-insert chips. Mounted with a per-test
  *  `key`, so the draft starts empty for a fresh result. */

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -235,7 +235,7 @@ describe('LanguageSelectorModal', () => {
     render(
       <LanguageSelectorModal
         currentLanguage="english"
-        currentCustomTextId="x"
+        currentFileImportTextId="x"
         onSelectLanguage={vi.fn()}
         onSelectImport={vi.fn()}
         onCurrentTextDeleted={onCurrentTextDeleted}
@@ -243,7 +243,7 @@ describe('LanguageSelectorModal', () => {
       />,
     )
 
-    // Modal opens on the Import tab because a custom text is selected.
+    // Modal opens on the Import tab because a fileImport text is selected.
     await waitFor(() => expect(screen.getByTestId('typing-text-delete-x')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('typing-text-delete-x'))
     await waitFor(() => expect(window.vialAPI.typingTestTextStoreDelete).toHaveBeenCalledWith('x'))

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -91,8 +91,8 @@ describe('TypingTestHistory', () => {
 
   it('filters the Text tab by imported text via the dropdown', () => {
     const results = [
-      makeResult({ wpm: 80, mode: 'custom', mode2: 't1', customTextName: 'Alpha' }),
-      makeResult({ wpm: 65, mode: 'custom', mode2: 't2', customTextName: 'Beta' }),
+      makeResult({ wpm: 80, mode: 'fileImport', mode2: 't1', fileImportTextName: 'Alpha' }),
+      makeResult({ wpm: 65, mode: 'fileImport', mode2: 't2', fileImportTextName: 'Beta' }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
 
@@ -109,7 +109,7 @@ describe('TypingTestHistory', () => {
 
   it('shows the Text-tab filter dropdown even with a single imported text', () => {
     const results = [
-      makeResult({ wpm: 80, mode: 'custom', mode2: 't1', customTextName: 'Alpha' }),
+      makeResult({ wpm: 80, mode: 'fileImport', mode2: 't1', fileImportTextName: 'Alpha' }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
 
@@ -210,7 +210,7 @@ describe('TypingTestHistory', () => {
     const onExportCsv = vi.fn()
     const results = [
       makeResult({ wpm: 80, mode: 'words', mode2: 30 }),
-      makeResult({ wpm: 70, mode: 'custom', mode2: 't1', customTextName: 'Alpha' }),
+      makeResult({ wpm: 70, mode: 'fileImport', mode2: 't1', fileImportTextName: 'Alpha' }),
     ]
     renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
@@ -242,14 +242,14 @@ describe('TypingTestHistory', () => {
     expect(onRename).toHaveBeenCalledWith(date, 'QWERTY baseline')
   })
 
-  it('shows the imported-text name (not the textId) for custom-mode rows under the Text tab', () => {
+  it('shows the imported-text name (not the textId) for fileImport-mode rows under the Text tab', () => {
     const results = [makeResult({
-      mode: 'custom',
+      mode: 'fileImport',
       mode2: 'b286fff1-78d1-40d5-8ea0-6dd57561badf',
-      customTextName: 'my-novel.txt',
+      fileImportTextName: 'my-novel.txt',
     })]
     renderWithI18n(<TypingTestHistory results={results} />)
-    // Custom rows live under the Text tab, not Monkeytype (the default).
+    // FileImport rows live under the Text tab, not Monkeytype (the default).
     fireEvent.click(screen.getByTestId('history-tab-text'))
     // The name shows in the table row (the dropdown also lists it as an option).
     expect(screen.getByText('my-novel.txt', { selector: 'td' })).toBeTruthy()
@@ -265,13 +265,13 @@ describe('TypingTestHistory', () => {
   it('separates Monkeytype and Text results into tabs', () => {
     const results = [
       makeResult({ wpm: 81, mode: 'words', mode2: 30 }),
-      makeResult({ wpm: 82, mode: 'custom', mode2: 'id-1', customTextName: 'novel.txt' }),
+      makeResult({ wpm: 82, mode: 'fileImport', mode2: 'id-1', fileImportTextName: 'novel.txt' }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
-    // Monkeytype tab (default): words result shown, custom hidden.
+    // Monkeytype tab (default): words result shown, fileImport hidden.
     expect(screen.getAllByText('81').length).toBeGreaterThan(0)
     expect(screen.queryByText('novel.txt')).toBeNull()
-    // Text tab: custom result shown, words hidden.
+    // Text tab: fileImport result shown, words hidden.
     fireEvent.click(screen.getByTestId('history-tab-text'))
     // The name shows in the table row (the dropdown also lists it as an option).
     expect(screen.getByText('novel.txt', { selector: 'td' })).toBeTruthy()

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -281,28 +281,28 @@ describe('TypingTestView quote mode display', () => {
 })
 
 describe('TypingTestView controls row (state-based)', () => {
-  const customConfig: TypingTestConfig = { mode: 'custom', textId: 'abc' }
+  const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 'abc' }
 
   it('shows Next Test (not Restart) before a run starts', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'waiting' }) })
+    renderView({ config: fileImportConfig, state: makeState({ status: 'waiting' }) })
     expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
     expect(screen.queryByTestId('typing-test-restart')).toBeNull()
   })
 
-  it('shows Pause + Restart while running (custom)', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+  it('shows Pause + Restart while running (fileImport)', () => {
+    renderView({ config: fileImportConfig, state: makeState({ status: 'running' }) })
     expect(screen.getByTestId('typing-memory-pause')).toBeInTheDocument()
     expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
   })
 
-  it('shows Resume + Restart while paused (custom)', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'paused' }) })
+  it('shows Resume + Restart while paused (fileImport)', () => {
+    renderView({ config: fileImportConfig, state: makeState({ status: 'paused' }) })
     expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
     expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
   })
 
-  it('shows Resume in the waiting state when a custom run is saved', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'waiting' }), hasSavedMemory: true })
+  it('shows Resume in the waiting state when a fileImport run is saved', () => {
+    renderView({ config: fileImportConfig, state: makeState({ status: 'waiting' }), hasSavedMemory: true })
     expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
   })
 
@@ -313,29 +313,29 @@ describe('TypingTestView controls row (state-based)', () => {
   })
 
   it('shows the Complete message on the finished screen', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'finished' }) })
+    renderView({ config: fileImportConfig, state: makeState({ status: 'finished' }) })
     expect(screen.getByTestId('typing-test-complete')).toBeInTheDocument()
   })
 
   it('hides the Complete message while running', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+    renderView({ config: fileImportConfig, state: makeState({ status: 'running' }) })
     expect(screen.queryByTestId('typing-test-complete')).toBeNull()
   })
 
   it('never shows Resume on the finished screen, even with a saved memory', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'finished' }), hasSavedMemory: true })
+    renderView({ config: fileImportConfig, state: makeState({ status: 'finished' }), hasSavedMemory: true })
     expect(screen.queryByTestId('typing-memory-resume')).toBeNull()
     expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
     expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
   })
 })
 
-describe('TypingTestView custom mode result naming', () => {
-  const customConfig: TypingTestConfig = { mode: 'custom', textId: 'abc' }
+describe('TypingTestView fileImport mode result naming', () => {
+  const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 'abc' }
 
   it('shows an inline name field (placeholder Unnamed) instead of the quote source', () => {
     renderView({
-      config: customConfig,
+      config: fileImportConfig,
       state: makeState({ status: 'finished', currentQuote: { id: 1, text: 'x', source: 'code', length: 1 } }),
     })
     expect(screen.queryByTestId('typing-test-quote-source')).toBeNull()
@@ -343,9 +343,9 @@ describe('TypingTestView custom mode result naming', () => {
     expect(field.textContent).toBe('Unnamed')
   })
 
-  it('shows both WPM and KPM in custom mode', () => {
+  it('shows both WPM and KPM in fileImport mode', () => {
     renderView({
-      config: customConfig,
+      config: fileImportConfig,
       state: makeState({ status: 'running' }),
       wpm: 24,
       kpm: 120,
@@ -356,7 +356,7 @@ describe('TypingTestView custom mode result naming', () => {
 
   it('preserves leading indentation per line (display only)', () => {
     renderView({
-      config: customConfig,
+      config: fileImportConfig,
       state: makeState({
         status: 'running',
         words: ['def', 'x'],
@@ -369,18 +369,18 @@ describe('TypingTestView custom mode result naming', () => {
     expect(screen.getByTestId('line-indent-1').textContent).toBe('  ')
   })
 
-  it('counts custom progress by character, the word gap included', () => {
+  it('counts fileImport progress by character, the word gap included', () => {
     // "AAA AA" -> 3 + 2 + 1 separator = 6 characters total.
     renderView({
-      config: customConfig,
+      config: fileImportConfig,
       state: makeState({ status: 'running', words: ['AAA', 'AA'], currentWordIndex: 1, currentInput: '' }),
     })
     // 1 word done (3 chars) + 1 separator passed = 4 / 6.
     expect(screen.getByTestId('typing-test-word-count').textContent).toBe('4 / 6')
   })
 
-  it('hides the words/time/quote settings bar in custom mode', () => {
-    renderView({ config: customConfig, state: makeState({ status: 'running' }) })
+  it('hides the words/time/quote settings bar in fileImport mode', () => {
+    renderView({ config: fileImportConfig, state: makeState({ status: 'running' }) })
     expect(screen.queryByTestId('mode-words')).toBeNull()
     expect(screen.queryByTestId('mode-time')).toBeNull()
     expect(screen.queryByTestId('mode-quote')).toBeNull()
@@ -389,7 +389,7 @@ describe('TypingTestView custom mode result naming', () => {
   it('names the finished result on commit', () => {
     const onNameResult = vi.fn()
     renderView({
-      config: customConfig,
+      config: fileImportConfig,
       state: makeState({ status: 'finished' }),
       onNameResult,
     })
@@ -482,7 +482,7 @@ describe('TypingTestView paused overlay', () => {
   })
 })
 
-describe('TypingTestView — imported custom text (line breaks)', () => {
+describe('TypingTestView — imported fileImport text (line breaks)', () => {
   it('renders one row per logical line with ⏎ at line ends, and uses the 4-line window', () => {
     const { container } = renderView({
       state: makeState({
@@ -503,7 +503,7 @@ describe('TypingTestView — imported custom text (line breaks)', () => {
     expect(screen.getByTestId('typing-test-words').className).toContain('typing-multiline-window')
   })
 
-  it('applies font size and line count as CSS vars on the custom window', () => {
+  it('applies font size and line count as CSS vars on the fileImport window', () => {
     renderView({
       displayLines: 6,
       fontSize: 32,
@@ -516,7 +516,7 @@ describe('TypingTestView — imported custom text (line breaks)', () => {
 
   it('shows character progress (not word/line progress) in the stats bar', () => {
     renderView({
-      config: { mode: 'custom', textId: 'x' },
+      config: { mode: 'fileImport', textId: 'x' },
       state: makeState({
         status: 'running',
         words: ['a', 'b', 'c', 'd'],

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -24,7 +24,7 @@ function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult
 }
 
 const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false } as TypingTestConfig
-const customConfig: TypingTestConfig = { mode: 'custom', textId: 't1' } as TypingTestConfig
+const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 't1' } as TypingTestConfig
 
 describe('matchingResults', () => {
   it('matches normal runs on mode + params + language + toggles', () => {
@@ -38,13 +38,13 @@ describe('matchingResults', () => {
     expect(out.map((r) => r.wpm)).toEqual([70])
   })
 
-  it('matches custom runs on the imported text id only', () => {
+  it('matches fileImport runs on the imported text id only', () => {
     const pool = [
-      makeResult({ wpm: 40, mode: 'custom', mode2: 't1', language: 'a' }),
-      makeResult({ wpm: 45, mode: 'custom', mode2: 't1', language: 'b' }), // same text, diff lang → still match
-      makeResult({ wpm: 99, mode: 'custom', mode2: 't2' }),                 // different text
+      makeResult({ wpm: 40, mode: 'fileImport', mode2: 't1', language: 'a' }),
+      makeResult({ wpm: 45, mode: 'fileImport', mode2: 't1', language: 'b' }), // same text, diff lang → still match
+      makeResult({ wpm: 99, mode: 'fileImport', mode2: 't2' }),                 // different text
     ]
-    const out = matchingResults(pool, customConfig, 'english')
+    const out = matchingResults(pool, fileImportConfig, 'english')
     expect(out.map((r) => r.wpm).sort()).toEqual([40, 45])
   })
 
@@ -66,15 +66,15 @@ describe('conditionKey', () => {
     expect(conditionKey(timeConfig, 'english')).toBe('time|10|english|false|false')
   })
 
-  it('keys custom on the imported text id only (language-independent)', () => {
-    expect(conditionKey(customConfig, 'english')).toBe('custom|t1')
-    expect(conditionKey(customConfig, 'japanese')).toBe('custom|t1')
+  it('keys fileImport on the imported text id only (language-independent)', () => {
+    expect(conditionKey(fileImportConfig, 'english')).toBe('fileImport|t1')
+    expect(conditionKey(fileImportConfig, 'japanese')).toBe('fileImport|t1')
   })
 
   it('distinguishes different conditions', () => {
     const a = conditionKey(wordsConfig, 'english')
     const b = conditionKey({ mode: 'time', duration: 10 } as TypingTestConfig, 'english')
-    const c = conditionKey(customConfig, 'english')
+    const c = conditionKey(fileImportConfig, 'english')
     expect(new Set([a, b, c]).size).toBe(3)
   })
 })
@@ -107,7 +107,7 @@ describe('computeComparison', () => {
   })
 
   it('pinned → the result with the matching date, condition-independent', () => {
-    const out = computeComparison(pool, customConfig, 'english', { kind: 'pinned', pinnedDate: '2026-06-19T00:00:00.000Z' })
+    const out = computeComparison(pool, fileImportConfig, 'english', { kind: 'pinned', pinnedDate: '2026-06-19T00:00:00.000Z' })
     expect(out?.wpm).toBe(80)
   })
 

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -25,11 +25,11 @@ describe('typingTestResultMaterialLabel', () => {
     expect(typingTestResultMaterialLabel({ ...base, mode: 'quote', language: 'japanese' }))
       .toBe('quote (japanese)')
   })
-  it('uses the snapshotted text name for custom mode', () => {
-    expect(typingTestResultMaterialLabel({ ...base, mode: 'custom', customTextName: 'novel.txt' }))
+  it('uses the snapshotted text name for fileImport mode', () => {
+    expect(typingTestResultMaterialLabel({ ...base, mode: 'fileImport', fileImportTextName: 'novel.txt' }))
       .toBe('novel.txt')
-    // Falls back to 'custom' when the name wasn't captured.
-    expect(typingTestResultMaterialLabel({ ...base, mode: 'custom' })).toBe('custom')
+    // Falls back to 'fileImport' when the name wasn't captured.
+    expect(typingTestResultMaterialLabel({ ...base, mode: 'fileImport' })).toBe('fileImport')
   })
 })
 
@@ -249,7 +249,7 @@ describe('buildResultNameChips', () => {
   const tStub = (k: string): string =>
     ({ 'editor.typingTest.wpm': 'WPM', 'editor.typingTest.kpm': 'KPM', 'editor.typingTest.accuracy': 'Accuracy' }[k] ?? k)
   it('builds material-label, timestamp and metric chips', () => {
-    const chips = buildResultNameChips({ ...base, mode: 'custom', customTextName: 'Scala - Test001' }, tStub)
+    const chips = buildResultNameChips({ ...base, mode: 'fileImport', fileImportTextName: 'Scala - Test001' }, tStub)
     expect(chips[0]).toBe('Scala - Test001')
     // compact local timestamp YYYYMMDDHHmmss (14 digits)
     expect(chips[1]).toMatch(/^\d{14}$/)

--- a/src/renderer/typing-test/__tests__/useTypingTest.fileImportText.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.fileImportText.test.ts
@@ -4,14 +4,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useTypingTest } from '../useTypingTest'
-import { getCustomTextData, clearCustomTextCache } from '../word-generator'
+import { getFileImportTextData, clearFileImportTextCache } from '../word-generator'
 
 const mockGet = vi.fn()
 const originalVialAPI = window.vialAPI
 
 beforeEach(() => {
   vi.clearAllMocks()
-  clearCustomTextCache()
+  clearFileImportTextCache()
   window.vialAPI = {
     ...(window.vialAPI ?? {}),
     typingTestTextStoreGet: mockGet,
@@ -19,7 +19,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  clearCustomTextCache()
+  clearFileImportTextCache()
   window.vialAPI = originalVialAPI
 })
 
@@ -27,7 +27,7 @@ const type = (result: { current: { processKeyEvent: (k: string, c: boolean, a: b
   act(() => result.current.processKeyEvent(key, false, false, false))
 }
 
-describe('useTypingTest — imported custom text (line breaks)', () => {
+describe('useTypingTest — imported fileImport text (line breaks)', () => {
   it('Enter advances at a line break, Space advances within a line; the wrong key is a no-op', async () => {
     // "a b" / "c d" → words [a,b,c,d], line break after index 1 (the word "b").
     mockGet.mockResolvedValue({
@@ -35,9 +35,9 @@ describe('useTypingTest — imported custom text (line breaks)', () => {
       data: { meta: { id: 't' }, data: { name: 'T', text: 'a b\nc d' } },
     })
     // Warm the cache so the hook's synchronous initial state has the words.
-    await getCustomTextData('t')
+    await getFileImportTextData('t')
 
-    const { result } = renderHook(() => useTypingTest({ mode: 'custom', textId: 't' }, 'english'))
+    const { result } = renderHook(() => useTypingTest({ mode: 'fileImport', textId: 't' }, 'english'))
     expect(result.current.state.words).toEqual(['a', 'b', 'c', 'd'])
     expect([...result.current.state.lineBreaks]).toEqual([1])
 
@@ -79,17 +79,17 @@ describe('useTypingTest — imported custom text (line breaks)', () => {
 })
 
 describe('useTypingTest — memory mode (pause / capture / restore)', () => {
-  const setupCustom = async () => {
+  const setupFileImport = async () => {
     mockGet.mockResolvedValue({
       success: true,
       data: { meta: { id: 't' }, data: { name: 'T', text: 'a b\nc d' } },
     })
-    await getCustomTextData('t')
-    return renderHook(() => useTypingTest({ mode: 'custom', textId: 't' }, 'english'))
+    await getFileImportTextData('t')
+    return renderHook(() => useTypingTest({ mode: 'fileImport', textId: 't' }, 'english'))
   }
 
   it('captureMemory snapshots progress; pause freezes and blocks input', async () => {
-    const { result } = await setupCustom()
+    const { result } = await setupFileImport()
     type(result, 'a')
     type(result, ' ')
     expect(result.current.state.currentWordIndex).toBe(1)
@@ -108,13 +108,13 @@ describe('useTypingTest — memory mode (pause / capture / restore)', () => {
     expect(result.current.state.currentInput).toBe('')
   })
 
-  it('captureMemory returns null for non-custom modes', () => {
+  it('captureMemory returns null for non-fileImport modes', () => {
     const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
     expect(result.current.captureMemory()).toBeNull()
   })
 
   it('restoreState(resume=true) continues running at the saved position', async () => {
-    const { result } = await setupCustom()
+    const { result } = await setupFileImport()
     const memory = {
       textId: 't', currentWordIndex: 2, currentInput: 'c',
       wordResults: [
@@ -134,7 +134,7 @@ describe('useTypingTest — memory mode (pause / capture / restore)', () => {
   })
 
   it('restoreState(resume=false) restores the snapshot frozen as paused', async () => {
-    const { result } = await setupCustom()
+    const { result } = await setupFileImport()
     const memory = {
       textId: 't', currentWordIndex: 1, currentInput: '',
       wordResults: [{ word: 'a', typed: 'a', correct: true }],

--- a/src/renderer/typing-test/comparison.ts
+++ b/src/renderer/typing-test/comparison.ts
@@ -13,12 +13,12 @@ export interface ComparisonStats {
 
 /** Stable key identifying the current test condition, used both to group
  *  same-condition history and to remember the per-condition baseline:
- *  - custom: the imported text id (`custom|textId`)
+ *  - fileImport: the imported text id (`fileImport|textId`)
  *  - normal: mode + params + language + toggles (mirrors `configKey`)
  *  This must agree with {@link matchingResults} so the saved baseline and the
  *  pinnable choices stay in lockstep. */
 export function conditionKey(config: TypingTestConfig, language: string): string {
-  if (config.mode === 'custom') return `custom|${String(deriveMode2(config) ?? '')}`
+  if (config.mode === 'fileImport') return `fileImport|${String(deriveMode2(config) ?? '')}`
   const hasToggles = config.mode === 'words' || config.mode === 'time'
   return configKey({
     mode: config.mode,
@@ -30,7 +30,7 @@ export function conditionKey(config: TypingTestConfig, language: string): string
 }
 
 /** Results from the pool sharing the current test's condition:
- *  - custom: the same imported text (matched on `mode2` = textId)
+ *  - fileImport: the same imported text (matched on `mode2` = textId)
  *  - normal: same mode + params + language + punctuation/numbers (`configKey`)
  *  `beforeMs`, when given, drops results at/after that time so the in-flight
  *  run (saved on finish) never compares against itself. */
@@ -40,7 +40,7 @@ export function matchingResults<T extends TypingTestResult>(
   language: string,
   beforeMs?: number,
 ): T[] {
-  const isCustom = config.mode === 'custom'
+  const isFileImport = config.mode === 'fileImport'
   const currentTextId = String(deriveMode2(config) ?? '')
   const hasToggles = config.mode === 'words' || config.mode === 'time'
   // configKey only reads these 5 fields, so a config-shaped partial is enough.
@@ -54,7 +54,7 @@ export function matchingResults<T extends TypingTestResult>(
 
   return pool.filter((r) => {
     if (beforeMs != null && new Date(r.date).getTime() >= beforeMs) return false
-    if (isCustom) return r.mode === 'custom' && String(r.mode2 ?? '') === currentTextId
+    if (isFileImport) return r.mode === 'fileImport' && String(r.mode2 ?? '') === currentTextId
     return configKey(r) === currentKey
   })
 }

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -20,20 +20,20 @@ export function computeConsistency(wpmHistory: number[]): number {
 }
 
 /** The single source of truth for the analytics `typing_test` material
- *  label: custom → the imported text name, every other mode →
+ *  label: fileImport → the imported text name, every other mode →
  *  `mode (language)`. Both the recording side (`typingTestAnalyticsLabel`
  *  in useInputModes) and the Analyze run filter
  *  (`typingTestResultMaterialLabel`) funnel through this so the join key
  *  stays byte-identical on both ends. */
-export function materialLabel(mode: string, language: string, customName: string | undefined): string {
-  if (mode === 'custom') return customName ?? 'custom'
+export function materialLabel(mode: string, language: string, fileImportName: string | undefined): string {
+  if (mode === 'fileImport') return fileImportName ?? 'fileImport'
   return `${mode} (${language})`
 }
 
 /** The material label a finished result was recorded under — used by the
  *  Analyze run filter to match a History row to its keystrokes. */
 export function typingTestResultMaterialLabel(result: TypingTestResult): string {
-  return materialLabel(result.mode ?? 'words', result.language ?? '', result.customTextName)
+  return materialLabel(result.mode ?? 'words', result.language ?? '', result.fileImportTextName)
 }
 
 /** Keystrokes per minute, derived from the stored char count and duration so
@@ -92,7 +92,7 @@ export function deriveMode2(config: TypingTestConfig): number | string {
       return config.duration
     case 'quote':
       return config.quoteLength
-    case 'custom':
+    case 'fileImport':
       // Group PBs per imported text via its id.
       return config.textId
   }
@@ -108,8 +108,8 @@ export interface BuildTypingTestResultInput {
   config: TypingTestConfig
   language: string
   wpmHistory: number[]
-  /** Imported-text display name (custom mode); ignored for other modes. */
-  customTextName?: string
+  /** Imported-text display name (fileImport mode); ignored for other modes. */
+  fileImportTextName?: string
   /** Run id of the finished run, linking History to analytics keystrokes. */
   runId?: string
 }
@@ -134,7 +134,7 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     rawWpm,
     mode: input.config.mode,
     mode2: deriveMode2(input.config),
-    customTextName: input.config.mode === 'custom' ? input.customTextName : undefined,
+    fileImportTextName: input.config.mode === 'fileImport' ? input.fileImportTextName : undefined,
     language: input.language,
     punctuation: hasPunctuation,
     numbers: hasNumbers,

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-export type TypingTestMode = 'words' | 'time' | 'quote' | 'custom'
+export type TypingTestMode = 'words' | 'time' | 'quote' | 'fileImport'
 export type QuoteLength = 'short' | 'medium' | 'long' | 'all'
 
 export type TypingTestConfig =
@@ -9,7 +9,7 @@ export type TypingTestConfig =
   | { mode: 'quote'; quoteLength: QuoteLength }
   // Imported user text, played verbatim in order via the quote rendering
   // path. `textId` references an entry in the typing-test-texts store.
-  | { mode: 'custom'; textId: string }
+  | { mode: 'fileImport'; textId: string }
 
 export interface Quote {
   id: number
@@ -22,7 +22,7 @@ export const WORD_COUNT_OPTIONS = [15, 30, 60, 120] as const
 export const TIME_DURATION_OPTIONS = [15, 30, 60, 120] as const
 export const DEFAULT_LANGUAGE = 'english'
 
-// Imported custom-text display preferences (custom mode only).
+// Imported file-import-text display preferences (fileImport mode only).
 export const DISPLAY_LINES_MIN = 2
 export const DISPLAY_LINES_MAX = 10
 export const DEFAULT_DISPLAY_LINES = 4

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -2,8 +2,8 @@
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { extractMOLayer, extractLTLayer, extractLMLayer, isTapKeycode } from './keycode-char-map'
-import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getCustomTextData, getCustomTextDataSync } from './word-generator'
-import type { CustomTextData } from './word-generator'
+import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync } from './word-generator'
+import type { FileImportTextData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, Quote } from './types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from './types'
@@ -68,11 +68,11 @@ export interface TypingTestState {
   incorrectChars: number
   currentQuote: Quote | null
   wpmHistory: number[]
-  /** Word indices that end a line (imported custom text only). At these
+  /** Word indices that end a line (imported fileImport text only). At these
    *  words Enter advances; elsewhere Space advances. Empty for every other
    *  mode, so their submit behaviour is unchanged. */
   lineBreaks: Set<number>
-  /** Leading whitespace per logical line (imported custom text, display only).
+  /** Leading whitespace per logical line (imported fileImport text, display only).
    *  Indexed by line order; empty for every other mode. */
   lineIndents: string[]
 }
@@ -117,16 +117,16 @@ function wordGenParams(config: TypingTestConfig & { mode: 'words' | 'time' }): {
 interface WordsForConfig {
   words: string[]
   quote: Quote | null
-  /** Line-end word indices (custom mode only); empty otherwise. */
+  /** Line-end word indices (fileImport mode only); empty otherwise. */
   lineBreaks: number[]
-  /** Per-line leading whitespace (custom mode only); empty otherwise. */
+  /** Per-line leading whitespace (fileImport mode only); empty otherwise. */
   lineIndents: string[]
 }
 
-/** Build the verbatim quote shell for an imported custom text so the
+/** Build the verbatim quote shell for an imported fileImport text so the
  *  finished screen can show its name as the source. Carries the line-break
  *  positions through so Enter can advance at line ends. */
-function customTextToWords(data: CustomTextData): WordsForConfig {
+function fileImportTextToWords(data: FileImportTextData): WordsForConfig {
   const text = data.words.join(' ')
   return {
     words: data.words,
@@ -141,11 +141,11 @@ function createWordsForConfigSync(config: TypingTestConfig, language: string): W
     const quote = selectQuote(config.quoteLength)
     return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
   }
-  if (config.mode === 'custom') {
-    const data = getCustomTextDataSync(config.textId)
+  if (config.mode === 'fileImport') {
+    const data = getFileImportTextDataSync(config.textId)
     // Cache miss — the async setConfig path fills words once the store
     // round-trip resolves. Return empty (never call sampleWords on []).
-    return data ? customTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
+    return data ? fileImportTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
   }
   const { count, opts } = wordGenParams(config)
   const { words } = generateWordsSync(count, opts, language)
@@ -157,9 +157,9 @@ async function createWordsForConfig(config: TypingTestConfig, language: string):
     const quote = selectQuote(config.quoteLength)
     return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
   }
-  if (config.mode === 'custom') {
-    const data = await getCustomTextData(config.textId)
-    return data ? customTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
+  if (config.mode === 'fileImport') {
+    const data = await getFileImportTextData(config.textId)
+    return data ? fileImportTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
   }
   const { count, opts } = wordGenParams(config)
   const { words } = await generateWords(count, opts, language)
@@ -346,14 +346,14 @@ export function useTypingTest(
     setState(freshState(result))
   }, [])
 
-  // --- Memory mode (imported custom text only): pause / capture / restore ---
+  // --- Memory mode (imported fileImport text only): pause / capture / restore ---
 
   /** Snapshot the in-progress test so it can be persisted and resumed.
-   *  Returns null unless an imported custom text is active. */
+   *  Returns null unless an imported fileImport text is active. */
   const captureMemory = useCallback((): TypingTestMemory | null => {
     const s = stateRef.current
     const cfg = configRef.current
-    if (cfg.mode !== 'custom') return null
+    if (cfg.mode !== 'fileImport') return null
     return {
       textId: cfg.textId,
       runId: s.runId,
@@ -381,7 +381,7 @@ export function useTypingTest(
    *  before continuing. Returns false when the text can no longer be loaded
    *  (e.g. deleted) so the caller can fall back to a fresh test. */
   const restoreState = useCallback(async (memory: TypingTestMemory, resume: boolean): Promise<boolean> => {
-    const cfg: TypingTestConfig = { mode: 'custom', textId: memory.textId }
+    const cfg: TypingTestConfig = { mode: 'fileImport', textId: memory.textId }
     setConfigState(cfg)
     configRef.current = cfg
     const seq = ++seqRef.current
@@ -552,8 +552,8 @@ export function useTypingTest(
       if (s.status !== 'waiting' && s.status !== 'running') return s
 
       // Space and Enter both advance a word, but they are distinct: at a
-      // line-end word (imported custom text) Enter is expected, elsewhere
-      // Space. The non-matching key is a no-op. For every non-custom mode
+      // line-end word (imported fileImport text) Enter is expected, elsewhere
+      // Space. The non-matching key is a no-op. For every non-fileImport mode
       // `lineBreaks` is empty, so Space always advances and Enter is always
       // ignored — identical to the previous behaviour.
       if (isSubmitKey(key) || key === 'Enter') {
@@ -665,7 +665,7 @@ export function useTypingTest(
     return Math.round((state.correctChars / 5) / minutes)
   }, [state.startTime, state.endTime, state.correctChars, tick])
 
-  // Keystrokes per minute (correct chars / minute). Custom mode shows this
+  // Keystrokes per minute (correct chars / minute). FileImport mode shows this
   // instead of WPM, since imported code / CJK text has no meaningful "words".
   const kpm = useMemo(() => {
     if (!state.startTime) return 0

--- a/src/renderer/typing-test/word-generator/__tests__/file-import-text.test.ts
+++ b/src/renderer/typing-test/word-generator/__tests__/file-import-text.test.ts
@@ -3,17 +3,17 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
-  getCustomTextData,
-  getCustomTextDataSync,
-  clearCustomTextCache,
-} from '../custom-text'
+  getFileImportTextData,
+  getFileImportTextDataSync,
+  clearFileImportTextCache,
+} from '../file-import-text'
 
 const mockGet = vi.fn()
 const originalVialAPI = window.vialAPI
 
 beforeEach(() => {
   vi.clearAllMocks()
-  clearCustomTextCache()
+  clearFileImportTextCache()
   window.vialAPI = {
     ...(window.vialAPI ?? {}),
     typingTestTextStoreGet: mockGet,
@@ -21,29 +21,29 @@ beforeEach(() => {
 })
 
 afterEach(() => {
-  clearCustomTextCache()
+  clearFileImportTextCache()
   window.vialAPI = originalVialAPI
 })
 
-describe('getCustomTextData', () => {
+describe('getFileImportTextData', () => {
   it('fetches via IPC, parses words + line breaks, and caches', async () => {
     mockGet.mockResolvedValue({
       success: true,
       data: { meta: { id: 't1' }, data: { name: 'My Text', text: 'one two\nthree four' } },
     })
 
-    const first = await getCustomTextData('t1')
+    const first = await getFileImportTextData('t1')
     // "one two" then a newline then "three four": break after word index 1.
     expect(first).toEqual({ name: 'My Text', words: ['one', 'two', 'three', 'four'], lineBreaks: [1], indents: ['', ''] })
     expect(mockGet).toHaveBeenCalledTimes(1)
 
     // Second call served from cache — no extra IPC.
-    const second = await getCustomTextData('t1')
+    const second = await getFileImportTextData('t1')
     expect(second).toBe(first)
     expect(mockGet).toHaveBeenCalledTimes(1)
 
     // Sync accessor now hits the warmed cache.
-    expect(getCustomTextDataSync('t1')).toBe(first)
+    expect(getFileImportTextDataSync('t1')).toBe(first)
   })
 
   it('single-line text has no line breaks', async () => {
@@ -51,25 +51,25 @@ describe('getCustomTextData', () => {
       success: true,
       data: { meta: { id: 't2' }, data: { name: 'Flat', text: 'one two three' } },
     })
-    const data = await getCustomTextData('t2')
+    const data = await getFileImportTextData('t2')
     expect(data).toEqual({ name: 'Flat', words: ['one', 'two', 'three'], lineBreaks: [], indents: [''] })
   })
 
   it('returns undefined for a missing entry and does not cache', async () => {
     mockGet.mockResolvedValue({ success: false, errorCode: 'NOT_FOUND' })
-    expect(await getCustomTextData('gone')).toBeUndefined()
-    expect(getCustomTextDataSync('gone')).toBeUndefined()
+    expect(await getFileImportTextData('gone')).toBeUndefined()
+    expect(getFileImportTextDataSync('gone')).toBeUndefined()
   })
 
-  it('clearCustomTextCache(id) forces a re-fetch', async () => {
+  it('clearFileImportTextCache(id) forces a re-fetch', async () => {
     mockGet.mockResolvedValue({
       success: true,
       data: { meta: { id: 't1' }, data: { name: 'A', text: 'x y' } },
     })
-    await getCustomTextData('t1')
-    clearCustomTextCache('t1')
-    expect(getCustomTextDataSync('t1')).toBeUndefined()
-    await getCustomTextData('t1')
+    await getFileImportTextData('t1')
+    clearFileImportTextCache('t1')
+    expect(getFileImportTextDataSync('t1')).toBeUndefined()
+    await getFileImportTextData('t1')
     expect(mockGet).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/typing-test/word-generator/file-import-text.ts
+++ b/src/renderer/typing-test/word-generator/file-import-text.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Imported custom-text source for the typing test. Mirrors the language
+// Imported file-import-text source for the typing test. Mirrors the language
 // cache: fetched once per id from the typing-test-texts store, then
 // served synchronously. Played verbatim in order via the quote path.
 
-import { parseCustomText } from '../../../shared/types/typing-test-text-store'
+import { parseFileImportText } from '../../../shared/types/typing-test-text-store'
 
-export interface CustomTextData {
+export interface FileImportTextData {
   name: string
   /** Words in original order (space- and newline-separated, flattened). */
   words: string[]
@@ -16,34 +16,34 @@ export interface CustomTextData {
   indents: string[]
 }
 
-const customTextCache = new Map<string, CustomTextData>()
+const fileImportTextCache = new Map<string, FileImportTextData>()
 
-export function getCustomTextDataSync(textId: string): CustomTextData | undefined {
-  return customTextCache.get(textId)
+export function getFileImportTextDataSync(textId: string): FileImportTextData | undefined {
+  return fileImportTextCache.get(textId)
 }
 
-export async function getCustomTextData(textId: string): Promise<CustomTextData | undefined> {
-  const cached = customTextCache.get(textId)
+export async function getFileImportTextData(textId: string): Promise<FileImportTextData | undefined> {
+  const cached = fileImportTextCache.get(textId)
   if (cached) return cached
 
   const result = await window.vialAPI.typingTestTextStoreGet(textId)
   if (!result.success || !result.data) return undefined
 
   const { name, text } = result.data.data
-  // Shares parseCustomText with the main-process import path so playback
+  // Shares parseFileImportText with the main-process import path so playback
   // and storage agree on word boundaries AND line breaks.
-  const { words, lineBreaks, indents } = parseCustomText(text)
-  const data: CustomTextData = { name, words, lineBreaks, indents }
-  customTextCache.set(textId, data)
+  const { words, lineBreaks, indents } = parseFileImportText(text)
+  const data: FileImportTextData = { name, words, lineBreaks, indents }
+  fileImportTextCache.set(textId, data)
   return data
 }
 
 /** Drop cached entries so the next read re-fetches from the store. Called
  *  by useTypingTestTexts after rename / delete / import / sync changes. */
-export function clearCustomTextCache(textId?: string): void {
+export function clearFileImportTextCache(textId?: string): void {
   if (textId) {
-    customTextCache.delete(textId)
+    fileImportTextCache.delete(textId)
   } else {
-    customTextCache.clear()
+    fileImportTextCache.clear()
   }
 }

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -3,6 +3,6 @@
 
 export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync, injectPunctuation, injectNumbers } from './word-generator'
 export { selectQuote, quoteToWords } from './quote-generator'
-export { getCustomTextData, getCustomTextDataSync, clearCustomTextCache } from './custom-text'
-export type { CustomTextData } from './custom-text'
+export { getFileImportTextData, getFileImportTextDataSync, clearFileImportTextCache } from './file-import-text'
+export type { FileImportTextData } from './file-import-text'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -19,12 +19,12 @@ export interface TypingTestResult {
   incorrectChars: number
   durationSeconds: number
   rawWpm?: number
-  mode?: 'words' | 'time' | 'quote' | 'custom'
+  mode?: 'words' | 'time' | 'quote' | 'fileImport'
   mode2?: number | string
-  /** Human-readable imported-text name, snapshotted at test time (custom
+  /** Human-readable imported-text name, snapshotted at test time (fileImport
    *  mode only). `mode2` keeps the stable textId for PB grouping; this is
    *  what History shows so the row isn't an opaque id. */
-  customTextName?: string
+  fileImportTextName?: string
   language?: string
   punctuation?: boolean
   numbers?: boolean
@@ -160,14 +160,14 @@ export const DEFAULT_PIPETTE_SETTINGS: PipetteSettings = {
   layerNames: [],
 }
 
-/** Serializable per-word result for resuming a paused custom typing test. */
+/** Serializable per-word result for resuming a paused fileImport typing test. */
 export interface TypingTestMemoryWord {
   word: string
   typed: string
   correct: boolean
 }
 
-/** Snapshot of an in-progress imported (custom) typing test, persisted so
+/** Snapshot of an in-progress imported (fileImport) typing test, persisted so
  * the user can pause and resume later. One slot per keyboard. Words and
  * line breaks are regenerated from `textId`, so only progress is stored. */
 export interface TypingTestMemory {
@@ -195,14 +195,14 @@ export interface PipetteSettings {
   layerNames: string[]
   typingTestResults?: TypingTestResult[]
   typingTestConfig?: Record<string, unknown>
-  /** Last words/time/quote config, restored when switching back from custom
+  /** Last words/time/quote config, restored when switching back from fileImport
    *  (imported text) so normal-mode Pattern/Units/Option settings survive. */
   typingTestNormalConfig?: Record<string, unknown>
   typingTestLanguage?: string
   typingTestViewOnly?: boolean
   typingTestViewOnlyWindowSize?: { width: number; height: number }
   typingTestViewOnlyAlwaysOnTop?: boolean
-  /** Paused custom typing-test snapshot (memory mode). Cleared on finish,
+  /** Paused fileImport typing-test snapshot (memory mode). Cleared on finish,
    * "start over", text change, or device switch. */
   typingTestMemory?: TypingTestMemory
   /** Imported-text display: visible line count (2–10, default 4). */

--- a/src/shared/types/typing-test-text-store.ts
+++ b/src/shared/types/typing-test-text-store.ts
@@ -65,7 +65,7 @@ export const TYPING_TEST_TEXT_MAX_FILE_BYTES = 5 * 1024 * 1024 // 5 MB
 /** Max stored words per imported text. Excess is truncated on import. */
 export const TYPING_TEST_TEXT_MAX_WORDS = 5000
 
-export interface ParsedCustomText {
+export interface ParsedFileImportText {
   /** Words in original order (space- and newline-separated, flattened). */
   words: string[]
   /** Indices of words that END a line — a newline follows them, so the
@@ -86,7 +86,7 @@ export interface ParsedCustomText {
  * Shared by the main store (canonicalize on import) and the renderer
  * (verbatim playback) so the two never disagree on words or break points.
  */
-export function parseCustomText(text: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): ParsedCustomText {
+export function parseFileImportText(text: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): ParsedFileImportText {
   const lines = text
     .replace(/\r\n?/g, '\n')
     .split('\n')
@@ -122,10 +122,10 @@ export function parseCustomText(text: string, maxWords: number = TYPING_TEST_TEX
 /**
  * Canonicalize raw imported text for storage: words joined by a single
  * space within a line and a newline at each line break. Round-trips
- * through `parseCustomText` so storage and playback agree exactly.
+ * through `parseFileImportText` so storage and playback agree exactly.
  */
-export function normalizeCustomText(raw: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): { text: string; wordCount: number } {
-  const { words, lineBreaks, indents } = parseCustomText(raw, maxWords)
+export function normalizeFileImportText(raw: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): { text: string; wordCount: number } {
+  const { words, lineBreaks, indents } = parseFileImportText(raw, maxWords)
   const breakSet = new Set(lineBreaks)
   let text = ''
   let lineIdx = 0


### PR DESCRIPTION
## Summary
Rename the typing-test imported-text mode from **Custom** to **File Import** across the whole typing-test domain:
- Persisted mode literal `'custom'` → `'fileImport'`; types and the comparison baseline key prefix (`custom|` → `fileImport|`).
- Field `customTextName` → `fileImportTextName`; functions/variables (`parseCustomText`, `isCustom`, `customTextId`, `customTexts`, …) → `fileImport…`.
- Word-generator file `custom-text.ts` → `file-import-text.ts` (+ its tests).
- i18n keys `mode.custom`→`mode.fileImport`, `tabCustom`→`tabFileImport`, `customText`→`fileImportText`; tab label now reads **File Import** / **ファイル取込**.

Unrelated uses of "custom" (custom keycodes, customFill key colors, custom i18n packs) are deliberately untouched.

## Notes
- Pre-release: no in-code migration layer; existing local user data was migrated directly (settings JSON `mode`/`customTextName`/baseline keys).

## Test plan
- [x] lint / build / 4307 tests pass
- [x] residual typing-test `custom` references: none