### PR TITLE
feat(hid): add dynamic entries and QMK settings to virtual device

### DIFF
--- a/src/main/__tests__/virtual-device-dynamic-entries.test.ts
+++ b/src/main/__tests__/virtual-device-dynamic-entries.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import {
+  TAP_DANCE_ENTRY_COUNT,
+  COMBO_ENTRY_COUNT,
+  KEY_OVERRIDE_ENTRY_COUNT,
+  ALT_REPEAT_KEY_ENTRY_COUNT,
+  createDefaultTapDanceEntries,
+  createDefaultComboEntries,
+  createDefaultKeyOverrideEntries,
+  createDefaultAltRepeatKeyEntries,
+  getTapDance,
+  setTapDance,
+  getCombo,
+  setCombo,
+  getKeyOverride,
+  setKeyOverride,
+  getAltRepeatKey,
+  setAltRepeatKey,
+  readTapDanceEntry,
+  writeTapDanceEntry,
+  readComboEntry,
+  writeComboEntry,
+  readKeyOverrideEntry,
+  writeKeyOverrideEntry,
+  readAltRepeatKeyEntry,
+  writeAltRepeatKeyEntry,
+} from '../virtual-device/dynamic-entries'
+
+describe('default entry factories', () => {
+  it('create arrays sized to the 32-entry tier', () => {
+    expect(createDefaultTapDanceEntries()).toHaveLength(TAP_DANCE_ENTRY_COUNT)
+    expect(createDefaultComboEntries()).toHaveLength(COMBO_ENTRY_COUNT)
+    expect(createDefaultKeyOverrideEntries()).toHaveLength(KEY_OVERRIDE_ENTRY_COUNT)
+    expect(createDefaultAltRepeatKeyEntries()).toHaveLength(ALT_REPEAT_KEY_ENTRY_COUNT)
+    expect(TAP_DANCE_ENTRY_COUNT).toBe(32)
+    expect(COMBO_ENTRY_COUNT).toBe(32)
+    expect(KEY_OVERRIDE_ENTRY_COUNT).toBe(32)
+    expect(ALT_REPEAT_KEY_ENTRY_COUNT).toBe(32)
+  })
+
+  it('tap dance defaults match dynamic_keymap_reset(): all-KC_NO with TAPPING_TERM', () => {
+    const entries = createDefaultTapDanceEntries()
+    for (const entry of entries) {
+      expect(entry).toEqual({ onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 200 })
+    }
+  })
+
+  it('combo defaults are all-zero', () => {
+    for (const entry of createDefaultComboEntries()) {
+      expect(entry).toEqual({ key1: 0, key2: 0, key3: 0, key4: 0, output: 0 })
+    }
+  })
+
+  it('key override defaults match dynamic_keymap_reset(): all layers, disabled, activation options set', () => {
+    for (const entry of createDefaultKeyOverrideEntries()) {
+      expect(entry.layers).toBe(0xffff)
+      expect(entry.options).toBe(0x07)
+      expect(entry.enabled).toBe(false)
+    }
+  })
+
+  it('alt repeat key defaults are all-zero/disabled', () => {
+    for (const entry of createDefaultAltRepeatKeyEntries()) {
+      expect(entry).toEqual({ lastKey: 0, altKey: 0, allowedMods: 0, options: 0, enabled: false })
+    }
+  })
+})
+
+describe('bounds-checked get/set', () => {
+  it('tap dance: get out of range returns status 0xff and an all-zero entry (not the factory default)', () => {
+    const entries = createDefaultTapDanceEntries()
+    const { status, entry } = getTapDance(entries, 32)
+    expect(status).toBe(0xff)
+    expect(entry).toEqual({ onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 0 })
+  })
+
+  it('tap dance: set out of range does not mutate the store', () => {
+    const entries = createDefaultTapDanceEntries()
+    const status = setTapDance(entries, 32, { onTap: 4, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 1 })
+    expect(status).toBe(0xff)
+    expect(entries[31]).toEqual({ onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 200 })
+  })
+
+  it('tap dance: in-range set/get round-trips', () => {
+    const entries = createDefaultTapDanceEntries()
+    const entry = { onTap: 4, onHold: 224, onDoubleTap: 0, onTapHold: 0, tappingTerm: 175 }
+    expect(setTapDance(entries, 3, entry)).toBe(0)
+    expect(getTapDance(entries, 3)).toEqual({ status: 0, entry })
+  })
+
+  it('combo/key-override/alt-repeat: out-of-range index rejected, in-range round-trips', () => {
+    const combos = createDefaultComboEntries()
+    expect(setCombo(combos, -1, { key1: 0, key2: 0, key3: 0, key4: 0, output: 0 })).toBe(0xff)
+    const combo = { key1: 0x0d, key2: 0x0e, key3: 0, key4: 0, output: 0x29 }
+    expect(setCombo(combos, 2, combo)).toBe(0)
+    expect(getCombo(combos, 2)).toEqual({ status: 0, entry: combo })
+    expect(getCombo(combos, 32).status).toBe(0xff)
+
+    const keyOverrides = createDefaultKeyOverrideEntries()
+    const keyOverride = {
+      triggerKey: 0x2a,
+      replacementKey: 0x4c,
+      layers: 0xffff,
+      triggerMods: 0x02,
+      negativeMods: 0,
+      suppressedMods: 0x02,
+      options: 0x07,
+      enabled: true,
+    }
+    expect(setKeyOverride(keyOverrides, 999, keyOverride)).toBe(0xff)
+    expect(setKeyOverride(keyOverrides, 1, keyOverride)).toBe(0)
+    expect(getKeyOverride(keyOverrides, 1)).toEqual({ status: 0, entry: keyOverride })
+    expect(getKeyOverride(keyOverrides, 999).status).toBe(0xff)
+
+    const altRepeatKeys = createDefaultAltRepeatKeyEntries()
+    const altRepeatKey = { lastKey: 0x06, altKey: 0x19, allowedMods: 0, options: 0x03, enabled: true }
+    expect(setAltRepeatKey(altRepeatKeys, 32, altRepeatKey)).toBe(0xff)
+    expect(setAltRepeatKey(altRepeatKeys, 4, altRepeatKey)).toBe(0)
+    expect(getAltRepeatKey(altRepeatKeys, 4)).toEqual({ status: 0, entry: altRepeatKey })
+    expect(getAltRepeatKey(altRepeatKeys, 32).status).toBe(0xff)
+  })
+})
+
+describe('wire codecs', () => {
+  it('tap dance entry round-trips through LE16 x5', () => {
+    const buf = new Uint8Array(10)
+    const entry = { onTap: 0x0004, onHold: 0x00e0, onDoubleTap: 0x1234, onTapHold: 0xabcd, tappingTerm: 200 }
+    writeTapDanceEntry(buf, 0, entry)
+    expect(readTapDanceEntry(buf, 0)).toEqual(entry)
+  })
+
+  it('combo entry round-trips through LE16 x5', () => {
+    const buf = new Uint8Array(10)
+    const entry = { key1: 0x0d, key2: 0x0e, key3: 0, key4: 0, output: 0x29 }
+    writeComboEntry(buf, 0, entry)
+    expect(readComboEntry(buf, 0)).toEqual(entry)
+  })
+
+  it('key override entry packs enabled into bit 7 of the combined options byte', () => {
+    const buf = new Uint8Array(10)
+    const entry = {
+      triggerKey: 0x2a,
+      replacementKey: 0x4c,
+      layers: 0xffff,
+      triggerMods: 0x02,
+      negativeMods: 0,
+      suppressedMods: 0x02,
+      options: 0x07,
+      enabled: true,
+    }
+    writeKeyOverrideEntry(buf, 0, entry)
+    expect(buf[9]).toBe(0x87)
+    expect(readKeyOverrideEntry(buf, 0)).toEqual(entry)
+  })
+
+  it('alt repeat key entry packs enabled into bit 3 of the combined options byte', () => {
+    const buf = new Uint8Array(6)
+    const entry = { lastKey: 0x06, altKey: 0x19, allowedMods: 0, options: 0x03, enabled: true }
+    writeAltRepeatKeyEntry(buf, 0, entry)
+    expect(buf[5]).toBe(0x0b)
+    expect(readAltRepeatKeyEntry(buf, 0)).toEqual(entry)
+  })
+})

