### PR TITLE
feat(ui): add Tatoeba typing-test sentence packs (english)

### DIFF
--- a/src/main/__tests__/language-store.test.ts
+++ b/src/main/__tests__/language-store.test.ts
@@ -299,14 +299,14 @@ describe('legacy download migration', () => {
     await mkdir(flatDir, { recursive: true })
     await writeFile(join(flatDir, 'german.json'), JSON.stringify({ name: 'german', words: ['hallo'] }))
 
-    // Re-run setup so the (fire-and-forget) migration executes against it.
+    // Re-run setup so the migration executes against the seeded file, then
+    // hit a handler that awaits it — guaranteeing the move has completed.
     handlers = new Map()
     setupLanguageStore()
+    await invoke('lang:list', 'monkeytype')
 
-    await vi.waitFor(async () => {
-      const moved = await readdir(join(flatDir, 'monkeytype')).catch(() => [] as string[])
-      expect(moved).toContain('german.json')
-    })
+    const moved = await readdir(join(flatDir, 'monkeytype'))
+    expect(moved).toContain('german.json')
     // The flat copy is gone.
     const flat = await readdir(flatDir)
     expect(flat).not.toContain('german.json')

--- a/src/main/__tests__/language-store.test.ts
+++ b/src/main/__tests__/language-store.test.ts
@@ -266,3 +266,49 @@ describe('language-store delete', () => {
     expect(result.success).toBe(false)
   })
 })
+
+describe('provider safety', () => {
+  it('falls back to the default provider for an unknown / traversal provider', async () => {
+    const monkeytypeDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
+    await mkdir(monkeytypeDir, { recursive: true })
+    await writeFile(join(monkeytypeDir, 'test_lang.json'), JSON.stringify({ name: 'test_lang', words: ['x'] }))
+    // A file a `../` provider could target if it were used verbatim as a path.
+    const outsideDir = join(testDir, 'local', 'downloads')
+    await writeFile(join(outsideDir, 'victim.json'), '{}')
+
+    // Unknown provider resolves to the default, so it reads the monkeytype file.
+    const got = await invoke('lang:get', 'test_lang', '../../') as { name: string } | null
+    expect(got?.name).toBe('test_lang')
+
+    // A traversal-style provider cannot escape the per-provider directory.
+    await invoke('lang:delete', 'victim', '../..')
+    const files = await readdir(outsideDir)
+    expect(files).toContain('victim.json')
+  })
+
+  it('lists the tatoeba provider (empty until a Hub override arrives)', async () => {
+    const result = await invoke('lang:list', 'tatoeba') as unknown[]
+    expect(result).toEqual([])
+  })
+})
+
+describe('legacy download migration', () => {
+  it('moves flat downloads into the monkeytype subdir on setup', async () => {
+    // Seed a download from before per-provider directories existed.
+    const flatDir = join(testDir, 'local', 'downloads', 'languages')
+    await mkdir(flatDir, { recursive: true })
+    await writeFile(join(flatDir, 'german.json'), JSON.stringify({ name: 'german', words: ['hallo'] }))
+
+    // Re-run setup so the (fire-and-forget) migration executes against it.
+    handlers = new Map()
+    setupLanguageStore()
+
+    await vi.waitFor(async () => {
+      const moved = await readdir(join(flatDir, 'monkeytype')).catch(() => [] as string[])
+      expect(moved).toContain('german.json')
+    })
+    // The flat copy is gone.
+    const flat = await readdir(flatDir)
+    expect(flat).not.toContain('german.json')
+  })
+})

