### PR TITLE
feat(ui): make typing-test dataset updates a manual, modal-driven action

### DIFF
--- a/src/main/__tests__/typing-dataset-sync.test.ts
+++ b/src/main/__tests__/typing-dataset-sync.test.ts
@@ -48,6 +48,48 @@ function overridePath(): string {
   return join(testDir, 'local', 'typing-test-dataset.json')
 }
 
+describe('checkTypingDatasetUpdate', () => {
+  it('reports an update when the Hub version differs, then caches it for the session', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype', version: HUB_VERSION }))
+    const first = await mod.checkTypingDatasetUpdate('monkeytype')
+    expect(first.updateAvailable).toBe(true)
+    expect(mockNet.fetch).toHaveBeenCalledTimes(1)
+
+    // Second call within the session must not re-hit the Hub.
+    mockNet.fetch.mockRejectedValue(new Error('should not be called'))
+    const second = await mod.checkTypingDatasetUpdate('monkeytype')
+    expect(second.updateAvailable).toBe(true)
+    expect(mockNet.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports no update when the Hub version matches', async () => {
+    const { TYPING_TEST_PROVIDER_DEFAULTS } = await import('../../shared/data/typing-test-providers')
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype', version: TYPING_TEST_PROVIDER_DEFAULTS[0].version }))
+    expect((await mod.checkTypingDatasetUpdate('monkeytype')).updateAvailable).toBe(false)
+  })
+
+  it('does not cache a Hub error, so a later check can retry', async () => {
+    mockNet.fetch.mockRejectedValueOnce(new Error('offline'))
+    expect((await mod.checkTypingDatasetUpdate('monkeytype')).updateAvailable).toBe(false)
+    // Now the Hub is reachable and reports a newer version.
+    mockNet.fetch.mockResolvedValue(okJson({ provider: 'monkeytype', version: HUB_VERSION }))
+    expect((await mod.checkTypingDatasetUpdate('monkeytype')).updateAvailable).toBe(true)
+  })
+
+  it('clears the pending flag once an update is applied', async () => {
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'monkeytype', version: HUB_VERSION }))
+      .mockResolvedValueOnce(okJson({
+        provider: 'monkeytype',
+        version: HUB_VERSION,
+        downloadUrlBase: NEW_DOWNLOAD_BASE,
+        languages: [{ name: 'english', wordCount: 200, rightToLeft: false, fileSize: 2540 }],
+      }))
+    await mod.syncTypingDataset('monkeytype')
+    expect((await mod.checkTypingDatasetUpdate('monkeytype')).updateAvailable).toBe(false)
+  })
+})
+
 describe('syncTypingDataset', () => {
   it('does nothing when the Hub version matches the current version', async () => {
     // Hub returns the SAME version as the bundled default → no fetch of full

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -12,7 +12,7 @@ import { setupI18nPackStore } from './i18n-pack-ipc'
 import { setupThemePackStore } from './theme-pack-ipc'
 import { setupHidIpc } from './hid-ipc'
 import { setupPipetteSettingsStore } from './pipette-settings-store'
-import { setupLanguageStore, startTypingDatasetStartupSync } from './language-store'
+import { setupLanguageStore } from './language-store'
 import { setupSyncIpc } from './sync/sync-ipc'
 import { setupHubIpc } from './hub/hub-ipc'
 import { startI18nStartupSync } from './hub/i18n-startup-sync'
@@ -353,10 +353,9 @@ app.whenReady().then(() => {
   // applied updates without a manual reload.
   startI18nStartupSync()
 
-  // Best-effort: follow upstream typing-test word-dataset updates. Compares
-  // the bundled/overridden version against the Hub and, on a mismatch, pulls
-  // the fresh manifest + download URL base. Never blocks startup.
-  startTypingDatasetStartupSync()
+  // The typing-test dataset is NOT auto-synced at startup. The Mode modal
+  // checks the Hub version when its tab is shown and surfaces a manual
+  // "Update" button (see TYPING_DATASET_CHECK / TYPING_DATASET_UPDATE).
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -205,6 +205,22 @@ export function setupLanguageStore(): void {
       }
     },
   )
+
+  // Check-only: is a newer dataset version available? (session-cached)
+  secureHandle(
+    IpcChannels.TYPING_DATASET_CHECK,
+    async (_event, provider?: string): Promise<{ provider: string; updateAvailable: boolean }> => {
+      return checkTypingDatasetUpdate(typeof provider === 'string' && provider ? provider : DEFAULT_TYPING_TEST_PROVIDER)
+    },
+  )
+
+  // Manual update: download + apply the newer dataset (from the modal button).
+  secureHandle(
+    IpcChannels.TYPING_DATASET_UPDATE,
+    async (_event, provider?: string): Promise<TypingDatasetSyncResult> => {
+      return syncTypingDataset(typeof provider === 'string' && provider ? provider : DEFAULT_TYPING_TEST_PROVIDER)
+    },
+  )
 }
 
 export interface TypingDatasetSyncResult {
@@ -212,6 +228,29 @@ export interface TypingDatasetSyncResult {
   changed: boolean
   fromVersion: string
   toVersion?: string
+}
+
+// "Update available?" result, remembered for the app session only (cleared on
+// process restart). Lets the Mode modal check once per session and reuse the
+// flag on reopen/tab-switch without re-hitting the Hub. An applied update or a
+// restart re-checks.
+const updateCheckCache = new Map<string, boolean>()
+
+/** Check (without downloading) whether the Hub has a newer dataset version for
+ *  the provider. The first call per session probes the Hub `/version`; later
+ *  calls reuse the cached result. A Hub error is reported as "no update" and is
+ *  NOT cached, so a later modal open can retry. */
+export async function checkTypingDatasetUpdate(
+  provider: string = DEFAULT_TYPING_TEST_PROVIDER,
+): Promise<{ provider: string; updateAvailable: boolean }> {
+  const cached = updateCheckCache.get(provider)
+  if (cached !== undefined) return { provider, updateAvailable: cached }
+  const current = await getEffectiveDataset(provider)
+  const hubVersion = await fetchTypingDatasetVersion(provider)
+  if (!hubVersion) return { provider, updateAvailable: false }
+  const updateAvailable = hubVersion !== current.version
+  updateCheckCache.set(provider, updateAvailable)
+  return { provider, updateAvailable }
 }
 
 /**
@@ -246,21 +285,9 @@ export async function syncTypingDataset(
   // so drop the old downloads; they re-fetch on demand against the new base.
   await clearDownloadedLanguages()
 
+  // The update is applied, so the session no longer has one pending.
+  updateCheckCache.set(provider, false)
+
   log('info', `Typing dataset ${provider}: updated ${current.version} -> ${fresh.version}`)
   return { provider, changed: true, fromVersion: current.version, toVersion: fresh.version }
-}
-
-/**
- * Fire-and-forget startup hook (wired in `main/index.ts` via
- * `app.whenReady()`). Checks the default provider's version against the Hub
- * in the background; never blocks startup and swallows all errors.
- */
-export function startTypingDatasetStartupSync(): void {
-  void syncTypingDataset()
-    .then((r) => {
-      if (r.changed) log('info', `Typing dataset startup sync: ${r.fromVersion} -> ${String(r.toVersion)}`)
-    })
-    .catch((err: unknown) => {
-      log('warn', `Typing dataset startup sync threw: ${err instanceof Error ? err.message : String(err)}`)
-    })
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -596,6 +596,10 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.LANG_DOWNLOAD, name),
   langDelete: (name: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.LANG_DELETE, name),
+  checkTypingDatasetUpdate: (provider?: string): Promise<{ provider: string; updateAvailable: boolean }> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_DATASET_CHECK, provider),
+  updateTypingDataset: (provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_DATASET_UPDATE, provider),
 
   // --- App Config ---
   appConfigGetAll: (): Promise<AppConfig> =>

--- a/src/renderer/__tests__/setup.ts
+++ b/src/renderer/__tests__/setup.ts
@@ -58,6 +58,9 @@ if (typeof window !== 'undefined') {
     pipetteSettingsListAllTypingResults: async () => [],
     // Connect-time keyboard naming — fire-and-forget in useDeviceLifecycle.
     keyboardMetaNameIfMissing: async () => undefined,
+    // Typing-dataset version check — LanguageSelectorModal calls this on mount.
+    checkTypingDatasetUpdate: async () => ({ provider: 'monkeytype', updateAvailable: false }),
+    updateTypingDataset: async () => ({ provider: 'monkeytype', changed: false, fromVersion: '' }),
     // i18n pack store: every renderer that mounts SettingsModal pulls in
     // LanguagePacksModal → useI18nPackStore, which calls i18nPackList on
     // mount. Stub the read paths to an empty list and the change-notifier

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -383,7 +383,10 @@
         "importErrorEmpty": "The file has no typeable text",
         "importOverwritePrompt": "\"{{name}}\" already exists. Overwrite?",
         "confirmOverwrite": "Overwrite",
-        "fileImportText": "Imported text"
+        "fileImportText": "Imported text",
+        "datasetUpdateAvailable": "An update is available for the word lists.",
+        "datasetUpdate": "Update",
+        "datasetUpdating": "Updating…"
       },
       "memory": {
         "pause": "Pause",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -383,7 +383,10 @@
         "importErrorEmpty": "打鍵できるテキストがありません",
         "importOverwritePrompt": "「{{name}}」は既に存在します。上書きしますか？",
         "confirmOverwrite": "上書き",
-        "fileImportText": "インポートテキスト"
+        "fileImportText": "インポートテキスト",
+        "datasetUpdateAvailable": "単語リストの更新があります。",
+        "datasetUpdate": "更新",
+        "datasetUpdating": "更新中…"
       },
       "memory": {
         "pause": "一時停止",

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -50,6 +50,8 @@ export function LanguageSelectorModal({
   const [languages, setLanguages] = useState<LanguageListEntry[]>([])
   const [search, setSearch] = useState('')
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+  const [updating, setUpdating] = useState(false)
   const backdropRef = useRef<HTMLDivElement>(null)
   const searchRef = useRef<HTMLInputElement>(null)
   // Flipped true when the currently-selected imported text is deleted, so a
@@ -74,6 +76,35 @@ export function LanguageSelectorModal({
   useEffect(() => {
     if (tab === 'existing') searchRef.current?.focus()
   }, [tab])
+
+  // Version check only — no auto-download. Runs when the MonkeyType tab is
+  // shown; the main process caches the result for the app session, so reopening
+  // the modal or switching tabs won't re-hit the Hub.
+  useEffect(() => {
+    if (tab !== 'existing') return
+    let alive = true
+    window.vialAPI.checkTypingDatasetUpdate('monkeytype')
+      .then((r) => { if (alive) setUpdateAvailable(r.updateAvailable) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [tab])
+
+  const handleUpdateDataset = useCallback(async () => {
+    setUpdating(true)
+    try {
+      const result = await window.vialAPI.updateTypingDataset('monkeytype')
+      if (result.changed) {
+        // The manifest may have new/changed languages; refresh the list.
+        const list = await window.vialAPI.langList()
+        setLanguages(list)
+        setUpdateAvailable(false)
+      }
+      // On `changed:false` (Hub unreachable / invalid payload) the update was
+      // NOT applied — keep the banner so the user can retry.
+    } finally {
+      setUpdating(false)
+    }
+  }, [])
 
   const handleBackdropClick = useCallback((e: React.MouseEvent) => {
     if (e.target === backdropRef.current) handleClose()
@@ -174,6 +205,26 @@ export function LanguageSelectorModal({
                 data-testid="language-search"
               />
             </div>
+
+            {updateAvailable && (
+              <div
+                className="flex items-center justify-between gap-3 border-b border-edge bg-accent/5 px-4 py-2"
+                data-testid="typing-dataset-update-banner"
+              >
+                <span className="text-sm text-content-secondary">
+                  {t('editor.typingTest.language.datasetUpdateAvailable')}
+                </span>
+                <button
+                  type="button"
+                  data-testid="typing-dataset-update-button"
+                  disabled={updating}
+                  onClick={handleUpdateDataset}
+                  className="inline-flex h-8 items-center rounded-md border border-accent bg-accent/10 px-3 text-sm text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {t(updating ? 'editor.typingTest.language.datasetUpdating' : 'editor.typingTest.language.datasetUpdate')}
+                </button>
+              </div>
+            )}
 
             <div className="flex-1 overflow-y-auto">
               {filtered.length === 0 && (

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -18,6 +18,8 @@ beforeEach(() => {
     langGet: vi.fn().mockResolvedValue(null),
     langDownload: vi.fn().mockResolvedValue({ success: true }),
     langDelete: vi.fn().mockResolvedValue({ success: true }),
+    checkTypingDatasetUpdate: vi.fn().mockResolvedValue({ provider: 'monkeytype', updateAvailable: false }),
+    updateTypingDataset: vi.fn().mockResolvedValue({ provider: 'monkeytype', changed: false, fromVersion: '' }),
   } as unknown as typeof window.vialAPI
 })
 
@@ -34,6 +36,47 @@ describe('LanguageSelectorModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('language-search')).toBeInTheDocument()
     })
+    // No update by default → no banner.
+    expect(screen.queryByTestId('typing-dataset-update-banner')).toBeNull()
+  })
+
+  it('shows the update banner and applies the update on click', async () => {
+    vi.mocked(window.vialAPI.checkTypingDatasetUpdate).mockResolvedValue({ provider: 'monkeytype', updateAvailable: true })
+    vi.mocked(window.vialAPI.updateTypingDataset).mockResolvedValue({ provider: 'monkeytype', changed: true, fromVersion: 'a', toVersion: 'b' })
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('typing-dataset-update-banner')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('typing-dataset-update-button'))
+
+    await waitFor(() => {
+      expect(window.vialAPI.updateTypingDataset).toHaveBeenCalledWith('monkeytype')
+      expect(screen.queryByTestId('typing-dataset-update-banner')).toBeNull()
+    })
+  })
+
+  it('keeps the banner when the update was not applied (offline retry path)', async () => {
+    vi.mocked(window.vialAPI.checkTypingDatasetUpdate).mockResolvedValue({ provider: 'monkeytype', updateAvailable: true })
+    vi.mocked(window.vialAPI.updateTypingDataset).mockResolvedValue({ provider: 'monkeytype', changed: false, fromVersion: 'a' })
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('typing-dataset-update-banner')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('typing-dataset-update-button'))
+
+    await waitFor(() => expect(window.vialAPI.updateTypingDataset).toHaveBeenCalled())
+    // Update not applied → banner stays so the user can retry.
+    expect(screen.getByTestId('typing-dataset-update-banner')).toBeInTheDocument()
   })
 
   it('displays downloaded and available sections', async () => {

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -173,6 +173,8 @@ export const IpcChannels = {
   LANG_GET: 'lang:get',
   LANG_DOWNLOAD: 'lang:download',
   LANG_DELETE: 'lang:delete',
+  TYPING_DATASET_CHECK: 'typing-dataset:check',
+  TYPING_DATASET_UPDATE: 'typing-dataset:update',
 
   // Data management (renderer → main → renderer)
   LIST_STORED_KEYBOARDS: 'data:list-stored-keyboards',

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -328,6 +328,8 @@ export interface VialAPI {
   langGet(name: string): Promise<unknown>
   langDownload(name: string): Promise<{ success: boolean; error?: string }>
   langDelete(name: string): Promise<{ success: boolean; error?: string }>
+  checkTypingDatasetUpdate(provider?: string): Promise<{ provider: string; updateAvailable: boolean }>
+  updateTypingDataset(provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }>
 
   // Data management
   listStoredKeyboards(): Promise<StoredKeyboardInfo[]>


### PR DESCRIPTION
## Summary
Replace the startup auto-download (PR #223) with a **check-only + manual update** flow.

- When the **Mode** modal shows the **MonkeyType** tab, probe the Hub `/version`. If it differs from the effective version, show an **"Update available"** banner with a manual **Update** button.
- Clicking **Update** downloads + applies the dataset (manifest + files, override persist, stale downloads cleared) and refreshes the language list. An unapplied result (offline / invalid payload) keeps the banner so the user can retry.
- The "update available" result is remembered **in-memory for the app session only** — reopening the modal or switching tabs reuses it; a restart re-checks; an applied update clears it.
- Adds `TYPING_DATASET_CHECK` / `TYPING_DATASET_UPDATE` IPC; removes the startup auto-sync hook.

## Notes
- File Import tab is excluded (user's own files, no version check).
- Same pattern will back the future Tatoeba provider (spec recorded in the backlog doc).

## Test plan
- [x] New tests: session-cached check, error-not-cached retry, applied-flag clear, update banner shows/applies, offline keeps banner
- [x] lint / build / 4327 tests pass