### PR TITLE
feat(ui): add trigram stats and IKI standard deviation to the Analyze n-gram view

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1042,10 +1042,17 @@
         "slow": "ペア間隔",
         "fingerIki": "指間隔"
       },
+      "gramToggle": {
+        "ariaLabel": "N-gram の粒度",
+        "bigram": "2-gram",
+        "trigram": "3-gram"
+      },
       "column": {
         "pair": "ペア",
         "count": "回数",
         "avgIki": "平均間隔",
+        "avgIkiTrigramTooltip": "3キー間にある2つの間隔の平均です。3キー全体の所要時間ではありません",
+        "sd": "SD",
         "p95": "p95 間隔"
       },
       "fingerIki": {

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -307,12 +307,17 @@ async function collectData(
       ? db.listBigramMinutesInRangeForUid(uid, fromMs, toMs, appScopes)
       : db.listBigramMinutesInRangeForUidAndHash(uid, machineHash, fromMs, toMs, appScopes)
     const bigramTotals = aggregatePairTotals(bigramRows)
+    // Hub's wire field is `bigramId` (see HUB-ANALYTICS-API.md); map it
+    // explicitly from the aggregator's `ngramId` instead of relying on
+    // structural assignability, so a future ngramId-only shape can't
+    // silently break this export.
     bigramTop = rankBigramsByCount(bigramTotals, ANALYTICS_BIGRAM_TOP_LIMIT)
+      .map(({ ngramId, count, hist, avgIki }) => ({ bigramId: ngramId, count, hist, avgIki }))
     bigramSlow = rankBigramsBySlow(
       bigramTotals,
       ANALYTICS_BIGRAM_SLOW_MIN_SAMPLE,
       ANALYTICS_BIGRAM_SLOW_LIMIT,
-    )
+    ).map(({ ngramId, count, hist, avgIki, p95 }) => ({ bigramId: ngramId, count, hist, avgIki, p95 }))
   }
 
   const layoutComparison = needsLayoutComparison

--- a/src/main/typing-analytics/__tests__/bigram-aggregate.test.ts
+++ b/src/main/typing-analytics/__tests__/bigram-aggregate.test.ts
@@ -7,17 +7,44 @@ import {
   percentileFromHist,
   rankBigramsByCount,
   rankBigramsBySlow,
+  sdFromSums,
   type BigramPairTotal,
 } from '../bigram-aggregate'
-import type { BigramMinuteCellRow } from '../db/typing-analytics-db'
+import type { NgramMinuteCellRow } from '../db/typing-analytics-db'
 
-function row(bigramId: string, count: number, hist: number[], minuteTs = 60_000): BigramMinuteCellRow {
-  return { bigramId, minuteTs, count, hist }
+function row(
+  ngramId: string,
+  count: number,
+  hist: number[],
+  minuteTs = 60_000,
+  sumIki: number | null = null,
+  sumSqIki: number | null = null,
+): NgramMinuteCellRow {
+  return { ngramId, minuteTs, count, hist, sumIki, sumSqIki }
 }
 
-function totals(entries: { bigramId: string; count: number; hist: number[] }[]): Map<string, BigramPairTotal> {
+function trigramRow(
+  ngramId: string,
+  count: number,
+  hist: number[],
+  minuteTs = 60_000,
+  sumIki: number | null = null,
+  sumSqIki: number | null = null,
+): NgramMinuteCellRow {
+  return { ngramId, minuteTs, count, hist, sumIki, sumSqIki }
+}
+
+function totals(entries: { ngramId: string; count: number; hist: number[]; sumIki?: number | null; sumSqIki?: number | null }[]): Map<string, BigramPairTotal> {
   const map = new Map<string, BigramPairTotal>()
-  for (const e of entries) map.set(e.bigramId, { ...e })
+  for (const e of entries) {
+    map.set(e.ngramId, {
+      ngramId: e.ngramId,
+      count: e.count,
+      hist: e.hist,
+      sumIki: e.sumIki ?? null,
+      sumSqIki: e.sumSqIki ?? null,
+    })
+  }
   return map
 }
 
@@ -42,8 +69,95 @@ describe('aggregatePairTotals', () => {
       row('B', 2, [0, 2, 0, 0, 0, 0, 0, 0]),
       row('A', 4, [3, 1, 0, 0, 0, 0, 0, 0]),
     ])
-    expect(map.get('A')).toEqual({ bigramId: 'A', count: 5, hist: [4, 1, 0, 0, 0, 0, 0, 0] })
-    expect(map.get('B')).toEqual({ bigramId: 'B', count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0] })
+    expect(map.get('A')).toEqual({
+      ngramId: 'A', count: 5, hist: [4, 1, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null,
+    })
+    expect(map.get('B')).toEqual({
+      ngramId: 'B', count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null,
+    })
+  })
+
+  it('groups trigram rows by ngramId, reusing the same pipeline as bigrams', () => {
+    const map = aggregatePairTotals([
+      trigramRow('4_11_7', 1, [1, 0, 0, 0, 0, 0, 0, 0]),
+      trigramRow('4_11_7', 1, [0, 1, 0, 0, 0, 0, 0, 0]),
+      trigramRow('11_7_5', 1, [0, 0, 1, 0, 0, 0, 0, 0]),
+    ])
+    expect(map.size).toBe(2)
+    expect(map.get('4_11_7')!.count).toBe(2)
+    expect(map.get('11_7_5')!.count).toBe(1)
+  })
+
+  it('accumulates sum/sumSq when every contributing row has them', () => {
+    const map = aggregatePairTotals([
+      row('A', 2, [2, 0, 0, 0, 0, 0, 0, 0], 60_000, 100, 5_000),
+      row('A', 3, [3, 0, 0, 0, 0, 0, 0, 0], 120_000, 150, 7_500),
+    ])
+    const e = map.get('A')!
+    expect(e.sumIki).toBe(250)
+    expect(e.sumSqIki).toBe(12_500)
+  })
+
+  it('nulls sum/sumSq for the whole pair once any contributing row lacks them', () => {
+    const map = aggregatePairTotals([
+      row('A', 2, [2, 0, 0, 0, 0, 0, 0, 0], 60_000, 100, 5_000),
+      // Older row predating the sum columns.
+      row('A', 1, [1, 0, 0, 0, 0, 0, 0, 0], 120_000, null, null),
+    ])
+    const e = map.get('A')!
+    expect(e.sumIki).toBeNull()
+    expect(e.sumSqIki).toBeNull()
+  })
+
+  it('does not resurrect sum/sumSq once nulled, even if a later row has them', () => {
+    const map = aggregatePairTotals([
+      // Older row predating the sum columns arrives first.
+      row('A', 1, [1, 0, 0, 0, 0, 0, 0, 0], 60_000, null, null),
+      row('A', 2, [2, 0, 0, 0, 0, 0, 0, 0], 120_000, 100, 5_000),
+    ])
+    const e = map.get('A')!
+    expect(e.sumIki).toBeNull()
+    expect(e.sumSqIki).toBeNull()
+  })
+})
+
+describe('sdFromSums', () => {
+  it('computes the population SD from sum and sum-of-squares', () => {
+    // IKI values [80, 100, 120]: mean=100, variance=((80-100)^2+(100-100)^2+(120-100)^2)/3=266.67
+    const sum = 80 + 100 + 120
+    const sumSq = 80 ** 2 + 100 ** 2 + 120 ** 2
+    const sd = sdFromSums(sum, sumSq, 3)
+    expect(sd).not.toBeNull()
+    expect(sd!).toBeCloseTo(Math.sqrt(266.666_667), 3)
+  })
+
+  it('clips floating-point rounding on equally-spaced keystrokes to 0, not NaN', () => {
+    // Simulate 3 equal-IKI pairs accumulated one row at a time (matching
+    // how aggregatePairTotals sums them). True variance is 0, but
+    // repeated float addition of a non-terminating fraction leaves a
+    // tiny negative residue in sumSq/n - (sum/n)^2 without the
+    // max(0, ...) clip — this would otherwise surface as NaN.
+    const value = 100 / 3
+    const count = 3
+    let sum = 0
+    let sumSq = 0
+    for (let i = 0; i < count; i += 1) {
+      sum += value
+      sumSq += value * value
+    }
+    const sd = sdFromSums(sum, sumSq, count)
+    expect(sd).toBe(0)
+    expect(Number.isNaN(sd)).toBe(false)
+  })
+
+  it('computes 0 for exactly equal integer IKI values too', () => {
+    const sd = sdFromSums(400, 40_000, 4)
+    expect(sd).toBe(0)
+  })
+
+  it('returns null for fewer than 2 samples', () => {
+    expect(sdFromSums(100, 10_000, 1)).toBeNull()
+    expect(sdFromSums(0, 0, 0)).toBeNull()
   })
 })
 
@@ -90,27 +204,44 @@ describe('percentileFromHist', () => {
 describe('rankBigramsByCount', () => {
   it('sorts pairs by count descending and applies the limit', () => {
     const map = totals([
-      { bigramId: 'A', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
-      { bigramId: 'B', count: 10, hist: [0, 10, 0, 0, 0, 0, 0, 0] },
-      { bigramId: 'C', count: 1, hist: [0, 0, 1, 0, 0, 0, 0, 0] },
+      { ngramId: 'A', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'B', count: 10, hist: [0, 10, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'C', count: 1, hist: [0, 0, 1, 0, 0, 0, 0, 0] },
     ])
-    expect(rankBigramsByCount(map, 2).map((e) => e.bigramId)).toEqual(['B', 'A'])
+    expect(rankBigramsByCount(map, 2).map((e) => e.ngramId)).toEqual(['B', 'A'])
   })
 
-  it('breaks ties by bigramId ascending so output is deterministic', () => {
+  it('breaks ties by ngramId ascending so output is deterministic', () => {
     const map = totals([
-      { bigramId: 'B', count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0] },
-      { bigramId: 'A', count: 3, hist: [0, 0, 3, 0, 0, 0, 0, 0] },
+      { ngramId: 'B', count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'A', count: 3, hist: [0, 0, 3, 0, 0, 0, 0, 0] },
     ])
-    expect(rankBigramsByCount(map, 5).map((e) => e.bigramId)).toEqual(['A', 'B'])
+    expect(rankBigramsByCount(map, 5).map((e) => e.ngramId)).toEqual(['A', 'B'])
   })
 
   it('attaches avgIki computed from each pair hist', () => {
     const map = totals([
-      { bigramId: 'A', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'A', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0] },
     ])
     const [entry] = rankBigramsByCount(map, 5)
     expect(entry.avgIki).toBe(30) // bucket 0 center
+  })
+
+  it('attaches sd computed from sum/sumSq when the pair has complete sums', () => {
+    const map = totals([
+      { ngramId: 'A', count: 2, hist: [2, 0, 0, 0, 0, 0, 0, 0], sumIki: 200, sumSqIki: 20_400 },
+    ])
+    const [entry] = rankBigramsByCount(map, 5)
+    expect(entry.sd).not.toBeNull()
+    expect(entry.sd!).toBeCloseTo(sdFromSums(200, 20_400, 2)!, 10)
+  })
+
+  it('reports sd as null when the pair has incomplete sums', () => {
+    const map = totals([
+      { ngramId: 'A', count: 2, hist: [2, 0, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null },
+    ])
+    const [entry] = rankBigramsByCount(map, 5)
+    expect(entry.sd).toBeNull()
   })
 })
 
@@ -118,30 +249,30 @@ describe('rankBigramsBySlow', () => {
   it('drops pairs below minSampleCount', () => {
     const map = totals([
       // Slow pair but only 1 sample → should be dropped at minSample=5.
-      { bigramId: 'low', count: 1, hist: [0, 0, 0, 0, 0, 0, 0, 1] },
+      { ngramId: 'low', count: 1, hist: [0, 0, 0, 0, 0, 0, 0, 1] },
       // Fast pair with enough samples → kept.
-      { bigramId: 'kept', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'kept', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
     ])
     const ranked = rankBigramsBySlow(map, 5, 5)
-    expect(ranked.map((e) => e.bigramId)).toEqual(['kept'])
+    expect(ranked.map((e) => e.ngramId)).toEqual(['kept'])
   })
 
   it('orders by avg IKI descending', () => {
     const map = totals([
       // Fast (avg ~30)
-      { bigramId: 'A', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
+      { ngramId: 'A', count: 5, hist: [5, 0, 0, 0, 0, 0, 0, 0] },
       // Slow (avg ~1500)
-      { bigramId: 'B', count: 5, hist: [0, 0, 0, 0, 0, 0, 0, 5] },
+      { ngramId: 'B', count: 5, hist: [0, 0, 0, 0, 0, 0, 0, 5] },
       // Medium (avg ~250)
-      { bigramId: 'C', count: 5, hist: [0, 0, 0, 0, 5, 0, 0, 0] },
+      { ngramId: 'C', count: 5, hist: [0, 0, 0, 0, 5, 0, 0, 0] },
     ])
-    expect(rankBigramsBySlow(map, 5, 5).map((e) => e.bigramId)).toEqual(['B', 'C', 'A'])
+    expect(rankBigramsBySlow(map, 5, 5).map((e) => e.ngramId)).toEqual(['B', 'C', 'A'])
   })
 
   it('attaches p95 computed from each pair hist', () => {
     const map = totals([
       // 4 samples in bucket 0, 1 in bucket 7. p95 of 5 samples = target 4.75 — lands in b7.
-      { bigramId: 'A', count: 5, hist: [4, 0, 0, 0, 0, 0, 0, 1] },
+      { ngramId: 'A', count: 5, hist: [4, 0, 0, 0, 0, 0, 0, 1] },
     ])
     const [entry] = rankBigramsBySlow(map, 5, 5)
     expect(entry.p95).not.toBeNull()
@@ -149,7 +280,24 @@ describe('rankBigramsBySlow', () => {
   })
 
   it('returns an empty array when no pair meets minSample', () => {
-    const map = totals([{ bigramId: 'x', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0] }])
+    const map = totals([{ ngramId: 'x', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0] }])
     expect(rankBigramsBySlow(map, 5, 5)).toEqual([])
+  })
+
+  it('attaches sd computed from sum/sumSq when the pair has complete sums', () => {
+    const map = totals([
+      { ngramId: 'A', count: 5, hist: [4, 0, 0, 0, 0, 0, 0, 1], sumIki: 900, sumSqIki: 500_000 },
+    ])
+    const [entry] = rankBigramsBySlow(map, 5, 5)
+    expect(entry.sd).not.toBeNull()
+    expect(entry.sd!).toBeCloseTo(sdFromSums(900, 500_000, 5)!, 10)
+  })
+
+  it('reports sd as null when the pair has incomplete sums (mixed old/new data)', () => {
+    const map = totals([
+      { ngramId: 'A', count: 5, hist: [4, 0, 0, 0, 0, 0, 0, 1], sumIki: null, sumSqIki: null },
+    ])
+    const [entry] = rankBigramsBySlow(map, 5, 5)
+    expect(entry.sd).toBeNull()
   })
 })

--- a/src/main/typing-analytics/__tests__/cache-rebuild.test.ts
+++ b/src/main/typing-analytics/__tests__/cache-rebuild.test.ts
@@ -12,9 +12,11 @@ import {
 import { TypingAnalyticsDB } from '../db/typing-analytics-db'
 import { SCHEMA_VERSION } from '../db/schema'
 import {
+  bigramMinuteRowId,
   charMinuteRowId,
   minuteStatsRowId,
   scopeRowId,
+  trigramMinuteRowId,
   type JsonlRow,
 } from '../jsonl/jsonl-row'
 import { appendRowsToFile } from '../jsonl/jsonl-writer'
@@ -82,6 +84,26 @@ function stats(machineHash: string, keystrokes: number, updatedAt = 1_000): Json
   }
 }
 
+function bigram(machineHash: string, updatedAt = 1_000): JsonlRow {
+  const scopeId = `${machineHash}|linux|${UID_A}`
+  return {
+    id: bigramMinuteRowId(scopeId, 60_000, ''),
+    kind: 'bigram-minute',
+    updated_at: updatedAt,
+    payload: { scopeId, minuteTs: 60_000, bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } } },
+  }
+}
+
+function trigram(machineHash: string, updatedAt = 1_000): JsonlRow {
+  const scopeId = `${machineHash}|linux|${UID_A}`
+  return {
+    id: trigramMinuteRowId(scopeId, 60_000, ''),
+    kind: 'trigram-minute',
+    updated_at: updatedAt,
+    payload: { scopeId, minuteTs: 60_000, trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } } },
+  }
+}
+
 describe('truncateCache', () => {
   let tmpDir: string
   let db: TypingAnalyticsDB
@@ -146,6 +168,27 @@ describe('rebuildCacheFromMasterFiles', () => {
   afterEach(() => {
     db.close()
     rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('propagates bigram/trigram counters, which were previously dropped from the result', async () => {
+    // Regression coverage: rebuildCacheFromMasterFiles used to sum
+    // scopes/charMinutes/matrixMinutes/minuteStats/sessions but silently
+    // discarded applyRowsToCache's bigramMinutes (and now trigramMinutes)
+    // counts, so a bigram/trigram-only file looked like a no-op in the
+    // rebuild report even though rows were actually applied.
+    await appendRowsToFile(deviceDayJsonlPath(tmpDir, UID_A, MY_HASH, SAMPLE_DAY), [
+      scope(MY_HASH),
+      bigram(MY_HASH),
+      trigram(MY_HASH),
+    ])
+
+    const result = await rebuildCacheFromMasterFiles(db, tmpDir)
+    expect(result.bigramMinutes).toBe(1)
+    expect(result.trigramMinutes).toBe(1)
+
+    const conn = db.getConnection()
+    expect((conn.prepare('SELECT COUNT(*) AS n FROM typing_bigram_minute').get() as { n: number }).n).toBe(1)
+    expect((conn.prepare('SELECT COUNT(*) AS n FROM typing_trigram_minute').get() as { n: number }).n).toBe(1)
   })
 
   it('replays every local and remote device file into the cache', async () => {

--- a/src/main/typing-analytics/__tests__/import-export.test.ts
+++ b/src/main/typing-analytics/__tests__/import-export.test.ts
@@ -51,6 +51,18 @@ function minuteStatsRow(day: string): string {
   })
 }
 
+function bigramMinuteRow(day: string): string {
+  return rowLine(day, 'bigram-minute', {
+    scopeId: 's1', minuteTs: dayStartMs(day), bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+  })
+}
+
+function trigramMinuteRow(day: string): string {
+  return rowLine(day, 'trigram-minute', {
+    scopeId: 's1', minuteTs: dayStartMs(day), trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+  })
+}
+
 function scopeRow(day: string): string {
   return rowLine(day, 'scope', {
     id: 's1', machineHash: HASH, osPlatform: 'linux', osRelease: '6.8',
@@ -213,6 +225,44 @@ describe('importTypingDataFiles', () => {
     expect(out.rejections[0]).toMatchObject({ fileName: name, reason: 'rows-outside-day-window' })
     // Original local file is untouched.
     expect(readFileSync(deviceDayJsonlPath(userData, UID, HASH, '2026-04-19'), 'utf-8')).toBe('{"id":"existing"}\n')
+  })
+
+  it('rejects a bigram-minute row whose minuteTs falls outside the day window', async () => {
+    // Regression coverage: rowTimestamp() used to fall through to
+    // default:null for 'bigram-minute' (and now 'trigram-minute'),
+    // which made rowsFallInsideDay() skip the check entirely — a
+    // bigram/trigram row from a completely different day would have
+    // silently passed validation instead of being rejected.
+    seedDay(userData, HASH, '2026-04-19', '{"id":"existing"}\n')
+    const name = exportFileNameFor(UID, HASH, '2026-04-19')
+    const wrongDayBody = bigramMinuteRow('2026-04-21')
+    const path = writeImport(name, wrongDayBody)
+
+    const out = await importTypingDataFiles(userData, [path], { cloudHasFile: null, now: FIXED_NOW })
+    expect(out.imported).toBe(0)
+    expect(out.rejections[0]).toMatchObject({ fileName: name, reason: 'rows-outside-day-window' })
+  })
+
+  it('rejects a trigram-minute row whose minuteTs falls outside the day window', async () => {
+    seedDay(userData, HASH, '2026-04-19', '{"id":"existing"}\n')
+    const name = exportFileNameFor(UID, HASH, '2026-04-19')
+    const wrongDayBody = trigramMinuteRow('2026-04-21')
+    const path = writeImport(name, wrongDayBody)
+
+    const out = await importTypingDataFiles(userData, [path], { cloudHasFile: null, now: FIXED_NOW })
+    expect(out.imported).toBe(0)
+    expect(out.rejections[0]).toMatchObject({ fileName: name, reason: 'rows-outside-day-window' })
+  })
+
+  it('accepts a bigram-minute row whose minuteTs falls inside the day window', async () => {
+    seedDay(userData, HASH, '2026-04-19', '{"id":"existing"}\n')
+    const name = exportFileNameFor(UID, HASH, '2026-04-19')
+    const body = bigramMinuteRow('2026-04-19')
+    const path = writeImport(name, body)
+
+    const out = await importTypingDataFiles(userData, [path], { cloudHasFile: null, now: FIXED_NOW })
+    expect(out.imported).toBe(1)
+    expect(out.rejections).toEqual([])
   })
 
   it('accepts a cloud-only target match when local does not have the file', async () => {

--- a/src/main/typing-analytics/__tests__/minute-buffer.test.ts
+++ b/src/main/typing-analytics/__tests__/minute-buffer.test.ts
@@ -301,6 +301,189 @@ describe('MinuteBuffer', () => {
     })
   })
 
+  describe('trigram tracking', () => {
+    it('records a triple after 3 consecutive matrix events as the average of the two intervals', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // KC_A
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_120), fp) // KC_H, iki1=120
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp) // KC_D, iki2=180
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [150]]]) // (120+180)/2
+    })
+
+    it('forms a rolling window of triples across 4+ events', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // iki=100
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_250), fp) // iki=150 -> triple 4_11_7 = 125
+      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_450), fp) // iki=200 -> triple 11_7_5 = 175
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([
+        ['4_11_7', [125]],
+        ['11_7_5', [175]],
+      ])
+    })
+
+    it('does not pair across char events but stays transparent to the chain', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(charEvent('a', 1_050), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp)
+      buffer.addEvent(charEvent('b', 1_150), fp)
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp)
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [150]]]) // (100+200)/2
+    })
+
+    it('drops the triple and resets the chain when the trailing interval exceeds the session gap', () => {
+      // SESSION_IDLE_GAP_MS = 5 minutes.
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // valid iki=100, chain=[4,11]
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_100 + 6 * 60_000), fp) // gap > 5min: no triple, chain resets to [7]
+      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_100 + 6 * 60_000 + 120), fp) // chain=[7,5], still no triple (only 2 deep)
+
+      const snaps = buffer.drainAll()
+      const allTrigrams = new Map(snaps.flatMap((s) => [...s.trigrams]))
+      expect(allTrigrams.size).toBe(0)
+    })
+
+    it('drops the triple entirely when only the leading interval is too slow', () => {
+      // First interval spans a session gap; second interval (last->curr) is
+      // fine on its own, but the stale k1 must not feed a triple.
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000 + 6 * 60_000), fp) // gap too large -> chain resets to [11]
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_000 + 6 * 60_000 + 100), fp) // chain=[11,7], only 2 deep, no triple yet
+
+      const snaps = buffer.drainAll()
+      const allTrigrams = new Map(snaps.flatMap((s) => [...s.trigrams]))
+      expect(allTrigrams.size).toBe(0)
+    })
+
+    it('does not advance the chain on tied timestamps', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // chain=[4,11]
+      // Tie ts — discarded, chain stays at [4,11]
+      buffer.addEvent(matrixEvent(0, 2, 0, 99, 1_100), fp)
+      // Forward ts — pairs against the un-advanced chain [4,11]
+      buffer.addEvent(matrixEvent(0, 3, 0, 7, 1_250), fp)
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [125]]]) // (100+150)/2
+    })
+
+    it('drops the cross-minute triple after drainClosed resets the chain', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 20_000), fp) // minute 0
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 40_000), fp) // minute 0, chain=[4,11]
+      const closed = buffer.drainClosed(60_000)
+      expect(closed).toHaveLength(1)
+      expect(closed[0].trigrams.size).toBe(0) // only 2 events so far, no triple yet
+
+      // Chain was cleared by drainClosed, so this event starts fresh.
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 90_000), fp) // minute 1
+      buffer.addEvent(matrixEvent(0, 3, 0, 5, 90_150), fp) // minute 1, chain=[7,5]
+      buffer.addEvent(matrixEvent(0, 4, 0, 6, 90_300), fp) // minute 1, first valid triple
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([['7_5_6', [150]]])
+    })
+
+    it('clears the chain after drainAll so a fresh batch does not bridge', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp)
+      buffer.drainAll()
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_500), fp)
+      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_650), fp)
+      buffer.addEvent(matrixEvent(0, 4, 0, 6, 1_800), fp)
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.trigrams.entries()]).toEqual([['7_5_6', [150]]])
+    })
+  })
+
+  describe('n-gram chain scope/run isolation', () => {
+    it('does not pair interleaved events from two different scopes', () => {
+      // Two keyboards typing in parallel interleave their matrix events;
+      // every scope switch restarts the chain, so no pair or triple may
+      // cross the boundary — and here no two consecutive events share a
+      // scope, so nothing is recorded at all.
+      const fpA = fingerprint({ uid: '0xAAAA' })
+      const fpB = fingerprint({ uid: '0xBBBB' })
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fpA)
+      buffer.addEvent(matrixEvent(0, 0, 0, 20, 1_050), fpB)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fpA)
+      buffer.addEvent(matrixEvent(0, 1, 0, 21, 1_150), fpB)
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_200), fpA)
+
+      const snaps = buffer.drainAll()
+      expect(snaps).toHaveLength(2)
+      for (const snap of snaps) {
+        expect(snap.bigrams.size).toBe(0)
+        expect(snap.trigrams.size).toBe(0)
+      }
+    })
+
+    it('pairs consecutive same-scope events after an interleaved foreign event reset the chain', () => {
+      const fpA = fingerprint({ uid: '0xAAAA' })
+      const fpB = fingerprint({ uid: '0xBBBB' })
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fpA)
+      // Foreign scope restarts the chain, so 4 can no longer head a pair.
+      buffer.addEvent(matrixEvent(0, 0, 0, 20, 1_050), fpB)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fpA)
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_250), fpA)
+
+      const snaps = buffer.drainAll()
+      const snapA = snaps.find((s) => s.scopeId === canonicalScopeKey(fpA))
+      const snapB = snaps.find((s) => s.scopeId === canonicalScopeKey(fpB))
+      expect([...(snapA?.bigrams.entries() ?? [])]).toEqual([['11_7', [150]]])
+      // Chain is only 2 deep after the reset — no triple, and certainly
+      // not 4_11_7 through the foreign event.
+      expect(snapA?.trigrams.size).toBe(0)
+      expect(snapB?.bigrams.size).toBe(0)
+      expect(snapB?.trigrams.size).toBe(0)
+    })
+
+    it('resets the chain when the run id changes within one scope', () => {
+      // REC input followed by a typing-test run: the run boundary must
+      // not produce a cross-run pair even though scope and timing both
+      // look continuous.
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      buffer.addEvent({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
+      buffer.addEvent({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
+
+      const snaps = buffer.drainAll()
+      const recSnap = snaps.find((s) => s.runId === '')
+      const runSnap = snaps.find((s) => s.runId === 'run-1')
+      expect(recSnap?.bigrams.size).toBe(0)
+      // Only the within-run pair survives; no 4_11 across the boundary
+      // and no 4_11_7 triple through it.
+      expect([...(runSnap?.bigrams.entries() ?? [])]).toEqual([['11_7', [150]]])
+      expect(runSnap?.trigrams.size).toBe(0)
+    })
+
+    it('keeps recording pairs and triples for an uninterrupted same-scope same-run stream', () => {
+      const fp = fingerprint()
+      buffer.addEvent({ ...matrixEvent(0, 0, 0, 4, 1_000), runId: 'run-1' }, fp)
+      buffer.addEvent({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
+      buffer.addEvent({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.bigrams.entries()]).toEqual([
+        ['4_11', [100]],
+        ['11_7', [150]],
+      ])
+      expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [125]]]) // (100+150)/2
+    })
+  })
+
   it('exposes an empty bigrams map when no matrix events arrived', () => {
     // Sanity check: the Map exists on every snapshot (downstream emit
     // layer relies on snapshot.bigrams.size, not optional access).
@@ -308,6 +491,7 @@ describe('MinuteBuffer', () => {
     buffer.addEvent(charEvent('a', 1_000), fp)
     const [snap] = buffer.drainAll()
     expect(snap.bigrams.size).toBe(0)
+    expect(snap.trigrams.size).toBe(0)
   })
 
   describe('app-name tagging', () => {

--- a/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
+++ b/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
@@ -244,6 +244,64 @@ describe('typing-analytics-service', () => {
       ])
     })
 
+    it('emits sum_iki / sumsq_iki alongside the bigram histogram', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+
+      const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
+      // Same 3 events as above: iki(4->11)=120, iki(11->7)=160.
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const rows = conn
+        .prepare('SELECT bigram_id, sum_iki, sumsq_iki FROM typing_bigram_minute ORDER BY bigram_id')
+        .all() as { bigram_id: string; sum_iki: number; sumsq_iki: number }[]
+      expect(rows).toEqual([
+        { bigram_id: '11_7', sum_iki: 160, sumsq_iki: 160 * 160 },
+        { bigram_id: '4_11', sum_iki: 120, sumsq_iki: 120 * 120 },
+      ])
+    })
+
+    it('emits a trigram-minute row when 3 consecutive matrix events flush', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+
+      const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
+      // iki(4->11)=120, iki(11->7)=160 -> trigram value = (120+160)/2 = 140.
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const rows = conn
+        .prepare('SELECT trigram_id, count, sum_iki, sumsq_iki FROM typing_trigram_minute')
+        .all() as { trigram_id: string; count: number; sum_iki: number; sumsq_iki: number }[]
+      expect(rows).toEqual([
+        { trigram_id: '4_11_7', count: 1, sum_iki: 140, sumsq_iki: 140 * 140 },
+      ])
+    })
+
+    it('does not emit a trigram-minute row when fewer than 3 consecutive matrix events flush', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+
+      const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const count = conn.prepare('SELECT COUNT(*) AS n FROM typing_trigram_minute').get() as { n: number }
+      expect(count.n).toBe(0)
+    })
+
     it('does not emit a bigram-minute row when only char events flush', async () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
@@ -471,7 +529,7 @@ describe('typing-analytics-service', () => {
         notifier.mockClear() // forget the seed's own flush notification
 
         const result = await deleteTypingDailySummaries(sampleKeyboard.uid, [])
-        expect(result).toEqual({ charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 })
+        expect(result).toEqual({ charMinutes: 0, matrixMinutes: 0, minuteStats: 0, bigramMinutes: 0, trigramMinutes: 0, sessions: 0 })
         expect(notifier).not.toHaveBeenCalled()
         expect(listTypingDailySummaries(sampleKeyboard.uid)).toHaveLength(1)
       })
@@ -547,7 +605,7 @@ describe('typing-analytics-service', () => {
         const handler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
         const result = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
         expect(result.view).toBe('top')
-        expect(result.entries.map((e: { bigramId: string }) => e.bigramId).sort()).toEqual(['11_7', '4_11'])
+        expect(result.entries.map((e: { ngramId: string }) => e.ngramId).sort()).toEqual(['11_7', '4_11'])
         expect(result.entries.every((e: { count: number }) => e.count === 1)).toBe(true)
       })
 
@@ -601,6 +659,61 @@ describe('typing-analytics-service', () => {
         expect(result.view).toBe('top')
         // The own machineHash is the only one in test data — same as 'all'.
         expect(result.entries).toHaveLength(2)
+      })
+
+      it('attaches sd to top/slow entries once IKI sums are recorded', async () => {
+        const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+        await ingestThree(ts)
+        const handler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+        const result = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
+        // Each bigram in ingestThree has exactly one row (n=1) so sd is
+        // undefined-for-variance (n < 2) → null, but the field must be
+        // present and typed, not just missing.
+        expect(result.entries.every((e: { sd: number | null }) => e.sd === null)).toBe(true)
+      })
+
+      describe('gram option', () => {
+        it('defaults to bigram results identical to an explicit gram: 2 request', async () => {
+          const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+          await ingestThree(ts)
+          const handler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+          const omitted = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
+          const explicit = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', { gram: 2 })
+          expect(omitted).toEqual(explicit)
+          expect(omitted.entries.map((e: { ngramId: string }) => e.ngramId).sort()).toEqual(['11_7', '4_11'])
+        })
+
+        it.each([0, 5, 'x', null, {}])('falls back to gram=2 for an invalid gram value (%s)', async (badGram) => {
+          const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+          await ingestThree(ts)
+          const handler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+          const baseline = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
+          const withBadGram = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', { gram: badGram })
+          expect(withBadGram).toEqual(baseline)
+        })
+
+        it('aggregates from the trigram table when gram: 3 is requested', async () => {
+          const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+          await ingestThree(ts)
+          const handler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+          const result = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', { gram: 3 })
+          expect(result.view).toBe('top')
+          expect(result.entries.map((e: { ngramId: string }) => e.ngramId)).toEqual(['4_11_7'])
+          expect(result.entries[0].count).toBe(1)
+        })
+
+        it('returns an empty result for gram: 3 when fewer than 3 consecutive keystrokes were recorded', async () => {
+          setupTypingAnalyticsIpc()
+          const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+          const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+          await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+          await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard })
+          await flushTypingAnalyticsNowForTests()
+
+          const aggHandler = getHandler(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+          const result = await aggHandler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', { gram: 3 })
+          expect(result.entries).toEqual([])
+        })
       })
     })
 

