### PR TITLE
feat(ui): add Aozora Bunko catalog import for typing test

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "better-sqlite3": "^12.9.0",
     "date-fns": "^4.1.0",
     "electron-store": "^11.0.2",
+    "fflate": "^0.8.3",
     "i18next": "^25.8.4",
     "jspdf": "^4.1.0",
     "lucide-react": "^0.564.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       electron-store:
         specifier: ^11.0.2
         version: 11.0.2
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       i18next:
         specifier: ^25.8.4
         version: 25.8.4(typescript@5.9.3)
@@ -2054,8 +2057,8 @@ packages:
       picomatch:
         optional: true
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -5475,7 +5478,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5847,7 +5850,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.6
       fast-png: 6.4.0
-      fflate: 0.8.2
+      fflate: 0.8.3
     optionalDependencies:
       canvg: 3.0.11
       core-js: 3.48.0

--- a/src/main/__tests__/language-store.test.ts
+++ b/src/main/__tests__/language-store.test.ts
@@ -171,7 +171,7 @@ describe('language-store download', () => {
     const langData = makeLangPayload('german', expected)
     mockNet.fetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(langData),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(langData).buffer),
     } as unknown as Response)
 
     const result = await invoke('lang:download', 'german') as { success: boolean }
@@ -186,7 +186,7 @@ describe('language-store download', () => {
     const langData = makeLangPayload('german', expected)
     mockNet.fetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(langData),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(langData).buffer),
     } as unknown as Response)
 
     await invoke('lang:download', 'german')
@@ -201,7 +201,7 @@ describe('language-store download', () => {
     const langData = makeLangPayload('german', expected * 2)
     mockNet.fetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(langData),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(langData).buffer),
     } as unknown as Response)
 
     const result = await invoke('lang:download', 'german') as { success: boolean; error?: string }
@@ -228,7 +228,7 @@ describe('language-store download', () => {
     const padded = padToBytes(JSON.stringify({ name: 'bad' }), expected)
     mockNet.fetch.mockResolvedValue({
       ok: true,
-      text: () => Promise.resolve(padded),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(padded).buffer),
     } as unknown as Response)
 
     const result = await invoke('lang:download', 'german') as { success: boolean }

--- a/src/main/__tests__/typing-dataset-sync.test.ts
+++ b/src/main/__tests__/typing-dataset-sync.test.ts
@@ -172,7 +172,10 @@ describe('effective dataset after override', () => {
 
     // Download must hit the overridden base URL, not the bundled default.
     mockNet.fetch.mockReset()
-    mockNet.fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve('xxxx') } as unknown as Response)
+    mockNet.fetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode('xxxx').buffer),
+    } as unknown as Response)
     await handlers.get('lang:download')!({}, 'spanish')
     expect(mockNet.fetch).toHaveBeenCalledWith(`${NEW_DOWNLOAD_BASE}/spanish.json`)
   })
@@ -220,11 +223,167 @@ describe('tatoeba Hub-only provider', () => {
     // Pack download hits the tatoeba packs URL and lands in the tatoeba dir,
     // never colliding with monkeytype's own 'english'.
     mockNet.fetch.mockReset()
-    mockNet.fetch.mockResolvedValueOnce({ ok: true, text: () => Promise.resolve(packText) } as unknown as Response)
+    mockNet.fetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(packText).buffer),
+    } as unknown as Response)
     const dl = await handlers.get('lang:download')!({}, 'english', 'tatoeba') as { success: boolean }
     expect(dl.success).toBe(true)
     expect(mockNet.fetch).toHaveBeenCalledWith(`${TATOEBA_BASE}/english.json`)
     const files = await readdir(join(testDir, 'local', 'downloads', 'languages', 'tatoeba'))
     expect(files).toContain('english.json')
+  })
+})
+
+describe('aozora catalog provider', () => {
+  const AOZORA_VERSION = 'aozora-8e31452a1d44'
+  const AOZORA_BASE = 'https://hub.example/aozora/cards'
+  const catalogDataset = {
+    provider: 'aozora',
+    version: AOZORA_VERSION,
+    downloadUrlBase: AOZORA_BASE,
+    model: 'catalog' as const,
+    languages: [
+      {
+        name: '001257/files/59898_ruby_70679.zip',
+        title: 'ウェストミンスター寺院',
+        author: 'アーヴィング ワシントン（訳: 吉田 甲子太郎）',
+        wordCount: 9666,
+        rightToLeft: false,
+        fileSize: 12553,
+      },
+    ],
+  }
+
+  it('getProviderDefault returns the aozora catalog placeholder', async () => {
+    const { getProviderDefault } = await import('../../shared/data/typing-test-providers')
+    const def = getProviderDefault('aozora')
+    expect(def).toBeDefined()
+    expect(def?.model).toBe('catalog')
+    expect(def?.version).toBe('')
+    expect(def?.downloadUrlBase).toBe('')
+    expect(def?.bundledLanguages).toEqual([])
+    expect(def?.languages).toEqual([])
+  })
+
+  it('lists nothing before a Hub override (nothing is bundled)', async () => {
+    const electron = await import('electron')
+    const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+    vi.mocked(electron.ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+      handlers.set(c, h)
+    }) as unknown as typeof electron.ipcMain.handle)
+    mod.setupLanguageStore()
+    const list = await handlers.get('lang:list')!({}, 'aozora') as unknown[]
+    expect(list).toEqual([])
+  })
+
+  it('a catalog override with model + title/author round-trips through LANG_LIST', async () => {
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'aozora', version: AOZORA_VERSION }))
+      .mockResolvedValueOnce(okJson(catalogDataset))
+    const sync = await mod.syncTypingDataset('aozora')
+    expect(sync.changed).toBe(true)
+
+    // Persisted verbatim, including `model`.
+    const written = JSON.parse(await readFile(overridePath(), 'utf-8')) as Record<string, typeof catalogDataset>
+    expect(written.aozora).toEqual(catalogDataset)
+
+    const electron = await import('electron')
+    const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+    vi.mocked(electron.ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+      handlers.set(c, h)
+    }) as unknown as typeof electron.ipcMain.handle)
+    mod.setupLanguageStore()
+
+    const list = await handlers.get('lang:list')!({}, 'aozora') as Array<{ name: string; title?: string; author?: string }>
+    expect(list).toHaveLength(1)
+    expect(list[0].name).toBe('001257/files/59898_ruby_70679.zip')
+    expect(list[0].title).toBe('ウェストミンスター寺院')
+    expect(list[0].author).toBe('アーヴィング ワシントン（訳: 吉田 甲子太郎）')
+  })
+
+  it('LANG_DOWNLOAD fails closed for a catalog-model dataset (no fetch attempted)', async () => {
+    // A synthetic no-slash entry name isolates the `model` check from the
+    // pre-existing (coincidental) rejection of `/`-bearing names — real
+    // Aozora workIds are ZIP paths and would already be blocked by that
+    // check before ever reaching the model check this test targets.
+    const override = {
+      aozora: {
+        provider: 'aozora',
+        version: AOZORA_VERSION,
+        downloadUrlBase: AOZORA_BASE,
+        model: 'catalog' as const,
+        languages: [{ name: 'sample-work', wordCount: 100, rightToLeft: false, fileSize: 10 }],
+      },
+    }
+    await writeFile(overridePath(), JSON.stringify(override), 'utf-8')
+
+    const electron = await import('electron')
+    const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+    vi.mocked(electron.ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+      handlers.set(c, h)
+    }) as unknown as typeof electron.ipcMain.handle)
+    mod.setupLanguageStore()
+
+    const result = await handlers.get('lang:download')!(
+      {}, 'sample-work', 'aozora',
+    ) as { success: boolean; error?: string }
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/catalog/i)
+    expect(mockNet.fetch).not.toHaveBeenCalled()
+  })
+
+  it('a legacy override without `model` (predating the field) still validates', async () => {
+    // Simulate a pre-existing persisted override that predates the `model`
+    // field entirely — must still be treated as valid (implicitly 'pack').
+    const legacyOverride = {
+      monkeytype: {
+        provider: 'monkeytype',
+        version: 'legacy-version',
+        downloadUrlBase: 'https://hub.example/legacy',
+        languages: [{ name: 'english', wordCount: 100, rightToLeft: false, fileSize: 42 }],
+      },
+    }
+    await writeFile(overridePath(), JSON.stringify(legacyOverride), 'utf-8')
+
+    const electron = await import('electron')
+    const handlers = new Map<string, (...a: unknown[]) => Promise<unknown>>()
+    vi.mocked(electron.ipcMain).handle.mockImplementation(((c: string, h: (...a: unknown[]) => Promise<unknown>) => {
+      handlers.set(c, h)
+    }) as unknown as typeof electron.ipcMain.handle)
+    mod.setupLanguageStore()
+
+    const list = await handlers.get('lang:list')!({}, 'monkeytype') as Array<{ name: string }>
+    expect(list.map((l) => l.name)).toEqual(['english'])
+  })
+
+  it('an aozora override without `model` falls back to the provider default (catalog), not pack', async () => {
+    // A persisted override that predates the `model` field (or a Hub payload
+    // that omitted it) must not be treated as pack-shaped for a catalog-only
+    // provider — that would fail every import closed.
+    const override = {
+      aozora: {
+        provider: 'aozora',
+        version: AOZORA_VERSION,
+        downloadUrlBase: AOZORA_BASE,
+        languages: catalogDataset.languages,
+      },
+    }
+    await writeFile(overridePath(), JSON.stringify(override), 'utf-8')
+
+    const effective = await mod.getEffectiveDataset('aozora')
+    expect(effective.model).toBe('catalog')
+  })
+
+  it('a Hub payload with an invalid `model` value is rejected end-to-end (no override written)', async () => {
+    mockNet.fetch
+      .mockResolvedValueOnce(okJson({ provider: 'aozora', version: AOZORA_VERSION }))
+      .mockResolvedValueOnce(okJson({ ...catalogDataset, model: 'bogus' }))
+
+    const result = await mod.syncTypingDataset('aozora')
+
+    expect(result.changed).toBe(false)
+    await expect(readFile(overridePath(), 'utf-8')).rejects.toThrow()
   })
 })

--- a/src/main/__tests__/typing-test-text-store.test.ts
+++ b/src/main/__tests__/typing-test-text-store.test.ts
@@ -132,6 +132,53 @@ describe('typing-test-text-store', () => {
       expect(metas).toHaveLength(1)
       expect(metas[0].wordCount).toBe(5)
     })
