### PR TITLE
feat(hid): add virtual GPK60-63R Vial keyboard emulator

### DIFF
--- a/e2e/helpers/electron.ts
+++ b/e2e/helpers/electron.ts
@@ -15,6 +15,8 @@ export interface LaunchAppOptions {
    * SQLite cache from them as the renderer loads.
    */
   onMainReady?: (ctx: { app: ElectronApplication; userDataPath: string }) => Promise<void>
+  /** Extra environment variables for the launched process, merged in last (override shell env). */
+  env?: Record<string, string>
 }
 
 /**
@@ -47,6 +49,7 @@ export async function launchApp(opts: LaunchAppOptions = {}): Promise<{
     env: {
       ...cleanEnv,
       ...(isDev ? { ELECTRON_RENDERER_URL: rendererUrl } : {}),
+      ...opts.env,
     },
   })
 

--- a/e2e/virtual-device.test.ts
+++ b/e2e/virtual-device.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Drives the software-emulated GPK60-63R Virtual device (no real hardware
+// required). Does NOT use connectTestDevice() — that helper targets the
+// physical GPK60-63R test device, a different vid/pid from the virtual one.
+//
+// `app.evaluate()` callbacks run inside Electron's main process and must be
+// self-contained (no closures over outer test-file variables) since
+// Playwright serializes the function body across the IPC boundary.
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { launchApp } from './helpers/electron'
+import { dismissNotificationModal } from './helpers/doc-capture-common'
+
+interface VirtualDeviceController {
+  pressKey(row: number, col: number): void
+  releaseKey(row: number, col: number): void
+  releaseAll(): void
+  holdKeys(pairs: [number, number][]): void
+  setUnlockCounterMax(n: number): void
+}
+
+const VIRTUAL_DEVICE_NAME = 'GPK60-63R Virtual'
+const CONNECT_TIMEOUT_MS = 15_000
+const UNLOCK_TIMEOUT_MS = 10_000
+
+let app: ElectronApplication
+let page: Page
+
+test.beforeAll(async () => {
+  const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: '1' } })
+  app = launched.app
+  page = launched.page
+  await dismissNotificationModal(page, { waitForAppearMs: 3_000 })
+})
+
+test.afterAll(async () => {
+  await app?.close()
+})
+
+test('virtual device appears in the device list and connects to the editor', async () => {
+  const deviceButton = page
+    .locator('[data-testid="device-button"]')
+    .filter({ has: page.locator('.font-semibold', { hasText: VIRTUAL_DEVICE_NAME }) })
+
+  await expect(deviceButton).toBeVisible({ timeout: CONNECT_TIMEOUT_MS })
+  await deviceButton.click()
+
+  await expect(page.locator('[data-testid="editor-content"]')).toBeVisible({ timeout: CONNECT_TIMEOUT_MS })
+
+  // Powered-on-but-locked, like a real Vial keyboard: no unlock prompt yet.
+  await expect(page.locator('text=Unlock Keyboard')).not.toBeVisible()
+})
+
+test('enabling the matrix tester while locked prompts the unlock dialog, which clears after the combo is held', async () => {
+  const settingsButton = page.locator('[aria-controls="keycodes-overlay-panel"]')
+  await settingsButton.click()
+
+  const toolsTab = page.locator('[data-testid="overlay-tab-tools"]')
+  await toolsTab.click()
+
+  const matrixToggle = page.locator('[data-testid="overlay-matrix-toggle"]')
+  await matrixToggle.click()
+
+  const unlockDialog = page.locator('text=Unlock Keyboard')
+  await expect(unlockDialog).toBeVisible({ timeout: UNLOCK_TIMEOUT_MS })
+
+  await app.evaluate(() => {
+    const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
+    controller.setUnlockCounterMax(3)
+    controller.holdKeys([[0, 0], [0, 1]])
+  })
+
+  await expect(unlockDialog).not.toBeVisible({ timeout: UNLOCK_TIMEOUT_MS })
+})
+
+test('pressing a key through the controller reflects in the matrix tester UI', async () => {
+  await app.evaluate(() => {
+    const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
+    controller.pressKey(2, 3)
+  })
+
+  const pressedKey = page.locator('[data-testid="keyboard-key"][data-pos="2,3"]')
+  await expect(pressedKey).toHaveAttribute('data-pressed', 'true', { timeout: 5_000 })
+
+  await app.evaluate(() => {
+    const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
+    controller.releaseKey(2, 3)
+  })
+
+  await expect(pressedKey).not.toHaveAttribute('data-pressed', 'true', { timeout: 5_000 })
+})

--- a/e2e/virtual-device.test.ts
+++ b/e2e/virtual-device.test.ts
@@ -60,6 +60,14 @@ test('enabling the matrix tester while locked prompts the unlock dialog, which c
   const toolsTab = page.locator('[data-testid="overlay-tab-tools"]')
   await toolsTab.click()
 
+  // Shorten the unlock countdown BEFORE the dialog's unlockStart() fires, so
+  // the sequence completes in a few 200ms polls instead of the firmware's
+  // default 50 (~10s of continuous holding).
+  await app.evaluate(() => {
+    const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
+    controller.setUnlockCounterMax(3)
+  })
+
   const matrixToggle = page.locator('[data-testid="overlay-matrix-toggle"]')
   await matrixToggle.click()
 
@@ -68,11 +76,15 @@ test('enabling the matrix tester while locked prompts the unlock dialog, which c
 
   await app.evaluate(() => {
     const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
-    controller.setUnlockCounterMax(3)
     controller.holdKeys([[0, 0], [0, 1]])
   })
 
   await expect(unlockDialog).not.toBeVisible({ timeout: UNLOCK_TIMEOUT_MS })
+
+  await app.evaluate(() => {
+    const controller = (globalThis as unknown as { __pipetteVirtualDevice: VirtualDeviceController }).__pipetteVirtualDevice
+    controller.releaseAll()
+  })
 })
 
 test('pressing a key through the controller reflects in the matrix tester UI', async () => {
@@ -81,7 +93,7 @@ test('pressing a key through the controller reflects in the matrix tester UI', a
     controller.pressKey(2, 3)
   })
 
-  const pressedKey = page.locator('[data-testid="keyboard-key"][data-pos="2,3"]')
+  const pressedKey = page.locator('[data-key-pos="2,3"]').first()
   await expect(pressedKey).toHaveAttribute('data-pressed', 'true', { timeout: 5_000 })
 
   await app.evaluate(() => {

--- a/src/main/__tests__/hid-service-virtual-device.test.ts
+++ b/src/main/__tests__/hid-service-virtual-device.test.ts
@@ -27,6 +27,7 @@ vi.mock('../../main/logger', () => ({
 
 import { listDevices, openHidDevice, closeHidDevice, sendReceive, isDeviceOpen } from '../hid-service'
 import { VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID, VIRTUAL_DEVICE_NAME } from '../virtual-device/gpk60-63r'
+import { isVirtualDeviceOpen } from '../virtual-device'
 
 function createMockDeviceInfo(overrides?: Record<string, unknown>) {
   return {
@@ -119,5 +120,17 @@ describe('virtual device enabled', () => {
     mockRead.mockResolvedValue(Buffer.alloc(MSG_LEN))
     await sendReceive([0x01])
     expect(mockWrite).toHaveBeenCalledTimes(1)
+  })
+
+  it('closeHidDevice clears the virtual-open flag even after the env flag is cleared', async () => {
+    await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    expect(isVirtualDeviceOpen()).toBe(true)
+
+    // Simulate the env flag being cleared out from under an already-open virtual device.
+    vi.stubEnv('PIPETTE_VIRTUAL_DEVICE', '0')
+    await closeHidDevice()
+
+    expect(isVirtualDeviceOpen()).toBe(false)
+    await expect(sendReceive([0x01])).rejects.toThrow('No HID device is open')
   })
 })

--- a/src/main/__tests__/hid-service-virtual-device.test.ts
+++ b/src/main/__tests__/hid-service-virtual-device.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Routing tests for the virtual-device seam inside hid-service.ts —
+// mirrors hid-service.test.ts's node-hid mocking pattern.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { MSG_LEN, HID_USAGE_PAGE, HID_USAGE } from '../../shared/constants/protocol'
+
+const mockWrite = vi.fn()
+const mockRead = vi.fn()
+const mockClose = vi.fn()
+const mockHIDAsyncOpen = vi.fn()
+const mockDevicesAsync = vi.fn()
+
+vi.mock('node-hid', () => ({
+  default: {
+    devicesAsync: (...args: unknown[]) => mockDevicesAsync(...args),
+    HIDAsync: {
+      open: (...args: unknown[]) => mockHIDAsyncOpen(...args),
+    },
+  },
+}))
+
+vi.mock('../../main/logger', () => ({
+  log: vi.fn(),
+  logHidPacket: vi.fn(),
+}))
+
+import { listDevices, openHidDevice, closeHidDevice, sendReceive, isDeviceOpen } from '../hid-service'
+import { VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID, VIRTUAL_DEVICE_NAME } from '../virtual-device/gpk60-63r'
+
+function createMockDeviceInfo(overrides?: Record<string, unknown>) {
+  return {
+    vendorId: 0x1234,
+    productId: 0x5678,
+    path: '/dev/hidraw0',
+    serialNumber: 'vial:f64c2b3c',
+    product: 'Real Test Keyboard',
+    usagePage: HID_USAGE_PAGE,
+    usage: HID_USAGE,
+    ...overrides,
+  }
+}
+
+function createMockOpenDevice() {
+  return { write: mockWrite, read: mockRead, close: mockClose }
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  vi.unstubAllEnvs()
+  mockWrite.mockReturnValue(MSG_LEN + 1)
+  mockDevicesAsync.mockResolvedValue([])
+  await closeHidDevice()
+})
+
+afterEach(async () => {
+  await closeHidDevice()
+  vi.unstubAllEnvs()
+})
+
+describe('virtual device disabled (env unset)', () => {
+  it('listDevices does not include the virtual device', async () => {
+    mockDevicesAsync.mockResolvedValue([])
+    const result = await listDevices()
+    expect(result.find((d) => d.productName === VIRTUAL_DEVICE_NAME)).toBeUndefined()
+  })
+
+  it('opening the virtual vid/pid falls through to real device lookup and fails', async () => {
+    mockDevicesAsync.mockResolvedValue([])
+    const result = await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    expect(result).toBe(false)
+  })
+})
+
+describe('virtual device enabled', () => {
+  beforeEach(() => {
+    vi.stubEnv('PIPETTE_VIRTUAL_DEVICE', '1')
+  })
+
+  it('listDevices appends the virtual device even with zero real devices', async () => {
+    mockDevicesAsync.mockResolvedValue([])
+    const result = await listDevices()
+    expect(result).toHaveLength(1)
+    expect(result[0].productName).toBe(VIRTUAL_DEVICE_NAME)
+    expect(result[0].vendorId).toBe(VIRTUAL_DEVICE_VID)
+    expect(result[0].productId).toBe(VIRTUAL_DEVICE_PID)
+  })
+
+  it('opens the virtual device without any node-hid calls', async () => {
+    const result = await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    expect(result).toBe(true)
+    expect(mockHIDAsyncOpen).not.toHaveBeenCalled()
+  })
+
+  it('sendReceive answers a protocol-version request with no node-hid calls', async () => {
+    await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    const resp = await sendReceive([0x01])
+    expect(resp.length).toBe(MSG_LEN)
+    expect((resp[1] << 8) | resp[2]).toBe(9)
+    expect(mockWrite).not.toHaveBeenCalled()
+    expect(mockRead).not.toHaveBeenCalled()
+  })
+
+  it('isDeviceOpen is true while the virtual device is open', async () => {
+    await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    await expect(isDeviceOpen()).resolves.toBe(true)
+  })
+
+  it('opening a real device closes the virtual device', async () => {
+    await openHidDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)
+    await expect(isDeviceOpen()).resolves.toBe(true)
+
+    mockDevicesAsync.mockResolvedValue([createMockDeviceInfo()])
+    mockHIDAsyncOpen.mockResolvedValue(createMockOpenDevice())
+    const opened = await openHidDevice(0x1234, 0x5678)
+    expect(opened).toBe(true)
+
+    // sendReceive should now go through the real (mocked) device, not the virtual one.
+    mockRead.mockResolvedValue(Buffer.alloc(MSG_LEN))
+    await sendReceive([0x01])
+    expect(mockWrite).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/__tests__/virtual-device-dataset.test.ts
+++ b/src/main/__tests__/virtual-device-dataset.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+// `keycodes.ts` must be the first module to touch this dependency pair —
+// it pulls in keycodes-utils.ts at its own tail to run one-time init.
+// Importing keycodes-utils.ts first would re-enter it mid-evaluation via
+// that tail import and trip a TDZ error on its module-level `let` state.
+import { setProtocolValue } from '../../shared/keycodes/keycodes'
+import { resolve } from '../../shared/keycodes/keycodes-utils'
+import { decompressLzma } from '../lzma'
+import {
+  LAYERS,
+  ROWS,
+  COLS,
+  MACRO_BUFFER_SIZE,
+  VIALRGB_SUPPORTED_EFFECTS,
+  buildDefaultKeymap,
+  buildDefaultMacroBuffer,
+  getCompressedDefinition,
+} from '../virtual-device/gpk60-63r'
+
+describe('buildDefaultKeymap', () => {
+  it('has length LAYERS * ROWS * COLS', () => {
+    const keymap = buildDefaultKeymap()
+    expect(keymap.length).toBe(LAYERS * ROWS * COLS)
+  })
+
+  it('sets (layer 0, row 0, col 0) to Escape', () => {
+    setProtocolValue(6)
+    const keymap = buildDefaultKeymap()
+    const index = (0 * ROWS + 0) * COLS + 0
+    expect(keymap[index]).toBe(resolve('KC_ESCAPE'))
+  })
+
+  it('sets LT(1, KC_SPACE) at (layer 0, row 4, col 4)', () => {
+    setProtocolValue(6)
+    const keymap = buildDefaultKeymap()
+    const index = (0 * ROWS + 4) * COLS + 4
+    const expected = resolve('QK_LAYER_TAP') | ((1 & 0x0f) << 8) | (resolve('KC_SPACE') & 0xff)
+    expect(keymap[index]).toBe(expected)
+  })
+
+  it('sets USER00 on layer 2 at row 2 col 0', () => {
+    setProtocolValue(6)
+    const keymap = buildDefaultKeymap()
+    const index = (2 * ROWS + 2) * COLS + 0
+    expect(keymap[index]).toBe(resolve('USER00'))
+  })
+
+  it('leaves physically-unused positions as KC_NO', () => {
+    const keymap = buildDefaultKeymap()
+    const unused: [number, number][] = [
+      [2, 13],
+      [3, 12],
+      [3, 13],
+      [4, 3],
+      [4, 5],
+      [4, 12],
+      [4, 13],
+    ]
+    for (const [row, col] of unused) {
+      for (let layer = 0; layer < LAYERS; layer++) {
+        const index = (layer * ROWS + row) * COLS + col
+        expect(keymap[index]).toBe(0)
+      }
+    }
+  })
+
+  it('layer 3 is entirely KC_NO', () => {
+    const keymap = buildDefaultKeymap()
+    for (let row = 0; row < ROWS; row++) {
+      for (let col = 0; col < COLS; col++) {
+        const index = (3 * ROWS + row) * COLS + col
+        expect(keymap[index]).toBe(0)
+      }
+    }
+  })
+})
+
+describe('buildDefaultMacroBuffer', () => {
+  it('is exactly MACRO_BUFFER_SIZE bytes', () => {
+    const buffer = buildDefaultMacroBuffer()
+    expect(buffer.length).toBe(MACRO_BUFFER_SIZE)
+  })
+
+  it('starts with the "Hello" text macro terminated by NUL', () => {
+    const buffer = buildDefaultMacroBuffer()
+    const text = Array.from(buffer.subarray(0, 5)).map((b) => String.fromCharCode(b)).join('')
+    expect(text).toBe('Hello')
+    expect(buffer[5]).toBe(0x00)
+  })
+})
+
+describe('VIALRGB_SUPPORTED_EFFECTS', () => {
+  it('is ascending, starts at 0, and excludes DIRECT (1)', () => {
+    expect(VIALRGB_SUPPORTED_EFFECTS[0]).toBe(0)
+    expect(VIALRGB_SUPPORTED_EFFECTS).not.toContain(1)
+    for (let i = 1; i < VIALRGB_SUPPORTED_EFFECTS.length; i++) {
+      expect(VIALRGB_SUPPORTED_EFFECTS[i]).toBeGreaterThan(VIALRGB_SUPPORTED_EFFECTS[i - 1])
+    }
+    expect(VIALRGB_SUPPORTED_EFFECTS.length).toBeGreaterThanOrEqual(20)
+  })
+})
+
+describe('getCompressedDefinition', () => {
+  it('round-trips through LZMA decompression to the virtual definition JSON', async () => {
+    const compressed = await getCompressedDefinition()
+    const jsonStr = await decompressLzma(Array.from(compressed))
+    expect(jsonStr).not.toBeNull()
+    const parsed = JSON.parse(jsonStr!) as { name: string; matrix: { rows: number; cols: number } }
+    expect(parsed.name).toBe('GPK60-63R Virtual')
+    expect(parsed.matrix.rows).toBe(5)
+    expect(parsed.matrix.cols).toBe(14)
+  })
+
+  it('caches the result across calls', async () => {
+    const first = await getCompressedDefinition()
+    const second = await getCompressedDefinition()
+    expect(second).toBe(first)
+  })
+})

--- a/src/main/__tests__/virtual-device-index.test.ts
+++ b/src/main/__tests__/virtual-device-index.test.ts
@@ -89,6 +89,19 @@ describe('getVirtualDeviceController', () => {
     controller.releaseAll()
   })
 
+  it('setUnlockCounterMax clamps a countdown already in progress', async () => {
+    await openVirtualDevice()
+    const controller = getVirtualDeviceController()
+    controller.reset()
+
+    // unlock start (0xFE 0x06) arms the countdown at the default max of 50
+    handleVirtualReport([0xfe, 0x06])
+    expect(controller.getState().unlockCounter).toBe(50)
+
+    controller.setUnlockCounterMax(3)
+    expect(controller.getState().unlockCounter).toBe(3)
+  })
+
   it('reset() restores factory defaults (relocked, empty matrix)', async () => {
     await openVirtualDevice()
     const controller = getVirtualDeviceController()

--- a/src/main/__tests__/virtual-device-index.test.ts
+++ b/src/main/__tests__/virtual-device-index.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  isVirtualDeviceEnabled,
+  getVirtualDeviceInfo,
+  matchesVirtualDevice,
+  openVirtualDevice,
+  closeVirtualDevice,
+  isVirtualDeviceOpen,
+  handleVirtualReport,
+  getVirtualDeviceController,
+} from '../virtual-device/index'
+import { VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID, VIRTUAL_DEVICE_NAME } from '../virtual-device/gpk60-63r'
+import { MSG_LEN } from '../../shared/constants/protocol'
+
+beforeEach(async () => {
+  await closeHelper()
+})
+
+afterEach(async () => {
+  await closeHelper()
+  vi.unstubAllEnvs()
+})
+
+async function closeHelper(): Promise<void> {
+  closeVirtualDevice()
+}
+
+describe('isVirtualDeviceEnabled', () => {
+  it('reads the env var live', () => {
+    vi.stubEnv('PIPETTE_VIRTUAL_DEVICE', '1')
+    expect(isVirtualDeviceEnabled()).toBe(true)
+    vi.stubEnv('PIPETTE_VIRTUAL_DEVICE', '0')
+    expect(isVirtualDeviceEnabled()).toBe(false)
+  })
+})
+
+describe('getVirtualDeviceInfo / matchesVirtualDevice', () => {
+  it('reports the virtual device identity', () => {
+    const info = getVirtualDeviceInfo()
+    expect(info.vendorId).toBe(VIRTUAL_DEVICE_VID)
+    expect(info.productId).toBe(VIRTUAL_DEVICE_PID)
+    expect(info.productName).toBe(VIRTUAL_DEVICE_NAME)
+    expect(info.type).toBe('vial')
+  })
+
+  it('matches only the virtual vid/pid pair', () => {
+    expect(matchesVirtualDevice(VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID)).toBe(true)
+    expect(matchesVirtualDevice(0x1234, 0x5678)).toBe(false)
+  })
+})
+
+describe('open/close lifecycle', () => {
+  it('is closed until openVirtualDevice() resolves', async () => {
+    expect(isVirtualDeviceOpen()).toBe(false)
+    await openVirtualDevice()
+    expect(isVirtualDeviceOpen()).toBe(true)
+    closeVirtualDevice()
+    expect(isVirtualDeviceOpen()).toBe(false)
+  })
+
+  it('handleVirtualReport throws when not open', () => {
+    expect(() => handleVirtualReport([0x01])).toThrow('not open')
+  })
+
+  it('handleVirtualReport answers a protocol-version request once open', async () => {
+    await openVirtualDevice()
+    const resp = handleVirtualReport([0x01])
+    expect(resp.length).toBe(MSG_LEN)
+    expect((resp[1] << 8) | resp[2]).toBe(9)
+  })
+})
+
+describe('getVirtualDeviceController', () => {
+  it('press/release/tap/holdKeys mutate matrix state reflected via the matrix report', async () => {
+    await openVirtualDevice()
+    const controller = getVirtualDeviceController()
+    controller.reset()
+    controller.getState() // touches state without side effects beyond read
+
+    controller.setUnlockCounterMax(2)
+    controller.holdKeys([[0, 0], [0, 1]])
+
+    const status = controller.getState()
+    expect(status.open).toBe(true)
+    expect(status.unlocked).toBe(false)
+
+    controller.releaseAll()
+  })
+
+  it('reset() restores factory defaults (relocked, empty matrix)', async () => {
+    await openVirtualDevice()
+    const controller = getVirtualDeviceController()
+    controller.pressKey(0, 0)
+    controller.reset()
+    const status = controller.getState()
+    expect(status.unlocked).toBe(false)
+    expect(status.unlockInProgress).toBe(false)
+  })
+})

--- a/src/main/__tests__/virtual-device-state.test.ts
+++ b/src/main/__tests__/virtual-device-state.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { ROWS, COLS, MACRO_BUFFER_SIZE, LAYERS } from '../virtual-device/gpk60-63r'
+import {
+  createVirtualDeviceState,
+  pressKey,
+  releaseKey,
+  releaseAll,
+  isHoldingUnlockCombo,
+  unlockPollTick,
+  packMatrixState,
+  keymapIndex,
+} from '../virtual-device/state'
+
+describe('createVirtualDeviceState', () => {
+  it('starts locked with a full unlock counter', () => {
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+    expect(state.unlockInProgress).toBe(false)
+    expect(state.unlockCounter).toBe(state.unlockCounterMax)
+  })
+
+  it('has a keymap of the expected size and an empty matrix', () => {
+    const state = createVirtualDeviceState()
+    expect(state.keymap.length).toBe(LAYERS * ROWS * COLS)
+    expect(state.macroBuffer.length).toBe(MACRO_BUFFER_SIZE)
+    expect(state.matrix.length).toBe(ROWS)
+    expect(state.matrix[0].length).toBe(COLS)
+    expect(state.matrix.every((row) => row.every((v) => v === false))).toBe(true)
+  })
+})
+
+describe('pressKey / releaseKey / releaseAll', () => {
+  it('tracks individual key state', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 2, 3)
+    expect(state.matrix[2][3]).toBe(true)
+    releaseKey(state, 2, 3)
+    expect(state.matrix[2][3]).toBe(false)
+  })
+
+  it('ignores out-of-range positions', () => {
+    const state = createVirtualDeviceState()
+    expect(() => pressKey(state, 99, 99)).not.toThrow()
+    expect(() => releaseKey(state, -1, -1)).not.toThrow()
+  })
+
+  it('releaseAll clears every pressed key', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 0, 0)
+    pressKey(state, 4, 11)
+    releaseAll(state)
+    expect(state.matrix.every((row) => row.every((v) => v === false))).toBe(true)
+  })
+})
+
+describe('isHoldingUnlockCombo', () => {
+  it('is true only when both combo keys (0,0) and (0,1) are held', () => {
+    const state = createVirtualDeviceState()
+    expect(isHoldingUnlockCombo(state)).toBe(false)
+    pressKey(state, 0, 0)
+    expect(isHoldingUnlockCombo(state)).toBe(false)
+    pressKey(state, 0, 1)
+    expect(isHoldingUnlockCombo(state)).toBe(true)
+    releaseKey(state, 0, 0)
+    expect(isHoldingUnlockCombo(state)).toBe(false)
+  })
+})
+
+describe('unlockPollTick', () => {
+  it('does nothing when no unlock sequence is in progress', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 1)
+    unlockPollTick(state, 1000)
+    expect(state.unlockCounter).toBe(state.unlockCounterMax)
+    expect(state.unlocked).toBe(false)
+  })
+
+  it('decrements the counter on 200ms-spaced polls while the combo is held', () => {
+    const state = createVirtualDeviceState()
+    state.unlockCounterMax = 3
+    state.unlockCounter = 3
+    state.unlockInProgress = true
+    state.unlockTimer = 0
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 1)
+
+    unlockPollTick(state, 200)
+    expect(state.unlockCounter).toBe(2)
+    expect(state.unlocked).toBe(false)
+
+    unlockPollTick(state, 400)
+    expect(state.unlockCounter).toBe(1)
+    expect(state.unlocked).toBe(false)
+
+    unlockPollTick(state, 600)
+    expect(state.unlockCounter).toBe(0)
+    expect(state.unlocked).toBe(true)
+    expect(state.unlockInProgress).toBe(false)
+  })
+
+  it('does not decrement when polls are spaced less than 100ms apart', () => {
+    const state = createVirtualDeviceState()
+    state.unlockCounterMax = 5
+    state.unlockCounter = 5
+    state.unlockInProgress = true
+    state.unlockTimer = 0
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 1)
+
+    unlockPollTick(state, 50)
+    expect(state.unlockCounter).toBe(5)
+  })
+
+  it('resets the counter to max when a combo key is released mid-sequence', () => {
+    const state = createVirtualDeviceState()
+    state.unlockCounterMax = 5
+    state.unlockCounter = 2
+    state.unlockInProgress = true
+    state.unlockTimer = 0
+    pressKey(state, 0, 0)
+    // (0,1) not held
+
+    unlockPollTick(state, 200)
+    expect(state.unlockCounter).toBe(5)
+    expect(state.unlocked).toBe(false)
+  })
+
+  it('lock() equivalent: setting unlocked=false relocks regardless of counter', () => {
+    const state = createVirtualDeviceState()
+    state.unlocked = true
+    state.unlocked = false
+    expect(state.unlocked).toBe(false)
+  })
+})
+
+describe('packMatrixState', () => {
+  it('packs pressed keys into BE16-per-row byte pairs', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 0, 0)
+    const bytes = packMatrixState(state)
+    // row 0: bit 0 set -> low byte 0x01, high byte 0x00
+    expect(bytes[0]).toBe(0x00)
+    expect(bytes[1]).toBe(0x01)
+  })
+
+  it('packs col 13 into the high byte bit 5', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 0, 13)
+    const bytes = packMatrixState(state)
+    expect(bytes[0]).toBe(1 << (13 - 8))
+    expect(bytes[1]).toBe(0x00)
+  })
+
+  it('packs col 11 (row 4) into the high byte bit 3', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 4, 11)
+    const bytes = packMatrixState(state)
+    expect(bytes[4 * 2]).toBe(1 << (11 - 8))
+    expect(bytes[4 * 2 + 1]).toBe(0x00)
+  })
+})
+
+describe('keymapIndex', () => {
+  it('computes layer-major, row-major, col-order flat index', () => {
+    expect(keymapIndex(0, 0, 0)).toBe(0)
+    expect(keymapIndex(0, 0, 1)).toBe(1)
+    expect(keymapIndex(1, 0, 0)).toBe(ROWS * COLS)
+  })
+})

--- a/src/main/__tests__/virtual-device-state.test.ts
+++ b/src/main/__tests__/virtual-device-state.test.ts
@@ -101,17 +101,20 @@ describe('unlockPollTick', () => {
     expect(state.unlockInProgress).toBe(false)
   })
 
-  it('does not decrement when polls are spaced less than 100ms apart', () => {
+  it('resets the counter to max when a held poll arrives less than 100ms after the last decrement', () => {
     const state = createVirtualDeviceState()
     state.unlockCounterMax = 5
-    state.unlockCounter = 5
+    state.unlockCounter = 3 // already decremented from a prior qualifying tick
     state.unlockInProgress = true
     state.unlockTimer = 0
     pressKey(state, 0, 0)
     pressKey(state, 0, 1)
 
+    // Still holding, but only 50ms since the last decrementing tick: firmware
+    // treats this as a non-qualifying poll and throws away all progress.
     unlockPollTick(state, 50)
     expect(state.unlockCounter).toBe(5)
+    expect(state.unlocked).toBe(false)
   })
 
   it('resets the counter to max when a combo key is released mid-sequence', () => {
@@ -125,6 +128,32 @@ describe('unlockPollTick', () => {
 
     unlockPollTick(state, 200)
     expect(state.unlockCounter).toBe(5)
+    expect(state.unlocked).toBe(false)
+  })
+
+  it('does not carry progress from before a release once the combo is re-pressed', () => {
+    const state = createVirtualDeviceState()
+    state.unlockCounterMax = 5
+    state.unlockCounter = 5
+    state.unlockInProgress = true
+    state.unlockTimer = 0
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 1)
+
+    // Held long enough: one qualifying decrement, counter -> max - 1.
+    unlockPollTick(state, 200)
+    expect(state.unlockCounter).toBe(4)
+
+    // Release resets the counter back to max (unlockTimer is left stale at 200).
+    releaseKey(state, 0, 1)
+    unlockPollTick(state, 210)
+    expect(state.unlockCounter).toBe(5)
+
+    // Re-press and poll shortly after — relative to the stale timer this is
+    // still < 100ms, so it must not decrement further, let alone unlock.
+    pressKey(state, 0, 1)
+    unlockPollTick(state, 260)
+    expect(state.unlockCounter).toBeGreaterThanOrEqual(4)
     expect(state.unlocked).toBe(false)
   })
 

--- a/src/main/__tests__/virtual-device-via-handler.test.ts
+++ b/src/main/__tests__/virtual-device-via-handler.test.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { MSG_LEN, BUFFER_FETCH_CHUNK } from '../../shared/constants/protocol'
+import { setProtocolValue } from '../../shared/keycodes/keycodes'
+import { resolve } from '../../shared/keycodes/keycodes-utils'
+import { ROWS, COLS, LAYERS, MACRO_BUFFER_SIZE } from '../virtual-device/gpk60-63r'
+import { createVirtualDeviceState, pressKey, keymapIndex } from '../virtual-device/state'
+import { handleViaReport } from '../virtual-device/via-handler'
+import { readBE16, writeBE16, readBE32, writeBE32 } from '../virtual-device/byte-utils'
+
+function req(...bytes: number[]): Uint8Array {
+  const buf = new Uint8Array(MSG_LEN)
+  buf.set(bytes.slice(0, MSG_LEN))
+  return buf
+}
+
+describe('handleViaReport', () => {
+  it('CMD_VIA_GET_PROTOCOL_VERSION returns BE16 9', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleViaReport(state, req(0x01))
+    expect(readBE16(resp, 1)).toBe(9)
+  })
+
+  it('CMD_VIA_GET_LAYER_COUNT returns 4', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleViaReport(state, req(0x11))
+    expect(resp[1]).toBe(LAYERS)
+  })
+
+  it('layout options round-trip through set/get', () => {
+    const state = createVirtualDeviceState()
+    const setReq = req(0x03, 0x02)
+    writeBE32(setReq, 2, 0xabcd1234)
+    handleViaReport(state, setReq)
+    expect(state.layoutOptions).toBe(0xabcd1234)
+
+    const getResp = handleViaReport(state, req(0x02, 0x02))
+    expect(readBE32(getResp, 2)).toBe(0xabcd1234)
+  })
+
+  it('fetches the full keymap buffer in 28-byte chunks, including an odd offset', () => {
+    const state = createVirtualDeviceState()
+    const totalBytes = LAYERS * ROWS * COLS * 2
+    const collected: number[] = []
+    for (let offset = 0; offset < totalBytes; offset += BUFFER_FETCH_CHUNK) {
+      const chunkSize = Math.min(BUFFER_FETCH_CHUNK, totalBytes - offset)
+      const r = new Uint8Array(MSG_LEN)
+      r[0] = 0x12
+      writeBE16(r, 1, offset)
+      r[3] = chunkSize
+      const resp = handleViaReport(state, r)
+      for (let i = 0; i < chunkSize; i++) collected.push(resp[4 + i])
+    }
+    expect(collected.length).toBe(totalBytes)
+    for (let i = 0; i < state.keymap.length; i++) {
+      const value = (collected[i * 2] << 8) | collected[i * 2 + 1]
+      expect(value).toBe(state.keymap[i])
+    }
+
+    // Odd-offset fetch mid-buffer should reassemble to the same bytes.
+    const oddOffset = 5
+    const oddReq = new Uint8Array(MSG_LEN)
+    oddReq[0] = 0x12
+    writeBE16(oddReq, 1, oddOffset)
+    oddReq[3] = 10
+    const oddResp = handleViaReport(state, oddReq)
+    for (let i = 0; i < 10; i++) {
+      expect(oddResp[4 + i]).toBe(collected[oddOffset + i])
+    }
+  })
+
+  it('setKeycode is reflected in the keymap buffer', () => {
+    const state = createVirtualDeviceState()
+    const setReq = req(0x05, 0, 1, 2)
+    writeBE16(setReq, 4, 0x1234)
+    handleViaReport(state, setReq)
+    expect(state.keymap[keymapIndex(0, 1, 2)]).toBe(0x1234)
+
+    const getReq = req(0x04, 0, 1, 2)
+    const getResp = handleViaReport(state, getReq)
+    expect(readBE16(getResp, 4)).toBe(0x1234)
+  })
+
+  it('blocks setting QK_BOOT while locked (stores KC_NO instead)', () => {
+    setProtocolValue(6)
+    const qkBoot = resolve('QK_BOOT')
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+
+    const setReq = req(0x05, 0, 0, 0)
+    writeBE16(setReq, 4, qkBoot)
+    handleViaReport(state, setReq)
+    expect(state.keymap[keymapIndex(0, 0, 0)]).toBe(0)
+  })
+
+  it('allows setting QK_BOOT once unlocked', () => {
+    setProtocolValue(6)
+    const qkBoot = resolve('QK_BOOT')
+    const state = createVirtualDeviceState()
+    state.unlocked = true
+
+    const setReq = req(0x05, 0, 0, 0)
+    writeBE16(setReq, 4, qkBoot)
+    handleViaReport(state, setReq)
+    expect(state.keymap[keymapIndex(0, 0, 0)]).toBe(qkBoot)
+  })
+
+  it('macro buffer round-trips through set/get in chunks', () => {
+    const state = createVirtualDeviceState()
+    const sample = new Uint8Array(MACRO_BUFFER_SIZE)
+    for (let i = 0; i < sample.length; i++) sample[i] = i % 256
+
+    for (let offset = 0; offset < sample.length; offset += BUFFER_FETCH_CHUNK) {
+      const chunkSize = Math.min(BUFFER_FETCH_CHUNK, sample.length - offset)
+      const r = new Uint8Array(MSG_LEN)
+      r[0] = 0x0f
+      writeBE16(r, 1, offset)
+      r[3] = chunkSize
+      r.set(sample.subarray(offset, offset + chunkSize), 4)
+      handleViaReport(state, r)
+    }
+
+    expect(Array.from(state.macroBuffer)).toEqual(Array.from(sample))
+
+    const collected: number[] = []
+    for (let offset = 0; offset < sample.length; offset += BUFFER_FETCH_CHUNK) {
+      const chunkSize = Math.min(BUFFER_FETCH_CHUNK, sample.length - offset)
+      const r = new Uint8Array(MSG_LEN)
+      r[0] = 0x0e
+      writeBE16(r, 1, offset)
+      r[3] = chunkSize
+      const resp = handleViaReport(state, r)
+      for (let i = 0; i < chunkSize; i++) collected.push(resp[4 + i])
+    }
+    expect(collected).toEqual(Array.from(sample))
+  })
+
+  it('matrix request while locked returns the request unchanged (echo)', () => {
+    const state = createVirtualDeviceState()
+    pressKey(state, 0, 0)
+    const r = req(0x02, 0x03)
+    const resp = handleViaReport(state, r)
+    expect(Array.from(resp)).toEqual(Array.from(r))
+  })
+
+  it('matrix request while unlocked reflects pressed keys at (0,0), (0,13), (4,11)', () => {
+    const state = createVirtualDeviceState()
+    state.unlocked = true
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 13)
+    pressKey(state, 4, 11)
+
+    const resp = handleViaReport(state, req(0x02, 0x03))
+    // row 0: bit0 (col0) low byte, bit5 (col13-8) high byte
+    expect(resp[2]).toBe(1 << 5)
+    expect(resp[3]).toBe(0x01)
+    // row 4: bit3 (col11-8) high byte
+    expect(resp[2 + 4 * 2]).toBe(1 << 3)
+    expect(resp[2 + 4 * 2 + 1]).toBe(0x00)
+  })
+})

--- a/src/main/__tests__/virtual-device-vial-handler.test.ts
+++ b/src/main/__tests__/virtual-device-vial-handler.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { MSG_LEN } from '../../shared/constants/protocol'
+import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO } from '../virtual-device/gpk60-63r'
+import { createVirtualDeviceState, pressKey } from '../virtual-device/state'
+import { handleVialReport } from '../virtual-device/vial-handler'
+import { writeLE32 } from '../virtual-device/byte-utils'
+
+function req(...bytes: number[]): Uint8Array {
+  const buf = new Uint8Array(MSG_LEN)
+  buf.set(bytes.slice(0, MSG_LEN))
+  return buf
+}
+
+const FAKE_COMPRESSED = new Uint8Array(70)
+for (let i = 0; i < FAKE_COMPRESSED.length; i++) FAKE_COMPRESSED[i] = (i * 3 + 7) % 256
+
+describe('handleVialReport', () => {
+  it('keyboard id: LE32 protocol, UID bytes, VialRGB flag', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x00), FAKE_COMPRESSED, 0)
+    const protocol = resp[0] | (resp[1] << 8) | (resp[2] << 16) | (resp[3] << 24)
+    expect(protocol).toBe(VIAL_PROTOCOL)
+    expect(Array.from(resp.subarray(4, 12))).toEqual(Array.from(VIRTUAL_DEVICE_UID_BYTES))
+    expect(resp[12]).toBe(1)
+  })
+
+  it('definition size + block reassembly equals the compressed buffer', () => {
+    const state = createVirtualDeviceState()
+    const sizeResp = handleVialReport(state, req(0xfe, 0x01), FAKE_COMPRESSED, 0)
+    const size = sizeResp[0] | (sizeResp[1] << 8) | (sizeResp[2] << 16) | (sizeResp[3] << 24)
+    expect(size).toBe(FAKE_COMPRESSED.length)
+
+    const blocks = Math.ceil(size / MSG_LEN)
+    const reassembled = new Uint8Array(size)
+    for (let block = 0; block < blocks; block++) {
+      const blockReq = new Uint8Array(MSG_LEN)
+      blockReq[0] = 0xfe
+      blockReq[1] = 0x02
+      writeLE32(blockReq, 2, block)
+      const resp = handleVialReport(state, blockReq, FAKE_COMPRESSED, 0)
+      const copyLen = Math.min(MSG_LEN, size - block * MSG_LEN)
+      reassembled.set(resp.subarray(0, copyLen), block * MSG_LEN)
+    }
+    expect(Array.from(reassembled)).toEqual(Array.from(FAKE_COMPRESSED))
+  })
+
+  it('unlock status: 0xFF-filled with unlocked/inProgress bytes and combo pairs', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x05), FAKE_COMPRESSED, 0)
+    expect(resp[0]).toBe(0) // locked
+    expect(resp[1]).toBe(0) // not in progress
+    for (let i = 0; i < VIRTUAL_DEVICE_UNLOCK_COMBO.length; i++) {
+      expect(resp[2 + i * 2]).toBe(VIRTUAL_DEVICE_UNLOCK_COMBO[i][0])
+      expect(resp[3 + i * 2]).toBe(VIRTUAL_DEVICE_UNLOCK_COMBO[i][1])
+    }
+    // Remaining slots are 0xFF sentinel pairs
+    const usedSlots = VIRTUAL_DEVICE_UNLOCK_COMBO.length
+    expect(resp[2 + usedSlots * 2]).toBe(0xff)
+    expect(resp[3 + usedSlots * 2]).toBe(0xff)
+  })
+
+  it('unlock start + poll sequence progresses the counter and eventually unlocks', () => {
+    const state = createVirtualDeviceState()
+    state.unlockCounterMax = 2
+    pressKey(state, 0, 0)
+    pressKey(state, 0, 1)
+
+    handleVialReport(state, req(0xfe, 0x06), FAKE_COMPRESSED, 0)
+    expect(state.unlockInProgress).toBe(true)
+
+    let resp = handleVialReport(state, req(0xfe, 0x07), FAKE_COMPRESSED, 200)
+    expect(resp[0]).toBe(0)
+    expect(resp[2]).toBe(1)
+
+    resp = handleVialReport(state, req(0xfe, 0x07), FAKE_COMPRESSED, 400)
+    expect(resp[0]).toBe(1)
+    expect(resp[2]).toBe(0)
+    expect(state.unlocked).toBe(true)
+  })
+
+  it('lock resets unlocked to false', () => {
+    const state = createVirtualDeviceState()
+    state.unlocked = true
+    handleVialReport(state, req(0xfe, 0x08), FAKE_COMPRESSED, 0)
+    expect(state.unlocked).toBe(false)
+  })
+
+  it('qmk settings query returns an all-0xFF response', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x09, 0x00, 0x00), FAKE_COMPRESSED, 0)
+    expect(Array.from(resp)).toEqual(new Array(MSG_LEN).fill(0xff))
+  })
+
+  it('dynamic entry counts are all zero', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x0d, 0x00), FAKE_COMPRESSED, 0)
+    expect(Array.from(resp)).toEqual(new Array(MSG_LEN).fill(0))
+  })
+
+  it('encoder get (sub 0x03) is a pure echo', () => {
+    const state = createVirtualDeviceState()
+    const r = req(0xfe, 0x03, 0, 1)
+    const resp = handleVialReport(state, r, FAKE_COMPRESSED, 0)
+    expect(resp.subarray(0, 4)).toEqual(r.subarray(0, 4))
+  })
+})

--- a/src/main/__tests__/virtual-device-vialrgb-handler.test.ts
+++ b/src/main/__tests__/virtual-device-vialrgb-handler.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { MSG_LEN, VIALRGB_GET_INFO, VIALRGB_GET_MODE, VIALRGB_GET_SUPPORTED, VIALRGB_SET_MODE } from '../../shared/constants/protocol'
+import { VIALRGB_SUPPORTED_EFFECTS } from '../virtual-device/gpk60-63r'
+import { createVirtualDeviceState } from '../virtual-device/state'
+import { getLightingValue, setLightingValue } from '../virtual-device/vialrgb-handler'
+import { readLE16, writeLE16 } from '../virtual-device/byte-utils'
+
+function req(...bytes: number[]): Uint8Array {
+  const buf = new Uint8Array(MSG_LEN)
+  buf.set(bytes.slice(0, MSG_LEN))
+  return buf
+}
+
+describe('getLightingValue', () => {
+  it('VIALRGB_GET_INFO returns LE16 protocol version and max brightness', () => {
+    const state = createVirtualDeviceState()
+    const r = req(0x08, VIALRGB_GET_INFO)
+    const resp = getLightingValue(state, r, new Uint8Array(r))
+    expect(readLE16(resp, 2)).toBe(1)
+    expect(resp[4]).toBe(255)
+  })
+
+  it('VIALRGB_GET_MODE reflects current state', () => {
+    const state = createVirtualDeviceState()
+    state.rgb = { mode: 7, speed: 100, hue: 50, sat: 200, val: 150 }
+    const r = req(0x08, VIALRGB_GET_MODE)
+    const resp = getLightingValue(state, r, new Uint8Array(r))
+    expect(readLE16(resp, 2)).toBe(7)
+    expect(resp[4]).toBe(100)
+    expect(resp[5]).toBe(50)
+    expect(resp[6]).toBe(200)
+    expect(resp[7]).toBe(150)
+  })
+
+  it('VIALRGB_GET_SUPPORTED pagination: gt=0 returns ascending effects greater than 0 (excludes DIRECT)', () => {
+    const state = createVirtualDeviceState()
+    const r = req(0x08, VIALRGB_GET_SUPPORTED)
+    writeLE16(r, 2, 0)
+    const resp = getLightingValue(state, r, new Uint8Array(r))
+
+    const expected = VIALRGB_SUPPORTED_EFFECTS.filter((e) => e > 0)
+    for (let i = 0; i < Math.min(expected.length, 15); i++) {
+      expect(readLE16(resp, 2 + i * 2)).toBe(expected[i])
+    }
+    expect(resp).not.toContain(1) // DIRECT excluded — no byte pair equals 1 as LE16 in the used slots
+
+    // Last page (beyond all known effects) is entirely 0xFF-padded.
+    const beyondReq = req(0x08, VIALRGB_GET_SUPPORTED)
+    writeLE16(beyondReq, 2, 9999)
+    const beyondResp = getLightingValue(state, beyondReq, new Uint8Array(beyondReq))
+    for (let i = 2; i < MSG_LEN; i++) {
+      expect(beyondResp[i]).toBe(0xff)
+    }
+  })
+})
+
+describe('setLightingValue', () => {
+  it('stores mode/speed/hsv from VIALRGB_SET_MODE', () => {
+    const state = createVirtualDeviceState()
+    const r = req(0x07, VIALRGB_SET_MODE)
+    writeLE16(r, 2, 9)
+    r[4] = 111
+    r[5] = 22
+    r[6] = 33
+    r[7] = 44
+    setLightingValue(state, r)
+    expect(state.rgb).toEqual({ mode: 9, speed: 111, hue: 22, sat: 33, val: 44 })
+  })
+
+  it('ignores unrelated lighting set sub-commands', () => {
+    const state = createVirtualDeviceState()
+    const before = { ...state.rgb }
+    setLightingValue(state, req(0x07, 0x99))
+    expect(state.rgb).toEqual(before)
+  })
+})

--- a/src/main/hid-service.ts
+++ b/src/main/hid-service.ts
@@ -29,6 +29,15 @@ import {
 import { logHidPacket } from './logger'
 import type { DeviceInfo, DeviceType, KeyboardDefinition, ProbeResult } from '../shared/types/protocol'
 import { decompressLzma, decompressXz, hasXzMagic } from './lzma'
+import {
+  isVirtualDeviceEnabled,
+  getVirtualDeviceInfo,
+  matchesVirtualDevice,
+  openVirtualDevice,
+  closeVirtualDevice,
+  isVirtualDeviceOpen,
+  handleVirtualReport,
+} from './virtual-device'
 
 let openDevice: HID.HIDAsync | null = null
 let openDevicePath: string | null = null
@@ -110,6 +119,10 @@ export async function listDevices(): Promise<DeviceInfo[]> {
     })
   }
 
+  if (isVirtualDeviceEnabled()) {
+    result.push(getVirtualDeviceInfo())
+  }
+
   return result
 }
 
@@ -130,8 +143,11 @@ function isTransientError(err: Error): boolean {
  * Retries with a delay to work around transient open failures on all platforms.
  */
 export async function openHidDevice(vendorId: number, productId: number): Promise<boolean> {
-  if (openDevice) {
-    await closeHidDevice()
+  await closeHidDevice()
+
+  if (isVirtualDeviceEnabled() && matchesVirtualDevice(vendorId, productId)) {
+    await openVirtualDevice()
+    return true
   }
 
   const devices = await HID.devicesAsync()
@@ -175,6 +191,10 @@ export async function closeHidDevice(): Promise<void> {
   }
   openDevice = null
   openDevicePath = null
+
+  if (isVirtualDeviceEnabled()) {
+    closeVirtualDevice()
+  }
 }
 
 /**
@@ -205,6 +225,14 @@ export function sendReceive(data: number[]): Promise<number[]> {
 
   return prev.then(async () => {
     try {
+      if (isVirtualDeviceOpen()) {
+        const padded = padToMsgLen(data)
+        logHidPacket('TX', new Uint8Array(padded))
+        const result = handleVirtualReport(padded)
+        logHidPacket('RX', new Uint8Array(result))
+        return result
+      }
+
       if (!openDevice) {
         throw new Error('No HID device is open')
       }
@@ -249,6 +277,13 @@ export function send(data: number[]): Promise<void> {
 
   return prev.then(() => {
     try {
+      if (isVirtualDeviceOpen()) {
+        const padded = padToMsgLen(data)
+        logHidPacket('TX', new Uint8Array(padded))
+        handleVirtualReport(padded)
+        return
+      }
+
       if (!openDevice) {
         throw new Error('No HID device is open')
       }
@@ -267,6 +302,7 @@ export function send(data: number[]): Promise<void> {
  * Re-enumerates USB devices to detect physical disconnection.
  */
 export async function isDeviceOpen(): Promise<boolean> {
+  if (isVirtualDeviceOpen()) return true
   if (!openDevice || !openDevicePath) return false
   const devices = await HID.devicesAsync()
   const present = devices.some((d) => d.path === openDevicePath)

--- a/src/main/hid-service.ts
+++ b/src/main/hid-service.ts
@@ -192,9 +192,11 @@ export async function closeHidDevice(): Promise<void> {
   openDevice = null
   openDevicePath = null
 
-  if (isVirtualDeviceEnabled()) {
-    closeVirtualDevice()
-  }
+  // Always clear the virtual-open flag, not just when the feature flag is
+  // currently set: sendReceive()/send()/isDeviceOpen() route on
+  // isVirtualDeviceOpen() alone, so a stale open flag would keep hijacking
+  // HID calls if the env var changes between open and close.
+  closeVirtualDevice()
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,7 @@ import {
 } from './typing-analytics/typing-analytics-service'
 import { registerPreSyncQuitFinalizer, notifyChange } from './sync/sync-service'
 import { secureHandle, secureOn } from './ipc-guard'
+import { isVirtualDeviceEnabled, getVirtualDeviceController } from './virtual-device'
 
 const isDev = !!process.env.ELECTRON_RENDERER_URL
 
@@ -309,6 +310,10 @@ app.whenReady().then(() => {
   log('info', 'Pipette starting')
   setupCsp()
   setupHidIpc()
+  if (isVirtualDeviceEnabled()) {
+    const globalWithVirtualDevice = globalThis as Record<string, unknown>
+    globalWithVirtualDevice.__pipetteVirtualDevice = getVirtualDeviceController()
+  }
   setupFileIO()
   setupSnapshotStore()
   setupAnalyzeFilterStore()

--- a/src/main/virtual-device/byte-utils.ts
+++ b/src/main/virtual-device/byte-utils.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Shared big-endian / little-endian byte helpers for the virtual device
+// protocol handlers. Endianness mixing follows the real firmware/preload
+// contract documented in src/preload/protocol.ts.
+
+export function readBE16(buf: Uint8Array, offset: number): number {
+  return (buf[offset] << 8) | buf[offset + 1]
+}
+
+export function writeBE16(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >> 8) & 0xff
+  buf[offset + 1] = value & 0xff
+}
+
+export function readBE32(buf: Uint8Array, offset: number): number {
+  return ((buf[offset] << 24) | (buf[offset + 1] << 16) | (buf[offset + 2] << 8) | buf[offset + 3]) >>> 0
+}
+
+export function writeBE32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = (value >>> 24) & 0xff
+  buf[offset + 1] = (value >>> 16) & 0xff
+  buf[offset + 2] = (value >>> 8) & 0xff
+  buf[offset + 3] = value & 0xff
+}
+
+export function readLE16(buf: Uint8Array, offset: number): number {
+  return buf[offset] | (buf[offset + 1] << 8)
+}
+
+export function writeLE16(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff
+  buf[offset + 1] = (value >> 8) & 0xff
+}
+
+export function writeLE32(buf: Uint8Array, offset: number, value: number): void {
+  buf[offset] = value & 0xff
+  buf[offset + 1] = (value >> 8) & 0xff
+  buf[offset + 2] = (value >> 16) & 0xff
+  buf[offset + 3] = (value >> 24) & 0xff
+}

--- a/src/main/virtual-device/byte-utils.ts
+++ b/src/main/virtual-device/byte-utils.ts
@@ -27,6 +27,10 @@ export function readLE16(buf: Uint8Array, offset: number): number {
   return buf[offset] | (buf[offset + 1] << 8)
 }
 
+export function readLE32(buf: Uint8Array, offset: number): number {
+  return (buf[offset] | (buf[offset + 1] << 8) | (buf[offset + 2] << 16) | (buf[offset + 3] << 24)) >>> 0
+}
+
 export function writeLE16(buf: Uint8Array, offset: number, value: number): void {
   buf[offset] = value & 0xff
   buf[offset + 1] = (value >> 8) & 0xff

--- a/src/main/virtual-device/gpk60-63r-definition.json
+++ b/src/main/virtual-device/gpk60-63r-definition.json
@@ -1,0 +1,159 @@
+{
+  "name": "GPK60-63R Virtual",
+  "vendorId": "0x7A79",
+  "productId": "0xF063",
+  "lighting": "vialrgb",
+  "matrix": {
+    "rows": 5,
+    "cols": 14
+  },
+  "customKeycodes": [
+    {
+      "shortName": "START\nCOLOR\nLAYER",
+      "title": "START COLOR LAYER",
+      "name": "START_COLOR_LAYER"
+    },
+    {
+      "shortName": "SET\nCOLOR\nLAYER0",
+      "title": "SET COLOR LAYER0",
+      "name": "SET_COLOR_LAYER0"
+    },
+    {
+      "shortName": "SET\nCOLOR\nLAYER1",
+      "title": "SET COLOR LAYER1",
+      "name": "SET_COLOR_LAYER1"
+    },
+    {
+      "shortName": "SET\nCOLOR\nLAYER2",
+      "title": "SET COLOR LAYER2",
+      "name": "SET_COLOR_LAYER2"
+    },
+    {
+      "shortName": "SET\nCOLOR\nLAYER3",
+      "title": "SET COLOR LAYER3",
+      "name": "SET_COLOR_LAYER3"
+    }
+  ],
+  "layouts": {
+    "keymap": [
+      [
+        "0,0",
+        "0,1",
+        "0,2",
+        "0,3",
+        "0,4",
+        "0,5",
+        "0,6",
+        "0,7",
+        "0,8",
+        "0,9",
+        "0,10",
+        "0,11",
+        "0,12",
+        {
+          "w": 2
+        },
+        "0,13"
+      ],
+      [
+        {
+          "w": 1.5
+        },
+        "1,0",
+        "1,1",
+        "1,2",
+        "1,3",
+        "1,4",
+        "1,5",
+        "1,6",
+        "1,7",
+        "1,8",
+        "1,9",
+        "1,10",
+        "1,11",
+        "1,12",
+        {
+          "w": 1.5
+        },
+        "1,13"
+      ],
+      [
+        {
+          "w": 1.75
+        },
+        "2,0",
+        "2,1",
+        "2,2",
+        "2,3",
+        "2,4",
+        "2,5",
+        "2,6",
+        "2,7",
+        "2,8",
+        "2,9",
+        "2,10",
+        "2,11",
+        {
+          "w": 2.25
+        },
+        "2,12"
+      ],
+      [
+        {
+          "w": 2.25
+        },
+        "3,0",
+        "3,1",
+        "3,2",
+        "3,3",
+        "3,4",
+        "3,5",
+        "3,6",
+        "3,7",
+        "3,8",
+        "3,9",
+        "3,10",
+        {
+          "w": 2.75
+        },
+        "3,11"
+      ],
+      [
+        {
+          "w": 1.25
+        },
+        "4,0",
+        {
+          "w": 1.25
+        },
+        "4,1",
+        {
+          "w": 1.5
+        },
+        "4,2",
+        {
+          "w": 2.75
+        },
+        "4,4",
+        {
+          "w": 2.25
+        },
+        "4,6",
+        {
+          "w": 1.25
+        },
+        "4,7",
+        "4,8",
+        {
+          "w": 1.25
+        },
+        "4,9",
+        {
+          "w": 1.5
+        },
+        "4,10",
+        "4,11"
+      ]
+    ]
+  }
+}

--- a/src/main/virtual-device/gpk60-63r.ts
+++ b/src/main/virtual-device/gpk60-63r.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Static dataset for the virtual GPK60-63R emulator.
+// Keymap layers, macro sample data, and identity constants mirror the
+// firmware source (keymaps/vial/keymap.c, keymaps/vial/vial.json) so the
+// emulator's protocol responses are shaped exactly like a physical device.
+
+import * as lzmaModule from 'lzma'
+// `keycodes.ts` must load before `keycodes-utils.ts` — the latter imports
+// from the former at the top, while `keycodes.ts` imports back from
+// `keycodes-utils.ts` at its own tail to run one-time init. Importing
+// `keycodes-utils.ts` first would re-enter it mid-evaluation and trip a
+// TDZ error on its module-level `let` state.
+import { setProtocolValue } from '../../shared/keycodes/keycodes'
+import { resolve, deserialize } from '../../shared/keycodes/keycodes-utils'
+import { SS_QMK_PREFIX, SS_TAP_CODE } from '../../shared/constants/protocol'
+import definitionJson from './gpk60-63r-definition.json'
+
+export const VIRTUAL_DEVICE_VID = 0x7a79
+export const VIRTUAL_DEVICE_PID = 0xf063
+export const VIRTUAL_DEVICE_NAME = 'GPK60-63R Virtual'
+export const VIRTUAL_DEVICE_SERIAL = 'vial:f64c2b3c:virtual'
+export const VIRTUAL_DEVICE_UID_BYTES = new Uint8Array([0x56, 0x49, 0x52, 0x54, 0x47, 0x50, 0x4b, 0x00])
+/** (row, col) pairs — hold both to unlock, matching the firmware's vial unlock combo. */
+export const VIRTUAL_DEVICE_UNLOCK_COMBO: readonly [number, number][] = [
+  [0, 0],
+  [0, 1],
+]
+
+export const VIAL_PROTOCOL = 6
+export const VIA_PROTOCOL = 9
+export const LAYERS = 4
+export const ROWS = 5
+export const COLS = 14
+export const MACRO_COUNT = 16
+export const MACRO_BUFFER_SIZE = 900
+
+/**
+ * Ascending list of VialRGB effect IDs the virtual keyboard reports as
+ * supported. Effect 0 (OFF) is always first; effect 1 (DIRECT) is
+ * deliberately excluded, matching how vial-qmk keyboards commonly omit
+ * DIRECT mode from the VIA UI. The remaining IDs are a representative
+ * spread of real rgb_matrix/vialrgb effect indices — exact values only
+ * matter for ascending order and GET_SUPPORTED pagination.
+ */
+export const VIALRGB_SUPPORTED_EFFECTS: readonly number[] = [
+  0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
+]
+
+// Column indices that have a physical switch, per matrix row (derived from
+// the KLE layout in vial.json — some rows have gaps for wider keys).
+const ROW_COLS: readonly (readonly number[])[] = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13],
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+  [0, 1, 2, 4, 6, 7, 8, 9, 10, 11],
+]
+
+// Layer contents transcribed from keymaps/vial/keymap.c LAYOUT() calls.
+// Plain identifiers use the canonical (non-alias) qmkId so `resolve()` can
+// look them up directly; parenthesized function-call tokens (LT/LCTL/MO)
+// go through `deserialize()`'s expression evaluator instead. Each row's
+// token count matches ROW_COLS[row].length; XXXXXXX in the firmware
+// source is KC_NO here.
+const LAYER_TOKENS: readonly (readonly string[])[][] = [
+  // Layer 0 — base
+  [
+    ['KC_ESCAPE', 'KC_1', 'KC_2', 'KC_3', 'KC_4', 'KC_5', 'KC_6', 'KC_7', 'KC_8', 'KC_9', 'KC_0', 'KC_MINUS', 'KC_EQUAL', 'KC_BSPACE'],
+    ['KC_TAB', 'KC_Q', 'KC_W', 'KC_E', 'KC_R', 'KC_T', 'KC_Y', 'KC_U', 'KC_I', 'KC_O', 'KC_P', 'KC_LBRACKET', 'KC_RBRACKET', 'KC_BSLASH'],
+    ['KC_LCTRL', 'KC_A', 'KC_S', 'KC_D', 'KC_F', 'KC_G', 'KC_H', 'KC_J', 'KC_K', 'KC_L', 'KC_SCOLON', 'KC_QUOTE', 'KC_ENTER'],
+    ['KC_LSHIFT', 'KC_Z', 'KC_X', 'KC_C', 'KC_V', 'KC_B', 'KC_N', 'KC_M', 'KC_COMMA', 'KC_DOT', 'KC_SLASH', 'KC_RSHIFT'],
+    ['LCTL(KC_SPACE)', 'KC_LGUI', 'KC_LALT', 'LT(1, KC_SPACE)', 'LT(1, KC_BSPACE)', 'KC_RALT', 'KC_RGUI', 'KC_APPLICATION', 'MO(1)', 'KC_DELETE'],
+  ],
+  // Layer 1 — Fn
+  [
+    ['KC_GRAVE', 'KC_F1', 'KC_F2', 'KC_F3', 'KC_F4', 'KC_F5', 'KC_F6', 'KC_F7', 'KC_F8', 'KC_F9', 'KC_F10', 'KC_F11', 'KC_F12', 'KC_NO'],
+    ['KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO'],
+    ['KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_LEFT', 'KC_DOWN', 'KC_UP', 'KC_RIGHT', 'KC_NO', 'KC_NO', 'KC_NO'],
+    ['KC_LSHIFT', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_UP', 'KC_NO', 'KC_RSHIFT'],
+    ['KC_NO', 'KC_NO', 'KC_NO', 'KC_LSHIFT', 'KC_LSHIFT', 'KC_LEFT', 'KC_DOWN', 'KC_RIGHT', 'KC_NO', 'MO(2)'],
+  ],
+  // Layer 2 — RGB / custom keycodes / boot
+  [
+    ['KC_NO', 'RGB_VAI', 'RGB_SAI', 'RGB_HUI', 'RGB_SPI', 'RGB_MOD', 'RGB_TOG', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'QK_CLEAR_EEPROM'],
+    ['KC_NO', 'RGB_VAD', 'RGB_SAD', 'RGB_HUD', 'RGB_SPD', 'RGB_RMOD', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO'],
+    ['USER00', 'USER01', 'USER02', 'USER03', 'USER04', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'QK_BOOT'],
+    ['KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO'],
+    ['KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO', 'KC_NO'],
+  ],
+  // Layer 3 — unused, all KC_NO
+  [
+    new Array<string>(14).fill('KC_NO'),
+    new Array<string>(14).fill('KC_NO'),
+    new Array<string>(13).fill('KC_NO'),
+    new Array<string>(12).fill('KC_NO'),
+    new Array<string>(10).fill('KC_NO'),
+  ],
+]
+
+/**
+ * Resolve a keymap.c token to its raw keycode value. Plain identifiers
+ * (e.g. `KC_ESCAPE`) go straight through `resolve()`'s canonical lookup;
+ * function-call tokens (e.g. `LT(1, KC_SPACE)`, `MO(1)`) are evaluated by
+ * `deserialize()`'s expression parser, which resolves its own operands
+ * internally and does not depend on keyboard-specific Keycode registration.
+ */
+function kc(token: string): number {
+  return token.includes('(') ? deserialize(token) : resolve(token)
+}
+
+/** Build the flat 4x5x14 keymap (layer-major, row-major, col order) as raw BE16-ready keycode values. */
+export function buildDefaultKeymap(): Uint16Array {
+  setProtocolValue(VIAL_PROTOCOL)
+  const keymap = new Uint16Array(LAYERS * ROWS * COLS)
+
+  for (let layer = 0; layer < LAYERS; layer++) {
+    for (let row = 0; row < ROWS; row++) {
+      const cols = ROW_COLS[row]
+      const tokens = LAYER_TOKENS[layer][row]
+      for (let i = 0; i < cols.length; i++) {
+        const index = (layer * ROWS + row) * COLS + cols[i]
+        keymap[index] = kc(tokens[i])
+      }
+    }
+  }
+
+  return keymap
+}
+
+/**
+ * Build a sample macro buffer: macro 0 is a plain text macro ("Hello"),
+ * macro 1 is a single tap-KC_A action in Vial v2 (SS_QMK_PREFIX-escaped)
+ * format. Remaining macro slots are empty. Total length is always
+ * MACRO_BUFFER_SIZE, zero-padded.
+ */
+export function buildDefaultMacroBuffer(): Uint8Array {
+  setProtocolValue(VIAL_PROTOCOL)
+  const buffer = new Uint8Array(MACRO_BUFFER_SIZE)
+  let offset = 0
+
+  for (const ch of 'Hello') {
+    buffer[offset++] = ch.charCodeAt(0)
+  }
+  buffer[offset++] = 0x00 // macro 0 terminator
+
+  const kcA = resolve('KC_A') & 0xff
+  buffer[offset++] = SS_QMK_PREFIX
+  buffer[offset++] = SS_TAP_CODE
+  buffer[offset++] = kcA
+  buffer[offset++] = 0x00 // macro 1 terminator
+
+  return buffer
+}
+
+function compressLzma(text: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    try {
+      lzmaModule.compress(text, 1, (result: number[] | null, error?: unknown) => {
+        if (error) {
+          reject(error instanceof Error ? error : new Error(String(error)))
+          return
+        }
+        if (result == null) {
+          reject(new Error('LZMA compression produced no output'))
+          return
+        }
+        // lzma.compress yields a plain array of signed bytes (-128..127).
+        const bytes = new Uint8Array(result.length)
+        for (let i = 0; i < result.length; i++) {
+          bytes[i] = result[i] & 0xff
+        }
+        resolve(bytes)
+      })
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)))
+    }
+  })
+}
+
+let cachedCompressedDefinition: Uint8Array | null = null
+
+/** Lazily compress the JSON keyboard definition (LZMA), caching the result. */
+export async function getCompressedDefinition(): Promise<Uint8Array> {
+  if (cachedCompressedDefinition) return cachedCompressedDefinition
+  const json = JSON.stringify(definitionJson)
+  cachedCompressedDefinition = await compressLzma(json)
+  return cachedCompressedDefinition
+}