--- a/src/main/typing-analytics/bigram-aggregate.ts
+++ b/src/main/typing-analytics/bigram-aggregate.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Range aggregation helpers for the Analyze Bigrams view. Pure
-// functions over BigramMinuteCellRow arrays — no DB / IPC concerns.
+// functions over NgramMinuteCellRow arrays — no DB / IPC concerns.
 // Histogram boundaries are imported from bigram-bucket so the merge,
 // emit, and aggregation layers all share the same bucket layout.
 // See .claude/plans/Plan-analyze-bigram.md for the metric design.
@@ -9,7 +9,7 @@ import {
   BIGRAM_BUCKET_CENTERS_MS,
   BIGRAM_BUCKET_UPPER_BOUNDS_MS,
 } from './bigram-bucket'
-import type { BigramMinuteCellRow } from './db/typing-analytics-db'
+import type { NgramMinuteCellRow } from './db/typing-analytics-db'
 import { BIGRAM_HIST_BUCKETS } from './jsonl/jsonl-row'
 import type {
   TypingBigramSlowEntry,
@@ -17,35 +17,79 @@ import type {
 } from '../../shared/types/typing-analytics'
 
 export interface BigramPairTotal {
-  bigramId: string
+  ngramId: string
   count: number
   hist: number[]
+  /** Running sum / sum-of-squares of raw IKI across contributing rows.
+   * Set to null the moment any contributing row lacks sum/sumSq (older
+   * data written before the sum columns existed) — see
+   * {@link aggregatePairTotals}. Once null, later rows for the same
+   * pair are no longer added to it. */
+  sumIki: number | null
+  sumSqIki: number | null
 }
 
-/** Sum per-(scope, minute, bigram) rows into one entry per bigramId.
- * Counts add directly; histograms add element-wise. Input may contain
- * mixed bigramIds in any order — the aggregator does not assume the
- * caller pre-grouped (the SQL ORDER BY is a hint, not a requirement). */
+/** Sum per-(scope, minute, pair) rows into one entry per pair id
+ * (bigramId or trigramId — both project as `ngramId`, see
+ * NgramMinuteCellRow). Counts add directly; histograms add
+ * element-wise. Input may contain mixed ids in any order — the
+ * aggregator does not assume the caller pre-grouped (the SQL ORDER BY
+ * is a hint, not a requirement).
+ *
+ * sum/sumSq accumulate only while every row seen so far for that pair
+ * has both fields populated. The moment one row is missing them (an
+ * older row written before the sum columns existed), the pair's sums
+ * are eagerly nulled and stay null for the rest of this call — mixing
+ * a partial sum with a real one would silently understate the SD
+ * instead of reporting "unknown". */
 export function aggregatePairTotals(
-  rows: readonly BigramMinuteCellRow[],
+  rows: readonly NgramMinuteCellRow[],
 ): Map<string, BigramPairTotal> {
   const totals = new Map<string, BigramPairTotal>()
   for (const row of rows) {
-    let entry = totals.get(row.bigramId)
+    const id = row.ngramId
+    let entry = totals.get(id)
     if (!entry) {
       entry = {
-        bigramId: row.bigramId,
+        ngramId: id,
         count: 0,
         hist: new Array<number>(BIGRAM_HIST_BUCKETS).fill(0),
+        sumIki: 0,
+        sumSqIki: 0,
       }
-      totals.set(row.bigramId, entry)
+      totals.set(id, entry)
     }
     entry.count += row.count
     for (let i = 0; i < BIGRAM_HIST_BUCKETS; i += 1) {
       entry.hist[i] += row.hist[i] ?? 0
     }
+    if (row.sumIki === null || row.sumSqIki === null) {
+      entry.sumIki = null
+      entry.sumSqIki = null
+    } else if (entry.sumIki !== null && entry.sumSqIki !== null) {
+      entry.sumIki += row.sumIki
+      entry.sumSqIki += row.sumSqIki
+    }
   }
   return totals
+}
+
+/** Standard deviation of raw IKI from accumulated sum / sum-of-squares.
+ * Clips the variance to 0 before the sqrt — with equally-spaced
+ * keystrokes, floating-point rounding in `sumSq/n - (sum/n)^2` can go
+ * very slightly negative, which would otherwise produce NaN instead of
+ * the correct answer (0). Returns null when there are fewer than 2
+ * samples (SD is undefined for n < 2). */
+export function sdFromSums(sum: number, sumSq: number, count: number): number | null {
+  if (count < 2) return null
+  const mean = sum / count
+  const variance = sumSq / count - mean * mean
+  return Math.sqrt(Math.max(0, variance))
+}
+
+function sdFromTotal(entry: BigramPairTotal): number | null {
+  if (entry.sumIki === null || entry.sumSqIki === null) return null
+  return sdFromSums(entry.sumIki, entry.sumSqIki, entry.count)
 }
 
 /** Weighted-average IKI from a histogram using bucket centers. Returns
@@ -101,19 +145,20 @@ export function percentileFromHist(
 export type BigramRanked = TypingBigramTopEntry
 
 /** Top-N pairs by occurrence count (descending). Ties broken by
- * bigramId ascending for deterministic output. */
+ * ngramId ascending for deterministic output. */
 export function rankBigramsByCount(
   totals: ReadonlyMap<string, BigramPairTotal>,
   limit: number,
 ): BigramRanked[] {
   const ranked = [...totals.values()]
-    .sort((a, b) => (b.count - a.count) || a.bigramId.localeCompare(b.bigramId))
+    .sort((a, b) => (b.count - a.count) || a.ngramId.localeCompare(b.ngramId))
     .slice(0, limit)
   return ranked.map((t) => ({
-    bigramId: t.bigramId,
+    ngramId: t.ngramId,
     count: t.count,
     hist: t.hist,
     avgIki: avgIkiFromHist(t.hist),
+    sd: sdFromTotal(t),
   }))
 }
 
@@ -121,7 +166,7 @@ export type BigramSlowRanked = TypingBigramSlowEntry
 
 /** Slowest-N pairs by avg IKI (descending). `minSample` filters out
  * pairs with fewer than N occurrences so a single late press doesn't
- * dominate the ranking. Ties broken by bigramId ascending. */
+ * dominate the ranking. Ties broken by ngramId ascending. */
 export function rankBigramsBySlow(
   totals: ReadonlyMap<string, BigramPairTotal>,
   minSample: number,
@@ -134,12 +179,13 @@ export function rankBigramsBySlow(
     if (avg === null) continue
     eligible.push({ entry, avg })
   }
-  eligible.sort((a, b) => (b.avg - a.avg) || a.entry.bigramId.localeCompare(b.entry.bigramId))
+  eligible.sort((a, b) => (b.avg - a.avg) || a.entry.ngramId.localeCompare(b.entry.ngramId))
   return eligible.slice(0, limit).map(({ entry, avg }) => ({
-    bigramId: entry.bigramId,
+    ngramId: entry.ngramId,
     count: entry.count,
     hist: entry.hist,
     avgIki: avg,
     p95: percentileFromHist(entry.hist, 0.95),
+    sd: sdFromTotal(entry),
   }))
 }

--- a/src/main/typing-analytics/bigram-bucket.ts
+++ b/src/main/typing-analytics/bigram-bucket.ts
@@ -60,3 +60,18 @@ export function bucketizeIki(ikis: readonly number[]): number[] {
   }
   return buckets
 }
+
+/** Sum and sum-of-squares of raw IKI values, persisted alongside the
+ * histogram so the range-aggregate layer can compute a true (non
+ * histogram-approximated) standard deviation. Used for both bigram and
+ * trigram emission — trigram values are already interval averages by
+ * the time they reach here, so the same accumulation applies. */
+export function sumAndSumSquares(values: readonly number[]): { sum: number; sumSq: number } {
+  let sum = 0
+  let sumSq = 0
+  for (const v of values) {
+    sum += v
+    sumSq += v * v
+  }
+  return { sum, sumSq }
+}

--- a/src/main/typing-analytics/cache-rebuild.ts
+++ b/src/main/typing-analytics/cache-rebuild.ts
@@ -23,6 +23,8 @@ export interface CacheRebuildResult {
   matrixMinutes: number
   minuteStats: number
   sessions: number
+  bigramMinutes: number
+  trigramMinutes: number
   jsonlFilesRead: number
 }
 
@@ -53,6 +55,8 @@ export async function rebuildCacheFromMasterFiles(
     matrixMinutes: 0,
     minuteStats: 0,
     sessions: 0,
+    bigramMinutes: 0,
+    trigramMinutes: 0,
     jsonlFilesRead: 0,
   }
 
@@ -65,6 +69,8 @@ export async function rebuildCacheFromMasterFiles(
     result.matrixMinutes += applied.matrixMinutes
     result.minuteStats += applied.minuteStats
     result.sessions += applied.sessions
+    result.bigramMinutes += applied.bigramMinutes
+    result.trigramMinutes += applied.trigramMinutes
     result.jsonlFilesRead += 1
   }
 

--- a/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
+++ b/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
@@ -134,6 +134,79 @@ describe('TypingAnalyticsDB', () => {
     }
   })
 