+
+    it('persists a catalog source and round-trips it through the index', async () => {
+      const result = await saveRecord({
+        name: 'Catalog Work',
+        text: 'a b c',
+        source: { provider: 'aozora', workId: '001257/files/59898_ruby_70679.zip' },
+      })
+      expect(result.success).toBe(true)
+      expect(result.data?.source).toEqual({ provider: 'aozora', workId: '001257/files/59898_ruby_70679.zip' })
+
+      const metas = await listMetas()
+      expect(metas[0].source).toEqual({ provider: 'aozora', workId: '001257/files/59898_ruby_70679.zip' })
+    })
+
+    it('leaves source unset for a plain file-import-style save', async () => {
+      const result = await saveRecord({ name: 'Plain', text: 'a b c' })
+      expect(result.success).toBe(true)
+      expect(result.data?.source).toBeUndefined()
+
+      const metas = await listMetas()
+      expect(metas[0].source).toBeUndefined()
+    })
+  })
+
+  describe('index source validation', () => {
+    it('drops a malformed source (non-string workId) instead of crashing', async () => {
+      await saveRecord({ name: 'Corrupt', text: 'a b c' })
+      const indexPath = join(mockUserDataPath, 'sync', TYPING_TEST_TEXT_SYNC_UNIT, 'index.json')
+      const index = JSON.parse(await readFile(indexPath, 'utf-8')) as { entries: Record<string, unknown>[] }
+      index.entries[0].source = { provider: 'aozora', workId: 12345 }
+      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8')
+
+      const metas = await listMetas()
+      expect(metas).toHaveLength(1)
+      expect(metas[0].source).toBeUndefined()
+    })
+
+    it('drops a non-object source', async () => {
+      await saveRecord({ name: 'Corrupt2', text: 'a b c' })
+      const indexPath = join(mockUserDataPath, 'sync', TYPING_TEST_TEXT_SYNC_UNIT, 'index.json')
+      const index = JSON.parse(await readFile(indexPath, 'utf-8')) as { entries: Record<string, unknown>[] }
+      index.entries[0].source = 'aozora'
+      await writeFile(indexPath, JSON.stringify(index, null, 2), 'utf-8')
+
+      const metas = await listMetas()
+      expect(metas[0].source).toBeUndefined()
+    })
   })
 
   describe('getRecord', () => {

--- a/src/main/aozora/__tests__/aozora-clean.test.ts
+++ b/src/main/aozora/__tests__/aozora-clean.test.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import {
+  normalizeNewlines,
+  removeHeader,
+  removeFooter,
+  resolveWarichu,
+  removeRuby,
+  resolveGaiji,
+  convertRepeatMarks,
+  removeAnnotations,
+  stripReplacementChar,
+  trimEdges,
+  cleanAozoraText,
+} from '../aozora-clean'
+
+describe('normalizeNewlines', () => {
+  it('converts CRLF to LF', () => {
+    expect(normalizeNewlines('a\r\nb\r\nc')).toBe('a\nb\nc')
+  })
+
+  it('converts lone CR to LF', () => {
+    expect(normalizeNewlines('a\rb\rc')).toBe('a\nb\nc')
+  })
+})
+
+describe('removeHeader', () => {
+  it('drops the leading title/author block when no legend block is present', () => {
+    const input = 'タイトル\n著者\n\n本文一行目'
+    expect(removeHeader(input)).toBe('\n本文一行目')
+  })
+
+  it('drops the title/author block and the dash-delimited legend block', () => {
+    const input = [
+      'タイトル',
+      '著者名',
+      '',
+      '------------------------------------------------------------------',
+      '【テキスト中に現れる記号について】',
+      '（凡例の中身）',
+      '------------------------------------------------------------------',
+      '本文',
+    ].join('\n')
+    expect(removeHeader(input)).toBe('\n本文')
+  })
+
+  it('still removes the legend block when its opening rule starts within the top 30 lines', () => {
+    const filler = Array.from({ length: 20 }, (_, n) => `前書き${n}行目`)
+    const input = [
+      'タイトル',
+      '著者名',
+      '',
+      ...filler,
+      '------------------------------------------------------------------',
+      '【テキスト中に現れる記号について】',
+      '------------------------------------------------------------------',
+      '本文',
+    ].join('\n')
+    expect(removeHeader(input)).not.toContain('【テキスト中に現れる記号について】')
+    expect(removeHeader(input)).toContain('本文')
+  })
+
+  it('preserves a dashed-rule pair that occurs deep in the body (past the top-of-file scan window)', () => {
+    const filler = Array.from({ length: 40 }, (_, n) => `本文${n}行目`)
+    const input = [
+      'タイトル',
+      '著者名',
+      '',
+      ...filler,
+      '------------------------------------------------------------------',
+      '場面転換',
+      '------------------------------------------------------------------',
+      '続きの本文',
+    ].join('\n')
+    const result = removeHeader(input)
+    expect(result).toContain('場面転換')
+    expect(result).toContain('続きの本文')
+    expect(result).toContain('本文0行目')
+  })
+})
+
+describe('removeFooter', () => {
+  it('cuts everything from 底本： (fullwidth colon) to the end', () => {
+    const input = '本文\n底本：「作品集」出版社\n発行日など'
+    expect(removeFooter(input)).toBe('本文\n')
+  })
+
+  it('cuts everything from an indented 底本: (halfwidth colon) to the end', () => {
+    const input = '本文\n　底本:出典社\n以下略'
+    expect(removeFooter(input)).toBe('本文\n')
+  })
+
+  it('leaves text untouched when no colophon marker is present', () => {
+    const input = '本文のみ、底本情報なし'
+    expect(removeFooter(input)).toBe(input)
+  })
+
+  it('cuts (and drops) everything from the ［＃本文終わり］ end-of-body marker', () => {
+    const input = '本文\n続き［＃本文終わり］\n入力者付記など'
+    expect(removeFooter(input)).toBe('本文\n')
+  })
+
+  it('when both markers are present, cuts at whichever comes first', () => {
+    const bodyMarkerFirst = '本文\n続き［＃本文終わり］\n底本：「作品集」出版社'
+    expect(removeFooter(bodyMarkerFirst)).toBe('本文\n')
+
+    const colophonFirst = '本文\n底本：「作品集」出版社\n続き［＃本文終わり］'
+    expect(removeFooter(colophonFirst)).toBe('本文\n')
+  })
+})
+
+describe('resolveWarichu', () => {
+  it('wraps inline note content in fullwidth parens', () => {
+    const input = 'テキスト［＃割り注］注釈内容［＃割り注終わり］続き'
+    expect(resolveWarichu(input)).toBe('テキスト（注釈内容）続き')
+  })
+
+  it('does not double-wrap content already in fullwidth parens', () => {
+    const input = 'テキスト［＃割り注］（既に括弧）［＃割り注終わり］続き'
+    expect(resolveWarichu(input)).toBe('テキスト（既に括弧）続き')
+  })
+})
+
+describe('removeRuby', () => {
+  it('removes 《…》 spans and the leading ｜ ruby-start marker', () => {
+    const input = '｜二十世紀《にじっせいき》の話'
+    expect(removeRuby(input)).toBe('二十世紀の話')
+  })
+
+  it('removes 《…》 spans without a ｜ marker', () => {
+    const input = '僕《ぼく》は元気'
+    expect(removeRuby(input)).toBe('僕は元気')
+  })
+})
+
+describe('resolveGaiji', () => {
+  it('resolves U+XXXX notation to the corresponding code point', () => {
+    const input = '※［＃「はしごだか」、U+9AD9、12-3］橋'
+    expect(resolveGaiji(input)).toBe('髙橋')
+  })
+
+  it('drops menkuten-only gaiji tokens and keeps the rest of the line', () => {
+    const input = '前※［＃「にんべん＋并」、第3水準1-14-8］後'
+    expect(resolveGaiji(input)).toBe('前後')
+  })
+})
+
+describe('convertRepeatMarks', () => {
+  it('converts ／″＼ before ／＼ so the three-character mark is not split', () => {
+    const input = 'あ／″＼い／＼う'
+    expect(convertRepeatMarks(input)).toBe('あ〴〵い〳〵う')
+  })
+})
+
+describe('removeAnnotations', () => {
+  it('removes nested ［＃…］ annotations from the innermost level out', () => {
+    const input = 'A［＃foo［＃bar］baz］B'
+    expect(removeAnnotations(input)).toBe('AB')
+  })
+
+  it('removes a simple ［＃…］ annotation', () => {
+    const input = '「会話文だ。」と彼は言った。［＃改ページ］'
+    expect(removeAnnotations(input)).toBe('「会話文だ。」と彼は言った。')
+  })
+
+  it('leaves plain ［…］ brackets without a ＃ marker untouched', () => {
+    const input = '入力［注記ではない］部分'
+    expect(removeAnnotations(input)).toBe(input)
+  })
+})
+
+describe('stripReplacementChar', () => {
+  it('removes U+FFFD replacement characters', () => {
+    const input = 'abc�def'
+    expect(stripReplacementChar(input)).toBe('abcdef')
+  })
+})
+
+describe('trimEdges', () => {
+  it('trims leading/trailing blank lines and drops horizontal-rule-only lines', () => {
+    const input = '\n\n-----\n本文\n＝＝＝＝\n続き\n\n'
+    expect(trimEdges(input)).toBe('本文\n続き')
+  })
+})
+
+describe('cleanAozoraText (composite fixture)', () => {
+  it('cleans a realistic Aozora Bunko sample end to end', () => {
+    const input = [
+      'タイトル',
+      '著者名',
+      '',
+      '-------------------------------------------------------',
+      '【テキスト中に現れる記号について】',
+      '',
+      '《》：ルビ',
+      '（例）僕《ぼく》',
+      '',
+      '｜：ルビの付く文字列の始まりを特定する記号',
+      '（例）｜二十世紀《にじっせいき》',
+      '',
+      '［＃］：入力者注　主に外字の説明や、傍点の位置の指定',
+      '（例）※［＃「にんべん＋并」、第3水準1-14-8］',
+      '-------------------------------------------------------',
+      '　本文が始まる。僕《ぼく》は｜二十世紀《にじっせいき》の話をした。',
+      '「会話文だ。」と彼は言った。［＃改ページ］',
+      'それから※［＃「はしごだか」、U+9AD9、12-3］橋君と話した／＼。',
+      '底本：「作品集　第一巻」出版社',
+      '　　1950（昭和25）年5月10日発行',
+      '※このファイルは青空文庫で作られました。',
+    ].join('\n')
+
+    const expected = [
+      '　本文が始まる。僕は二十世紀の話をした。',
+      '「会話文だ。」と彼は言った。',
+      'それから髙橋君と話した〳〵。',
+    ].join('\n')
+
+    expect(cleanAozoraText(input)).toBe(expected)
+  })
+
+  it('handles CRLF input end to end', () => {
+    const input = ['タイトル', '著者', '', '本文《ふりがな》あり'].join('\r\n')
+    expect(cleanAozoraText(input)).toBe('本文あり')
+  })
+})

--- a/src/main/aozora/__tests__/aozora-import.test.ts
+++ b/src/main/aozora/__tests__/aozora-import.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { zipSync } from 'fflate'
+
+vi.mock('electron', () => {
+  const net = { fetch: vi.fn() }
+  return { net }
+})
+vi.mock('../../logger', () => ({ log: vi.fn() }))
+vi.mock('../../language-store', () => ({ getEffectiveDataset: vi.fn() }))
+vi.mock('../../typing-test-text-store', () => ({ saveRecord: vi.fn() }))
+
+import { net } from 'electron'
+import { getEffectiveDataset } from '../../language-store'
+import { saveRecord } from '../../typing-test-text-store'
+import { importAozoraWork } from '../aozora-import'
+
+const mockFetch = vi.mocked(net.fetch)
+const mockGetDataset = vi.mocked(getEffectiveDataset)
+const mockSaveRecord = vi.mocked(saveRecord)
+
+const WORK_ID = '001257/files/59898_ruby_70679.zip'
+const DOWNLOAD_BASE = 'https://hub.example/aozora/cards'
+
+interface FixtureEntry {
+  name: string
+  title?: string
+  author?: string
+  wordCount: number
+  rightToLeft: boolean
+  fileSize: number
+}
+
+function datasetWith(entry: FixtureEntry | null) {
+  return {
+    provider: 'aozora',
+    version: 'aozora-test',
+    downloadUrlBase: DOWNLOAD_BASE,
+    model: 'catalog' as const,
+    languages: entry ? [entry] : [],
+  }
+}
+
+function arrayBufferOf(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer
+}
+
+function okResponse(bytes: Uint8Array) {
+  return { ok: true, status: 200, arrayBuffer: () => Promise.resolve(arrayBufferOf(bytes)) } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('importAozoraWork', () => {
+  it('downloads, unzips, decodes, cleans and saves a work (happy path)', async () => {
+    // A leading blank line keeps removeHeader() a no-op, so the fixture
+    // doesn't need a full title/author/colophon structure (that pipeline is
+    // covered by aozora-clean.test.ts) — this test only needs the whole
+    // importer pipeline to hand a non-empty, correctly decoded string to
+    // saveRecord.
+    const sjisBytes = new Uint8Array([
+      ...Buffer.from('\nSample text about ', 'ascii'),
+      0x90, 0xC2, 0x8B, 0xF3, // 青空
+      ...Buffer.from(' library used for testing.\n', 'ascii'),
+    ])
+    const zipBytes = zipSync({ 'work.txt': sjisBytes })
+
+    mockGetDataset.mockResolvedValue(datasetWith({
+      name: WORK_ID,
+      title: 'サンプル作品',
+      author: '青空太郎',
+      wordCount: 10,
+      rightToLeft: false,
+      fileSize: zipBytes.byteLength,
+    }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+    const savedMeta = {
+      id: 'abc',
+      name: 'サンプル作品（青空太郎）',
+      wordCount: 8,
+      filename: 'abc.json',
+      savedAt: 'x',
+      updatedAt: 'x',
+      source: { provider: 'aozora', workId: WORK_ID },
+    }
+    mockSaveRecord.mockResolvedValue({ success: true, data: savedMeta })
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(mockFetch).toHaveBeenCalledWith(`${DOWNLOAD_BASE}/${WORK_ID}`)
+    expect(mockSaveRecord).toHaveBeenCalledWith({
+      name: 'サンプル作品（青空太郎）',
+      text: 'Sample text about 青空 library used for testing.',
+      source: { provider: 'aozora', workId: WORK_ID },
+    })
+    expect(result).toEqual({ success: true, meta: savedMeta })
+  })
+
+  it('fails with NOT_IN_CATALOG when the work is not in the manifest', async () => {
+    mockGetDataset.mockResolvedValue(datasetWith(null))
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result).toEqual({ success: false, errorCode: 'NOT_IN_CATALOG', error: expect.any(String) })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fails with NOT_IN_CATALOG when the effective aozora dataset is not catalog-shaped', async () => {
+    mockGetDataset.mockResolvedValue({
+      provider: 'aozora',
+      version: 'aozora-test',
+      downloadUrlBase: DOWNLOAD_BASE,
+      model: 'pack' as const,
+      languages: [{ name: WORK_ID, wordCount: 10, rightToLeft: false, fileSize: 10 }],
+    })
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result).toEqual({ success: false, errorCode: 'NOT_IN_CATALOG', error: expect.any(String) })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fails with DOWNLOAD_FAILED on a non-OK HTTP response', async () => {
+    mockGetDataset.mockResolvedValue(datasetWith({ name: WORK_ID, wordCount: 1, rightToLeft: false, fileSize: 10 }))
+    mockFetch.mockResolvedValue({ ok: false, status: 404 } as unknown as Response)
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.errorCode).toBe('DOWNLOAD_FAILED')
+    expect(mockSaveRecord).not.toHaveBeenCalled()
+  })
+
+  it('fails with SIZE_MISMATCH when the downloaded byte length differs from the manifest', async () => {
+    const zipBytes = zipSync({ 'work.txt': new Uint8Array(Buffer.from('hello', 'ascii')) })
+    mockGetDataset.mockResolvedValue(datasetWith({
+      name: WORK_ID, wordCount: 1, rightToLeft: false, fileSize: zipBytes.byteLength + 1,
+    }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.errorCode).toBe('SIZE_MISMATCH')
+    expect(mockSaveRecord).not.toHaveBeenCalled()
+  })
+
+  it('fails with NO_TEXT_ENTRY when the zip has no usable .txt entry (only .png / __MACOSX)', async () => {
+    const zipBytes = zipSync({
+      'image.png': new Uint8Array([1, 2, 3]),
+      '__MACOSX/work.txt': new Uint8Array([4, 5, 6]),
+    })
+    mockGetDataset.mockResolvedValue(datasetWith({ name: WORK_ID, wordCount: 1, rightToLeft: false, fileSize: zipBytes.byteLength }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.errorCode).toBe('NO_TEXT_ENTRY')
+    expect(mockSaveRecord).not.toHaveBeenCalled()
+  })
+
+  it('fails with DECODE_FAILED when the Shift_JIS decode yields excessive replacement characters', async () => {
+    // 0x80 is an undefined single-byte lead in Shift_JIS, so every byte
+    // decodes to U+FFFD — well past the 0.5% threshold.
+    const garbage = new Uint8Array(100).fill(0x80)
+    const zipBytes = zipSync({ 'work.txt': garbage })
+    mockGetDataset.mockResolvedValue(datasetWith({ name: WORK_ID, wordCount: 1, rightToLeft: false, fileSize: zipBytes.byteLength }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.errorCode).toBe('DECODE_FAILED')
+    expect(mockSaveRecord).not.toHaveBeenCalled()
+  })
+
+  it('fails with EMPTY_TEXT when the cleaned text is empty', async () => {
+    // A single non-blank line with nothing after it is entirely consumed by
+    // removeHeader() as the title/author block, leaving nothing behind.
+    const raw = new Uint8Array(Buffer.from('OnlyTitleLine', 'ascii'))
+    const zipBytes = zipSync({ 'work.txt': raw })
+    mockGetDataset.mockResolvedValue(datasetWith({ name: WORK_ID, wordCount: 1, rightToLeft: false, fileSize: zipBytes.byteLength }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result.success).toBe(false)
+    if (!result.success) expect(result.errorCode).toBe('EMPTY_TEXT')
+    expect(mockSaveRecord).not.toHaveBeenCalled()
+  })
+
+  it('passes through a DUPLICATE_NAME failure from the text store unchanged', async () => {
+    const sjisBytes = new Uint8Array(Buffer.from('\nHello duplicate work content.\n', 'ascii'))
+    const zipBytes = zipSync({ 'work.txt': sjisBytes })
+    mockGetDataset.mockResolvedValue(datasetWith({ name: WORK_ID, title: 'Dup', wordCount: 1, rightToLeft: false, fileSize: zipBytes.byteLength }))
+    mockFetch.mockResolvedValue(okResponse(zipBytes))
+    mockSaveRecord.mockResolvedValue({ success: false, errorCode: 'DUPLICATE_NAME', error: 'A text with the same name already exists' })
+
+    const result = await importAozoraWork(WORK_ID)
+
+    expect(result).toEqual({ success: false, errorCode: 'DUPLICATE_NAME', error: 'A text with the same name already exists' })
+  })
+})

--- a/src/main/aozora/aozora-clean.ts
+++ b/src/main/aozora/aozora-clean.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// TypeScript port of the aozorabunko-extractor cleaning pipeline
+// (globis-org/aozorabunko-extractor). Turns a raw Aozora Bunko text
+// (already decoded from Shift_JIS to a JS string) into plain text
+// suitable for the typing-test fileImport flow: ruby, gaiji notation,
+// input-editor annotations and the title/legend/colophon boilerplate
+// are stripped while paragraph structure is preserved verbatim.
+//
+// Every function here is pure (no I/O) so the pipeline can be unit
+// tested step by step in addition to the composite entry point,
+// cleanAozoraText.
+
+/** Normalizes CRLF and lone CR line endings to LF. */
+export function normalizeNewlines(text: string): string {
+  return text.replace(/\r\n?/g, '\n')
+}
+
+// The annotation-legend block only ever sits right after the title/author
+// block, near the top of the file. Requiring its opening dash line to start
+// within this many lines of the file keeps removeHeader from matching a
+// dashed horizontal rule that legitimately occurs later in the body (e.g. a
+// scene break), which would otherwise delete everything between two such
+// rules.
+const HEADER_SCAN_LIMIT = 30
+
+/**
+ * Drops the leading title/author block (the first run of non-blank
+ * lines at the very start of the file) and, if present, the
+ * annotation-legend block delimited by two horizontal-rule lines of
+ * 30+ dashes whose opening rule starts within the first
+ * HEADER_SCAN_LIMIT lines of the file.
+ */
+export function removeHeader(text: string): string {
+  const lines = text.split('\n')
+  let i = 0
+  while (i < lines.length && lines[i].trim() !== '') i++
+  const bodyLines = lines.slice(i)
+
+  const isDashRule = (line: string): boolean => /^-{30,}$/.test(line)
+  // Convert the absolute (whole-file) scan limit into an index relative to
+  // bodyLines, which starts after the title block at line `i`.
+  const scanEnd = Math.max(0, HEADER_SCAN_LIMIT - i)
+  const openIdx = bodyLines.findIndex((line, idx) => idx < scanEnd && isDashRule(line))
+  if (openIdx === -1) return bodyLines.join('\n')
+
+  const closeIdx = bodyLines.findIndex((line, idx) => idx > openIdx && isDashRule(line))
+  if (closeIdx === -1) return bodyLines.join('\n')
+
+  return [...bodyLines.slice(0, openIdx), ...bodyLines.slice(closeIdx + 1)].join('\n')
+}
+
+/**
+ * Cuts everything from whichever comes first: the colophon marker (底本：
+ * or 底本:, optionally indented) or an explicit end-of-body marker
+ * （［＃本文終わり］, which is removed along with everything after it).
+ */
+export function removeFooter(text: string): string {
+  const colophon = text.search(/^[ \t　]*底本[：:]/m)
+  const endOfBody = text.search(/^.*［＃本文終わり］.*$/m)
+  const candidates = [colophon, endOfBody].filter((idx) => idx !== -1)
+  if (candidates.length === 0) return text
+  return text.slice(0, Math.min(...candidates))
+}
+
+/**
+ * Resolves inline notes: ［＃割り注］X［＃割り注終わり］ becomes
+ * （X）, unless X is already wrapped in full-width parens.
+ */
+export function resolveWarichu(text: string): string {
+  return text.replace(/［＃割り注］([\s\S]*?)［＃割り注終わり］/g, (_full, content: string) => {
+    if (/^（[\s\S]*）$/.test(content)) return content
+    return `（${content}）`
+  })
+}
+
+/**
+ * Removes ruby annotations: 《…》 spans and the U+FF5C ruby-start
+ * marker.
+ */
+export function removeRuby(text: string): string {
+  return text.replace(/《[^》]*》|｜/g, '')
+}
+
+/**
+ * Resolves gaiji (non-standard character) notation: ※［＃…］. When
+ * the bracket content carries a U+XXXX code point it is substituted
+ * in directly; otherwise (menkuten-only references such as
+ * "第3水準1-14-8") the whole token is dropped and the surrounding
+ * line is kept intact.
+ */
+export function resolveGaiji(text: string): string {
+  return text.replace(/※［＃([^］]*)］/g, (_full, content: string) => {
+    const match = content.match(/U\+([0-9A-Fa-f]{4,6})/)
+    if (!match) return ''
+    return String.fromCodePoint(parseInt(match[1], 16))
+  })
+}
+
+/**
+ * Converts kunojiten repeat marks. The three-character form must be
+ * converted before the two-character form, otherwise ／″＼ would be
+ * partially matched by the ／＼ pattern.
+ */
+export function convertRepeatMarks(text: string): string {
+  return text.replace(/／″＼/g, '〴〵').replace(/／＼/g, '〳〵')
+}
+
+/**
+ * Removes remaining input-editor annotations: ［＃…］. Nested
+ * annotations are resolved by repeatedly stripping the innermost
+ * bracket-free span until none remain. Plain brackets without a
+ * leading ＃ (e.g. ［ordinary text］) are left untouched.
+ */
+export function removeAnnotations(text: string): string {
+  let result = text
+  while (/［＃[^［］]*］/.test(result)) {
+    result = result.replace(/［＃[^［］]*］/g, '')
+  }
+  return result
+}
+
+/** Strips the Unicode replacement character (U+FFFD). */
+export function stripReplacementChar(text: string): string {
+  return text.replace(/�/g, '')
+}
+
+/**
+ * Trims leading/trailing blank lines and drops any line that
+ * consists solely of horizontal-rule characters (-, ＝, =, ―).
+ */
+export function trimEdges(text: string): string {
+  const isRuleLine = (line: string): boolean => /^[-＝=―]+$/.test(line.trim())
+  const lines = text.split('\n').filter((line) => !isRuleLine(line))
+  let start = 0
+  let end = lines.length
+  while (start < end && lines[start].trim() === '') start++
+  while (end > start && lines[end - 1].trim() === '') end--
+  return lines.slice(start, end).join('\n')
+}
+
+/**
+ * Runs the full aozorabunko-extractor cleaning pipeline on a raw
+ * Aozora Bunko text and returns plain text ready for the fileImport
+ * typing-test flow.
+ */
+export function cleanAozoraText(raw: string): string {
+  let text = normalizeNewlines(raw)
+  text = removeHeader(text)
+  text = removeFooter(text)
+  text = resolveWarichu(text)
+  text = removeRuby(text)
+  text = resolveGaiji(text)
+  text = convertRepeatMarks(text)
+  text = removeAnnotations(text)
+  text = stripReplacementChar(text)
+  text = trimEdges(text)
+  return text
+}

--- a/src/main/aozora/aozora-import.ts
+++ b/src/main/aozora/aozora-import.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Downloads one Aozora Bunko catalog work (a Shift_JIS-encoded ZIP,
+// referenced by the manifest's `name` — a path relative to the dataset's
+// `downloadUrlBase`), unzips it, decodes and cleans the text, and saves the
+// result into the local Typing Test text store (fileImport model, verbatim
+// paragraph structure). Unlike LANG_DOWNLOAD (pack model, one JSON file per
+// language), a catalog work is a whole ZIP archive that needs unpacking and
+// Shift_JIS decoding before it can be used.
+//
+// Only manifest-listed names are ever fetched: importAozoraWork() looks the
+// workId up in the effective aozora dataset first and fails closed
+// (NOT_IN_CATALOG) if it is not present, so this never turns into an
+// open URL-fetch proxy.
+
+import { unzipSync } from 'fflate'
+import { fetchVerifiedBytes } from '../download-util'
+import { getEffectiveDataset } from '../language-store'
+import { saveRecord } from '../typing-test-text-store'
+import { cleanAozoraText } from './aozora-clean'
+import { log } from '../logger'
+import type { AozoraImportErrorCode, AozoraImportResult } from '../../shared/types/aozora-import'
+
+const AOZORA_PROVIDER = 'aozora'
+
+// Above this share of U+FFFD (Unicode replacement character) in the decoded
+// text, the Shift_JIS decode is treated as having failed outright rather
+// than as carrying a few unmappable characters — a typing test cannot make
+// progress through a run of replacement characters.
+const FFFD_RATIO_THRESHOLD = 0.005
+
+function fail(errorCode: AozoraImportErrorCode, error: string): AozoraImportResult {
+  return { success: false, errorCode, error }
+}
+
+/** Picks the ZIP entry to decode: the largest file whose path ends in an
+ *  ASCII `.txt` (case-insensitive), skipping directories and macOS resource
+ *  fork noise. Aozora ZIPs sometimes carry a Shift_JIS-encoded filename that
+ *  arrives here mojibake'd (fflate doesn't re-decode zip filenames as
+ *  Shift_JIS), but the `.txt` suffix itself is always plain ASCII, so the
+ *  match is robust regardless of how the rest of the name decoded. */
+function pickTextEntry(unzipped: Record<string, Uint8Array>): Uint8Array | null {
+  let best: Uint8Array | null = null
+  for (const [path, data] of Object.entries(unzipped)) {
+    if (path.includes('__MACOSX')) continue
+    if (!/\.txt$/i.test(path)) continue
+    if (!best || data.byteLength > best.byteLength) best = data
+  }
+  return best
+}
+
+/** Imports one Aozora Bunko work by its catalog `name` (== workId, the
+ *  manifest's relative ZIP path) into the local Typing Test text store. */
+export async function importAozoraWork(workId: string): Promise<AozoraImportResult> {
+  const dataset = await getEffectiveDataset(AOZORA_PROVIDER)
+  if (dataset.model !== 'catalog') {
+    return fail('NOT_IN_CATALOG', `Aozora dataset is not catalog-shaped (model: ${String(dataset.model)})`)
+  }
+  const entry = dataset.languages.find((e) => e.name === workId)
+  if (!entry) {
+    return fail('NOT_IN_CATALOG', `Aozora work not in catalog: ${workId}`)
+  }
+
+  const fetched = await fetchVerifiedBytes(`${dataset.downloadUrlBase}/${workId}`, entry.fileSize)
+  if (!fetched.ok) {
+    if (fetched.reason === 'size-mismatch') {
+      const detail = `expected ${String(fetched.expected)} bytes, got ${String(fetched.actual)}`
+      log('warn', `Aozora work ${workId}: size mismatch (${detail})`)
+      return fail('SIZE_MISMATCH', detail)
+    }
+    const detail = fetched.reason === 'http' ? `HTTP ${String(fetched.status)}` : String(fetched.error)
+    log('warn', `Aozora download failed for ${workId}: ${detail}`)
+    return fail('DOWNLOAD_FAILED', detail)
+  }
+  const bytes = fetched.bytes
+
+  let unzipped: Record<string, Uint8Array>
+  try {
+    unzipped = unzipSync(bytes)
+  } catch (err) {
+    return fail('NO_TEXT_ENTRY', `Failed to unzip: ${String(err)}`)
+  }
+
+  const textBytes = pickTextEntry(unzipped)
+  if (!textBytes) {
+    return fail('NO_TEXT_ENTRY', 'Zip contains no .txt entry')
+  }
+
+  const decoded = new TextDecoder('shift_jis').decode(textBytes)
+  const fffdCount = (decoded.match(/�/g) ?? []).length
+  if (decoded.length > 0 && fffdCount / decoded.length > FFFD_RATIO_THRESHOLD) {
+    return fail('DECODE_FAILED', 'Decoded text exceeds the replacement-character threshold')
+  }
+
+  const cleaned = cleanAozoraText(decoded)
+  if (!cleaned.trim()) {
+    return fail('EMPTY_TEXT', 'Cleaned text is empty')
+  }
+
+  const name = entry.title ? `${entry.title}（${entry.author ?? ''}）` : workId
+  const result = await saveRecord({ name, text: cleaned, source: { provider: AOZORA_PROVIDER, workId } })
+  if (!result.success || !result.data) {
+    return fail(result.errorCode ?? 'IO_ERROR', result.error ?? 'Failed to save text')
+  }
+
+  log('info', `Imported Aozora work: ${workId} -> ${result.data.id}`)
+  return { success: true, meta: result.data }
+}

--- a/src/main/aozora/aozora-ipc.ts
+++ b/src/main/aozora/aozora-ipc.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// IPC handler for the Aozora Bunko catalog importer.
+
+import { IpcChannels } from '../../shared/ipc/channels'
+import { secureHandle } from '../ipc-guard'
+import { importAozoraWork } from './aozora-import'
+import type { AozoraImportResult } from '../../shared/types/aozora-import'
+
+export function setupAozoraIpc(): void {
+  secureHandle(
+    IpcChannels.AOZORA_IMPORT,
+    async (_event, workId: unknown): Promise<AozoraImportResult> => {
+      if (typeof workId !== 'string' || !workId) {
+        return { success: false, errorCode: 'NOT_IN_CATALOG', error: 'Invalid work id' }
+      }
+      return importAozoraWork(workId)
+    },
+  )
+}

--- a/src/main/download-util.ts
+++ b/src/main/download-util.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared fetch-and-verify helper for the two IPC paths that download a
+// file from a Hub-provided URL and check it against a manifest-declared
+// byte size: LANG_DOWNLOAD (language-store.ts, one JSON pack file) and the
+// Aozora importer (aozora-import.ts, one ZIP archive).
+
+import { net } from 'electron'
+
+export type FetchVerifiedBytesResult =
+  | { ok: true; bytes: Uint8Array }
+  | { ok: false; reason: 'http'; status: number }
+  | { ok: false; reason: 'size-mismatch'; expected: number; actual: number }
+  | { ok: false; reason: 'network'; error: unknown }
+
+/** Fetches `url` and verifies both the HTTP status and that the response's
+ *  byte length matches `expectedSize`, returning the raw bytes on success.
+ *  Callers own the context-specific error code/message and logging — this
+ *  only centralizes the fetch → ok-check → size-check sequence. */
+export async function fetchVerifiedBytes(url: string, expectedSize: number): Promise<FetchVerifiedBytesResult> {
+  try {
+    const response = await net.fetch(url)
+    if (!response.ok) {
+      return { ok: false, reason: 'http', status: response.status }
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer())
+    if (bytes.byteLength !== expectedSize) {
+      return { ok: false, reason: 'size-mismatch', expected: expectedSize, actual: bytes.byteLength }
+    }
+    return { ok: true, bytes }
+  } catch (error) {
+    return { ok: false, reason: 'network', error }
+  }
+}

--- a/src/main/hub/__tests__/hub-typing-dataset.test.ts
+++ b/src/main/hub/__tests__/hub-typing-dataset.test.ts
@@ -80,4 +80,71 @@ describe('fetchTypingDataset', () => {
     mockNet.fetch.mockResolvedValue(okJson({ ...validDataset, provider: 'evil' }))
     expect(await fetchTypingDataset('monkeytype')).toBeNull()
   })
+
+  const catalogDataset = {
+    provider: 'aozora',
+    version: 'aozora-abc123def456',
+    downloadUrlBase: 'https://example.test/cards',
+    model: 'catalog',
+    languages: [
+      {
+        name: '001257/files/59898_ruby_70679.zip',
+        title: 'ウェストミンスター寺院',
+        author: 'アーヴィング ワシントン（訳: 吉田 甲子太郎）',
+        wordCount: 9666,
+        rightToLeft: false,
+        fileSize: 12553,
+      },
+    ],
+  }
+
+  it('passes through a catalog dataset with model + title/author entries', async () => {
+    mockNet.fetch.mockResolvedValue(okJson(catalogDataset))
+    expect(await fetchTypingDataset('aozora')).toEqual(catalogDataset)
+  })
+
+  it('accepts a dataset payload with no model field (defaults to pack)', async () => {
+    mockNet.fetch.mockResolvedValue(okJson(validDataset))
+    const result = await fetchTypingDataset('monkeytype')
+    expect(result).not.toBeNull()
+    expect(result?.model).toBeUndefined()
+  })
+
+  it('rejects a dataset payload with an invalid model value', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({ ...catalogDataset, model: 'bogus' }))
+    expect(await fetchTypingDataset('aozora')).toBeNull()
+  })
+
+  it('rejects a language entry with a non-string title', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({
+      ...catalogDataset,
+      languages: [{ ...catalogDataset.languages[0], title: 123 }],
+    }))
+    expect(await fetchTypingDataset('aozora')).toBeNull()
+  })
+
+  it('rejects a language entry with a non-string author', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({
+      ...catalogDataset,
+      languages: [{ ...catalogDataset.languages[0], author: 123 }],
+    }))
+    expect(await fetchTypingDataset('aozora')).toBeNull()
+  })
+
+  it('passes through a language entry carrying authorKana', async () => {
+    const withKana = {
+      ...catalogDataset,
+      languages: [{ ...catalogDataset.languages[0], authorKana: 'アーヴィング ワシントン' }],
+    }
+    mockNet.fetch.mockResolvedValue(okJson(withKana))
+    expect(await fetchTypingDataset('aozora')).toEqual(withKana)
+  })
+
+  it('rejects a language entry with a non-string authorKana', async () => {
+    mockNet.fetch.mockResolvedValue(okJson({
+      ...catalogDataset,
+      languages: [{ ...catalogDataset.languages[0], authorKana: 123 }],
+    }))
+    expect(await fetchTypingDataset('aozora')).toBeNull()
+  })
 })