--- a/src/main/virtual-device/index.ts
+++ b/src/main/virtual-device/index.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Public API for the virtual GPK60-63R emulator — the seam hid-service.ts
+// calls into, plus a controller exposed to E2E tests for driving key
+// presses and the unlock sequence without real HID hardware.
+
+import { CMD_VIA_VIAL_PREFIX, MSG_LEN } from '../../shared/constants/protocol'
+import type { DeviceInfo } from '../../shared/types/protocol'
+import { VIRTUAL_DEVICE_VID, VIRTUAL_DEVICE_PID, VIRTUAL_DEVICE_NAME, VIRTUAL_DEVICE_SERIAL, getCompressedDefinition } from './gpk60-63r'
+import { createVirtualDeviceState, pressKey, releaseKey, releaseAll } from './state'
+import type { VirtualDeviceState } from './state'
+import { handleViaReport } from './via-handler'
+import { handleVialReport } from './vial-handler'
+
+let state: VirtualDeviceState | null = null
+let compressedDefinition: Uint8Array | null = null
+let open = false
+
+/** Read live (not cached at module load) so tests can toggle the env var per-case. */
+export function isVirtualDeviceEnabled(): boolean {
+  return process.env.PIPETTE_VIRTUAL_DEVICE === '1'
+}
+
+export function getVirtualDeviceInfo(): DeviceInfo {
+  return {
+    vendorId: VIRTUAL_DEVICE_VID,
+    productId: VIRTUAL_DEVICE_PID,
+    productName: VIRTUAL_DEVICE_NAME,
+    serialNumber: VIRTUAL_DEVICE_SERIAL,
+    type: 'vial',
+  }
+}
+
+export function matchesVirtualDevice(vendorId: number, productId: number): boolean {
+  return vendorId === VIRTUAL_DEVICE_VID && productId === VIRTUAL_DEVICE_PID
+}
+
+function ensureState(): VirtualDeviceState {
+  if (!state) state = createVirtualDeviceState()
+  return state
+}
+
+/**
+ * Open the virtual device. State persists across re-opens within the same
+ * process (like a powered-on keyboard keeping its EEPROM) — only `reset()`
+ * on the controller restores factory defaults.
+ */
+export async function openVirtualDevice(): Promise<void> {
+  ensureState()
+  compressedDefinition = await getCompressedDefinition()
+  open = true
+}
+
+export function closeVirtualDevice(): void {
+  open = false
+}
+
+export function isVirtualDeviceOpen(): boolean {
+  return open
+}
+
+/** Handle one raw 32-byte HID report and return the 32-byte response. */
+export function handleVirtualReport(data: number[]): number[] {
+  if (!open || !state || !compressedDefinition) {
+    throw new Error('Virtual device is not open')
+  }
+
+  const req = new Uint8Array(MSG_LEN)
+  for (let i = 0; i < Math.min(data.length, MSG_LEN); i++) {
+    req[i] = data[i]
+  }
+
+  const now = Date.now()
+  const resp =
+    req[0] === CMD_VIA_VIAL_PREFIX
+      ? handleVialReport(state, req, compressedDefinition, now)
+      : handleViaReport(state, req)
+
+  return Array.from(resp)
+}
+
+export interface VirtualDeviceControllerState {
+  open: boolean
+  unlocked: boolean
+  unlockInProgress: boolean
+  unlockCounter: number
+}
+
+export interface VirtualDeviceController {
+  pressKey(row: number, col: number): void
+  releaseKey(row: number, col: number): void
+  tapKey(row: number, col: number, holdMs?: number): Promise<void>
+  releaseAll(): void
+  holdKeys(pairs: [number, number][]): void
+  setUnlockCounterMax(n: number): void
+  getState(): VirtualDeviceControllerState
+  reset(): void
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Exposed on `globalThis.__pipetteVirtualDevice` for Playwright E2E tests to drive. */
+export function getVirtualDeviceController(): VirtualDeviceController {
+  return {
+    pressKey(row, col) {
+      pressKey(ensureState(), row, col)
+    },
+    releaseKey(row, col) {
+      releaseKey(ensureState(), row, col)
+    },
+    async tapKey(row, col, holdMs = 0) {
+      const s = ensureState()
+      pressKey(s, row, col)
+      if (holdMs > 0) await delay(holdMs)
+      releaseKey(s, row, col)
+    },
+    releaseAll() {
+      releaseAll(ensureState())
+    },
+    holdKeys(pairs) {
+      const s = ensureState()
+      for (const [row, col] of pairs) pressKey(s, row, col)
+    },
+    setUnlockCounterMax(n) {
+      ensureState().unlockCounterMax = n
+    },
+    getState() {
+      const s = ensureState()
+      return { open, unlocked: s.unlocked, unlockInProgress: s.unlockInProgress, unlockCounter: s.unlockCounter }
+    },
+    reset() {
+      state = createVirtualDeviceState()
+    },
+  }
+}

--- a/src/main/virtual-device/index.ts
+++ b/src/main/virtual-device/index.ts
@@ -123,7 +123,11 @@ export function getVirtualDeviceController(): VirtualDeviceController {
       for (const [row, col] of pairs) pressKey(s, row, col)
     },
     setUnlockCounterMax(n) {
-      ensureState().unlockCounterMax = n
+      const s = ensureState()
+      s.unlockCounterMax = n
+      // Clamp a countdown already in progress so tests shortening the
+      // sequence take effect immediately instead of after a combo release.
+      if (s.unlockCounter > n) s.unlockCounter = n
     },
     getState() {
       const s = ensureState()

--- a/src/main/virtual-device/state.ts
+++ b/src/main/virtual-device/state.ts
@@ -87,24 +87,26 @@ export function isHoldingUnlockCombo(state: VirtualDeviceState): boolean {
 /**
  * Advance the unlock state machine by one poll tick, given the current
  * clock time (injected for testability — no Date.now() inside).
- * Ported from vial-qmk's vial_unlock_poll():
- *   - no-op if an unlock sequence isn't in progress
- *   - if the combo is held and >= 100ms elapsed since the last tick,
- *     decrement the counter; reaching 0 unlocks the keyboard
- *   - releasing any combo key resets the counter back to its max
+ * Ported from vial-qmk's vial_unlock_poll(), which uses a single if/else:
+ * the counter only decrements when the combo is held AND >= 100ms elapsed
+ * since the last decrementing tick; every other case — combo not held, or
+ * held but polled too soon — resets the counter back to its max. This
+ * enforces a *continuous* hold: any qualifying poll that doesn't land on a
+ * held+elapsed tick throws away all prior progress, so a stale unlockTimer
+ * left over from before a release can never grant free progress once the
+ * combo is re-pressed (the release's own poll already reset the counter).
+ * Reaching 0 unlocks the keyboard.
  */
 export function unlockPollTick(state: VirtualDeviceState, now: number): void {
   if (!state.unlockInProgress) return
 
-  if (isHoldingUnlockCombo(state)) {
-    if (now - state.unlockTimer >= UNLOCK_POLL_MIN_INTERVAL_MS) {
-      state.unlockTimer = now
-      state.unlockCounter--
-      if (state.unlockCounter <= 0) {
-        state.unlockCounter = 0
-        state.unlocked = true
-        state.unlockInProgress = false
-      }
+  if (isHoldingUnlockCombo(state) && now - state.unlockTimer >= UNLOCK_POLL_MIN_INTERVAL_MS) {
+    state.unlockTimer = now
+    state.unlockCounter--
+    if (state.unlockCounter <= 0) {
+      state.unlockCounter = 0
+      state.unlocked = true
+      state.unlockInProgress = false
     }
   } else {
     state.unlockCounter = state.unlockCounterMax

--- a/src/main/virtual-device/state.ts
+++ b/src/main/virtual-device/state.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Matrix / unlock state machine for the virtual GPK60-63R.
+// The unlock sequence mirrors vial-qmk's vial.c vial_unlock_poll(): the
+// keyboard only unlocks after the combo has been held continuously for
+// unlockCounterMax poll ticks spaced >= 100ms apart.
+
+import {
+  LAYERS,
+  ROWS,
+  COLS,
+  VIRTUAL_DEVICE_UNLOCK_COMBO,
+  VIALRGB_SUPPORTED_EFFECTS,
+  buildDefaultKeymap,
+  buildDefaultMacroBuffer,
+} from './gpk60-63r'
+
+export interface VialRGBState {
+  mode: number
+  speed: number
+  hue: number
+  sat: number
+  val: number
+}
+
+export interface VirtualDeviceState {
+  keymap: Uint16Array
+  macroBuffer: Uint8Array
+  layoutOptions: number
+  /** matrix[row][col] — true while the switch is held down. */
+  matrix: boolean[][]
+  unlocked: boolean
+  unlockInProgress: boolean
+  unlockCounter: number
+  unlockCounterMax: number
+  /** Timestamp (ms) of the last unlock poll tick that made progress. */
+  unlockTimer: number
+  rgb: VialRGBState
+}
+
+const UNLOCK_COUNTER_MAX_DEFAULT = 50
+const UNLOCK_POLL_MIN_INTERVAL_MS = 100
+
+function createMatrix(): boolean[][] {
+  return Array.from({ length: ROWS }, () => new Array<boolean>(COLS).fill(false))
+}
+
+export function createVirtualDeviceState(): VirtualDeviceState {
+  return {
+    keymap: buildDefaultKeymap(),
+    macroBuffer: buildDefaultMacroBuffer(),
+    layoutOptions: 0,
+    matrix: createMatrix(),
+    unlocked: false,
+    unlockInProgress: false,
+    unlockCounter: UNLOCK_COUNTER_MAX_DEFAULT,
+    unlockCounterMax: UNLOCK_COUNTER_MAX_DEFAULT,
+    unlockTimer: 0,
+    rgb: {
+      mode: VIALRGB_SUPPORTED_EFFECTS[1] ?? 0,
+      speed: 128,
+      hue: 128,
+      sat: 255,
+      val: 128,
+    },
+  }
+}
+
+export function pressKey(state: VirtualDeviceState, row: number, col: number): void {
+  if (row < 0 || row >= ROWS || col < 0 || col >= COLS) return
+  state.matrix[row][col] = true
+}
+
+export function releaseKey(state: VirtualDeviceState, row: number, col: number): void {
+  if (row < 0 || row >= ROWS || col < 0 || col >= COLS) return
+  state.matrix[row][col] = false
+}
+
+export function releaseAll(state: VirtualDeviceState): void {
+  for (const row of state.matrix) row.fill(false)
+}
+
+/** Returns true only while every key of the unlock combo is currently held. */
+export function isHoldingUnlockCombo(state: VirtualDeviceState): boolean {
+  return VIRTUAL_DEVICE_UNLOCK_COMBO.every(([row, col]) => state.matrix[row]?.[col] === true)
+}
+
+/**
+ * Advance the unlock state machine by one poll tick, given the current
+ * clock time (injected for testability — no Date.now() inside).
+ * Ported from vial-qmk's vial_unlock_poll():
+ *   - no-op if an unlock sequence isn't in progress
+ *   - if the combo is held and >= 100ms elapsed since the last tick,
+ *     decrement the counter; reaching 0 unlocks the keyboard
+ *   - releasing any combo key resets the counter back to its max
+ */
+export function unlockPollTick(state: VirtualDeviceState, now: number): void {
+  if (!state.unlockInProgress) return
+
+  if (isHoldingUnlockCombo(state)) {
+    if (now - state.unlockTimer >= UNLOCK_POLL_MIN_INTERVAL_MS) {
+      state.unlockTimer = now
+      state.unlockCounter--
+      if (state.unlockCounter <= 0) {
+        state.unlockCounter = 0
+        state.unlocked = true
+        state.unlockInProgress = false
+      }
+    }
+  } else {
+    state.unlockCounter = state.unlockCounterMax
+  }
+}
+
+/** Pack the matrix into the VIA switch-matrix-state byte layout (2 bytes per row, big-endian). */
+export function packMatrixState(state: VirtualDeviceState): Uint8Array {
+  const bytes = new Uint8Array(ROWS * 2)
+  for (let row = 0; row < ROWS; row++) {
+    let bits = 0
+    for (let col = 0; col < COLS; col++) {
+      if (state.matrix[row][col]) bits |= 1 << col
+    }
+    bytes[row * 2] = (bits >> 8) & 0xff
+    bytes[row * 2 + 1] = bits & 0xff
+  }
+  return bytes
+}
+
+export function keymapIndex(layer: number, row: number, col: number): number {
+  return (layer * ROWS + row) * COLS + col
+}
+
+/** Every unused/out-of-range keymap position resolves to KC_NO (0). */
+export function isValidKeymapPosition(layer: number, row: number, col: number): boolean {
+  return layer >= 0 && layer < LAYERS && row >= 0 && row < ROWS && col >= 0 && col < COLS
+}

--- a/src/main/virtual-device/via-handler.ts
+++ b/src/main/virtual-device/via-handler.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// VIA protocol command handler for the virtual device (byte0 !== 0xFE).
+// Response starts as an exact copy of the request — an unhandled command
+// falls through unchanged, which is how real firmware "echoes" commands
+// it doesn't support (the app's echo-detection treats that as unsupported).
+
+import { BUFFER_FETCH_CHUNK } from '../../shared/constants/protocol'
+import {
+  CMD_VIA_GET_PROTOCOL_VERSION,
+  CMD_VIA_GET_KEYBOARD_VALUE,
+  CMD_VIA_SET_KEYBOARD_VALUE,
+  CMD_VIA_GET_KEYCODE,
+  CMD_VIA_SET_KEYCODE,
+  CMD_VIA_LIGHTING_GET_VALUE,
+  CMD_VIA_LIGHTING_SET_VALUE,
+  CMD_VIA_LIGHTING_SAVE,
+  CMD_VIA_MACRO_GET_COUNT,
+  CMD_VIA_MACRO_GET_BUFFER_SIZE,
+  CMD_VIA_MACRO_GET_BUFFER,
+  CMD_VIA_MACRO_SET_BUFFER,
+  CMD_VIA_GET_LAYER_COUNT,
+  CMD_VIA_KEYMAP_GET_BUFFER,
+  VIA_LAYOUT_OPTIONS,
+  VIA_SWITCH_MATRIX_STATE,
+} from '../../shared/constants/protocol'
+import { setProtocolValue } from '../../shared/keycodes/keycodes'
+import { resolve } from '../../shared/keycodes/keycodes-utils'
+import { readBE16, writeBE16, readBE32, writeBE32 } from './byte-utils'
+import { VIAL_PROTOCOL, LAYERS, ROWS, COLS, MACRO_COUNT, MACRO_BUFFER_SIZE } from './gpk60-63r'
+import type { VirtualDeviceState } from './state'
+import { isValidKeymapPosition, keymapIndex, packMatrixState } from './state'
+import { getLightingValue, setLightingValue } from './vialrgb-handler'
+
+function isBootKeycode(keycode: number): boolean {
+  setProtocolValue(VIAL_PROTOCOL)
+  return keycode === resolve('QK_BOOT')
+}
+
+export function handleViaReport(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const cmd = req[0]
+
+  switch (cmd) {
+    case CMD_VIA_GET_PROTOCOL_VERSION: {
+      writeBE16(resp, 1, 9)
+      break
+    }
+
+    case CMD_VIA_GET_KEYBOARD_VALUE: {
+      const sub = req[1]
+      if (sub === VIA_LAYOUT_OPTIONS) {
+        writeBE32(resp, 2, state.layoutOptions)
+      } else if (sub === VIA_SWITCH_MATRIX_STATE) {
+        if (state.unlocked) {
+          resp.set(packMatrixState(state), 2)
+        }
+        // Locked: leave the echoed request bytes unchanged, matching firmware.
+      }
+      break
+    }
+
+    case CMD_VIA_SET_KEYBOARD_VALUE: {
+      const sub = req[1]
+      if (sub === VIA_LAYOUT_OPTIONS) {
+        state.layoutOptions = readBE32(req, 2)
+      }
+      break
+    }
+
+    case CMD_VIA_GET_KEYCODE: {
+      const [layer, row, col] = [req[1], req[2], req[3]]
+      const value = isValidKeymapPosition(layer, row, col) ? state.keymap[keymapIndex(layer, row, col)] : 0
+      writeBE16(resp, 4, value)
+      break
+    }
+
+    case CMD_VIA_SET_KEYCODE: {
+      const [layer, row, col] = [req[1], req[2], req[3]]
+      const keycode = readBE16(req, 4)
+      if (isValidKeymapPosition(layer, row, col)) {
+        const blocked = !state.unlocked && isBootKeycode(keycode)
+        state.keymap[keymapIndex(layer, row, col)] = blocked ? 0 : keycode
+      }
+      break
+    }
+
+    case CMD_VIA_GET_LAYER_COUNT: {
+      resp[1] = LAYERS
+      break
+    }
+
+    case CMD_VIA_KEYMAP_GET_BUFFER: {
+      const offset = readBE16(req, 1)
+      const size = Math.min(req[3], BUFFER_FETCH_CHUNK)
+      const keymapBytes = new Uint8Array(LAYERS * ROWS * COLS * 2)
+      for (let i = 0; i < state.keymap.length; i++) {
+        writeBE16(keymapBytes, i * 2, state.keymap[i])
+      }
+      for (let i = 0; i < size; i++) {
+        const srcIndex = offset + i
+        resp[4 + i] = srcIndex < keymapBytes.length ? keymapBytes[srcIndex] : 0
+      }
+      break
+    }
+
+    case CMD_VIA_MACRO_GET_COUNT: {
+      resp[1] = MACRO_COUNT
+      break
+    }
+
+    case CMD_VIA_MACRO_GET_BUFFER_SIZE: {
+      writeBE16(resp, 1, MACRO_BUFFER_SIZE)
+      break
+    }
+
+    case CMD_VIA_MACRO_GET_BUFFER: {
+      const offset = readBE16(req, 1)
+      const size = Math.min(req[3], BUFFER_FETCH_CHUNK)
+      for (let i = 0; i < size; i++) {
+        const srcIndex = offset + i
+        resp[4 + i] = srcIndex < state.macroBuffer.length ? state.macroBuffer[srcIndex] : 0
+      }
+      break
+    }
+
+    case CMD_VIA_MACRO_SET_BUFFER: {
+      const offset = readBE16(req, 1)
+      const size = Math.min(req[3], BUFFER_FETCH_CHUNK)
+      for (let i = 0; i < size; i++) {
+        const dstIndex = offset + i
+        if (dstIndex < state.macroBuffer.length) {
+          state.macroBuffer[dstIndex] = req[4 + i]
+        }
+      }
+      break
+    }
+
+    case CMD_VIA_LIGHTING_GET_VALUE: {
+      getLightingValue(state, req, resp)
+      break
+    }
+
+    case CMD_VIA_LIGHTING_SET_VALUE: {
+      setLightingValue(state, req)
+      break
+    }
+
+    case CMD_VIA_LIGHTING_SAVE: {
+      // No persistent EEPROM to flush — ack only.
+      break
+    }
+
+    default:
+      // Unhandled command: echo request back unchanged.
+      break
+  }
+
+  return resp
+}

--- a/src/main/virtual-device/vial-handler.ts
+++ b/src/main/virtual-device/vial-handler.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Vial protocol command handler for the virtual device (byte0 === 0xFE,
+// byte1 selects the sub-command). Supported commands build their response
+// from a zeroed buffer; unsupported ones echo the request back unchanged
+// so the app's echo-detection correctly reports the feature as absent.
+
+import { MSG_LEN } from '../../shared/constants/protocol'
+import {
+  CMD_VIAL_GET_KEYBOARD_ID,
+  CMD_VIAL_GET_SIZE,
+  CMD_VIAL_GET_DEFINITION,
+  CMD_VIAL_GET_UNLOCK_STATUS,
+  CMD_VIAL_UNLOCK_START,
+  CMD_VIAL_UNLOCK_POLL,
+  CMD_VIAL_LOCK,
+  CMD_VIAL_QMK_SETTINGS_QUERY,
+  CMD_VIAL_DYNAMIC_ENTRY_OP,
+  DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES,
+} from '../../shared/constants/protocol'
+import { writeLE32 } from './byte-utils'
+import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO } from './gpk60-63r'
+import type { VirtualDeviceState } from './state'
+import { unlockPollTick } from './state'
+
+/** VialRGB support flag reported in the keyboard-id response (byte 12). */
+const VIALRGB_FLAG = 1
+const UNLOCK_COMBO_SLOTS = 15
+
+function handleKeyboardId(): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN)
+  writeLE32(resp, 0, VIAL_PROTOCOL)
+  resp.set(VIRTUAL_DEVICE_UID_BYTES, 4)
+  resp[12] = VIALRGB_FLAG
+  return resp
+}
+
+function handleDefinitionSize(compressedLength: number): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN)
+  writeLE32(resp, 0, compressedLength)
+  return resp
+}
+
+function handleDefinitionBlock(req: Uint8Array, compressed: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN)
+  const block = req[2] | (req[3] << 8) | (req[4] << 16) | (req[5] << 24)
+  const start = block * MSG_LEN
+  const copyLen = Math.max(0, Math.min(MSG_LEN, compressed.length - start))
+  for (let i = 0; i < copyLen; i++) {
+    resp[i] = compressed[start + i]
+  }
+  return resp
+}
+
+function handleUnlockStatus(state: VirtualDeviceState): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN).fill(0xff)
+  resp[0] = state.unlocked ? 1 : 0
+  resp[1] = state.unlockInProgress ? 1 : 0
+  for (let i = 0; i < UNLOCK_COMBO_SLOTS; i++) {
+    const pair = VIRTUAL_DEVICE_UNLOCK_COMBO[i]
+    if (pair) {
+      resp[2 + i * 2] = pair[0]
+      resp[3 + i * 2] = pair[1]
+    } else {
+      resp[2 + i * 2] = 0xff
+      resp[3 + i * 2] = 0xff
+    }
+  }
+  return resp
+}
+
+function handleUnlockPoll(state: VirtualDeviceState, now: number): Uint8Array {
+  unlockPollTick(state, now)
+  const resp = new Uint8Array(MSG_LEN).fill(0xff)
+  resp[0] = state.unlocked ? 1 : 0
+  resp[1] = state.unlockInProgress ? 1 : 0
+  resp[2] = Math.max(0, state.unlockCounter)
+  return resp
+}
+
+export function handleVialReport(
+  state: VirtualDeviceState,
+  req: Uint8Array,
+  compressedDefinition: Uint8Array,
+  now: number,
+): Uint8Array {
+  const sub = req[1]
+
+  switch (sub) {
+    case CMD_VIAL_GET_KEYBOARD_ID:
+      return handleKeyboardId()
+
+    case CMD_VIAL_GET_SIZE:
+      return handleDefinitionSize(compressedDefinition.length)
+
+    case CMD_VIAL_GET_DEFINITION:
+      return handleDefinitionBlock(req, compressedDefinition)
+
+    case CMD_VIAL_GET_UNLOCK_STATUS:
+      return handleUnlockStatus(state)
+
+    case CMD_VIAL_UNLOCK_START:
+      state.unlockInProgress = true
+      state.unlockCounter = state.unlockCounterMax
+      state.unlockTimer = now
+      return new Uint8Array(req)
+
+    case CMD_VIAL_UNLOCK_POLL:
+      return handleUnlockPoll(state, now)
+
+    case CMD_VIAL_LOCK:
+      state.unlocked = false
+      return new Uint8Array(req)
+
+    case CMD_VIAL_QMK_SETTINGS_QUERY:
+      // QMK Settings is not implemented by the virtual firmware.
+      return new Uint8Array(MSG_LEN).fill(0xff)
+
+    case CMD_VIAL_DYNAMIC_ENTRY_OP:
+      if (req[2] === DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES) {
+        // Tap dance, combo, key override, alt-repeat-key: all zero. Feature flags: none.
+        return new Uint8Array(MSG_LEN)
+      }
+      // Individual entry get/set and other dynamic ops: unsupported, echo.
+      return new Uint8Array(req)
+
+    default:
+      // Encoders (0x03/0x04), QMK settings get/set/reset (0x0a/0x0b/0x0c): unsupported, echo.
+      return new Uint8Array(req)
+  }
+}