+  it('upgrades a v6 DB to v7: adds sum_iki/sumsq_iki and typing_trigram_minute without a cache rebuild', () => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+    tmpDir = mkdtempSync(join(tmpdir(), 'pipette-typing-analytics-db-upgrade67-'))
+    const dbPath = join(tmpDir, 'typing-analytics.db')
+
+    const v6 = new Database(dbPath)
+    v6.exec(`
+      CREATE TABLE typing_analytics_meta (
+        key TEXT PRIMARY KEY, value TEXT NOT NULL
+      );
+      CREATE TABLE typing_scopes (
+        id TEXT PRIMARY KEY,
+        machine_hash TEXT NOT NULL, os_platform TEXT NOT NULL,
+        os_release TEXT NOT NULL, os_arch TEXT NOT NULL,
+        keyboard_uid TEXT NOT NULL,
+        keyboard_vendor_id INTEGER NOT NULL,
+        keyboard_product_id INTEGER NOT NULL,
+        keyboard_product_name TEXT NOT NULL,
+        updated_at INTEGER NOT NULL,
+        is_deleted INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE typing_bigram_minute (
+        scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
+        bigram_id TEXT NOT NULL, count INTEGER NOT NULL,
+        hist BLOB NOT NULL,
+        app_name TEXT, typing_test TEXT,
+        run_id TEXT NOT NULL DEFAULT '',
+        updated_at INTEGER NOT NULL,
+        is_deleted INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (scope_id, minute_ts, run_id, bigram_id)
+      );
+      INSERT INTO typing_scopes (
+        id, machine_hash, os_platform, os_release, os_arch,
+        keyboard_uid, keyboard_vendor_id, keyboard_product_id, keyboard_product_name,
+        updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 'hash-abc', 'linux', '6.8.0', 'x64',
+        '0xAABB', 65261, 0, 'Pipette', 1000, 0
+      );
+      INSERT INTO typing_bigram_minute (
+        scope_id, minute_ts, bigram_id, count, hist, app_name, typing_test, run_id, updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 60000, '4_11', 3, X'0300000000000000000000000000000000000000000000000000000000', NULL, NULL, '', 2000, 0
+      );
+      INSERT INTO typing_analytics_meta (key, value) VALUES ('schema_version', '6');
+    `)
+    v6.close()
+
+    db = new TypingAnalyticsDB(dbPath)
+    expect(db.getMeta('schema_version')).toBe(String(SCHEMA_VERSION))
+    expect(db.cacheNeedsRebuild).toBe(false)
+
+    const conn = db.getConnection()
+    const bigramCols = conn.prepare('PRAGMA table_info(typing_bigram_minute)').all() as { name: string }[]
+    expect(bigramCols.some((c) => c.name === 'sum_iki')).toBe(true)
+    expect(bigramCols.some((c) => c.name === 'sumsq_iki')).toBe(true)
+
+    // Existing count/hist row survives the migration untouched, with the
+    // new sum columns reading as NULL (no source data to backfill from).
+    const row = conn.prepare('SELECT count, sum_iki, sumsq_iki FROM typing_bigram_minute WHERE bigram_id = ?').get('4_11') as {
+      count: number
+      sum_iki: number | null
+      sumsq_iki: number | null
+    }
+    expect(row.count).toBe(3)
+    expect(row.sum_iki).toBeNull()
+    expect(row.sumsq_iki).toBeNull()
+
+    const trigramTable = conn.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'typing_trigram_minute'`).get()
+    expect(trigramTable).toBeDefined()
+  })
+
   it('upserts a scope row and keeps the newest updatedAt', () => {
     db.upsertScope(sampleScope({ updatedAt: 1_000 }))
     db.upsertScope(sampleScope({ updatedAt: 500, keyboardProductName: 'stale' }))
@@ -298,6 +371,45 @@ describe('TypingAnalyticsDB', () => {
     expect(remoteSessions).toEqual([{ id: 'remote-new' }, { id: 'remote-old' }])
   })
 
+  it('retainOwnData also removes bigram/trigram rows before the cutoff for the local machine only', () => {
+    const localScope = sampleScope({ id: 'local', machineHash: MACHINE_HASH })
+    const remoteScope = sampleScope({ id: 'remote', machineHash: 'other-machine' })
+    db.upsertScope(localScope)
+    db.upsertScope(remoteScope)
+
+    for (const scopeId of ['local', 'remote'] as const) {
+      db.mergeBigramMinute({
+        scopeId, minuteTs: 50_000, bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      db.mergeBigramMinute({
+        scopeId, minuteTs: 200_000, bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 2_000, isDeleted: false,
+      })
+      db.mergeTrigramMinute({
+        scopeId, minuteTs: 50_000, trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      db.mergeTrigramMinute({
+        scopeId, minuteTs: 200_000, trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 2_000, isDeleted: false,
+      })
+    }
+
+    db.retainOwnData(MACHINE_HASH, 100_000)
+
+    const conn = db.getConnection()
+    const localBigrams = conn.prepare('SELECT minute_ts FROM typing_bigram_minute WHERE scope_id = ? ORDER BY minute_ts').all('local') as Array<{ minute_ts: number }>
+    expect(localBigrams).toEqual([{ minute_ts: 200_000 }])
+    const remoteBigrams = conn.prepare('SELECT minute_ts FROM typing_bigram_minute WHERE scope_id = ? ORDER BY minute_ts').all('remote') as Array<{ minute_ts: number }>
+    expect(remoteBigrams).toEqual([{ minute_ts: 50_000 }, { minute_ts: 200_000 }])
+
+    const localTrigrams = conn.prepare('SELECT minute_ts FROM typing_trigram_minute WHERE scope_id = ? ORDER BY minute_ts').all('local') as Array<{ minute_ts: number }>
+    expect(localTrigrams).toEqual([{ minute_ts: 200_000 }])
+    const remoteTrigrams = conn.prepare('SELECT minute_ts FROM typing_trigram_minute WHERE scope_id = ? ORDER BY minute_ts').all('remote') as Array<{ minute_ts: number }>
+    expect(remoteTrigrams).toEqual([{ minute_ts: 50_000 }, { minute_ts: 200_000 }])
+  })
+
   it('reopens an existing database file without error', () => {
     db.upsertScope(sampleScope())
     const path = join(tmpDir, 'typing-analytics.db')
@@ -451,6 +563,81 @@ describe('TypingAnalyticsDB', () => {
         isDeleted: false,
       })
       const count = db.getConnection().prepare('SELECT COUNT(*) AS n FROM typing_bigram_minute').get() as { n: number }
+      expect(count.n).toBe(0)
+    })
+
+    it('mergeBigramMinute stores sum_iki / sumsq_iki when present and NULL when absent', () => {
+      db.mergeBigramMinute({
+        scopeId: 'scope-1',
+        minuteTs: 60_000,
+        bigrams: {
+          'with-sum': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], s: 240, sq: 28_800 },
+          'without-sum': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] },
+        },
+        updatedAt: 3_000,
+        isDeleted: false,
+      })
+      const rows = db.getConnection()
+        .prepare('SELECT bigram_id, sum_iki, sumsq_iki FROM typing_bigram_minute ORDER BY bigram_id')
+        .all() as { bigram_id: string; sum_iki: number | null; sumsq_iki: number | null }[]
+      expect(rows).toEqual([
+        { bigram_id: 'with-sum', sum_iki: 240, sumsq_iki: 28_800 },
+        { bigram_id: 'without-sum', sum_iki: null, sumsq_iki: null },
+      ])
+    })
+
+    it('mergeTrigramMinute fans a payload into per-triple rows with packed hist BLOB', () => {
+      db.mergeTrigramMinute({
+        scopeId: 'scope-1',
+        minuteTs: 60_000,
+        trigrams: {
+          '4_11_7': { c: 3, h: [0, 1, 2, 0, 0, 0, 0, 0], s: 450, sq: 67_500 },
+        },
+        updatedAt: 3_000,
+        isDeleted: false,
+      })
+      const conn = db.getConnection()
+      const rows = conn
+        .prepare('SELECT trigram_id, count, hist, sum_iki, sumsq_iki FROM typing_trigram_minute')
+        .all() as { trigram_id: string; count: number; hist: Uint8Array; sum_iki: number; sumsq_iki: number }[]
+      expect(rows).toHaveLength(1)
+      expect(rows[0].trigram_id).toBe('4_11_7')
+      expect(rows[0].count).toBe(3)
+      expect(rows[0].sum_iki).toBe(450)
+      expect(rows[0].sumsq_iki).toBe(67_500)
+      expect(rows[0].hist.byteLength).toBe(32)
+      const histBuf = Buffer.from(rows[0].hist.buffer, rows[0].hist.byteOffset, rows[0].hist.byteLength)
+      expect(histBuf.readUInt32LE(2 * 4)).toBe(2)
+    })
+
+    it('mergeTrigramMinute follows LWW: stale updated_at does not overwrite', () => {
+      db.mergeTrigramMinute({
+        scopeId: 'scope-1',
+        minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 5, h: [0, 5, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 3_000,
+        isDeleted: false,
+      })
+      db.mergeTrigramMinute({
+        scopeId: 'scope-1',
+        minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 999, h: [9, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 2_500,
+        isDeleted: false,
+      })
+      const row = db.getConnection().prepare('SELECT count FROM typing_trigram_minute WHERE trigram_id = ?').get('4_11_7') as { count: number }
+      expect(row.count).toBe(5)
+    })
+
+    it('mergeTrigramMinute is a no-op for an empty trigrams payload', () => {
+      db.mergeTrigramMinute({
+        scopeId: 'scope-1',
+        minuteTs: 60_000,
+        trigrams: {},
+        updatedAt: 3_000,
+        isDeleted: false,
+      })
+      const count = db.getConnection().prepare('SELECT COUNT(*) AS n FROM typing_trigram_minute').get() as { n: number }
       expect(count.n).toBe(0)
     })
   })
@@ -674,6 +861,38 @@ describe('TypingAnalyticsDB', () => {
       expect(ccdd.is_deleted).toBe(0)
     })
 
+    it('tombstoneRowsForUidInRange also tombstones bigram/trigram rows in range and leaves out-of-range ones live', () => {
+      db.mergeBigramMinute({
+        scopeId: 'scope-aabb-local', minuteTs: 60_000,
+        bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      db.mergeTrigramMinute({
+        scopeId: 'scope-aabb-local', minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      // Outside the [0, 90_000) tombstone window — must stay live.
+      db.mergeBigramMinute({
+        scopeId: 'scope-ccdd-local', minuteTs: 120_000,
+        bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+
+      const result = db.tombstoneRowsForUidInRange('0xAABB', 0, 90_000, 5_000)
+      expect(result.bigramMinutes).toBe(1)
+      expect(result.trigramMinutes).toBe(1)
+
+      const conn = db.getConnection()
+      const bigram = conn.prepare('SELECT is_deleted FROM typing_bigram_minute WHERE scope_id = ?').get('scope-aabb-local') as { is_deleted: number }
+      expect(bigram.is_deleted).toBe(1)
+      const trigram = conn.prepare('SELECT is_deleted FROM typing_trigram_minute WHERE scope_id = ?').get('scope-aabb-local') as { is_deleted: number }
+      expect(trigram.is_deleted).toBe(1)
+      // ccdd's uid ('0xCCDD') isn't touched by a tombstone scoped to '0xAABB'.
+      const untouched = conn.prepare('SELECT is_deleted FROM typing_bigram_minute WHERE scope_id = ?').get('scope-ccdd-local') as { is_deleted: number }
+      expect(untouched.is_deleted).toBe(0)
+    })
+
     it('tombstoneRowsForUidHashInRange restricts the tombstone to a single machine_hash', () => {
       const result = db.tombstoneRowsForUidHashInRange('0xAABB', MACHINE_HASH, 0, 90_000, 5_000)
       expect(result.charMinutes).toBe(1) // only scope-aabb-local
@@ -704,6 +923,23 @@ describe('TypingAnalyticsDB', () => {
       // Re-run listKeyboardsWithTypingData — 0xAABB no longer has live rows so it drops out.
       const remaining = db.listKeyboardsWithTypingData().map((r) => r.uid)
       expect(remaining).toEqual(['0xCCDD'])
+    })
+
+    it('tombstoneAllRowsForUid also tombstones every bigram/trigram row for the uid', () => {
+      db.mergeBigramMinute({
+        scopeId: 'scope-aabb-local', minuteTs: 60_000,
+        bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      db.mergeTrigramMinute({
+        scopeId: 'scope-aabb-local', minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+
+      const result = db.tombstoneAllRowsForUid('0xAABB', 6_000)
+      expect(result.bigramMinutes).toBe(1)
+      expect(result.trigramMinutes).toBe(1)
     })
 
     it('listDailySummariesForUid ignores tombstoned rows', () => {
@@ -1004,7 +1240,7 @@ describe('TypingAnalyticsDB', () => {
       bigramRow('scope-local', 60_000, '4_11', 3, [0, 2, 1, 0, 0, 0, 0, 0])
       const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
       expect(rows).toEqual([
-        { bigramId: '4_11', minuteTs: 60_000, count: 3, hist: [0, 2, 1, 0, 0, 0, 0, 0] },
+        { ngramId: '4_11', minuteTs: 60_000, count: 3, hist: [0, 2, 1, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null },
       ])
     })
 
@@ -1021,21 +1257,96 @@ describe('TypingAnalyticsDB', () => {
       })
       bigramRow('scope-local', 120_000, 'C', 4, [0, 0, 0, 4, 0, 0, 0, 0]) // in
       const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 240_000)
-      expect(rows.map((r) => r.bigramId).sort()).toEqual(['C'])
+      expect(rows.map((r) => r.ngramId).sort()).toEqual(['C'])
     })
 
     it('excludes other keyboards on the same machine', () => {
       bigramRow('scope-local', 60_000, 'kept', 1, [1, 0, 0, 0, 0, 0, 0, 0])
       bigramRow('scope-other-uid', 60_000, 'dropped', 99, [0, 0, 0, 99, 0, 0, 0, 0])
       const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
-      expect(rows.map((r) => r.bigramId)).toEqual(['kept'])
+      expect(rows.map((r) => r.ngramId)).toEqual(['kept'])
     })
 
     it('listBigramMinutesInRangeForUidAndHash restricts to one machine_hash', () => {
       bigramRow('scope-local', 60_000, 'kept', 1, [1, 0, 0, 0, 0, 0, 0, 0])
       bigramRow('scope-other-machine', 60_000, 'remote', 1, [1, 0, 0, 0, 0, 0, 0, 0])
       const rows = db.listBigramMinutesInRangeForUidAndHash('0xAABB', MACHINE_HASH, 60_000, 120_000)
-      expect(rows.map((r) => r.bigramId)).toEqual(['kept'])
+      expect(rows.map((r) => r.ngramId)).toEqual(['kept'])
+    })
+
+    it('returns sumIki / sumSqIki when the row has them, null otherwise', () => {
+      bigramRow('scope-local', 60_000, 'with-sum', 2, [0, 2, 0, 0, 0, 0, 0, 0])
+      db.mergeBigramMinute({
+        scopeId: 'scope-local', minuteTs: 60_000,
+        bigrams: { 'with-sum': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], s: 240, sq: 28_800 } },
+        updatedAt: 2_000, isDeleted: false,
+      })
+      const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([
+        { ngramId: 'with-sum', minuteTs: 60_000, count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: 240, sumSqIki: 28_800 },
+      ])
+    })
+  })
+
+  describe('listTrigramMinutesInRangeForUid (Analyze > n-gram)', () => {
+    function trigramRow(
+      scopeId: string,
+      minuteTs: number,
+      trigramId: string,
+      count: number,
+      h: number[],
+      updatedAt = 1_000,
+    ): void {
+      db.mergeTrigramMinute({
+        scopeId,
+        minuteTs,
+        trigrams: { [trigramId]: { c: count, h } },
+        updatedAt,
+        isDeleted: false,
+      })
+    }
+
+    beforeEach(() => {
+      db.upsertScope(sampleScope({ id: 'scope-local', machineHash: MACHINE_HASH, keyboardUid: '0xAABB' }))
+      db.upsertScope(sampleScope({ id: 'scope-other-machine', machineHash: 'other', keyboardUid: '0xAABB' }))
+      db.upsertScope(sampleScope({ id: 'scope-other-uid', machineHash: MACHINE_HASH, keyboardUid: '0xCCDD' }))
+    })
+
+    it('returns rows in range with hist decoded back to a number array', () => {
+      trigramRow('scope-local', 60_000, '4_11_7', 3, [0, 2, 1, 0, 0, 0, 0, 0])
+      const rows = db.listTrigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([
+        { ngramId: '4_11_7', minuteTs: 60_000, count: 3, hist: [0, 2, 1, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null },
+      ])
+    })
+
+    it('drops rows outside the window and respects tombstones', () => {
+      trigramRow('scope-local', 30_000, 'A_B_C', 1, [1, 0, 0, 0, 0, 0, 0, 0]) // before window
+      trigramRow('scope-local', 60_000, 'B_C_D', 2, [0, 2, 0, 0, 0, 0, 0, 0]) // in
+      db.mergeTrigramMinute({
+        scopeId: 'scope-local',
+        minuteTs: 60_000,
+        trigrams: { 'B_C_D': { c: 0, h: [0, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 5_000,
+        isDeleted: true,
+      })
+      trigramRow('scope-local', 120_000, 'C_D_E', 4, [0, 0, 0, 4, 0, 0, 0, 0]) // in
+      const rows = db.listTrigramMinutesInRangeForUid('0xAABB', 60_000, 240_000)
+      expect(rows.map((r) => r.ngramId).sort()).toEqual(['C_D_E'])
+    })
+
+    it('excludes other keyboards on the same machine', () => {
+      trigramRow('scope-local', 60_000, 'kept', 1, [1, 0, 0, 0, 0, 0, 0, 0])
+      trigramRow('scope-other-uid', 60_000, 'dropped', 99, [0, 0, 0, 99, 0, 0, 0, 0])
+      const rows = db.listTrigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
+      expect(rows.map((r) => r.ngramId)).toEqual(['kept'])
+    })
+
+    it('listTrigramMinutesInRangeForUidAndHash restricts to one machine_hash', () => {
+      trigramRow('scope-local', 60_000, 'kept', 1, [1, 0, 0, 0, 0, 0, 0, 0])
+      trigramRow('scope-other-machine', 60_000, 'remote', 1, [1, 0, 0, 0, 0, 0, 0, 0])
+      const rows = db.listTrigramMinutesInRangeForUidAndHash('0xAABB', MACHINE_HASH, 60_000, 120_000)
+      expect(rows.map((r) => r.ngramId)).toEqual(['kept'])
     })
   })
 

--- a/src/main/typing-analytics/db/schema.ts
+++ b/src/main/typing-analytics/db/schema.ts
@@ -2,7 +2,7 @@
 // SQLite schema for the typing analytics database. See
 // .claude/plans/typing-analytics.md for the design rationale.
 
-export const SCHEMA_VERSION = 6
+export const SCHEMA_VERSION = 7
 
 /** User-data tables in the order a rebuild should truncate them. Listed
  * child-before-parent so any future FK_ON delete won't trip itself. */
@@ -11,6 +11,7 @@ export const DATA_TABLE_NAMES = [
   'typing_matrix_minute',
   'typing_minute_stats',
   'typing_bigram_minute',
+  'typing_trigram_minute',
   'typing_sessions',
   'typing_scopes',
 ] as const
@@ -152,6 +153,14 @@ CREATE TABLE IF NOT EXISTS typing_bigram_minute (
   -- are log-scale (see Plan-analyze-bigram.md); count is the sum across
   -- buckets and is denormalized for fast top-N ranking.
   hist BLOB NOT NULL,
+  -- Sum / sum-of-squares of the raw IKI values (ms) that fed the hist
+  -- column, for a true standard deviation instead of a histogram bucket
+  -- approximation.
+  -- NULL for rows written before this field existed — a range that mixes
+  -- such rows with sum-bearing ones reports SD as null rather than an
+  -- approximation (see Plan-trigram-and-iki-variance.md).
+  sum_iki REAL,
+  sumsq_iki REAL,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
   -- See typing_char_minute.typing_test comment.
@@ -171,6 +180,42 @@ CREATE INDEX IF NOT EXISTS idx_bigram_minute_scope_test_ts
   ON typing_bigram_minute(scope_id, typing_test, minute_ts);
 CREATE INDEX IF NOT EXISTS idx_bigram_minute_scope_run_ts
   ON typing_bigram_minute(scope_id, run_id, minute_ts);
+
+CREATE TABLE IF NOT EXISTS typing_trigram_minute (
+  scope_id TEXT NOT NULL,
+  minute_ts INTEGER NOT NULL,
+  -- Triple key in the form "\${k1}_\${k2}_\${k3}". See
+  -- typing_bigram_minute.bigram_id comment.
+  trigram_id TEXT NOT NULL,
+  count INTEGER NOT NULL,
+  -- See typing_bigram_minute.hist comment.
+  hist BLOB NOT NULL,
+  -- See typing_bigram_minute.sum_iki / sumsq_iki comment.
+  sum_iki REAL,
+  sumsq_iki REAL,
+  -- See typing_char_minute.app_name comment.
+  app_name TEXT,
+  -- See typing_char_minute.typing_test comment.
+  typing_test TEXT,
+  -- See typing_char_minute.run_id comment.
+  run_id TEXT NOT NULL DEFAULT '',
+  updated_at INTEGER NOT NULL,
+  is_deleted INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (scope_id, minute_ts, run_id, trigram_id),
+  FOREIGN KEY (scope_id) REFERENCES typing_scopes(id)
+);
+-- No (scope_id, minute_ts) index here: it would be a strict prefix of
+-- the PRIMARY KEY (scope_id, minute_ts, run_id, trigram_id) above and
+-- SQLite can already use that for range scans. typing_bigram_minute
+-- carries the equivalent index (idx_bigram_minute_scope_minute) because
+-- it predates this table and is left untouched rather than risking an
+-- unrelated migration.
+CREATE INDEX IF NOT EXISTS idx_trigram_minute_scope_app_ts
+  ON typing_trigram_minute(scope_id, app_name, minute_ts);
+CREATE INDEX IF NOT EXISTS idx_trigram_minute_scope_test_ts
+  ON typing_trigram_minute(scope_id, typing_test, minute_ts);
+CREATE INDEX IF NOT EXISTS idx_trigram_minute_scope_run_ts
+  ON typing_trigram_minute(scope_id, run_id, minute_ts);
 
 CREATE TABLE IF NOT EXISTS typing_sessions (
   id TEXT PRIMARY KEY,

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -12,8 +12,10 @@ import {
   BIGRAM_HIST_BUCKETS,
   type JsonlBigramMinuteEntry,
   type JsonlBigramMinutePayload,
+  type JsonlTrigramMinuteEntry,
+  type JsonlTrigramMinutePayload,
 } from '../jsonl/jsonl-row'
-import { TYPING_APP_UNKNOWN_NAME } from '../../../shared/types/typing-analytics'
+import { emptyTombstoneResult, TYPING_APP_UNKNOWN_NAME } from '../../../shared/types/typing-analytics'
 
 export interface TypingScopeRow {
   id: string
@@ -100,20 +102,31 @@ export interface SessionRow {
  * row shape so the merge / parse layers share a single source of
  * truth. `bigramId` follows the `${prevKeycode}_${currKeycode}` format;
  * `h` is the decoded 8-bucket histogram that the merge layer encodes
- * to a compact BLOB for storage. */
+ * to a compact BLOB for storage. `s` / `sq` are the optional raw-IKI
+ * sum / sum-of-squares pair (see JsonlBigramMinuteEntry). */
 export type BigramMinuteEntry = JsonlBigramMinuteEntry
 export type BigramMinuteRow = JsonlBigramMinutePayload
 
-/** Row shape returned by range queries against typing_bigram_minute.
+/** Same shape as {@link BigramMinuteEntry} / {@link BigramMinuteRow} for
+ * trigrams — see JsonlTrigramMinuteEntry / JsonlTrigramMinutePayload. */
+export type TrigramMinuteEntry = JsonlTrigramMinuteEntry
+export type TrigramMinuteRow = JsonlTrigramMinutePayload
+
+/** Row shape returned by range queries against typing_bigram_minute or
+ * typing_trigram_minute — both tables project their id column as
+ * `ngramId` so a single shape covers 2-gram and 3-gram callers alike.
  * `hist` is decoded from the on-disk BLOB so callers don't depend on
- * better-sqlite3's binary representation. One row per (scope, minute,
- * bigram) — the aggregation layer (range / view IPC) sums these into
- * pair-totals. */
-export interface BigramMinuteCellRow {
-  bigramId: string
+ * better-sqlite3's binary representation. `sumIki` / `sumSqIki` are
+ * null when the row predates the sum columns (see schema.ts). One row
+ * per (scope, minute, ngram) — the aggregation layer (range / view
+ * IPC) sums these into pair-totals. */
+export interface NgramMinuteCellRow {
+  ngramId: string
   minuteTs: number
   count: number
   hist: number[]
+  sumIki: number | null
+  sumSqIki: number | null
 }
 
 /** Row shapes carried across sync bundles. Live columns plus the
@@ -135,6 +148,10 @@ export interface SessionExportRow extends SessionRow {
   isDeleted: boolean
 }
 export interface BigramMinuteExportRow extends BigramMinuteRow {
+  updatedAt: number
+  isDeleted: boolean
+}
+export interface TrigramMinuteExportRow extends TrigramMinuteRow {
   updatedAt: number
   isDeleted: boolean
 }
@@ -244,6 +261,149 @@ function runIdFilterClause(column: string): string {
   return `AND (json_array_length(@runIdsJson) = 0 OR ${column} IN (SELECT value FROM json_each(@runIdsJson)))`
 }
 
+// Tombstone range deletes only flip live rows (is_deleted = 0) so existing
+// tombstones keep their original updated_at for GC purposes. Shared by
+// every per-table tombstone statement (char/matrix/minute_stats/session
+// plus the bigram/trigram pair prepared by prepareNgramStatements below) —
+// the WHERE clause itself carries no table-specific column, only the FK.
+const TOMBSTONE_RANGE_WHERE = `
+  scope_id IN (SELECT id FROM typing_scopes WHERE keyboard_uid = @uid)
+    AND is_deleted = 0
+`
+
+// Hash-scoped variant — Sync-delete of another device's day removes only
+// that device's rows while keeping same-day contributions from other
+// hashes intact.
+const TOMBSTONE_HASH_RANGE_WHERE = `
+  scope_id IN (
+    SELECT id FROM typing_scopes
+     WHERE keyboard_uid = @uid AND machine_hash = @machineHash
+  )
+    AND is_deleted = 0
+`
+
+/** Prepared statements for one n-gram table (typing_bigram_minute or
+ * typing_trigram_minute). Both tables are structurally identical aside
+ * from their id column name, so every statement here is generated from
+ * the same template with `table` / `idColumn` interpolated — see
+ * {@link prepareNgramStatements}. */
+interface NgramStatements {
+  merge: Statement
+  selectInRangeForUid: Statement
+  selectInRangeForUidAndHash: Statement
+  tombstoneForHashInRange: Statement
+  tombstoneInRange: Statement
+  tombstoneAll: Statement
+  deleteBefore: Statement
+}
+
+/** Build the seven prepared statements one n-gram table needs. `table`
+ * and `idColumn` are always hard-coded literals from the call sites
+ * below (never user input), so interpolating them directly into the SQL
+ * text is safe — every value-level parameter still goes through
+ * better-sqlite3's `@name` binding. */
+function prepareNgramStatements(
+  db: DatabaseType,
+  table: 'typing_bigram_minute' | 'typing_trigram_minute',
+  idColumn: 'bigram_id' | 'trigram_id',
+): NgramStatements {
+  return {
+    // Authoritative LWW upsert for sync merge — replaces the target row
+    // wholesale, respects the incoming is_deleted flag, and only fires
+    // when excluded.updated_at is strictly newer than the existing row.
+    merge: db.prepare(`
+      INSERT INTO ${table} (
+        scope_id, minute_ts, ${idColumn}, count, hist, sum_iki, sumsq_iki, app_name, typing_test, run_id, updated_at, is_deleted
+      )
+      VALUES (
+        @scopeId, @minuteTs, @ngramId, @count, @hist, @sumIki, @sumSqIki, @appName, @typingTest, @runId, @updatedAt, @isDeleted
+      )
+      ON CONFLICT(scope_id, minute_ts, run_id, ${idColumn}) DO UPDATE SET
+        count = excluded.count,
+        hist = excluded.hist,
+        sum_iki = excluded.sum_iki,
+        sumsq_iki = excluded.sumsq_iki,
+        app_name = excluded.app_name,
+        typing_test = excluded.typing_test,
+        updated_at = excluded.updated_at,
+        is_deleted = excluded.is_deleted
+      WHERE excluded.updated_at > ${table}.updated_at
+    `),
+
+    // Per-(scope, minute, ngram) rows in range for the Analyze n-gram
+    // view. The aggregation layer sums each pair's count + hist across
+    // rows; SQL keeps the per-minute / per-ngram granularity so the
+    // caller can also emit time-series data (e.g. peak detection)
+    // without re-querying. ORDER BY ngramId groups rows for the same
+    // pair together so the aggregator can accumulate without an
+    // intermediate Map sort.
+    selectInRangeForUid: db.prepare(`
+      SELECT t.${idColumn} AS ngramId,
+             t.minute_ts AS minuteTs,
+             t.count AS count,
+             t.hist AS hist,
+             t.sum_iki AS sumIki,
+             t.sumsq_iki AS sumSqIki
+        FROM ${table} t
+        JOIN typing_scopes s ON s.id = t.scope_id
+       WHERE s.keyboard_uid = @uid
+         AND s.is_deleted = 0
+         AND t.is_deleted = 0
+         AND t.minute_ts >= @sinceMs
+         AND t.minute_ts < @untilMs
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')} ${runIdFilterClause('t.run_id')}
+       ORDER BY t.${idColumn} ASC, t.minute_ts ASC
+    `),
+
+    // Same as selectInRangeForUid but restricted to a single machine_hash
+    // for the Analyze "This device" scope.
+    selectInRangeForUidAndHash: db.prepare(`
+      SELECT t.${idColumn} AS ngramId,
+             t.minute_ts AS minuteTs,
+             t.count AS count,
+             t.hist AS hist,
+             t.sum_iki AS sumIki,
+             t.sumsq_iki AS sumSqIki
+        FROM ${table} t
+        JOIN typing_scopes s ON s.id = t.scope_id
+       WHERE s.keyboard_uid = @uid
+         AND s.machine_hash = @machineHash
+         AND s.is_deleted = 0
+         AND t.is_deleted = 0
+         AND t.minute_ts >= @sinceMs
+         AND t.minute_ts < @untilMs
+         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')} ${runIdFilterClause('t.run_id')}
+       ORDER BY t.${idColumn} ASC, t.minute_ts ASC
+    `),
+
+    tombstoneForHashInRange: db.prepare(`
+      UPDATE ${table}
+         SET is_deleted = 1, updated_at = @updatedAt
+       WHERE ${TOMBSTONE_HASH_RANGE_WHERE}
+         AND minute_ts >= @startMs AND minute_ts < @endMs
+    `),
+
+    tombstoneInRange: db.prepare(`
+      UPDATE ${table}
+         SET is_deleted = 1, updated_at = @updatedAt
+       WHERE ${TOMBSTONE_RANGE_WHERE}
+         AND minute_ts >= @startMs AND minute_ts < @endMs
+    `),
+
+    tombstoneAll: db.prepare(`
+      UPDATE ${table}
+         SET is_deleted = 1, updated_at = @updatedAt
+       WHERE ${TOMBSTONE_RANGE_WHERE}
+    `),
+
+    deleteBefore: db.prepare(`
+      DELETE FROM ${table}
+       WHERE scope_id IN (SELECT id FROM typing_scopes WHERE machine_hash = @machineHash)
+         AND minute_ts < @cutoffMs
+    `),
+  }
+}
+
 export class TypingAnalyticsDB {
   private readonly db: DatabaseType
   private readonly upsertScopeStmt: Statement
@@ -256,7 +416,10 @@ export class TypingAnalyticsDB {
   private readonly mergeMatrixMinuteStmt: Statement
   private readonly mergeMinuteStatsStmt: Statement
   private readonly mergeSessionStmt: Statement
-  private readonly mergeBigramMinuteStmt: Statement
+  // Bigram/trigram merge, range-select, tombstone and delete-before
+  // statements live behind this map (keyed by gram size) instead of 14
+  // separate fields — see prepareNgramStatements above.
+  private readonly ngramStmts: { readonly 2: NgramStatements; readonly 3: NgramStatements }
   private readonly selectScopesForUidStmt: Statement
   private readonly selectCharMinutesForUidStmt: Statement
   private readonly selectMatrixMinutesForUidStmt: Statement
@@ -281,8 +444,6 @@ export class TypingAnalyticsDB {
   private readonly selectMatrixCellsByDayForUidAndHashStmt: Statement
   private readonly selectMinuteStatsInRangeForUidStmt: Statement
   private readonly selectMinuteStatsInRangeForUidAndHashStmt: Statement
-  private readonly selectBigramMinutesInRangeForUidStmt: Statement
-  private readonly selectBigramMinutesInRangeForUidAndHashStmt: Statement
   private readonly selectSessionsInRangeForUidStmt: Statement
   private readonly selectSessionsInRangeForUidAndHashStmt: Statement
   private readonly selectBksMinuteInRangeForUidStmt: Statement
@@ -505,6 +666,11 @@ export class TypingAnalyticsDB {
          AND minute_ts < @cutoffMs
     `)
 
