### PR TITLE
fix(ui): stop stripping non-ASCII text from tatoeba sentences

### DIFF
--- a/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
@@ -79,4 +79,20 @@ describe('useTypingTest — tatoeba mode', () => {
 
     expect(result.current.state.words).toEqual([])
   })
+
+  it('plays a Japanese pack without ASCII-stripping the sentences (regression)', async () => {
+    // Real sentence from the Tatoeba japanese pack (CC BY 2.0 FR). Before the
+    // tokenizer fix this collapsed to a single stray '0' via quoteToWords'
+    // ASCII whitelist.
+    mockLangGet.mockResolvedValue({
+      name: 'japanese',
+      words: ['「0℃！ やばい熱ある」「かわいそうな雪だるまさん」'],
+    })
+    await getTatoebaPack('japanese-regression')
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'japanese-regression' }, 'english'))
+
+    expect(result.current.state.words.join('')).not.toBe('0')
+    expect(result.current.state.words.some((w) => w.includes('やばい'))).toBe(true)
+  })
 })

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { extractMOLayer, extractLTLayer, extractLMLayer, isTapKeycode } from './keycode-char-map'
-import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync, getTatoebaPack, getTatoebaPackSync, tatoebaQuote } from './word-generator'
+import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync, getTatoebaPack, getTatoebaPackSync, tatoebaQuote, tatoebaQuoteToWords } from './word-generator'
 import type { FileImportTextData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, Quote } from './types'
@@ -137,12 +137,15 @@ function fileImportTextToWords(data: FileImportTextData): WordsForConfig {
 }
 
 /** Build a word-flow config from a sampled Tatoeba quote (empty when the pack
- *  is uncached / not downloaded). Reuses the quote path so counting and
- *  rendering match quote mode. */
+ *  is uncached / not downloaded). Reuses the quote path's rendering and
+ *  char-based counting, but tokenizes with `tatoebaQuoteToWords` (NOT
+ *  `quoteToWords`) — Tatoeba sentences span 72 languages in arbitrary
+ *  scripts, and `quoteToWords`'s ASCII whitelist would strip non-Latin text
+ *  down to almost nothing. */
 function tatoebaWordsForConfig(pack: { name: string; words: string[] } | undefined): WordsForConfig {
   if (!pack) return { words: [], quote: null, lineBreaks: [], lineIndents: [] }
   const quote = tatoebaQuote(pack)
-  return { words: quoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
+  return { words: tatoebaQuoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
 }
 
 function createWordsForConfigSync(config: TypingTestConfig, language: string): WordsForConfig {

--- a/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
+++ b/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
@@ -6,6 +6,7 @@ import {
   getTatoebaPack,
   getTatoebaPackSync,
   tatoebaQuote,
+  tatoebaQuoteToWords,
   TATOEBA_SENTENCE_COUNT,
 } from '../tatoeba-pack'
 
@@ -83,5 +84,35 @@ describe('tatoebaQuote', () => {
     // Joined by single spaces; no sentence here contains a space, so token
     // count equals the sampled sentence count.
     expect(quote.text.split(' ')).toHaveLength(TATOEBA_SENTENCE_COUNT)
+  })
+})
+
+describe('tatoebaQuoteToWords', () => {
+  it('keeps non-ASCII characters intact — regression for the ASCII-strip bug', () => {
+    // Real sentences from the Tatoeba japanese pack (CC BY 2.0 FR). The old
+    // quoteToWords()-based tokenizer whitelist-stripped everything but ASCII,
+    // collapsing sentences like these down to a single stray digit.
+    const words = [
+      '「0℃！ やばい熱ある」「かわいそうな雪だるまさん」',
+      '「いい考えね」と思ったのは３名だけでした。',
+    ]
+    const quote = tatoebaQuote({ name: 'japanese', words })
+
+    const tokens = tatoebaQuoteToWords(quote)
+
+    expect(tokens.join('')).not.toBe('0')
+    expect(tokens.some((t) => t.includes('やばい'))).toBe(true)
+    expect(tokens.some((t) => t.includes('思ったのは３名だけでした。'))).toBe(true)
+  })
+
+  it('splits on whitespace without stripping punctuation/accents', () => {
+    const quote = tatoebaQuote({ name: 'french', words: ["C'est très bien.", 'Où est-il ?'] })
+    const tokens = tatoebaQuoteToWords(quote)
+    expect(tokens).toEqual(["C'est", 'très', 'bien.', 'Où', 'est-il', '?'])
+  })
+
+  it('returns no tokens for an empty quote', () => {
+    const quote = tatoebaQuote({ name: 'empty', words: [] })
+    expect(tatoebaQuoteToWords(quote)).toEqual([])
   })
 })

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -5,6 +5,6 @@ export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync,
 export { selectQuote, quoteToWords } from './quote-generator'
 export { getFileImportTextData, getFileImportTextDataSync, clearFileImportTextCache } from './file-import-text'
 export type { FileImportTextData } from './file-import-text'
-export { getTatoebaPack, getTatoebaPackSync, clearTatoebaPackCache, tatoebaQuote, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
+export { getTatoebaPack, getTatoebaPackSync, clearTatoebaPackCache, tatoebaQuote, tatoebaQuoteToWords, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
 export type { TatoebaPack } from './tatoeba-pack'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/renderer/typing-test/word-generator/tatoeba-pack.ts
+++ b/src/renderer/typing-test/word-generator/tatoeba-pack.ts
@@ -57,6 +57,17 @@ export function tatoebaQuote(pack: TatoebaPack): Quote {
   return { id: 0, text, source: pack.name, length: text.length }
 }
 
+/** Tokenize a Tatoeba quote into word-flow display units. Deliberately NOT
+ *  `quoteToWords` — that function whitelist-strips to ASCII, which is correct
+ *  for MonkeyType's English quotes but destroys Tatoeba sentences in any
+ *  non-ASCII script (Japanese, Cyrillic, accented Latin, etc. — most of the
+ *  72 Tatoeba languages). Splits on whitespace only and keeps every
+ *  character as-is, mirroring parseFileImportText's script-agnostic
+ *  tokenizer. */
+export function tatoebaQuoteToWords(quote: Quote): string[] {
+  return quote.text.split(/\s+/).filter((w) => w.length > 0)
+}
+
 /** Pick `count` sentences, avoiding an immediate repeat (mirrors sampleWords). */
 function sampleSentences(list: readonly string[], count: number): string[] {
   if (list.length === 0) return []


### PR DESCRIPTION
## Summary

- Fix a live bug in `tatoeba` typing-test mode: since the Hub expanded the `tatoeba` provider from english-only to **72 languages**, sentences in any non-ASCII script were being destroyed by `quoteToWords()` — an ASCII-whitelist tokenizer written for MonkeyType's English quotes. Verified: two real Japanese sentences collapsed to a single stray `'0'` character.
- Add `tatoebaQuoteToWords()`, a script-agnostic tokenizer that splits on whitespace only and keeps every character as-is (mirrors `parseFileImportText`'s approach). `tatoeba` mode now uses it; `quote` mode's `quoteToWords()` is untouched.

## Test plan

- [x] `npx tsc --noEmit`, `pnpm run lint`, `pnpm test` (4355 passed), `pnpm run build` all green
- [x] New regression tests with real Tatoeba japanese-pack sentences (`tatoeba-pack.test.ts`, `useTypingTest.tatoeba.test.ts`) confirming non-ASCII text survives tokenization
- [x] Confirmed `quoteToWords()` is still used only by `quote` mode paths
