### PR TITLE
fix(ui): size the typing-test reading window to the window, not the keymap

### DIFF
--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -361,10 +361,6 @@ export function TypingTestPane({
   const [cssScale, setCssScale] = useState(1)
   const paneWrapperRef = useRef<HTMLDivElement>(null)
   const paneNaturalSizeRef = useRef({ w: 0, h: 0 })
-  // Measured rendered width of the centred keyboard, so the reading window
-  // (above it, in TypingTestView) can match the keymap's width.
-  const keyboardBoxRef = useRef<HTMLDivElement>(null)
-  const [keyboardWidth, setKeyboardWidth] = useState<number>()
   const MARGIN = 20
 
   // Calculate default compact window size: keyboard at 100% + pane padding + margins
@@ -395,17 +391,6 @@ export function TypingTestPane({
     }
     return { width: w, height: h }
   }, [keys, layoutOptions])
-
-  // Track the keyboard's rendered width so the reading window can match it.
-  useEffect(() => {
-    const el = keyboardBoxRef.current
-    if (!el) return
-    const update = () => setKeyboardWidth(el.getBoundingClientRect().width)
-    update()
-    const ro = new ResizeObserver(update)
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [viewOnly])
 
   // App.tsx entry paths (analytics back, post-unlock, view restore, status bar)
   // call setWindowCompactMode with an undefined saved size, which main skips —
@@ -706,9 +691,6 @@ export function TypingTestPane({
       <div className={viewOnly ? 'contents' : 'flex min-w-0 flex-1 flex-col items-center'}>
       {!viewOnly && (
         <TypingTestView
-          // Keymap hidden → its measured width is gone; let the reading window
-          // fall back to its own max width instead of collapsing.
-          readingMaxWidth={hideKeymap ? undefined : keyboardWidth}
           hideStatsRow={hideStatsRow}
           hideControls={hideControls}
           comparison={comparison}
@@ -751,9 +733,7 @@ export function TypingTestPane({
               where centring pushes content half-off and halves scrollWidth. */}
           <div className={`flex w-full items-start${viewOnly ? '' : ' justify-center'}`}>
           <div className="shrink-0">
-          {/* Measure only the keyboard so the reading window matches the
-              keymap width, even for a small board. */}
-          <div ref={keyboardBoxRef} className="w-fit">
+          <div className="w-fit">
           {/* Keymap hidden only in the editor view — view-only mode is
               keyboard-focused, so the toggle never applies there. */}
           {!(hideKeymap && !viewOnly) && (

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -23,9 +23,6 @@ interface Props {
   remainingSeconds: number | null
   config: TypingTestConfig
   paused: boolean
-  /** Max width for the reading window, matched to the keyboard below so the
-   *  typing text lines up with the keymap (px). */
-  readingMaxWidth?: number
   /** Hide the stats / results (WPM) row. Persisted per keyboard. */
   hideStatsRow?: boolean
   /** Hide the operation (Next Test button) controls row. Persisted per
@@ -100,7 +97,6 @@ export function TypingTestView({
   remainingSeconds,
   config,
   paused,
-  readingMaxWidth,
   hideStatsRow,
   hideControls,
   comparison,
@@ -253,7 +249,7 @@ export function TypingTestView({
       <div
         data-testid="typing-test-words"
         className="relative w-full max-w-4xl font-mono leading-normal typing-multiline-window"
-        style={{ ...multilineStyle, maxWidth: readingMaxWidth }}
+        style={multilineStyle}
         onClick={() => imeInputRef.current?.focus()}
       >
         {/* Hidden textarea for IME composition input */}
@@ -395,10 +391,9 @@ export function TypingTestView({
           hides the LIVE metrics during a run — once finished, the results
           always show. */}
       {(!hideStatsRow || state.status === 'finished') && (
-      // Not capped to readingMaxWidth (the keyboard width) like the reading
-      // window: the metrics row sits below the board and centres on the full
-      // available width, so all stats stay on one line instead of wrapping
-      // when the keyboard is narrower than the row.
+      // Centres on the full available (window-driven) width so all stats stay
+      // on one line instead of wrapping — independent of the keyboard width,
+      // like the reading window above.
       <div
         data-testid="typing-test-results"
         className="flex w-full flex-col items-center gap-2"


### PR DESCRIPTION
## Summary
- The reading window was capped to the measured keyboard width, so the typed text reflowed differently per keyboard.
- Drop the keyboard-width coupling and let the window use its own `w-full max-w-4xl` (window-driven) width.
- Remove the now-dead keyboard-width measurement (ref + ResizeObserver) and the `readingMaxWidth` prop.

## Effect
- Text width no longer depends on the keymap size; it varies with the window.
- The same window size renders the same text layout regardless of the keyboard. Consistent with the stats row (already window-driven in #216).

## Test plan
- [x] lint / build / 4307 tests pass
- [x] no residual keyboardWidth references