--- a/src/main/hub/hub-typing-dataset.ts
+++ b/src/main/hub/hub-typing-dataset.ts
@@ -34,8 +34,18 @@ export function isManifestEntry(v: unknown): v is LanguageManifestEntry {
     typeof e.name === 'string' &&
     typeof e.wordCount === 'number' &&
     typeof e.rightToLeft === 'boolean' &&
-    typeof e.fileSize === 'number'
+    typeof e.fileSize === 'number' &&
+    // Catalog providers (aozora) carry title/author/authorKana; pack
+    // providers omit them. All three are optional, but when present must
+    // be strings.
+    (e.title === undefined || typeof e.title === 'string') &&
+    (e.author === undefined || typeof e.author === 'string') &&
+    (e.authorKana === undefined || typeof e.authorKana === 'string')
   )
+}
+
+export function isValidModel(v: unknown): v is 'pack' | 'catalog' | undefined {
+  return v === undefined || v === 'pack' || v === 'catalog'
 }
 
 /** Lightweight version probe. Returns the Hub's current `version` for the
@@ -70,6 +80,7 @@ export async function fetchTypingDataset(provider: string): Promise<TypingTestDa
       // The base URL is fetched from the main process, so reject anything
       // that isn't plain HTTPS to avoid an SSRF vector via a bad Hub payload.
       !/^https:\/\//.test(d.downloadUrlBase) ||
+      !isValidModel(d.model) ||
       !Array.isArray(d.languages) ||
       !d.languages.every(isManifestEntry)
     ) {
@@ -79,6 +90,7 @@ export async function fetchTypingDataset(provider: string): Promise<TypingTestDa
       provider: d.provider,
       version: d.version,
       downloadUrlBase: d.downloadUrlBase,
+      model: d.model,
       languages: d.languages,
     }
   } catch {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -13,6 +13,7 @@ import { setupThemePackStore } from './theme-pack-ipc'
 import { setupHidIpc } from './hid-ipc'
 import { setupPipetteSettingsStore } from './pipette-settings-store'
 import { setupLanguageStore } from './language-store'
+import { setupAozoraIpc } from './aozora/aozora-ipc'
 import { setupSyncIpc } from './sync/sync-ipc'
 import { setupHubIpc } from './hub/hub-ipc'
 import { startI18nStartupSync } from './hub/i18n-startup-sync'
@@ -318,6 +319,7 @@ app.whenReady().then(() => {
   setupThemePackStore()
   setupPipetteSettingsStore()
   setupLanguageStore()
+  setupAozoraIpc()
   setupAppConfigIpc()
   setupSyncIpc()
   setupHubIpc()

--- a/src/main/language-store.ts
+++ b/src/main/language-store.ts
@@ -1,4 +1,4 @@
-import { app, net } from 'electron'
+import { app } from 'electron'
 import { dirname, join } from 'node:path'
 import { mkdir, readFile, readdir, rename, unlink, writeFile } from 'node:fs/promises'
 import { IpcChannels } from '../shared/ipc/channels'
@@ -7,7 +7,8 @@ import {
   DEFAULT_TYPING_TEST_PROVIDER,
   getProviderDefault,
 } from '../shared/data/typing-test-providers'
-import { fetchTypingDataset, fetchTypingDatasetVersion, isManifestEntry } from './hub/hub-typing-dataset'
+import { fetchTypingDataset, fetchTypingDatasetVersion, isManifestEntry, isValidModel } from './hub/hub-typing-dataset'
+import { fetchVerifiedBytes } from './download-util'
 import { log } from './logger'
 import { secureHandle } from './ipc-guard'
 
@@ -57,18 +58,34 @@ function isValidOverride(ov: unknown): ov is TypingTestDataset {
     typeof d.version === 'string' &&
     typeof d.downloadUrlBase === 'string' &&
     /^https:\/\//.test(d.downloadUrlBase) &&
+    // Absent `model` means 'pack' (see TypingTestDataset doc comment), so
+    // overrides persisted before this field existed stay valid.
+    isValidModel(d.model) &&
     Array.isArray(d.languages) &&
     d.languages.every(isManifestEntry)
   )
 }
 
-async function getEffectiveDataset(provider: string): Promise<TypingTestDataset> {
+export async function getEffectiveDataset(provider: string): Promise<TypingTestDataset> {
   const def = getProviderDefault(provider)
   const overrides = await loadOverrides()
   const ov = overrides[provider]
-  if (isValidOverride(ov)) return ov
+  if (isValidOverride(ov)) {
+    // A legacy override (or a Hub payload that omitted `model`) predates the
+    // field and must not be silently treated as pack-shaped when the
+    // provider's own default says otherwise — an aozora override missing
+    // `model` would fail every import closed instead of using the catalog
+    // flow. Fall back to the provider default's model in that case.
+    return { ...ov, model: ov.model ?? def?.model }
+  }
   if (!def) throw new Error(`Unknown typing-test provider: ${provider}`)
-  return { provider: def.provider, version: def.version, downloadUrlBase: def.downloadUrlBase, languages: def.languages }
+  return {
+    provider: def.provider,
+    version: def.version,
+    downloadUrlBase: def.downloadUrlBase,
+    model: def.model,
+    languages: def.languages,
+  }
 }
 
 function bundledSet(provider: string): Set<string> {
@@ -199,6 +216,8 @@ export function setupLanguageStore(): void {
       await legacyMigration
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return null
+      const dataset = await getEffectiveDataset(p)
+      if (dataset.model === 'catalog') return null
       try {
         const raw = await readFile(getLanguagePath(p, name), 'utf-8')
         const data: unknown = JSON.parse(raw)
@@ -218,22 +237,28 @@ export function setupLanguageStore(): void {
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return { success: false, error: 'Language is bundled' }
       const dataset = await getEffectiveDataset(p)
+      if (dataset.model === 'catalog') {
+        return { success: false, error: 'Dataset uses the catalog model; use the catalog import flow instead' }
+      }
       const entry = dataset.languages.find((e) => e.name === name)
       if (!entry) return { success: false, error: 'Unknown language' }
 
       const url = `${dataset.downloadUrlBase}/${name}.json`
-      try {
-        const response = await net.fetch(url)
-        if (!response.ok) {
-          return { success: false, error: `HTTP ${response.status}` }
+      const fetched = await fetchVerifiedBytes(url, entry.fileSize)
+      if (!fetched.ok) {
+        if (fetched.reason === 'http') {
+          return { success: false, error: `HTTP ${fetched.status}` }
         }
-        const text = await response.text()
-        const actualSize = Buffer.byteLength(text, 'utf-8')
-        if (actualSize !== entry.fileSize) {
-          const detail = `size mismatch (expected ${entry.fileSize}, got ${actualSize})`
+        if (fetched.reason === 'size-mismatch') {
+          const detail = `size mismatch (expected ${fetched.expected}, got ${fetched.actual})`
           log('warn', `Language ${p}/${name}: ${detail}`)
           return { success: false, error: `Integrity check failed: ${detail}` }
         }
+        log('warn', `Failed to download language ${p}/${name}: ${fetched.error}`)
+        return { success: false, error: String(fetched.error) }
+      }
+      try {
+        const text = new TextDecoder('utf-8').decode(fetched.bytes)
         const data: unknown = JSON.parse(text)
         if (!validateLanguageData(data)) {
           return { success: false, error: 'Invalid language data' }
@@ -256,6 +281,10 @@ export function setupLanguageStore(): void {
       await legacyMigration
       const p = resolveProvider(provider)
       if (bundledSet(p).has(name)) return { success: false, error: 'Cannot delete bundled language' }
+      const dataset = await getEffectiveDataset(p)
+      if (dataset.model === 'catalog') {
+        return { success: false, error: 'Dataset uses the catalog model; use the catalog import flow instead' }
+      }
       try {
         await unlink(getLanguagePath(p, name))
         log('info', `Deleted language: ${p}/${name}`)

--- a/src/main/typing-test-text-store.ts
+++ b/src/main/typing-test-text-store.ts
@@ -66,7 +66,12 @@ async function readIndex(): Promise<TypingTestTextIndex> {
   try {
     const raw = await readFile(getIndexPath(), 'utf-8')
     const parsed = JSON.parse(raw) as TypingTestTextIndex
-    if (Array.isArray(parsed?.entries)) return parsed
+    if (Array.isArray(parsed?.entries)) {
+      // Unknown/optional fields pass through untouched; `source` is the one
+      // field validated here since malformed values (e.g. a non-string
+      // workId) would otherwise reach catalog-matching logic unchecked.
+      return { entries: parsed.entries.map((e) => ({ ...e, source: sanitizeSource(e.source) })) }
+    }
   } catch {
     // missing / corrupt — return empty
   }
@@ -91,6 +96,13 @@ function validateName(value: unknown): TypingTestTextStoreResult<string> {
     return fail('INVALID_NAME', `name must be at most ${String(MAX_NAME_LENGTH)} characters`)
   }
   return ok(trimmed)
+}
+
+function sanitizeSource(value: unknown): TypingTestTextMeta['source'] {
+  if (!value || typeof value !== 'object') return undefined
+  const obj = value as Record<string, unknown>
+  if (typeof obj.provider !== 'string' || typeof obj.workId !== 'string') return undefined
+  return { provider: obj.provider, workId: obj.workId }
 }
 
 function normalizeFile(parsed: unknown): TypingTestTextEntryFile | null {
@@ -134,6 +146,9 @@ export interface SaveTextInput {
   name: string
   /** Raw text — normalized + word-capped here. */
   text: string
