### PR TITLE
feat(hub): follow Hub-distributed typing-test dataset versions

### DIFF
--- a/src/main/__tests__/typing-dataset-sync.test.ts
+++ b/src/main/__tests__/typing-dataset-sync.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdir, writeFile, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+vi.mock('electron', () => {
+  const app = { getPath: vi.fn() }
+  const ipcMain = { handle: vi.fn() }
+  const net = { fetch: vi.fn() }
+  return { app, ipcMain, net }
+})
+vi.mock('../logger', () => ({ log: vi.fn() }))
+vi.mock('../ipc-guard', async () => {
+  const { ipcMain } = await import('electron')
+  return { secureHandle: ipcMain.handle }
+})
+
+const HUB_VERSION = 'newcommit0000000000000000000000000000000'
+const NEW_DOWNLOAD_BASE = 'https://hub.example/languages'
+
+let testDir: string
+let mod: typeof import('../language-store')
+let mockNet: { fetch: ReturnType<typeof vi.fn> }
+
+function okJson(data: unknown) {
+  return { ok: true, json: () => Promise.resolve({ ok: true, data }) }
+}
+
+beforeEach(async () => {
+  vi.resetModules()
+  testDir = join(tmpdir(), `tt-dataset-sync-${Date.now()}-${Math.round(performance.now())}`)
+  await mkdir(join(testDir, 'local', 'downloads', 'languages'), { recursive: true })
+
+  const electron = await import('electron')
+  vi.mocked(electron.app).getPath.mockReturnValue(testDir)
+  mockNet = vi.mocked(electron.net) as unknown as { fetch: ReturnType<typeof vi.fn> }
+  mod = await import('../language-store')
+})
+
+afterEach(async () => {
+  await rm(testDir, { recursive: true, force: true })
+  vi.clearAllMocks()
+})
+
+function overridePath(): string {
+  return join(testDir, 'local', 'typing-test-dataset.json')
+}
+
+describe('syncTypingDataset', () => {
+  it('does nothing when the Hub version matches the current version', async () => {
+    // Hub returns the SAME version as the bundled default → no fetch of full
+    // dataset, no override file written.
+    const { TYPING_TEST_PROVIDER_DEFAULTS } = await import('../../shared/data/typing-test-providers')
+    const currentVersion = TYPING_TEST_PROVIDER_DEFAULTS[0].version
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype', version: currentVersion }))
+
+    const result = await mod.syncTypingDataset('monkeytype')
+
+    expect(result.changed).toBe(false)
+    await expect(readFile(overridePath(), 'utf-8')).rejects.toThrow()
+  })
+
+  it('writes an override and clears downloads when the Hub version differs', async () => {
+    // Seed a stale downloaded file that must be cleared on a version bump.
+    await writeFile(join(testDir, 'local', 'downloads', 'languages', 'german.json'), '{}', 'utf-8')
+
+    const freshDataset = {
+      provider: 'monkeytype',
+      version: HUB_VERSION,
+      downloadUrlBase: NEW_DOWNLOAD_BASE,
+      languages: [
+        { name: 'english', wordCount: 200, rightToLeft: false, fileSize: 2540 },
+        { name: 'spanish', wordCount: 500, rightToLeft: false, fileSize: 9000 },
+      ],
+    }
+    // First call = /version probe, second = full dataset.
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'monkeytype', version: HUB_VERSION }))
+      .mockResolvedValueOnce(okJson(freshDataset))
+
+    const result = await mod.syncTypingDataset('monkeytype')
+
+    expect(result.changed).toBe(true)
+    expect(result.toVersion).toBe(HUB_VERSION)
+
+    // Override persisted verbatim.
+    const written = JSON.parse(await readFile(overridePath(), 'utf-8')) as Record<string, typeof freshDataset>
+    expect(written.monkeytype).toEqual(freshDataset)
+
+    // Stale download removed.
+    const remaining = await readdir(join(testDir, 'local', 'downloads', 'languages'))
+    expect(remaining).not.toContain('german.json')
+  })
+
+  it('returns changed:false when the Hub is unreachable', async () => {
+    mockNet.fetch.mockRejectedValue(new Error('offline'))
+    const result = await mod.syncTypingDataset('monkeytype')
+    expect(result.changed).toBe(false)
+    await expect(readFile(overridePath(), 'utf-8')).rejects.toThrow()
+  })
+})
+
+describe('effective dataset after override', () => {
+  it('LANG_LIST and LANG_DOWNLOAD use the overridden manifest + URL', async () => {
+    const freshDataset = {
+      provider: 'monkeytype',
+      version: HUB_VERSION,
+      downloadUrlBase: NEW_DOWNLOAD_BASE,
+      languages: [{ name: 'spanish', wordCount: 500, rightToLeft: false, fileSize: 4 }],
+    }
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'monkeytype', version: HUB_VERSION }))
+      .mockResolvedValueOnce(okJson(freshDataset))
+    await mod.syncTypingDataset('monkeytype')
+
+    // Register IPC handlers and capture them.
+    const electron = await import('electron')
+    const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+    vi.mocked(electron.ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+      handlers.set(c, h)
+    }) as unknown as typeof electron.ipcMain.handle)
+    mod.setupLanguageStore()
+
+    const list = await handlers.get('lang:list')!({}) as Array<{ name: string }>
+    expect(list.map((l) => l.name)).toEqual(['spanish'])
+
+    // Download must hit the overridden base URL, not the bundled default.
+    mockNet.fetch.mockReset()
+    mockNet.fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('xxxx') } as unknown as Response)
+    await handlers.get('lang:download')!({}, 'spanish')
+    expect(mockNet.fetch).toHaveBeenCalledWith(`${NEW_DOWNLOAD_BASE}/spanish.json`)
+  })
+})

