### PR TITLE
feat(ui): render tatoeba sentences one per line in typing test

### DIFF
--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -121,8 +121,8 @@ export function TypingTestView({
   // Guard: prevent duplicate space submission when both keydown and input fire
   const lastSpaceTimeRef = useRef(0)
 
-  // Imported fileImport text (line breaks present) renders as explicit line
-  // rows; every other mode keeps the flat word-flow layout. `null` = flat.
+  // Sources with line breaks render as explicit line rows; every other mode
+  // keeps the flat word-flow layout. `null` = flat.
   const lines = useMemo(
     () => (state.lineBreaks.size > 0 ? groupIntoLines(state.words, state.lineBreaks) : null),
     [state.words, state.lineBreaks],

--- a/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
@@ -95,4 +95,31 @@ describe('useTypingTest — tatoeba mode', () => {
     expect(result.current.state.words.join('')).not.toBe('0')
     expect(result.current.state.words.some((w) => w.includes('やばい'))).toBe(true)
   })
+
+  it('renders each sampled sentence as its own line and advances past a sentence-end word on Enter, not Space', async () => {
+    // Two sentences, both under TATOEBA_SENTENCE_COUNT, so the sampler keeps
+    // the whole list in order (deterministic): words = ['ab', 'cd', 'ef'],
+    // lineBreaks = [1] (after 'cd', the first sentence's last word).
+    mockLangGet.mockResolvedValue({ name: 'english-z', words: ['ab cd', 'ef'] })
+    await getTatoebaPack('english-z')
+
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-z' }, 'english'))
+
+    expect(result.current.state.words).toEqual(['ab', 'cd', 'ef'])
+    expect([...result.current.state.lineBreaks]).toEqual([1])
+
+    // Word 0 ('ab') is not a sentence-end word: Space advances, Enter is a no-op.
+    type(result, 'a')
+    type(result, 'Enter')
+    expect(result.current.state.currentWordIndex).toBe(0)
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(1)
+
+    // Word 1 ('cd') is the sentence-end word: Space is a no-op, Enter advances.
+    type(result, 'c')
+    type(result, ' ')
+    expect(result.current.state.currentWordIndex).toBe(1)
+    type(result, 'Enter')
+    expect(result.current.state.currentWordIndex).toBe(2)
+  })
 })

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef, useMemo, useEffect } from 'react'
 import { extractMOLayer, extractLTLayer, extractLMLayer, isTapKeycode } from './keycode-char-map'
-import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync, getTatoebaPack, getTatoebaPackSync, tatoebaQuote, tatoebaQuoteToWords } from './word-generator'
+import { generateWords, generateWordsSync, getLanguageData, selectQuote, quoteToWords, getFileImportTextData, getFileImportTextDataSync, getTatoebaPack, getTatoebaPackSync, tatoebaRun } from './word-generator'
 import type { FileImportTextData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, Quote } from './types'