--- a/src/main/virtual-device/vial-handler.ts
+++ b/src/main/virtual-device/vial-handler.ts
@@ -17,7 +17,7 @@ import {
   CMD_VIAL_DYNAMIC_ENTRY_OP,
   DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES,
 } from '../../shared/constants/protocol'
-import { writeLE32 } from './byte-utils'
+import { readLE32, writeLE32 } from './byte-utils'
 import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO } from './gpk60-63r'
 import type { VirtualDeviceState } from './state'
 import { unlockPollTick } from './state'
@@ -42,7 +42,7 @@ function handleDefinitionSize(compressedLength: number): Uint8Array {
 
 function handleDefinitionBlock(req: Uint8Array, compressed: Uint8Array): Uint8Array {
   const resp = new Uint8Array(MSG_LEN)
-  const block = req[2] | (req[3] << 8) | (req[4] << 16) | (req[5] << 24)
+  const block = readLE32(req, 2)
   const start = block * MSG_LEN
   const copyLen = Math.max(0, Math.min(MSG_LEN, compressed.length - start))
   for (let i = 0; i < copyLen; i++) {
@@ -60,10 +60,8 @@ function handleUnlockStatus(state: VirtualDeviceState): Uint8Array {
     if (pair) {
       resp[2 + i * 2] = pair[0]
       resp[3 + i * 2] = pair[1]
-    } else {
-      resp[2 + i * 2] = 0xff
-      resp[3 + i * 2] = 0xff
     }
+    // Empty slots keep the 0xff sentinel from the pre-fill, matching firmware.
   }
   return resp
 }

--- a/src/main/virtual-device/vialrgb-handler.ts
+++ b/src/main/virtual-device/vialrgb-handler.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// VialRGB lighting sub-commands, reached through CMD_VIA_LIGHTING_GET_VALUE /
+// CMD_VIA_LIGHTING_SET_VALUE (byte1 selects the VialRGB sub-command).
+
+import { MSG_LEN, VIALRGB_GET_INFO, VIALRGB_GET_MODE, VIALRGB_GET_SUPPORTED, VIALRGB_SET_MODE } from '../../shared/constants/protocol'
+import { readLE16, writeLE16 } from './byte-utils'
+import { VIALRGB_SUPPORTED_EFFECTS } from './gpk60-63r'
+import type { VirtualDeviceState } from './state'
+
+const VIALRGB_PROTOCOL_VERSION = 1
+const VIALRGB_MAX_BRIGHTNESS = 255
+/** Slots available for effect IDs after the 2-byte response header. */
+const SUPPORTED_ENTRIES_PER_PAGE = Math.floor((MSG_LEN - 2) / 2)
+
+/** Handle CMD_VIA_LIGHTING_GET_VALUE sub-commands. `resp` is the echo-seeded response buffer. */
+export function getLightingValue(state: VirtualDeviceState, req: Uint8Array, resp: Uint8Array): Uint8Array {
+  const sub = req[1]
+
+  switch (sub) {
+    case VIALRGB_GET_INFO: {
+      writeLE16(resp, 2, VIALRGB_PROTOCOL_VERSION)
+      resp[4] = VIALRGB_MAX_BRIGHTNESS
+      break
+    }
+
+    case VIALRGB_GET_MODE: {
+      writeLE16(resp, 2, state.rgb.mode)
+      resp[4] = state.rgb.speed
+      resp[5] = state.rgb.hue
+      resp[6] = state.rgb.sat
+      resp[7] = state.rgb.val
+      break
+    }
+
+    case VIALRGB_GET_SUPPORTED: {
+      const greaterThan = readLE16(req, 2)
+      resp.fill(0xff, 2, MSG_LEN)
+      const candidates = VIALRGB_SUPPORTED_EFFECTS.filter((effect) => effect > greaterThan)
+      const count = Math.min(candidates.length, SUPPORTED_ENTRIES_PER_PAGE)
+      for (let i = 0; i < count; i++) {
+        writeLE16(resp, 2 + i * 2, candidates[i])
+      }
+      break
+    }
+
+    default:
+      // Unhandled lighting sub-command: leave the echoed request bytes as-is.
+      break
+  }
+
+  return resp
+}
+
+/** Handle CMD_VIA_LIGHTING_SET_VALUE sub-commands (mutates state; caller returns the echo response). */
+export function setLightingValue(state: VirtualDeviceState, req: Uint8Array): void {
+  if (req[1] !== VIALRGB_SET_MODE) return
+
+  state.rgb.mode = readLE16(req, 2)
+  state.rgb.speed = req[4]
+  state.rgb.hue = req[5]
+  state.rgb.sat = req[6]
+  state.rgb.val = req[7]
+}

--- a/src/preload/__tests__/protocol-virtual-device.test.ts
+++ b/src/preload/__tests__/protocol-virtual-device.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Integration test: the REAL preload protocol parsers (src/preload/protocol.ts)
+// wired to the virtual GPK60-63R emulator (src/main/virtual-device), proving
+// wire-format compatibility without Playwright/Electron. Runs under plain
+// Vitest so CI's `test` step exercises it.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { MSG_LEN } from '../../shared/constants/protocol'
+
+// Mocked in place of the real IPC bridge: routes straight into the virtual
+// device's report handler. Uses a dynamic import inside each function body
+// (rather than a module-level import) so it resolves after Vitest's mock
+// hoisting has fully linked the module graph.
+vi.mock('../hid-transport', () => ({
+  sendReceive: async (data: Uint8Array): Promise<Uint8Array> => {
+    const { handleVirtualReport } = await import('../../main/virtual-device')
+    return Uint8Array.from(handleVirtualReport(Array.from(data)))
+  },
+  send: async (data: Uint8Array): Promise<void> => {
+    const { handleVirtualReport } = await import('../../main/virtual-device')
+    handleVirtualReport(Array.from(data))
+  },
+}))
+
+import {
+  getProtocolVersion,
+  getKeyboardId,
+  getLayerCount,
+  getKeymapBuffer,
+  getUnlockStatus,
+  unlockStart,
+  unlockPoll,
+  getDefinitionSize,
+  getDefinitionRaw,
+  getDynamicEntryCount,
+  qmkSettingsQuery,
+  getVialRGBInfo,
+  getVialRGBMode,
+  getVialRGBSupported,
+} from '../protocol'
+import { openVirtualDevice, closeVirtualDevice, getVirtualDeviceController } from '../../main/virtual-device'
+import {
+  LAYERS,
+  VIRTUAL_DEVICE_UID_BYTES,
+  VIRTUAL_DEVICE_UNLOCK_COMBO,
+  VIALRGB_SUPPORTED_EFFECTS,
+  buildDefaultKeymap,
+} from '../../main/virtual-device/gpk60-63r'
+import { decompressLzma } from '../../main/lzma'
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/** Mirrors protocol.ts's readLE64Hex so the expected uid isn't a hand-transcribed magic string. */
+function expectedUidHex(bytes: Uint8Array): string {
+  let hex = '0x'
+  for (let i = bytes.length - 1; i >= 0; i--) {
+    hex += bytes[i].toString(16).padStart(2, '0')
+  }
+  return hex
+}
+
+/** Flattens the first `count` keycodes of a keymap into BE16 byte pairs, matching the wire format. */
+function keymapToBE16Bytes(keymap: Uint16Array, count: number): number[] {
+  const bytes: number[] = []
+  for (let i = 0; i < count; i++) {
+    bytes.push((keymap[i] >> 8) & 0xff, keymap[i] & 0xff)
+  }
+  return bytes
+}
+
+beforeAll(async () => {
+  await openVirtualDevice()
+})
+
+afterAll(() => {
+  closeVirtualDevice()
+})
+
+describe('preload protocol against the virtual device emulator', () => {
+  it('getProtocolVersion resolves to VIA protocol 9', async () => {
+    await expect(getProtocolVersion()).resolves.toBe(9)
+  })
+
+  it('getKeyboardId resolves to vial protocol 6 and the VIRTGPK uid', async () => {
+    const id = await getKeyboardId()
+    expect(id.vialProtocol).toBe(6)
+    expect(id.uid).toBe(expectedUidHex(VIRTUAL_DEVICE_UID_BYTES))
+  })
+
+  it('getLayerCount resolves to the emulator layer count', async () => {
+    await expect(getLayerCount()).resolves.toBe(LAYERS)
+  })
+
+  it('getKeymapBuffer round-trips the first chunk of buildDefaultKeymap', async () => {
+    const expectedKeymap = buildDefaultKeymap()
+    const chunk = await getKeymapBuffer(0, 28)
+    expect(chunk).toEqual(keymapToBE16Bytes(expectedKeymap, 14))
+  })
+
+  it('getUnlockStatus reports locked with the two-key unlock combo', async () => {
+    const status = await getUnlockStatus()
+    expect(status.unlocked).toBe(false)
+    expect(status.keys).toEqual(VIRTUAL_DEVICE_UNLOCK_COMBO)
+  })
+
+  it('getDefinitionSize/getDefinitionRaw decompress to the GPK60-63R Virtual definition', async () => {
+    const size = await getDefinitionSize()
+    const raw = await getDefinitionRaw(size)
+    const jsonStr = await decompressLzma(Array.from(raw))
+    expect(jsonStr).not.toBeNull()
+    const definition = JSON.parse(jsonStr as string) as { name: string }
+    expect(definition.name).toBe('GPK60-63R Virtual')
+  })
+
+  it('getDynamicEntryCount returns all zeros without throwing echo-detected', async () => {
+    await expect(getDynamicEntryCount()).resolves.toEqual({
+      tapDance: 0,
+      combo: 0,
+      keyOverride: 0,
+      altRepeatKey: 0,
+      featureFlags: 0,
+    })
+  })
+
+  it('qmkSettingsQuery yields an all-0xFF (unsupported / empty) qsid list', async () => {
+    const result = await qmkSettingsQuery(0)
+    expect(result).toHaveLength(MSG_LEN)
+    expect(result.every((b) => b === 0xff)).toBe(true)
+  })
+
+  it('getVialRGBInfo/getVialRGBMode/getVialRGBSupported parse cleanly', async () => {
+    const info = await getVialRGBInfo()
+    expect(info.version).toBe(1)
+    expect(info.maxBrightness).toBe(255)
+
+    const mode = await getVialRGBMode()
+    expect(typeof mode.mode).toBe('number')
+    expect(typeof mode.speed).toBe('number')
+    expect(typeof mode.hue).toBe('number')
+    expect(typeof mode.sat).toBe('number')
+    expect(typeof mode.val).toBe('number')
+
+    const supported = await getVialRGBSupported()
+    expect(supported.has(0)).toBe(true)
+    expect(supported.size).toBe(VIALRGB_SUPPORTED_EFFECTS.length)
+  })
+
+  it('unlocks via unlockStart + repeated unlockPoll while the combo is held', async () => {
+    const controller = getVirtualDeviceController()
+    controller.reset()
+    controller.holdKeys(VIRTUAL_DEVICE_UNLOCK_COMBO as [number, number][])
+    controller.setUnlockCounterMax(2)
+
+    await unlockStart()
+
+    let result: number[] = []
+    for (let attempt = 0; attempt < 3 && result[0] !== 1; attempt++) {
+      await delay(120)
+      result = await unlockPoll()
+    }
+    expect(result[0]).toBe(1)
+
+    const status = await getUnlockStatus()
+    expect(status.unlocked).toBe(true)
+
+    controller.releaseAll()
+  })
+})

--- a/src/renderer/components/keyboard/KeyWidget.tsx
+++ b/src/renderer/components/keyboard/KeyWidget.tsx
@@ -255,6 +255,8 @@ function KeyWidgetInner({
   return (
     <g
       transform={groupTransform}
+      data-key-pos={kleKey.row >= 0 && kleKey.col >= 0 ? `${kleKey.row},${kleKey.col}` : undefined}
+      data-pressed={pressed ? 'true' : undefined}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onMouseEnter={(e) => {


### PR DESCRIPTION
## Summary

Adds a software-emulated Vial keyboard (**GPK60-63R Virtual**) to the main process so tests and doc-screenshot capture no longer require real hardware. Enabled only with `PIPETTE_VIRTUAL_DEVICE=1`; production behavior is unchanged.

- The emulator plugs in at the `hid-service.ts` transport seam (the sole node-hid importer): it appears in `listDevices()`, opens via the normal path, and answers 32-byte `sendReceive`/`send` reports synchronously inside the existing mutex. The real enumeration → open → `reload()` → `protocol.ts` pipeline runs unmodified.
- Protocol behavior mirrors vial-qmk: responses overwrite a request copy (unsupported commands echo, matching the app's echo detection), unlock counter 50 with 100ms gate and reset on any non-qualifying poll, matrix state packed per-row big-endian, QMK settings query answered 0xFF-filled, dynamic entry counts zeroed, VialRGB info/mode/supported implemented, definition served LZMA-compressed.
- Distinct identity so it never collides with the real GPK60-63R: name `GPK60-63R Virtual`, pid `0xF063`, UID `VIRTGPK` (settings/snapshots stay separate).
- Test control surface: `globalThis.__pipetteVirtualDevice` (press/release/hold keys, unlock counter override, reset) drivable from Playwright via `electronApp.evaluate`, so the unlock dialog completes through the real protocol.
- `KeyWidget` now exposes `data-key-pos`/`data-pressed` attributes (no visual change) for e2e assertions and upcoming doc-capture automation.

## Tests

- 74 new Vitest cases: dataset/keymap round-trips, unlock state machine (firmware-exact single-else), keymap/macro buffer chunking, matrix packing, echo semantics, hid-service routing with node-hid mocked, and an integration suite driving the **real `src/preload/protocol.ts` parsers** against the emulator (runs in CI).
- New e2e smoke `e2e/virtual-device.test.ts` (3 passing locally, no hardware): connect → locked matrix-tester prompt → unlock via held virtual combo → key press reflected in the UI.

Follow-ups (separate PRs): migrate `doc-capture*.ts` helpers to the virtual device.