--- a/src/main/__tests__/virtual-device-qmk-settings.test.ts
+++ b/src/main/__tests__/virtual-device-qmk-settings.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { readLE16, readLE32 } from '../virtual-device/byte-utils'
+import {
+  SUPPORTED_QSIDS,
+  createDefaultQmkSettings,
+  resetQmkSettings,
+  qmkSettingsQuery,
+  qmkSettingsGet,
+  qmkSettingsSet,
+} from '../virtual-device/qmk-settings'
+
+describe('createDefaultQmkSettings', () => {
+  it('matches qmk_settings_reset()/quantum default macros', () => {
+    const store = createDefaultQmkSettings()
+    expect(store.comboTerm).toBe(50)
+    expect(store.autoShiftTimeout).toBe(175)
+    expect(store.oskTapToggle).toBe(5)
+    expect(store.oskTimeout).toBe(5000)
+    expect(store.tappingTerm).toBe(200)
+    expect(store.mousekeyDelay).toBe(10)
+    expect(store.mousekeyInterval).toBe(20)
+    expect(store.mousekeyMoveDelta).toBe(8)
+    expect(store.mousekeyMaxSpeed).toBe(10)
+    expect(store.mousekeyTimeToMax).toBe(30)
+    expect(store.mousekeyWheelDelay).toBe(10)
+    expect(store.mousekeyWheelInterval).toBe(80)
+    expect(store.mousekeyWheelMaxSpeed).toBe(8)
+    expect(store.mousekeyWheelTimeToMax).toBe(40)
+    expect(store.tapCodeDelay).toBe(10)
+    expect(store.tapHoldCapsDelay).toBe(80)
+    expect(store.tappingToggle).toBe(5)
+    expect(store.quickTapTerm).toBe(200)
+    expect(store.flowTapTerm).toBe(0)
+    expect(store.magicFlags).toBe(0)
+    expect(store.tappingV2).toBe(0)
+  })
+})
+
+describe('SUPPORTED_QSIDS', () => {
+  it('has 26 entries: qsid 8 is absent, mousekey qsids 9-17 are present', () => {
+    expect(SUPPORTED_QSIDS).toHaveLength(26)
+    expect(SUPPORTED_QSIDS).not.toContain(8)
+    for (const qsid of [9, 10, 11, 12, 13, 14, 15, 16, 17]) {
+      expect(SUPPORTED_QSIDS).toContain(qsid)
+    }
+  })
+
+  it('is already in ascending order (protos[] table declaration order)', () => {
+    const sorted = [...SUPPORTED_QSIDS].sort((a, b) => a - b)
+    expect(SUPPORTED_QSIDS).toEqual(sorted)
+  })
+})
+
+describe('qmkSettingsQuery', () => {
+  it('fills the buffer with 0xFFFF-terminated qsids greater than the cursor', () => {
+    const buf = new Uint8Array(32)
+    qmkSettingsQuery(0, buf)
+    const firstPage = SUPPORTED_QSIDS.slice(0, 16)
+    for (let i = 0; i < firstPage.length; i++) {
+      expect(readLE16(buf, i * 2)).toBe(firstPage[i])
+    }
+  })
+
+  it('a cursor past the last qsid yields an all-0xFFFF buffer', () => {
+    const buf = new Uint8Array(32)
+    qmkSettingsQuery(9999, buf)
+    expect(Array.from(buf)).toEqual(new Array(32).fill(0xff))
+  })
+})
+
+describe('qmkSettingsGet/qmkSettingsSet', () => {
+  it('round-trips a u8 field (qsid 1)', () => {
+    const store = createDefaultQmkSettings()
+    const buf = new Uint8Array(4)
+    buf[0] = 0x0f
+    expect(qmkSettingsSet(store, 1, buf, 0)).toBe(0)
+    expect(store.graveEscOverride).toBe(0x0f)
+    const out = new Uint8Array(4)
+    expect(qmkSettingsGet(store, 1, out, 0)).toBe(0)
+    expect(out[0]).toBe(0x0f)
+  })
+
+  it('round-trips a u16 field (qsid 7 = tapping_term)', () => {
+    const store = createDefaultQmkSettings()
+    const buf = new Uint8Array(4)
+    buf[0] = 0x2c
+    buf[1] = 0x01 // 300 LE16
+    expect(qmkSettingsSet(store, 7, buf, 0)).toBe(0)
+    expect(store.tappingTerm).toBe(300)
+    const out = new Uint8Array(4)
+    qmkSettingsGet(store, 7, out, 0)
+    expect(readLE16(out, 0)).toBe(300)
+  })
+
+  it('round-trips the u32 magic-settings field (qsid 21) without disturbing other bits', () => {
+    const store = createDefaultQmkSettings()
+    const buf = new Uint8Array(4)
+    buf[0] = 0x81 // bit0 (swap ctrl/caps) + bit7 (nkro)
+    expect(qmkSettingsSet(store, 21, buf, 0)).toBe(0)
+    expect(store.magicFlags).toBe(0x81)
+    const out = new Uint8Array(4)
+    qmkSettingsGet(store, 21, out, 0)
+    expect(readLE32(out, 0)).toBe(0x81)
+  })
+
+  it('individual tappingV2 bit qsids (22/23/24/26) address distinct bits of the same byte', () => {
+    const store = createDefaultQmkSettings()
+    const one = new Uint8Array([1])
+    qmkSettingsSet(store, 22, one, 0)
+    qmkSettingsSet(store, 26, one, 0)
+    expect(store.tappingV2).toBe((1 << 0) | (1 << 3))
+
+    const out23 = new Uint8Array(1)
+    qmkSettingsGet(store, 23, out23, 0)
+    expect(out23[0]).toBe(0)
+
+    const out22 = new Uint8Array(1)
+    qmkSettingsGet(store, 22, out22, 0)
+    expect(out22[0]).toBe(1)
+
+    // Clearing bit 22 must not disturb bit 26.
+    const zero = new Uint8Array([0])
+    qmkSettingsSet(store, 22, zero, 0)
+    expect(store.tappingV2).toBe(1 << 3)
+  })
+
+  it('rejects an unsupported qsid (8) without touching the store', () => {
+    const store = createDefaultQmkSettings()
+    const before = { ...store }
+    const buf = new Uint8Array([1, 2, 3, 4])
+    expect(qmkSettingsSet(store, 8, buf, 0)).toBe(0xff)
+    expect(store).toEqual(before)
+    const out = new Uint8Array(4)
+    expect(qmkSettingsGet(store, 8, out, 0)).toBe(0xff)
+  })
+})
+
+describe('resetQmkSettings', () => {
+  it('restores every field to its default after mutation', () => {
+    const store = createDefaultQmkSettings()
+    store.tappingTerm = 999
+    store.tappingV2 = 0x0f
+    resetQmkSettings(store)
+    expect(store).toEqual(createDefaultQmkSettings())
+  })
+})