@@ -117,7 +117,8 @@ function wordGenParams(config: TypingTestConfig & { mode: 'words' | 'time' }): {
 interface WordsForConfig {
   words: string[]
   quote: Quote | null
-  /** Line-end word indices (fileImport mode only); empty otherwise. */
+  /** Line-end word indices — Enter advances past them; empty for flat
+   *  word-flow sources. */
   lineBreaks: number[]
   /** Per-line leading whitespace (fileImport mode only); empty otherwise. */
   lineIndents: string[]
@@ -136,16 +137,14 @@ function fileImportTextToWords(data: FileImportTextData): WordsForConfig {
   }
 }
 
-/** Build a word-flow config from a sampled Tatoeba quote (empty when the pack
- *  is uncached / not downloaded). Reuses the quote path's rendering and
- *  char-based counting, but tokenizes with `tatoebaQuoteToWords` (NOT
- *  `quoteToWords`) — Tatoeba sentences span 72 languages in arbitrary
- *  scripts, and `quoteToWords`'s ASCII whitelist would strip non-Latin text
- *  down to almost nothing. */
+/** Build a word-flow config from a sampled Tatoeba run (empty when the pack
+ *  is uncached / not downloaded). Reuses the quote path's char-based
+ *  counting and carries the run's per-sentence `lineBreaks` through so each
+ *  sampled sentence renders on its own line, same as imported fileImport
+ *  text. */
 function tatoebaWordsForConfig(pack: { name: string; words: string[] } | undefined): WordsForConfig {
   if (!pack) return { words: [], quote: null, lineBreaks: [], lineIndents: [] }
-  const quote = tatoebaQuote(pack)
-  return { words: tatoebaQuoteToWords(quote), quote, lineBreaks: [], lineIndents: [] }
+  return { ...tatoebaRun(pack), lineIndents: [] }
 }
 
 function createWordsForConfigSync(config: TypingTestConfig, language: string): WordsForConfig {
@@ -571,10 +570,9 @@ export function useTypingTest(
       if (s.status !== 'waiting' && s.status !== 'running') return s
 
       // Space and Enter both advance a word, but they are distinct: at a
-      // line-end word (imported fileImport text) Enter is expected, elsewhere
-      // Space. The non-matching key is a no-op. For every non-fileImport mode
-      // `lineBreaks` is empty, so Space always advances and Enter is always
-      // ignored — identical to the previous behaviour.
+      // line-end word Enter is expected, elsewhere Space. The non-matching
+      // key is a no-op. Flat word-flow sources have no `lineBreaks`, so
+      // Space always advances and Enter is always ignored.
       if (isSubmitKey(key) || key === 'Enter') {
         if (s.status === 'waiting') {
           return { ...s, status: 'running', startTime: Date.now() }

--- a/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
+++ b/src/renderer/typing-test/word-generator/__tests__/tatoeba-pack.test.ts
@@ -5,8 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   getTatoebaPack,
   getTatoebaPackSync,
-  tatoebaQuote,
-  tatoebaQuoteToWords,
+  tatoebaRun,
   TATOEBA_SENTENCE_COUNT,
 } from '../tatoeba-pack'
 
@@ -52,67 +51,78 @@ describe('getTatoebaPack', () => {
   })
 })
 
-describe('tatoebaQuote', () => {
+describe('tatoebaRun', () => {
   it('folds sampled sentences into one quote labelled by the pack name', () => {
     const words = Array.from({ length: 50 }, (_, i) => `Sentence number ${i}.`)
-    const quote = tatoebaQuote({ name: 'english', words })
+    const run = tatoebaRun({ name: 'english', words })
 
-    expect(quote.source).toBe('english')
-    expect(quote.length).toBe(quote.text.length)
-    expect(quote.text.length).toBeGreaterThan(0)
-    // Every sampled sentence comes from the pack.
-    for (const sentence of quote.text.split('. ').map((s) => (s.endsWith('.') ? s : `${s}.`))) {
-      expect(words).toContain(sentence)
-    }
+    expect(run.quote.source).toBe('english')
+    expect(run.quote.length).toBe(run.quote.text.length)
+    expect(run.quote.text.length).toBeGreaterThan(0)
+    expect(run.quote.text).toBe(run.words.join(' '))
   })
 
   it('uses every sentence when the pack has fewer than the sample size', () => {
     const words = ['Only one.', 'And two.']
-    const quote = tatoebaQuote({ name: 'small', words })
-    expect(quote.text).toBe('Only one. And two.')
+    const run = tatoebaRun({ name: 'small', words })
+    expect(run.quote.text).toBe('Only one. And two.')
+    expect(run.words).toEqual(['Only', 'one.', 'And', 'two.'])
+    // Break after the first sentence's last word (index 1); none after the
+    // final sentence.
+    expect(run.lineBreaks).toEqual([1])
   })
 
-  it('returns an empty quote for an empty pack', () => {
-    const quote = tatoebaQuote({ name: 'empty', words: [] })
-    expect(quote.text).toBe('')
-    expect(quote.length).toBe(0)
+  it('returns an empty run for an empty pack', () => {
+    const run = tatoebaRun({ name: 'empty', words: [] })
+    expect(run.words).toEqual([])
+    expect(run.lineBreaks).toEqual([])
+    expect(run.quote.text).toBe('')
+    expect(run.quote.length).toBe(0)
   })
 
   it('samples exactly the configured number of sentences from a large pack', () => {
     const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
-    const quote = tatoebaQuote({ name: 'big', words })
-    // Joined by single spaces; no sentence here contains a space, so token
-    // count equals the sampled sentence count.
-    expect(quote.text.split(' ')).toHaveLength(TATOEBA_SENTENCE_COUNT)
+    const run = tatoebaRun({ name: 'big', words })
+    // Every sentence here is a single space-free token, so word count
+    // equals the sampled sentence count.
+    expect(run.words).toHaveLength(TATOEBA_SENTENCE_COUNT)
   })
-})
 
-describe('tatoebaQuoteToWords', () => {
+  it('places a line break on every sentence boundary except the final one, across mixed scripts', () => {
+    // Mix of multi-word English sentences and space-free Japanese
+    // sentences (each Japanese sentence collapses to a single "word").
+    const words = ['One two three.', 'いい天気ですね。', 'Four five.', 'すぐに終わりますよ。']
+    const run = tatoebaRun({ name: 'mixed', words })
+
+    expect(run.words).toEqual(['One', 'two', 'three.', 'いい天気ですね。', 'Four', 'five.', 'すぐに終わりますよ。'])
+    // Sentence-last-word indices: 2 (three.), 3 (いい天気ですね。), 5 (five.) —
+    // the final sentence's break is dropped.
+    expect(run.lineBreaks).toEqual([2, 3, 5])
+  })
+
+  it('gives a single-sentence pack no line breaks', () => {
+    const run = tatoebaRun({ name: 'solo', words: ['ab cd'] })
+    expect(run.words).toEqual(['ab', 'cd'])
+    expect(run.lineBreaks).toEqual([])
+  })
+
   it('keeps non-ASCII characters intact — regression for the ASCII-strip bug', () => {
-    // Real sentences from the Tatoeba japanese pack (CC BY 2.0 FR). The old
-    // quoteToWords()-based tokenizer whitelist-stripped everything but ASCII,
-    // collapsing sentences like these down to a single stray digit.
+    // Real sentences from the Tatoeba japanese pack (CC BY 2.0 FR). A
+    // quoteToWords()-based tokenizer would whitelist-strip everything but
+    // ASCII, collapsing sentences like these down to a single stray digit.
     const words = [
       '「0℃！ やばい熱ある」「かわいそうな雪だるまさん」',
       '「いい考えね」と思ったのは３名だけでした。',
     ]
-    const quote = tatoebaQuote({ name: 'japanese', words })
+    const run = tatoebaRun({ name: 'japanese', words })
 
-    const tokens = tatoebaQuoteToWords(quote)
-
-    expect(tokens.join('')).not.toBe('0')
-    expect(tokens.some((t) => t.includes('やばい'))).toBe(true)
-    expect(tokens.some((t) => t.includes('思ったのは３名だけでした。'))).toBe(true)
+    expect(run.words.join('')).not.toBe('0')
+    expect(run.words.some((w) => w.includes('やばい'))).toBe(true)
+    expect(run.words.some((w) => w.includes('思ったのは３名だけでした。'))).toBe(true)
   })
 
   it('splits on whitespace without stripping punctuation/accents', () => {
-    const quote = tatoebaQuote({ name: 'french', words: ["C'est très bien.", 'Où est-il ?'] })
-    const tokens = tatoebaQuoteToWords(quote)
-    expect(tokens).toEqual(["C'est", 'très', 'bien.', 'Où', 'est-il', '?'])
-  })
-
-  it('returns no tokens for an empty quote', () => {
-    const quote = tatoebaQuote({ name: 'empty', words: [] })
-    expect(tatoebaQuoteToWords(quote)).toEqual([])
+    const run = tatoebaRun({ name: 'french', words: ["C'est très bien.", 'Où est-il ?'] })
+    expect(run.words).toEqual(["C'est", 'très', 'bien.', 'Où', 'est-il', '?'])
   })
 })

--- a/src/renderer/typing-test/word-generator/index.ts
+++ b/src/renderer/typing-test/word-generator/index.ts
@@ -5,6 +5,6 @@ export { generateWords, generateWordsSync, getLanguageData, getLanguageDataSync,
 export { selectQuote, quoteToWords } from './quote-generator'
 export { getFileImportTextData, getFileImportTextDataSync, clearFileImportTextCache } from './file-import-text'
 export type { FileImportTextData } from './file-import-text'
-export { getTatoebaPack, getTatoebaPackSync, clearTatoebaPackCache, tatoebaQuote, tatoebaQuoteToWords, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
+export { getTatoebaPack, getTatoebaPackSync, clearTatoebaPackCache, tatoebaRun, TATOEBA_SENTENCE_COUNT } from './tatoeba-pack'
 export type { TatoebaPack } from './tatoeba-pack'
 export type { LanguageData, GenerateOptions, GeneratedWords } from './types'

--- a/src/renderer/typing-test/word-generator/tatoeba-pack.ts
+++ b/src/renderer/typing-test/word-generator/tatoeba-pack.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Tatoeba sentence packs for the typing test. Distributed via the Hub-only
 // 'tatoeba' provider and cached per language, then played through the quote
-// path: a batch of sampled sentences is concatenated into a single quote so
-// the word-flow renderer and char-based counting are reused verbatim.
+// path: a batch of sampled sentences is folded into one quote (for char-based
+// counting and the finished-screen source label) while keeping each
+// sentence's word span, so line breaks can be placed at sentence boundaries.
 
+import { parseFileImportText } from '../../../shared/types/typing-test-text-store'
 import type { Quote } from '../types'
 import { randomInt } from './random'
 
@@ -50,22 +52,29 @@ export function clearTatoebaPackCache(language?: string): void {
   }
 }
 
-/** Sample a batch of sentences and fold them into one quote for the word-flow
- *  path. `source` carries the pack name so the finished screen can label it. */
-export function tatoebaQuote(pack: TatoebaPack): Quote {
-  const text = sampleSentences(pack.words, TATOEBA_SENTENCE_COUNT).join(' ')
-  return { id: 0, text, source: pack.name, length: text.length }
+/** A sampled batch of Tatoeba sentences, tokenized into word-flow units with
+ *  a line break recorded at every sentence boundary (same convention as
+ *  `parseFileImportText`: the index of each sentence's last word, except
+ *  the final sentence). */
+export interface TatoebaRun {
+  words: string[]
+  lineBreaks: number[]
+  quote: Quote
 }
 
-/** Tokenize a Tatoeba quote into word-flow display units. Deliberately NOT
- *  `quoteToWords` — that function whitelist-strips to ASCII, which is correct
- *  for MonkeyType's English quotes but destroys Tatoeba sentences in any
- *  non-ASCII script (Japanese, Cyrillic, accented Latin, etc. — most of the
- *  72 Tatoeba languages). Splits on whitespace only and keeps every
- *  character as-is, mirroring parseFileImportText's script-agnostic
- *  tokenizer. */
-export function tatoebaQuoteToWords(quote: Quote): string[] {
-  return quote.text.split(/\s+/).filter((w) => w.length > 0)
+/** Sample a batch of sentences and build a word-flow run that renders each
+ *  sentence on its own line. Encodes the sentences with `parseFileImportText`
+ *  (one sentence per line) — deliberately NOT `quoteToWords`, whose ASCII
+ *  whitelist would destroy Tatoeba sentences in any non-ASCII script
+ *  (Japanese, Cyrillic, accented Latin, etc. — most of the 72 Tatoeba
+ *  languages). `quote` folds every sampled sentence into one string so the
+ *  finished screen can label the source and char-based progress counting is
+ *  reused verbatim. */
+export function tatoebaRun(pack: TatoebaPack): TatoebaRun {
+  const sentences = sampleSentences(pack.words, TATOEBA_SENTENCE_COUNT)
+  const { words, lineBreaks } = parseFileImportText(sentences.join('\n'))
+  const text = words.join(' ')
+  return { words, lineBreaks, quote: { id: 0, text, source: pack.name, length: text.length } }
 }
 
 /** Pick `count` sentences, avoiding an immediate repeat (mirrors sampleWords). */


### PR DESCRIPTION
## Summary
- Tatoeba mode joined the 5 sampled sentences into one flat quote, so short sentences wrapped onto the same visual line (e.g. two short Japanese sentences displayed side by side).
- `tatoebaRun()` now encodes the sampled batch with `parseFileImportText(sentences.join('\n'))`, producing the same `lineBreaks` convention as file import (index of each sentence's last word, final break dropped). The existing line-row rendering, ⏎ end-of-line marker, and Enter-advance semantics apply unchanged.
- `quote.text` stays `words.join(' ')`, so char-based progress counting and the finished-screen source label are unaffected.

## Behavior change
- Each sampled sentence renders on its own line.
- At a sentence end, Enter (not Space) advances — identical to file import. IME composition Enter is unaffected (`isComposing` guard).

## Tests
- `tatoeba-pack.test.ts`: sentence-boundary lineBreaks (mixed scripts), packs smaller than the sample size, single-sentence pack, empty pack, non-ASCII regression.
- `useTypingTest.tatoeba.test.ts`: Enter advances / Space no-ops at sentence-end words, and the inverse mid-sentence.
- `vitest` typing-test suite 389/389, `tsc --noEmit` and `eslint` clean.