--- a/src/main/hub/__tests__/hub-typing-dataset.test.ts
+++ b/src/main/hub/__tests__/hub-typing-dataset.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment node
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('electron', () => ({ net: { fetch: vi.fn() } }))
+
+import { net } from 'electron'
+import { fetchTypingDatasetVersion, fetchTypingDataset } from '../hub-typing-dataset'
+
+const mockNet = vi.mocked(net)
+
+function okJson(data: unknown) {
+  return { ok: true, json: () => Promise.resolve({ ok: true, data }) } as unknown as Response
+}
+
+beforeEach(() => {
+  mockNet.fetch.mockReset()
+})
+afterEach(() => vi.clearAllMocks())
+
+describe('fetchTypingDatasetVersion', () => {
+  it('returns the version string on success', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype', version: 'abc123' }))
+    expect(await fetchTypingDatasetVersion('monkeytype')).toBe('abc123')
+    expect(mockNet.fetch).toHaveBeenCalledWith(expect.stringContaining('/api/typing-test/datasets/monkeytype/version'))
+  })
+
+  it('returns null on HTTP error', async () => {
+    mockNet.fetch.mockResolvedValue({ ok: false, json: () => Promise.resolve({}) } as unknown as Response)
+    expect(await fetchTypingDatasetVersion('monkeytype')).toBeNull()
+  })
+
+  it('returns null on a network throw', async () => {
+    mockNet.fetch.mockRejectedValue(new Error('offline'))
+    expect(await fetchTypingDatasetVersion('monkeytype')).toBeNull()
+  })
+
+  it('returns null when version is missing from the payload', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype' }))
+    expect(await fetchTypingDatasetVersion('monkeytype')).toBeNull()
+  })
+})
+
+describe('fetchTypingDataset', () => {
+  const validDataset = {
+    provider: 'monkeytype',
+    version: 'abc123',
+    downloadUrlBase: 'https://example.test/languages',
+    languages: [{ name: 'english', wordCount: 200, rightToLeft: false, fileSize: 2540 }],
+  }
+
+  it('returns the validated dataset on success', async () => {
+    mockNet.fetch.mockResolvedValue(okJson(validDataset))
+    expect(await fetchTypingDataset('monkeytype')).toEqual(validDataset)
+  })
+
+  it('returns null when a language entry is malformed', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ ...validDataset, languages: [{ name: 'x' }] }))
+    expect(await fetchTypingDataset('monkeytype')).toBeNull()
+  })
+
+  it('returns null when downloadUrlBase is missing', async () => {
+    const { downloadUrlBase, ...rest } = validDataset
+    void downloadUrlBase
+    mockNet.fetch.mockResolvedValue(okJson(rest))
+    expect(await fetchTypingDataset('monkeytype')).toBeNull()
+  })
+
+  it('returns null on a network throw', async () => {
+    mockNet.fetch.mockRejectedValue(new Error('offline'))
+    expect(await fetchTypingDataset('monkeytype')).toBeNull()
+  })
+
+  it('rejects a non-HTTPS downloadUrlBase (SSRF guard)', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ ...validDataset, downloadUrlBase: 'http://example.test/x' }))
+    expect(await fetchTypingDataset('monkeytype')).toBeNull()
+  })
+
+  it('rejects a provider mismatch', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ ...validDataset, provider: 'evil' }))
+    expect(await fetchTypingDataset('monkeytype')).toBeNull()
+  })
+})

