### PR TITLE
fix(sync): resolve keyboard name on connect even after a reset tombstone

### DIFF
--- a/src/main/__tests__/keyboard-meta.test.ts
+++ b/src/main/__tests__/keyboard-meta.test.ts
@@ -31,7 +31,7 @@ import {
   mergeKeyboardMetaIndex,
   readKeyboardMetaIndex,
   upsertKeyboardMeta,
-  upsertKeyboardMetaIfMissing,
+  nameKeyboardOnConnect,
   tombstoneKeyboardMeta,
   tombstoneAllKeyboardMeta,
   applyRemoteKeyboardMetaIndex,
@@ -209,30 +209,33 @@ describe('getActiveKeyboardMetaMap', () => {
   })
 })
 
-describe('upsertKeyboardMetaIfMissing', () => {
+describe('nameKeyboardOnConnect', () => {
   it('records the name when the keyboard has none', async () => {
-    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('upserted')
+    expect(await nameKeyboardOnConnect('0xc5', 'Ieneko54R')).toBe('upserted')
     const map = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
     expect(map.get('0xc5')).toBe('Ieneko54R')
   })
 
-  it('does not overwrite an existing name (no churn on reconnect)', async () => {
+  it('does not overwrite an active name (preserves a user rename, no churn)', async () => {
     await upsertKeyboardMeta('0xc5', 'My Custom Name')
-    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('unchanged')
+    expect(await nameKeyboardOnConnect('0xc5', 'Ieneko54R')).toBe('unchanged')
     const map = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
     expect(map.get('0xc5')).toBe('My Custom Name')
   })
 
   it('is a no-op for an empty uid or name', async () => {
-    expect(await upsertKeyboardMetaIfMissing('', 'Name')).toBe('unchanged')
-    expect(await upsertKeyboardMetaIfMissing('0xc5', '   ')).toBe('unchanged')
+    expect(await nameKeyboardOnConnect('', 'Name')).toBe('unchanged')
+    expect(await nameKeyboardOnConnect('0xc5', '   ')).toBe('unchanged')
     expect(getActiveKeyboardMetaMap(await readKeyboardMetaIndex()).size).toBe(0)
   })
 
-  it('does not revive a tombstoned entry the user deleted', async () => {
+  it('revives a tombstoned entry so a reconnected keyboard is named again', async () => {
+    // Reproduces the "Delete all → reconnect" state: the uid is tombstoned but
+    // the physical keyboard is back, so connecting must restore its name.
     await upsertKeyboardMeta('0xc5', 'Ieneko54R')
     await tombstoneKeyboardMeta('0xc5')
-    expect(await upsertKeyboardMetaIfMissing('0xc5', 'Ieneko54R')).toBe('unchanged')
-    expect(getActiveKeyboardMetaMap(await readKeyboardMetaIndex()).has('0xc5')).toBe(false)
+    expect(await nameKeyboardOnConnect('0xc5', 'Ieneko54R')).toBe('upserted')
+    const map = getActiveKeyboardMetaMap(await readKeyboardMetaIndex())
+    expect(map.get('0xc5')).toBe('Ieneko54R')
   })
 })

--- a/src/main/sync/keyboard-meta.ts
+++ b/src/main/sync/keyboard-meta.ts
@@ -101,13 +101,19 @@ export async function upsertKeyboardMeta(
   })
 }
 
-/** Record `deviceName` for `uid` only when the index has NO entry for it yet.
- *  Used at connect time to name keyboards that never saved a keymap snapshot,
- *  without overwriting a name the user set or reviving a tombstone they deleted
- *  (and without churning the index on every reconnect). The presence check and
- *  the write share one lock so a concurrent writer can't be clobbered. Same
- *  'unchanged' | 'upserted' contract as {@link upsertKeyboardMeta}. */
-export async function upsertKeyboardMetaIfMissing(
+/** Name a keyboard from its firmware `deviceName` at connect time.
+ *  - No entry yet → record the name.
+ *  - Tombstoned entry → revive it with the firmware name. The physical
+ *    keyboard is present, so its name should resolve again — a tombstone
+ *    (e.g. left by a "Delete all"/reset) must not permanently block naming a
+ *    reconnected device.
+ *  - Active entry → left untouched, so a user's manual rename is never
+ *    clobbered and reconnects don't churn the index.
+ *
+ *  The presence check and the write share one lock so a concurrent writer
+ *  can't be clobbered. Same 'unchanged' | 'upserted' contract as
+ *  {@link upsertKeyboardMeta}. */
+export async function nameKeyboardOnConnect(
   uid: string,
   deviceName: string,
 ): Promise<'unchanged' | 'upserted'> {
@@ -115,10 +121,18 @@ export async function upsertKeyboardMetaIfMissing(
   if (!uid || !normalized) return 'unchanged'
   return withMetaWriteLock(async () => {
     const index = await readKeyboardMetaIndex()
-    // Any entry — active OR tombstoned — counts as "has a name decision";
-    // only a uid the index has never seen gets the connect-time name.
-    if (findEntry(index, uid)) return 'unchanged'
-    index.entries.push({ uid, deviceName: normalized, updatedAt: new Date().toISOString() })
+    const existing = findEntry(index, uid)
+    // Active entry → keep the (possibly user-renamed) name as-is.
+    if (existing && !existing.deletedAt) return 'unchanged'
+    const now = new Date().toISOString()
+    if (existing) {
+      // Revive a tombstone with the firmware name.
+      existing.deviceName = normalized
+      existing.updatedAt = now
+      delete existing.deletedAt
+    } else {
+      index.entries.push({ uid, deviceName: normalized, updatedAt: now })
+    }
     index.entries = gcKeyboardMetaTombstones(index.entries)
     await writeKeyboardMetaIndex(index)
     return 'upserted'

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -58,7 +58,7 @@ import {
   tombstoneAllKeyboardMeta,
   tombstoneKeyboardMeta,
   upsertKeyboardMeta,
-  upsertKeyboardMetaIfMissing,
+  nameKeyboardOnConnect,
 } from './keyboard-meta'
 import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import { I18N_SYNC_UNIT_PREFIX } from '../../shared/types/i18n-store'
@@ -270,10 +270,11 @@ export function setupSyncIpc(): void {
       }),
   )
 
-  // --- Name a keyboard on connect (only if it has no name yet) ---
+  // --- Name a keyboard on connect (names a new uid, revives a tombstone;
+  //     leaves an active/user-renamed entry untouched) ---
   secureHandle(IpcChannels.KEYBOARD_META_NAME_IF_MISSING, async (_event, uid: string, name: string): Promise<void> => {
     if (typeof uid !== 'string' || !isSafeKey(uid) || typeof name !== 'string') return
-    const result = await upsertKeyboardMetaIfMissing(uid, name)
+    const result = await nameKeyboardOnConnect(uid, name)
     if (result === 'upserted') notifyChange(KEYBOARD_META_SYNC_UNIT)
   })
 


### PR DESCRIPTION
## Summary
After a Delete-all / reset, a keyboard's meta entry is tombstoned. The connect-time naming used `upsertKeyboardMetaIfMissing`, which treated any entry (active **or** tombstoned) as a final decision — so reconnecting the physical keyboard never restored its name and the Data modal showed the raw uid.

- Replace it with `nameKeyboardOnConnect`:
  - never-seen uid → record the name,
  - **tombstoned entry → revive it** with the firmware name (the device is physically present),
  - active entry → left untouched, preserving a user rename and avoiding reconnect churn.
- The revival carries `updatedAt=now` so it wins the meta-index LWW merge and propagates over sync.

## Why
This is the realistic "Delete all → reconnect" state; the name must resolve through normal operation (just connecting), without hand-editing data.

## Test plan
- [x] New test: a tombstoned entry is revived on connect
- [x] Existing: active name preserved, empty uid/name no-op
- [x] lint / build / 4321 tests pass