--- a/src/main/__tests__/virtual-device-qmk-settings.test.ts
+++ b/src/main/__tests__/virtual-device-qmk-settings.test.ts
@@ -28,7 +28,7 @@ describe('createDefaultQmkSettings', () => {
     expect(store.mousekeyWheelInterval).toBe(80)
     expect(store.mousekeyWheelMaxSpeed).toBe(8)
     expect(store.mousekeyWheelTimeToMax).toBe(40)
-    expect(store.tapCodeDelay).toBe(10)
+    expect(store.tapCodeDelay).toBe(0)
     expect(store.tapHoldCapsDelay).toBe(80)
     expect(store.tappingToggle).toBe(5)
     expect(store.quickTapTerm).toBe(200)

--- a/src/main/__tests__/virtual-device-state.test.ts
+++ b/src/main/__tests__/virtual-device-state.test.ts
@@ -29,6 +29,31 @@ describe('createVirtualDeviceState', () => {
     expect(state.matrix[0].length).toBe(COLS)
     expect(state.matrix.every((row) => row.every((v) => v === false))).toBe(true)
   })
+
+  it('seeds a sample entry at index 0 of every dynamic-entry store', () => {
+    const state = createVirtualDeviceState()
+    expect(state.tapDanceEntries).toHaveLength(32)
+    expect(state.tapDanceEntries[0].onTap).not.toBe(0)
+    expect(state.tapDanceEntries[1]).toEqual({ onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: 200 })
+
+    expect(state.comboEntries).toHaveLength(32)
+    expect(state.comboEntries[0].key1).not.toBe(0)
+    expect(state.comboEntries[0].output).not.toBe(0)
+
+    expect(state.keyOverrideEntries).toHaveLength(32)
+    expect(state.keyOverrideEntries[0].enabled).toBe(true)
+    expect(state.keyOverrideEntries[0].triggerKey).not.toBe(0)
+
+    expect(state.altRepeatKeyEntries).toHaveLength(32)
+    expect(state.altRepeatKeyEntries[0].enabled).toBe(true)
+    expect(state.altRepeatKeyEntries[0].lastKey).not.toBe(0)
+  })
+
+  it('starts with default QMK settings', () => {
+    const state = createVirtualDeviceState()
+    expect(state.qmkSettings.tappingTerm).toBe(200)
+    expect(state.qmkSettings.comboTerm).toBe(50)
+  })
 })
 
 describe('pressKey / releaseKey / releaseAll', () => {

--- a/src/main/__tests__/virtual-device-vial-handler.test.ts
+++ b/src/main/__tests__/virtual-device-vial-handler.test.ts
@@ -204,6 +204,26 @@ describe('handleVialReport', () => {
     expect(readLE16(getResp, 1)).toBe(0) // QK_BOOT replaced with KC_NO while locked
   })
 
+  it('tap dance set stores QK_BOOT unchanged once unlocked', () => {
+    const state = createVirtualDeviceState()
+    state.unlocked = true
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x02
+    setPkt[3] = 6
+    writeLE16(setPkt, 4, 0x7c00) // QK_BOOT (protocol v6)
+    writeLE16(setPkt, 6, 0)
+    writeLE16(setPkt, 8, 0)
+    writeLE16(setPkt, 10, 0)
+    writeLE16(setPkt, 12, 200)
+    const setResp = handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)
+    expect(setResp[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x01, 6), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 1)).toBe(0x7c00) // QK_BOOT stored unchanged once unlocked
+  })
+
   it('combo set/get round-trips and out-of-range index is rejected', () => {
     const state = createVirtualDeviceState()
     const setPkt = new Uint8Array(MSG_LEN)
@@ -227,6 +247,26 @@ describe('handleVialReport', () => {
     expect(handleVialReport(state, badIdx, FAKE_COMPRESSED, 0)[0]).toBe(0xff)
   })
 
+  it('combo set blocks QK_BOOT in output while locked, condition keys untouched', () => {
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x04
+    setPkt[3] = 2
+    writeLE16(setPkt, 4, 1)
+    writeLE16(setPkt, 6, 2)
+    writeLE16(setPkt, 8, 0)
+    writeLE16(setPkt, 10, 0)
+    writeLE16(setPkt, 12, 0x7c00) // QK_BOOT output
+    expect(handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x03, 2), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 9)).toBe(0) // output replaced with KC_NO while locked
+    expect(readLE16(getResp, 1)).toBe(1) // condition keycodes are not gated by vial.c's firewall
+  })
+
   it('key override get exposes the seeded sample enabled bit and combined options byte', () => {
     const state = createVirtualDeviceState()
     const resp = handleVialReport(state, req(0xfe, 0x0d, 0x05, 0x00), FAKE_COMPRESSED, 0)
@@ -234,6 +274,28 @@ describe('handleVialReport', () => {
     const optionsByte = resp[10]
     expect((optionsByte & 0x80) !== 0).toBe(true) // enabled
     expect(optionsByte & 0x7f).toBe(0x07)
+  })
+
+  it('key override set blocks QK_BOOT in replacement while locked, trigger key untouched', () => {
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x06
+    setPkt[3] = 1
+    writeLE16(setPkt, 4, 4) // triggerKey
+    writeLE16(setPkt, 6, 0x7c00) // replacementKey = QK_BOOT
+    writeLE16(setPkt, 8, 0) // layers
+    setPkt[10] = 0 // triggerMods
+    setPkt[11] = 0 // negativeMods
+    setPkt[12] = 0 // suppressedMods
+    setPkt[13] = 0x80 // enabled bit only
+    expect(handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x05, 1), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 3)).toBe(0) // replacement replaced with KC_NO while locked
+    expect(readLE16(getResp, 1)).toBe(4) // trigger key is not gated by vial.c's firewall
   })
 
   it('alt repeat key set/get round-trips through the 6-byte wire entry', () => {
@@ -253,6 +315,25 @@ describe('handleVialReport', () => {
     expect(readLE16(getResp, 1)).toBe(4)
     expect(readLE16(getResp, 3)).toBe(5)
     expect((getResp[6] & 0x08) !== 0).toBe(true)
+  })
+
+  it('alt repeat key set blocks QK_BOOT in both keycode and alt keycode while locked', () => {
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x08
+    setPkt[3] = 3
+    writeLE16(setPkt, 4, 0x7c00) // lastKey = QK_BOOT
+    writeLE16(setPkt, 6, 0x7c00) // altKey = QK_BOOT
+    setPkt[8] = 0
+    setPkt[9] = 0x08 // enabled bit only
+    expect(handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x07, 3), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 1)).toBe(0) // lastKey replaced with KC_NO while locked
+    expect(readLE16(getResp, 3)).toBe(0) // altKey replaced with KC_NO while locked
   })
 
   it('encoder get (sub 0x03) is a pure echo', () => {

--- a/src/main/__tests__/virtual-device-vial-handler.test.ts
+++ b/src/main/__tests__/virtual-device-vial-handler.test.ts
@@ -5,7 +5,15 @@ import { MSG_LEN } from '../../shared/constants/protocol'
 import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO } from '../virtual-device/gpk60-63r'
 import { createVirtualDeviceState, pressKey } from '../virtual-device/state'
 import { handleVialReport } from '../virtual-device/vial-handler'
-import { writeLE32 } from '../virtual-device/byte-utils'
+import { writeLE32, writeLE16, readLE16 } from '../virtual-device/byte-utils'
+import {
+  TAP_DANCE_ENTRY_COUNT,
+  COMBO_ENTRY_COUNT,
+  KEY_OVERRIDE_ENTRY_COUNT,
+  ALT_REPEAT_KEY_ENTRY_COUNT,
+  DYNAMIC_ENTRY_FEATURE_FLAGS,
+} from '../virtual-device/dynamic-entries'
+import { SUPPORTED_QSIDS } from '../virtual-device/qmk-settings'
 
 function req(...bytes: number[]): Uint8Array {
   const buf = new Uint8Array(MSG_LEN)
@@ -87,16 +95,164 @@ describe('handleVialReport', () => {
     expect(state.unlocked).toBe(false)
   })
 
-  it('qmk settings query returns an all-0xFF response', () => {
+  it('qmk settings query returns the full first page of supported qsids, 0xFFFF-padded', () => {
     const state = createVirtualDeviceState()
     const resp = handleVialReport(state, req(0xfe, 0x09, 0x00, 0x00), FAKE_COMPRESSED, 0)
-    expect(Array.from(resp)).toEqual(new Array(MSG_LEN).fill(0xff))
+    const firstPage = SUPPORTED_QSIDS.slice(0, 16)
+    for (let i = 0; i < firstPage.length; i++) {
+      expect(readLE16(resp, i * 2)).toBe(firstPage[i])
+    }
+    for (let i = firstPage.length; i < 16; i++) {
+      expect(readLE16(resp, i * 2)).toBe(0xffff)
+    }
   })
 
-  it('dynamic entry counts are all zero', () => {
+  it('qmk settings query second page starts past the last qsid seen and ends in 0xFFFF padding', () => {
+    const state = createVirtualDeviceState()
+    const lastOfFirstPage = SUPPORTED_QSIDS[15]
+    const resp = handleVialReport(
+      state,
+      req(0xfe, 0x09, lastOfFirstPage & 0xff, (lastOfFirstPage >> 8) & 0xff),
+      FAKE_COMPRESSED,
+      0,
+    )
+    const secondPage = SUPPORTED_QSIDS.slice(16)
+    for (let i = 0; i < secondPage.length; i++) {
+      expect(readLE16(resp, i * 2)).toBe(secondPage[i])
+    }
+    expect(readLE16(resp, secondPage.length * 2)).toBe(0xffff)
+  })
+
+  it('qmk settings get/set round-trips a known qsid (7 = tapping_term) and rejects an unsupported one', () => {
+    const state = createVirtualDeviceState()
+    const getPkt = req(0xfe, 0x0a, 0x07, 0x00)
+    const before = handleVialReport(state, getPkt, FAKE_COMPRESSED, 0)
+    expect(before[0]).toBe(0)
+    expect(readLE16(before, 1)).toBe(200) // TAPPING_TERM default
+
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0b
+    writeLE16(setPkt, 2, 7)
+    writeLE16(setPkt, 4, 150)
+    const setResp = handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)
+    expect(setResp[0]).toBe(0)
+
+    const after = handleVialReport(state, getPkt, FAKE_COMPRESSED, 0)
+    expect(readLE16(after, 1)).toBe(150)
+
+    // qsid 8 was never assigned by this vial-qmk version's protos[] table.
+    const unsupported = handleVialReport(state, req(0xfe, 0x0a, 0x08, 0x00), FAKE_COMPRESSED, 0)
+    expect(unsupported[0]).toBe(0xff)
+  })
+
+  it('qmk settings reset restores defaults and echoes the request', () => {
+    const state = createVirtualDeviceState()
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0b
+    writeLE16(setPkt, 2, 7)
+    writeLE16(setPkt, 4, 999)
+    handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)
+
+    const resetPkt = req(0xfe, 0x0c)
+    const resetResp = handleVialReport(state, resetPkt, FAKE_COMPRESSED, 0)
+    expect(Array.from(resetResp)).toEqual(Array.from(resetPkt))
+
+    const after = handleVialReport(state, req(0xfe, 0x0a, 0x07, 0x00), FAKE_COMPRESSED, 0)
+    expect(readLE16(after, 1)).toBe(200)
+  })
+
+  it('dynamic entry counts report the 32-entry tier and caps-word/layer-lock feature flags', () => {
     const state = createVirtualDeviceState()
     const resp = handleVialReport(state, req(0xfe, 0x0d, 0x00), FAKE_COMPRESSED, 0)
-    expect(Array.from(resp)).toEqual(new Array(MSG_LEN).fill(0))
+    expect(resp[0]).toBe(TAP_DANCE_ENTRY_COUNT)
+    expect(resp[1]).toBe(COMBO_ENTRY_COUNT)
+    expect(resp[2]).toBe(KEY_OVERRIDE_ENTRY_COUNT)
+    expect(resp[3]).toBe(ALT_REPEAT_KEY_ENTRY_COUNT)
+    expect(resp[MSG_LEN - 1]).toBe(DYNAMIC_ENTRY_FEATURE_FLAGS)
+  })
+
+  it('tap dance get returns the seeded sample at index 0 and a zero entry out of range', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x0d, 0x01, 0x00), FAKE_COMPRESSED, 0)
+    expect(resp[0]).toBe(0)
+    expect(readLE16(resp, 1)).not.toBe(0) // onTap = KC_A, non-zero
+
+    const outOfRange = handleVialReport(state, req(0xfe, 0x0d, 0x01, 32), FAKE_COMPRESSED, 0)
+    expect(outOfRange[0]).toBe(0xff)
+    expect(Array.from(outOfRange.subarray(1, 11))).toEqual(new Array(10).fill(0))
+  })
+
+  it('tap dance set stores an entry and blocks QK_BOOT while locked', () => {
+    const state = createVirtualDeviceState()
+    expect(state.unlocked).toBe(false)
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x02
+    setPkt[3] = 5
+    writeLE16(setPkt, 4, 0x7c00) // QK_BOOT (protocol v6)
+    writeLE16(setPkt, 6, 0)
+    writeLE16(setPkt, 8, 0)
+    writeLE16(setPkt, 10, 0)
+    writeLE16(setPkt, 12, 200)
+    const setResp = handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)
+    expect(setResp[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x01, 5), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 1)).toBe(0) // QK_BOOT replaced with KC_NO while locked
+  })
+
+  it('combo set/get round-trips and out-of-range index is rejected', () => {
+    const state = createVirtualDeviceState()
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x04
+    setPkt[3] = 1
+    writeLE16(setPkt, 4, 1)
+    writeLE16(setPkt, 6, 2)
+    writeLE16(setPkt, 8, 0)
+    writeLE16(setPkt, 10, 0)
+    writeLE16(setPkt, 12, 41)
+    expect(handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x03, 1), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 1)).toBe(1)
+    expect(readLE16(getResp, 9)).toBe(41)
+
+    const badIdx = new Uint8Array(setPkt)
+    badIdx[3] = 32
+    expect(handleVialReport(state, badIdx, FAKE_COMPRESSED, 0)[0]).toBe(0xff)
+  })
+
+  it('key override get exposes the seeded sample enabled bit and combined options byte', () => {
+    const state = createVirtualDeviceState()
+    const resp = handleVialReport(state, req(0xfe, 0x0d, 0x05, 0x00), FAKE_COMPRESSED, 0)
+    expect(resp[0]).toBe(0)
+    const optionsByte = resp[10]
+    expect((optionsByte & 0x80) !== 0).toBe(true) // enabled
+    expect(optionsByte & 0x7f).toBe(0x07)
+  })
+
+  it('alt repeat key set/get round-trips through the 6-byte wire entry', () => {
+    const state = createVirtualDeviceState()
+    const setPkt = new Uint8Array(MSG_LEN)
+    setPkt[0] = 0xfe
+    setPkt[1] = 0x0d
+    setPkt[2] = 0x08
+    setPkt[3] = 2
+    writeLE16(setPkt, 4, 4)
+    writeLE16(setPkt, 6, 5)
+    setPkt[8] = 0
+    setPkt[9] = 0x08 // enabled bit only
+    expect(handleVialReport(state, setPkt, FAKE_COMPRESSED, 0)[0]).toBe(0)
+
+    const getResp = handleVialReport(state, req(0xfe, 0x0d, 0x07, 2), FAKE_COMPRESSED, 0)
+    expect(readLE16(getResp, 1)).toBe(4)
+    expect(readLE16(getResp, 3)).toBe(5)
+    expect((getResp[6] & 0x08) !== 0).toBe(true)
   })
 
   it('encoder get (sub 0x03) is a pure echo', () => {

--- a/src/main/virtual-device/dynamic-entries.ts
+++ b/src/main/virtual-device/dynamic-entries.ts
@@ -1,0 +1,253 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Tap dance / combo / key override / alt-repeat-key stores and wire codecs
+// for the virtual GPK60-63R emulator.
+//
+// Entry counts mirror vial-qmk's quantum/vial.h tiering, which picks 32/16/8/4
+// entries per kind from TOTAL_EEPROM_BYTE_COUNT. This board's EEPROM is
+// emulated via wear-leveling on internal flash (STM32L4 has no real EEPROM):
+// builddefs/common_features.mk selects EEPROM_WEAR_LEVELING with
+// WEAR_LEVELING_DRIVER=embedded_flash for STM32L4xx, and
+// platforms/chibios/drivers/wear_leveling/wear_leveling_efl_config.h defaults
+// WEAR_LEVELING_BACKING_SIZE to 8192 (logical size = backing/2 = 4096), none
+// of which the keyboard overrides. TOTAL_EEPROM_BYTE_COUNT = 4096 is > 4000,
+// landing every dynamic-entry kind in the top (32-entry) tier.
+//
+// Alt-repeat-key entries require VIAL_ALT_REPEAT_KEY_ENABLE, which vial.h
+// defines when REPEAT_KEY_ENABLE is set and NO_ALT_REPEAT_KEY is not.
+// builddefs/build_vial.mk defaults REPEAT_KEY_ENABLE to yes for all
+// VIAL_ENABLE builds, and the keyboard does not override it or define
+// NO_ALT_REPEAT_KEY, so alt-repeat-key entries are supported.
+
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../shared/types/protocol'
+import { readLE16, writeLE16 } from './byte-utils'
+
+export const TAP_DANCE_ENTRY_COUNT = 32
+export const COMBO_ENTRY_COUNT = 32
+export const KEY_OVERRIDE_ENTRY_COUNT = 32
+export const ALT_REPEAT_KEY_ENTRY_COUNT = 32
+
+/**
+ * Feature flags byte from dynamic_vial_get_number_of_entries (bit 0 = Caps
+ * Word, bit 1 = Layer Lock). Both CAPS_WORD_ENABLE and LAYER_LOCK_ENABLE
+ * default to yes in build_vial.mk and the keyboard does not override either.
+ */
+export const DYNAMIC_ENTRY_FEATURE_FLAGS = 0x03
+
+/** quantum/action_tapping.h TAPPING_TERM default, used by dynamic_keymap_reset(). */
+const TAPPING_TERM_DEFAULT = 200
+
+/**
+ * Key override options bits set by dynamic_keymap_reset(): trigger-down +
+ * required-mod-down + negative-mod-up activation. The vial_ko_enabled bit is
+ * intentionally left unset — a freshly reset entry exists but is disabled
+ * until a user configures it.
+ */
+const KEY_OVERRIDE_DEFAULT_OPTIONS = 0x07
+
+function defaultTapDanceEntry(): TapDanceEntry {
+  return { onTap: 0, onHold: 0, onDoubleTap: 0, onTapHold: 0, tappingTerm: TAPPING_TERM_DEFAULT }
+}
+
+function defaultComboEntry(): ComboEntry {
+  return { key1: 0, key2: 0, key3: 0, key4: 0, output: 0 }
+}
+
+function defaultKeyOverrideEntry(): KeyOverrideEntry {
+  return {
+    triggerKey: 0,
+    replacementKey: 0,
+    layers: 0xffff,
+    triggerMods: 0,
+    negativeMods: 0,
+    suppressedMods: 0,
+    options: KEY_OVERRIDE_DEFAULT_OPTIONS,
+    enabled: false,
+  }
+}
+
+function defaultAltRepeatKeyEntry(): AltRepeatKeyEntry {
+  return { lastKey: 0, altKey: 0, allowedMods: 0, options: 0, enabled: false }
+}
+
+/** Zero entries returned for out-of-range get() calls — mirror vial.c's
+ *  stack-zero-initialized local struct that dynamic_keymap_get_* leaves
+ *  untouched when the index is out of bounds. Frozen shared singletons:
+ *  callers only serialize them, never mutate. */
+const ZERO_TAP_DANCE: TapDanceEntry = Object.freeze({
+  onTap: 0,
+  onHold: 0,
+  onDoubleTap: 0,
+  onTapHold: 0,
+  tappingTerm: 0,
+})
+const ZERO_COMBO: ComboEntry = Object.freeze({ key1: 0, key2: 0, key3: 0, key4: 0, output: 0 })
+const ZERO_KEY_OVERRIDE: KeyOverrideEntry = Object.freeze({
+  triggerKey: 0,
+  replacementKey: 0,
+  layers: 0,
+  triggerMods: 0,
+  negativeMods: 0,
+  suppressedMods: 0,
+  options: 0,
+  enabled: false,
+})
+const ZERO_ALT_REPEAT_KEY: AltRepeatKeyEntry = Object.freeze({
+  lastKey: 0,
+  altKey: 0,
+  allowedMods: 0,
+  options: 0,
+  enabled: false,
+})
+
+export function createDefaultTapDanceEntries(): TapDanceEntry[] {
+  return Array.from({ length: TAP_DANCE_ENTRY_COUNT }, defaultTapDanceEntry)
+}
+
+export function createDefaultComboEntries(): ComboEntry[] {
+  return Array.from({ length: COMBO_ENTRY_COUNT }, defaultComboEntry)
+}
+
+export function createDefaultKeyOverrideEntries(): KeyOverrideEntry[] {
+  return Array.from({ length: KEY_OVERRIDE_ENTRY_COUNT }, defaultKeyOverrideEntry)
+}
+
+export function createDefaultAltRepeatKeyEntries(): AltRepeatKeyEntry[] {
+  return Array.from({ length: ALT_REPEAT_KEY_ENTRY_COUNT }, defaultAltRepeatKeyEntry)
+}
+
+// --- Wire codecs — byte layouts match vial_*_entry_t in vial-qmk's quantum/vial.h ---
+
+export function writeTapDanceEntry(buf: Uint8Array, offset: number, entry: TapDanceEntry): void {
+  writeLE16(buf, offset, entry.onTap)
+  writeLE16(buf, offset + 2, entry.onHold)
+  writeLE16(buf, offset + 4, entry.onDoubleTap)
+  writeLE16(buf, offset + 6, entry.onTapHold)
+  writeLE16(buf, offset + 8, entry.tappingTerm)
+}
+
+export function readTapDanceEntry(buf: Uint8Array, offset: number): TapDanceEntry {
+  return {
+    onTap: readLE16(buf, offset),
+    onHold: readLE16(buf, offset + 2),
+    onDoubleTap: readLE16(buf, offset + 4),
+    onTapHold: readLE16(buf, offset + 6),
+    tappingTerm: readLE16(buf, offset + 8),
+  }
+}
+
+export function writeComboEntry(buf: Uint8Array, offset: number, entry: ComboEntry): void {
+  writeLE16(buf, offset, entry.key1)
+  writeLE16(buf, offset + 2, entry.key2)
+  writeLE16(buf, offset + 4, entry.key3)
+  writeLE16(buf, offset + 6, entry.key4)
+  writeLE16(buf, offset + 8, entry.output)
+}
+
+export function readComboEntry(buf: Uint8Array, offset: number): ComboEntry {
+  return {
+    key1: readLE16(buf, offset),
+    key2: readLE16(buf, offset + 2),
+    key3: readLE16(buf, offset + 4),
+    key4: readLE16(buf, offset + 6),
+    output: readLE16(buf, offset + 8),
+  }
+}
+
+export function writeKeyOverrideEntry(buf: Uint8Array, offset: number, entry: KeyOverrideEntry): void {
+  writeLE16(buf, offset, entry.triggerKey)
+  writeLE16(buf, offset + 2, entry.replacementKey)
+  writeLE16(buf, offset + 4, entry.layers)
+  buf[offset + 6] = entry.triggerMods
+  buf[offset + 7] = entry.negativeMods
+  buf[offset + 8] = entry.suppressedMods
+  buf[offset + 9] = (entry.options & 0x7f) | (entry.enabled ? 0x80 : 0)
+}
+
+export function readKeyOverrideEntry(buf: Uint8Array, offset: number): KeyOverrideEntry {
+  const optionsByte = buf[offset + 9]
+  return {
+    triggerKey: readLE16(buf, offset),
+    replacementKey: readLE16(buf, offset + 2),
+    layers: readLE16(buf, offset + 4),
+    triggerMods: buf[offset + 6],
+    negativeMods: buf[offset + 7],
+    suppressedMods: buf[offset + 8],
+    options: optionsByte & 0x7f,
+    enabled: (optionsByte & 0x80) !== 0,
+  }
+}
+
+export function writeAltRepeatKeyEntry(buf: Uint8Array, offset: number, entry: AltRepeatKeyEntry): void {
+  writeLE16(buf, offset, entry.lastKey)
+  writeLE16(buf, offset + 2, entry.altKey)
+  buf[offset + 4] = entry.allowedMods
+  buf[offset + 5] = (entry.options & 0x07) | (entry.enabled ? 0x08 : 0)
+}
+
+export function readAltRepeatKeyEntry(buf: Uint8Array, offset: number): AltRepeatKeyEntry {
+  const optionsByte = buf[offset + 5]
+  return {
+    lastKey: readLE16(buf, offset),
+    altKey: readLE16(buf, offset + 2),
+    allowedMods: buf[offset + 4],
+    options: optionsByte & 0x07,
+    enabled: (optionsByte & 0x08) !== 0,
+  }
+}
+
+// --- Bounds-checked get/set — mirrors nvm_dynamic_keymap.c's `index >= COUNT -> -1` guard.
+// get() always yields an entry (the zero entry when out of range) because the real firmware's
+// get handlers memcpy their local (possibly untouched) struct into the response regardless of
+// the status byte. set() only writes to the store when the index is in range. ---
+
+export interface EntryLookup<T> {
+  status: number
+  entry: T
+}
+
+function lookupEntry<T>(entries: T[], index: number, zero: T): EntryLookup<T> {
+  if (index >= 0 && index < entries.length) {
+    return { status: 0, entry: entries[index] }
+  }
+  return { status: 0xff, entry: zero }
+}
+
+function storeEntry<T>(entries: T[], index: number, entry: T): number {
+  if (index >= 0 && index < entries.length) {
+    entries[index] = entry
+    return 0
+  }
+  return 0xff
+}
+
+export function getTapDance(entries: TapDanceEntry[], index: number): EntryLookup<TapDanceEntry> {
+  return lookupEntry(entries, index, ZERO_TAP_DANCE)
+}
+
+export function setTapDance(entries: TapDanceEntry[], index: number, entry: TapDanceEntry): number {
+  return storeEntry(entries, index, entry)
+}
+
+export function getCombo(entries: ComboEntry[], index: number): EntryLookup<ComboEntry> {
+  return lookupEntry(entries, index, ZERO_COMBO)
+}
+
+export function setCombo(entries: ComboEntry[], index: number, entry: ComboEntry): number {
+  return storeEntry(entries, index, entry)
+}
+
+export function getKeyOverride(entries: KeyOverrideEntry[], index: number): EntryLookup<KeyOverrideEntry> {
+  return lookupEntry(entries, index, ZERO_KEY_OVERRIDE)
+}
+
+export function setKeyOverride(entries: KeyOverrideEntry[], index: number, entry: KeyOverrideEntry): number {
+  return storeEntry(entries, index, entry)
+}
+
+export function getAltRepeatKey(entries: AltRepeatKeyEntry[], index: number): EntryLookup<AltRepeatKeyEntry> {
+  return lookupEntry(entries, index, ZERO_ALT_REPEAT_KEY)
+}
+
+export function setAltRepeatKey(entries: AltRepeatKeyEntry[], index: number, entry: AltRepeatKeyEntry): number {
+  return storeEntry(entries, index, entry)
+}

--- a/src/main/virtual-device/gpk60-63r.ts
+++ b/src/main/virtual-device/gpk60-63r.ts
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Static dataset for the virtual GPK60-63R emulator.
-// Keymap layers, macro sample data, and identity constants mirror the
-// firmware source (keymaps/vial/keymap.c, keymaps/vial/vial.json) so the
-// emulator's protocol responses are shaped exactly like a physical device.
+// Dataset and keycode-resolution helpers for the virtual GPK60-63R emulator.
+// Keymap layers, macro/dynamic-entry sample data, and identity constants
+// mirror the firmware source (keymaps/vial/keymap.c, keymaps/vial/vial.json)
+// so the emulator's protocol responses are shaped exactly like a physical
+// device. Small protocol-behavior helpers derived from the dataset (e.g. the
+// QK_BOOT firewall check) also live here, since this is the one module that
+// owns protocol-version-aware keycode resolution.
 
 import * as lzmaModule from 'lzma'
 // `keycodes.ts` must load before `keycodes-utils.ts` — the latter imports
@@ -13,6 +16,7 @@ import * as lzmaModule from 'lzma'
 import { setProtocolValue } from '../../shared/keycodes/keycodes'
 import { resolve, deserialize } from '../../shared/keycodes/keycodes-utils'
 import { SS_QMK_PREFIX, SS_TAP_CODE } from '../../shared/constants/protocol'
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../shared/types/protocol'
 import definitionJson from './gpk60-63r-definition.json'
 
 export const VIRTUAL_DEVICE_VID = 0x7a79
@@ -108,6 +112,14 @@ function kc(token: string): number {
   return token.includes('(') ? deserialize(token) : resolve(token)
 }
 
+/** True for the QK_BOOT keycode — vial-qmk's vial_keycode_firewall() blocks writing this
+ *  value into any dynamic store (keymap, tap dance, combo, key override, alt-repeat-key)
+ *  while the board is locked. */
+export function isBootKeycode(keycode: number): boolean {
+  setProtocolValue(VIAL_PROTOCOL)
+  return keycode === resolve('QK_BOOT')
+}
+
 /** Build the flat 4x5x14 keymap (layer-major, row-major, col order) as raw BE16-ready keycode values. */
 export function buildDefaultKeymap(): Uint16Array {
   setProtocolValue(VIAL_PROTOCOL)
@@ -150,6 +162,47 @@ export function buildDefaultMacroBuffer(): Uint8Array {
   buffer[offset++] = 0x00 // macro 1 terminator
 
   return buffer
+}
+
+/**
+ * Sample dynamic entries seeded at index 0 of each store so the doc
+ * screenshots (and a fresh app run) show a configured tile instead of an
+ * empty one, mirroring how buildDefaultMacroBuffer() seeds sample macros.
+ */
+export function buildSampleTapDance(): TapDanceEntry {
+  setProtocolValue(VIAL_PROTOCOL)
+  return {
+    onTap: resolve('KC_A'),
+    onHold: resolve('KC_LCTRL'),
+    onDoubleTap: 0,
+    onTapHold: 0,
+    tappingTerm: 200,
+  }
+}
+
+export function buildSampleCombo(): ComboEntry {
+  setProtocolValue(VIAL_PROTOCOL)
+  return { key1: resolve('KC_J'), key2: resolve('KC_K'), key3: 0, key4: 0, output: resolve('KC_ESCAPE') }
+}
+
+export function buildSampleKeyOverride(): KeyOverrideEntry {
+  setProtocolValue(VIAL_PROTOCOL)
+  const shift = resolve('MOD_LSFT')
+  return {
+    triggerKey: resolve('KC_BSPACE'),
+    replacementKey: resolve('KC_DELETE'),
+    layers: 0xffff,
+    triggerMods: shift,
+    negativeMods: 0,
+    suppressedMods: shift,
+    options: 0x07, // trigger-down + required-mod-down + negative-mod-up activation
+    enabled: true,
+  }
+}
+
+export function buildSampleAltRepeatKey(): AltRepeatKeyEntry {
+  setProtocolValue(VIAL_PROTOCOL)
+  return { lastKey: resolve('KC_C'), altKey: resolve('KC_V'), allowedMods: 0, options: 0, enabled: true }
 }
 
 function compressLzma(text: string): Promise<Uint8Array> {

--- a/src/main/virtual-device/qmk-settings.ts
+++ b/src/main/virtual-device/qmk-settings.ts
@@ -99,7 +99,7 @@ export function createDefaultQmkSettings(): QmkSettingsStore {
     mousekeyWheelInterval: 80, // MOUSEKEY_WHEEL_INTERVAL
     mousekeyWheelMaxSpeed: 8, // MOUSEKEY_WHEEL_MAX_SPEED
     mousekeyWheelTimeToMax: 40, // MOUSEKEY_WHEEL_TIME_TO_MAX
-    tapCodeDelay: 10, // qmk_settings.h TAP_CODE_DELAY
+    tapCodeDelay: 0, // quantum/action.h TAP_CODE_DELAY (included by qmk_settings.h before its own #ifndef guard, so action.h's 0 wins over qmk_settings.h's fallback 10)
     tapHoldCapsDelay: 80, // qmk_settings.h TAP_HOLD_CAPS_DELAY
     tappingToggle: 5, // quantum/action_tapping.h TAPPING_TOGGLE
     magicFlags: 0,

--- a/src/main/virtual-device/qmk-settings.ts
+++ b/src/main/virtual-device/qmk-settings.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// QMK Settings store and wire protocol for the virtual GPK60-63R emulator.
+//
+// The field list, per-qsid width, and defaults mirror vial-qmk's
+// quantum/qmk_settings.c `protos[]` table and qmk_settings_reset(). Qsids 9-17
+// (mousekey_*) are only registered when `defined(MOUSEKEY_ENABLE) &&
+// !defined(MK_3_SPEED)`; the keyboard's info.json sets `"mousekey": true` and
+// nothing defines MK_3_SPEED, so those qsids are included. Qsid 8 (a legacy
+// tapping_v2 bitfield from older vial-qmk releases) was never assigned a slot
+// in this vial-qmk version's `protos[]` table — the ids jump from 7 to 9 — so
+// it is intentionally absent here too, matching upstream.
+
+import { readLE16, writeLE16, readLE32, writeLE32 } from './byte-utils'
+
+export interface QmkSettingsStore {
+  graveEscOverride: number
+  comboTerm: number
+  autoShift: number
+  autoShiftTimeout: number
+  oskTapToggle: number
+  oskTimeout: number
+  tappingTerm: number
+  mousekeyDelay: number
+  mousekeyInterval: number
+  mousekeyMoveDelta: number
+  mousekeyMaxSpeed: number
+  mousekeyTimeToMax: number
+  mousekeyWheelDelay: number
+  mousekeyWheelInterval: number
+  mousekeyWheelMaxSpeed: number
+  mousekeyWheelTimeToMax: number
+  tapCodeDelay: number
+  tapHoldCapsDelay: number
+  tappingToggle: number
+  /** Magic-settings bit flags (mod swaps, NKRO, ...) — qsid 21. */
+  magicFlags: number
+  /** Bitfield backing qsids 22/23/24/26 (permissive hold / hold-on-other / retro tapping / chordal hold). */
+  tappingV2: number
+  quickTapTerm: number
+  flowTapTerm: number
+}
+
+/**
+ * Wire descriptor per qsid, mirroring qmk_settings.c's `protos[]` entries:
+ * scalar qsids carry a byte width + backing store field, the tapping_v2
+ * qsids carry the bit they address inside `tappingV2`. Declared in the same
+ * (already qsid-ascending) order the firmware table declares them —
+ * qmk_settings_query() walks that order.
+ */
+type QsidProto = { width: 1 | 2 | 4; field: keyof QmkSettingsStore } | { bit: number }
+
+const QSID_PROTOS: ReadonlyMap<number, QsidProto> = new Map<number, QsidProto>([
+  [1, { width: 1, field: 'graveEscOverride' }],
+  [2, { width: 2, field: 'comboTerm' }],
+  [3, { width: 1, field: 'autoShift' }],
+  [4, { width: 2, field: 'autoShiftTimeout' }],
+  [5, { width: 1, field: 'oskTapToggle' }],
+  [6, { width: 2, field: 'oskTimeout' }],
+  [7, { width: 2, field: 'tappingTerm' }],
+  [9, { width: 2, field: 'mousekeyDelay' }],
+  [10, { width: 2, field: 'mousekeyInterval' }],
+  [11, { width: 2, field: 'mousekeyMoveDelta' }],
+  [12, { width: 2, field: 'mousekeyMaxSpeed' }],
+  [13, { width: 2, field: 'mousekeyTimeToMax' }],
+  [14, { width: 2, field: 'mousekeyWheelDelay' }],
+  [15, { width: 2, field: 'mousekeyWheelInterval' }],
+  [16, { width: 2, field: 'mousekeyWheelMaxSpeed' }],
+  [17, { width: 2, field: 'mousekeyWheelTimeToMax' }],
+  [18, { width: 2, field: 'tapCodeDelay' }],
+  [19, { width: 2, field: 'tapHoldCapsDelay' }],
+  [20, { width: 1, field: 'tappingToggle' }],
+  [21, { width: 4, field: 'magicFlags' }],
+  [22, { bit: 0 }],
+  [23, { bit: 1 }],
+  [24, { bit: 2 }],
+  [25, { width: 2, field: 'quickTapTerm' }],
+  [26, { bit: 3 }],
+  [27, { width: 2, field: 'flowTapTerm' }],
+])
+
+/** Supported qsids in firmware-table order (Map preserves insertion order). */
+export const SUPPORTED_QSIDS: readonly number[] = [...QSID_PROTOS.keys()]
+
+export function createDefaultQmkSettings(): QmkSettingsStore {
+  return {
+    graveEscOverride: 0,
+    comboTerm: 50, // quantum/process_keycode/process_combo.h COMBO_TERM
+    autoShift: 0,
+    autoShiftTimeout: 175, // quantum/process_keycode/process_auto_shift.h AUTO_SHIFT_TIMEOUT
+    oskTapToggle: 5, // qmk_settings.h ONESHOT_TAP_TOGGLE
+    oskTimeout: 5000, // qmk_settings.h ONESHOT_TIMEOUT
+    tappingTerm: 200, // quantum/action_tapping.h TAPPING_TERM
+    mousekeyDelay: 10, // quantum/mousekey.h MOUSEKEY_DELAY (no MK_3_SPEED/MK_KINETIC_SPEED/MOUSEKEY_INERTIA)
+    mousekeyInterval: 20, // MOUSEKEY_INTERVAL
+    mousekeyMoveDelta: 8, // MOUSEKEY_MOVE_DELTA
+    mousekeyMaxSpeed: 10, // MOUSEKEY_MAX_SPEED
+    mousekeyTimeToMax: 30, // MOUSEKEY_TIME_TO_MAX
+    mousekeyWheelDelay: 10, // MOUSEKEY_WHEEL_DELAY
+    mousekeyWheelInterval: 80, // MOUSEKEY_WHEEL_INTERVAL
+    mousekeyWheelMaxSpeed: 8, // MOUSEKEY_WHEEL_MAX_SPEED
+    mousekeyWheelTimeToMax: 40, // MOUSEKEY_WHEEL_TIME_TO_MAX
+    tapCodeDelay: 10, // qmk_settings.h TAP_CODE_DELAY
+    tapHoldCapsDelay: 80, // qmk_settings.h TAP_HOLD_CAPS_DELAY
+    tappingToggle: 5, // quantum/action_tapping.h TAPPING_TOGGLE
+    magicFlags: 0,
+    tappingV2: 0,
+    quickTapTerm: 200, // qmk_settings_reset(): QS.quick_tap_term = TAPPING_TERM
+    flowTapTerm: 0,
+  }
+}
+
+export function resetQmkSettings(store: QmkSettingsStore): void {
+  Object.assign(store, createDefaultQmkSettings())
+}
+
+/**
+ * Fill `buf` with the qsids greater than `qsidGreaterThan`, LE16-encoded,
+ * starting at offset 0 — mirrors qmk_settings_query()'s full-buffer memset(0xFF)
+ * + append-in-table-order behavior (the buffer IS the response, unlike get/set
+ * which only touch a sub-range).
+ */
+export function qmkSettingsQuery(qsidGreaterThan: number, buf: Uint8Array): void {
+  buf.fill(0xff)
+  let offset = 0
+  for (const qsid of SUPPORTED_QSIDS) {
+    if (offset + 2 > buf.length) break
+    if (qsid > qsidGreaterThan) {
+      writeLE16(buf, offset, qsid)
+      offset += 2
+    }
+  }
+}
+
+/** Returns 0 (ok, value written to buf at offset) or 0xff (unsupported qsid, buf untouched). */
+export function qmkSettingsGet(store: QmkSettingsStore, qsid: number, buf: Uint8Array, offset: number): number {
+  const proto = QSID_PROTOS.get(qsid)
+  if (!proto) return 0xff
+
+  if ('bit' in proto) {
+    buf[offset] = (store.tappingV2 >> proto.bit) & 1
+    return 0
+  }
+  const value = store[proto.field]
+  if (proto.width === 1) {
+    buf[offset] = value & 0xff
+  } else if (proto.width === 2) {
+    writeLE16(buf, offset, value)
+  } else {
+    writeLE32(buf, offset, value)
+  }
+  return 0
+}
+
+/** Returns 0 (ok, value read from buf at offset) or 0xff (unsupported qsid, store untouched). */
+export function qmkSettingsSet(store: QmkSettingsStore, qsid: number, buf: Uint8Array, offset: number): number {
+  const proto = QSID_PROTOS.get(qsid)
+  if (!proto) return 0xff
+
+  if ('bit' in proto) {
+    if (buf[offset] & 1) {
+      store.tappingV2 |= 1 << proto.bit
+    } else {
+      store.tappingV2 &= ~(1 << proto.bit)
+    }
+    return 0
+  }
+  if (proto.width === 1) {
+    store[proto.field] = buf[offset]
+  } else if (proto.width === 2) {
+    store[proto.field] = readLE16(buf, offset)
+  } else {
+    store[proto.field] = readLE32(buf, offset)
+  }
+  return 0
+}

--- a/src/main/virtual-device/state.ts
+++ b/src/main/virtual-device/state.ts
@@ -4,6 +4,7 @@
 // keyboard only unlocks after the combo has been held continuously for
 // unlockCounterMax poll ticks spaced >= 100ms apart.
 
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../shared/types/protocol'
 import {
   LAYERS,
   ROWS,
@@ -12,7 +13,19 @@ import {
   VIALRGB_SUPPORTED_EFFECTS,
   buildDefaultKeymap,
   buildDefaultMacroBuffer,
+  buildSampleTapDance,
+  buildSampleCombo,
+  buildSampleKeyOverride,
+  buildSampleAltRepeatKey,
 } from './gpk60-63r'
+import {
+  createDefaultTapDanceEntries,
+  createDefaultComboEntries,
+  createDefaultKeyOverrideEntries,
+  createDefaultAltRepeatKeyEntries,
+} from './dynamic-entries'
+import { createDefaultQmkSettings } from './qmk-settings'
+import type { QmkSettingsStore } from './qmk-settings'
 
 export interface VialRGBState {
   mode: number
@@ -35,6 +48,11 @@ export interface VirtualDeviceState {
   /** Timestamp (ms) of the last unlock poll tick that made progress. */
   unlockTimer: number
   rgb: VialRGBState
+  tapDanceEntries: TapDanceEntry[]
+  comboEntries: ComboEntry[]
+  keyOverrideEntries: KeyOverrideEntry[]
+  altRepeatKeyEntries: AltRepeatKeyEntry[]
+  qmkSettings: QmkSettingsStore
 }
 
 const UNLOCK_COUNTER_MAX_DEFAULT = 50
@@ -45,6 +63,17 @@ function createMatrix(): boolean[][] {
 }
 
 export function createVirtualDeviceState(): VirtualDeviceState {
+  const tapDanceEntries = createDefaultTapDanceEntries()
+  const comboEntries = createDefaultComboEntries()
+  const keyOverrideEntries = createDefaultKeyOverrideEntries()
+  const altRepeatKeyEntries = createDefaultAltRepeatKeyEntries()
+  // Seed index 0 of each store with a sample so a fresh device (and the doc
+  // screenshots) show a configured tile, mirroring the sample macros below.
+  tapDanceEntries[0] = buildSampleTapDance()
+  comboEntries[0] = buildSampleCombo()
+  keyOverrideEntries[0] = buildSampleKeyOverride()
+  altRepeatKeyEntries[0] = buildSampleAltRepeatKey()
+
   return {
     keymap: buildDefaultKeymap(),
     macroBuffer: buildDefaultMacroBuffer(),
@@ -62,6 +91,11 @@ export function createVirtualDeviceState(): VirtualDeviceState {
       sat: 255,
       val: 128,
     },
+    tapDanceEntries,
+    comboEntries,
+    keyOverrideEntries,
+    altRepeatKeyEntries,
+    qmkSettings: createDefaultQmkSettings(),
   }
 }
 

--- a/src/main/virtual-device/via-handler.ts
+++ b/src/main/virtual-device/via-handler.ts
@@ -23,18 +23,11 @@ import {
   VIA_LAYOUT_OPTIONS,
   VIA_SWITCH_MATRIX_STATE,
 } from '../../shared/constants/protocol'
-import { setProtocolValue } from '../../shared/keycodes/keycodes'
-import { resolve } from '../../shared/keycodes/keycodes-utils'
 import { readBE16, writeBE16, readBE32, writeBE32 } from './byte-utils'
-import { VIAL_PROTOCOL, LAYERS, ROWS, COLS, MACRO_COUNT, MACRO_BUFFER_SIZE } from './gpk60-63r'
+import { LAYERS, ROWS, COLS, MACRO_COUNT, MACRO_BUFFER_SIZE, isBootKeycode } from './gpk60-63r'
 import type { VirtualDeviceState } from './state'
 import { isValidKeymapPosition, keymapIndex, packMatrixState } from './state'
 import { getLightingValue, setLightingValue } from './vialrgb-handler'
-
-function isBootKeycode(keycode: number): boolean {
-  setProtocolValue(VIAL_PROTOCOL)
-  return keycode === resolve('QK_BOOT')
-}
 
 export function handleViaReport(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
   const resp = new Uint8Array(req)

--- a/src/main/virtual-device/vial-handler.ts
+++ b/src/main/virtual-device/vial-handler.ts
@@ -14,13 +14,50 @@ import {
   CMD_VIAL_UNLOCK_POLL,
   CMD_VIAL_LOCK,
   CMD_VIAL_QMK_SETTINGS_QUERY,
+  CMD_VIAL_QMK_SETTINGS_GET,
+  CMD_VIAL_QMK_SETTINGS_SET,
+  CMD_VIAL_QMK_SETTINGS_RESET,
   CMD_VIAL_DYNAMIC_ENTRY_OP,
   DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES,
+  DYNAMIC_VIAL_TAP_DANCE_GET,
+  DYNAMIC_VIAL_TAP_DANCE_SET,
+  DYNAMIC_VIAL_COMBO_GET,
+  DYNAMIC_VIAL_COMBO_SET,
+  DYNAMIC_VIAL_KEY_OVERRIDE_GET,
+  DYNAMIC_VIAL_KEY_OVERRIDE_SET,
+  DYNAMIC_VIAL_ALT_REPEAT_KEY_GET,
+  DYNAMIC_VIAL_ALT_REPEAT_KEY_SET,
 } from '../../shared/constants/protocol'
-import { readLE32, writeLE32 } from './byte-utils'
-import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO } from './gpk60-63r'
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../shared/types/protocol'
+import { readLE16, readLE32, writeLE32 } from './byte-utils'
+import { VIAL_PROTOCOL, VIRTUAL_DEVICE_UID_BYTES, VIRTUAL_DEVICE_UNLOCK_COMBO, isBootKeycode } from './gpk60-63r'
 import type { VirtualDeviceState } from './state'
 import { unlockPollTick } from './state'
+import {
+  TAP_DANCE_ENTRY_COUNT,
+  COMBO_ENTRY_COUNT,
+  KEY_OVERRIDE_ENTRY_COUNT,
+  ALT_REPEAT_KEY_ENTRY_COUNT,
+  DYNAMIC_ENTRY_FEATURE_FLAGS,
+  getTapDance,
+  setTapDance,
+  getCombo,
+  setCombo,
+  getKeyOverride,
+  setKeyOverride,
+  getAltRepeatKey,
+  setAltRepeatKey,
+  readTapDanceEntry,
+  writeTapDanceEntry,
+  readComboEntry,
+  writeComboEntry,
+  readKeyOverrideEntry,
+  writeKeyOverrideEntry,
+  readAltRepeatKeyEntry,
+  writeAltRepeatKeyEntry,
+} from './dynamic-entries'
+import type { EntryLookup } from './dynamic-entries'
+import { qmkSettingsQuery, qmkSettingsGet, qmkSettingsSet, resetQmkSettings } from './qmk-settings'
 
 /** VialRGB support flag reported in the keyboard-id response (byte 12). */
 const VIALRGB_FLAG = 1
@@ -75,6 +112,129 @@ function handleUnlockPoll(state: VirtualDeviceState, now: number): Uint8Array {
   return resp
 }
 
+/** Replaces a QK_BOOT keycode with KC_NO while locked — vial_keycode_firewall()'s behavior. */
+function gateBootKeycode(state: VirtualDeviceState, keycode: number): number {
+  return !state.unlocked && isBootKeycode(keycode) ? 0 : keycode
+}
+
+function handleGetNumberOfEntries(): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN)
+  resp[0] = TAP_DANCE_ENTRY_COUNT
+  resp[1] = COMBO_ENTRY_COUNT
+  resp[2] = KEY_OVERRIDE_ENTRY_COUNT
+  resp[3] = ALT_REPEAT_KEY_ENTRY_COUNT
+  resp[MSG_LEN - 1] = DYNAMIC_ENTRY_FEATURE_FLAGS
+  return resp
+}
+
+/**
+ * Shared shape of every dynamic-entry GET: echo the request, look the entry
+ * up by req[3], put the status byte at offset 0 and the wire entry at offset 1.
+ * (SET handlers stay separate — each entry kind firewalls a different subset
+ * of its fields against QK_BOOT.)
+ */
+function handleEntryGet<T>(
+  req: Uint8Array,
+  entries: T[],
+  lookup: (entries: T[], index: number) => EntryLookup<T>,
+  writeEntry: (buf: Uint8Array, offset: number, entry: T) => void,
+): Uint8Array {
+  const resp = new Uint8Array(req)
+  const { status, entry } = lookup(entries, req[3])
+  resp[0] = status
+  writeEntry(resp, 1, entry)
+  return resp
+}
+
+function handleTapDanceSet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const raw = readTapDanceEntry(req, 4)
+  const entry: TapDanceEntry = {
+    onTap: gateBootKeycode(state, raw.onTap),
+    onHold: gateBootKeycode(state, raw.onHold),
+    onDoubleTap: gateBootKeycode(state, raw.onDoubleTap),
+    onTapHold: gateBootKeycode(state, raw.onTapHold),
+    tappingTerm: raw.tappingTerm,
+  }
+  resp[0] = setTapDance(state.tapDanceEntries, req[3], entry)
+  return resp
+}
+
+function handleComboSet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const raw = readComboEntry(req, 4)
+  const entry: ComboEntry = { ...raw, output: gateBootKeycode(state, raw.output) }
+  resp[0] = setCombo(state.comboEntries, req[3], entry)
+  return resp
+}
+
+function handleKeyOverrideSet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const raw = readKeyOverrideEntry(req, 4)
+  const entry: KeyOverrideEntry = { ...raw, replacementKey: gateBootKeycode(state, raw.replacementKey) }
+  resp[0] = setKeyOverride(state.keyOverrideEntries, req[3], entry)
+  return resp
+}
+
+function handleAltRepeatKeySet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const raw = readAltRepeatKeyEntry(req, 4)
+  const entry: AltRepeatKeyEntry = {
+    ...raw,
+    lastKey: gateBootKeycode(state, raw.lastKey),
+    altKey: gateBootKeycode(state, raw.altKey),
+  }
+  resp[0] = setAltRepeatKey(state.altRepeatKeyEntries, req[3], entry)
+  return resp
+}
+
+function handleDynamicEntryOp(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  switch (req[2]) {
+    case DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES:
+      return handleGetNumberOfEntries()
+    case DYNAMIC_VIAL_TAP_DANCE_GET:
+      return handleEntryGet(req, state.tapDanceEntries, getTapDance, writeTapDanceEntry)
+    case DYNAMIC_VIAL_TAP_DANCE_SET:
+      return handleTapDanceSet(state, req)
+    case DYNAMIC_VIAL_COMBO_GET:
+      return handleEntryGet(req, state.comboEntries, getCombo, writeComboEntry)
+    case DYNAMIC_VIAL_COMBO_SET:
+      return handleComboSet(state, req)
+    case DYNAMIC_VIAL_KEY_OVERRIDE_GET:
+      return handleEntryGet(req, state.keyOverrideEntries, getKeyOverride, writeKeyOverrideEntry)
+    case DYNAMIC_VIAL_KEY_OVERRIDE_SET:
+      return handleKeyOverrideSet(state, req)
+    case DYNAMIC_VIAL_ALT_REPEAT_KEY_GET:
+      return handleEntryGet(req, state.altRepeatKeyEntries, getAltRepeatKey, writeAltRepeatKeyEntry)
+    case DYNAMIC_VIAL_ALT_REPEAT_KEY_SET:
+      return handleAltRepeatKeySet(state, req)
+    default:
+      // Unrecognized dynamic-entry sub-op: unsupported, echo.
+      return new Uint8Array(req)
+  }
+}
+
+function handleQmkSettingsQuery(req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(MSG_LEN)
+  const qsidGreaterThan = readLE16(req, 2)
+  qmkSettingsQuery(qsidGreaterThan, resp)
+  return resp
+}
+
+function handleQmkSettingsGet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const qsid = readLE16(req, 2)
+  resp[0] = qmkSettingsGet(state.qmkSettings, qsid, resp, 1)
+  return resp
+}
+
+function handleQmkSettingsSet(state: VirtualDeviceState, req: Uint8Array): Uint8Array {
+  const resp = new Uint8Array(req)
+  const qsid = readLE16(req, 2)
+  resp[0] = qmkSettingsSet(state.qmkSettings, qsid, req, 4)
+  return resp
+}
+
 export function handleVialReport(
   state: VirtualDeviceState,
   req: Uint8Array,
@@ -110,19 +270,24 @@ export function handleVialReport(
       return new Uint8Array(req)
 
     case CMD_VIAL_QMK_SETTINGS_QUERY:
-      // QMK Settings is not implemented by the virtual firmware.
-      return new Uint8Array(MSG_LEN).fill(0xff)
+      return handleQmkSettingsQuery(req)
 
-    case CMD_VIAL_DYNAMIC_ENTRY_OP:
-      if (req[2] === DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES) {
-        // Tap dance, combo, key override, alt-repeat-key: all zero. Feature flags: none.
-        return new Uint8Array(MSG_LEN)
-      }
-      // Individual entry get/set and other dynamic ops: unsupported, echo.
+    case CMD_VIAL_QMK_SETTINGS_GET:
+      return handleQmkSettingsGet(state, req)
+
+    case CMD_VIAL_QMK_SETTINGS_SET:
+      return handleQmkSettingsSet(state, req)
+
+    case CMD_VIAL_QMK_SETTINGS_RESET:
+      resetQmkSettings(state.qmkSettings)
+      // vial.c's reset case never touches msg, so the request is echoed back unchanged.
       return new Uint8Array(req)
 
+    case CMD_VIAL_DYNAMIC_ENTRY_OP:
+      return handleDynamicEntryOp(state, req)
+
     default:
-      // Encoders (0x03/0x04), QMK settings get/set/reset (0x0a/0x0b/0x0c): unsupported, echo.
+      // Encoders (0x03/0x04): unsupported, echo.
       return new Uint8Array(req)
   }
 }