+    this.ngramStmts = {
+      2: prepareNgramStatements(this.db, 'typing_bigram_minute', 'bigram_id'),
+      3: prepareNgramStatements(this.db, 'typing_trigram_minute', 'trigram_id'),
+    }
+
     this.deleteSessionsBeforeStmt = this.db.prepare(`
       DELETE FROM typing_sessions
        WHERE scope_id IN (SELECT id FROM typing_scopes WHERE machine_hash = @machineHash)
@@ -631,22 +797,9 @@ export class TypingAnalyticsDB {
       WHERE excluded.updated_at > typing_sessions.updated_at
     `)
 
-    this.mergeBigramMinuteStmt = this.db.prepare(`
-      INSERT INTO typing_bigram_minute (
-        scope_id, minute_ts, bigram_id, count, hist, app_name, typing_test, run_id, updated_at, is_deleted
-      )
-      VALUES (
-        @scopeId, @minuteTs, @bigramId, @count, @hist, @appName, @typingTest, @runId, @updatedAt, @isDeleted
-      )
-      ON CONFLICT(scope_id, minute_ts, run_id, bigram_id) DO UPDATE SET
-        count = excluded.count,
-        hist = excluded.hist,
-        app_name = excluded.app_name,
-        typing_test = excluded.typing_test,
-        updated_at = excluded.updated_at,
-        is_deleted = excluded.is_deleted
-      WHERE excluded.updated_at > typing_bigram_minute.updated_at
-    `)
+    // this.ngramStmts (built earlier in this constructor) owns the
+    // bigram/trigram merge, range-select, tombstone and delete-before
+    // statements — see prepareNgramStatements above.
 
     // Sync export selects. Live rows within the live window or tombstones
     // within the longer tombstone window. typing_scopes is selected without
@@ -1226,44 +1379,8 @@ export class TypingAnalyticsDB {
        ORDER BY keystrokes DESC
     `)
 
-    // Bigram per-pair rows in range. The aggregation layer sums each
-    // pair's count + hist across rows; SQL keeps the per-minute / per-
-    // bigram granularity so the caller can also emit time-series data
-    // (e.g. peak detection) without re-querying. ORDER BY bigramId
-    // groups rows for the same pair together so the aggregator can
-    // accumulate without an intermediate Map sort.
-    this.selectBigramMinutesInRangeForUidStmt = this.db.prepare(`
-      SELECT t.bigram_id AS bigramId,
-             t.minute_ts AS minuteTs,
-             t.count AS count,
-             t.hist AS hist
-        FROM typing_bigram_minute t
-        JOIN typing_scopes s ON s.id = t.scope_id
-       WHERE s.keyboard_uid = @uid
-         AND s.is_deleted = 0
-         AND t.is_deleted = 0
-         AND t.minute_ts >= @sinceMs
-         AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')} ${runIdFilterClause('t.run_id')}
-       ORDER BY t.bigram_id ASC, t.minute_ts ASC
-    `)
-
-    this.selectBigramMinutesInRangeForUidAndHashStmt = this.db.prepare(`
-      SELECT t.bigram_id AS bigramId,
-             t.minute_ts AS minuteTs,
-             t.count AS count,
-             t.hist AS hist
-        FROM typing_bigram_minute t
-        JOIN typing_scopes s ON s.id = t.scope_id
-       WHERE s.keyboard_uid = @uid
-         AND s.machine_hash = @machineHash
-         AND s.is_deleted = 0
-         AND t.is_deleted = 0
-         AND t.minute_ts >= @sinceMs
-         AND t.minute_ts < @untilMs
-         ${appFilterClause('t.app_name')} ${typingTestFilterClause('t.typing_test')} ${runIdFilterClause('t.run_id')}
-       ORDER BY t.bigram_id ASC, t.minute_ts ASC
-    `)
+    // Bigram/trigram per-pair range-select statements live in
+    // this.ngramStmts[gram] — see prepareNgramStatements above.
 
     // Sessions whose start falls inside [@sinceMs, @untilMs). We filter
     // on `start_ms` so "last 24 hours" captures every session the user
@@ -1649,26 +1766,24 @@ export class TypingAnalyticsDB {
 
     // Tombstone range deletes. Only flips live rows (is_deleted = 0) so
     // existing tombstones keep their original updated_at for GC purposes.
-    const tombstoneRangeWhere = `
-      scope_id IN (SELECT id FROM typing_scopes WHERE keyboard_uid = @uid)
-        AND is_deleted = 0
-    `
+    // Bigram/trigram range/all-tombstone statements live in
+    // this.ngramStmts[gram] — see prepareNgramStatements above.
     this.tombstoneCharMinutesInRangeStmt = this.db.prepare(`
       UPDATE typing_char_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     this.tombstoneMatrixMinutesInRangeStmt = this.db.prepare(`
       UPDATE typing_matrix_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     this.tombstoneMinuteStatsInRangeStmt = this.db.prepare(`
       UPDATE typing_minute_stats
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     // Sessions use overlap semantics instead of start_ms-containment so a
@@ -1678,64 +1793,57 @@ export class TypingAnalyticsDB {
     this.tombstoneSessionsInRangeStmt = this.db.prepare(`
       UPDATE typing_sessions
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
          AND end_ms > @startMs AND start_ms < @endMs
     `)
 
     // Hash-scoped range variants — Sync-delete of another device's day
     // removes only that device's rows while keeping same-day contributions
     // from other hashes intact.
-    const tombstoneHashRangeWhere = `
-      scope_id IN (
-        SELECT id FROM typing_scopes
-         WHERE keyboard_uid = @uid AND machine_hash = @machineHash
-      )
-        AND is_deleted = 0
-    `
     this.tombstoneCharMinutesForHashInRangeStmt = this.db.prepare(`
       UPDATE typing_char_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneHashRangeWhere}
+       WHERE ${TOMBSTONE_HASH_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     this.tombstoneMatrixMinutesForHashInRangeStmt = this.db.prepare(`
       UPDATE typing_matrix_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneHashRangeWhere}
+       WHERE ${TOMBSTONE_HASH_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     this.tombstoneMinuteStatsForHashInRangeStmt = this.db.prepare(`
       UPDATE typing_minute_stats
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneHashRangeWhere}
+       WHERE ${TOMBSTONE_HASH_RANGE_WHERE}
          AND minute_ts >= @startMs AND minute_ts < @endMs
     `)
     this.tombstoneSessionsForHashInRangeStmt = this.db.prepare(`
       UPDATE typing_sessions
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneHashRangeWhere}
+       WHERE ${TOMBSTONE_HASH_RANGE_WHERE}
          AND end_ms > @startMs AND start_ms < @endMs
     `)
 
     this.tombstoneAllCharMinutesStmt = this.db.prepare(`
       UPDATE typing_char_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
     `)
     this.tombstoneAllMatrixMinutesStmt = this.db.prepare(`
       UPDATE typing_matrix_minute
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
     `)
     this.tombstoneAllMinuteStatsStmt = this.db.prepare(`
       UPDATE typing_minute_stats
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
     `)
     this.tombstoneAllSessionsStmt = this.db.prepare(`
       UPDATE typing_sessions
          SET is_deleted = 1, updated_at = @updatedAt
-       WHERE ${tombstoneRangeWhere}
+       WHERE ${TOMBSTONE_RANGE_WHERE}
     `)
   }
 
@@ -1838,6 +1946,8 @@ export class TypingAnalyticsDB {
       this.deleteCharMinuteBeforeStmt.run({ machineHash, cutoffMs })
       this.deleteMatrixMinuteBeforeStmt.run({ machineHash, cutoffMs })
       this.deleteMinuteStatsBeforeStmt.run({ machineHash, cutoffMs })
+      this.ngramStmts[2].deleteBefore.run({ machineHash, cutoffMs })
+      this.ngramStmts[3].deleteBefore.run({ machineHash, cutoffMs })
       this.deleteSessionsBeforeStmt.run({ machineHash, cutoffMs })
     })
     tx()
@@ -2212,33 +2322,36 @@ export class TypingAnalyticsDB {
     }[]
   }
 
-  /** Per-(scope, minute, bigram) rows in `[sinceMs, untilMs)` for the
-   * Analyze Bigrams view. Hist is decoded from the BLOB so the
-   * aggregation layer stays independent of the on-disk encoding. Rows
-   * are ordered by `bigramId, minuteTs` so a streaming aggregator can
-   * accumulate per-pair totals without sorting. */
-  listBigramMinutesInRangeForUid(
+  /** Per-(scope, minute, ngram) rows in `[sinceMs, untilMs)` for the
+   * Analyze Bigrams / n-gram view. `gram` selects `typing_bigram_minute`
+   * (2) or `typing_trigram_minute` (3) via {@link ngramStmts}. Hist is
+   * decoded from the BLOB so the aggregation layer stays independent of
+   * the on-disk encoding. Rows are ordered by `ngramId, minuteTs` so a
+   * streaming aggregator can accumulate per-pair totals without sorting. */
+  listNgramMinutesInRangeForUid(
+    gram: 2 | 3,
     uid: string,
     sinceMs: number,
     untilMs: number,
     appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
-  ): BigramMinuteCellRow[] {
-    return this.toBigramMinuteCellRows(
-      this.selectBigramMinutesInRangeForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes), runIdsJson: JSON.stringify(runIdScopes) }),
+  ): NgramMinuteCellRow[] {
+    return this.toNgramMinuteCellRows(
+      this.ngramStmts[gram].selectInRangeForUid.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes), runIdsJson: JSON.stringify(runIdScopes) }),
     )
   }
 
