### PR TITLE
feat(ui): add Tatoeba attribution to the About/legal screen

### DIFF
--- a/src/renderer/components/__tests__/legal-content.test.ts
+++ b/src/renderer/components/__tests__/legal-content.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { LEGAL_SECTIONS } from '../legal-content'
+
+describe('LEGAL_SECTIONS', () => {
+  it('discloses the Tatoeba typing-test text source, its licenses, and the CC0 exceptions', () => {
+    const section = LEGAL_SECTIONS.find((s) => s.title === 'Typing Test Text Sources')
+    expect(section).toBeDefined()
+
+    const text = section!.paragraphs.join(' ')
+    expect(text).toContain('Tatoeba')
+    // CC BY 2.0 FR is the default license (attribution required) for most packs.
+    expect(text).toContain('CC BY 2.0 FR')
+    // CC0 1.0 covers the exception packs, which must be named explicitly so the
+    // disclosure stays accurate if the CC0 language set ever grows.
+    expect(text).toContain('CC0 1.0')
+    for (const lang of ['English', 'Bangla', 'Kabyle', 'Russian']) {
+      expect(text).toContain(lang)
+    }
+    // Curation/modification notice, required by CC BY's "indicate changes" term.
+    expect(text).toMatch(/curated|modified/i)
+  })
+
+  it('keeps the section ordered before Disclaimer (last section stays a catch-all)', () => {
+    const titles = LEGAL_SECTIONS.map((s) => s.title)
+    expect(titles[titles.length - 1]).toBe('Disclaimer')
+    expect(titles).toContain('Typing Test Text Sources')
+  })
+})

--- a/src/renderer/components/legal-content.ts
+++ b/src/renderer/components/legal-content.ts
@@ -27,6 +27,13 @@ export const LEGAL_SECTIONS: LegalSection[] = [
     ],
   },
   {
+    title: 'Typing Test Text Sources',
+    paragraphs: [
+      'Tatoeba-based Typing Test sentence packs are curated from the Tatoeba Project (https://tatoeba.org) and its contributors. Most language packs are licensed under CC BY 2.0 FR (https://creativecommons.org/licenses/by/2.0/fr/); the English, Bangla, Kabyle, and Russian packs are dedicated to the public domain under CC0 1.0 (https://creativecommons.org/publicdomain/zero/1.0/).',
+      'These packs are a curated, modified snapshot of the Tatoeba corpus (filtered, de-duplicated, and length-limited), not the original data.',
+    ],
+  },
+  {
     title: 'Disclaimer',
     paragraphs: [
       'Pipette is provided as-is, without warranty of any kind. Use of the software is at your own risk.',


### PR DESCRIPTION
## Summary

Phase 2 of the Tatoeba typing-test integration: add the required attribution to the About/legal screen.

- The Hub redistributes Tatoeba.org sentences across 72 languages under two licenses: **CC0 1.0** (`english`, `bangla`, `kabyle`, `russian` — no attribution needed) and **CC BY 2.0 FR** (all other packs — attribution required).
- Rather than a per-language conditional (the manifest carries no per-language `license` field by design), the Hub uses a single **collective credit** shown always in the app's legal screen — this mirrors how the redistribution repo's own `NOTICE` already satisfies CC BY at the point of redistribution.
- Adds a "Typing Test Text Sources" section to `legal-content.ts` naming the source, both licenses, the CC0 exceptions, and the curation/modification notice CC BY 2.0 FR requires. Follows the file's existing hardcoded-English, non-i18n pattern (legal text stays in one canonical language).

## Test plan

- [x] `npx tsc --noEmit`, `pnpm run lint`, `pnpm test` (4357 passed), `pnpm run build` all green
- [x] New unit test locking in the CC BY / CC0 disclosure text and section ordering
- [x] Existing `SettingsModal` About-tab test still passes unchanged