--- a/src/preload/__tests__/protocol-virtual-device.test.ts
+++ b/src/preload/__tests__/protocol-virtual-device.test.ts
@@ -33,7 +33,14 @@ import {
   getDefinitionSize,
   getDefinitionRaw,
   getDynamicEntryCount,
+  getTapDance,
+  getCombo,
+  getKeyOverride,
+  getAltRepeatKey,
   qmkSettingsQuery,
+  qmkSettingsGet,
+  qmkSettingsSet,
+  qmkSettingsReset,
   getVialRGBInfo,
   getVialRGBMode,
   getVialRGBSupported,
@@ -114,20 +121,56 @@ describe('preload protocol against the virtual device emulator', () => {
     expect(definition.name).toBe('GPK60-63R Virtual')
   })
 
-  it('getDynamicEntryCount returns all zeros without throwing echo-detected', async () => {
+  it('getDynamicEntryCount reports the 32-entry tier and caps-word/layer-lock feature flags', async () => {
     await expect(getDynamicEntryCount()).resolves.toEqual({
-      tapDance: 0,
-      combo: 0,
-      keyOverride: 0,
-      altRepeatKey: 0,
-      featureFlags: 0,
+      tapDance: 32,
+      combo: 32,
+      keyOverride: 32,
+      altRepeatKey: 32,
+      featureFlags: 0x03,
     })
   })
 
-  it('qmkSettingsQuery yields an all-0xFF (unsupported / empty) qsid list', async () => {
+  it('getTapDance/getCombo/getKeyOverride/getAltRepeatKey parse the seeded sample at index 0', async () => {
+    const tapDance = await getTapDance(0)
+    expect(tapDance.onTap).not.toBe(0)
+    expect(tapDance.onHold).not.toBe(0)
+
+    const combo = await getCombo(0)
+    expect(combo.key1).not.toBe(0)
+    expect(combo.key2).not.toBe(0)
+    expect(combo.output).not.toBe(0)
+
+    const keyOverride = await getKeyOverride(0)
+    expect(keyOverride.enabled).toBe(true)
+    expect(keyOverride.triggerKey).not.toBe(0)
+    expect(keyOverride.replacementKey).not.toBe(0)
+
+    const altRepeatKey = await getAltRepeatKey(0)
+    expect(altRepeatKey.enabled).toBe(true)
+    expect(altRepeatKey.lastKey).not.toBe(0)
+    expect(altRepeatKey.altKey).not.toBe(0)
+  })
+
+  it('qmkSettingsQuery yields a non-empty ascending qsid list (not the all-0xFF placeholder)', async () => {
     const result = await qmkSettingsQuery(0)
     expect(result).toHaveLength(MSG_LEN)
-    expect(result.every((b) => b === 0xff)).toBe(true)
+    expect(result.every((b) => b === 0xff)).toBe(false)
+    // First entry (LE16) should be qsid 1 (grave_esc_override).
+    expect(result[0] | (result[1] << 8)).toBe(1)
+  })
+
+  it('qmkSettingsGet/qmkSettingsSet/qmkSettingsReset round-trip a known default (qsid 7 = tapping_term)', async () => {
+    const before = await qmkSettingsGet(7)
+    expect(before[0] | (before[1] << 8)).toBe(200)
+
+    await qmkSettingsSet(7, [44, 1]) // 300 LE16
+    const after = await qmkSettingsGet(7)
+    expect(after[0] | (after[1] << 8)).toBe(300)
+
+    await qmkSettingsReset()
+    const reset = await qmkSettingsGet(7)
+    expect(reset[0] | (reset[1] << 8)).toBe(200)
   })
 
   it('getVialRGBInfo/getVialRGBMode/getVialRGBSupported parse cleanly', async () => {


### PR DESCRIPTION
## Summary

Completes the virtual GPK60-63R's protocol surface with the features a real build actually ships: vial-qmk's `build_vial.mk` defaults `QMK_SETTINGS`/`TAP_DANCE_ENABLE`/`COMBO_ENABLE`/`KEY_OVERRIDE_ENABLE` (and Repeat Key) to **yes** under `VIAL_ENABLE`, so the emulator's previous zeroed dynamic-entry counts were not firmware-faithful and blocked 9 doc screenshots (tap dance / combo / key override / alt-repeat / QMK settings editors).

- Dynamic entries: tap dance, combo, key override, alt-repeat — **32 entries each**, derived (not assumed) from the vial.h EEPROM tier chain for STM32L432 (`WEAR_LEVELING_LOGICAL_SIZE` 4096 > 4000 → top tier). Get/set wire formats and bounds semantics ported from `vial.c`/`dynamic_keymap.c`, including `vial_keycode_firewall` (QK_BOOT → KC_NO while locked, per the exact fields the firmware gates). Counts response carries the firmware flags byte (Caps Word + Layer Lock = 0x03).
- QMK settings: 26 qsids (1-7, 9-27) with defaults traced through the real macro chain (e.g. `tap_code_delay` = 0 because `action.h` wins the include-order race against `qmk_settings.h`'s dead fallback). Query pagination / get / set / reset per `qmk_settings.c`.
- Slot-0 sample entries (tap dance, combo, key override, alt-repeat) ship by default so doc captures render configured tiles — a deliberate deviation from the firmware's zeroed factory state, same convention as the existing sample macros; `reset()` restores this baseline.

## Tests

- New suites for the entry stores and QMK settings store; vial-handler suite extended (exact counts bytes, out-of-range indices, locked/unlocked firewall per entry kind, query pagination, get/set/reset round-trips).
- Preload integration suite extended: the real `src/preload/protocol.ts` parsers read counts 32/32/32/32 + flags 0x03, parse the seeded samples, and round-trip qsid values against the emulator.
- Totals: 4622 unit tests green, tsc/eslint clean.

Follow-up (next PR): re-run `doc:screenshots` against the completed emulator.