-  /** Same as {@link listBigramMinutesInRangeForUid} but restricted to
-   * a single machine_hash for the Analyze "This device" scope. */
-  listBigramMinutesInRangeForUidAndHash(
+  /** Same as {@link listNgramMinutesInRangeForUid} but restricted to a
+   * single machine_hash for the Analyze "This device" scope. */
+  listNgramMinutesInRangeForUidAndHash(
+    gram: 2 | 3,
     uid: string,
     machineHash: string,
     sinceMs: number,
     untilMs: number,
     appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
-  ): BigramMinuteCellRow[] {
-    return this.toBigramMinuteCellRows(
-      this.selectBigramMinutesInRangeForUidAndHashStmt.all({
+  ): NgramMinuteCellRow[] {
+    return this.toNgramMinuteCellRows(
+      this.ngramStmts[gram].selectInRangeForUidAndHash.all({
         uid,
         machineHash,
         sinceMs,
@@ -2248,13 +2361,58 @@ export class TypingAnalyticsDB {
     )
   }
 
-  private toBigramMinuteCellRows(raws: unknown): BigramMinuteCellRow[] {
-    return (raws as { bigramId: string; minuteTs: number; count: number; hist: Uint8Array }[]).map((r) => ({
-      bigramId: r.bigramId,
+  private toNgramMinuteCellRows(raws: unknown): NgramMinuteCellRow[] {
+    return (raws as { ngramId: string; minuteTs: number; count: number; hist: Uint8Array; sumIki: number | null; sumSqIki: number | null }[]).map((r) => ({
+      ngramId: r.ngramId,
       minuteTs: r.minuteTs,
       count: r.count,
       hist: decodeHistBuffer(r.hist),
+      sumIki: r.sumIki,
+      sumSqIki: r.sumSqIki,
     }))
+  }
+
+  /** @deprecated thin gram=2 wrapper kept for existing call sites
+   * (hub-analytics.ts, tests) — prefer {@link listNgramMinutesInRangeForUid}. */
+  listBigramMinutesInRangeForUid(
+    uid: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): NgramMinuteCellRow[] {
+    return this.listNgramMinutesInRangeForUid(2, uid, sinceMs, untilMs, appScopes, typingTestScopes, runIdScopes)
+  }
+
+  /** @deprecated thin gram=2 wrapper — see {@link listBigramMinutesInRangeForUid}. */
+  listBigramMinutesInRangeForUidAndHash(
+    uid: string,
+    machineHash: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): NgramMinuteCellRow[] {
+    return this.listNgramMinutesInRangeForUidAndHash(2, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes, runIdScopes)
+  }
+
+  /** @deprecated thin gram=3 wrapper — see {@link listBigramMinutesInRangeForUid}. */
+  listTrigramMinutesInRangeForUid(
+    uid: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): NgramMinuteCellRow[] {
+    return this.listNgramMinutesInRangeForUid(3, uid, sinceMs, untilMs, appScopes, typingTestScopes, runIdScopes)
+  }
+
+  /** @deprecated thin gram=3 wrapper — see {@link listBigramMinutesInRangeForUid}. */
+  listTrigramMinutesInRangeForUidAndHash(
+    uid: string,
+    machineHash: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): NgramMinuteCellRow[] {
+    return this.listNgramMinutesInRangeForUidAndHash(3, uid, machineHash, sinceMs, untilMs, appScopes, typingTestScopes, runIdScopes)
   }
 
   /** Live sessions that intersect `[sinceMs, untilMs)` for a keyboard
@@ -2384,11 +2542,13 @@ export class TypingAnalyticsDB {
     endMs: number,
     updatedAt: number,
   ): TypingTombstoneResult {
-    const result: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+    const result = emptyTombstoneResult()
     const tx = this.db.transaction(() => {
       result.charMinutes = this.tombstoneCharMinutesForHashInRangeStmt.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
       result.matrixMinutes = this.tombstoneMatrixMinutesForHashInRangeStmt.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
       result.minuteStats = this.tombstoneMinuteStatsForHashInRangeStmt.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
+      result.bigramMinutes = this.ngramStmts[2].tombstoneForHashInRange.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
+      result.trigramMinutes = this.ngramStmts[3].tombstoneForHashInRange.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
       result.sessions = this.tombstoneSessionsForHashInRangeStmt.run({ uid, machineHash, startMs, endMs, updatedAt }).changes
     })
     tx()
@@ -2401,11 +2561,13 @@ export class TypingAnalyticsDB {
     endMs: number,
     updatedAt: number,
   ): TypingTombstoneResult {
-    const result: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+    const result = emptyTombstoneResult()
     const tx = this.db.transaction(() => {
       result.charMinutes = this.tombstoneCharMinutesInRangeStmt.run({ uid, startMs, endMs, updatedAt }).changes
       result.matrixMinutes = this.tombstoneMatrixMinutesInRangeStmt.run({ uid, startMs, endMs, updatedAt }).changes
       result.minuteStats = this.tombstoneMinuteStatsInRangeStmt.run({ uid, startMs, endMs, updatedAt }).changes
+      result.bigramMinutes = this.ngramStmts[2].tombstoneInRange.run({ uid, startMs, endMs, updatedAt }).changes
+      result.trigramMinutes = this.ngramStmts[3].tombstoneInRange.run({ uid, startMs, endMs, updatedAt }).changes
       result.sessions = this.tombstoneSessionsInRangeStmt.run({ uid, startMs, endMs, updatedAt }).changes
     })
     tx()
@@ -2416,11 +2578,13 @@ export class TypingAnalyticsDB {
    * themselves are left intact so the next recording session reuses
    * them without a fresh fingerprint build. */
   tombstoneAllRowsForUid(uid: string, updatedAt: number): TypingTombstoneResult {
-    const result: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+    const result = emptyTombstoneResult()
     const tx = this.db.transaction(() => {
       result.charMinutes = this.tombstoneAllCharMinutesStmt.run({ uid, updatedAt }).changes
       result.matrixMinutes = this.tombstoneAllMatrixMinutesStmt.run({ uid, updatedAt }).changes
       result.minuteStats = this.tombstoneAllMinuteStatsStmt.run({ uid, updatedAt }).changes
+      result.bigramMinutes = this.ngramStmts[2].tombstoneAll.run({ uid, updatedAt }).changes
+      result.trigramMinutes = this.ngramStmts[3].tombstoneAll.run({ uid, updatedAt }).changes
       result.sessions = this.tombstoneAllSessionsStmt.run({ uid, updatedAt }).changes
     })
     tx()
@@ -2564,7 +2728,10 @@ export class TypingAnalyticsDB {
 
   /** Apply a single JSONL bigram-minute row by expanding each pair into
    * its own SQLite upsert. The caller is expected to wrap the batch in
-   * a transaction (see {@link applyRowsToCache}). */
+   * a transaction (see {@link applyRowsToCache}). LWW-replace, same as
+   * every other merge* method — the incoming row already holds the full
+   * per-minute total for its pair, not a delta to accumulate. `s`/`sq`
+   * fall back to null when the source row predates the sum columns. */
   mergeBigramMinute(row: BigramMinuteExportRow): void {
     const isDeleted = row.isDeleted ? 1 : 0
     const appName = row.appName ?? null
@@ -2572,12 +2739,39 @@ export class TypingAnalyticsDB {
     const runId = row.runId ?? ''
     for (const bigramId of Object.keys(row.bigrams)) {
       const entry = row.bigrams[bigramId]
-      this.mergeBigramMinuteStmt.run({
+      this.ngramStmts[2].merge.run({
         scopeId: row.scopeId,
         minuteTs: row.minuteTs,
-        bigramId,
+        ngramId: bigramId,
         count: entry.c,
         hist: encodeHistBuffer(entry.h),
+        sumIki: entry.s ?? null,
+        sumSqIki: entry.sq ?? null,
+        appName,
+        typingTest,
+        runId,
+        updatedAt: row.updatedAt,
+        isDeleted,
+      })
+    }
+  }
+
+  /** Same as {@link mergeBigramMinute} for trigram-minute rows. */
+  mergeTrigramMinute(row: TrigramMinuteExportRow): void {
+    const isDeleted = row.isDeleted ? 1 : 0
+    const appName = row.appName ?? null
+    const typingTest = row.typingTest ?? null
+    const runId = row.runId ?? ''
+    for (const trigramId of Object.keys(row.trigrams)) {
+      const entry = row.trigrams[trigramId]
+      this.ngramStmts[3].merge.run({
+        scopeId: row.scopeId,
+        minuteTs: row.minuteTs,
+        ngramId: trigramId,
+        count: entry.c,
+        hist: encodeHistBuffer(entry.h),
+        sumIki: entry.s ?? null,
+        sumSqIki: entry.sq ?? null,
         appName,
         typingTest,
         runId,
@@ -2650,6 +2844,22 @@ export class TypingAnalyticsDB {
         DROP TABLE IF EXISTS typing_bigram_minute;
       `)
       this.cacheNeedsRebuild = true
+    }
+    // v6 -> v7: Add sum_iki / sumsq_iki to typing_bigram_minute (nullable —
+    // see Plan-trigram-and-iki-variance.md) and introduce typing_trigram_minute.
+    // The new table is handled by CREATE_SCHEMA_SQL's unconditional
+    // `CREATE TABLE IF NOT EXISTS`, same as any fresh install, so nothing to
+    // do here for it. The ALTER below only applies when typing_bigram_minute
+    // still has the pre-v7 shape: a DB migrating up from before v6 already
+    // dropped that table in the branch above and CREATE_SCHEMA_SQL recreates
+    // it with these columns built in, so re-altering here would hit "no such
+    // table". No cache rebuild: existing rows just gain nullable columns —
+    // there is nothing to replay from the JSONL masters.
+    if (fromVersion === 6) {
+      this.db.exec(`
+        ALTER TABLE typing_bigram_minute ADD COLUMN sum_iki REAL;
+        ALTER TABLE typing_bigram_minute ADD COLUMN sumsq_iki REAL;
+      `)
     }
   }
 

--- a/src/main/typing-analytics/import-export.ts
+++ b/src/main/typing-analytics/import-export.ts
@@ -243,6 +243,8 @@ function rowTimestamp(row: JsonlRow): number | null {
     case 'char-minute':
     case 'matrix-minute':
     case 'minute-stats':
+    case 'bigram-minute':
+    case 'trigram-minute':
       return row.payload.minuteTs
     case 'session':
       return row.payload.startMs

--- a/src/main/typing-analytics/jsonl/__tests__/apply-to-cache.test.ts
+++ b/src/main/typing-analytics/jsonl/__tests__/apply-to-cache.test.ts
@@ -12,6 +12,7 @@ import {
   minuteStatsRowId,
   scopeRowId,
   sessionRowId,
+  trigramMinuteRowId,
   type JsonlRow,
 } from '../jsonl-row'
 import { applyRowsToCache } from '../apply-to-cache'
@@ -99,10 +100,22 @@ function bigramRow(
   bigrams: Record<string, { c: number; h: number[] }>,
 ): JsonlRow {
   return {
-    id: bigramMinuteRowId(SCOPE_ID, 60_000),
+    id: bigramMinuteRowId(SCOPE_ID, 60_000, ''),
     kind: 'bigram-minute',
     updated_at: updatedAt,
     payload: { scopeId: SCOPE_ID, minuteTs: 60_000, bigrams },
+  }
+}
+
+function trigramRow(
+  updatedAt: number,
+  trigrams: Record<string, { c: number; h: number[] }>,
+): JsonlRow {
+  return {
+    id: trigramMinuteRowId(SCOPE_ID, 60_000, ''),
+    kind: 'trigram-minute',
+    updated_at: updatedAt,
+    payload: { scopeId: SCOPE_ID, minuteTs: 60_000, trigrams },
   }
 }
 
@@ -136,6 +149,7 @@ describe('applyRowsToCache', () => {
       minuteStats: 1,
       sessions: 1,
       bigramMinutes: 0,
+      trigramMinutes: 0,
     })
     const conn = db.getConnection()
     expect(conn.prepare('SELECT COUNT(*) AS n FROM typing_scopes').get()).toEqual({ n: 1 })
@@ -224,6 +238,37 @@ describe('applyRowsToCache', () => {
     expect(row.count).toBe(5)
   })
 
+  it('expands a trigram-minute row into per-triple rows in typing_trigram_minute', () => {
+    const rows: JsonlRow[] = [
+      scopeRow(1_000),
+      trigramRow(1_000, {
+        '4_11_7': { c: 3, h: [0, 1, 2, 0, 0, 0, 0, 0] },
+      }),
+    ]
+    const result = applyRowsToCache(db, rows)
+    expect(result.trigramMinutes).toBe(1)
+    const conn = db.getConnection()
+    const dbRows = conn
+      .prepare('SELECT trigram_id, count, hist FROM typing_trigram_minute')
+      .all() as { trigram_id: string; count: number; hist: Uint8Array }[]
+    expect(dbRows).toHaveLength(1)
+    expect(dbRows[0].trigram_id).toBe('4_11_7')
+    expect(dbRows[0].count).toBe(3)
+  })
+
+  it('LWW: a stale trigram-minute row does not override a newer aggregate', () => {
+    applyRowsToCache(db, [
+      scopeRow(1_000),
+      trigramRow(2_000, { '4_11_7': { c: 5, h: [0, 5, 0, 0, 0, 0, 0, 0] } }),
+    ])
+    applyRowsToCache(db, [
+      trigramRow(1_500, { '4_11_7': { c: 999, h: [9, 0, 0, 0, 0, 0, 0, 0] } }),
+    ])
+    const conn = db.getConnection()
+    const row = conn.prepare('SELECT count FROM typing_trigram_minute WHERE trigram_id = ?').get('4_11_7') as { count: number }
+    expect(row.count).toBe(5)
+  })
+
   it('returns zero counters when given an empty batch', () => {
     expect(applyRowsToCache(db, [])).toEqual({
       scopes: 0,
@@ -232,6 +277,7 @@ describe('applyRowsToCache', () => {
       minuteStats: 0,
       sessions: 0,
       bigramMinutes: 0,
+      trigramMinutes: 0,
     })
   })
 })

--- a/src/main/typing-analytics/jsonl/__tests__/jsonl-row.test.ts
+++ b/src/main/typing-analytics/jsonl/__tests__/jsonl-row.test.ts
@@ -10,6 +10,7 @@ import {
   scopeRowId,
   serializeRow,
   sessionRowId,
+  trigramMinuteRowId,
   type JsonlRow,
 } from '../jsonl-row'
 
@@ -44,6 +45,11 @@ describe('composite id builders', () => {
   it('builds bigram-minute row ids without per-pair suffix (one row per minute)', () => {
     expect(bigramMinuteRowId('s', 60_000, '')).toBe('bigram|s|60000|')
     expect(bigramMinuteRowId('s', 60_000, 'run-1')).toBe('bigram|s|60000|run-1')
+  })
+
+  it('builds trigram-minute row ids without per-triple suffix (one row per minute)', () => {
+    expect(trigramMinuteRowId('s', 60_000, '')).toBe('trigram|s|60000|')
+    expect(trigramMinuteRowId('s', 60_000, 'run-1')).toBe('trigram|s|60000|run-1')
   })
 })
 
@@ -120,15 +126,27 @@ describe('serializeRow / parseRow round-trip', () => {
         payload: { id: 'uuid-1', scopeId: 'scope-1', startMs: 1_000, endMs: 2_000 },
       },
       {
-        id: bigramMinuteRowId('scope-1', 60_000),
+        id: bigramMinuteRowId('scope-1', 60_000, ''),
         kind: 'bigram-minute',
         updated_at: 2_000,
         payload: {
           scopeId: 'scope-1',
           minuteTs: 60_000,
           bigrams: {
-            '4_11': { c: 10, h: [1, 0, 0, 2, 3, 1, 2, 1] },
+            '4_11': { c: 10, h: [1, 0, 0, 2, 3, 1, 2, 1], s: 1_200, sq: 180_000 },
             '22_22': { c: 20, h: [2, 3, 5, 4, 3, 2, 1, 0] },
+          },
+        },
+      },
+      {
+        id: trigramMinuteRowId('scope-1', 60_000, ''),
+        kind: 'trigram-minute',
+        updated_at: 2_000,
+        payload: {
+          scopeId: 'scope-1',
+          minuteTs: 60_000,
+          trigrams: {
+            '4_11_7': { c: 6, h: [0, 1, 2, 1, 1, 1, 0, 0], s: 720, sq: 96_000 },
           },
         },
       },
@@ -247,6 +265,105 @@ describe('parseRow rejections', () => {
       payload: {
         minuteTs: 60_000,
         bigrams: { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+      },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
+  it('accepts a bigram-minute entry with both s and sq present', () => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], s: 240, sq: 28_800 } },
+      },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('accepts a bigram-minute entry with s/sq entirely absent (legacy row)', () => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0] } },
+      },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it.each([
+    ['s only', { s: 240 }],
+    ['sq only', { sq: 28_800 }],
+    ['non-finite s', { s: Number.NaN, sq: 28_800 }],
+    ['non-finite sq', { s: 240, sq: Number.POSITIVE_INFINITY }],
+    ['non-numeric s', { s: '240', sq: 28_800 }],
+  ])('returns null for a bigram-minute entry with an incomplete/invalid sum pair (%s)', (_label, extra) => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], ...extra } },
+      },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
+  it('round-trips a trigram-minute row with an empty triple set', () => {
+    const empty: JsonlRow = {
+      id: trigramMinuteRowId('scope-1', 60_000, ''),
+      kind: 'trigram-minute',
+      updated_at: 1,
+      payload: { scopeId: 'scope-1', minuteTs: 60_000, trigrams: {} },
+    }
+    expect(parseRow(serializeRow(empty).trimEnd())).toEqual(empty)
+  })
+
+  it('returns null for a trigram-minute row with a histogram of the wrong length', () => {
+    const line = JSON.stringify({
+      id: 'trigram|s|60000',
+      kind: 'trigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0] } }, // expected 8 buckets
+      },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
+  it('returns null for a trigram-minute row missing scopeId', () => {
+    const line = JSON.stringify({
+      id: 'trigram|s|60000',
+      kind: 'trigram-minute',
+      updated_at: 1,
+      payload: {
+        minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+      },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
+  it('returns null for a trigram-minute entry with an incomplete sum pair', () => {
+    const line = JSON.stringify({
+      id: 'trigram|s|60000',
+      kind: 'trigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0], s: 150 } },
       },
     })
     expect(parseRow(line)).toBeNull()

--- a/src/main/typing-analytics/jsonl/apply-to-cache.ts
+++ b/src/main/typing-analytics/jsonl/apply-to-cache.ts
@@ -16,6 +16,7 @@ export interface ApplyRowsResult {
   minuteStats: number
   sessions: number
   bigramMinutes: number
+  trigramMinutes: number
 }
 
 export function applyRowsToCache(
@@ -29,6 +30,7 @@ export function applyRowsToCache(
     minuteStats: 0,
     sessions: 0,
     bigramMinutes: 0,
+    trigramMinutes: 0,
   }
   if (rows.length === 0) return result
 
@@ -67,6 +69,10 @@ export function applyRowsToCache(
         case 'bigram-minute':
           db.mergeBigramMinute({ ...row.payload, ...common })
           result.bigramMinutes += 1
+          break
+        case 'trigram-minute':
+          db.mergeTrigramMinute({ ...row.payload, ...common })
+          result.trigramMinutes += 1
           break
       }
     }

--- a/src/main/typing-analytics/jsonl/jsonl-row.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-row.ts
@@ -35,6 +35,7 @@ export type JsonlRowKind =
   | 'minute-stats'
   | 'session'
   | 'bigram-minute'
+  | 'trigram-minute'
 
 export interface JsonlScopePayload {
   id: string
@@ -98,10 +99,18 @@ export interface JsonlSessionPayload {
 
 /** Per-bigram aggregate within a single minute. `c` = count of pair
  * occurrences. `h` = 8-bucket IKI histogram (log-scale buckets, see
- * Plan-analyze-bigram.md). */
+ * Plan-analyze-bigram.md). `s` / `sq` are the sum and sum-of-squares of
+ * the raw IKI values that fed `h`, kept alongside the histogram so a
+ * range aggregate can compute a true standard deviation instead of a
+ * bucket-midpoint approximation. Optional and always a pair: rows
+ * written before this field existed (or merged from an older peer)
+ * omit both, and SD then reads as null rather than an approximation —
+ * see isBigramMinuteEntry / isNgramMinuteEntry. */
 export interface JsonlBigramMinuteEntry {
   c: number
   h: number[]
+  s?: number
+  sq?: number
 }
 
 export interface JsonlBigramMinutePayload {
@@ -110,6 +119,24 @@ export interface JsonlBigramMinutePayload {
   /** Pair key format: `${prevKeycode}_${currKeycode}` (numeric keycodes
    * joined by underscore). One row per minute aggregates all bigrams. */
   bigrams: Record<string, JsonlBigramMinuteEntry>
+  appName?: AppNameField
+  typingTest?: TypingTestField
+  runId?: RunIdField
+}
+
+/** Per-trigram aggregate within a single minute. Same shape as
+ * {@link JsonlBigramMinuteEntry} (count / histogram / optional sum
+ * pair) — trigram IKI values are already the 2-interval average by the
+ * time they reach this layer (see MinuteBuffer.recordTrigram), so the
+ * same histogram bucketing and sum/sumSq accumulation apply unchanged. */
+export type JsonlTrigramMinuteEntry = JsonlBigramMinuteEntry
+
+export interface JsonlTrigramMinutePayload {
+  scopeId: string
+  minuteTs: number
+  /** Triple key format: `${k1}_${k2}_${k3}` (numeric keycodes joined by
+   * underscore). One row per minute aggregates all trigrams. */
+  trigrams: Record<string, JsonlTrigramMinuteEntry>
   appName?: AppNameField
   typingTest?: TypingTestField
   runId?: RunIdField
@@ -155,6 +182,11 @@ export interface JsonlBigramMinuteRow extends JsonlRowBase {
   payload: JsonlBigramMinutePayload
 }
 
+export interface JsonlTrigramMinuteRow extends JsonlRowBase {
+  kind: 'trigram-minute'
+  payload: JsonlTrigramMinutePayload
+}
+
 export type JsonlRow =
   | JsonlScopeRow
   | JsonlCharMinuteRow
@@ -162,6 +194,7 @@ export type JsonlRow =
   | JsonlMinuteStatsRow
   | JsonlSessionRow
   | JsonlBigramMinuteRow
+  | JsonlTrigramMinuteRow
 
 const KNOWN_KINDS: ReadonlySet<string> = new Set<JsonlRowKind>([
   'scope',
@@ -170,6 +203,7 @@ const KNOWN_KINDS: ReadonlySet<string> = new Set<JsonlRowKind>([
   'minute-stats',
   'session',
   'bigram-minute',
+  'trigram-minute',
 ])
 
 function enc(value: string | number): string {
@@ -210,6 +244,10 @@ export function sessionRowId(sessionId: string): string {
 
 export function bigramMinuteRowId(scopeId: string, minuteTs: number, runId: string): string {
   return `bigram|${enc(scopeId)}|${minuteTs}|${enc(runId)}`
+}
+
+export function trigramMinuteRowId(scopeId: string, minuteTs: number, runId: string): string {
+  return `trigram|${enc(scopeId)}|${minuteTs}|${enc(runId)}`
 }
 
 /** Serialize a single row as a newline-terminated JSON line. */
@@ -338,23 +376,48 @@ function isBigramHist(value: unknown): boolean {
   return true
 }
 
-function isBigramMinuteEntry(value: unknown): boolean {
-  if (typeof value !== 'object' || value === null) return false
-  const o = value as Record<string, unknown>
-  return typeof o.c === 'number' && Number.isFinite(o.c) && isBigramHist(o.h)
+/** `s` / `sq` are optional but must appear as a pair: both absent is a
+ * legacy row (valid), both present must be finite numbers, and exactly
+ * one present is malformed (rejected). This keeps the DB layer's "only
+ * a complete sum pair yields a real SD" invariant enforceable straight
+ * off the wire. */
+function hasValidSumPair(o: Record<string, unknown>): boolean {
+  const hasS = 's' in o
+  const hasSq = 'sq' in o
+  if (!hasS && !hasSq) return true
+  if (!hasS || !hasSq) return false
+  return typeof o.s === 'number' && Number.isFinite(o.s) && typeof o.sq === 'number' && Number.isFinite(o.sq)
 }
 
-function isBigramMinutePayload(p: Record<string, unknown>): boolean {
+/** Shared validator for bigram and trigram minute entries — both use
+ * the identical `{c, h, s?, sq?}` shape (see JsonlTrigramMinuteEntry). */
+function isNgramMinuteEntry(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false
+  const o = value as Record<string, unknown>
+  return typeof o.c === 'number' && Number.isFinite(o.c) && isBigramHist(o.h) && hasValidSumPair(o)
+}
+
+/** Shared validator for bigram-minute / trigram-minute payloads — same
+ * shape except for the entries field name (`bigrams` vs `trigrams`). */
+function isNgramMinutePayload(p: Record<string, unknown>, field: 'bigrams' | 'trigrams'): boolean {
   if (!hasStringField(p, 'scopeId') || !hasNumberField(p, 'minuteTs')) return false
   if (!isOptionalAppName(p)) return false
   if (!isOptionalTypingTest(p)) return false
   if (!isOptionalRunId(p)) return false
-  const bigrams = p.bigrams
-  if (typeof bigrams !== 'object' || bigrams === null) return false
-  for (const value of Object.values(bigrams as Record<string, unknown>)) {
-    if (!isBigramMinuteEntry(value)) return false
+  const entries = p[field]
+  if (typeof entries !== 'object' || entries === null) return false
+  for (const value of Object.values(entries as Record<string, unknown>)) {
+    if (!isNgramMinuteEntry(value)) return false
   }
   return true
+}
+
+function isBigramMinutePayload(p: Record<string, unknown>): boolean {
+  return isNgramMinutePayload(p, 'bigrams')
+}
+
+function isTrigramMinutePayload(p: Record<string, unknown>): boolean {
+  return isNgramMinutePayload(p, 'trigrams')
 }
 
 /** Parse one JSONL line into a typed row. Returns `null` for malformed
@@ -396,6 +459,9 @@ export function parseRow(line: string): JsonlRow | null {
       break
     case 'bigram-minute':
       if (!isBigramMinutePayload(payloadObj)) return null
+      break
+    case 'trigram-minute':
+      if (!isTrigramMinutePayload(payloadObj)) return null
       break
   }
 

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -47,6 +47,13 @@ export interface MinuteSnapshot {
    * persisting; the snapshot exposes raw IKIs so consumers can choose
    * their own bucketing if needed. */
   bigrams: Map<string, number[]>
+  /** Per-trigram interval-average values (ms) accumulated within this
+   * minute. Triple key format: `${k1}_${k2}_${k3}`. Each value is the
+   * average of the two inter-key intervals that make up the triple
+   * (`(iki1 + iki2) / 2`), giving trigrams the same "interval speed"
+   * semantics as bigrams so the existing histogram bucketing applies
+   * unchanged. */
+  trigrams: Map<string, number[]>
   /** Active application name observed during this minute, or null when:
    *  - Monitor App is disabled
    *  - the minute observed multiple distinct apps (mixed → null)
@@ -78,6 +85,7 @@ interface Entry {
   matrixCounts: Map<string, MatrixCellCounts>
   intervals: number[]
   bigrams: Map<string, number[]>
+  trigrams: Map<string, number[]>
   keystrokes: number
   firstEventMs: number
   lastEventMs: number
@@ -138,6 +146,7 @@ function finalize(entry: Entry): MinuteSnapshot {
     charCounts: entry.charCounts,
     matrixCounts: entry.matrixCounts,
     bigrams: entry.bigrams,
+    trigrams: entry.trigrams,
     appName,
     typingTest,
     runId: entry.runId,
@@ -146,12 +155,27 @@ function finalize(entry: Entry): MinuteSnapshot {
 
 export class MinuteBuffer {
   private readonly buffers = new Map<string, Entry>()
-  // Bigram tracking is matrix-only (char events have no keycode). Reset
-  // on minute close so cross-minute pairs are dropped per the design
-  // (see Plan-analyze-bigram.md — 0.3% loss accepted to keep the flush
-  // path simple).
-  private previousMatrixKeycode: number | null = null
-  private previousMatrixTimestamp: number | null = null
+  // Bigram/trigram tracking is matrix-only (char events have no
+  // keycode) and shares a single 2-deep chain of the last two matrix
+  // events: k1 (older) -> k2 (newer, the bigram "previous") -> the
+  // incoming event closes the pair/triple. `prevIki` caches the
+  // already-validated k1->k2 interval so a trigram emit never has to
+  // recompute or re-check it — see recordNgramChain. Reset on minute
+  // close so cross-minute pairs are dropped per the design (see
+  // Plan-analyze-bigram.md — 0.3% loss accepted to keep the flush path
+  // simple).
+  private k1Keycode: number | null = null
+  private k2Keycode: number | null = null
+  private k2Ts: number | null = null
+  private prevIki: number | null = null
+  // `${scopeId}|${runId}` the chain currently belongs to. Two keyboards
+  // typing in parallel (or a run boundary inside one minute) interleave
+  // events from different scopes/runs; pairing across them would record
+  // phantom n-grams into whichever entry the newer event lands in, so a
+  // mismatch restarts the chain from the incoming event. minuteTs is
+  // deliberately not part of this key — minute boundaries reset through
+  // the existing drain/resetBigramChain path.
+  private chainKey: string | null = null
 
   addEvent(event: TypingAnalyticsEvent, fingerprint: TypingAnalyticsFingerprint): void {
     const scopeId = canonicalScopeKey(fingerprint)
@@ -172,6 +196,7 @@ export class MinuteBuffer {
         matrixCounts: new Map(),
         intervals: [],
         bigrams: new Map(),
+        trigrams: new Map(),
         keystrokes: 0,
         firstEventMs: event.ts,
         lastEventMs: event.ts,
@@ -213,40 +238,73 @@ export class MinuteBuffer {
         holdCount: (existing?.holdCount ?? 0) + holdDelta,
       })
 
-      this.recordBigram(entry, event.keycode, event.ts)
+      this.recordNgramChain(entry, `${scopeId}|${runId}`, event.keycode, event.ts)
     }
   }
 
-  private recordBigram(entry: Entry, currKeycode: number, ts: number): void {
-    if (
-      this.previousMatrixKeycode !== null &&
-      this.previousMatrixTimestamp !== null
-    ) {
-      const iki = ts - this.previousMatrixTimestamp
-      // Forward-time only (out-of-order matches the existing intervals
-      // policy of dropping rather than reconstructing) and within session
-      // gap (cross-session pairs are noise, not typing rhythm).
-      if (iki > 0 && iki <= SESSION_IDLE_GAP_MS) {
-        const pairKey = `${this.previousMatrixKeycode}_${currKeycode}`
-        let ikis = entry.bigrams.get(pairKey)
-        if (!ikis) {
-          ikis = []
-          entry.bigrams.set(pairKey, ikis)
+  /** Advance the shared bigram/trigram chain by one matrix event and
+   * emit any pair/triple the new event completes. `k2` is the bigram
+   * "previous"; `k1` is the event before that, so the incoming event
+   * (`curr`) closes the pair `k2_curr` and, when `k1` is also present,
+   * the triple `k1_k2_curr`.
+   *
+   * Eligibility (`0 < iki <= SESSION_IDLE_GAP_MS`) is checked once for
+   * the `k2 -> curr` interval and reused for both emissions — the
+   * trigram value additionally needs `prevIki`, the already-validated
+   * `k1 -> k2` interval cached from the previous call, so it never
+   * re-derives or re-checks that older interval.
+   *
+   * A tied/out-of-order event (`iki <= 0`) is discarded without
+   * disturbing the chain. Otherwise the chain always advances on a
+   * strictly-forward event, even when the interval exceeds the session
+   * gap — a big gap just means `prevIki` (and therefore any trigram
+   * through it) reads as invalid until two consecutive eligible
+   * intervals rebuild it; the bigram side never depended on `k1` and is
+   * unaffected.
+   *
+   * `chainKey` scopes the chain to one `${scopeId}|${runId}` stream: an
+   * event from a different keyboard or test run restarts the chain from
+   * itself instead of pairing against the other stream's keys. */
+  private recordNgramChain(entry: Entry, chainKey: string, currKeycode: number, ts: number): void {
+    if (this.k2Ts === null || this.chainKey !== chainKey) {
+      // First matrix event this chain has seen, or the event belongs to
+      // a different scope/run than the current chain — nothing valid to
+      // pair against.
+      this.k1Keycode = null
+      this.prevIki = null
+      this.k2Keycode = currKeycode
+      this.k2Ts = ts
+      this.chainKey = chainKey
+      return
+    }
+    const iki = ts - this.k2Ts
+    if (iki <= 0) {
+      // Tie / out-of-order: discard this event, chain unchanged.
+      return
+    }
+    const eligible = iki <= SESSION_IDLE_GAP_MS
+    if (eligible) {
+      const pairKey = `${this.k2Keycode}_${currKeycode}`
+      let ikis = entry.bigrams.get(pairKey)
+      if (!ikis) {
+        ikis = []
+        entry.bigrams.set(pairKey, ikis)
+      }
+      ikis.push(iki)
+      if (this.k1Keycode !== null && this.prevIki !== null) {
+        const tripleKey = `${this.k1Keycode}_${this.k2Keycode}_${currKeycode}`
+        let ikis3 = entry.trigrams.get(tripleKey)
+        if (!ikis3) {
+          ikis3 = []
+          entry.trigrams.set(tripleKey, ikis3)
         }
-        ikis.push(iki)
+        ikis3.push((this.prevIki + iki) / 2)
       }
     }
-    // Strict forward only — matches the `iki > 0` filter above. Ties
-    // (same ts as prev) shouldn't have emitted a bigram and likewise
-    // shouldn't advance the chain, otherwise the next event would pair
-    // against the tied keycode rather than the older one we kept.
-    if (
-      this.previousMatrixTimestamp === null ||
-      ts > this.previousMatrixTimestamp
-    ) {
-      this.previousMatrixKeycode = currKeycode
-      this.previousMatrixTimestamp = ts
-    }
+    this.k1Keycode = this.k2Keycode
+    this.prevIki = eligible ? iki : null
+    this.k2Keycode = currKeycode
+    this.k2Ts = ts
   }
 
   /** Tag every currently-open buffer entry with an observed application
@@ -293,8 +351,11 @@ export class MinuteBuffer {
   }
 
   private resetBigramChain(): void {
-    this.previousMatrixKeycode = null
-    this.previousMatrixTimestamp = null
+    this.k1Keycode = null
+    this.k2Keycode = null
+    this.k2Ts = null
+    this.prevIki = null
+    this.chainKey = null
   }
 
   isEmpty(): boolean {

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -26,7 +26,7 @@ import type {
   TypingBigramAggregateView,
 } from '../../shared/types/typing-analytics'
 import type { KleKey } from '../../shared/kle/types'
-import { canonicalScopeKey } from '../../shared/types/typing-analytics'
+import { canonicalScopeKey, emptyTombstoneResult } from '../../shared/types/typing-analytics'
 import { isHashScope, isOwnScope, normalizeAppScopes, parseDeviceScope } from '../../shared/types/analyze-filters'
 import { log } from '../logger'
 import { getCurrentAppName } from './app-monitor'
@@ -68,10 +68,12 @@ import {
   minuteStatsRowId,
   scopeRowId,
   sessionRowId,
+  trigramMinuteRowId,
+  type JsonlBigramMinuteEntry,
   type JsonlRow,
 } from './jsonl/jsonl-row'
 import { appendRowsToFile } from './jsonl/jsonl-writer'
-import { bucketizeIki } from './bigram-bucket'
+import { bucketizeIki, sumAndSumSquares } from './bigram-bucket'
 import {
   aggregatePairTotals,
   rankBigramsByCount,
@@ -207,7 +209,7 @@ export function setupTypingAnalyticsIpc(): void {
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_DELETE_ITEMS,
     async (_event, uid: unknown, dates: unknown): Promise<TypingTombstoneResult> => {
-      const empty: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+      const empty = emptyTombstoneResult()
       if (typeof uid !== 'string' || uid.length === 0) return empty
       if (!Array.isArray(dates)) return empty
       const validDates = dates.filter((d): d is string => typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d))
@@ -219,7 +221,7 @@ export function setupTypingAnalyticsIpc(): void {
   secureHandle(
     IpcChannels.TYPING_ANALYTICS_DELETE_ALL,
     async (_event, uid: unknown): Promise<TypingTombstoneResult> => {
-      const empty: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+      const empty = emptyTombstoneResult()
       if (typeof uid !== 'string' || uid.length === 0) return empty
       return deleteAllTypingForKeyboard(uid)
     },
@@ -761,6 +763,7 @@ export function setupTypingAnalyticsIpc(): void {
       const opts = parseBigramAggregateOptions(options)
       const limit = opts.limit ?? 30
       const minSample = opts.minSampleCount ?? 5
+      const gram = opts.gram ?? 2
       const apps = normalizeAppScopes(appScopes)
       const typingTests = normalizeAppScopes(typingTestScopes)
       const runIds = normalizeAppScopes(runIdScopes)
@@ -772,8 +775,8 @@ export function setupTypingAnalyticsIpc(): void {
           ? parsedScope.machineHash
           : undefined
       const rows = machineHash === undefined
-        ? db.listBigramMinutesInRangeForUid(uid, sinceMs, untilMs, apps, typingTests, runIds)
-        : db.listBigramMinutesInRangeForUidAndHash(uid, machineHash, sinceMs, untilMs, apps, typingTests, runIds)
+        ? db.listNgramMinutesInRangeForUid(gram, uid, sinceMs, untilMs, apps, typingTests, runIds)
+        : db.listNgramMinutesInRangeForUidAndHash(gram, uid, machineHash, sinceMs, untilMs, apps, typingTests, runIds)
       const totals = aggregatePairTotals(rows)
       if (parsedView === 'slow') {
         return { view: 'slow', entries: rankBigramsBySlow(totals, minSample, limit) }
@@ -1244,7 +1247,7 @@ export async function deleteTypingDailySummaries(
     if (range) ranges.push(range)
   }
   if (ranges.length === 0) {
-    return { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+    return emptyTombstoneResult()
   }
   const machineHash = await getMachineHash()
   const userDataDir = app.getPath('userData')
@@ -1265,12 +1268,14 @@ export async function deleteTypingDailySummaries(
   }
   const db = getTypingAnalyticsDB()
   const updatedAt = Date.now()
-  const result: TypingTombstoneResult = { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, sessions: 0 }
+  const result = emptyTombstoneResult()
   for (const range of ranges) {
     const r = db.tombstoneRowsForUidInRange(uid, range.startMs, range.endMs, updatedAt)
     result.charMinutes += r.charMinutes
     result.matrixMinutes += r.matrixMinutes
     result.minuteStats += r.minuteStats
+    result.bigramMinutes += r.bigramMinutes
+    result.trigramMinutes += r.trigramMinutes
     result.sessions += r.sessions
   }
   await notifySyncIfTouched(uid, result, [...utcDays])
@@ -1330,7 +1335,9 @@ async function notifySyncIfTouched(
   result: TypingTombstoneResult,
   days: readonly UtcDay[],
 ): Promise<void> {
-  const touched = result.charMinutes + result.matrixMinutes + result.minuteStats + result.sessions
+  const touched =
+    result.charMinutes + result.matrixMinutes + result.minuteStats +
+    result.bigramMinutes + result.trigramMinutes + result.sessions
   if (touched === 0 || days.length === 0) return
   const notifier = syncNotifier
   if (!notifier) return
@@ -1443,6 +1450,9 @@ function parseBigramAggregateOptions(value: unknown): TypingBigramAggregateOptio
   if (typeof o.limit === 'number' && Number.isFinite(o.limit) && o.limit > 0) {
     out.limit = Math.floor(o.limit)
   }
+  if (o.gram === 2 || o.gram === 3) {
+    out.gram = o.gram
+  }
   return out
 }
 
@@ -1549,10 +1559,6 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
     })
   }
   if (snapshot.bigrams.size > 0) {
-    const bigrams: Record<string, { c: number; h: number[] }> = {}
-    for (const [pairKey, ikis] of snapshot.bigrams) {
-      bigrams[pairKey] = { c: ikis.length, h: bucketizeIki(ikis) }
-    }
     rows.push({
       id: bigramMinuteRowId(snapshot.scopeId, snapshot.minuteTs, runId),
       kind: 'bigram-minute',
@@ -1560,7 +1566,22 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
       payload: {
         scopeId: snapshot.scopeId,
         minuteTs: snapshot.minuteTs,
-        bigrams,
+        bigrams: toNgramEntries(snapshot.bigrams),
+        appName,
+        typingTest,
+        runId,
+      },
+    })
+  }
+  if (snapshot.trigrams.size > 0) {
+    rows.push({
+      id: trigramMinuteRowId(snapshot.scopeId, snapshot.minuteTs, runId),
+      kind: 'trigram-minute',
+      updated_at: updatedAt,
+      payload: {
+        scopeId: snapshot.scopeId,
+        minuteTs: snapshot.minuteTs,
+        trigrams: toNgramEntries(snapshot.trigrams),
         appName,
         typingTest,
         runId,
@@ -1568,6 +1589,18 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
     })
   }
   return rows
+}
+
+/** Bucketize each pair/triple's raw IKI samples into the JSONL entry
+ * shape (`c`/`h`/`s`/`sq`) shared by bigram-minute and trigram-minute
+ * rows — see {@link buildSnapshotRows}. */
+function toNgramEntries(ikisByKey: ReadonlyMap<string, number[]>): Record<string, JsonlBigramMinuteEntry> {
+  const entries: Record<string, JsonlBigramMinuteEntry> = {}
+  for (const [key, ikis] of ikisByKey) {
+    const { sum, sumSq } = sumAndSumSquares(ikis)
+    entries[key] = { c: ikis.length, h: bucketizeIki(ikis), s: sum, sq: sumSq }
+  }
+  return entries
 }
 
 function buildSessionRow(

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -67,6 +67,7 @@ export interface AnalyzeExportContext {
   interval: { viewMode: IntervalViewMode; granularity: GranularityChoice }
   activity: { metric: ActivityMetric; minActiveMs: number }
   layer: { baseLayer: number }
+  bigrams: { gram: 2 | 3 }
   // `Required<>` only strips the `?`, so `targetLayoutId` is still
   // `string | null`. The runtime guard in pickBuilders (and
   // isCategoryAvailable) narrows it before passing to the builder.
@@ -318,7 +319,7 @@ function pickBuilders(
     out.push(buildByAppCsv(scope))
   }
   if (selected.bigrams) {
-    out.push(buildBigramsCsv(scope))
+    out.push(buildBigramsCsv({ ...scope, gram: ctx.bigrams.gram }))
   }
   if (selected.layoutComparison && ctx.snapshot !== null && ctx.layoutComparison.targetLayoutId !== null) {
     out.push(buildLayoutComparisonCsv({

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -621,13 +621,14 @@ export function AnalyzePane({
         minActiveMs: wpmFilter.minActiveMs,
       },
       layer: { baseLayer: layerFilter.baseLayer },
+      bigrams: { gram: bigramsFilter.gram },
       layoutComparison: layoutComparisonFilter,
       fingerOverrides: fingerAssignments,
       conditions: { device: deviceLabel, app: appLabel, keymap: keymapLabel, range: rangeLabel },
     }
   }, [
     selected, deviceScopes, appScopes, typingTestScopes, runIdScopes, deviceInfos, range, effectiveSnapshot, selectedSnapshotSavedAt,
-    snapshotSummaries, heatmapFilter, wpmFilter, intervalFilter, activityFilter, layerFilter,
+    snapshotSummaries, heatmapFilter, wpmFilter, intervalFilter, activityFilter, layerFilter, bigramsFilter.gram,
     layoutComparisonFilter, fingerAssignments, t,
   ])
 
@@ -1348,10 +1349,12 @@ export function AnalyzePane({
                   slowLimit={bigramsFilter.slowLimit}
                   fingerLimit={bigramsFilter.fingerLimit}
                   pairIntervalThresholdMs={bigramsFilter.pairIntervalThresholdMs}
+                  gram={bigramsFilter.gram}
                   onTopLimitChange={(topLimit) => setBigrams({ topLimit })}
                   onSlowLimitChange={(slowLimit) => setBigrams({ slowLimit })}
                   onFingerLimitChange={(fingerLimit) => setBigrams({ fingerLimit })}
                   onPairIntervalThresholdChange={(pairIntervalThresholdMs) => setBigrams({ pairIntervalThresholdMs })}
+                  onGramChange={(gram) => setBigrams({ gram })}
                   snapshot={effectiveSnapshot}
                   fingerOverrides={fingerAssignments}
                 />

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -35,6 +35,7 @@ import {
   percentileFromHist,
 } from './analyze-bigram-heatmap'
 import { FILTER_SELECT, LIST_LIMIT_OPTIONS } from './analyze-filter-styles'
+import { SegmentedToggle } from './SegmentedToggle'
 import type { RangeMs } from './analyze-types'
 import { Stat, TooltipShell } from './analyze-tooltip'
 import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
@@ -56,10 +57,16 @@ interface BigramsChartProps {
    * components rename this to `minAvgIkiMs` to make the avgIki bucket
    * approximation explicit at the predicate site. */
   pairIntervalThresholdMs: number
+  /** 2 = bigram, 3 = trigram — forwarded to the IPC as
+   * `options.gram`. The Finger IKI quadrant only exists for bigrams
+   * (a 3-key finger-pair isn't a defined concept), so it's hidden
+   * whenever `gram === 3`. */
+  gram: 2 | 3
   onTopLimitChange: (next: number) => void
   onSlowLimitChange: (next: number) => void
   onFingerLimitChange: (next: number) => void
   onPairIntervalThresholdChange: (next: number) => void
+  onGramChange: (next: 2 | 3) => void
   snapshot: TypingKeymapSnapshot | null
   fingerOverrides?: Record<string, FingerType>
 }
@@ -81,10 +88,12 @@ export function BigramsChart({
   slowLimit,
   fingerLimit,
   pairIntervalThresholdMs,
+  gram,
   onTopLimitChange,
   onSlowLimitChange,
   onFingerLimitChange,
   onPairIntervalThresholdChange,
+  onGramChange,
   snapshot,
   fingerOverrides,
 }: BigramsChartProps): JSX.Element {
@@ -106,6 +115,7 @@ export function BigramsChart({
     setError(false)
     fetchBigramAggregateForRange(uid, scope, range.fromMs, range.toMs, 'top', {
       limit: ALL_PAIRS_LIMIT,
+      gram,
     }, appScopes, typingTestScopes, runIdScopes)
       .then((next) => {
         if (cancelled) return
@@ -123,37 +133,33 @@ export function BigramsChart({
     }
     // scope is captured inside the effect via closure but not listed —
     // scopeKey is the stable identity proxy.
-  }, [uid, range.fromMs, range.toMs, scopeKey, appScopes.join('|')])
+  }, [uid, range.fromMs, range.toMs, scopeKey, appScopes.join('|'), gram])
 
   const entries = result.entries
 
-  if (loading) {
-    return (
-      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-loading">
-        {t('analyze.bigrams.loading')}
-      </div>
-    )
-  }
-  if (error) {
-    return (
-      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-error">
-        {t('analyze.bigrams.error')}
-      </div>
-    )
-  }
-  if (entries.length === 0) {
-    return (
-      <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-empty">
-        {t('analyze.bigrams.empty')}
-      </div>
-    )
-  }
+  // Finger IKI has no defined meaning for trigrams (a 3-key finger pair
+  // isn't a thing), so gram === 3 renders Top + Slow only. Dropping to a
+  // single row keeps the two quadrants full-height instead of leaving an
+  // empty grid cell where Finger IKI used to sit.
+  const showFingerIki = gram === 2
+  const gridClass = showFingerIki
+    ? 'grid h-full min-h-0 grid-cols-2 grid-rows-2 gap-3'
+    : 'grid h-full min-h-0 grid-cols-2 grid-rows-1 gap-3'
 
-  return (
-    <div
-      className="grid h-full min-h-0 grid-cols-2 grid-rows-2 gap-3"
-      data-testid="analyze-bigrams-content"
-    >
+  const body = loading ? (
+    <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-loading">
+      {t('analyze.bigrams.loading')}
+    </div>
+  ) : error ? (
+    <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-error">
+      {t('analyze.bigrams.error')}
+    </div>
+  ) : entries.length === 0 ? (
+    <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-empty">
+      {t('analyze.bigrams.empty')}
+    </div>
+  ) : (
+    <div className={gridClass} data-testid="analyze-bigrams-content">
       <Quadrant
         title={t('analyze.bigrams.quadrant.top')}
         controls={
@@ -164,44 +170,46 @@ export function BigramsChart({
           />
         }
       >
-        <TopRanking entries={entries} listLimit={topLimit} />
+        <TopRanking entries={entries} listLimit={topLimit} gram={gram} />
       </Quadrant>
-      <Quadrant
-        title={t('analyze.bigrams.quadrant.fingerIki')}
-        controls={
-          <>
-            <PairIntervalThresholdInput
-              value={pairIntervalThresholdMs}
-              onChange={onPairIntervalThresholdChange}
-              testId="analyze-bigrams-finger-threshold-input"
-            />
-            <select
-              value={fingerSort}
-              onChange={(e) => setFingerSort(e.target.value as FingerSort)}
-              className={FILTER_SELECT}
-              data-testid="analyze-bigrams-finger-sort-select"
-              aria-label={t('analyze.bigrams.fingerIki.sortLabel')}
-            >
-              <option value="desc">{t('analyze.bigrams.fingerIki.sort.desc')}</option>
-              <option value="asc">{t('analyze.bigrams.fingerIki.sort.asc')}</option>
-            </select>
-            <LimitSelect
-              value={fingerLimit}
-              onChange={onFingerLimitChange}
-              testId="analyze-bigrams-finger-limit-select"
-            />
-          </>
-        }
-      >
-        <BigramFingerBarChart
-          entries={entries}
-          snapshot={snapshot}
-          fingerOverrides={fingerOverrides}
-          listLimit={fingerLimit}
-          sort={fingerSort}
-          minAvgIkiMs={pairIntervalThresholdMs}
-        />
-      </Quadrant>
+      {showFingerIki && (
+        <Quadrant
+          title={t('analyze.bigrams.quadrant.fingerIki')}
+          controls={
+            <>
+              <PairIntervalThresholdInput
+                value={pairIntervalThresholdMs}
+                onChange={onPairIntervalThresholdChange}
+                testId="analyze-bigrams-finger-threshold-input"
+              />
+              <select
+                value={fingerSort}
+                onChange={(e) => setFingerSort(e.target.value as FingerSort)}
+                className={FILTER_SELECT}
+                data-testid="analyze-bigrams-finger-sort-select"
+                aria-label={t('analyze.bigrams.fingerIki.sortLabel')}
+              >
+                <option value="desc">{t('analyze.bigrams.fingerIki.sort.desc')}</option>
+                <option value="asc">{t('analyze.bigrams.fingerIki.sort.asc')}</option>
+              </select>
+              <LimitSelect
+                value={fingerLimit}
+                onChange={onFingerLimitChange}
+                testId="analyze-bigrams-finger-limit-select"
+              />
+            </>
+          }
+        >
+          <BigramFingerBarChart
+            entries={entries}
+            snapshot={snapshot}
+            fingerOverrides={fingerOverrides}
+            listLimit={fingerLimit}
+            sort={fingerSort}
+            minAvgIkiMs={pairIntervalThresholdMs}
+          />
+        </Quadrant>
+      )}
       <Quadrant
         title={t('analyze.bigrams.quadrant.slow')}
         controls={
@@ -223,9 +231,49 @@ export function BigramsChart({
           entries={entries}
           listLimit={slowLimit}
           minAvgIkiMs={pairIntervalThresholdMs}
+          gram={gram}
         />
       </Quadrant>
     </div>
+  )
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2" data-testid="analyze-bigrams-root">
+      <div className="flex shrink-0 justify-end">
+        <GramToggle value={gram} onChange={onGramChange} />
+      </div>
+      <div className="min-h-0 flex-1">{body}</div>
+    </div>
+  )
+}
+
+const GRAM_OPTIONS: readonly (2 | 3)[] = [2, 3]
+
+const GRAM_LABEL_KEY: Record<2 | 3, string> = {
+  2: 'analyze.bigrams.gramToggle.bigram',
+  3: 'analyze.bigrams.gramToggle.trigram',
+}
+
+interface GramToggleProps {
+  value: 2 | 3
+  onChange: (next: 2 | 3) => void
+}
+
+/** Segmented 2-gram / 3-gram switch — built from the same
+ * `SegmentedToggle` primitive as `FilterDimensionToggle` so the Bigrams
+ * tab's own toggle reads as the same control family as the rest of the
+ * Analyze filter row. */
+function GramToggle({ value, onChange }: GramToggleProps): JSX.Element {
+  const { t } = useTranslation()
+  return (
+    <SegmentedToggle
+      options={GRAM_OPTIONS}
+      value={value}
+      onChange={onChange}
+      labelFor={(option) => t(GRAM_LABEL_KEY[option])}
+      ariaLabel={t('analyze.bigrams.gramToggle.ariaLabel')}
+      testId="analyze-bigrams-gram-toggle"
+    />
   )
 }
 
@@ -329,7 +377,7 @@ function PairIntervalThresholdInput({
   )
 }
 
-type SortKey = 'count' | 'avgIki' | 'p95'
+type SortKey = 'count' | 'avgIki' | 'sd' | 'p95'
 interface SortState<K extends SortKey> {
   key: K
   dir: 'asc' | 'desc'
@@ -342,25 +390,44 @@ function compareNumeric(a: number | null, b: number | null, dir: 'asc' | 'desc')
   return dir === 'asc' ? a - b : b - a
 }
 
+/** Compares two ranking rows on the currently active sort field. Every
+ * sortable field is `number | null`, so a field lookup plus
+ * `compareNumeric` replaces a per-field switch for both `TopRanking`
+ * and `SlowRanking`. */
+function compareBySortKey<K extends SortKey>(
+  a: Record<K, number | null>,
+  b: Record<K, number | null>,
+  sort: SortState<K>,
+): number {
+  return compareNumeric(a[sort.key], b[sort.key], sort.dir)
+}
+
+/** Toggles direction when the clicked column is already active,
+ * otherwise switches to that column defaulting to `desc`. */
+function toggleSort<K extends SortKey>(prev: SortState<K>, key: K): SortState<K> {
+  return prev.key === key
+    ? { key, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+    : { key, dir: 'desc' }
+}
+
+function fmtMs(value: number | null): string {
+  return value !== null ? `${Math.round(value)} ms` : '—'
+}
+
 interface TopRankingProps {
   entries: readonly TypingBigramTopEntry[]
   listLimit: number
+  gram: 2 | 3
 }
 
-function TopRanking({ entries, listLimit }: TopRankingProps): JSX.Element {
+function TopRanking({ entries, listLimit, gram }: TopRankingProps): JSX.Element {
   const { t } = useTranslation()
-  const [sort, setSort] = useState<SortState<'count' | 'avgIki'>>({ key: 'count', dir: 'desc' })
+  const [sort, setSort] = useState<SortState<'count' | 'avgIki' | 'sd'>>({ key: 'count', dir: 'desc' })
+  const toggle = (key: 'count' | 'avgIki' | 'sd'): void => setSort((prev) => toggleSort(prev, key))
 
   const sliced = useMemo(() => {
     const arr = [...entries].slice(0, Math.max(listLimit, 0))
-    arr.sort((a, b) => {
-      switch (sort.key) {
-        case 'count':
-          return sort.dir === 'asc' ? a.count - b.count : b.count - a.count
-        case 'avgIki':
-          return compareNumeric(a.avgIki, b.avgIki, sort.dir)
-      }
-    })
+    arr.sort((a, b) => compareBySortKey(a, b, sort))
     return arr
   }, [entries, listLimit, sort])
 
@@ -368,7 +435,7 @@ function TopRanking({ entries, listLimit }: TopRankingProps): JSX.Element {
     return <EmptyQuadrant text={t('analyze.bigrams.empty')} />
   }
   return (
-    <table className="w-full text-xs">
+    <table className="w-full text-xs" data-testid="analyze-bigrams-top-ranking">
       <thead className="text-content-muted">
         <tr>
           <th className="px-1 py-1 text-right font-medium">#</th>
@@ -378,34 +445,33 @@ function TopRanking({ entries, listLimit }: TopRankingProps): JSX.Element {
             label={t('analyze.bigrams.column.count')}
             active={sort.key === 'count'}
             indicator={sortIndicator(sort, 'count')}
-            onClick={() =>
-              setSort((prev) => (prev.key === 'count'
-                ? { key: 'count', dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-                : { key: 'count', dir: 'desc' }))
-            }
+            onClick={() => toggle('count')}
           />
           <SortHeader
             align="right"
             label={t('analyze.bigrams.column.avgIki')}
+            title={gram === 3 ? t('analyze.bigrams.column.avgIkiTrigramTooltip') : undefined}
             active={sort.key === 'avgIki'}
             indicator={sortIndicator(sort, 'avgIki')}
-            onClick={() =>
-              setSort((prev) => (prev.key === 'avgIki'
-                ? { key: 'avgIki', dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-                : { key: 'avgIki', dir: 'desc' }))
-            }
+            onClick={() => toggle('avgIki')}
+          />
+          <SortHeader
+            align="right"
+            label={t('analyze.bigrams.column.sd')}
+            active={sort.key === 'sd'}
+            indicator={sortIndicator(sort, 'sd')}
+            onClick={() => toggle('sd')}
           />
         </tr>
       </thead>
       <tbody>
         {sliced.map((entry, i) => (
-          <tr key={entry.bigramId} className="border-t border-surface-dim">
+          <tr key={entry.ngramId} className="border-t border-surface-dim">
             <td className="px-1 py-1 text-right tabular-nums text-content-muted">{i + 1}</td>
-            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.bigramId)}</td>
+            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.ngramId)}</td>
             <td className="px-2 py-1 text-right tabular-nums">{entry.count.toLocaleString()}</td>
-            <td className="px-2 py-1 text-right tabular-nums">
-              {entry.avgIki !== null ? `${Math.round(entry.avgIki)} ms` : '—'}
-            </td>
+            <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.avgIki)}</td>
+            <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.sd)}</td>
           </tr>
         ))}
       </tbody>
@@ -414,10 +480,11 @@ function TopRanking({ entries, listLimit }: TopRankingProps): JSX.Element {
 }
 
 interface SlowEntry {
-  bigramId: string
+  ngramId: string
   count: number
   hist: number[]
   avgIki: number | null
+  sd: number | null
   p95: number | null
 }
 
@@ -427,11 +494,13 @@ interface SlowRankingProps {
   /** Shared threshold from `pairIntervalThresholdMs` — see
    * `avgIkiAtOrAboveThreshold` for the bucket-center caveat. */
   minAvgIkiMs: number
+  gram: 2 | 3
 }
 
-function SlowRanking({ entries, listLimit, minAvgIkiMs }: SlowRankingProps): JSX.Element {
+function SlowRanking({ entries, listLimit, minAvgIkiMs, gram }: SlowRankingProps): JSX.Element {
   const { t } = useTranslation()
-  const [sort, setSort] = useState<SortState<'count' | 'avgIki' | 'p95'>>({ key: 'avgIki', dir: 'desc' })
+  const [sort, setSort] = useState<SortState<'count' | 'avgIki' | 'sd' | 'p95'>>({ key: 'avgIki', dir: 'desc' })
+  const toggle = (key: 'count' | 'avgIki' | 'sd' | 'p95'): void => setSort((prev) => toggleSort(prev, key))
 
   const slowEntries = useMemo<SlowEntry[]>(() => {
     const eligible: SlowEntry[] = []
@@ -439,23 +508,15 @@ function SlowRanking({ entries, listLimit, minAvgIkiMs }: SlowRankingProps): JSX
       const avg = avgIkiAtOrAboveThreshold(entry.hist, minAvgIkiMs)
       if (avg === null) continue
       eligible.push({
-        bigramId: entry.bigramId,
+        ngramId: entry.ngramId,
         count: entry.count,
         hist: entry.hist,
         avgIki: avg,
+        sd: entry.sd,
         p95: percentileFromHist(entry.hist, 0.95),
       })
     }
-    eligible.sort((a, b) => {
-      switch (sort.key) {
-        case 'count':
-          return sort.dir === 'asc' ? a.count - b.count : b.count - a.count
-        case 'avgIki':
-          return compareNumeric(a.avgIki, b.avgIki, sort.dir)
-        case 'p95':
-          return compareNumeric(a.p95, b.p95, sort.dir)
-      }
-    })
+    eligible.sort((a, b) => compareBySortKey(a, b, sort))
     return eligible.slice(0, Math.max(listLimit, 0))
   }, [entries, listLimit, minAvgIkiMs, sort])
 
@@ -473,48 +534,41 @@ function SlowRanking({ entries, listLimit, minAvgIkiMs }: SlowRankingProps): JSX
             label={t('analyze.bigrams.column.count')}
             active={sort.key === 'count'}
             indicator={sortIndicator(sort, 'count')}
-            onClick={() =>
-              setSort((prev) => (prev.key === 'count'
-                ? { key: 'count', dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-                : { key: 'count', dir: 'desc' }))
-            }
+            onClick={() => toggle('count')}
           />
           <SortHeader
             align="right"
             label={t('analyze.bigrams.column.avgIki')}
+            title={gram === 3 ? t('analyze.bigrams.column.avgIkiTrigramTooltip') : undefined}
             active={sort.key === 'avgIki'}
             indicator={sortIndicator(sort, 'avgIki')}
-            onClick={() =>
-              setSort((prev) => (prev.key === 'avgIki'
-                ? { key: 'avgIki', dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-                : { key: 'avgIki', dir: 'desc' }))
-            }
+            onClick={() => toggle('avgIki')}
+          />
+          <SortHeader
+            align="right"
+            label={t('analyze.bigrams.column.sd')}
+            active={sort.key === 'sd'}
+            indicator={sortIndicator(sort, 'sd')}
+            onClick={() => toggle('sd')}
           />
           <SortHeader
             align="right"
             label={t('analyze.bigrams.column.p95')}
             active={sort.key === 'p95'}
             indicator={sortIndicator(sort, 'p95')}
-            onClick={() =>
-              setSort((prev) => (prev.key === 'p95'
-                ? { key: 'p95', dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-                : { key: 'p95', dir: 'desc' }))
-            }
+            onClick={() => toggle('p95')}
           />
         </tr>
       </thead>
       <tbody>
         {slowEntries.map((entry, i) => (
-          <tr key={entry.bigramId} className="border-t border-surface-dim">
+          <tr key={entry.ngramId} className="border-t border-surface-dim">
             <td className="px-1 py-1 text-right tabular-nums text-content-muted">{i + 1}</td>
-            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.bigramId)}</td>
+            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.ngramId)}</td>
             <td className="px-2 py-1 text-right tabular-nums">{entry.count.toLocaleString()}</td>
-            <td className="px-2 py-1 text-right tabular-nums">
-              {entry.avgIki !== null ? `${Math.round(entry.avgIki)} ms` : '—'}
-            </td>
-            <td className="px-2 py-1 text-right tabular-nums">
-              {entry.p95 !== null ? `${Math.round(entry.p95)} ms` : '—'}
-            </td>
+            <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.avgIki)}</td>
+            <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.sd)}</td>
+            <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.p95)}</td>
           </tr>
         ))}
       </tbody>
@@ -533,11 +587,17 @@ interface SortHeaderProps {
   align: 'left' | 'right'
   active: boolean
   onClick: () => void
+  /** Header tooltip (native `title`). Absent by default — only the
+   * trigram Avg IKI header sets one today. */
+  title?: string
 }
 
-function SortHeader({ label, indicator, align, active, onClick }: SortHeaderProps): JSX.Element {
+function SortHeader({ label, indicator, align, active, onClick, title }: SortHeaderProps): JSX.Element {
   return (
-    <th className={`select-none px-2 py-1 font-medium ${align === 'right' ? 'text-right' : 'text-left'}`}>
+    <th
+      className={`select-none px-2 py-1 font-medium ${align === 'right' ? 'text-right' : 'text-left'}`}
+      title={title}
+    >
       <button
         type="button"
         onClick={onClick}

--- a/src/renderer/components/analyze/FilterDimensionToggle.tsx
+++ b/src/renderer/components/analyze/FilterDimensionToggle.tsx
@@ -6,7 +6,7 @@
 
 import { useTranslation } from 'react-i18next'
 import { FILTER_DIMENSIONS, type FilterDimension } from '../../../shared/types/analyze-filters'
-import { SEGMENT_TOGGLE_ACTIVE, SEGMENT_TOGGLE_INACTIVE } from '../../constants/ui-tokens'
+import { SegmentedToggle } from './SegmentedToggle'
 
 interface Props {
   value: FilterDimension
@@ -22,27 +22,13 @@ const LABEL_KEY: Record<FilterDimension, string> = {
 export function FilterDimensionToggle({ value, onChange, testId = 'analyze-filter-dimension' }: Props) {
   const { t } = useTranslation()
   return (
-    <div
-      className="inline-flex items-center gap-0.5 rounded-md border border-edge p-0.5"
-      role="group"
-      aria-label={t('analyze.filters.dimensionLabel')}
-      data-testid={testId}
-    >
-      {FILTER_DIMENSIONS.map((dim) => {
-        const active = value === dim
-        return (
-          <button
-            key={dim}
-            type="button"
-            className={active ? SEGMENT_TOGGLE_ACTIVE : SEGMENT_TOGGLE_INACTIVE}
-            aria-pressed={active}
-            onClick={() => onChange(dim)}
-            data-testid={`${testId}-${dim}`}
-          >
-            {t(LABEL_KEY[dim])}
-          </button>
-        )
-      })}
-    </div>
+    <SegmentedToggle
+      options={FILTER_DIMENSIONS}
+      value={value}
+      onChange={onChange}
+      labelFor={(dim) => t(LABEL_KEY[dim])}
+      ariaLabel={t('analyze.filters.dimensionLabel')}
+      testId={testId}
+    />
   )
 }

--- a/src/renderer/components/analyze/SegmentedToggle.tsx
+++ b/src/renderer/components/analyze/SegmentedToggle.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Generic segmented button group shared by the Analyze filter dimension
+// toggle (App / TypingTest) and the Bigrams gram toggle (2 / 3). Owns the
+// role="group" + aria-pressed markup and the SEGMENT_TOGGLE_* styling so
+// both call sites stay visually and behaviorally identical.
+
+import { SEGMENT_TOGGLE_ACTIVE, SEGMENT_TOGGLE_INACTIVE } from '../../constants/ui-tokens'
+
+interface SegmentedToggleProps<T extends string | number> {
+  options: readonly T[]
+  value: T
+  onChange: (next: T) => void
+  labelFor: (option: T) => string
+  ariaLabel: string
+  testId: string
+}
+
+export function SegmentedToggle<T extends string | number>({
+  options,
+  value,
+  onChange,
+  labelFor,
+  ariaLabel,
+  testId,
+}: SegmentedToggleProps<T>): JSX.Element {
+  return (
+    <div
+      className="inline-flex items-center gap-0.5 rounded-md border border-edge p-0.5"
+      role="group"
+      aria-label={ariaLabel}
+      data-testid={testId}
+    >
+      {options.map((option) => {
+        const active = value === option
+        return (
+          <button
+            key={option}
+            type="button"
+            className={active ? SEGMENT_TOGGLE_ACTIVE : SEGMENT_TOGGLE_INACTIVE}
+            aria-pressed={active}
+            onClick={() => onChange(option)}
+            data-testid={`${testId}-${option}`}
+          >
+            {labelFor(option)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/components/analyze/__tests__/AnalyzeExportModal-upload.test.tsx
+++ b/src/renderer/components/analyze/__tests__/AnalyzeExportModal-upload.test.tsx
@@ -44,6 +44,8 @@ const CTX: AnalyzeExportContext = {
   range: { fromMs: 0, toMs: 86_400_000 },
   deviceScope: 'all',
   appScopes: [],
+  typingTestScopes: [],
+  runIdScopes: [],
   snapshot: SNAPSHOT as unknown as AnalyzeExportContext['snapshot'],
   heatmap: {
     selectedLayers: [0],
@@ -57,6 +59,7 @@ const CTX: AnalyzeExportContext = {
   interval: { viewMode: 'timeSeries', granularity: 'auto' },
   activity: { metric: 'keystrokes', minActiveMs: 60_000 },
   layer: { baseLayer: 0 },
+  bigrams: { gram: 2 },
   layoutComparison: { sourceLayoutId: '', targetLayoutId: null },
   fingerOverrides: {},
   conditions: { device: 'All', app: 'All', keymap: '—', range: '7 days' },

--- a/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { BigramsChart } from '../BigramsChart'
 import type { TypingBigramAggregateResult } from '../../../../shared/types/typing-analytics'
 
@@ -32,14 +32,18 @@ function renderChart(overrides: Partial<Parameters<typeof BigramsChart>[0]> = {}
       range={range}
       deviceScopes={['own']}
       appScopes={[]}
+      typingTestScopes={[]}
+      runIdScopes={[]}
       topLimit={10}
       slowLimit={10}
       fingerLimit={10}
       pairIntervalThresholdMs={0}
+      gram={2}
       onTopLimitChange={noop}
       onSlowLimitChange={noop}
       onFingerLimitChange={noop}
       onPairIntervalThresholdChange={noop}
+      onGramChange={noop}
       snapshot={null}
       {...overrides}
     />,
@@ -75,7 +79,7 @@ describe('BigramsChart', () => {
     fetchSpy.mockResolvedValue({
       view: 'top',
       entries: [
-        { bigramId: '4_11', count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100 },
+        { ngramId: '4_11', count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100, sd: 25 },
       ],
     })
     renderChart()
@@ -94,7 +98,7 @@ describe('BigramsChart', () => {
     fetchSpy.mockResolvedValue({
       view: 'top',
       entries: [
-        { bigramId: '4_11', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0], avgIki: 30 },
+        { ngramId: '4_11', count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 0 },
       ],
     })
     const onTopLimitChange = vi.fn()
@@ -112,7 +116,7 @@ describe('BigramsChart', () => {
     fetchSpy.mockResolvedValue({
       view: 'top',
       entries: [
-        { bigramId: '4_11', count: 5, hist: [0, 0, 5, 0, 0, 0, 0, 0], avgIki: 125 },
+        { ngramId: '4_11', count: 5, hist: [0, 0, 5, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 },
       ],
     })
     const onSlowLimitChange = vi.fn()
@@ -141,8 +145,8 @@ describe('BigramsChart', () => {
   // (slow), so any threshold in (30, 400] hides the fast one without
   // touching the slow one.
   const thresholdEntries = [
-    { bigramId: '4_11', count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0], avgIki: 30 },
-    { bigramId: '7_22', count: 5, hist: [0, 0, 0, 0, 0, 5, 0, 0], avgIki: 400 },
+    { ngramId: '4_11', count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 4 },
+    { ngramId: '7_22', count: 5, hist: [0, 0, 0, 0, 0, 5, 0, 0], avgIki: 400, sd: 40 },
   ]
 
   it('renders both rows in the Slow ranking when the threshold is 0', async () => {
@@ -242,14 +246,18 @@ describe('BigramsChart', () => {
         range={range}
         deviceScopes={['own']}
         appScopes={[]}
+        typingTestScopes={[]}
+        runIdScopes={[]}
         topLimit={10}
         slowLimit={10}
         fingerLimit={10}
         pairIntervalThresholdMs={0}
+        gram={2}
         onTopLimitChange={noop}
         onSlowLimitChange={noop}
         onFingerLimitChange={noop}
         onPairIntervalThresholdChange={noop}
+        onGramChange={noop}
         snapshot={null}
       />,
     )
@@ -264,14 +272,18 @@ describe('BigramsChart', () => {
         range={range}
         deviceScopes={['own']}
         appScopes={[]}
+        typingTestScopes={[]}
+        runIdScopes={[]}
         topLimit={10}
         slowLimit={10}
         fingerLimit={10}
         pairIntervalThresholdMs={250}
+        gram={2}
         onTopLimitChange={noop}
         onSlowLimitChange={noop}
         onFingerLimitChange={noop}
         onPairIntervalThresholdChange={noop}
+        onGramChange={noop}
         snapshot={null}
       />,
     )
@@ -280,4 +292,137 @@ describe('BigramsChart', () => {
     expect(fingerInput.value).toBe('250')
     expect(slowInput.value).toBe('250')
   })
+
+  it('fires onGramChange when the 3-gram toggle button is clicked', async () => {
+    fetchSpy.mockResolvedValue({ view: 'top', entries: [] })
+    const onGramChange = vi.fn()
+    renderChart({ onGramChange })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-bigrams-gram-toggle-3')).toBeTruthy()
+    })
+    fireEvent.click(screen.getByTestId('analyze-bigrams-gram-toggle-3'))
+    expect(onGramChange).toHaveBeenCalledWith(3)
+  })
+
+  it('passes gram through to the fetch options', async () => {
+    fetchSpy.mockResolvedValue({ view: 'top', entries: [] })
+    renderChart({ gram: 3 })
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+    const options = fetchSpy.mock.calls[0]?.[5] as { gram?: number } | undefined
+    expect(options?.gram).toBe(3)
+  })
+
+  it('re-fetches when gram changes', async () => {
+    fetchSpy.mockResolvedValue({ view: 'top', entries: [] })
+    const { rerender } = render(<BigramsChartHarness gram={2} />)
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+    rerender(<BigramsChartHarness gram={3} />)
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2))
+    expect(fetchSpy.mock.calls[1]?.[5]).toMatchObject({ gram: 3 })
+  })
+
+  it('hides the Finger IKI quadrant and switches to a single-row grid for trigrams', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: '4_11_42', count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100, sd: 25 },
+      ],
+    })
+    renderChart({ gram: 3 })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-bigrams-content')).toBeTruthy()
+    })
+    expect(screen.getByText('analyze.bigrams.quadrant.top')).toBeTruthy()
+    expect(screen.getByText('analyze.bigrams.quadrant.slow')).toBeTruthy()
+    expect(screen.queryByText('analyze.bigrams.quadrant.fingerIki')).toBeNull()
+    expect(screen.getByTestId('analyze-bigrams-content').className).toContain('grid-rows-1')
+  })
+
+  it('shows the Finger IKI quadrant for bigrams', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: '4_11', count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100, sd: 25 },
+      ],
+    })
+    renderChart({ gram: 2 })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-bigrams-content')).toBeTruthy()
+    })
+    expect(screen.getByText('analyze.bigrams.quadrant.fingerIki')).toBeTruthy()
+    expect(screen.getByTestId('analyze-bigrams-content').className).toContain('grid-rows-2')
+  })
+
+  it('renders the SD column with a value and falls back to "—" for null', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: '4_11', count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100, sd: 25 },
+        { ngramId: '7_22', count: 5, hist: [0, 0, 0, 0, 0, 5, 0, 0], avgIki: 400, sd: null },
+      ],
+    })
+    renderChart()
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-bigrams-top-ranking')).toBeTruthy()
+    })
+    const topTable = screen.getByTestId('analyze-bigrams-top-ranking')
+    expect(topTable.textContent).toContain('25 ms')
+    // The row with sd === null renders the "—" fallback rather than a
+    // stray "null ms" or crashing.
+    const cells = Array.from(topTable.querySelectorAll('td')).map((td) => td.textContent)
+    expect(cells).toContain('—')
+  })
+
+  it('sorts the Top ranking by SD when the SD header is clicked', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: '4_11', count: 10, hist: [1, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 5 },
+        { ngramId: '7_22', count: 5, hist: [0, 0, 0, 0, 0, 5, 0, 0], avgIki: 400, sd: 40 },
+      ],
+    })
+    renderChart()
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-bigrams-top-ranking')).toBeTruthy()
+    })
+    const topTable = screen.getByTestId('analyze-bigrams-top-ranking')
+    const sdHeader = within(topTable).getByText('analyze.bigrams.column.sd')
+    fireEvent.click(sdHeader)
+    // Default click direction is descending — highest SD (40) first.
+    let rows = topTable.querySelectorAll('tbody tr')
+    expect(rows[0]?.textContent).toContain('40 ms')
+    fireEvent.click(sdHeader)
+    rows = topTable.querySelectorAll('tbody tr')
+    expect(rows[0]?.textContent).toContain('5 ms')
+  })
 })
+
+/** Minimal wrapper so the "re-fetches when gram changes" test can
+ * rerender with a new `gram` prop through React's normal update path
+ * (a raw `renderChart` call can't be rerun with different overrides on
+ * an existing render). */
+function BigramsChartHarness({ gram }: { gram: 2 | 3 }): JSX.Element {
+  return (
+    <BigramsChart
+      uid="0xAABB"
+      range={range}
+      deviceScopes={['own']}
+      appScopes={[]}
+      typingTestScopes={[]}
+      runIdScopes={[]}
+      topLimit={10}
+      slowLimit={10}
+      fingerLimit={10}
+      pairIntervalThresholdMs={0}
+      gram={gram}
+      onTopLimitChange={noop}
+      onSlowLimitChange={noop}
+      onFingerLimitChange={noop}
+      onPairIntervalThresholdChange={noop}
+      onGramChange={noop}
+      snapshot={null}
+    />
+  )
+}

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-finger.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-finger.test.ts
@@ -8,11 +8,11 @@ import type { FingerType } from '../../../../shared/kle/kle-ergonomics'
 import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
 
 function entry(
-  bigramId: string,
+  ngramId: string,
   count: number,
   hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0],
 ): TypingBigramTopEntry {
-  return { bigramId, count, hist, avgIki: null }
+  return { ngramId, count, hist, avgIki: null }
 }
 
 describe('aggregateFingerPairs', () => {

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-format.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-format.test.ts
@@ -16,13 +16,20 @@ describe('bigramPairLabel', () => {
 
   it('falls back to the raw id when the format is malformed', () => {
     expect(bigramPairLabel('not-a-bigram')).toBe('not-a-bigram')
-    expect(bigramPairLabel('4_11_22')).toBe('4_11_22')
+    expect(bigramPairLabel('4_11_42_11')).toBe('4_11_42_11')
     expect(bigramPairLabel('4_')).toBe('4_')
+    expect(bigramPairLabel('4__42')).toBe('4__42')
   })
 
-  it('falls back to the raw id when either side is non-numeric', () => {
+  it('falls back to the raw id when any side is non-numeric', () => {
     expect(bigramPairLabel('foo_11')).toBe('foo_11')
     expect(bigramPairLabel('4_bar')).toBe('4_bar')
+    expect(bigramPairLabel('4_11_bar')).toBe('4_11_bar')
+  })
+
+  it('decodes a trigram id (k1_k2_k3) into prev → mid → curr labels', () => {
+    // KC_A = 4, KC_H = 11, KC_BSPC = 42.
+    expect(bigramPairLabel('4_11_42')).toBe('A → H → Bksp')
   })
 
   it('decodes layer-tap mask codes via the static template fallback', () => {

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-heatmap.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-heatmap.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../analyze-bigram-heatmap'
 import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
 
-function entry(bigramId: string, count: number, hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0]): TypingBigramTopEntry {
-  return { bigramId, count, hist, avgIki: null }
+function entry(ngramId: string, count: number, hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0]): TypingBigramTopEntry {
+  return { ngramId, count, hist, avgIki: null }
 }
 
 describe('aggregateKeyHeatmap', () => {

--- a/src/renderer/components/analyze/__tests__/analyze-typing-profile.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-typing-profile.test.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../../../shared/types/typing-analytics'
 
 function bigram(prev: number, curr: number, count: number): TypingBigramTopEntry {
-  return { bigramId: `${prev}_${curr}`, count, hist: new Array(8).fill(0), avgIki: null }
+  return { ngramId: `${prev}_${curr}`, count, hist: new Array(8).fill(0), avgIki: null }
 }
 
 function minute(minuteMs: number, keystrokes: number, activeMs: number): TypingMinuteStatsRow {

--- a/src/renderer/components/analyze/analyze-bigram-finger.ts
+++ b/src/renderer/components/analyze/analyze-bigram-finger.ts
@@ -75,7 +75,7 @@ export function aggregateFingerPairs(
 ): Map<string, FingerPairTotal> {
   const totals = new Map<string, FingerPairTotal>()
   for (const entry of entries) {
-    const parts = entry.bigramId.split('_')
+    const parts = entry.ngramId.split('_')
     if (parts.length !== 2) continue
     const prev = Number(parts[0])
     const curr = Number(parts[1])

--- a/src/renderer/components/analyze/analyze-bigram-format.ts
+++ b/src/renderer/components/analyze/analyze-bigram-format.ts
@@ -6,19 +6,19 @@
 
 import { codeToLabel } from '../../../shared/keycodes/keycodes'
 
-/** Convert a stored bigram pair id like `"4_11"` into a display label
- * such as `"A → H"`. Falls back to the raw id when either side is not
- * a finite number, so the renderer never throws on schema drift. */
+/** Convert a stored n-gram id — `"4_11"` (bigram) or `"4_11_42"`
+ * (trigram) — into a display label such as `"A → H"` or
+ * `"A → H → Bksp"`. Falls back to the raw id when the part count isn't
+ * 2 or 3, any part is empty, or any part is not a finite number, so
+ * the renderer never throws on schema drift. */
 export function bigramPairLabel(bigramId: string): string {
   const parts = bigramId.split('_')
-  if (parts.length !== 2) return bigramId
-  const [prevStr, currStr] = parts
-  // Reject empty halves explicitly: `Number('')` coerces to 0 rather
+  if (parts.length !== 2 && parts.length !== 3) return bigramId
+  // Reject empty parts explicitly: `Number('')` coerces to 0 rather
   // than NaN, which would otherwise label `"4_"` as `"A → "` instead
   // of returning the raw id.
-  if (prevStr.length === 0 || currStr.length === 0) return bigramId
-  const prev = Number(prevStr)
-  const curr = Number(currStr)
-  if (!Number.isFinite(prev) || !Number.isFinite(curr)) return bigramId
-  return `${codeToLabel(prev)} → ${codeToLabel(curr)}`
+  if (parts.some((p) => p.length === 0)) return bigramId
+  const codes = parts.map(Number)
+  if (codes.some((n) => !Number.isFinite(n))) return bigramId
+  return codes.map((n) => codeToLabel(n)).join(' → ')
 }

--- a/src/renderer/components/analyze/analyze-bigram-heatmap.ts
+++ b/src/renderer/components/analyze/analyze-bigram-heatmap.ts
@@ -34,7 +34,7 @@ export function aggregateKeyHeatmap(
   const totals = new Map<number, number>()
   const parsed: { prev: number; curr: number; entry: TypingBigramTopEntry }[] = []
   for (const entry of entries) {
-    const parts = entry.bigramId.split('_')
+    const parts = entry.ngramId.split('_')
     if (parts.length !== 2) continue
     const prev = Number(parts[0])
     const curr = Number(parts[1])

--- a/src/renderer/components/analyze/analyze-csv-builders.ts
+++ b/src/renderer/components/analyze/analyze-csv-builders.ts
@@ -117,6 +117,7 @@ const SLUG = {
   layer: 'analyze-layer',
   ergonomics: 'analyze-ergonomics',
   bigrams: 'analyze-bigrams',
+  trigrams: 'analyze-trigrams',
   layoutComparison: 'analyze-layout-comparison',
 } as const
 
@@ -403,20 +404,28 @@ export async function buildErgonomicsCsv(args: ScopeArgs & {
 // user sees on screen instead of cutting off at the 30-row default.
 const BIGRAMS_EXPORT_LIMIT = 5000
 
-export async function buildBigramsCsv(args: ScopeArgs): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], runIdScopes = [] } = args
+export async function buildBigramsCsv(args: ScopeArgs & {
+  /** 2 = bigram (default, matches the historical export shape), 3 =
+   * trigram. Only changes the id column header and output filename —
+   * the row shape (id, count, avg, sd) is the same for both, since
+   * `ngramId` already carries however many `_`-joined key codes the
+   * selected gram produces. */
+  gram?: 2 | 3
+}): Promise<CsvBundleEntry> {
+  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], runIdScopes = [], gram = 2 } = args
   const result = await fetchBigramAggregateForRange(
-    uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAMS_EXPORT_LIMIT }, appScopes, typingTestScopes, runIdScopes,
+    uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAMS_EXPORT_LIMIT, gram }, appScopes, typingTestScopes, runIdScopes,
   ).catch(() => ({ view: 'top' as const, entries: [] }))
   const entries = result.view === 'top' ? result.entries : []
   const rows = entries.map((e) => [
-    e.bigramId,
+    e.ngramId,
     e.count,
     e.avgIki === null ? '' : Math.round(e.avgIki),
+    e.sd === null ? '' : Math.round(e.sd),
   ])
   return {
-    slug: SLUG.bigrams,
-    content: buildCsv(['bigram_id', 'count', 'avg_iki_ms'], rows),
+    slug: gram === 3 ? SLUG.trigrams : SLUG.bigrams,
+    content: buildCsv([gram === 3 ? 'trigram_id' : 'bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms'], rows),
   }
 }
 

--- a/src/renderer/hooks/__tests__/useAnalyzeFilters.test.ts
+++ b/src/renderer/hooks/__tests__/useAnalyzeFilters.test.ts
@@ -251,6 +251,60 @@ describe('useAnalyzeFilters', () => {
     expect(result.current.filters.bigrams.fingerLimit).toBe(DEFAULT_ANALYZE_FILTERS.bigrams.fingerLimit)
   })
 
+  it('defaults bigrams.gram to 2 and persists gram through setBigrams', async () => {
+    const { result } = renderHook(() => useAnalyzeFilters('uid-a'))
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.filters.bigrams.gram).toBe(2)
+    patchSpy.mockClear()
+    getSpy.mockClear().mockResolvedValue(null)
+
+    act(() => { result.current.setBigrams({ gram: 3 }) })
+    act(() => { vi.advanceTimersByTime(300) })
+    await flushMicrotasks()
+    await flushMicrotasks()
+
+    expect(patchSpy).toHaveBeenCalledTimes(1)
+    expect(patchSpy.mock.calls[0][1].analyze?.filters?.bigrams?.gram).toBe(3)
+    expect(result.current.filters.bigrams.gram).toBe(3)
+    // Sibling defaults must survive the partial patch.
+    expect(result.current.filters.bigrams.topLimit).toBe(DEFAULT_ANALYZE_FILTERS.bigrams.topLimit)
+  })
+
+  it('restores a persisted gram of 3 on mount, and normalizes an absent gram to 2', async () => {
+    getSpy.mockResolvedValueOnce({
+      _rev: 1,
+      keyboardLayout: 'qwerty',
+      autoAdvance: true,
+      layerNames: [],
+      analyze: {
+        filters: {
+          bigrams: { gram: 3 },
+        },
+      },
+    })
+    const { result: withGram } = renderHook(() => useAnalyzeFilters('uid-a'))
+    await waitFor(() => expect(withGram.current.ready).toBe(true))
+    expect(withGram.current.filters.bigrams.gram).toBe(3)
+
+    // Pre-trigram persisted settings never wrote `gram` at all — absence
+    // must normalize to 2, not `undefined`, so downstream consumers
+    // (BigramsChart, the IPC options) never see a non-literal value.
+    getSpy.mockResolvedValueOnce({
+      _rev: 1,
+      keyboardLayout: 'qwerty',
+      autoAdvance: true,
+      layerNames: [],
+      analyze: {
+        filters: {
+          bigrams: { topLimit: 20 },
+        },
+      },
+    })
+    const { result: withoutGram } = renderHook(() => useAnalyzeFilters('uid-b'))
+    await waitFor(() => expect(withoutGram.current.ready).toBe(true))
+    expect(withoutGram.current.filters.bigrams.gram).toBe(2)
+  })
+
   it('defaults filterDimension to app', async () => {
     const { result } = renderHook(() => useAnalyzeFilters('uid-a'))
     await waitFor(() => expect(result.current.ready).toBe(true))

--- a/src/renderer/hooks/useAnalyzeFilters.ts
+++ b/src/renderer/hooks/useAnalyzeFilters.ts
@@ -125,6 +125,7 @@ export const DEFAULT_ANALYZE_FILTERS: AnalyzeFiltersState = {
     slowLimit: 10,
     fingerLimit: 20,
     pairIntervalThresholdMs: 0,
+    gram: 2,
   },
   layoutComparison: {
     sourceLayoutId: 'qwerty',

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1042,10 +1042,17 @@
         "slow": "Pair interval",
         "fingerIki": "Finger IKI"
       },
+      "gramToggle": {
+        "ariaLabel": "N-gram size",
+        "bigram": "2-gram",
+        "trigram": "3-gram"
+      },
       "column": {
         "pair": "Pair",
         "count": "Count",
         "avgIki": "Avg IKI",
+        "avgIkiTrigramTooltip": "Average of the two intervals between the three keystrokes — not the total time across all three.",
+        "sd": "SD",
         "p95": "p95 IKI"
       },
       "fingerIki": {

--- a/src/shared/types/__tests__/analyze-filters.test.ts
+++ b/src/shared/types/__tests__/analyze-filters.test.ts
@@ -234,6 +234,18 @@ describe('isValidAnalyzeFilterSettings', () => {
       isValidAnalyzeFilterSettings({ bigrams: { pairIntervalThresholdMs: '200' } }),
     ).toBe(false)
   })
+
+  it('accepts gram as 2 or 3, and absent (back-compat with pre-trigram settings)', () => {
+    expect(isValidAnalyzeFilterSettings({ bigrams: { gram: 2 } })).toBe(true)
+    expect(isValidAnalyzeFilterSettings({ bigrams: { gram: 3 } })).toBe(true)
+    expect(isValidAnalyzeFilterSettings({ bigrams: {} })).toBe(true)
+  })
+
+  it('rejects gram values other than 2 or 3', () => {
+    expect(isValidAnalyzeFilterSettings({ bigrams: { gram: 4 } })).toBe(false)
+    expect(isValidAnalyzeFilterSettings({ bigrams: { gram: 0 } })).toBe(false)
+    expect(isValidAnalyzeFilterSettings({ bigrams: { gram: '2' } })).toBe(false)
+  })
 })
 
 describe('normalizeDeviceScopes', () => {

--- a/src/shared/types/analyze-filters.ts
+++ b/src/shared/types/analyze-filters.ts
@@ -294,6 +294,11 @@ export interface BigramFilters {
    * approximation, not exact ms (see Task-P3-bigrams-pair-interval-
    * threshold.md for rationale). */
   pairIntervalThresholdMs?: number
+  /** 2 = bigram, 3 = trigram — matches `TypingBigramAggregateOptions.gram`.
+   * Absent (older persisted settings) normalizes to `2` via the
+   * `{ ...DEFAULT, ...saved }` merge in `restoreFilters`, same as every
+   * other optional field on this shape. */
+  gram?: 2 | 3
 }
 
 export interface LayoutComparisonFilters {
@@ -489,6 +494,7 @@ function isValidBigramFilters(value: unknown): boolean {
   if (o.slowLimit !== undefined && !isPositiveInt(o.slowLimit)) return false
   if (o.fingerLimit !== undefined && !isPositiveInt(o.fingerLimit)) return false
   if (o.pairIntervalThresholdMs !== undefined && !isNonNegativeInt(o.pairIntervalThresholdMs)) return false
+  if (o.gram !== undefined && o.gram !== 2 && o.gram !== 3) return false
   return true
 }
 

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -311,7 +311,15 @@ export interface TypingTombstoneResult {
   charMinutes: number
   matrixMinutes: number
   minuteStats: number
+  bigramMinutes: number
+  trigramMinutes: number
   sessions: number
+}
+
+/** All-zero {@link TypingTombstoneResult}, for call sites that need to
+ * return early (invalid input, empty range) before any table is touched. */
+export function emptyTombstoneResult(): TypingTombstoneResult {
+  return { charMinutes: 0, matrixMinutes: 0, minuteStats: 0, bigramMinutes: 0, trigramMinutes: 0, sessions: 0 }
 }
 
 /** Sub-view requested from the bigram aggregate IPC. `top` ranks by
@@ -328,16 +336,25 @@ export interface TypingBigramAggregateOptions {
   /** Maximum number of pairs returned. Defaults to 30 at the handler
    * level if absent. */
   limit?: number
+  /** 2 = bigram (`typing_bigram_minute`), 3 = trigram
+   * (`typing_trigram_minute`). Defaults to 2 at the handler level if
+   * absent or invalid. */
+  gram?: 2 | 3
 }
 
-/** Per-pair entry in a `top` view response. `avgIki` is null when the
- * pair has no recorded IKI samples (count = 0 — usually filtered
- * upstream but kept defensive). */
+/** Per-pair entry in a `top` view response. `ngramId` is the
+ * `_`-joined keycode chain — 2 codes for a bigram, 3 for a trigram
+ * (see `gram` on {@link TypingBigramAggregateOptions}). `avgIki` is
+ * null when the pair has no recorded IKI samples (count = 0 — usually
+ * filtered upstream but kept defensive). `sd` is null when any
+ * contributing row predates the sum/sumSq columns — see
+ * aggregatePairTotals. */
 export interface TypingBigramTopEntry {
-  bigramId: string
+  ngramId: string
   count: number
   hist: number[]
   avgIki: number | null
+  sd: number | null
 }
 
 /** Per-pair entry in a `slow` view response. Adds `p95` so the UI can


### PR DESCRIPTION
## Summary

Extends the Analyze Bigrams tab into an n-gram view: trigram (3-key) frequency/speed rankings and an exact IKI standard deviation column for both bigrams and trigrams.

## Recording & storage

- `MinuteBuffer` maintains a single 2-deep matrix-key chain, isolated per `scope|run`, and emits bigrams and trigrams from it. Trigram IKI is defined as the mean of its two intervals so it shares the bigram bucket scale.
- Each n-gram minute entry now carries optional `s`/`sq` (sum / sum of squares, validated as an all-or-nothing finite pair) so SD is exact, not histogram-approximated. Ranges that include legacy rows report SD as null instead of a misleading partial value.
- SQLite schema v6→v7: nullable `sum_iki`/`sumsq_iki` on `typing_bigram_minute`, new `typing_trigram_minute` table. Additive migration, no cache rebuild (historical JSONL has no source data to backfill from).
- Trigram data is intentionally excluded from the Hub analytics export.

## IPC & UI

- The existing bigram aggregate channel gains a validated `gram: 2|3` option (untrusted parser falls back to 2).
- Bigrams tab: 2/3-gram segmented toggle, sortable SD column (null renders as "—"), trigram-aware pair labels and CSV export. The Finger IKI quadrant stays bigram-only since a finger-pair representation is undefined for three keys.

## Fixes

- Tombstone / retention / sync notification previously skipped `typing_bigram_minute`; both n-gram tables are now covered.
- `rowTimestamp` no longer drops `bigram-minute` rows from the import day-window check.
- N-gram chains no longer pair keys across keyboards or typing-test runs.

## Tests

- ~100 new tests across minute-buffer, jsonl-row, db (incl. v6→v7 migration), aggregate SD math, IPC gram fallback, and BigramsChart UI. Full suite: 244 files / 4731 green; lint and build clean.