+  /** Set when saving a catalog import (e.g. Aozora Bunko). Renderer-facing
+   *  file imports never pass this — only main-process catalog importers do. */
+  source?: TypingTestTextMeta['source']
 }
 
 async function writeRecord(meta: TypingTestTextMeta, data: TypingTestTextEntryFile): Promise<void> {
@@ -167,6 +182,7 @@ export async function saveRecord(input: SaveTextInput): Promise<TypingTestTextSt
       filename,
       savedAt: now.toISOString(),
       updatedAt: now.toISOString(),
+      source: input.source,
     }
 
     await writeRecord(meta, data)

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -79,6 +79,7 @@ import type {
   TypingBigramAggregateView,
 } from '../shared/types/typing-analytics'
 import type { LanguageListEntry } from '../shared/types/language-store'
+import type { AozoraImportResult } from '../shared/types/aozora-import'
 import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyPostsParams, HubFetchMyKeyboardPostsResult, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams, HubUploadAnalyticsPostParams, HubUpdateAnalyticsPostParams, HubPreviewAnalyticsPostParams, HubAnalyticsPreview, HubI18nPackTimestampsResponse } from '../shared/types/hub'
 import type { NotificationFetchResult } from '../shared/types/notification'
 
@@ -600,6 +601,10 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.TYPING_DATASET_CHECK, provider),
   updateTypingDataset: (provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }> =>
     ipcRenderer.invoke(IpcChannels.TYPING_DATASET_UPDATE, provider),
+
+  // --- Aozora Bunko catalog import (IPC to main) ---
+  aozoraImport: (workId: string): Promise<AozoraImportResult> =>
+    ipcRenderer.invoke(IpcChannels.AOZORA_IMPORT, workId),
 
   // --- App Config ---
   appConfigGetAll: (): Promise<AppConfig> =>

--- a/src/renderer/components/__tests__/legal-content.test.ts
+++ b/src/renderer/components/__tests__/legal-content.test.ts
@@ -22,6 +22,17 @@ describe('LEGAL_SECTIONS', () => {
     expect(text).toMatch(/curated|modified/i)
   })
 