--- a/src/main/hub/hub-typing-dataset.ts
+++ b/src/main/hub/hub-typing-dataset.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hub client for `/api/typing-test/datasets` — the version-distribution
+// API for typing-test word datasets. Lets the desktop follow upstream
+// (monkeytype etc.) word-list updates without an app re-release: compare
+// the locally pinned version against the Hub's and, on a mismatch, pull
+// the fresh manifest + download URL base.
+//
+// All endpoints are anonymous, read-only and server-cached. Both fetchers
+// resolve to `null` on any network / shape error so callers can silently
+// fall back to the bundled defaults.
+
+import { net } from 'electron'
+import type { LanguageManifestEntry, TypingTestDataset } from '../../shared/types/language-store'
+
+const HUB_API_DEFAULT = 'https://pipette-hub-worker.keymaps.workers.dev'
+const isDev = !!process.env.ELECTRON_RENDERER_URL
+const HUB_API_BASE = (isDev && process.env.PIPETTE_HUB_URL) || HUB_API_DEFAULT
+
+interface HubApiResponse<T> {
+  ok: boolean
+  data: T
+  error?: string
+}
+
+function datasetRoute(provider: string): string {
+  return `${HUB_API_BASE}/api/typing-test/datasets/${encodeURIComponent(provider)}`
+}
+
+export function isManifestEntry(v: unknown): v is LanguageManifestEntry {
+  if (typeof v !== 'object' || v === null) return false
+  const e = v as Record<string, unknown>
+  return (
+    typeof e.name === 'string' &&
+    typeof e.wordCount === 'number' &&
+    typeof e.rightToLeft === 'boolean' &&
+    typeof e.fileSize === 'number'
+  )
+}
+
+/** Lightweight version probe. Returns the Hub's current `version` for the
+ *  provider, or `null` if unreachable / unknown provider / bad shape. */
+export async function fetchTypingDatasetVersion(provider: string): Promise<string | null> {
+  try {
+    const res = await net.fetch(`${datasetRoute(provider)}/version`)
+    if (!res.ok) return null
+    const body = (await res.json()) as HubApiResponse<{ provider: string; version: string }>
+    if (!body.ok || typeof body.data?.version !== 'string') return null
+    return body.data.version
+  } catch {
+    return null
+  }
+}
+
+/** Full dataset (version + downloadUrlBase + language manifest). Returns
+ *  `null` on any error or if the payload fails validation. */
+export async function fetchTypingDataset(provider: string): Promise<TypingTestDataset | null> {
+  try {
+    const res = await net.fetch(datasetRoute(provider))
+    if (!res.ok) return null
+    const body = (await res.json()) as HubApiResponse<TypingTestDataset>
+    const d = body.data
+    if (
+      !body.ok ||
+      !d ||
+      typeof d.provider !== 'string' ||
+      d.provider !== provider ||
+      typeof d.version !== 'string' ||
+      typeof d.downloadUrlBase !== 'string' ||
+      // The base URL is fetched from the main process, so reject anything
+      // that isn't plain HTTPS to avoid an SSRF vector via a bad Hub payload.
+      !/^https:\/\//.test(d.downloadUrlBase) ||
+      !Array.isArray(d.languages) ||
+      !d.languages.every(isManifestEntry)
+    ) {
+      return null
+    }
+    return {
+      provider: d.provider,
+      version: d.version,
+      downloadUrlBase: d.downloadUrlBase,
+      languages: d.languages,
+    }
+  } catch {
+    return null
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import { setupI18nPackStore } from './i18n-pack-ipc'
 import { setupThemePackStore } from './theme-pack-ipc'
 import { setupHidIpc } from './hid-ipc'
 import { setupPipetteSettingsStore } from './pipette-settings-store'
-import { setupLanguageStore } from './language-store'
+import { setupLanguageStore, startTypingDatasetStartupSync } from './language-store'
 import { setupSyncIpc } from './sync/sync-ipc'
 import { setupHubIpc } from './hub/hub-ipc'
 import { startI18nStartupSync } from './hub/i18n-startup-sync'
@@ -352,6 +352,11 @@ app.whenReady().then(() => {
   // notified via I18N_PACK_CHANGED so the language picker reflects any
   // applied updates without a manual reload.
   startI18nStartupSync()
+
+  // Best-effort: follow upstream typing-test word-dataset updates. Compares
+  // the bundled/overridden version against the Hub and, on a mismatch, pulls
+  // the fresh manifest + download URL base. Never blocks startup.
+  startTypingDatasetStartupSync()
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -1,24 +1,69 @@
 import { app, net } from 'electron'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises'
 import { IpcChannels } from '../shared/ipc/channels'
-import type { LanguageManifestEntry, LanguageListEntry, LanguageDownloadStatus } from '../shared/types/language-store'
-import manifest from '../shared/data/language-manifest.json'
+import type { LanguageListEntry, LanguageDownloadStatus, TypingTestDataset } from '../shared/types/language-store'
+import {
+  DEFAULT_TYPING_TEST_PROVIDER,
+  getProviderDefault,
+} from '../shared/data/typing-test-providers'
+import { fetchTypingDataset, fetchTypingDatasetVersion, isManifestEntry } from './hub/hub-typing-dataset'
 import { log } from './logger'
 import { secureHandle } from './ipc-guard'
 
-const BUNDLED_LANGUAGES = new Set(['english'])
-
-const MANIFEST_MAP = new Map(
-  (manifest as LanguageManifestEntry[]).map((e) => [e.name, e]),
-)
-
-const LANG_SOURCE_COMMIT = '629c82e112a2db2122c789dc6abe970b82c3f8c5'
-const DOWNLOAD_URL_BASE =
-  `https://github.com/monkeytypegame/monkeytype/raw/${LANG_SOURCE_COMMIT}/frontend/static/languages`
-
 function getLanguagesDir(): string {
   return join(app.getPath('userData'), 'local', 'downloads', 'languages')
+}
+
+/** Persisted Hub overrides keyed by provider. Absent / partial → bundled
+ *  defaults are used. Lives under `local/` (machine-local, never synced). */
+function getOverridePath(): string {
+  return join(app.getPath('userData'), 'local', 'typing-test-dataset.json')
+}
+
+// In-memory cache of the override file so the hot LANG_LIST / LANG_DOWNLOAD
+// paths don't re-read disk on every call. Reset whenever the file changes.
+let overridesCache: Record<string, TypingTestDataset> | null = null
+
+async function loadOverrides(): Promise<Record<string, TypingTestDataset>> {
+  if (overridesCache) return overridesCache
+  try {
+    const parsed: unknown = JSON.parse(await readFile(getOverridePath(), 'utf-8'))
+    overridesCache = (parsed && typeof parsed === 'object') ? (parsed as Record<string, TypingTestDataset>) : {}
+  } catch {
+    overridesCache = {}
+  }
+  return overridesCache
+}
+
+/** Effective dataset for a provider: the persisted Hub override if present
+ *  and well-formed, otherwise the bundled default from the provider config. */
+/** A persisted override is trusted only if it is fully well-formed — a
+ *  corrupt local file must not poison LANG_LIST / LANG_DOWNLOAD, so we fall
+ *  back to the bundled default instead. Mirrors the Hub-client validation. */
+function isValidOverride(ov: unknown): ov is TypingTestDataset {
+  if (typeof ov !== 'object' || ov === null) return false
+  const d = ov as Record<string, unknown>
+  return (
+    typeof d.version === 'string' &&
+    typeof d.downloadUrlBase === 'string' &&
+    /^https:\/\//.test(d.downloadUrlBase) &&
+    Array.isArray(d.languages) &&
+    d.languages.every(isManifestEntry)
+  )
+}
+
+async function getEffectiveDataset(provider: string): Promise<TypingTestDataset> {
+  const def = getProviderDefault(provider)
+  const overrides = await loadOverrides()
+  const ov = overrides[provider]
+  if (isValidOverride(ov)) return ov
+  if (!def) throw new Error(`Unknown typing-test provider: ${provider}`)
+  return { provider: def.provider, version: def.version, downloadUrlBase: def.downloadUrlBase, languages: def.languages }
+}
+
+function bundledSet(provider: string): Set<string> {
+  return new Set(getProviderDefault(provider)?.bundledLanguages ?? [])
 }
 
 function isSafeName(name: string): boolean {
@@ -41,8 +86,25 @@ async function getDownloadedSet(): Promise<Set<string>> {
   }
 }
 
-function getStatus(name: string, downloadedSet: Set<string>): LanguageDownloadStatus {
-  if (BUNDLED_LANGUAGES.has(name)) return 'bundled'
+/** Remove every downloaded language file. Called after a version change so
+ *  stale files (fetched from the old version's URL, with a now-mismatched
+ *  fileSize) are re-downloaded fresh on demand. */
+async function clearDownloadedLanguages(): Promise<void> {
+  let files: string[]
+  try {
+    files = await readdir(getLanguagesDir())
+  } catch {
+    return
+  }
+  await Promise.all(
+    files
+      .filter((f) => f.endsWith('.json'))
+      .map((f) => unlink(join(getLanguagesDir(), f)).catch(() => {})),
+  )
+}
+
+function getStatus(name: string, downloadedSet: Set<string>, bundled: Set<string>): LanguageDownloadStatus {
+  if (bundled.has(name)) return 'bundled'
   if (downloadedSet.has(name)) return 'downloaded'
   return 'not-downloaded'
 }
@@ -66,10 +128,12 @@ export function setupLanguageStore(): void {
   secureHandle(
     IpcChannels.LANG_LIST,
     async (): Promise<LanguageListEntry[]> => {
+      const dataset = await getEffectiveDataset(DEFAULT_TYPING_TEST_PROVIDER)
       const downloaded = await getDownloadedSet()
-      return (manifest as LanguageManifestEntry[]).map((entry) => ({
+      const bundled = bundledSet(DEFAULT_TYPING_TEST_PROVIDER)
+      return dataset.languages.map((entry) => ({
         ...entry,
-        status: getStatus(entry.name, downloaded),
+        status: getStatus(entry.name, downloaded, bundled),
       }))
     },
   )
@@ -78,7 +142,7 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_GET,
     async (_event, name: string): Promise<LanguageFileData | null> => {
       if (!isSafeName(name)) return null
-      if (BUNDLED_LANGUAGES.has(name)) return null
+      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return null
       try {
         const raw = await readFile(getLanguagePath(name), 'utf-8')
         const data: unknown = JSON.parse(raw)
@@ -94,11 +158,12 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_DOWNLOAD,
     async (_event, name: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
-      if (BUNDLED_LANGUAGES.has(name)) return { success: false, error: 'Language is bundled' }
-      const entry = MANIFEST_MAP.get(name)
+      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return { success: false, error: 'Language is bundled' }
+      const dataset = await getEffectiveDataset(DEFAULT_TYPING_TEST_PROVIDER)
+      const entry = dataset.languages.find((e) => e.name === name)
       if (!entry) return { success: false, error: 'Unknown language' }
 
-      const url = `${DOWNLOAD_URL_BASE}/${name}.json`
+      const url = `${dataset.downloadUrlBase}/${name}.json`
       try {
         const response = await net.fetch(url)
         if (!response.ok) {
@@ -130,7 +195,7 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_DELETE,
     async (_event, name: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
-      if (BUNDLED_LANGUAGES.has(name)) return { success: false, error: 'Cannot delete bundled language' }
+      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return { success: false, error: 'Cannot delete bundled language' }
       try {
         await unlink(getLanguagePath(name))
         log('info', `Deleted language: ${name}`)
@@ -140,4 +205,62 @@ export function setupLanguageStore(): void {
       }
     },
   )
+}
+
+export interface TypingDatasetSyncResult {
+  provider: string
+  changed: boolean
+  fromVersion: string
+  toVersion?: string
+}
+
+/**
+ * Compare the effective dataset version against the Hub's and, on a
+ * mismatch, pull the fresh dataset, persist it as the provider override,
+ * and clear stale downloaded language files. Never throws — returns
+ * `changed:false` on any network / shape error so the bundled defaults
+ * keep working offline.
+ */
+export async function syncTypingDataset(
+  provider: string = DEFAULT_TYPING_TEST_PROVIDER,
+): Promise<TypingDatasetSyncResult> {
+  const current = await getEffectiveDataset(provider)
+  const hubVersion = await fetchTypingDatasetVersion(provider)
+  if (!hubVersion || hubVersion === current.version) {
+    return { provider, changed: false, fromVersion: current.version }
+  }
+
+  const fresh = await fetchTypingDataset(provider)
+  if (!fresh || fresh.version === current.version) {
+    return { provider, changed: false, fromVersion: current.version }
+  }
+
+  const overrides = await loadOverrides()
+  const next = { ...overrides, [provider]: fresh }
+  const path = getOverridePath()
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, JSON.stringify(next), 'utf-8')
+  overridesCache = next
+
+  // The new version's files live at a different URL and may differ in size,
+  // so drop the old downloads; they re-fetch on demand against the new base.
+  await clearDownloadedLanguages()
+
+  log('info', `Typing dataset ${provider}: updated ${current.version} -> ${fresh.version}`)
+  return { provider, changed: true, fromVersion: current.version, toVersion: fresh.version }
+}
+
+/**
+ * Fire-and-forget startup hook (wired in `main/index.ts` via
+ * `app.whenReady()`). Checks the default provider's version against the Hub
+ * in the background; never blocks startup and swallows all errors.
+ */
+export function startTypingDatasetStartupSync(): void {
+  void syncTypingDataset()
+    .then((r) => {
+      if (r.changed) log('info', `Typing dataset startup sync: ${r.fromVersion} -> ${String(r.toVersion)}`)
+    })
+    .catch((err: unknown) => {
+      log('warn', `Typing dataset startup sync threw: ${err instanceof Error ? err.message : String(err)}`)
+    })
 }

--- a/src/shared/data/typing-test-providers.ts
+++ b/src/shared/data/typing-test-providers.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Bundled default typing-test word datasets, one entry per provider.
+// These are the fallback values shipped with the app; the Hub
+// (`GET /api/typing-test/datasets/:provider`) can override version /
+// downloadUrlBase / languages at runtime when the upstream source moves.
+//
+// To support another provider, add an entry here with its own manifest —
+// the rest of the pipeline (language store, Hub sync) is provider-agnostic.
+//
+// NOTE: for monkeytype the commit hash appears in BOTH `version` and
+// `downloadUrlBase`. Bump them together (mirrors the Hub-side note), which
+// is why the commit is a single constant interpolated into both.
+
+import type { LanguageManifestEntry, TypingTestProviderDefault } from '../types/language-store'
+import monkeytypeLanguages from './language-manifest.json'
+
+const MONKEYTYPE_COMMIT = '629c82e112a2db2122c789dc6abe970b82c3f8c5'
+
+/** Provider used by the typing test today. */
+export const DEFAULT_TYPING_TEST_PROVIDER = 'monkeytype'
+
+export const TYPING_TEST_PROVIDER_DEFAULTS: readonly TypingTestProviderDefault[] = [
+  {
+    provider: 'monkeytype',
+    version: MONKEYTYPE_COMMIT,
+    downloadUrlBase: `https://github.com/monkeytypegame/monkeytype/raw/${MONKEYTYPE_COMMIT}/frontend/static/languages`,
+    bundledLanguages: ['english'],
+    languages: monkeytypeLanguages as LanguageManifestEntry[],
+  },
+]
+
+export function getProviderDefault(provider: string): TypingTestProviderDefault | undefined {
+  return TYPING_TEST_PROVIDER_DEFAULTS.find((p) => p.provider === provider)
+}

--- a/src/shared/types/language-store.ts
+++ b/src/shared/types/language-store.ts
@@ -10,3 +10,22 @@ export type LanguageDownloadStatus = 'bundled' | 'downloaded' | 'not-downloaded'
 export interface LanguageListEntry extends LanguageManifestEntry {
   status: LanguageDownloadStatus
 }
+
+/** A typing-test word dataset for one provider. Matches the Hub
+ *  `GET /api/typing-test/datasets/:provider` response shape so a Hub
+ *  payload can be persisted as an override verbatim. `version` is an
+ *  opaque snapshot id (the upstream commit hash for monkeytype). */
+export interface TypingTestDataset {
+  provider: string
+  version: string
+  /** Base URL for per-language word files: `<downloadUrlBase>/<name>.json`. */
+  downloadUrlBase: string
+  languages: LanguageManifestEntry[]
+}
+
+/** Bundled default dataset for a provider, shipped with the app and used
+ *  until/unless the Hub provides a newer version. Extends the wire dataset
+ *  with the set of languages baked into the app bundle (never downloaded). */
+export interface TypingTestProviderDefault extends TypingTestDataset {
+  bundledLanguages: string[]
+}


### PR DESCRIPTION
## Summary
The Normal-mode word dataset (version, download URL base, language manifest) was hardcoded, so the app could not follow upstream updates without a re-release. Add a Hub version-distribution client and check it on startup.

- **Provider config file** (`src/shared/data/typing-test-providers.ts`): the bundled defaults are extracted here so adding another provider is a single entry.
- **Hub client** (`src/main/hub/hub-typing-dataset.ts`): `GET /api/typing-test/datasets/:provider[/version]`, shape-validated, returns `null` on any error.
- **Effective dataset** in `language-store.ts`: a persisted per-provider override (`local/typing-test-dataset.json`) takes precedence over the bundled default; `LANG_LIST`/`LANG_DOWNLOAD` read it.
- **Startup sync** (`syncTypingDataset` / `startTypingDatasetStartupSync`): compares versions; on a mismatch pulls the fresh dataset, persists the override, and clears stale downloads. Background, non-blocking; offline keeps the current effective dataset.

## Security
- Hub/override payloads are validated (entry shape, **HTTPS-only** `downloadUrlBase`, provider match) before any main-process `net.fetch` — guards against an SSRF vector from a bad payload. A corrupt local override falls back to the bundled default.

## Test plan
- [x] 14 new tests (Hub fetchers + sync + effective-dataset); existing language-store tests unchanged
- [x] lint / build / 4321 tests pass

_Desktop-side contract doc lives at `.claude/docs/HUB-TYPING-DATASET-API.md` (gitignored, local)._