--- a/src/main/__tests__/language-store.test.ts
+++ b/src/main/__tests__/language-store.test.ts
@@ -73,7 +73,7 @@ describe('language-store list', () => {
   })
 
   it('detects downloaded languages', async () => {
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     await mkdir(langDir, { recursive: true })
     await writeFile(join(langDir, 'german.json'), JSON.stringify({ name: 'german', words: ['hallo'] }))
 
@@ -96,7 +96,7 @@ describe('language-store get', () => {
   })
 
   it('returns language data for downloaded language', async () => {
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     await mkdir(langDir, { recursive: true })
     const data = { name: 'test_lang', words: ['hello', 'world'], rightToLeft: false }
     await writeFile(join(langDir, 'test_lang.json'), JSON.stringify(data))
@@ -118,7 +118,7 @@ describe('language-store get', () => {
   })
 
   it('returns null for invalid JSON', async () => {
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     await mkdir(langDir, { recursive: true })
     await writeFile(join(langDir, 'bad.json'), 'not json')
 
@@ -127,7 +127,7 @@ describe('language-store get', () => {
   })
 
   it('returns null for data missing words array', async () => {
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     await mkdir(langDir, { recursive: true })
     await writeFile(join(langDir, 'nowords.json'), JSON.stringify({ name: 'nowords' }))
 
@@ -177,7 +177,7 @@ describe('language-store download', () => {
     const result = await invoke('lang:download', 'german') as { success: boolean }
     expect(result.success).toBe(true)
 
-    const files = await readdir(join(testDir, 'local', 'downloads', 'languages'))
+    const files = await readdir(join(testDir, 'local', 'downloads', 'languages', 'monkeytype'))
     expect(files).toContain('german.json')
   })
 
@@ -209,7 +209,7 @@ describe('language-store download', () => {
     expect(result.error).toContain('size mismatch')
 
     // Verify no file was written
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     let files: string[] = []
     try { files = await readdir(langDir) } catch { /* dir may not exist */ }
     expect(files).not.toContain('german.json')
@@ -250,7 +250,7 @@ describe('language-store delete', () => {
   })
 
   it('deletes downloaded language', async () => {
-    const langDir = join(testDir, 'local', 'downloads', 'languages')
+    const langDir = join(testDir, 'local', 'downloads', 'languages', 'monkeytype')
     await mkdir(langDir, { recursive: true })
     await writeFile(join(langDir, 'test.json'), '{}')
 

--- a/src/main/__tests__/typing-dataset-sync.test.ts
+++ b/src/main/__tests__/typing-dataset-sync.test.ts
@@ -105,8 +105,10 @@ describe('syncTypingDataset', () => {
   })
 
   it('writes an override and clears downloads when the Hub version differs', async () => {
-    // Seed a stale downloaded file that must be cleared on a version bump.
-    await writeFile(join(testDir, 'local', 'downloads', 'languages', 'german.json'), '{}', 'utf-8')
+    // Seed a stale downloaded file (under the provider's dir) that must be
+    // cleared on a version bump.
+    await mkdir(join(testDir, 'local', 'downloads', 'languages', 'monkeytype'), { recursive: true })
+    await writeFile(join(testDir, 'local', 'downloads', 'languages', 'monkeytype', 'german.json'), '{}', 'utf-8')
 
     const freshDataset = {
       provider: 'monkeytype',
@@ -132,7 +134,7 @@ describe('syncTypingDataset', () => {
     expect(written.monkeytype).toEqual(freshDataset)
 
     // Stale download removed.
-    const remaining = await readdir(join(testDir, 'local', 'downloads', 'languages'))
+    const remaining = await readdir(join(testDir, 'local', 'downloads', 'languages', 'monkeytype'))
     expect(remaining).not.toContain('german.json')
   })
 
@@ -173,5 +175,56 @@ describe('effective dataset after override', () => {
     mockNet.fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('xxxx') } as unknown as Response)
     await handlers.get('lang:download')!({}, 'spanish')
     expect(mockNet.fetch).toHaveBeenCalledWith(`${NEW_DOWNLOAD_BASE}/spanish.json`)
+  })
+})
+
+describe('tatoeba Hub-only provider', () => {
+  const TATOEBA_VERSION = 'tatoeba-20260701-8e31452a1d44'
+  const TATOEBA_BASE = 'https://hub.example/datasets/tatoeba/packs'
+
+  function captureHandlers() {
+    return import('electron').then(({ ipcMain }) => {
+      const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+      vi.mocked(ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+        handlers.set(c, h)
+      }) as unknown as typeof ipcMain.handle)
+      mod.setupLanguageStore()
+      return handlers
+    })
+  }
+
+  it('lists nothing before a Hub override (nothing is bundled)', async () => {
+    const handlers = await captureHandlers()
+    const list = await handlers.get('lang:list')!({}, 'tatoeba') as unknown[]
+    expect(list).toEqual([])
+  })
+
+  it('after an override, lists + downloads packs into a provider-isolated dir', async () => {
+    // A tatoeba pack is a verbatim `{ name, words }` document of sentences.
+    const packText = JSON.stringify({ name: 'english', words: ['Hello there.', 'How are you?'] })
+    const fresh = {
+      provider: 'tatoeba',
+      version: TATOEBA_VERSION,
+      downloadUrlBase: TATOEBA_BASE,
+      languages: [{ name: 'english', wordCount: 2, rightToLeft: false, fileSize: Buffer.byteLength(packText, 'utf-8') }],
+    }
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'tatoeba', version: TATOEBA_VERSION }))
+      .mockResolvedValueOnce(okJson(fresh))
+    expect((await mod.syncTypingDataset('tatoeba')).changed).toBe(true)
+
+    const handlers = await captureHandlers()
+    const list = await handlers.get('lang:list')!({}, 'tatoeba') as Array<{ name: string }>
+    expect(list.map((l) => l.name)).toEqual(['english'])
+
+    // Pack download hits the tatoeba packs URL and lands in the tatoeba dir,
+    // never colliding with monkeytype's own 'english'.
+    mockNet.fetch.mockReset()
+    mockNet.fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(packText) } as unknown as Response)
+    const dl = await handlers.get('lang:download')!({}, 'english', 'tatoeba') as { success: boolean }
+    expect(dl.success).toBe(true)
+    expect(mockNet.fetch).toHaveBeenCalledWith(`${TATOEBA_BASE}/english.json`)
+    const files = await readdir(join(testDir, 'local', 'downloads', 'languages', 'tatoeba'))
+    expect(files).toContain('english.json')
   })
 })

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -11,8 +11,12 @@ import { fetchTypingDataset, fetchTypingDatasetVersion, isManifestEntry } from '
 import { log } from './logger'
 import { secureHandle } from './ipc-guard'
 
-function getLanguagesDir(): string {
-  return join(app.getPath('userData'), 'local', 'downloads', 'languages')
+// Downloaded language files are namespaced per provider so that two providers
+// exposing the same language name (e.g. both monkeytype and tatoeba ship an
+// 'english') never collide, and a version-change cleanup for one provider does
+// not wipe another's downloads.
+function getLanguagesDir(provider: string): string {
+  return join(app.getPath('userData'), 'local', 'downloads', 'languages', provider)
 }
 
 /** Persisted Hub overrides keyed by provider. Absent / partial → bundled
@@ -70,13 +74,19 @@ function isSafeName(name: string): boolean {
   return typeof name === 'string' && name.length > 0 && !/[/\\]/.test(name)
 }
 
-function getLanguagePath(name: string): string {
-  return join(getLanguagesDir(), `${name}.json`)
+/** Resolve the provider arg from an IPC call, defaulting to the historical
+ *  provider so pre-multi-provider callers keep working unchanged. */
+function resolveProvider(provider?: string): string {
+  return typeof provider === 'string' && provider ? provider : DEFAULT_TYPING_TEST_PROVIDER
 }
 
-async function getDownloadedSet(): Promise<Set<string>> {
+function getLanguagePath(provider: string, name: string): string {
+  return join(getLanguagesDir(provider), `${name}.json`)
+}
+
+async function getDownloadedSet(provider: string): Promise<Set<string>> {
   try {
-    const files = await readdir(getLanguagesDir())
+    const files = await readdir(getLanguagesDir(provider))
     const names = files
       .filter((f) => f.endsWith('.json'))
       .map((f) => f.replace(/\.json$/, ''))
@@ -86,20 +96,21 @@ async function getDownloadedSet(): Promise<Set<string>> {
   }
 }
 
-/** Remove every downloaded language file. Called after a version change so
- *  stale files (fetched from the old version's URL, with a now-mismatched
- *  fileSize) are re-downloaded fresh on demand. */
-async function clearDownloadedLanguages(): Promise<void> {
+/** Remove every downloaded language file for a provider. Called after a
+ *  version change so stale files (fetched from the old version's URL, with a
+ *  now-mismatched fileSize) are re-downloaded fresh on demand. */
+async function clearDownloadedLanguages(provider: string): Promise<void> {
+  const dir = getLanguagesDir(provider)
   let files: string[]
   try {
-    files = await readdir(getLanguagesDir())
+    files = await readdir(dir)
   } catch {
     return
   }
   await Promise.all(
     files
       .filter((f) => f.endsWith('.json'))
-      .map((f) => unlink(join(getLanguagesDir(), f)).catch(() => {})),
+      .map((f) => unlink(join(dir, f)).catch(() => {})),
   )
 }
 
@@ -127,10 +138,11 @@ function validateLanguageData(data: unknown): data is LanguageFileData {
 export function setupLanguageStore(): void {
   secureHandle(
     IpcChannels.LANG_LIST,
-    async (): Promise<LanguageListEntry[]> => {
-      const dataset = await getEffectiveDataset(DEFAULT_TYPING_TEST_PROVIDER)
-      const downloaded = await getDownloadedSet()
-      const bundled = bundledSet(DEFAULT_TYPING_TEST_PROVIDER)
+    async (_event, provider?: string): Promise<LanguageListEntry[]> => {
+      const p = resolveProvider(provider)
+      const dataset = await getEffectiveDataset(p)
+      const downloaded = await getDownloadedSet(p)
+      const bundled = bundledSet(p)
       return dataset.languages.map((entry) => ({
         ...entry,
         status: getStatus(entry.name, downloaded, bundled),
@@ -140,11 +152,12 @@ export function setupLanguageStore(): void {
 
   secureHandle(
     IpcChannels.LANG_GET,
-    async (_event, name: string): Promise<LanguageFileData | null> => {
+    async (_event, name: string, provider?: string): Promise<LanguageFileData | null> => {
       if (!isSafeName(name)) return null
-      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return null
+      const p = resolveProvider(provider)
+      if (bundledSet(p).has(name)) return null
       try {
-        const raw = await readFile(getLanguagePath(name), 'utf-8')
+        const raw = await readFile(getLanguagePath(p, name), 'utf-8')
         const data: unknown = JSON.parse(raw)
         if (!validateLanguageData(data)) return null
         return data
@@ -156,10 +169,11 @@ export function setupLanguageStore(): void {
 
   secureHandle(
     IpcChannels.LANG_DOWNLOAD,
-    async (_event, name: string): Promise<{ success: boolean; error?: string }> => {
+    async (_event, name: string, provider?: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
-      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return { success: false, error: 'Language is bundled' }
-      const dataset = await getEffectiveDataset(DEFAULT_TYPING_TEST_PROVIDER)
+      const p = resolveProvider(provider)
+      if (bundledSet(p).has(name)) return { success: false, error: 'Language is bundled' }
+      const dataset = await getEffectiveDataset(p)
       const entry = dataset.languages.find((e) => e.name === name)
       if (!entry) return { success: false, error: 'Unknown language' }
 
@@ -173,19 +187,19 @@ export function setupLanguageStore(): void {
         const actualSize = Buffer.byteLength(text, 'utf-8')
         if (actualSize !== entry.fileSize) {
           const detail = `size mismatch (expected ${entry.fileSize}, got ${actualSize})`
-          log('warn', `Language ${name}: ${detail}`)
+          log('warn', `Language ${p}/${name}: ${detail}`)
           return { success: false, error: `Integrity check failed: ${detail}` }
         }
         const data: unknown = JSON.parse(text)
         if (!validateLanguageData(data)) {
           return { success: false, error: 'Invalid language data' }
         }
-        await mkdir(getLanguagesDir(), { recursive: true })
-        await writeFile(getLanguagePath(name), text, 'utf-8')
-        log('info', `Downloaded language: ${name}`)
+        await mkdir(getLanguagesDir(p), { recursive: true })
+        await writeFile(getLanguagePath(p, name), text, 'utf-8')
+        log('info', `Downloaded language: ${p}/${name}`)
         return { success: true }
       } catch (err) {
-        log('warn', `Failed to download language ${name}: ${err}`)
+        log('warn', `Failed to download language ${p}/${name}: ${err}`)
         return { success: false, error: String(err) }
       }
     },
@@ -193,12 +207,13 @@ export function setupLanguageStore(): void {
 
   secureHandle(
     IpcChannels.LANG_DELETE,
-    async (_event, name: string): Promise<{ success: boolean; error?: string }> => {
+    async (_event, name: string, provider?: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
-      if (bundledSet(DEFAULT_TYPING_TEST_PROVIDER).has(name)) return { success: false, error: 'Cannot delete bundled language' }
+      const p = resolveProvider(provider)
+      if (bundledSet(p).has(name)) return { success: false, error: 'Cannot delete bundled language' }
       try {
-        await unlink(getLanguagePath(name))
-        log('info', `Deleted language: ${name}`)
+        await unlink(getLanguagePath(p, name))
+        log('info', `Deleted language: ${p}/${name}`)
         return { success: true }
       } catch (err) {
         return { success: false, error: String(err) }
@@ -283,7 +298,7 @@ export async function syncTypingDataset(
 
   // The new version's files live at a different URL and may differ in size,
   // so drop the old downloads; they re-fetch on demand against the new base.
-  await clearDownloadedLanguages()
+  await clearDownloadedLanguages(provider)
 
   // The update is applied, so the session no longer has one pending.
   updateCheckCache.set(provider, false)

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -1,6 +1,6 @@
 import { app, net } from 'electron'
 import { dirname, join } from 'node:path'
-import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises'
 import { IpcChannels } from '../shared/ipc/channels'
 import type { LanguageListEntry, LanguageDownloadStatus, TypingTestDataset } from '../shared/types/language-store'
 import {
@@ -74,14 +74,39 @@ function isSafeName(name: string): boolean {
   return typeof name === 'string' && name.length > 0 && !/[/\\]/.test(name)
 }
 
-/** Resolve the provider arg from an IPC call, defaulting to the historical
- *  provider so pre-multi-provider callers keep working unchanged. */
+/** Resolve the provider arg from an IPC call. Only a registered provider is
+ *  accepted — since the provider becomes a filesystem path segment, an
+ *  unknown / malformed value (e.g. a `../` traversal attempt) must never reach
+ *  disk, so it falls back to the historical default instead. */
 function resolveProvider(provider?: string): string {
-  return typeof provider === 'string' && provider ? provider : DEFAULT_TYPING_TEST_PROVIDER
+  if (typeof provider === 'string' && getProviderDefault(provider)) return provider
+  return DEFAULT_TYPING_TEST_PROVIDER
 }
 
 function getLanguagePath(provider: string, name: string): string {
   return join(getLanguagesDir(provider), `${name}.json`)
+}
+
+/** Move pre-multi-provider downloads (flat `languages/*.json`) into the
+ *  monkeytype sub-directory they now live in, so a user who had downloaded
+ *  extra MonkeyType languages keeps them after upgrading — important offline,
+ *  where they could not simply be re-fetched. Best-effort and idempotent:
+ *  once the flat files are moved there is nothing left to migrate. */
+async function migrateLegacyDownloads(): Promise<void> {
+  const root = join(app.getPath('userData'), 'local', 'downloads', 'languages')
+  let entries
+  try {
+    entries = await readdir(root, { withFileTypes: true })
+  } catch {
+    return // no downloads directory yet
+  }
+  const legacy = entries.filter((e) => e.isFile() && e.name.endsWith('.json'))
+  if (legacy.length === 0) return
+  const dest = getLanguagesDir(DEFAULT_TYPING_TEST_PROVIDER)
+  await mkdir(dest, { recursive: true })
+  await Promise.all(
+    legacy.map((e) => rename(join(root, e.name), join(dest, e.name)).catch(() => {})),
+  )
 }
 
 async function getDownloadedSet(provider: string): Promise<Set<string>> {
@@ -136,6 +161,11 @@ function validateLanguageData(data: unknown): data is LanguageFileData {
 }
 
 export function setupLanguageStore(): void {
+  // One-time move of legacy flat downloads into the monkeytype sub-directory.
+  // Best-effort at startup; the tiny window before it resolves only makes a
+  // previously-downloaded language momentarily read as not-downloaded.
+  void migrateLegacyDownloads()
+
   secureHandle(
     IpcChannels.LANG_LIST,
     async (_event, provider?: string): Promise<LanguageListEntry[]> => {

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -29,6 +29,11 @@ function getOverridePath(): string {
 // paths don't re-read disk on every call. Reset whenever the file changes.
 let overridesCache: Record<string, TypingTestDataset> | null = null
 
+// The one-time legacy-download migration, started at setup. Every handler that
+// touches the download directory awaits it first so a read never races the
+// in-flight move (which would momentarily hide a migrated language).
+let legacyMigration: Promise<void> = Promise.resolve()
+
 async function loadOverrides(): Promise<Record<string, TypingTestDataset>> {
   if (overridesCache) return overridesCache
   try {
@@ -102,11 +107,17 @@ async function migrateLegacyDownloads(): Promise<void> {
   }
   const legacy = entries.filter((e) => e.isFile() && e.name.endsWith('.json'))
   if (legacy.length === 0) return
-  const dest = getLanguagesDir(DEFAULT_TYPING_TEST_PROVIDER)
-  await mkdir(dest, { recursive: true })
-  await Promise.all(
-    legacy.map((e) => rename(join(root, e.name), join(dest, e.name)).catch(() => {})),
-  )
+  // Never reject: handlers await this promise, so a failed migration must fall
+  // through to a no-op rather than breaking every LANG_* call.
+  try {
+    const dest = getLanguagesDir(DEFAULT_TYPING_TEST_PROVIDER)
+    await mkdir(dest, { recursive: true })
+    await Promise.all(
+      legacy.map((e) => rename(join(root, e.name), join(dest, e.name)).catch(() => {})),
+    )
+  } catch (err) {
+    log('warn', `Legacy download migration failed: ${err}`)
+  }
 }
 
 async function getDownloadedSet(provider: string): Promise<Set<string>> {
@@ -162,13 +173,14 @@ function validateLanguageData(data: unknown): data is LanguageFileData {
 
 export function setupLanguageStore(): void {
   // One-time move of legacy flat downloads into the monkeytype sub-directory.
-  // Best-effort at startup; the tiny window before it resolves only makes a
-  // previously-downloaded language momentarily read as not-downloaded.
-  void migrateLegacyDownloads()
+  // Handlers await this before touching the download dir, so a migrated
+  // language is never momentarily reported as not-downloaded.
+  legacyMigration = migrateLegacyDownloads()
 
   secureHandle(
     IpcChannels.LANG_LIST,
     async (_event, provider?: string): Promise<LanguageListEntry[]> => {
+      await legacyMigration
       const p = resolveProvider(provider)
       const dataset = await getEffectiveDataset(p)
       const downloaded = await getDownloadedSet(p)
@@ -184,6 +196,7 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_GET,
     async (_event, name: string, provider?: string): Promise<LanguageFileData | null> => {
       if (!isSafeName(name)) return null
+      await legacyMigration
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return null
       try {
@@ -201,6 +214,7 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_DOWNLOAD,
     async (_event, name: string, provider?: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
+      await legacyMigration
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return { success: false, error: 'Language is bundled' }
       const dataset = await getEffectiveDataset(p)
@@ -239,6 +253,7 @@ export function setupLanguageStore(): void {
     IpcChannels.LANG_DELETE,
     async (_event, name: string, provider?: string): Promise<{ success: boolean; error?: string }> => {
       if (!isSafeName(name)) return { success: false, error: 'Invalid language name' }
+      await legacyMigration
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return { success: false, error: 'Cannot delete bundled language' }
       try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -588,14 +588,14 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.TYPING_ANALYTICS_IMPORT),
 
   // --- Language Store (IPC to main) ---
-  langList: (): Promise<LanguageListEntry[]> =>
-    ipcRenderer.invoke(IpcChannels.LANG_LIST),
-  langGet: (name: string): Promise<unknown> =>
-    ipcRenderer.invoke(IpcChannels.LANG_GET, name),
-  langDownload: (name: string): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke(IpcChannels.LANG_DOWNLOAD, name),
-  langDelete: (name: string): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke(IpcChannels.LANG_DELETE, name),
+  langList: (provider?: string): Promise<LanguageListEntry[]> =>
+    ipcRenderer.invoke(IpcChannels.LANG_LIST, provider),
+  langGet: (name: string, provider?: string): Promise<unknown> =>
+    ipcRenderer.invoke(IpcChannels.LANG_GET, name, provider),
+  langDownload: (name: string, provider?: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.LANG_DOWNLOAD, name, provider),
+  langDelete: (name: string, provider?: string): Promise<{ success: boolean; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.LANG_DELETE, name, provider),
   checkTypingDatasetUpdate: (provider?: string): Promise<{ provider: string; updateAvailable: boolean }> =>
     ipcRenderer.invoke(IpcChannels.TYPING_DATASET_CHECK, provider),
   updateTypingDataset: (provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }> =>

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -485,14 +485,24 @@ export function TypingTestPane({
   // Mode / language. The mode kind (FileImport / Normal) goes in the label —
   // "Mode(FileImport):" — and the button shows just the source (file name or
   // language), truncated to one line; the full text is on the title.
-  const modeType = typingTest.config.mode === 'fileImport'
-    ? t('editor.typingTest.language.tabFileImport')
-    : t('editor.typingTest.language.tabMonkeytype')
-  const modeLabel = typingTest.isLanguageLoading
-    ? t('editor.typingTest.language.loadingLanguage')
-    : typingTest.config.mode === 'fileImport'
-    ? (typingTest.state.currentQuote?.source ?? t('editor.typingTest.language.fileImportText'))
-    : typingTest.language.replace(/_/g, ' ')
+  let modeType: string
+  if (typingTest.config.mode === 'fileImport') {
+    modeType = t('editor.typingTest.language.tabFileImport')
+  } else if (typingTest.config.mode === 'tatoeba') {
+    modeType = t('editor.typingTest.language.tabTatoeba')
+  } else {
+    modeType = t('editor.typingTest.language.tabMonkeytype')
+  }
+  let modeLabel: string
+  if (typingTest.isLanguageLoading) {
+    modeLabel = t('editor.typingTest.language.loadingLanguage')
+  } else if (typingTest.config.mode === 'fileImport') {
+    modeLabel = typingTest.state.currentQuote?.source ?? t('editor.typingTest.language.fileImportText')
+  } else if (typingTest.config.mode === 'tatoeba') {
+    modeLabel = typingTest.config.language.replace(/_/g, ' ')
+  } else {
+    modeLabel = typingTest.language.replace(/_/g, ' ')
+  }
 
   // Config controls, pinned to the window's top-left as a sidebar in editor
   // mode (view-only has no config UI). Lifted out of the keymap row so it sits
@@ -530,14 +540,19 @@ export function TypingTestPane({
           <LanguageSelectorModal
             currentLanguage={typingTest.language}
             currentFileImportTextId={typingTest.config.mode === 'fileImport' ? typingTest.config.textId : undefined}
+            currentTatoebaLanguage={typingTest.config.mode === 'tatoeba' ? typingTest.config.language : undefined}
             onSelectLanguage={(name) => {
-              // Picking a language leaves fileImport mode — restore the last normal
-              // (words/time/quote) config so its Pattern/Units/Option settings
-              // survive the round trip; fall back to the default if none saved.
-              if (typingTest.config.mode === 'fileImport') onConfigChange(monkeytypeConfig ?? DEFAULT_CONFIG)
+              // Picking a MonkeyType language leaves fileImport / tatoeba mode —
+              // restore the last normal (words/time/quote) config so its
+              // Pattern/Units/Option settings survive the round trip; fall back
+              // to the default if none saved.
+              if (typingTest.config.mode === 'fileImport' || typingTest.config.mode === 'tatoeba') {
+                onConfigChange(monkeytypeConfig ?? DEFAULT_CONFIG)
+              }
               void onLanguageChange(name)
             }}
             onSelectImport={(textId) => onConfigChange({ mode: 'fileImport', textId })}
+            onSelectTatoeba={(language) => onConfigChange({ mode: 'tatoeba', language })}
             onCurrentTextDeleted={() => {
               // The selected imported text was deleted — fall back to
               // the default (words mode, English).
@@ -591,7 +606,7 @@ export function TypingTestPane({
             </select>
           </div>
         </div>
-        {typingTest.config.mode !== 'fileImport' && (
+        {typingTest.config.mode !== 'fileImport' && typingTest.config.mode !== 'tatoeba' && (
           <TypingTestSettingsBar config={typingTest.config} onConfigChange={onConfigChange} />
         )}
       </PanelSection>

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -20,7 +20,11 @@ function typingTestAnalyticsLabel(
   language: string,
   currentQuote: { source: string } | null,
 ): string {
-  return materialLabel(config.mode, language, currentQuote?.source)
+  // Tatoeba's material label keys off the sentence-pack language (in the
+  // config), not the MonkeyType word language, so the recording side and the
+  // Analyze run filter still produce an identical join key.
+  const effectiveLanguage = config.mode === 'tatoeba' ? config.language : language
+  return materialLabel(config.mode, effectiveLanguage, currentQuote?.source)
 }
 
 export interface UseInputModesOptions {

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -423,6 +423,46 @@ describe('useDevicePrefs', () => {
       }))
     })
 
+    it('restores a tatoeba typingTestConfig from IPC', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: { mode: 'tatoeba', language: 'english' },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
+    })
+
+    it('does not cache a tatoeba config as the MonkeyType fallback', async () => {
+      setupMocks()
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      // Set a normal config → it becomes the MonkeyType fallback.
+      act(() => {
+        result.current.setTypingTestConfig({ mode: 'words', wordCount: 60, punctuation: false, numbers: false })
+      })
+      // Switch to tatoeba → the fallback must stay the last normal config.
+      act(() => {
+        result.current.setTypingTestConfig({ mode: 'tatoeba', language: 'english' })
+      })
+
+      expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
+      expect(result.current.typingTestMonkeytypeConfig).toEqual({ mode: 'words', wordCount: 60, punctuation: false, numbers: false })
+    })
+
     it('setTypingTestLanguage saves via IPC', async () => {
       setupMocks()
       const { result } = renderHookWithConfig(() => useDevicePrefs())

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -442,6 +442,27 @@ describe('useDevicePrefs', () => {
       expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
     })
 
+    it('rejects a stale tatoeba value persisted in the MonkeyType fallback', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        // An older build could have saved a tatoeba config here; it must not
+        // come back as the MonkeyType fallback.
+        typingTestMonkeytypeConfig: { mode: 'tatoeba', language: 'english' },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestMonkeytypeConfig).toBeUndefined()
+    })
+
     it('does not cache a tatoeba config as the MonkeyType fallback', async () => {
       setupMocks()
       const { result } = renderHookWithConfig(() => useDevicePrefs())

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -41,9 +41,18 @@ function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
     case 'fileImport':
       if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
       return { mode: 'fileImport', textId: obj.textId }
+    case 'tatoeba':
+      if (typeof obj.language !== 'string' || obj.language.length === 0) return undefined
+      return { mode: 'tatoeba', language: obj.language }
     default:
       return undefined
   }
+}
+
+/** The MonkeyType-family modes whose config is remembered as the fallback
+ *  restored when leaving fileImport / tatoeba. */
+function isMonkeytypeMode(mode: TypingTestConfig['mode']): boolean {
+  return mode === 'words' || mode === 'time' || mode === 'quote'
 }
 
 function validateTypingTestLanguage(raw: unknown): string | undefined {
@@ -481,11 +490,12 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     const prev = typingTestConfigRef.current
     updateTypingTestConfig(cfg)
     // Remember the last normal (words/time/quote) config so it survives a
-    // switch into fileImport (imported text) and back. When entering fileImport,
-    // capture the outgoing normal config too — covers old prefs where
-    // typingTestMonkeytypeConfig was never saved.
-    if (cfg.mode !== 'fileImport') updateTypingTestMonkeytypeConfig(cfg)
-    else if (prev && prev.mode !== 'fileImport') updateTypingTestMonkeytypeConfig(prev)
+    // switch into a non-normal mode (fileImport / tatoeba) and back. When
+    // entering such a mode, capture the outgoing normal config too — covers old
+    // prefs where typingTestMonkeytypeConfig was never saved. tatoeba must NOT
+    // be cached here, else selecting a MonkeyType language would restore it.
+    if (isMonkeytypeMode(cfg.mode)) updateTypingTestMonkeytypeConfig(cfg)
+    else if (prev && isMonkeytypeMode(prev.mode)) updateTypingTestMonkeytypeConfig(prev)
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateTypingTestConfig, updateTypingTestMonkeytypeConfig])
 

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -55,6 +55,14 @@ function isMonkeytypeMode(mode: TypingTestConfig['mode']): boolean {
   return mode === 'words' || mode === 'time' || mode === 'quote'
 }
 
+/** The MonkeyType fallback config must be a normal (words/time/quote) config.
+ *  Reject any fileImport / tatoeba value — including a stale one persisted by
+ *  an older build — so leaving those modes never restores them. */
+function validateMonkeytypeConfig(raw: unknown): TypingTestConfig | undefined {
+  const cfg = validateTypingTestConfig(raw)
+  return cfg && isMonkeytypeMode(cfg.mode) ? cfg : undefined
+}
+
 function validateTypingTestLanguage(raw: unknown): string | undefined {
   if (typeof raw !== 'string' || raw.length === 0) return undefined
   return raw
@@ -204,7 +212,7 @@ function validateIpcPrefs(
     layerNames,
     typingTestResults,
     typingTestConfig,
-    typingTestMonkeytypeConfig: validateTypingTestConfig(data.typingTestMonkeytypeConfig),
+    typingTestMonkeytypeConfig: validateMonkeytypeConfig(data.typingTestMonkeytypeConfig),
     typingTestLanguage: validateTypingTestLanguage(data.typingTestLanguage),
     typingTestViewOnly,
     typingTestViewOnlyWindowSize: validateWindowSize(data.typingTestViewOnlyWindowSize),

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -374,6 +374,7 @@
         "loadingLanguage": "Loading language...",
         "downloadFailed": "Download failed",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
         "tabFileImport": "File Import",
         "import": "Import UTF-8 text file",
         "importEmpty": "No imported texts yet",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -374,6 +374,7 @@
         "loadingLanguage": "言語を読み込み中...",
         "downloadFailed": "ダウンロードに失敗しました",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
         "tabFileImport": "ファイル取込",
         "import": "UTF-8 テキストをインポート",
         "importEmpty": "インポートされたテキストはありません",

--- a/src/renderer/typing-test/LanguagePackTab.tsx
+++ b/src/renderer/typing-test/LanguagePackTab.tsx
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Check, Download, Trash2, Loader2 } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
+import type { LanguageListEntry } from '../../shared/types/language-store'
+
+function formatName(name: string): string {
+  return name.replace(/_/g, ' ')
+}
+
+interface Props {
+  /** Dataset provider whose packs this tab lists (e.g. 'monkeytype', 'tatoeba'). */
+  provider: string
+  /** Name of the pack currently in use for this provider, highlighted with a
+   *  check. `undefined` when another mode/provider is active. */
+  currentSelected?: string
+  onSelect: (name: string) => void
+}
+
+/**
+ * A provider's downloadable language/sentence packs: search + a session-cached
+ * "update available" banner + the downloaded/available lists with per-row
+ * download / delete. Shared verbatim by the MonkeyType and Tatoeba tabs; only
+ * one tab is mounted at a time, so the test ids are intentionally identical
+ * across providers.
+ */
+export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) {
+  const { t } = useTranslation()
+  const [languages, setLanguages] = useState<LanguageListEntry[]>([])
+  const [search, setSearch] = useState('')
+  const [downloading, setDownloading] = useState<Set<string>>(new Set())
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+  const [updating, setUpdating] = useState(false)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    let alive = true
+    window.vialAPI.langList(provider).then((list) => {
+      if (alive) setLanguages(list)
+    }).catch(() => {})
+    return () => { alive = false }
+  }, [provider])
+
+  useEffect(() => { searchRef.current?.focus() }, [])
+
+  // Version check only — no auto-download. Runs when this tab is shown; the
+  // main process caches the result for the app session, so reopening the modal
+  // or switching tabs won't re-hit the Hub.
+  useEffect(() => {
+    let alive = true
+    window.vialAPI.checkTypingDatasetUpdate(provider)
+      .then((r) => { if (alive) setUpdateAvailable(r.updateAvailable) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [provider])
+
+  const handleUpdateDataset = useCallback(async () => {
+    setUpdating(true)
+    try {
+      const result = await window.vialAPI.updateTypingDataset(provider)
+      if (result.changed) {
+        // The manifest may have new/changed languages; refresh the list.
+        const list = await window.vialAPI.langList(provider)
+        setLanguages(list)
+        setUpdateAvailable(false)
+      }
+      // On `changed:false` (Hub unreachable / invalid payload) the update was
+      // NOT applied — keep the banner so the user can retry.
+    } finally {
+      setUpdating(false)
+    }
+  }, [provider])
+
+  const handleDownload = useCallback(async (name: string) => {
+    setDownloading((s) => new Set(s).add(name))
+    try {
+      const result = await window.vialAPI.langDownload(name, provider)
+      if (result.success) {
+        setLanguages((prev) =>
+          prev.map((l) => (l.name === name ? { ...l, status: 'downloaded' as const } : l)),
+        )
+      }
+    } finally {
+      setDownloading((s) => {
+        const next = new Set(s)
+        next.delete(name)
+        return next
+      })
+    }
+  }, [provider])
+
+  const handleDelete = useCallback(async (name: string) => {
+    const result = await window.vialAPI.langDelete(name, provider)
+    if (result.success) {
+      setLanguages((prev) =>
+        prev.map((l) => (l.name === name ? { ...l, status: 'not-downloaded' as const } : l)),
+      )
+    }
+  }, [provider])
+
+  const filtered = useMemo(() => {
+    if (!search) return languages
+    const q = search.toLowerCase()
+    return languages.filter((l) => formatName(l.name).toLowerCase().includes(q))
+  }, [languages, search])
+
+  const downloaded = useMemo(() => filtered.filter((l) => l.status !== 'not-downloaded'), [filtered])
+  const available = useMemo(() => filtered.filter((l) => l.status === 'not-downloaded'), [filtered])
+
+  return (
+    <>
+      <div className="border-b border-edge px-4 py-2">
+        <input
+          ref={searchRef}
+          type="text"
+          className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
+          placeholder={t('editor.typingTest.language.searchPlaceholder')}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          data-testid="language-search"
+        />
+      </div>
+
+      {updateAvailable && (
+        <div
+          className="flex items-center justify-between gap-3 border-b border-edge bg-accent/5 px-4 py-2"
+          data-testid="typing-dataset-update-banner"
+        >
+          <span className="text-sm text-content-secondary">
+            {t('editor.typingTest.language.datasetUpdateAvailable')}
+          </span>
+          <button
+            type="button"
+            data-testid="typing-dataset-update-button"
+            disabled={updating}
+            onClick={handleUpdateDataset}
+            className="inline-flex h-8 items-center rounded-md border border-accent bg-accent/10 px-3 text-sm text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t(updating ? 'editor.typingTest.language.datasetUpdating' : 'editor.typingTest.language.datasetUpdate')}
+          </button>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 && (
+          <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
+        )}
+
+        {downloaded.length > 0 && (
+          <div>
+            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+              {t('editor.typingTest.language.downloaded')}
+            </div>
+            {downloaded.map((lang) => (
+              <LanguageRow
+                key={lang.name}
+                lang={lang}
+                isCurrent={lang.name === currentSelected}
+                isDownloading={downloading.has(lang.name)}
+                onSelect={onSelect}
+                onDelete={handleDelete}
+              />
+            ))}
+          </div>
+        )}
+
+        {available.length > 0 && (
+          <div>
+            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+              {t('editor.typingTest.language.available')}
+            </div>
+            {available.map((lang) => (
+              <LanguageRow
+                key={lang.name}
+                lang={lang}
+                isCurrent={false}
+                isDownloading={downloading.has(lang.name)}
+                onSelect={onSelect}
+                onDownload={handleDownload}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  )
+}
+
+interface LanguageRowProps {
+  lang: LanguageListEntry
+  isCurrent: boolean
+  isDownloading: boolean
+  onSelect: (name: string) => void
+  onDownload?: (name: string) => void
+  onDelete?: (name: string) => void
+}
+
+function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onDelete }: LanguageRowProps) {
+  const { t } = useTranslation()
+  const canSelect = lang.status !== 'not-downloaded'
+
+  let rowStyle = ''
+  if (isCurrent) {
+    rowStyle = 'bg-accent/10'
+  } else if (canSelect) {
+    rowStyle = 'cursor-pointer hover:bg-surface-alt'
+  }
+
+  return (
+    <div
+      data-testid={`language-row-${lang.name}`}
+      className={`flex items-center gap-2 px-4 py-2 text-sm transition-colors ${rowStyle}`}
+      onClick={canSelect ? () => onSelect(lang.name) : undefined}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {isCurrent && <Check size={ICON_SM} className="shrink-0 text-accent" aria-hidden="true" />}
+        <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>
+          {formatName(lang.name)}
+        </span>
+        {lang.rightToLeft && (
+          <span className="shrink-0 rounded bg-surface-alt px-1 py-0.5 text-2xs text-content-muted">RTL</span>
+        )}
+      </div>
+
+      <span className="shrink-0 text-xs text-content-muted">
+        {t('editor.typingTest.language.words', { count: lang.wordCount })}
+      </span>
+
+      {lang.status === 'not-downloaded' && onDownload && (
+        <button
+          type="button"
+          data-testid={`language-download-${lang.name}`}
+          className="shrink-0 rounded p-1 text-content-muted hover:text-accent"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDownload(lang.name)
+          }}
+          disabled={isDownloading}
+        >
+          {isDownloading ? (
+            <Loader2 size={ICON_SM} className="animate-spin" aria-hidden="true" />
+          ) : (
+            <Download size={ICON_SM} aria-hidden="true" />
+          )}
+        </button>
+      )}
+
+      {lang.status === 'downloaded' && onDelete && (
+        <button
+          type="button"
+          data-testid={`language-delete-${lang.name}`}
+          className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete(lang.name)
+          }}
+        >
+          <Trash2 size={ICON_SM} aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/typing-test/LanguagePackTab.tsx
+++ b/src/renderer/typing-test/LanguagePackTab.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Check, Download, Trash2, Loader2 } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
+import { clearTatoebaPackCache } from './word-generator'
 import type { LanguageListEntry } from '../../shared/types/language-store'
 
 function formatName(name: string): string {
@@ -61,6 +62,9 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
     try {
       const result = await window.vialAPI.updateTypingDataset(provider)
       if (result.changed) {
+        // The update dropped the old downloaded files; forget any cached packs
+        // so the session doesn't keep playing stale sentences.
+        if (provider === 'tatoeba') clearTatoebaPackCache()
         // The manifest may have new/changed languages; refresh the list.
         const list = await window.vialAPI.langList(provider)
         setLanguages(list)
@@ -78,6 +82,8 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
     try {
       const result = await window.vialAPI.langDownload(name, provider)
       if (result.success) {
+        // Re-downloading replaces the file on disk; drop any cached copy.
+        if (provider === 'tatoeba') clearTatoebaPackCache(name)
         setLanguages((prev) =>
           prev.map((l) => (l.name === name ? { ...l, status: 'downloaded' as const } : l)),
         )
@@ -94,6 +100,8 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
   const handleDelete = useCallback(async (name: string) => {
     const result = await window.vialAPI.langDelete(name, provider)
     if (result.success) {
+      // The file is gone; forget any cached copy so it can't still be played.
+      if (provider === 'tatoeba') clearTatoebaPackCache(name)
       setLanguages((prev) =>
         prev.map((l) => (l.name === name ? { ...l, status: 'not-downloaded' as const } : l)),
       )

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
+import { useState, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
-import { Check, Download, Trash2, Loader2, FileUp } from 'lucide-react'
+import { Check, Trash2, Loader2, FileUp } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
-import type { LanguageListEntry } from '../../shared/types/language-store'
+import { LanguagePackTab } from './LanguagePackTab'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 
-type Tab = 'existing' | 'import'
+type Tab = 'existing' | 'tatoeba' | 'import'
 
 /** Store error code → i18n key for the Import tab error line. Unlisted
  *  codes fall back to the generic importFailed message. */
@@ -24,36 +24,38 @@ interface Props {
   currentLanguage: string
   /** Active imported text id, when the current config is in fileImport mode. */
   currentFileImportTextId?: string
+  /** Active tatoeba pack language, when the current config is in tatoeba mode. */
+  currentTatoebaLanguage?: string
   onSelectLanguage: (name: string) => void
   /** Called when an imported text is picked — switches to fileImport mode. */
   onSelectImport: (textId: string) => void
+  /** Called when a tatoeba pack is picked — switches to tatoeba mode. */
+  onSelectTatoeba: (language: string) => void
   /** Called on close when the currently-selected imported text was deleted
    *  (and nothing else was picked) so the caller can reset to the default. */
   onCurrentTextDeleted?: () => void
   onClose: () => void
 }
 
-function formatName(name: string): string {
-  return name.replace(/_/g, ' ')
+function initialTab(fileImportTextId?: string, tatoebaLanguage?: string): Tab {
+  if (fileImportTextId) return 'import'
+  if (tatoebaLanguage) return 'tatoeba'
+  return 'existing'
 }
 
 export function LanguageSelectorModal({
   currentLanguage,
   currentFileImportTextId,
+  currentTatoebaLanguage,
   onSelectLanguage,
   onSelectImport,
+  onSelectTatoeba,
   onCurrentTextDeleted,
   onClose,
 }: Props) {
   const { t } = useTranslation()
-  const [tab, setTab] = useState<Tab>(currentFileImportTextId ? 'import' : 'existing')
-  const [languages, setLanguages] = useState<LanguageListEntry[]>([])
-  const [search, setSearch] = useState('')
-  const [downloading, setDownloading] = useState<Set<string>>(new Set())
-  const [updateAvailable, setUpdateAvailable] = useState(false)
-  const [updating, setUpdating] = useState(false)
+  const [tab, setTab] = useState<Tab>(() => initialTab(currentFileImportTextId, currentTatoebaLanguage))
   const backdropRef = useRef<HTMLDivElement>(null)
-  const searchRef = useRef<HTMLInputElement>(null)
   // Flipped true when the currently-selected imported text is deleted, so a
   // plain close (Esc / backdrop / X — not an explicit pick) resets to default.
   const deletedCurrentRef = useRef(false)
@@ -65,77 +67,9 @@ export function LanguageSelectorModal({
 
   useEscapeClose(handleClose)
 
-  useEffect(() => {
-    let alive = true
-    window.vialAPI.langList().then((list) => {
-      if (alive) setLanguages(list)
-    }).catch(() => {})
-    return () => { alive = false }
-  }, [])
-
-  useEffect(() => {
-    if (tab === 'existing') searchRef.current?.focus()
-  }, [tab])
-
-  // Version check only — no auto-download. Runs when the MonkeyType tab is
-  // shown; the main process caches the result for the app session, so reopening
-  // the modal or switching tabs won't re-hit the Hub.
-  useEffect(() => {
-    if (tab !== 'existing') return
-    let alive = true
-    window.vialAPI.checkTypingDatasetUpdate('monkeytype')
-      .then((r) => { if (alive) setUpdateAvailable(r.updateAvailable) })
-      .catch(() => {})
-    return () => { alive = false }
-  }, [tab])
-
-  const handleUpdateDataset = useCallback(async () => {
-    setUpdating(true)
-    try {
-      const result = await window.vialAPI.updateTypingDataset('monkeytype')
-      if (result.changed) {
-        // The manifest may have new/changed languages; refresh the list.
-        const list = await window.vialAPI.langList()
-        setLanguages(list)
-        setUpdateAvailable(false)
-      }
-      // On `changed:false` (Hub unreachable / invalid payload) the update was
-      // NOT applied — keep the banner so the user can retry.
-    } finally {
-      setUpdating(false)
-    }
-  }, [])
-
   const handleBackdropClick = useCallback((e: React.MouseEvent) => {
     if (e.target === backdropRef.current) handleClose()
   }, [handleClose])
-
-  const handleDownload = useCallback(async (name: string) => {
-    setDownloading((s) => new Set(s).add(name))
-    try {
-      const result = await window.vialAPI.langDownload(name)
-      if (result.success) {
-        setLanguages((prev) =>
-          prev.map((l) => (l.name === name ? { ...l, status: 'downloaded' as const } : l)),
-        )
-      }
-    } finally {
-      setDownloading((s) => {
-        const next = new Set(s)
-        next.delete(name)
-        return next
-      })
-    }
-  }, [])
-
-  const handleDelete = useCallback(async (name: string) => {
-    const result = await window.vialAPI.langDelete(name)
-    if (result.success) {
-      setLanguages((prev) =>
-        prev.map((l) => (l.name === name ? { ...l, status: 'not-downloaded' as const } : l)),
-      )
-    }
-  }, [])
 
   const handleSelect = useCallback((name: string) => {
     onSelectLanguage(name)
@@ -147,14 +81,10 @@ export function LanguageSelectorModal({
     onClose()
   }, [onSelectImport, onClose])
 
-  const filtered = useMemo(() => {
-    if (!search) return languages
-    const q = search.toLowerCase()
-    return languages.filter((l) => formatName(l.name).toLowerCase().includes(q))
-  }, [languages, search])
-
-  const downloaded = useMemo(() => filtered.filter((l) => l.status !== 'not-downloaded'), [filtered])
-  const available = useMemo(() => filtered.filter((l) => l.status === 'not-downloaded'), [filtered])
+  const handleSelectTatoeba = useCallback((language: string) => {
+    onSelectTatoeba(language)
+    onClose()
+  }, [onSelectTatoeba, onClose])
 
   return (
     <div
@@ -183,6 +113,16 @@ export function LanguageSelectorModal({
           <button
             type="button"
             role="tab"
+            aria-selected={tab === 'tatoeba'}
+            data-testid="language-tab-tatoeba"
+            className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'tatoeba' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
+            onClick={() => setTab('tatoeba')}
+          >
+            {t('editor.typingTest.language.tabTatoeba')}
+          </button>
+          <button
+            type="button"
+            role="tab"
             aria-selected={tab === 'import'}
             data-testid="language-tab-import"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'import' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
@@ -192,83 +132,23 @@ export function LanguageSelectorModal({
           </button>
         </div>
 
-        {tab === 'existing' ? (
-          <>
-            <div className="border-b border-edge px-4 py-2">
-              <input
-                ref={searchRef}
-                type="text"
-                className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
-                placeholder={t('editor.typingTest.language.searchPlaceholder')}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                data-testid="language-search"
-              />
-            </div>
+        {tab === 'existing' && (
+          <LanguagePackTab
+            provider="monkeytype"
+            currentSelected={currentFileImportTextId || currentTatoebaLanguage ? undefined : currentLanguage}
+            onSelect={handleSelect}
+          />
+        )}
 
-            {updateAvailable && (
-              <div
-                className="flex items-center justify-between gap-3 border-b border-edge bg-accent/5 px-4 py-2"
-                data-testid="typing-dataset-update-banner"
-              >
-                <span className="text-sm text-content-secondary">
-                  {t('editor.typingTest.language.datasetUpdateAvailable')}
-                </span>
-                <button
-                  type="button"
-                  data-testid="typing-dataset-update-button"
-                  disabled={updating}
-                  onClick={handleUpdateDataset}
-                  className="inline-flex h-8 items-center rounded-md border border-accent bg-accent/10 px-3 text-sm text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {t(updating ? 'editor.typingTest.language.datasetUpdating' : 'editor.typingTest.language.datasetUpdate')}
-                </button>
-              </div>
-            )}
+        {tab === 'tatoeba' && (
+          <LanguagePackTab
+            provider="tatoeba"
+            currentSelected={currentTatoebaLanguage}
+            onSelect={handleSelectTatoeba}
+          />
+        )}
 
-            <div className="flex-1 overflow-y-auto">
-              {filtered.length === 0 && (
-                <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
-              )}
-
-              {downloaded.length > 0 && (
-                <div>
-                  <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-                    {t('editor.typingTest.language.downloaded')}
-                  </div>
-                  {downloaded.map((lang) => (
-                    <LanguageRow
-                      key={lang.name}
-                      lang={lang}
-                      isCurrent={!currentFileImportTextId && lang.name === currentLanguage}
-                      isDownloading={downloading.has(lang.name)}
-                      onSelect={handleSelect}
-                      onDelete={handleDelete}
-                    />
-                  ))}
-                </div>
-              )}
-
-              {available.length > 0 && (
-                <div>
-                  <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-                    {t('editor.typingTest.language.available')}
-                  </div>
-                  {available.map((lang) => (
-                    <LanguageRow
-                      key={lang.name}
-                      lang={lang}
-                      isCurrent={false}
-                      isDownloading={downloading.has(lang.name)}
-                      onSelect={handleSelect}
-                      onDownload={handleDownload}
-                    />
-                  ))}
-                </div>
-              )}
-            </div>
-          </>
-        ) : (
+        {tab === 'import' && (
           <ImportTab
             currentFileImportTextId={currentFileImportTextId}
             onSelect={handleSelectImport}
@@ -436,78 +316,3 @@ function ImportRow({ meta, isCurrent, onSelect, onDelete }: ImportRowProps) {
   )
 }
 
-interface LanguageRowProps {
-  lang: LanguageListEntry
-  isCurrent: boolean
-  isDownloading: boolean
-  onSelect: (name: string) => void
-  onDownload?: (name: string) => void
-  onDelete?: (name: string) => void
-}
-
-function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onDelete }: LanguageRowProps) {
-  const { t } = useTranslation()
-  const canSelect = lang.status !== 'not-downloaded'
-
-  let rowStyle = ''
-  if (isCurrent) {
-    rowStyle = 'bg-accent/10'
-  } else if (canSelect) {
-    rowStyle = 'cursor-pointer hover:bg-surface-alt'
-  }
-
-  return (
-    <div
-      data-testid={`language-row-${lang.name}`}
-      className={`flex items-center gap-2 px-4 py-2 text-sm transition-colors ${rowStyle}`}
-      onClick={canSelect ? () => onSelect(lang.name) : undefined}
-    >
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        {isCurrent && <Check size={ICON_SM} className="shrink-0 text-accent" aria-hidden="true" />}
-        <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>
-          {formatName(lang.name)}
-        </span>
-        {lang.rightToLeft && (
-          <span className="shrink-0 rounded bg-surface-alt px-1 py-0.5 text-2xs text-content-muted">RTL</span>
-        )}
-      </div>
-
-      <span className="shrink-0 text-xs text-content-muted">
-        {t('editor.typingTest.language.words', { count: lang.wordCount })}
-      </span>
-
-      {lang.status === 'not-downloaded' && onDownload && (
-        <button
-          type="button"
-          data-testid={`language-download-${lang.name}`}
-          className="shrink-0 rounded p-1 text-content-muted hover:text-accent"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDownload(lang.name)
-          }}
-          disabled={isDownloading}
-        >
-          {isDownloading ? (
-            <Loader2 size={ICON_SM} className="animate-spin" aria-hidden="true" />
-          ) : (
-            <Download size={ICON_SM} aria-hidden="true" />
-          )}
-        </button>
-      )}
-
-      {lang.status === 'downloaded' && onDelete && (
-        <button
-          type="button"
-          data-testid={`language-delete-${lang.name}`}
-          className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete(lang.name)
-          }}
-        >
-          <Trash2 size={ICON_SM} aria-hidden="true" />
-        </button>
-      )}
-    </div>
-  )
-}

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -136,21 +136,22 @@ export function TypingTestView({
     [fontSize, displayLines],
   )
 
-  // Imported fileImport text counts progress by character (spaces included): each
-  // word-gap is one separator char, so total = Σ word lengths + (words - 1).
-  // Gated on the mode (not `lines`) so single-line imports count chars too.
-  const isFileImport = config.mode === 'fileImport'
+  // Char-progress modes (imported fileImport text; Tatoeba sentences) count
+  // progress by character (spaces included): each word-gap is one separator
+  // char, so total = Σ word lengths + (words - 1). Gated on the mode (not
+  // `lines`) so single-line / word-flow sources count chars too.
+  const charProgress = config.mode === 'fileImport' || config.mode === 'tatoeba'
   const totalChars = useMemo(
-    () => (isFileImport ? state.words.reduce((sum, w) => sum + w.length, 0) + Math.max(0, state.words.length - 1) : 0),
-    [isFileImport, state.words],
+    () => (charProgress ? state.words.reduce((sum, w) => sum + w.length, 0) + Math.max(0, state.words.length - 1) : 0),
+    [charProgress, state.words],
   )
   const typedChars = useMemo(() => {
-    if (!isFileImport) return 0
+    if (!charProgress) return 0
     let sum = state.currentInput.length
     for (let i = 0; i < state.currentWordIndex && i < state.words.length; i++) sum += state.words[i].length
     sum += Math.min(state.currentWordIndex, Math.max(0, state.words.length - 1)) // separators passed
     return Math.min(sum, totalChars)
-  }, [isFileImport, state.words, state.currentWordIndex, state.currentInput, totalChars])
+  }, [charProgress, state.words, state.currentWordIndex, state.currentInput, totalChars])
 
   function clearImeInput(): void {
     if (imeInputRef.current) imeInputRef.current.value = ''
@@ -439,13 +440,13 @@ export function TypingTestView({
             </span>
           </div>
           <div className="flex items-baseline gap-1.5">
-            {/* Imported fileImport text tracks character progress (spaces included);
-                everything else tracks words. */}
-            <span className="text-content-muted">{t(isFileImport ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
+            {/* Char-progress modes (fileImport / Tatoeba) track character
+                progress (spaces included); everything else tracks words. */}
+            <span className="text-content-muted">{t(charProgress ? 'editor.typingTest.chars' : 'editor.typingTest.words')}:</span>
             <span data-testid="typing-test-word-count" className="font-mono text-lg font-semibold tabular-nums">
               {!showStats
                 ? '-'
-                : isFileImport
+                : charProgress
                 ? t('editor.typingTest.wordCount', { current: typedChars, total: totalChars })
                 : t('editor.typingTest.wordCount', {
                     current: state.currentWordIndex,

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -186,7 +186,66 @@ describe('LanguageSelectorModal', () => {
 
     fireEvent.click(screen.getByTestId('language-download-german'))
 
-    expect(window.vialAPI.langDownload).toHaveBeenCalledWith('german')
+    expect(window.vialAPI.langDownload).toHaveBeenCalledWith('german', 'monkeytype')
+  })
+
+  it('lists the tatoeba provider and version-checks it when its tab is shown', async () => {
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onSelectTatoeba={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-tatoeba'))
+
+    await waitFor(() => {
+      expect(window.vialAPI.langList).toHaveBeenCalledWith('tatoeba')
+      expect(window.vialAPI.checkTypingDatasetUpdate).toHaveBeenCalledWith('tatoeba')
+    })
+  })
+
+  it('picks a tatoeba pack → onSelectTatoeba + onClose', async () => {
+    const onSelectTatoeba = vi.fn()
+    const onClose = vi.fn()
+
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onSelectTatoeba={onSelectTatoeba}
+        onClose={onClose}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-tatoeba'))
+    await waitFor(() => expect(screen.getByTestId('language-row-english_1k')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('language-row-english_1k'))
+
+    expect(onSelectTatoeba).toHaveBeenCalledWith('english_1k')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('opens on the tatoeba tab when a tatoeba pack is active', async () => {
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        currentTatoebaLanguage="english_1k"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onSelectTatoeba={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('language-tab-tatoeba')).toHaveAttribute('aria-selected', 'true'),
+    )
   })
 
   it('shows delete button for downloaded (non-bundled) languages', async () => {

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -25,6 +25,7 @@ function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult
 
 const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false } as TypingTestConfig
 const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 't1' } as TypingTestConfig
+const tatoebaConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english' } as TypingTestConfig
 
 describe('matchingResults', () => {
   it('matches normal runs on mode + params + language + toggles', () => {
@@ -46,6 +47,17 @@ describe('matchingResults', () => {
     ]
     const out = matchingResults(pool, fileImportConfig, 'english')
     expect(out.map((r) => r.wpm).sort()).toEqual([40, 45])
+  })
+
+  it('matches tatoeba runs on the pack language (mode2), independent of word language', () => {
+    const pool = [
+      makeResult({ wpm: 40, mode: 'tatoeba', mode2: 'english', language: 'english' }),  // match
+      makeResult({ wpm: 45, mode: 'tatoeba', mode2: 'english', language: 'german' }),   // same pack, stray lang → still match
+      makeResult({ wpm: 99, mode: 'tatoeba', mode2: 'french' }),                        // different pack
+      makeResult({ wpm: 12, mode: 'words', mode2: 'english' }),                         // different mode
+    ]
+    const out = matchingResults(pool, tatoebaConfig, 'german')
+    expect(out.map((r) => r.wpm).sort((a, b) => a - b)).toEqual([40, 45])
   })
 
   it('excludes results at/after beforeMs (the in-flight run)', () => {
@@ -71,11 +83,17 @@ describe('conditionKey', () => {
     expect(conditionKey(fileImportConfig, 'japanese')).toBe('fileImport|t1')
   })
 
+  it('keys tatoeba on the pack language only (word-language-independent)', () => {
+    expect(conditionKey(tatoebaConfig, 'german')).toBe('tatoeba|english')
+    expect(conditionKey(tatoebaConfig, 'japanese')).toBe('tatoeba|english')
+  })
+
   it('distinguishes different conditions', () => {
     const a = conditionKey(wordsConfig, 'english')
     const b = conditionKey({ mode: 'time', duration: 10 } as TypingTestConfig, 'english')
     const c = conditionKey(fileImportConfig, 'english')
-    expect(new Set([a, b, c]).size).toBe(3)
+    const d = conditionKey(tatoebaConfig, 'english')
+    expect(new Set([a, b, c, d]).size).toBe(4)
   })
 })
 

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -31,6 +31,10 @@ describe('typingTestResultMaterialLabel', () => {
     // Falls back to 'fileImport' when the name wasn't captured.
     expect(typingTestResultMaterialLabel({ ...base, mode: 'fileImport' })).toBe('fileImport')
   })
+  it('uses tatoeba-<language> for tatoeba mode', () => {
+    expect(typingTestResultMaterialLabel({ ...base, mode: 'tatoeba', language: 'english' }))
+      .toBe('tatoeba-english')
+  })
 })
 
 describe('computeRawWpm', () => {
@@ -223,6 +227,26 @@ describe('buildTypingTestResult', () => {
     })
     expect(result.mode).toBe('quote')
     expect(result.mode2).toBe('medium')
+  })
+
+  it('stores the tatoeba pack language as language + mode2, not the input language', () => {
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'english' }
+    const result = buildTypingTestResult({
+      correctChars: 120,
+      incorrectChars: 4,
+      wordCount: 20,
+      wpm: 65,
+      accuracy: 97,
+      elapsedMs: 40000,
+      config,
+      // The top-level (MonkeyType) language is irrelevant for tatoeba.
+      language: 'german',
+      wpmHistory: [],
+    })
+    expect(result.mode).toBe('tatoeba')
+    expect(result.mode2).toBe('english')
+    expect(result.language).toBe('english')
+    expect(typingTestResultMaterialLabel(result)).toBe('tatoeba-english')
   })
 })
 

--- a/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTypingTest } from '../useTypingTest'
+import { getTatoebaPack } from '../word-generator'
+
+const mockLangGet = vi.fn()
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.vialAPI = {
+    ...(window.vialAPI ?? {}),
+    langGet: mockLangGet,
+  } as unknown as typeof window.vialAPI
+})
+
+afterEach(() => {
+  window.vialAPI = originalVialAPI
+})
+
+const type = (result: { current: { processKeyEvent: (k: string, c: boolean, a: boolean, m: boolean) => void } }, key: string): void => {
+  act(() => result.current.processKeyEvent(key, false, false, false))
+}
+
+describe('useTypingTest — tatoeba mode', () => {
+  it('plays a downloaded pack as word-flow (no line breaks) and finishes on the last char', async () => {
+    // A single-sentence pack makes the sampled quote deterministic (the
+    // sampler returns the whole list when it is smaller than the batch size).
+    mockLangGet.mockResolvedValue({ name: 'english-x', words: ['ab cd'] })
+    // Warm the cache so the hook's synchronous initial state has the words.
+    await getTatoebaPack('english-x')
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-x' }, 'english'))
+
+    // Word-flow: sentence split into space-delimited tokens, no line breaks.
+    expect(result.current.state.words).toEqual(['ab', 'cd'])
+    expect([...result.current.state.lineBreaks]).toEqual([])
+    expect(result.current.state.currentQuote?.source).toBe('english-x')
+
+    // Space advances between words; Enter is ignored (word-flow, not line-row).
+    type(result, 'a')
+    type(result, 'b')
+    type(result, 'Enter') // ignored in word-flow modes
+    expect(result.current.state.currentWordIndex).toBe(0)
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(1)
+
+    // Last word finishes on the final character (no trailing separator).
+    type(result, 'c')
+    type(result, 'd')
+    expect(result.current.state.status).toBe('finished')
+  })
+
+  it('loads the pack asynchronously when switching into tatoeba mode', async () => {
+    mockLangGet.mockResolvedValue({ name: 'english-y', words: ['hi yo'] })
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
+
+    await act(async () => {
+      await result.current.setConfig({ mode: 'tatoeba', language: 'english-y' })
+    })
+
+    expect(result.current.config).toEqual({ mode: 'tatoeba', language: 'english-y' })
+    expect(result.current.state.words).toEqual(['hi', 'yo'])
+    expect(mockLangGet).toHaveBeenCalledWith('english-y', 'tatoeba')
+  })
+
+  it('yields no words when the pack is not downloaded', async () => {
+    mockLangGet.mockResolvedValue(null)
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
+
+    await act(async () => {
+      await result.current.setConfig({ mode: 'tatoeba', language: 'missing' })
+    })
+
+    expect(result.current.state.words).toEqual([])
+  })
+})

--- a/src/renderer/typing-test/comparison.ts
+++ b/src/renderer/typing-test/comparison.ts
@@ -19,6 +19,9 @@ export interface ComparisonStats {
  *  pinnable choices stay in lockstep. */
 export function conditionKey(config: TypingTestConfig, language: string): string {
   if (config.mode === 'fileImport') return `fileImport|${String(deriveMode2(config) ?? '')}`
+  // Tatoeba is grouped by its sentence-pack language (mode2), independent of
+  // the MonkeyType word language — mirrors the fileImport short form.
+  if (config.mode === 'tatoeba') return `tatoeba|${String(deriveMode2(config) ?? '')}`
   const hasToggles = config.mode === 'words' || config.mode === 'time'
   return configKey({
     mode: config.mode,
@@ -41,7 +44,9 @@ export function matchingResults<T extends TypingTestResult>(
   beforeMs?: number,
 ): T[] {
   const isFileImport = config.mode === 'fileImport'
-  const currentTextId = String(deriveMode2(config) ?? '')
+  const isTatoeba = config.mode === 'tatoeba'
+  // For fileImport this is the textId; for tatoeba, the pack language.
+  const currentMode2 = String(deriveMode2(config) ?? '')
   const hasToggles = config.mode === 'words' || config.mode === 'time'
   // configKey only reads these 5 fields, so a config-shaped partial is enough.
   const currentKey = configKey({
@@ -54,7 +59,8 @@ export function matchingResults<T extends TypingTestResult>(
 
   return pool.filter((r) => {
     if (beforeMs != null && new Date(r.date).getTime() >= beforeMs) return false
-    if (isFileImport) return r.mode === 'fileImport' && String(r.mode2 ?? '') === currentTextId
+    if (isFileImport) return r.mode === 'fileImport' && String(r.mode2 ?? '') === currentMode2
+    if (isTatoeba) return r.mode === 'tatoeba' && String(r.mode2 ?? '') === currentMode2
     return configKey(r) === currentKey
   })
 }

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -27,6 +27,9 @@ export function computeConsistency(wpmHistory: number[]): number {
  *  stays byte-identical on both ends. */
 export function materialLabel(mode: string, language: string, fileImportName: string | undefined): string {
   if (mode === 'fileImport') return fileImportName ?? 'fileImport'
+  // Tatoeba runs are sliced by their sentence-pack language, not the
+  // (irrelevant) MonkeyType word language, so they get a dedicated label.
+  if (mode === 'tatoeba') return `tatoeba-${language}`
   return `${mode} (${language})`
 }
 
@@ -95,6 +98,9 @@ export function deriveMode2(config: TypingTestConfig): number | string {
     case 'fileImport':
       // Group PBs per imported text via its id.
       return config.textId
+    case 'tatoeba':
+      // Group PBs per sentence-pack language.
+      return config.language
   }
 }
 
@@ -135,7 +141,9 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     mode: input.config.mode,
     mode2: deriveMode2(input.config),
     fileImportTextName: input.config.mode === 'fileImport' ? input.fileImportTextName : undefined,
-    language: input.language,
+    // Tatoeba stores its sentence-pack language (from the config) so the
+    // material label and PB grouping key it, not the MonkeyType word language.
+    language: input.config.mode === 'tatoeba' ? input.config.language : input.language,
     punctuation: hasPunctuation,
     numbers: hasNumbers,
     consistency,

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-export type TypingTestMode = 'words' | 'time' | 'quote' | 'fileImport'
+export type TypingTestMode = 'words' | 'time' | 'quote' | 'fileImport' | 'tatoeba'
 export type QuoteLength = 'short' | 'medium' | 'long' | 'all'
 
 export type TypingTestConfig =
@@ -10,6 +10,10 @@ export type TypingTestConfig =
   // Imported user text, played verbatim in order via the quote rendering
   // path. `textId` references an entry in the typing-test-texts store.
   | { mode: 'fileImport'; textId: string }
+  // Tatoeba sentence pack (Hub-distributed). Sentences are played verbatim
+  // in order via the same char-count/word-flow path as fileImport. `language`
+  // selects the downloaded pack (e.g. 'english').
+  | { mode: 'tatoeba'; language: string }
 
 export interface Quote {
   id: number

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { extractMOLayer, extractLTLayer, extractLMLayer, isTapKeycode } from './keycode-char-map'
-import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync } from './word-generator'
+import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync, getTatoebaPack, getTatoebaPackSync, tatoebaQuote } from './word-generator'
 import type { FileImportTextData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, Quote } from './types'
@@ -136,6 +136,15 @@ function fileImportTextToWords(data: FileImportTextData): WordsForConfig {
   }
 }
 
+/** Build a word-flow config from a sampled Tatoeba quote (empty when the pack
+ *  is uncached / not downloaded). Reuses the quote path so counting and
+ *  rendering match quote mode. */
+function tatoebaWordsForConfig(pack: { name: string; words: string[] } | undefined): WordsForConfig {
+  if (!pack) return { words: [], quote: null, lineBreaks: [], lineIndents: [] }
+  const quote = tatoebaQuote(pack)
+  return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
+}
+
 function createWordsForConfigSync(config: TypingTestConfig, language: string): WordsForConfig {
   if (config.mode === 'quote') {
     const quote = selectQuote(config.quoteLength)
@@ -146,6 +155,10 @@ function createWordsForConfigSync(config: TypingTestConfig, language: string): W
     // Cache miss — the async setConfig path fills words once the store
     // round-trip resolves. Return empty (never call sampleWords on []).
     return data ? fileImportTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
+  }
+  if (config.mode === 'tatoeba') {
+    // Cache miss — the async path fills words once langGet resolves.
+    return tatoebaWordsForConfig(getTatoebaPackSync(config.language))
   }
   const { count, opts } = wordGenParams(config)
   const { words } = generateWordsSync(count, opts, language)
@@ -160,6 +173,9 @@ async function createWordsForConfig(config: TypingTestConfig, language: string):
   if (config.mode === 'fileImport') {
     const data = await getFileImportTextData(config.textId)
     return data ? fileImportTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [] }
+  }
+  if (config.mode === 'tatoeba') {
+    return tatoebaWordsForConfig(await getTatoebaPack(config.language))
   }
   const { count, opts } = wordGenParams(config)
   const { words } = await generateWords(count, opts, language)

--- a/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
+++ b/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  getTatoebaPack,
+  getTatoebaPackSync,
+  tatoebaQuote,
+  TATOEBA_SENTENCE_COUNT,
+} from '../tatoeba-pack'
+
+const mockLangGet = vi.fn()
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.vialAPI = {
+    ...(window.vialAPI ?? {}),
+    langGet: mockLangGet,
+  } as unknown as typeof window.vialAPI
+})
+
+afterEach(() => {
+  window.vialAPI = originalVialAPI
+})
+
+describe('getTatoebaPack', () => {
+  it('fetches the tatoeba provider via IPC, validates, and caches', async () => {
+    const pack = { name: 'english', words: ['Hello there.', 'How are you?'] }
+    mockLangGet.mockResolvedValue(pack)
+
+    // Unique language key per test avoids the module-level cache leaking.
+    const first = await getTatoebaPack('english-a')
+    expect(first).toEqual(pack)
+    expect(mockLangGet).toHaveBeenCalledWith('english-a', 'tatoeba')
+
+    // Second call served from cache — no extra IPC.
+    const second = await getTatoebaPack('english-a')
+    expect(second).toBe(first)
+    expect(mockLangGet).toHaveBeenCalledTimes(1)
+    expect(getTatoebaPackSync('english-a')).toBe(first)
+  })
+
+  it('returns undefined for a malformed pack and does not cache', async () => {
+    mockLangGet.mockResolvedValue({ name: 'english' }) // missing words
+    expect(await getTatoebaPack('english-b')).toBeUndefined()
+    expect(getTatoebaPackSync('english-b')).toBeUndefined()
+
+    mockLangGet.mockResolvedValue(null)
+    expect(await getTatoebaPack('english-c')).toBeUndefined()
+  })
+})
+
+describe('tatoebaQuote', () => {
+  it('folds sampled sentences into one quote labelled by the pack name', () => {
+    const words = Array.from({ length: 50 }, (_, i) => `Sentence number ${i}.`)
+    const quote = tatoebaQuote({ name: 'english', words })
+
+    expect(quote.source).toBe('english')
+    expect(quote.length).toBe(quote.text.length)
+    expect(quote.text.length).toBeGreaterThan(0)
+    // Every sampled sentence comes from the pack.
+    for (const sentence of quote.text.split('. ').map((s) => (s.endsWith('.') ? s : `${s}.`))) {
+      expect(words).toContain(sentence)
+    }
+  })
+
+  it('uses every sentence when the pack has fewer than the sample size', () => {
+    const words = ['Only one.', 'And two.']
+    const quote = tatoebaQuote({ name: 'small', words })
+    expect(quote.text).toBe('Only one. And two.')
+  })
+
+  it('returns an empty quote for an empty pack', () => {
+    const quote = tatoebaQuote({ name: 'empty', words: [] })
+    expect(quote.text).toBe('')
+    expect(quote.length).toBe(0)
+  })
+
+  it('samples exactly the configured number of sentences from a large pack', () => {
+    const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    const quote = tatoebaQuote({ name: 'big', words })
+    // Joined by single spaces; no sentence here contains a space, so token
+    // count equals the sampled sentence count.
+    expect(quote.text.split(' ')).toHaveLength(TATOEBA_SENTENCE_COUNT)
+  })
+})

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -5,4 +5,6 @@ export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync,
 export { selectQuote, quoteToWords } from './quote-generator'
 export { getFileImportTextData, getFileImportTextDataSync, clearFileImportTextCache } from './file-import-text'
 export type { FileImportTextData } from './file-import-text'
+export { getTatoebaPack, getTatoebaPackSync, tatoebaQuote, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
+export type { TatoebaPack } from './tatoeba-pack'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -5,6 +5,6 @@ export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync,
 export { selectQuote, quoteToWords } from './quote-generator'
 export { getFileImportTextData, getFileImportTextDataSync, clearFileImportTextCache } from './file-import-text'
 export type { FileImportTextData } from './file-import-text'
-export { getTatoebaPack, getTatoebaPackSync, tatoebaQuote, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
+export { getTatoebaPack, getTatoebaPackSync, clearTatoebaPackCache, tatoebaQuote, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
 export type { TatoebaPack } from './tatoeba-pack'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/renderer/typing-test/word-generator/tatoeba-pack.ts
+++ b/src/renderer/typing-test/word-generator/tatoeba-pack.ts
@@ -39,6 +39,17 @@ export async function getTatoebaPack(language: string): Promise<TatoebaPack | un
   return data
 }
 
+/** Drop cached packs so the next read re-fetches from disk. Called after a
+ *  download / delete / dataset update changes the on-disk pack files, so a
+ *  stale copy is never played for the rest of the session. */
+export function clearTatoebaPackCache(language?: string): void {
+  if (language) {
+    packCache.delete(language)
+  } else {
+    packCache.clear()
+  }
+}
+
 /** Sample a batch of sentences and fold them into one quote for the word-flow
  *  path. `source` carries the pack name so the finished screen can label it. */
 export function tatoebaQuote(pack: TatoebaPack): Quote {

--- a/src/renderer/typing-test/word-generator/tatoeba-pack.ts
+++ b/src/renderer/typing-test/word-generator/tatoeba-pack.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Tatoeba sentence packs for the typing test. Distributed via the Hub-only
+// 'tatoeba' provider and cached per language, then played through the quote
+// path: a batch of sampled sentences is concatenated into a single quote so
+// the word-flow renderer and char-based counting are reused verbatim.
+
+import type { Quote } from '../types'
+import { randomInt } from './random'
+
+/** Sentences sampled per test — sized to feel like a words/quote run given
+ *  the short, independent daily sentences Tatoeba packs contain. */
+export const TATOEBA_SENTENCE_COUNT = 5
+
+/** A downloaded Tatoeba pack: `words` are full sentences, not tokens. */
+export interface TatoebaPack {
+  name: string
+  words: string[]
+}
+
+const packCache = new Map<string, TatoebaPack>()
+
+function isPack(v: unknown): v is TatoebaPack {
+  if (typeof v !== 'object' || v === null) return false
+  const p = v as Record<string, unknown>
+  return typeof p.name === 'string' && Array.isArray(p.words) && p.words.every((w) => typeof w === 'string')
+}
+
+export function getTatoebaPackSync(language: string): TatoebaPack | undefined {
+  return packCache.get(language)
+}
+
+export async function getTatoebaPack(language: string): Promise<TatoebaPack | undefined> {
+  const cached = packCache.get(language)
+  if (cached) return cached
+
+  const data = await window.vialAPI.langGet(language, 'tatoeba')
+  if (!isPack(data)) return undefined
+  packCache.set(language, data)
+  return data
+}
+
+/** Sample a batch of sentences and fold them into one quote for the word-flow
+ *  path. `source` carries the pack name so the finished screen can label it. */
+export function tatoebaQuote(pack: TatoebaPack): Quote {
+  const text = sampleSentences(pack.words, TATOEBA_SENTENCE_COUNT).join(' ')
+  return { id: 0, text, source: pack.name, length: text.length }
+}
+
+/** Pick `count` sentences, avoiding an immediate repeat (mirrors sampleWords). */
+function sampleSentences(list: readonly string[], count: number): string[] {
+  if (list.length === 0) return []
+  if (list.length <= count) return [...list]
+
+  const result: string[] = []
+  let lastIdx = -1
+  for (let i = 0; i < count; i++) {
+    let idx = randomInt(0, list.length - 1)
+    let attempts = 0
+    while (idx === lastIdx && attempts < 100) {
+      idx = randomInt(0, list.length - 1)
+      attempts++
+    }
+    result.push(list[idx])
+    lastIdx = idx
+  }
+  return result
+}

--- a/src/shared/data/typing-test-providers.ts
+++ b/src/shared/data/typing-test-providers.ts
@@ -28,6 +28,19 @@ export const TYPING_TEST_PROVIDER_DEFAULTS: readonly TypingTestProviderDefault[]
     bundledLanguages: ['english'],
     languages: monkeytypeLanguages as LanguageManifestEntry[],
   },
+  // Tatoeba is a Hub-only provider: no data ships with the app. The bundled
+  // default is an empty placeholder — version, downloadUrlBase and the
+  // language list are all supplied by the Hub override at runtime
+  // (`GET /api/typing-test/datasets/tatoeba`). With an empty bundled version,
+  // the first version check always reports an update so packs are fetched to
+  // install. `bundledLanguages` is empty because nothing is baked in.
+  {
+    provider: 'tatoeba',
+    version: '',
+    downloadUrlBase: '',
+    bundledLanguages: [],
+    languages: [],
+  },
 ]
 
 export function getProviderDefault(provider: string): TypingTestProviderDefault | undefined {

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -19,7 +19,7 @@ export interface TypingTestResult {
   incorrectChars: number
   durationSeconds: number
   rawWpm?: number
-  mode?: 'words' | 'time' | 'quote' | 'fileImport'
+  mode?: 'words' | 'time' | 'quote' | 'fileImport' | 'tatoeba'
   mode2?: number | string
   /** Human-readable imported-text name, snapshotted at test time (fileImport
    *  mode only). `mode2` keeps the stable textId for PB grouping; this is

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -324,10 +324,10 @@ export interface VialAPI {
   syncOnPendingChange(callback: (pending: boolean) => void): () => void
 
   // Language Store
-  langList(): Promise<LanguageListEntry[]>
-  langGet(name: string): Promise<unknown>
-  langDownload(name: string): Promise<{ success: boolean; error?: string }>
-  langDelete(name: string): Promise<{ success: boolean; error?: string }>
+  langList(provider?: string): Promise<LanguageListEntry[]>
+  langGet(name: string, provider?: string): Promise<unknown>
+  langDownload(name: string, provider?: string): Promise<{ success: boolean; error?: string }>
+  langDelete(name: string, provider?: string): Promise<{ success: boolean; error?: string }>
   checkTypingDatasetUpdate(provider?: string): Promise<{ provider: string; updateAvailable: boolean }>
   updateTypingDataset(provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }>
 


### PR DESCRIPTION
## Summary

Add **Tatoeba** as a typing-test data source (english only). Tatoeba supplies short, independent daily sentences, distributed as sentence packs through the Hub, and played as a new `tatoeba` typing mode that reuses the existing word-flow / char-count infrastructure.

This is Phase 1 (english / CC0). Japanese (CC BY) packs and the About-tab attribution are a later phase.

## What changed

- **New `tatoeba` typing mode** — config variant `{ mode: 'tatoeba', language }`. A downloaded pack is sampled into a quote and played via the existing quote path (word-flow display, char-based progress like File Import).
- **Hub-only dataset provider** — Tatoeba ships no bundled data; its version / download URL / language list come from the Hub override at runtime. The empty bundled version makes the first version check report an update so packs are fetched to install.
- **Multi-provider language store** — `LANG_LIST/GET/DOWNLOAD/DELETE` are provider-parameterized (defaulting to `monkeytype` for back-compat). Downloads are namespaced under `local/downloads/languages/<provider>/` so two providers exposing the same language name (both ship an `english`) never collide, and a version-change cleanup for one provider can't wipe another's downloads. A one-time migration moves pre-existing flat downloads into the `monkeytype` subdir.
- **Third "Tatoeba" tab** in the mode modal — the MonkeyType tab's pack list + version-check/update banner were extracted into a reusable, provider-parameterized `LanguagePackTab` shared by both tabs.
- **Analytics label** — Tatoeba runs are labelled `tatoeba-<pack-language>` and grouped (PB / comparison) by pack language, mirroring how File Import keys on its text id. The recording-side and Analyze-side labels stay byte-identical.

## Security / robustness

- Only a registered provider is accepted as a filesystem path segment (unknown / traversal values fall back to the default).
- The legacy-download migration is awaited by every handler that reads the download dir, so a migrated language never momentarily reads as not-downloaded; the migration body is rejection-safe.
- The MonkeyType fallback config validates through a stricter check (words/time/quote only), so a stale tatoeba value from an older build can't strand the app in tatoeba mode.
- The renderer pack cache is invalidated on tatoeba download / delete / update.

## Testing

`npx tsc --noEmit`, `pnpm run lint`, `pnpm test` (4351 passed), and `pnpm run build` all green. New unit tests cover the Hub-only provider, per-provider download isolation, provider-validation path safety, legacy migration, the Tatoeba modal tab, pack loading/sampling, the `tatoeba` typing mode, analytics labelling, config persistence, and stale-fallback rejection.

## Out of scope (follow-up)

- Japanese (CC BY) packs + About-tab attribution section.
- Dedicated History tab / mode filter for tatoeba (currently grouped under the general tab).
