### PR TITLE
fix(ui): manage aozora imports from the catalog tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,15 @@ We are deeply grateful to the Vial team and contributors for making open-source 
 The Typing Test feature is based on [Monkeytype](https://github.com/monkeytypegame/monkeytype) (GPL-3.0).
 Thank you to the Monkeytype team for their excellent open-source typing test.
 
+Typing Test sentence packs are curated from the [Tatoeba Project](https://tatoeba.org) and its contributors.
+Most language packs are licensed under [CC BY 2.0 FR](https://creativecommons.org/licenses/by/2.0/fr/); some packs are dedicated to the public domain under [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/).
+Thank you to the Tatoeba community for building an open corpus of example sentences.
+
+The Aozora Bunko catalog lets you type public-domain Japanese literature. Catalog metadata and work texts are
+sourced from [Aozora Bunko](https://www.aozora.gr.jp/) via the [aozorabunko GitHub mirror](https://github.com/aozorabunko/aozorabunko),
+with Aozora's ruby and editorial annotation markup cleaned during import.
+Thank you to the Aozora Bunko volunteers for decades of careful digitization.
+
 ## License
 
 [GPL-3.0-or-later](LICENSE)

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -390,7 +390,6 @@
         "datasetUpdate": "Update",
         "datasetUpdating": "Updating…",
         "catalogSearchPlaceholder": "Search title or author...",
-        "catalogImported": "Imported",
         "catalogImportAction": "Import",
         "estimatedChars": "~{{count}} chars",
         "catalogImportErrorDuplicate": "A text with this title already exists",

--- a/src/renderer/i18n/locales/japanese.json
+++ b/src/renderer/i18n/locales/japanese.json
@@ -390,7 +390,6 @@
         "datasetUpdate": "更新",
         "datasetUpdating": "更新中…",
         "catalogSearchPlaceholder": "作品名・著者名で検索...",
-        "catalogImported": "取り込み済み",
         "catalogImportAction": "取り込む",
         "estimatedChars": "約 {{count}} 文字",
         "catalogImportErrorDuplicate": "同じ作品名のテキストが既に存在します",

--- a/src/renderer/typing-test/AozoraCatalogTab.tsx
+++ b/src/renderer/typing-test/AozoraCatalogTab.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
 // Aozora Bunko catalog browser: search-first UI over the 10,468-entry
-// catalog manifest (rendered incrementally — see PAGE_SIZE). Picking an
-// unimported work downloads + cleans it into the typing-test-texts store;
-// an already-imported work is just selected like any other fileImport text.
+// catalog manifest (rendered incrementally — see PAGE_SIZE), split into
+// Imported / Available sections like LanguagePackTab's downloaded/available
+// packs. Picking an unimported work downloads + cleans it into the
+// typing-test-texts store; an already-imported work is just selected like
+// any other fileImport text, and can be deleted back into Available.
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -12,6 +14,7 @@ import { ICON_SM } from '../constants/ui-tokens'
 import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { useTypingDatasetUpdate } from './useTypingDatasetUpdate'
 import { DatasetUpdateBanner } from './DatasetUpdateBanner'
+import { SectionHeader, RowDeleteButton } from './list-parts'
 import { KANA_ROWS, KANA_ROW_COLUMNS, KANA_COLUMN_TO_ROW, normalizeKanaInitial, type KanaRow } from './kana-initial'
 import type { LanguageListEntry } from '../../shared/types/language-store'
 import type { AozoraImportErrorCode } from '../../shared/types/aozora-import'
@@ -71,9 +74,11 @@ interface Props {
    *  (an imported Aozora work plays back through that same mode). */
   currentTextId?: string
   onSelect: (textId: string) => void
+  /** Fired with the text id whenever an imported work is deleted. */
+  onDeleted?: (textId: string) => void
 }
 
-export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
+export function AozoraCatalogTab({ currentTextId, onSelect, onDeleted }: Props) {
   const { t } = useTranslation()
   const [catalog, setCatalog] = useState<LanguageListEntry[]>(cachedCatalog ?? [])
   const [search, setSearch] = useState('')
@@ -88,7 +93,7 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
   const searchRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
-  const { metas, refresh: refreshMetas } = useTypingTestTexts()
+  const { metas, refresh: refreshMetas, remove } = useTypingTestTexts()
   const { updateAvailable, updating, applyUpdate } = useTypingDatasetUpdate(AOZORA_PROVIDER)
 
   useEffect(() => {
@@ -106,7 +111,7 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
   useEffect(() => { searchRef.current?.focus() }, [])
 
   // A new query, a reloaded catalog (dataset update), or a changed kana
-  // filter all start the plain list back at the first page — otherwise a
+  // filter all start the Available list back at the first page — otherwise a
   // narrower filter could leave visibleCount pointing past the new,
   // shorter match set.
   useEffect(() => { setVisibleCount(PAGE_SIZE) }, [search, catalog, selectedRow, selectedColumn])
@@ -162,15 +167,16 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
   const query = search.trim().toLowerCase()
 
   // Single filter pass: partitions matches into the "Imported" section
-  // (already-downloaded works, only shown while browsing with no active
-  // query, so a work never appears twice on the page) and the plain list,
-  // while counting total matches for the empty-result state. The kana
-  // filter (row, or the narrower column once one is picked) combines with
-  // the text search as AND.
-  const { imported, plain, totalMatched } = useMemo(() => {
+  // (already-imported works) and the "Available" section (everything
+  // else), always both sectioned — mirrors LanguagePackTab's downloaded/
+  // available split — so an imported work never blends into the plain
+  // list mid-search. The empty-result state is derived from both lists
+  // being empty rather than a separate counter. The kana filter (row, or
+  // the narrower column once one is picked) combines with the text search
+  // as AND.
+  const { imported, available } = useMemo(() => {
     const imported: LanguageListEntry[] = []
-    const plain: LanguageListEntry[] = []
-    let totalMatched = 0
+    const available: LanguageListEntry[] = []
     for (const { entry, haystack, kanaInitial } of searchIndex) {
       if (query && !haystack.includes(query)) continue
       if (selectedColumn) {
@@ -178,22 +184,24 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
       } else if (selectedRow) {
         if (!kanaInitial || KANA_COLUMN_TO_ROW[kanaInitial] !== selectedRow) continue
       }
-      totalMatched++
-      if (!query && importedTextIdByWorkId.has(entry.name)) {
+      if (importedTextIdByWorkId.has(entry.name)) {
         imported.push(entry)
       } else {
-        plain.push(entry)
+        available.push(entry)
       }
     }
-    return { imported, plain, totalMatched }
+    return { imported, available }
   }, [searchIndex, query, importedTextIdByWorkId, selectedRow, selectedColumn])
 
-  const hasMore = visibleCount < plain.length
+  // Pagination only applies to the Available list — imported works are few
+  // enough (per-user) to render in full.
+  const hasMore = visibleCount < available.length
 
   // Infinite scroll: observes a sentinel placed after the last rendered
-  // plain-list row, using the scroll container itself as the intersection
-  // root. Re-created whenever hasMore flips (the sentinel mounts/unmounts)
-  // so a stale observer never lingers once every match is rendered.
+  // Available-list row, using the scroll container itself as the
+  // intersection root. Re-created whenever hasMore flips (the sentinel
+  // mounts/unmounts) so a stale observer never lingers once every match
+  // is rendered.
   useEffect(() => {
     if (!hasMore) return
     const sentinel = sentinelRef.current
@@ -232,9 +240,20 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
     }
   }, [refreshMetas, onSelect, t])
 
-  // Shared row renderer for both the "Imported" section and the plain list:
-  // an already-imported entry naturally hides its import button/spinner/
-  // error inside AozoraRow (see `imported` there), so passing the same
+  // Soft-deletes the imported text behind a catalog entry (same tombstone
+  // as ImportTab's remove). The metas refresh this triggers naturally moves
+  // the row from Imported back to Available. `onDeleted` is reported
+  // optimistically before the IPC round-trip so closing the modal
+  // mid-delete still resets a deleted current text; a failed delete turns
+  // the reset into a harmless no-op.
+  const handleDelete = useCallback(async (textId: string) => {
+    onDeleted?.(textId)
+    await remove(textId)
+  }, [remove, onDeleted])
+
+  // Shared row renderer for both the Imported and Available sections: an
+  // already-imported entry naturally swaps its import button for a delete
+  // button inside AozoraRow (see `imported` there), so passing the same
   // importing/error lookups to both sections is behavior-identical.
   const renderRow = useCallback((entry: LanguageListEntry) => {
     const textId = importedTextIdByWorkId.get(entry.name)
@@ -250,9 +269,10 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
         error={errors[entry.name]}
         onSelect={onSelect}
         onImport={handleImport}
+        onDelete={handleDelete}
       />
     )
-  }, [importedTextIdByWorkId, currentTextId, importing, errors, onSelect, handleImport])
+  }, [importedTextIdByWorkId, currentTextId, importing, errors, onSelect, handleImport, handleDelete])
 
   return (
     <>
@@ -311,20 +331,23 @@ export function AozoraCatalogTab({ currentTextId, onSelect }: Props) {
           <p className="px-4 py-6 text-center text-sm text-danger" data-testid="aozora-catalog-error">
             {t('editor.typingTest.language.catalogLoadFailed')}
           </p>
-        ) : totalMatched === 0 && (
+        ) : imported.length === 0 && available.length === 0 && (
           <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.noResults')}</p>
         )}
 
         {imported.length > 0 && (
           <div>
-            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-              {t('editor.typingTest.language.catalogImported')}
-            </div>
+            <SectionHeader label={t('editor.typingTest.language.downloaded')} />
             {imported.map(renderRow)}
           </div>
         )}
 
-        {plain.slice(0, visibleCount).map(renderRow)}
+        {available.length > 0 && (
+          <div>
+            <SectionHeader label={t('editor.typingTest.language.available')} />
+            {available.slice(0, visibleCount).map(renderRow)}
+          </div>
+        )}
 
         {hasMore && <div ref={sentinelRef} className="h-px" data-testid="aozora-sentinel" />}
       </div>
@@ -341,9 +364,10 @@ interface AozoraRowProps {
   error?: string
   onSelect: (textId: string) => void
   onImport: (workId: string) => void
+  onDelete: (textId: string) => void
 }
 
-function AozoraRow({ entry, textId, isCurrent, isImporting, error, onSelect, onImport }: AozoraRowProps) {
+function AozoraRow({ entry, textId, isCurrent, isImporting, error, onSelect, onImport, onDelete }: AozoraRowProps) {
   const { t } = useTranslation()
   const imported = textId !== undefined
 
@@ -393,6 +417,10 @@ function AozoraRow({ entry, textId, isCurrent, isImporting, error, onSelect, onI
               <Download size={ICON_SM} aria-hidden="true" />
             )}
           </button>
+        )}
+
+        {imported && (
+          <RowDeleteButton testId={`aozora-delete-${entry.name}`} onClick={() => onDelete(textId)} />
         )}
       </div>
       {error && (

--- a/src/renderer/typing-test/LanguagePackTab.tsx
+++ b/src/renderer/typing-test/LanguagePackTab.tsx
@@ -2,11 +2,12 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Check, Download, Trash2, Loader2 } from 'lucide-react'
+import { Check, Download, Loader2 } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import { clearTatoebaPackCache } from './word-generator'
 import { useTypingDatasetUpdate } from './useTypingDatasetUpdate'
 import { DatasetUpdateBanner } from './DatasetUpdateBanner'
+import { SectionHeader, RowDeleteButton } from './list-parts'
 import type { LanguageListEntry } from '../../shared/types/language-store'
 
 function formatName(name: string): string {
@@ -124,9 +125,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
 
         {downloaded.length > 0 && (
           <div>
-            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-              {t('editor.typingTest.language.downloaded')}
-            </div>
+            <SectionHeader label={t('editor.typingTest.language.downloaded')} />
             {downloaded.map((lang) => (
               <LanguageRow
                 key={lang.name}
@@ -142,9 +141,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
 
         {available.length > 0 && (
           <div>
-            <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
-              {t('editor.typingTest.language.available')}
-            </div>
+            <SectionHeader label={t('editor.typingTest.language.available')} />
             {available.map((lang) => (
               <LanguageRow
                 key={lang.name}
@@ -222,17 +219,7 @@ function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onD
       )}
 
       {lang.status === 'downloaded' && onDelete && (
-        <button
-          type="button"
-          data-testid={`language-delete-${lang.name}`}
-          className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete(lang.name)
-          }}
-        >
-          <Trash2 size={ICON_SM} aria-hidden="true" />
-        </button>
+        <RowDeleteButton testId={`language-delete-${lang.name}`} onClick={() => onDelete(lang.name)} />
       )}
     </div>
   )

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useEscapeClose } from '../hooks/useEscapeClose'
 import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
 import { MODAL_LG } from '../components/editors/store-modal-shared'
-import { Check, Trash2, Loader2, FileUp } from 'lucide-react'
+import { Check, Loader2, FileUp } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import { LanguagePackTab } from './LanguagePackTab'
 import { AozoraCatalogTab } from './AozoraCatalogTab'
+import { RowDeleteButton } from './list-parts'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 
 type Tab = 'existing' | 'tatoeba' | 'import' | 'aozora'
@@ -61,11 +62,37 @@ export function LanguageSelectorModal({
   // Flipped true when the currently-selected imported text is deleted, so a
   // plain close (Esc / backdrop / X — not an explicit pick) resets to default.
   const deletedCurrentRef = useRef(false)
+  // Flipped true on the first manual tab click so the async initial-tab
+  // correction below never overrides the user's own navigation.
+  const userNavigatedRef = useRef(false)
+  const { metas } = useTypingTestTexts()
+
+  // `initialTab`'s 'import' guess is wrong for catalog-managed texts: they
+  // are excluded from the File Import list (managed by their catalog tab),
+  // so the current selection would look missing. Metas load async, so the
+  // correction happens here once they resolve.
+  useEffect(() => {
+    if (userNavigatedRef.current || tab !== 'import' || !currentFileImportTextId) return
+    const source = metas.find((m) => m.id === currentFileImportTextId)?.source
+    if (source?.provider === 'aozora') setTab('aozora')
+  }, [metas, tab, currentFileImportTextId])
+
+  const selectTab = useCallback((next: Tab) => {
+    userNavigatedRef.current = true
+    setTab(next)
+  }, [])
 
   const handleClose = useCallback(() => {
     if (deletedCurrentRef.current) onCurrentTextDeleted?.()
     onClose()
   }, [onClose, onCurrentTextDeleted])
+
+  // Shared by both the Aozora and File Import tabs: only the deletion of the
+  // currently-selected imported text should flip deletedCurrentRef, so the
+  // current-or-not distinction lives here rather than in either tab.
+  const handleTextDeleted = useCallback((id: string) => {
+    if (id === currentFileImportTextId) deletedCurrentRef.current = true
+  }, [currentFileImportTextId])
 
   useEscapeClose(handleClose)
 
@@ -108,7 +135,7 @@ export function LanguageSelectorModal({
             aria-selected={tab === 'existing'}
             data-testid="language-tab-existing"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'existing' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
-            onClick={() => setTab('existing')}
+            onClick={() => selectTab('existing')}
           >
             {t('editor.typingTest.language.tabMonkeytype')}
           </button>
@@ -118,7 +145,7 @@ export function LanguageSelectorModal({
             aria-selected={tab === 'tatoeba'}
             data-testid="language-tab-tatoeba"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'tatoeba' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
-            onClick={() => setTab('tatoeba')}
+            onClick={() => selectTab('tatoeba')}
           >
             {t('editor.typingTest.language.tabTatoeba')}
           </button>
@@ -128,7 +155,7 @@ export function LanguageSelectorModal({
             aria-selected={tab === 'aozora'}
             data-testid="language-tab-aozora"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'aozora' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
-            onClick={() => setTab('aozora')}
+            onClick={() => selectTab('aozora')}
           >
             {t('editor.typingTest.language.tabAozora')}
           </button>
@@ -138,7 +165,7 @@ export function LanguageSelectorModal({
             aria-selected={tab === 'import'}
             data-testid="language-tab-import"
             className={`flex-1 px-4 py-2 text-sm font-medium transition-colors ${tab === 'import' ? 'border-b-2 border-accent text-accent' : 'text-content-secondary hover:text-content'}`}
-            onClick={() => setTab('import')}
+            onClick={() => selectTab('import')}
           >
             {t('editor.typingTest.language.tabFileImport')}
           </button>
@@ -164,6 +191,7 @@ export function LanguageSelectorModal({
           <AozoraCatalogTab
             currentTextId={currentFileImportTextId}
             onSelect={handleSelectImport}
+            onDeleted={handleTextDeleted}
           />
         )}
 
@@ -171,7 +199,7 @@ export function LanguageSelectorModal({
           <ImportTab
             currentFileImportTextId={currentFileImportTextId}
             onSelect={handleSelectImport}
-            onDeleteCurrent={() => { deletedCurrentRef.current = true }}
+            onDeleted={handleTextDeleted}
           />
         )}
       </div>
@@ -182,11 +210,11 @@ export function LanguageSelectorModal({
 interface ImportTabProps {
   currentFileImportTextId?: string
   onSelect: (id: string) => void
-  /** Fired when the currently-selected imported text is deleted. */
-  onDeleteCurrent?: () => void
+  /** Fired with the text id whenever an imported text is deleted. */
+  onDeleted?: (textId: string) => void
 }
 
-function ImportTab({ currentFileImportTextId, onSelect, onDeleteCurrent }: ImportTabProps) {
+function ImportTab({ currentFileImportTextId, onSelect, onDeleted }: ImportTabProps) {
   const { t } = useTranslation()
   const { metas, importFromFile, confirmImport, remove } = useTypingTestTexts()
   const [importing, setImporting] = useState(false)
@@ -194,11 +222,20 @@ function ImportTab({ currentFileImportTextId, onSelect, onDeleteCurrent }: Impor
   // Name of an import awaiting overwrite confirmation (null = none pending).
   const [overwriteName, setOverwriteName] = useState<string | null>(null)
 
+  // Catalog-managed texts (e.g. Aozora Bunko imports) are listed and
+  // deleted from their own catalog tab, not here. Excluded by the
+  // presence of `source` rather than a specific provider name, so any
+  // future catalog provider is excluded the same way.
+  const fileImportMetas = useMemo(() => metas.filter((meta) => !meta.source), [metas])
+
   const handleRemove = useCallback(async (id: string) => {
-    const result = await remove(id)
-    if (result.success && id === currentFileImportTextId) onDeleteCurrent?.()
-    return result
-  }, [remove, currentFileImportTextId, onDeleteCurrent])
+    // Optimistic: report before the IPC round-trip so closing the modal
+    // mid-delete still resets a deleted current text. A failed delete turns
+    // the reset into a harmless no-op rather than leaving the config
+    // pointing at a tombstoned text.
+    onDeleted?.(id)
+    return remove(id)
+  }, [remove, onDeleted])
 
   const handleImport = useCallback(async () => {
     setImporting(true)
@@ -279,10 +316,10 @@ function ImportTab({ currentFileImportTextId, onSelect, onDeleteCurrent }: Impor
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {metas.length === 0 ? (
+        {fileImportMetas.length === 0 ? (
           <p className="px-4 py-6 text-center text-sm text-content-muted">{t('editor.typingTest.language.importEmpty')}</p>
         ) : (
-          metas.map((meta) => (
+          fileImportMetas.map((meta) => (
             <ImportRow
               key={meta.id}
               meta={meta}
@@ -319,18 +356,7 @@ function ImportRow({ meta, isCurrent, onSelect, onDelete }: ImportRowProps) {
       <span className="shrink-0 text-xs text-content-muted">
         {t('editor.typingTest.language.words', { count: meta.wordCount })}
       </span>
-      <button
-        type="button"
-        data-testid={`typing-text-delete-${meta.id}`}
-        aria-label={t('common.delete')}
-        className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
-        onClick={(e) => {
-          e.stopPropagation()
-          void onDelete(meta.id)
-        }}
-      >
-        <Trash2 size={ICON_SM} aria-hidden="true" />
-      </button>
+      <RowDeleteButton testId={`typing-text-delete-${meta.id}`} onClick={() => { void onDelete(meta.id) }} />
     </div>
   )
 }

--- a/src/renderer/typing-test/__tests__/AozoraCatalogTab.test.tsx
+++ b/src/renderer/typing-test/__tests__/AozoraCatalogTab.test.tsx
@@ -55,6 +55,7 @@ beforeEach(() => {
     checkTypingDatasetUpdate: vi.fn().mockResolvedValue({ provider: 'aozora', updateAvailable: false }),
     updateTypingDataset: vi.fn().mockResolvedValue({ provider: 'aozora', changed: false, fromVersion: '' }),
     typingTestTextStoreList: vi.fn().mockResolvedValue({ success: true, data: emptyMetas }),
+    typingTestTextStoreDelete: vi.fn().mockResolvedValue({ success: true }),
     aozoraImport: vi.fn(),
   } as unknown as typeof window.vialAPI
 
@@ -245,6 +246,99 @@ describe('AozoraCatalogTab', () => {
     await waitFor(() => expect(screen.getByTestId('aozora-row-works/0.zip')).toBeInTheDocument())
     expect(screen.getByTestId('aozora-row-works/0.zip').className).toContain('bg-accent/10')
     expect(screen.getByTestId('aozora-row-works/1.zip').className).not.toContain('bg-accent/10')
+  })
+})
+
+function makeSearchPartitionCatalog(): LanguageListEntry[] {
+  return [
+    { name: 'works/imported.zip', title: 'Shared Term Imported', author: 'Author A', wordCount: 1000, rightToLeft: false, fileSize: 2000, status: 'not-downloaded' },
+    { name: 'works/avail.zip', title: 'Shared Term Available', author: 'Author B', wordCount: 1000, rightToLeft: false, fileSize: 2000, status: 'not-downloaded' },
+    { name: 'works/other.zip', title: 'Unrelated Title', author: 'Author C', wordCount: 1000, rightToLeft: false, fileSize: 2000, status: 'not-downloaded' },
+  ]
+}
+
+// Wraps a single imported meta (matching makeSearchPartitionCatalog's
+// "imported" entry) in the typingTestTextStoreList result shape, for the
+// tests below that only care about that one imported work.
+function importedListResult() {
+  return { success: true, data: [importedMeta('imported-id', 'Shared Term Imported（Author A）', 'works/imported.zip')] }
+}
+
+describe('AozoraCatalogTab sections and delete', () => {
+  beforeEach(() => {
+    window.vialAPI.langList = vi.fn().mockResolvedValue(makeSearchPartitionCatalog())
+  })
+
+  it('keeps an imported match under the Downloaded header instead of blending into Available during a search', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue(importedListResult())
+
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+    await waitFor(() => expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(3))
+
+    fireEvent.change(screen.getByTestId('aozora-search'), { target: { value: 'Shared Term' } })
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId(/^aozora-row-/)).toHaveLength(2)
+    })
+    // Unrelated title is filtered out entirely.
+    expect(screen.queryByTestId('aozora-row-works/other.zip')).not.toBeInTheDocument()
+
+    // Both sections render with their sticky headers even mid-search.
+    expect(screen.getByText('Downloaded')).toBeInTheDocument()
+    expect(screen.getByText('Available')).toBeInTheDocument()
+
+    // The imported match has no import button (it's already imported)...
+    expect(screen.queryByTestId('aozora-import-works/imported.zip')).not.toBeInTheDocument()
+    // ...while the non-imported match still offers one.
+    expect(screen.getByTestId('aozora-import-works/avail.zip')).toBeInTheDocument()
+  })
+
+  it('deletes an imported work, returning it to the Available section once metas refresh', async () => {
+    const emptyList = { success: true, data: emptyMetas }
+    window.vialAPI.typingTestTextStoreList = vi.fn()
+      .mockResolvedValueOnce(importedListResult())
+      .mockResolvedValue(emptyList)
+
+    renderWithI18n(<AozoraCatalogTab onSelect={vi.fn()} />)
+
+    await waitFor(() => expect(screen.getByTestId('aozora-delete-works/imported.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-delete-works/imported.zip'))
+
+    await waitFor(() => {
+      expect(window.vialAPI.typingTestTextStoreDelete).toHaveBeenCalledWith('imported-id')
+    })
+    await waitFor(() => {
+      expect(screen.queryByTestId('aozora-delete-works/imported.zip')).not.toBeInTheDocument()
+      expect(screen.getByTestId('aozora-import-works/imported.zip')).toBeInTheDocument()
+    })
+  })
+
+  it('fires onDeleted with the deleted text id when the deleted work is the currently-selected text', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue(importedListResult())
+    const onDeleted = vi.fn()
+
+    renderWithI18n(
+      <AozoraCatalogTab currentTextId="imported-id" onSelect={vi.fn()} onDeleted={onDeleted} />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('aozora-delete-works/imported.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-delete-works/imported.zip'))
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledWith('imported-id'))
+  })
+
+  it('fires onDeleted with the deleted text id even when it is not the currently-selected text', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue(importedListResult())
+    const onDeleted = vi.fn()
+
+    renderWithI18n(
+      <AozoraCatalogTab currentTextId="some-other-id" onSelect={vi.fn()} onDeleted={onDeleted} />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('aozora-delete-works/imported.zip')).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId('aozora-delete-works/imported.zip'))
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledWith('imported-id'))
   })
 })
 

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -24,8 +24,16 @@ beforeEach(() => {
     langDelete: vi.fn().mockResolvedValue({ success: true }),
     checkTypingDatasetUpdate: vi.fn().mockResolvedValue({ provider: 'monkeytype', updateAvailable: false }),
     updateTypingDataset: vi.fn().mockResolvedValue({ provider: 'monkeytype', changed: false, fromVersion: '' }),
+    // The modal itself reads the text metas (initial-tab correction for
+    // catalog-managed texts), so every render needs a list mock.
+    typingTestTextStoreList: vi.fn().mockResolvedValue({ success: true, data: [] }),
+    typingTestTextStoreDelete: vi.fn().mockResolvedValue({ success: true }),
   } as unknown as typeof window.vialAPI
 })
+
+function textMeta(id: string, name: string, source?: { provider: string; workId: string }) {
+  return { id, name, wordCount: 10, filename: 'f.json', savedAt: '', updatedAt: '', source }
+}
 
 describe('LanguageSelectorModal', () => {
   it('renders with title and search input', async () => {
@@ -428,6 +436,93 @@ describe('LanguageSelectorModal', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('deleting a non-current aozora work then closing does not fire onCurrentTextDeleted', async () => {
+    const workId = '001257/files/59898.zip'
+    window.vialAPI = {
+      ...window.vialAPI,
+      langList: vi.fn((provider?: string) => {
+        if (provider === 'aozora') {
+          return Promise.resolve([
+            { name: workId, title: 'Sample Work', author: 'Sample Author', wordCount: 1000, rightToLeft: false, fileSize: 2000 },
+          ])
+        }
+        return Promise.resolve(mockLanguages)
+      }),
+      typingTestTextStoreList: vi.fn().mockResolvedValue({
+        success: true,
+        data: [{
+          id: 'aozora-1',
+          name: 'Sample Work（Sample Author）',
+          wordCount: 1000,
+          filename: 'a.json',
+          savedAt: '',
+          updatedAt: '',
+          source: { provider: 'aozora', workId },
+        }],
+      }),
+      typingTestTextStoreDelete: vi.fn().mockResolvedValue({ success: true }),
+    } as unknown as typeof window.vialAPI
+
+    const onCurrentTextDeleted = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        currentFileImportTextId="some-other-id"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onCurrentTextDeleted={onCurrentTextDeleted}
+        onClose={onClose}
+      />,
+    )
+
+    // currentFileImportTextId is set, so the modal opens on the Import tab;
+    // switch to Aozora to reach the deletable imported row.
+    fireEvent.click(screen.getByTestId('language-tab-aozora'))
+    await waitFor(() => expect(screen.getByTestId(`aozora-delete-${workId}`)).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId(`aozora-delete-${workId}`))
+    await waitFor(() => expect(window.vialAPI.typingTestTextStoreDelete).toHaveBeenCalledWith('aozora-1'))
+
+    fireEvent.click(screen.getByTestId('language-modal-close'))
+    expect(onCurrentTextDeleted).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('excludes catalog-managed texts (with a `source`) from the File Import list', async () => {
+    window.vialAPI = {
+      ...window.vialAPI,
+      typingTestTextStoreList: vi.fn().mockResolvedValue({
+        success: true,
+        data: [
+          { id: 'file-id', name: 'My File Import', wordCount: 5, filename: 'file.json', savedAt: '', updatedAt: '' },
+          {
+            id: 'catalog-id',
+            name: 'Aozora Work',
+            wordCount: 5,
+            filename: 'catalog.json',
+            savedAt: '',
+            updatedAt: '',
+            source: { provider: 'aozora', workId: 'works/0.zip' },
+          },
+        ],
+      }),
+    } as unknown as typeof window.vialAPI
+
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-import'))
+
+    await waitFor(() => expect(screen.getByTestId('typing-text-row-file-id')).toBeInTheDocument())
+    expect(screen.queryByTestId('typing-text-row-catalog-id')).not.toBeInTheDocument()
+  })
+
   it('does not fire onCurrentTextDeleted when nothing was deleted', async () => {
     const onCurrentTextDeleted = vi.fn()
     const onClose = vi.fn()
@@ -444,5 +539,44 @@ describe('LanguageSelectorModal', () => {
     fireEvent.click(screen.getByTestId('language-modal-close'))
     expect(onCurrentTextDeleted).not.toHaveBeenCalled()
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('hops from the File Import tab to Aozora when the current text is a catalog import', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+      success: true,
+      data: [textMeta('az-1', '船旅（アーヴィング ワシントン）', { provider: 'aozora', workId: 'works/az.zip' })],
+    })
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        currentFileImportTextId="az-1"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('language-tab-aozora')).toHaveAttribute('aria-selected', 'true')
+    })
+  })
+
+  it('stays on the File Import tab when the current text is a plain file import', async () => {
+    window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+      success: true,
+      data: [textMeta('file-1', 'My Notes')],
+    })
+    render(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        currentFileImportTextId="file-1"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('My Notes')).toBeInTheDocument())
+    expect(screen.getByTestId('language-tab-import')).toHaveAttribute('aria-selected', 'true')
   })
 })

--- a/src/renderer/typing-test/list-parts.tsx
+++ b/src/renderer/typing-test/list-parts.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useTranslation } from 'react-i18next'
+import { Trash2 } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
+
+interface SectionHeaderProps {
+  label: string
+}
+
+/** Sticky section header shared by the downloadable/imported list panes
+ *  (LanguagePackTab's Downloaded/Available, AozoraCatalogTab's Imported/
+ *  Available). */
+export function SectionHeader({ label }: SectionHeaderProps) {
+  return (
+    <div className="sticky top-0 bg-surface px-4 py-2 text-xs font-medium uppercase text-content-muted">
+      {label}
+    </div>
+  )
+}
+
+interface RowDeleteButtonProps {
+  testId: string
+  onClick: () => void
+}
+
+/** Trash-icon row button shared by every deletable list row (Aozora catalog,
+ *  language pack, file import). */
+export function RowDeleteButton({ testId, onClick }: RowDeleteButtonProps) {
+  const { t } = useTranslation()
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      aria-label={t('common.delete')}
+      className="shrink-0 rounded p-1 text-content-muted hover:text-danger"
+      onClick={(e) => {
+        e.stopPropagation()
+        onClick()
+      }}
+    >
+      <Trash2 size={ICON_SM} aria-hidden="true" />
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
- Aozora works and user file imports shared one list: imported works were hard to tell apart from available ones in the catalog, and could only be deleted from the File Import tab.
- The catalog tab now mirrors the pack tabs' management UX: always-visible **Downloaded / Available** sections (text search and the kana filter apply to both; infinite scroll paginates the Available list only), a delete button on downloaded rows (soft tombstone — the work returns to Available and can be re-imported), and section labels unified with the pack tabs.
- **Separate management:** the File Import tab now lists only user file imports — texts carrying a catalog `source` are excluded (mechanism-based, so future catalog providers are covered) and are managed from their own tab.
- The modal owns the deleted-current-text check once (`onDeleted(textId)` from both tabs), reports deletions optimistically so closing mid-IPC still resets a deleted current text, and hops to the Aozora tab on open when the current text is a catalog import (it would otherwise look missing in the File Import list).
- Section headers and the row delete button are extracted into shared components (`list-parts.tsx`) used by the pack tabs, the catalog tab, and the File Import rows — this also fixes a missing `aria-label` on the pack tabs' delete button.
- README: credit the Tatoeba Project and Aozora Bunko alongside the existing Monkeytype acknowledgment.

## Tests
227 files / 4453 tests pass; `tsc --noEmit` and `eslint` clean. New coverage: search-time sectioning, delete → row returns to Available, optimistic `onDeleted`, modal-level deleted-current reset, catalog-import exclusion from the File Import list, and the initial-tab hop for catalog-managed current texts.