+  it('discloses the Aozora Bunko catalog source and its public-domain status', () => {
+    const section = LEGAL_SECTIONS.find((s) => s.title === 'Typing Test Text Sources')
+    expect(section).toBeDefined()
+
+    const text = section!.paragraphs.join(' ')
+    expect(text).toContain('Aozora Bunko')
+    expect(text).toContain('aozora.gr.jp')
+    expect(text).toContain('github.com/aozorabunko/aozorabunko')
+    expect(text).toMatch(/public domain/i)
+  })
+
   it('keeps the section ordered before Disclaimer (last section stays a catch-all)', () => {
     const titles = LEGAL_SECTIONS.map((s) => s.title)
     expect(titles[titles.length - 1]).toBe('Disclaimer')

--- a/src/renderer/components/legal-content.ts
+++ b/src/renderer/components/legal-content.ts
@@ -31,6 +31,7 @@ export const LEGAL_SECTIONS: LegalSection[] = [
     paragraphs: [
       'Tatoeba-based Typing Test sentence packs are curated from the Tatoeba Project (https://tatoeba.org) and its contributors. Most language packs are licensed under CC BY 2.0 FR (https://creativecommons.org/licenses/by/2.0/fr/); the English, Bangla, Kabyle, and Russian packs are dedicated to the public domain under CC0 1.0 (https://creativecommons.org/publicdomain/zero/1.0/).',
       'These packs are a curated, modified snapshot of the Tatoeba corpus (filtered, de-duplicated, and length-limited), not the original data.',
+      'Aozora Bunko catalog works are texts whose Japanese copyright has expired or been explicitly waived by the rights holder, and are in the public domain. Catalog metadata (titles, authors) and work texts are sourced from Aozora Bunko (https://www.aozora.gr.jp/) via the aozorabunko GitHub mirror (https://github.com/aozorabunko/aozorabunko); ruby and editorial annotation markup is programmatically cleaned during import.',
     ],
   },
   {

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -376,6 +376,7 @@
         "tabMonkeytype": "MonkeyType",
         "tabTatoeba": "Tatoeba",
         "tabFileImport": "File Import",
+        "tabAozora": "Aozora Bunko",
         "import": "Import UTF-8 text file",
         "importEmpty": "No imported texts yet",
         "importFailed": "Import failed",
@@ -387,7 +388,17 @@
         "fileImportText": "Imported text",
         "datasetUpdateAvailable": "An update is available for the word lists.",
         "datasetUpdate": "Update",
-        "datasetUpdating": "Updating…"
+        "datasetUpdating": "Updating…",
+        "catalogSearchPlaceholder": "Search title or author...",
+        "catalogImported": "Imported",
+        "catalogImportAction": "Import",
+        "estimatedChars": "~{{count}} chars",
+        "catalogImportErrorDuplicate": "A text with this title already exists",
+        "catalogImportErrorGeneric": "Download failed ({{code}})",
+        "catalogLoadFailed": "Failed to load the catalog. Check your connection and try again.",
+        "kanaRowLabel": "row",
+        "kanaRowGroupAriaLabel": "Filter by author reading, gojuon row",
+        "kanaColumnGroupAriaLabel": "Filter by author reading, gojuon column"
       },
       "memory": {
         "pause": "Pause",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -376,6 +376,7 @@
         "tabMonkeytype": "MonkeyType",
         "tabTatoeba": "Tatoeba",
         "tabFileImport": "ファイル取込",
+        "tabAozora": "青空文庫",
         "import": "UTF-8 テキストをインポート",
         "importEmpty": "インポートされたテキストはありません",
         "importFailed": "インポートに失敗しました",
@@ -387,7 +388,17 @@
         "fileImportText": "インポートテキスト",
         "datasetUpdateAvailable": "単語リストの更新があります。",
         "datasetUpdate": "更新",
-        "datasetUpdating": "更新中…"
+        "datasetUpdating": "更新中…",
+        "catalogSearchPlaceholder": "作品名・著者名で検索...",
+        "catalogImported": "取り込み済み",
+        "catalogImportAction": "取り込む",
+        "estimatedChars": "約 {{count}} 文字",
+        "catalogImportErrorDuplicate": "同じ作品名のテキストが既に存在します",
+        "catalogImportErrorGeneric": "ダウンロードに失敗しました（{{code}}）",
+        "catalogLoadFailed": "カタログの読み込みに失敗しました。接続を確認して再度お試しください。",
+        "kanaRowLabel": "行",
+        "kanaRowGroupAriaLabel": "著者名の読みの行で絞り込む",
+        "kanaColumnGroupAriaLabel": "著者名の読みの段で絞り込む"
       },
       "memory": {
         "pause": "一時停止",

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -290,8 +290,8 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --width-modal-sm: 440px;     /* EditorSettingsModal, FavoriteStoreModal, LayoutStoreModal */
   --width-modal-md: 600px;     /* MissingKeyLabelDialog, UnlockDialog, QmkSettings, JsonEditor */
   --width-modal-notify: 560px; /* NotificationModal, AnalyzeExportModal */
-  --width-modal-typing: 480px; /* LanguageSelectorModal, TypingRecordingConsentModal */
-  --width-modal-lg: 760px;     /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal, SettingsModal */
+  --width-modal-typing: 480px; /* TypingRecordingConsentModal */
+  --width-modal-lg: 760px;     /* ThemePacksModal, KeyLabelsModal, LanguagePacksModal, SettingsModal, LanguageSelectorModal */
   --width-modal-data: 860px;   /* DataModal */
   --width-modal-goal: 720px;   /* GoalAchievementsModal */
   --width-modal-app: 500px;    /* App toast, MacroTextEditor */

--- a/src/renderer/typing-test/AozoraCatalogTab.tsx
+++ b/src/renderer/typing-test/AozoraCatalogTab.tsx
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Aozora Bunko catalog browser: search-first UI over the 10,468-entry
+// catalog manifest (rendered incrementally — see PAGE_SIZE). Picking an
+// unimported work downloads + cleans it into the typing-test-texts store;
+// an already-imported work is just selected like any other fileImport text.
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Check, Download, Loader2 } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
+import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
+import { useTypingDatasetUpdate } from './useTypingDatasetUpdate'
+import { DatasetUpdateBanner } from './DatasetUpdateBanner'
+import { KANA_ROWS, KANA_ROW_COLUMNS, KANA_COLUMN_TO_ROW, normalizeKanaInitial, type KanaRow } from './kana-initial'
+import type { LanguageListEntry } from '../../shared/types/language-store'
+import type { AozoraImportErrorCode } from '../../shared/types/aozora-import'
+
+const PAGE_SIZE = 50
+const AOZORA_PROVIDER = 'aozora'
+
+/** Catalog error code → i18n key for the per-row inline error line.
+ *  DUPLICATE_NAME (the text store's own name-collision check) gets a
+ *  specific message; every other code — including the download/unzip/
+ *  decode pipeline's own codes — falls back to a generic message that
+ *  carries the raw code for diagnosis. */
+function importErrorKey(errorCode: AozoraImportErrorCode): string {
+  return errorCode === 'DUPLICATE_NAME'
+    ? 'editor.typingTest.language.catalogImportErrorDuplicate'
+    : 'editor.typingTest.language.catalogImportErrorGeneric'
+}
+
+// Matches the AozoraRow accent idiom: bg-accent/10 + text-accent when
+// selected, text-content-muted (brightening to text-accent on hover)
+// otherwise — the same pattern the row's own import button uses.
+function kanaButtonClass(active: boolean): string {
+  const base = 'flex h-6 w-6 items-center justify-center rounded text-sm transition-colors'
+  return active
+    ? `${base} bg-accent/10 font-semibold text-accent`
+    : `${base} text-content-muted hover:text-accent`
+}
+
+interface KanaButtonProps {
+  label: string
+  active: boolean
+  testId: string
+  onClick: () => void
+}
+
+// One kana toggle, shared by the row tier and the column tier.
+function KanaButton({ label, active, testId, onClick }: KanaButtonProps) {
+  return (
+    <button type="button" data-testid={testId} aria-pressed={active} className={kanaButtonClass(active)} onClick={onClick}>
+      {label}
+    </button>
+  )
+}
+
+// Module-level cache of the ~10,468-entry catalog manifest: a tab remount
+// (e.g. switching Typing Test tabs) reuses it instead of repeating the full
+// IPC fetch. The list only changes when a dataset update is applied, so it
+// is invalidated from handleUpdateDataset below rather than on every mount.
+let cachedCatalog: LanguageListEntry[] | null = null
+
+export function clearAozoraCatalogCache(): void {
+  cachedCatalog = null
+}
+
+interface Props {
+  /** Active imported text id, when the current config is in fileImport mode
+   *  (an imported Aozora work plays back through that same mode). */
+  currentTextId?: string
+  onSelect: (textId: string) => void
+}
+
+export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
+  const { t } = useTranslation()
+  const [catalog, setCatalog] = useState<LanguageListEntry[]>(cachedCatalog ?? [])
+  const [search, setSearch] = useState('')
+  const [selectedRow, setSelectedRow] = useState<KanaRow | null>(null)
+  const [selectedColumn, setSelectedColumn] = useState<string | null>(null)
+  const [importing, setImporting] = useState<Set<string>>(new Set())
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  // Distinguishes "the catalog fetch failed" from "the catalog is genuinely
+  // empty" so a load failure doesn't silently render as an empty result list.
+  const [catalogLoadFailed, setCatalogLoadFailed] = useState(false)
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const { metas, refresh: refreshMetas } = useTypingTestTexts()
+  const { updateAvailable, updating, applyUpdate } = useTypingDatasetUpdate(AOZORA_PROVIDER)
+
+  useEffect(() => {
+    if (cachedCatalog) return
+    let alive = true
+    window.vialAPI.langList(AOZORA_PROVIDER).then((list) => {
+      cachedCatalog = list
+      if (alive) setCatalog(list)
+    }).catch(() => {
+      if (alive) setCatalogLoadFailed(true)
+    })
+    return () => { alive = false }
+  }, [])
+
+  useEffect(() => { searchRef.current?.focus() }, [])
+
+  // A new query, a reloaded catalog (dataset update), or a changed kana
+  // filter all start the plain list back at the first page — otherwise a
+  // narrower filter could leave visibleCount pointing past the new,
+  // shorter match set.
+  useEffect(() => { setVisibleCount(PAGE_SIZE) }, [search, catalog, selectedRow, selectedColumn])
+
+  function handleRowClick(row: KanaRow): void {
+    setSelectedRow((prev) => (prev === row ? null : row))
+    setSelectedColumn(null)
+  }
+
+  function handleColumnClick(column: string): void {
+    setSelectedColumn((prev) => (prev === column ? null : column))
+  }
+
+  const handleUpdateDataset = useCallback(async () => {
+    const changed = await applyUpdate()
+    if (changed) {
+      // The update may have changed the manifest; drop the cached catalog
+      // so a later tab remount re-fetches instead of serving stale entries.
+      clearAozoraCatalogCache()
+      const list = await window.vialAPI.langList(AOZORA_PROVIDER)
+      cachedCatalog = list
+      setCatalog(list)
+    }
+  }, [applyUpdate])
+
+  // workId (catalog entry `name`) -> the text id it was imported as. Soft-
+  // deleted texts don't count as imported.
+  const importedTextIdByWorkId = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const meta of metas) {
+      if (meta.deletedAt) continue
+      if (meta.source?.provider === AOZORA_PROVIDER && meta.source.workId) {
+        map.set(meta.source.workId, meta.id)
+      }
+    }
+    return map
+  }, [metas])
+
+  // Precomputed lowercase search haystack and normalized author-kana
+  // initial, built once per catalog load so a keystroke or a kana-filter
+  // click only re-runs the (cheap) comparison instead of re-normalizing
+  // every entry. authorKana is the canonical source; an entry from an
+  // older cached override that lacks it falls back to its display-name
+  // author (a foreign author's display name is already katakana).
+  const searchIndex = useMemo(
+    () => catalog.map((entry) => ({
+      entry,
+      haystack: `${entry.title ?? ''}\n${entry.author ?? ''}`.toLowerCase(),
+      kanaInitial: normalizeKanaInitial(entry.authorKana) ?? normalizeKanaInitial(entry.author),
+    })),
+    [catalog],
+  )
+  const query = search.trim().toLowerCase()
+
+  // Single filter pass: partitions matches into the "Imported" section
+  // (already-downloaded works, only shown while browsing with no active
+  // query, so a work never appears twice on the page) and the plain list,
+  // while counting total matches for the empty-result state. The kana
+  // filter (row, or the narrower column once one is picked) combines with
+  // the text search as AND.
+  const { imported, plain, totalMatched } = useMemo(() => {
+    const imported: LanguageListEntry[] = []
+    const plain: LanguageListEntry[] = []
+    let totalMatched = 0
+    for (const { entry, haystack, kanaInitial } of searchIndex) {
+      if (query && !haystack.includes(query)) continue
+      if (selectedColumn) {
+        if (kanaInitial !== selectedColumn) continue
+      } else if (selectedRow) {
+        if (!kanaInitial || KANA_COLUMN_TO_ROW[kanaInitial] !== selectedRow) continue
+      }
+      totalMatched++
+      if (!query && importedTextIdByWorkId.has(entry.name)) {
+        imported.push(entry)
+      } else {
+        plain.push(entry)
+      }
+    }
+    return { imported, plain, totalMatched }
+  }, [searchIndex, query, importedTextIdByWorkId, selectedRow, selectedColumn])
+
+  const hasMore = visibleCount < plain.length
+
+  // Infinite scroll: observes a sentinel placed after the last rendered
+  // plain-list row, using the scroll container itself as the intersection
+  // root. Re-created whenever hasMore flips (the sentinel mounts/unmounts)
+  // so a stale observer never lingers once every match is rendered.
+  useEffect(() => {
+    if (!hasMore) return
+    const sentinel = sentinelRef.current
+    const root = scrollRef.current
+    if (!sentinel || !root) return
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0]?.isIntersecting) {
+        setVisibleCount((prev) => prev + PAGE_SIZE)
+      }
+    }, { root })
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore])
+
+  const handleImport = useCallback(async (workId: string) => {
+    setImporting((prev) => new Set(prev).add(workId))
+    setErrors((prev) => {
+      const next = { ...prev }
+      delete next[workId]
+      return next
+    })
+    try {
+      const result = await window.vialAPI.aozoraImport(workId)
+      if (result.success) {
+        await refreshMetas()
+        onSelect(result.meta.id)
+        return
+      }
+      setErrors((prev) => ({ ...prev, [workId]: t(importErrorKey(result.errorCode), { code: result.errorCode }) }))
+    } finally {
+      setImporting((prev) => {
+        const next = new Set(prev)
+        next.delete(workId)
+        return next
+      })
+    }
+  }, [refreshMetas, onSelect, t])
+
+  // Shared row renderer for both the "Imported" section and the plain list:
+  // an already-imported entry naturally hides its import button/spinner/
+  // error inside AozoraRow (see `imported` there), so passing the same
+  // importing/error lookups to both sections is behavior-identical.
+  const renderRow = useCallback((entry: LanguageListEntry) => {
+    const textId = importedTextIdByWorkId.get(entry.name)
+    return (
+      <AozoraRow
+        key={entry.name}
+        entry={entry}
+        textId={textId}
+        // Guard against undefined === undefined: an unimported row has no
+        // textId, and outside fileImport mode there is no currentTextId.
+        isCurrent={textId !== undefined && textId === currentTextId}
+        isImporting={importing.has(entry.name)}
+        error={errors[entry.name]}
+        onSelect={onSelect}
+        onImport={handleImport}
+      />
+    )
+  }, [importedTextIdByWorkId, currentTextId, importing, errors, onSelect, handleImport])
+
+  return (
+    <>
+      <div className="border-b border-edge px-4 py-2">
+        <input
+          ref={searchRef}
+          type="text"
+          className="w-full rounded-md border border-edge bg-surface-alt px-3 py-1.5 text-sm text-content placeholder:text-content-muted focus:border-accent focus:outline-none"
+          placeholder={t('editor.typingTest.language.catalogSearchPlaceholder')}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          data-testid="aozora-search"
+        />
+
+        <div
+          className="mt-2 flex flex-wrap items-center gap-1"
+          role="group"
+          aria-label={t('editor.typingTest.language.kanaRowGroupAriaLabel')}
+        >
+          {KANA_ROWS.map((row) => (
+            <KanaButton
+              key={row}
+              label={row}
+              active={selectedRow === row}
+              testId={`aozora-kana-row-${row}`}
+              onClick={() => handleRowClick(row)}
+            />
+          ))}
+          <span className="text-xs text-content-muted">{t('editor.typingTest.language.kanaRowLabel')}</span>
+        </div>
+
+        {selectedRow && (
+          <div
+            className="mt-2 flex flex-wrap items-center gap-1"
+            role="group"
+            aria-label={t('editor.typingTest.language.kanaColumnGroupAriaLabel')}
+            data-testid="aozora-kana-columns"
+          >
+            {KANA_ROW_COLUMNS[selectedRow].map((column) => (
+              <KanaButton
+                key={column}
+                label={column}
+                active={selectedColumn === column}
+                testId={`aozora-kana-col-${column}`}
+                onClick={() => handleColumnClick(column)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <DatasetUpdateBanner updateAvailable={updateAvailable} updating={updating} onUpdate={handleUpdateDataset} />
+
+      <div ref={scrollRef} className="flex-1 overflow-y-auto">
+        {catalogLoadFailed ? (
+          <p className="px-4 py-6 text-center text-sm text-danger" data-testid="aozora-catalog-error">
+            {t('editor.typingTest.language.catalogLoadFailed')}
+          </p>
+        ) : totalMatched === 0 && (
+          <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
+        )}
+
+        {imported.length > 0 && (
+          <div>
+            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+              {t('editor.typingTest.language.catalogImported')}
+            </div>
+            {imported.map(renderRow)}
+          </div>
+        )}
+
+        {plain.slice(0, visibleCount).map(renderRow)}
+
+        {hasMore && <div ref={sentinelRef} className="h-px" data-testid="aozora-sentinel" />}
+      </div>
+    </>
+  )
+}
+
+interface AozoraRowProps {
+  entry: LanguageListEntry
+  /** Id of the text this catalog entry was imported as, if any. */
+  textId?: string
+  isCurrent: boolean
+  isImporting: boolean
+  error?: string
+  onSelect: (textId: string) => void
+  onImport: (workId: string) => void
+}
+
+function AozoraRow({ entry, textId, isCurrent, isImporting, error, onSelect, onImport }: AozoraRowProps) {
+  const { t } = useTranslation()
+  const imported = textId !== undefined
+
+  let rowStyle = ''
+  if (isCurrent) {
+    rowStyle = 'bg-accent/10'
+  } else if (imported) {
+    rowStyle = 'cursor-pointer hover:bg-surface-alt'
+  }
+
+  return (
+    <div>
+      <div
+        data-testid={`aozora-row-${entry.name}`}
+        className={`flex items-center gap-3 px-4 py-2 text-sm transition-colors ${rowStyle}`}
+        onClick={imported ? () => onSelect(textId) : undefined}
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex min-w-0 items-center gap-2">
+            {isCurrent && <Check size={ICON_SM} className="shrink-0 text-accent" aria-hidden="true" />}
+            <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>
+              {entry.title ?? entry.name}
+            </span>
+          </div>
+          {entry.author && <span className="truncate text-xs text-content-muted">{entry.author}</span>}
+        </div>
+
+        <span className="shrink-0 text-xs text-content-muted">
+          {t('editor.typingTest.language.estimatedChars', { count: entry.wordCount })}
+        </span>
+
+        {!imported && (
+          <button
+            type="button"
+            data-testid={`aozora-import-${entry.name}`}
+            aria-label={t('editor.typingTest.language.catalogImportAction')}
+            className="shrink-0 rounded p-1 text-content-muted hover:text-accent"
+            onClick={(e) => {
+              e.stopPropagation()
+              onImport(entry.name)
+            }}
+            disabled={isImporting}
+          >
+            {isImporting ? (
+              <Loader2 size={ICON_SM} className="animate-spin" aria-hidden="true" />
+            ) : (
+              <Download size={ICON_SM} aria-hidden="true" />
+            )}
+          </button>
+        )}
+      </div>
+      {error && (
+        <p className="px-4 pb-2 text-xs text-danger" data-testid={`aozora-error-${entry.name}`}>{error}</p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/typing-test/DatasetUpdateBanner.tsx
+++ b/src/renderer/typing-test/DatasetUpdateBanner.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// "An update is available" banner, shared by every dataset tab
+// (MonkeyType / Tatoeba / Aozora). Pairs with useTypingDatasetUpdate;
+// the caller owns the refresh-on-change side effects since those differ
+// per provider (e.g. clearing the tatoeba pack cache).
+
+import { useTranslation } from 'react-i18next'
+
+interface Props {
+  updateAvailable: boolean
+  updating: boolean
+  onUpdate: () => void
+}
+
+export function DatasetUpdateBanner({ updateAvailable, updating, onUpdate }: Props) {
+  const { t } = useTranslation()
+  if (!updateAvailable) return null
+
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-b border-edge bg-accent/5 px-4 py-2"
+      data-testid="typing-dataset-update-banner"
+    >
+      <span className="text-sm text-content-secondary">
+        {t('editor.typingTest.language.datasetUpdateAvailable')}
+      </span>
+      <button
+        type="button"
+        data-testid="typing-dataset-update-button"
+        disabled={updating}
+        onClick={onUpdate}
+        className="inline-flex h-8 items-center rounded-md border border-accent bg-accent/10 px-3 text-sm text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {t(updating ? 'editor.typingTest.language.datasetUpdating' : 'editor.typingTest.language.datasetUpdate')}
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/typing-test/LanguagePackTab.tsx
+++ b/src/renderer/typing-test/LanguagePackTab.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { Check, Download, Trash2, Loader2 } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import { clearTatoebaPackCache } from './word-generator'
+import { useTypingDatasetUpdate } from './useTypingDatasetUpdate'
+import { DatasetUpdateBanner } from './DatasetUpdateBanner'
 import type { LanguageListEntry } from '../../shared/types/language-store'
 
 function formatName(name: string): string {
@@ -32,8 +34,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
   const [languages, setLanguages] = useState<LanguageListEntry[]>([])
   const [search, setSearch] = useState('')
   const [downloading, setDownloading] = useState<Set<string>>(new Set())
-  const [updateAvailable, setUpdateAvailable] = useState(false)
-  const [updating, setUpdating] = useState(false)
+  const { updateAvailable, updating, applyUpdate } = useTypingDatasetUpdate(provider)
   const searchRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
@@ -46,36 +47,19 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
 
   useEffect(() => { searchRef.current?.focus() }, [])
 
-  // Version check only — no auto-download. Runs when this tab is shown; the
-  // main process caches the result for the app session, so reopening the modal
-  // or switching tabs won't re-hit the Hub.
-  useEffect(() => {
-    let alive = true
-    window.vialAPI.checkTypingDatasetUpdate(provider)
-      .then((r) => { if (alive) setUpdateAvailable(r.updateAvailable) })
-      .catch(() => {})
-    return () => { alive = false }
-  }, [provider])
-
   const handleUpdateDataset = useCallback(async () => {
-    setUpdating(true)
-    try {
-      const result = await window.vialAPI.updateTypingDataset(provider)
-      if (result.changed) {
-        // The update dropped the old downloaded files; forget any cached packs
-        // so the session doesn't keep playing stale sentences.
-        if (provider === 'tatoeba') clearTatoebaPackCache()
-        // The manifest may have new/changed languages; refresh the list.
-        const list = await window.vialAPI.langList(provider)
-        setLanguages(list)
-        setUpdateAvailable(false)
-      }
-      // On `changed:false` (Hub unreachable / invalid payload) the update was
-      // NOT applied — keep the banner so the user can retry.
-    } finally {
-      setUpdating(false)
+    const changed = await applyUpdate()
+    if (changed) {
+      // The update dropped the old downloaded files; forget any cached packs
+      // so the session doesn't keep playing stale sentences.
+      if (provider === 'tatoeba') clearTatoebaPackCache()
+      // The manifest may have new/changed languages; refresh the list.
+      const list = await window.vialAPI.langList(provider)
+      setLanguages(list)
     }
-  }, [provider])
+    // On `changed:false` (Hub unreachable / invalid payload) the update was
+    // NOT applied — keep the banner so the user can retry.
+  }, [applyUpdate, provider])
 
   const handleDownload = useCallback(async (name: string) => {
     setDownloading((s) => new Set(s).add(name))
@@ -131,25 +115,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
         />
       </div>
 
-      {updateAvailable && (
-        <div
-          className="flex items-center justify-between gap-3 border-b border-edge bg-accent/5 px-4 py-2"
-          data-testid="typing-dataset-update-banner"
-        >
-          <span className="text-sm text-content-secondary">
-            {t('editor.typingTest.language.datasetUpdateAvailable')}
-          </span>
-          <button
-            type="button"
-            data-testid="typing-dataset-update-button"
-            disabled={updating}
-            onClick={handleUpdateDataset}
-            className="inline-flex h-8 items-center rounded-md border border-accent bg-accent/10 px-3 text-sm text-accent transition-colors hover:bg-accent/20 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {t(updating ? 'editor.typingTest.language.datasetUpdating' : 'editor.typingTest.language.datasetUpdate')}
-          </button>
-        </div>
-      )}
+      <DatasetUpdateBanner updateAvailable={updateAvailable} updating={updating} onUpdate={handleUpdateDataset} />
 
       <div className="flex-1 overflow-y-auto">
         {filtered.length === 0 && (

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -5,12 +5,14 @@ import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
+import { MODAL_LG } from '../components/editors/store-modal-shared'
 import { Check, Trash2, Loader2, FileUp } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import { LanguagePackTab } from './LanguagePackTab'
+import { AozoraCatalogTab } from './AozoraCatalogTab'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 
-type Tab = 'existing' | 'tatoeba' | 'import'
+type Tab = 'existing' | 'tatoeba' | 'import' | 'aozora'
 
 /** Store error code → i18n key for the Import tab error line. Unlisted
  *  codes fall back to the generic importFailed message. */
@@ -93,7 +95,7 @@ export function LanguageSelectorModal({
       role="dialog"
       onClick={handleBackdropClick}
     >
-      <div className="flex h-modal-80vh w-modal-typing flex-col rounded-2xl border border-edge bg-surface shadow-xl">
+      <div className={`flex h-modal-80vh ${MODAL_LG} flex-col rounded-2xl border border-edge bg-surface shadow-xl`}>
         <div className="flex items-center justify-between border-b border-edge px-4 py-3">
           <h2 className="text-lg font-semibold text-content">{t('editor.typingTest.language.title')}</h2>
           <ModalCloseButton testid="language-modal-close" onClick={handleClose} />
@@ -123,6 +125,16 @@ export function LanguageSelectorModal({
           <button
             type="button"
             role="tab"
+            aria-selected={tab === 'aozora'}
+            data-testid="language-tab-aozora"
+            className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'aozora' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
+            onClick={() => setTab('aozora')}
+          >
+            {t('editor.typingTest.language.tabAozora')}
+          </button>
+          <button
+            type="button"
+            role="tab"
             aria-selected={tab === 'import'}
             data-testid="language-tab-import"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'import' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
@@ -145,6 +157,13 @@ export function LanguageSelectorModal({
             provider="tatoeba"
             currentSelected={currentTatoebaLanguage}
             onSelect={handleSelectTatoeba}
+          />
+        )}
+
+        {tab === 'aozora' && (
+          <AozoraCatalogTab
+            currentTextId={currentFileImportTextId}
+            onSelect={handleSelectImport}
           />
         )}
 

--- a/src/renderer/typing-test/__tests__/AozoraCatalogTab.test.tsx
+++ b/src/renderer/typing-test/__tests__/AozoraCatalogTab.test.tsx
@@ -1,0 +1,415 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { AozoraCatalogTab, clearAozoraCatalogCache } from '../AozoraCatalogTab'
+import type { LanguageListEntry } from '../../../shared/types/language-store'
+import type { TypingTestTextMeta } from '../../../shared/types/typing-test-text-store'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+// jsdom has no IntersectionObserver. This mock captures the callback passed
+// by the component so a test can fire a synthetic intersection entry for the
+// sentinel, and tracks disconnect() calls so a test can assert cleanup.
+let observerCallback: IntersectionObserverCallback | null = null
+let observerDisconnect: ReturnType<typeof vi.fn>
+
+class MockIntersectionObserver {
+  constructor(callback: IntersectionObserverCallback) {
+    observerCallback = callback
+  }
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = observerDisconnect
+}
+
+function fireSentinelIntersection() {
+  observerCallback?.([{ isIntersecting: true } as IntersectionObserverEntry], observerCallback as unknown as IntersectionObserver)
+}
+
+function makeCatalog(count: number): LanguageListEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `works/${i}.zip`,
+    title: `Work Title ${i}`,
+    author: i === 0 ? 'Distinctive Author' : `Author ${i}`,
+    authorKana: 'だざい おさむ',
+    wordCount: 1000 + i,
+    rightToLeft: false,
+    fileSize: 2000,
+    status: 'not-downloaded' as const,
+  }))
+}
+
+const emptyMetas: TypingTestTextMeta[] = []
+
+beforeEach(() => {
+  // The catalog tab caches the fetched list at module scope so a tab
+  // remount doesn't re-fetch; each test needs a fresh fetch of its own mock.
+  clearAozoraCatalogCache()
+  window.vialAPI = {
+    langList: vi.fn().mockResolvedValue(makeCatalog(60)),
+    checkTypingDatasetUpdate: vi.fn().mockResolvedValue({ provider: 'aozora', updateAvailable: false }),
+    updateTypingDataset: vi.fn().mockResolvedValue({ provider: 'aozora', changed: false, fromVersion: '' }),
+    typingTestTextStoreList: vi.fn().mockResolvedValue({ success: true, data: emptyMetas }),
+    aozoraImport: vi.fn(),
+  } as unknown as typeof window.vialAPI
+
+  observerCallback = null
+  observerDisconnect = vi.fn()
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('AozoraCatalogTab', () => {
+  it('renders only the first page of the catalog initially', async () => {
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50)
+    })
+    expect(screen.getByTestId('aozora-sentinel')).toBeInTheDocument()
+  })
+
+  it('appends the next page each time the sentinel intersects, and removes it once everything is rendered', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeCatalog(120))
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50))
+
+    fireSentinelIntersection()
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(100))
+    expect(screen.getByTestId('aozora-sentinel')).toBeInTheDocument()
+
+    fireSentinelIntersection()
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(120))
+    expect(screen.queryByTestId('aozora-sentinel')).not.toBeInTheDocument()
+  })
+
+  it('resets to the first page when the query changes', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeCatalog(120))
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50))
+    fireSentinelIntersection()
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(100))
+
+    fireEvent.change(screen.getByTestId('aozora-search'), { target: { value: 'Work Title' } })
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50)
+    })
+  })
+
+  it('filters by case-insensitive substring match on title and author', async () => {
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/^aozora-row-/).length).toBeGreaterThan(0)
+    })
+
+    fireEvent.change(screen.getByTestId('aozora-search'), { target: { value: 'distinctive' } })
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('Distinctive Author')
+    })
+    expect(screen.queryByTestId('aozora-sentinel')).not.toBeInTheDocument()
+  })
+
+  it('imports an unimported work and selects the resulting text on success', async () => {
+    const onSelect = vi.fn()
+    vi.mocked(window.vialAPI.aozoraImport).mockResolvedValue({
+      success: true,
+      meta: { id: 'new-id', name: 'Work Title 0（Distinctive Author）', wordCount: 1000, filename: 'f.json', savedAt: '', updatedAt: '' },
+    })
+
+    renderWithI18n(<AozoraCatalogTab onSelect={onSelect} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-import-works/0.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-import-works/0.zip'))
+
+    await waitFor(() => {
+      expect(window.vialAPI.aozoraImport).toHaveBeenCalledWith('works/0.zip')
+      expect(onSelect).toHaveBeenCalledWith('new-id')
+    })
+  })
+
+  it('shows a specific message for a DUPLICATE_NAME import failure', async () => {
+    vi.mocked(window.vialAPI.aozoraImport).mockResolvedValue({
+      success: false,
+      errorCode: 'DUPLICATE_NAME',
+      error: 'duplicate',
+    })
+
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-import-works/0.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-import-works/0.zip'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aozora-error-works/0.zip')).toHaveTextContent('already exists')
+    })
+  })
+
+  it('shows a generic download-failed message (with the code) for other errors', async () => {
+    vi.mocked(window.vialAPI.aozoraImport).mockResolvedValue({
+      success: false,
+      errorCode: 'SIZE_MISMATCH',
+      error: 'size mismatch',
+    })
+
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-import-works/0.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-import-works/0.zip'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aozora-error-works/0.zip')).toHaveTextContent('SIZE_MISMATCH')
+    })
+  })
+
+  it('shows a catalog-level error line instead of an empty result list when the initial load fails', async () => {
+    window.vialAPI.langList = vi.fn().mockRejectedValue(new Error('network error'))
+
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aozora-catalog-error')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('aozora-row-works/0.zip')).not.toBeInTheDocument()
+    expect(screen.queryByText(/no matching languages|no results/i)).not.toBeInTheDocument()
+  })
+
+  it('an already-imported work is clickable and calls onSelect with the linked text id', async () => {
+    const onSelect = vi.fn()
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'existing-id',
+        name: 'Work Title 0（Distinctive Author）',
+        wordCount: 1000,
+        filename: 'f.json',
+        savedAt: '',
+        updatedAt: '',
+        source: { provider: 'aozora', workId: 'works/0.zip' },
+      }],
+    })
+
+    renderWithI18n(<AozoraCatalogTab onSelect={onSelect} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-row-works/0.zip')).toBeInTheDocument())
+    // Already imported — no import button on that row.
+    expect(screen.queryByTestId('aozora-import-works/0.zip')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('aozora-row-works/0.zip'))
+
+    expect(onSelect).toHaveBeenCalledWith('existing-id')
+  })
+
+  it('marks no row as current when no fileImport text is selected', async () => {
+    // Regression: unimported rows have no textId, and outside fileImport mode
+    // there is no currentTextId — undefined === undefined must not mark every
+    // row as the selected one.
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/).length).toBeGreaterThan(0))
+    for (const row of screen.getAllByTestId(/^aozora-row-/)) {
+      expect(row.className).not.toContain('bg-accent/10')
+    }
+  })
+
+  it('marks only the row linked to the selected fileImport text as current', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+      success: true,
+      data: [{
+        id: 'existing-id',
+        name: 'Work Title 0（Distinctive Author）',
+        wordCount: 1000,
+        filename: 'f.json',
+        savedAt: '',
+        updatedAt: '',
+        source: { provider: 'aozora', workId: 'works/0.zip' },
+      }],
+    })
+
+    renderWithI18n(<AozoraCatalogTab currentTextId="existing-id" onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-row-works/0.zip')).toBeInTheDocument())
+    expect(screen.getByTestId('aozora-row-works/0.zip').className).toContain('bg-accent/10')
+    expect(screen.getByTestId('aozora-row-works/1.zip').className).not.toContain('bg-accent/10')
+  })
+})
+
+function kanaEntry(name: string, title: string, author: string, authorKana?: string): LanguageListEntry {
+  return { name, title, author, authorKana, wordCount: 1000, rightToLeft: false, fileSize: 2000, status: 'not-downloaded' }
+}
+
+function importedMeta(id: string, name: string, workId: string): TypingTestTextMeta {
+  return { id, name, wordCount: 1000, filename: 'f.json', savedAt: '', updatedAt: '', source: { provider: 'aozora', workId } }
+}
+
+function makeKanaCatalog(): LanguageListEntry[] {
+  return [
+    kanaEntry('works/dazai.zip', 'Run, Melos!', '太宰 治', 'だざい おさむ'), // タ row, タ column
+    kanaEntry('works/mori.zip', 'The Dancing Girl', '森 鴎外', 'もり おうがい'), // マ row, モ column
+    // No authorKana — display name is already katakana.
+    kanaEntry('works/irving.zip', 'Rip Van Winkle', 'アーヴィング ワシントン'),
+    // No authorKana, kanji display name — never matches a kana filter.
+    kanaEntry('works/akutagawa.zip', 'Rashomon', '芥川 龍之介'),
+  ]
+}
+
+describe('AozoraCatalogTab kana filter', () => {
+  it('filters to a row and clears on re-click', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('Run, Melos!')
+    })
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+  })
+
+  it('reveals the column tier only while a row is selected, and narrows the match on column pick', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+    expect(screen.queryByTestId('aozora-kana-columns')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-マ'))
+    await waitFor(() => expect(screen.getByTestId('aozora-kana-columns')).toBeInTheDocument())
+    // マ row has both マミムメモ columns rendered — narrow to モ, the entry's actual column.
+    fireEvent.click(screen.getByTestId('aozora-kana-col-モ'))
+
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('The Dancing Girl')
+    })
+
+    // A different column under the same row narrows to zero matches.
+    fireEvent.click(screen.getByTestId('aozora-kana-col-ミ'))
+    await waitFor(() => expect(screen.queryAllByTestId(/^aozora-row-/)).toHaveLength(0))
+  })
+
+  it('clears the selected column when switching to a different row', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => expect(screen.getByTestId('aozora-kana-columns')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-kana-col-タ'))
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(1))
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-マ'))
+    await waitFor(() => {
+      // Column narrowed to タ no longer applies — only the row filter does.
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('The Dancing Girl')
+    })
+    expect(screen.getByTestId('aozora-kana-col-モ').getAttribute('aria-pressed')).toBe('false')
+  })
+
+  it('combines the kana row filter with the text search as AND', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(1))
+
+    fireEvent.change(screen.getByTestId('aozora-search'), { target: { value: 'Rashomon' } })
+    await waitFor(() => expect(screen.queryAllByTestId(/^aozora-row-/)).toHaveLength(0))
+  })
+
+  it('resets pagination to the first page when the kana filter changes', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeCatalog(120))
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50))
+    fireSentinelIntersection()
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(100))
+
+    // makeCatalog gives every entry the same authorKana (だざい おさむ, タ row),
+    // so selecting タ still matches all 120 — but pagination must still reset.
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(50))
+  })
+
+  it('hides an entry with no authorKana and a non-kana display name while a kana filter is active, but shows it unfiltered', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('aozora-row-works/akutagawa.zip')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => {
+      expect(screen.queryByTestId('aozora-row-works/akutagawa.zip')).not.toBeInTheDocument()
+    })
+  })
+
+  it('falls back to a katakana display name for an entry with no authorKana', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+
+    fireEvent.click(screen.getByTestId('aozora-kana-row-ア'))
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('Rip Van Winkle')
+    })
+  })
+
+  it('applies the kana filter to the Imported section too', async () => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeKanaCatalog())
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+      success: true,
+      data: [importedMeta('dazai-id', 'Run, Melos!（太宰 治）', 'works/dazai.zip')],
+    })
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    // Browsing: the imported dazai row sits in the Imported section.
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(4))
+    expect(screen.queryByTestId('aozora-import-works/dazai.zip')).not.toBeInTheDocument()
+
+    // マ row matches only mori — the imported dazai work is hidden with it.
+    fireEvent.click(screen.getByTestId('aozora-kana-row-マ'))
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('The Dancing Girl')
+    })
+
+    // タ row matches dazai — the imported row comes back.
+    fireEvent.click(screen.getByTestId('aozora-kana-row-タ'))
+    await waitFor(() => {
+      const rows = screen.getAllByTestId(/^aozora-row-/)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toHaveTextContent('Run, Melos!')
+    })
+  })
+})

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -3,6 +3,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { LanguageSelectorModal } from '../LanguageSelectorModal'
+import { clearAozoraCatalogCache } from '../AozoraCatalogTab'
 import type { LanguageListEntry } from '../../../shared/types/language-store'
 
 const mockLanguages: LanguageListEntry[] = [
@@ -13,6 +14,9 @@ const mockLanguages: LanguageListEntry[] = [
 ]
 
 beforeEach(() => {
+  // The Aozora catalog tab caches its fetched list at module scope so a tab
+  // remount doesn't re-fetch; each test needs a fresh fetch of its own mock.
+  clearAozoraCatalogCache()
   window.vialAPI = {
     langList: vi.fn().mockResolvedValue(mockLanguages),
     langGet: vi.fn().mockResolvedValue(null),
@@ -353,6 +357,75 @@ describe('LanguageSelectorModal', () => {
     fireEvent.click(screen.getByTestId('language-modal-close'))
     expect(onCurrentTextDeleted).toHaveBeenCalledTimes(1)
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('lists the aozora catalog and version-checks it when its tab is shown', async () => {
+    window.vialAPI = {
+      ...window.vialAPI,
+      typingTestTextStoreList: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    } as unknown as typeof window.vialAPI
+
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-aozora'))
+
+    await waitFor(() => {
+      expect(window.vialAPI.langList).toHaveBeenCalledWith('aozora')
+      expect(window.vialAPI.checkTypingDatasetUpdate).toHaveBeenCalledWith('aozora')
+    })
+  })
+
+  it('picks an already-imported aozora work → onSelectImport + onClose', async () => {
+    const onSelectImport = vi.fn()
+    const onClose = vi.fn()
+    const workId = '001257/files/59898.zip'
+    window.vialAPI = {
+      ...window.vialAPI,
+      langList: vi.fn((provider?: string) => {
+        if (provider === 'aozora') {
+          return Promise.resolve([
+            { name: workId, title: 'Sample Work', author: 'Sample Author', wordCount: 1000, rightToLeft: false, fileSize: 2000 },
+          ])
+        }
+        return Promise.resolve(mockLanguages)
+      }),
+      typingTestTextStoreList: vi.fn().mockResolvedValue({
+        success: true,
+        data: [{
+          id: 'aozora-1',
+          name: 'Sample Work（Sample Author）',
+          wordCount: 1000,
+          filename: 'a.json',
+          savedAt: '',
+          updatedAt: '',
+          source: { provider: 'aozora', workId },
+        }],
+      }),
+    } as unknown as typeof window.vialAPI
+
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={onSelectImport}
+        onClose={onClose}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-aozora'))
+    await waitFor(() => expect(screen.getByTestId(`aozora-row-${workId}`)).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId(`aozora-row-${workId}`))
+
+    expect(onSelectImport).toHaveBeenCalledWith('aozora-1')
+    expect(onClose).toHaveBeenCalled()
   })
 
   it('does not fire onCurrentTextDeleted when nothing was deleted', async () => {

--- a/src/renderer/typing-test/__tests__/kana-initial.test.ts
+++ b/src/renderer/typing-test/__tests__/kana-initial.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeKanaInitial, KANA_ROWS, KANA_ROW_COLUMNS } from '../kana-initial'
+
+describe('normalizeKanaInitial', () => {
+  it('converts a hiragana reading to its katakana initial', () => {
+    expect(normalizeKanaInitial('だざい おさむ')).toBe('タ')
+  })
+
+  it('keeps an already-katakana reading as-is', () => {
+    expect(normalizeKanaInitial('アーヴィング ワシントン')).toBe('ア')
+  })
+
+  it('folds a dakuten kana to its base column kana', () => {
+    expect(normalizeKanaInitial('がぎがき')).toBe('カ')
+    expect(normalizeKanaInitial('ザメンホフ')).toBe('サ')
+    expect(normalizeKanaInitial('ダンテ')).toBe('タ')
+  })
+
+  it('folds a handakuten kana to its base column kana', () => {
+    expect(normalizeKanaInitial('ぱすかる')).toBe('ハ')
+  })
+
+  it('folds ヴ to ウ', () => {
+    expect(normalizeKanaInitial('ヴェルヌ')).toBe('ウ')
+    expect(normalizeKanaInitial('ゔぇるぬ')).toBe('ウ')
+  })
+
+  it('folds a small kana to its full-size counterpart', () => {
+    expect(normalizeKanaInitial('ぁいうえお')).toBe('ア')
+    expect(normalizeKanaInitial('ォずぼーん')).toBe('オ')
+    expect(normalizeKanaInitial('ヶ原')).toBe('ケ')
+    expect(normalizeKanaInitial('ゕ')).toBe('カ')
+  })
+
+  it('handles canonically decomposed input (base kana + combining mark)', () => {
+    // A decomposed first char splits into base + U+3099/U+309A; the base
+    // kana alone already lands on the right column.
+    expect(normalizeKanaInitial('がき')).toBe('カ')
+    expect(normalizeKanaInitial('ぱり')).toBe('ハ')
+    expect(normalizeKanaInitial('ヴェルヌ')).toBe('ウ')
+  })
+
+  it('skips leading whitespace before reading the first character', () => {
+    expect(normalizeKanaInitial('  だざい おさむ')).toBe('タ')
+  })
+
+  it('returns null for an empty or undefined string', () => {
+    expect(normalizeKanaInitial('')).toBeNull()
+    expect(normalizeKanaInitial(undefined)).toBeNull()
+    expect(normalizeKanaInitial('   ')).toBeNull()
+  })
+
+  it('returns null when the first character is not part of the gojuon grid', () => {
+    expect(normalizeKanaInitial('太宰 治')).toBeNull()
+    expect(normalizeKanaInitial('ンドゥール')).toBeNull()
+    expect(normalizeKanaInitial('Smith John')).toBeNull()
+  })
+
+  it('exposes each row header inside its own column set', () => {
+    for (const row of KANA_ROWS) {
+      expect(KANA_ROW_COLUMNS[row]).toContain(row)
+    }
+  })
+
+  it('gives ヤ three columns and ワ a single column', () => {
+    expect(KANA_ROW_COLUMNS['ヤ']).toEqual(['ヤ', 'ユ', 'ヨ'])
+    expect(KANA_ROW_COLUMNS['ワ']).toEqual(['ワ'])
+  })
+})

--- a/src/renderer/typing-test/kana-initial.ts
+++ b/src/renderer/typing-test/kana-initial.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Gojuon (五十音) initial-kana classification for the Aozora catalog's
+// author filter. Pure normalization only: hiragana -> katakana,
+// dakuten/handakuten -> base kana, small kana -> full-size kana. The kana
+// characters themselves are linguistic data, not translatable UI text, so
+// they live here as constants rather than i18n keys.
+
+/** The ten gojuon row headers, in reading order. */
+export const KANA_ROWS = ['ア', 'カ', 'サ', 'タ', 'ナ', 'ハ', 'マ', 'ヤ', 'ラ', 'ワ'] as const
+
+export type KanaRow = (typeof KANA_ROWS)[number]
+
+/** Each row's column kana. ヤ has 3 columns and ワ has 1; every other row
+ *  has the full 5 (modern reference readings never start with ヰ/ヱ/ヲ, so
+ *  those historical ワ-row columns are intentionally omitted). */
+export const KANA_ROW_COLUMNS: Record<KanaRow, readonly string[]> = {
+  ア: ['ア', 'イ', 'ウ', 'エ', 'オ'],
+  カ: ['カ', 'キ', 'ク', 'ケ', 'コ'],
+  サ: ['サ', 'シ', 'ス', 'セ', 'ソ'],
+  タ: ['タ', 'チ', 'ツ', 'テ', 'ト'],
+  ナ: ['ナ', 'ニ', 'ヌ', 'ネ', 'ノ'],
+  ハ: ['ハ', 'ヒ', 'フ', 'ヘ', 'ホ'],
+  マ: ['マ', 'ミ', 'ム', 'メ', 'モ'],
+  ヤ: ['ヤ', 'ユ', 'ヨ'],
+  ラ: ['ラ', 'リ', 'ル', 'レ', 'ロ'],
+  ワ: ['ワ'],
+}
+
+// Every base kana across all ten rows — used to reject a normalized
+// character that isn't actually part of the gojuon grid (kanji, ン, ...).
+const ALL_COLUMN_KANA = new Set(Object.values(KANA_ROW_COLUMNS).flat())
+
+/** Column kana -> its row header, inverted from KANA_ROW_COLUMNS once at
+ *  load so a row filter is a single equality test per entry. */
+export const KANA_COLUMN_TO_ROW: Readonly<Record<string, KanaRow>> = Object.fromEntries(
+  (Object.entries(KANA_ROW_COLUMNS) as [KanaRow, readonly string[]][])
+    .flatMap(([row, columns]) => columns.map((column) => [column, row])),
+)
+
+// Small kana, folded to their full-size counterpart.
+const SMALL_FOLD: Record<string, string> = {
+  ァ: 'ア', ィ: 'イ', ゥ: 'ウ', ェ: 'エ', ォ: 'オ',
+  ヵ: 'カ', ヶ: 'ケ',
+  ッ: 'ツ',
+  ャ: 'ヤ', ュ: 'ユ', ョ: 'ヨ',
+  ヮ: 'ワ',
+}
+
+// Hiragana ぁ..ゖ maps onto katakana ァ..ヶ at a constant +0x60 codepoint
+// offset — the standard Unicode block relationship between the two scripts.
+const HIRAGANA_START = 0x3041 // ぁ
+const HIRAGANA_END = 0x3096 // ゖ
+const HIRAGANA_TO_KATAKANA_OFFSET = 0x60
+
+function toKatakana(char: string): string {
+  const code = char.codePointAt(0)
+  if (code === undefined || code < HIRAGANA_START || code > HIRAGANA_END) return char
+  return String.fromCodePoint(code + HIRAGANA_TO_KATAKANA_OFFSET)
+}
+
+/** Normalizes a reading/name string down to a single base gojuon kana: the
+ *  first non-space character, converted to katakana, with dakuten/
+ *  handakuten and small-kana marks folded off. Returns `null` when the
+ *  string is empty/undefined, or its first character isn't part of the
+ *  gojuon grid at all (a kanji name, ン, a Latin letter, ...) — such
+ *  entries never match a row/column filter. */
+export function normalizeKanaInitial(text: string | undefined): string | null {
+  if (!text) return null
+  const trimmed = text.trimStart()
+  if (trimmed.length === 0) return null
+  const first = [...trimmed][0]
+  const katakana = toKatakana(first)
+  // NFD strips combining dakuten/handakuten (ガ→カ, パ→ハ, ヴ→ウ) — the
+  // same folding as the Aozora Bunko author index. Small kana are distinct
+  // codepoints (not decompositions), so they need their own table.
+  const folded = SMALL_FOLD[katakana] ?? katakana.normalize('NFD')[0]
+  return ALL_COLUMN_KANA.has(folded) ? folded : null
+}

--- a/src/renderer/typing-test/useTypingDatasetUpdate.ts
+++ b/src/renderer/typing-test/useTypingDatasetUpdate.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared "dataset update available" check/apply flow for a Typing Test
+// provider (monkeytype / tatoeba / aozora). The main process caches the
+// version check for the app session, so mounting this once per tab-open
+// (or switching tabs) won't re-hit the Hub. Extracted so every dataset
+// tab (LanguagePackTab, AozoraCatalogTab) shares one implementation
+// instead of re-deriving the same two IPC calls.
+
+import { useState, useEffect, useCallback } from 'react'
+
+export interface UseTypingDatasetUpdateReturn {
+  updateAvailable: boolean
+  updating: boolean
+  /** Apply the update. Resolves to whether it actually changed anything —
+   *  `false` means the Hub was unreachable or returned an invalid payload,
+   *  in which case the caller should keep showing the banner for a retry. */
+  applyUpdate: () => Promise<boolean>
+}
+
+export function useTypingDatasetUpdate(provider: string): UseTypingDatasetUpdateReturn {
+  const [updateAvailable, setUpdateAvailable] = useState(false)
+  const [updating, setUpdating] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    window.vialAPI.checkTypingDatasetUpdate(provider)
+      .then((r) => { if (alive) setUpdateAvailable(r.updateAvailable) })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [provider])
+
+  const applyUpdate = useCallback(async (): Promise<boolean> => {
+    setUpdating(true)
+    try {
+      const result = await window.vialAPI.updateTypingDataset(provider)
+      if (result.changed) setUpdateAvailable(false)
+      return result.changed
+    } finally {
+      setUpdating(false)
+    }
+  }, [provider])
+
+  return { updateAvailable, updating, applyUpdate }
+}

--- a/src/shared/data/typing-test-providers.ts
+++ b/src/shared/data/typing-test-providers.ts
@@ -41,6 +41,21 @@ export const TYPING_TEST_PROVIDER_DEFAULTS: readonly TypingTestProviderDefault[]
     bundledLanguages: [],
     languages: [],
   },
+  // Aozora is a Hub-only catalog provider (see typing-test-datasets.ts on the
+  // Hub side): each language entry is a whole downloadable work rather than a
+  // sampled word/sentence pack, so `model: 'catalog'` is baked into the
+  // placeholder itself — resolveProvider() must never fall through to the
+  // pack-shaped monkeytype default for this provider. Otherwise mirrors the
+  // tatoeba placeholder: nothing ships with the app, everything comes from
+  // the Hub override at runtime.
+  {
+    provider: 'aozora',
+    version: '',
+    downloadUrlBase: '',
+    model: 'catalog',
+    bundledLanguages: [],
+    languages: [],
+  },
 ]
 
 export function getProviderDefault(provider: string): TypingTestProviderDefault | undefined {

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -176,6 +176,9 @@ export const IpcChannels = {
   TYPING_DATASET_CHECK: 'typing-dataset:check',
   TYPING_DATASET_UPDATE: 'typing-dataset:update',
 
+  // Aozora Bunko catalog import (renderer → main → renderer)
+  AOZORA_IMPORT: 'aozora:import',
+
   // Data management (renderer → main → renderer)
   LIST_STORED_KEYBOARDS: 'data:list-stored-keyboards',
   // Record a keyboard's display name on connect, only when it has none yet.

--- a/src/shared/types/aozora-import.ts
+++ b/src/shared/types/aozora-import.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Result shape for importing one Aozora Bunko catalog work into the local
+// Typing Test text store. Kept as a standalone shared type (rather than
+// living next to the main-process importer) so preload/renderer can
+// reference it without importing a main-process module.
+
+import type { TypingTestTextMeta, TypingTestTextStoreErrorCode } from './typing-test-text-store'
+
+/** Failure modes specific to the download/unzip/decode/clean pipeline,
+ *  layered on top of the text store's own save-time error codes (e.g.
+ *  `DUPLICATE_NAME`, `EMPTY_TEXT` — the store's `EMPTY_TEXT` fires if the
+ *  normalized text is empty; the importer's own `EMPTY_TEXT` fires earlier,
+ *  right after cleaning, before a save is even attempted). */
+export type AozoraImportErrorCode =
+  | 'NOT_IN_CATALOG'
+  | 'DOWNLOAD_FAILED'
+  | 'SIZE_MISMATCH'
+  | 'NO_TEXT_ENTRY'
+  | 'DECODE_FAILED'
+  | 'EMPTY_TEXT'
+  | TypingTestTextStoreErrorCode
+
+export type AozoraImportResult =
+  | { success: true; meta: TypingTestTextMeta }
+  | { success: false; errorCode: AozoraImportErrorCode; error: string }

--- a/src/shared/types/language-store.ts
+++ b/src/shared/types/language-store.ts
@@ -3,6 +3,17 @@ export interface LanguageManifestEntry {
   wordCount: number
   rightToLeft: boolean
   fileSize: number
+  /** Work title. Present for catalog providers (aozora); used by the
+   *  desktop's catalog picker UI. Absent for pack providers. */
+  title?: string
+  /** Work author. Present for catalog providers (aozora); used by the
+   *  desktop's catalog picker UI. Absent for pack providers. */
+  author?: string
+  /** Lead author's reading, used for the gojuon (五十音) filter in the
+   *  desktop's catalog picker UI. Hiragana for Japanese authors, katakana
+   *  for foreign authors. Present for catalog providers (aozora) only;
+   *  older cached overrides predating this field may still lack it. */
+  authorKana?: string
 }
 
 export type LanguageDownloadStatus = 'bundled' | 'downloaded' | 'not-downloaded'
@@ -20,6 +31,16 @@ export interface TypingTestDataset {
   version: string
   /** Base URL for per-language word files: `<downloadUrlBase>/<name>.json`. */
   downloadUrlBase: string
+  /** Wire-level discriminator: 'pack' = interchangeable word/sentence
+   *  entries meant to be sampled (monkeytype, tatoeba); 'catalog' = each
+   *  entry is one whole work to individually download (aozora). Optional
+   *  and absent means 'pack' — overrides persisted before this field
+   *  existed never carried it, so treating a missing value as 'pack' keeps
+   *  them valid without a migration. Also implies how to read `wordCount`
+   *  on each entry: exact for 'pack', an estimate for 'catalog' (the Hub
+   *  never downloads/cleans a catalog work, so it can't know the exact
+   *  post-cleaning length). */
+  model?: 'pack' | 'catalog'
   languages: LanguageManifestEntry[]
 }
 

--- a/src/shared/types/typing-test-text-store.ts
+++ b/src/shared/types/typing-test-text-store.ts
@@ -23,6 +23,11 @@ export interface TypingTestTextMeta {
   updatedAt: string
   /** Soft delete tombstone (ISO 8601). 30-day GC matches favorites. */
   deletedAt?: string
+  /** Set when this entry was imported from a catalog (e.g. the Aozora
+   *  Bunko browser) rather than a local file. `workId` is the catalog
+   *  entry's `name` path, used to detect already-imported works and avoid
+   *  duplicate imports. Absent for user file imports. */
+  source?: { provider: string; workId: string }
 }
 
 export interface TypingTestTextIndex {

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -60,6 +60,7 @@ import type {
   TypingBigramAggregateView,
 } from './typing-analytics'
 import type { LanguageListEntry } from './language-store'
+import type { AozoraImportResult } from './aozora-import'
 import type { HubUploadPostParams, HubUpdatePostParams, HubPatchPostParams, HubUploadResult, HubDeleteResult, HubFetchMyPostsResult, HubFetchMyKeyboardPostsResult, HubFetchMyPostsParams, HubUserResult, HubUploadFavoritePostParams, HubUpdateFavoritePostParams, HubUploadAnalyticsPostParams, HubUpdateAnalyticsPostParams, HubPreviewAnalyticsPostParams, HubAnalyticsPreview, HubUploadI18nPostParams, HubUpdateI18nPostParams, HubI18nListParams, HubI18nListResponse, HubI18nExportV1, HubI18nPackTimestampsResponse, HubUploadThemePostParams, HubUpdateThemePostParams, HubThemeListParams, HubThemeListResponse, HubThemePackBody, HubThemePackTimestampsResponse, HubPrivateUploadResult, HubPrivateKind, HubPrivateUploadPostParams, HubPrivateUploadFavoritePostParams, HubPrivateUploadAnalyticsPostParams } from './hub'
 import type { HubPrivateLink } from './hub-private'
 import type { NotificationFetchResult } from './notification'
@@ -330,6 +331,9 @@ export interface VialAPI {
   langDelete(name: string, provider?: string): Promise<{ success: boolean; error?: string }>
   checkTypingDatasetUpdate(provider?: string): Promise<{ provider: string; updateAvailable: boolean }>
   updateTypingDataset(provider?: string): Promise<{ provider: string; changed: boolean; fromVersion: string; toVersion?: string }>
+
+  // Aozora Bunko catalog import
+  aozoraImport(workId: string): Promise<AozoraImportResult>
 
   // Data management
   listStoredKeyboards(): Promise<StoredKeyboardInfo[]>


### PR DESCRIPTION
## Summary
- Add the Hub's `aozora` catalog provider (`model: 'catalog'`, ~10.5k public-domain works, 新字新仮名 only). The Hub ships only the catalog manifest; the desktop downloads a selected work's zip directly from the commit-pinned aozorabunko GitHub mirror.
- Import pipeline (main process): manifest-membership check (no arbitrary URL fetches) → size-verified download (shared `fetchVerifiedBytes`) → fflate unzip (ASCII `.txt` entry, `__MACOSX` skipped) → `TextDecoder('shift_jis')` with a U+FFFD ratio gate → `cleanAozoraText` (a TypeScript port of the aozorabunko-extractor pipeline: header/footer, ruby 《》｜, warichu, gaiji (U+ resolution), kunojiten, residual ［＃…］ annotations) → saved into the typing-test-texts store with `source: { provider, workId }`.
- Imported works play back as regular fileImport texts — no new typing mode.
- New `aozora:import` IPC (the pack-oriented `lang:download` path rejects catalog datasets; the importer rejects pack datasets — the `model` discriminator is load-bearing, with a provider-default fallback for legacy overrides).

## UI
- New Aozora Bunko tab in the language selector (ordered before File Import): search-first catalog browser with infinite scroll (50-row pages, IntersectionObserver sentinel), per-row import with inline errors, imported works selectable in place.
- Two-tier gojūon author filter under the search box (row → column), driven by the manifest's `authorKana` readings: hiragana→katakana, NFD dakuten/handakuten fold, small-kana fold, display-name fallback for legacy cached catalogs.
- Language selector modal widened to the LG tier (760px); dataset update banner logic extracted into `useTypingDatasetUpdate` shared by the pack tabs and the catalog tab.
- Aozora Bunko attribution added to the About/legal screen.

## Verified against live data
Ran the production pipeline against the live Hub catalog: 走れメロス plus 5 random works — zip sizes matched the manifest exactly, 0 replacement chars, no residual markup, heads/tails cut correctly (verbatim paragraph structure preserved).

## Tests
227 files / 4445 tests pass; `tsc --noEmit` and `eslint` clean. New suites: aozora-clean (markup pipeline fixtures), aozora-import (zip/decode/error paths), kana-initial (normalization), AozoraCatalogTab (catalog browsing, import flow, kana filter, infinite scroll, selection-state regressions).