### PR TITLE
fix(ui): resolve finger-map keycodes under the snapshot's vial protocol

### DIFF
--- a/src/renderer/components/analyze/__tests__/analyze-bigram-finger.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-finger.test.ts
@@ -3,9 +3,12 @@
 import { describe, it, expect } from 'vitest'
 import {
   aggregateFingerPairs,
+  buildKeycodeFingerMap,
 } from '../analyze-bigram-finger'
+import { deserialize, getProtocol, setProtocol } from '../../../../shared/keycodes/keycodes'
+import { parseKle } from '../../../../shared/kle/kle-parser'
 import type { FingerType } from '../../../../shared/kle/kle-ergonomics'
-import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
+import type { TypingBigramTopEntry, TypingKeymapSnapshot } from '../../../../shared/types/typing-analytics'
 
 function entry(
   ngramId: string,
@@ -13,6 +16,31 @@ function entry(
   hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0],
 ): TypingBigramTopEntry {
   return { ngramId, count, hist, avgIki: null }
+}
+
+/** Resolve `qmkId` to its numeric code under a specific protocol,
+ * restoring the global protocol afterwards. */
+function deserializeUnderProtocol(qmkId: string, protocol: number): number {
+  const prev = getProtocol()
+  setProtocol(protocol)
+  try {
+    return deserialize(qmkId)
+  } finally {
+    setProtocol(prev)
+  }
+}
+
+function snapshotWithKeymap(keymap: string[][][]): TypingKeymapSnapshot {
+  return {
+    uid: '0x00',
+    machineHash: 'h',
+    productName: 'Test',
+    savedAt: 0,
+    layers: keymap.length,
+    matrix: { rows: keymap[0]?.length ?? 0, cols: keymap[0]?.[0]?.length ?? 0 },
+    keymap,
+    layout: null,
+  }
 }
 
 describe('aggregateFingerPairs', () => {
@@ -60,5 +88,45 @@ describe('aggregateFingerPairs', () => {
     )
     expect(totals.size).toBe(1)
     expect(totals.get('left-index_right-middle')?.count).toBe(1)
+  })
+})
+
+describe('buildKeycodeFingerMap', () => {
+  const keys = parseKle([['0,0']]).keys
+
+  it('resolves snapshot keycodes under the snapshot vialProtocol', () => {
+    // QK_BOOT is protocol-dependent (0x5c00 in v5, 0x7c00 in v6), so it
+    // exercises the protocol plumbing the same way key-heatmap-helpers
+    // does for Speed mode.
+    const v5BootCode = deserializeUnderProtocol('QK_BOOT', 5)
+    const v6BootCode = deserializeUnderProtocol('QK_BOOT', 6)
+    expect(v5BootCode).not.toBe(v6BootCode)
+
+    const snapshot = snapshotWithKeymap([[['QK_BOOT']]])
+    const overrides: Record<string, FingerType> = { '0,0': 'left-index' }
+
+    // Without a snapshot protocol, QK_BOOT resolves under the current
+    // default (v6) and the map is keyed by the v6 code.
+    const withoutProtocol = buildKeycodeFingerMap(snapshot, keys, overrides)
+    expect(withoutProtocol.get(v5BootCode)).toBeUndefined()
+    expect(withoutProtocol.get(v6BootCode)).toBe('left-index')
+
+    // With vialProtocol=5 the map is keyed by the v5 code instead —
+    // matching what a v5 snapshot's recorded bigram data uses.
+    const withProtocol = buildKeycodeFingerMap(snapshot, keys, overrides, 5)
+    expect(withProtocol.get(v5BootCode)).toBe('left-index')
+    expect(withProtocol.get(v6BootCode)).toBeUndefined()
+  })
+
+  it('restores the global protocol after resolving', () => {
+    const prev = getProtocol()
+    const snapshot = snapshotWithKeymap([[['KC_A']]])
+    buildKeycodeFingerMap(snapshot, keys, { '0,0': 'left-index' }, 5)
+    expect(getProtocol()).toBe(prev)
+  })
+
+  it('returns an empty map for an empty keymap', () => {
+    const snapshot = snapshotWithKeymap([])
+    expect(buildKeycodeFingerMap(snapshot, keys, {}, 5).size).toBe(0)
   })
 })

--- a/src/renderer/components/analyze/analyze-bigram-finger.ts
+++ b/src/renderer/components/analyze/analyze-bigram-finger.ts
@@ -17,6 +17,7 @@ import type {
   TypingKeymapSnapshot,
 } from '../../../shared/types/typing-analytics'
 import { foldHist, HIST_BUCKETS, parseBigramId } from './analyze-bigram-heatmap'
+import { withSnapshotProtocol } from './analyze-protocol'
 
 /** Build a numeric-keycode → finger lookup from the snapshot's layer-0
  * keymap, honouring user finger overrides keyed by `${row},${col}`.
@@ -24,36 +25,46 @@ import { foldHist, HIST_BUCKETS, parseBigramId } from './analyze-bigram-heatmap'
  * positions, the earliest (top-left first by KleKey order) wins. The
  * approximation is OK for typical layouts where alphas live on a single
  * spot; modifiers may hit either hand but the visualization treats
- * them as a single finger anyway. */
+ * them as a single finger anyway.
+ *
+ * Keycodes decode under `vialProtocol` (the snapshot's own protocol —
+ * see `withSnapshotProtocol`) so the resulting numeric codes match the
+ * ones the bigram aggregate stores. Callers should pass
+ * `snapshot.vialProtocol` so protocol-dependent codes (QK_BOOT, macros,
+ * ...) resolve to the value recorded at capture time rather than the
+ * current session's default. */
 export function buildKeycodeFingerMap(
   snapshot: TypingKeymapSnapshot,
   keys: readonly KleKey[],
   fingerOverrides?: Record<string, FingerType>,
+  vialProtocol?: number,
 ): Map<number, FingerType> {
-  const result = new Map<number, FingerType>()
-  if (snapshot.keymap.length === 0) return result
-  const layer0 = snapshot.keymap[0]
-  if (!layer0) return result
-  const ergonomicsByPos = buildErgonomicsByPos([...keys])
-  for (const key of keys) {
-    const row = layer0[key.row]
-    if (!row) continue
-    const qmkId = row[key.col]
-    if (typeof qmkId !== 'string' || qmkId.length === 0) continue
-    let code: number
-    try {
-      code = deserialize(qmkId)
-    } catch {
-      continue
+  return withSnapshotProtocol(vialProtocol, () => {
+    const result = new Map<number, FingerType>()
+    if (snapshot.keymap.length === 0) return result
+    const layer0 = snapshot.keymap[0]
+    if (!layer0) return result
+    const ergonomicsByPos = buildErgonomicsByPos([...keys])
+    for (const key of keys) {
+      const row = layer0[key.row]
+      if (!row) continue
+      const qmkId = row[key.col]
+      if (typeof qmkId !== 'string' || qmkId.length === 0) continue
+      let code: number
+      try {
+        code = deserialize(qmkId)
+      } catch {
+        continue
+      }
+      if (!Number.isFinite(code)) continue
+      if (result.has(code)) continue
+      const pos = posKey(key.row, key.col)
+      const override = fingerOverrides?.[pos]
+      const finger = override ?? ergonomicsByPos.get(pos)?.finger
+      if (finger) result.set(code, finger)
     }
-    if (!Number.isFinite(code)) continue
-    if (result.has(code)) continue
-    const pos = posKey(key.row, key.col)
-    const override = fingerOverrides?.[pos]
-    const finger = override ?? ergonomicsByPos.get(pos)?.finger
-    if (finger) result.set(code, finger)
-  }
-  return result
+    return result
+  })
 }
 
 export interface FingerPairTotal {

--- a/src/renderer/components/analyze/analyze-protocol.ts
+++ b/src/renderer/components/analyze/analyze-protocol.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Shared helper for resolving snapshot-recorded QMK ids against the
+// snapshot's own vial protocol version instead of the current session's.
+// Lives outside any single Analyze view (heatmap, finger IKI, ...) so
+// both can depend on it without one view importing from another.
+
+import { getProtocol, setProtocol } from '../../../shared/keycodes/keycodes'
+
+/** Run `body` with `getProtocol()` temporarily set to `protocol` so
+ * keycode string↔number conversion resolves against the snapshot's own
+ * protocol version, then restore. Protocol-dependent keycodes (macros,
+ * tap dance, QK_BOOT, …) map to different numeric values in v5 and v6,
+ * and per-snapshot aggregates (heatmap cells, bigram pairs) store the
+ * numeric codes recorded under the snapshot's protocol — resolving with
+ * the current global protocol would mismatch a v5 snapshot viewed in a
+ * v6 session. Mirrors `withImportProtocol` in
+ * `src/main/favorite-store.ts`; `undefined` (older snapshots without
+ * `vialProtocol`) keeps the current default. */
+export function withSnapshotProtocol<T>(protocol: number | undefined, body: () => T): T {
+  if (protocol === undefined) return body()
+  const prev = getProtocol()
+  setProtocol(protocol)
+  try {
+    return body()
+  } finally {
+    setProtocol(prev)
+  }
+}

--- a/src/renderer/components/analyze/key-heatmap-helpers.ts
+++ b/src/renderer/components/analyze/key-heatmap-helpers.ts
@@ -4,13 +4,14 @@
 
 import type { TypingBigramTopEntry, TypingHeatmapByCell, TypingHeatmapCell, TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
 import type { KeyboardLayout } from '../../../shared/kle/types'
-import { resolveSnapshotLabel, keycodeGroup, deserialize, serialize, codeToLabel, getProtocol, setProtocol } from '../../../shared/keycodes/keycodes'
+import { resolveSnapshotLabel, keycodeGroup, deserialize, serialize, codeToLabel } from '../../../shared/keycodes/keycodes'
 import type { KeycodeGroup } from '../../../shared/keycodes/keycodes'
 import { posKey } from '../../../shared/kle/pos-key'
 import { avgIkiFromHist, foldHist, HIST_BUCKETS, parseBigramId } from './analyze-bigram-heatmap'
 import { PALETTE_MIN_T, paletteColorFromIntensity } from '../../utils/chart-palette'
 import type { EffectiveTheme } from '../../hooks/useEffectiveTheme'
 import type { HeatmapNormalization, RangeMs } from './analyze-types'
+import { withSnapshotProtocol } from './analyze-protocol'
 
 export { AGGREGATE_MODES, KEY_GROUPS, HEATMAP_MODES } from '../../../shared/types/analyze-filters'
 export type { AggregateMode, KeyGroupFilter, HeatmapMode } from '../../../shared/types/analyze-filters'
@@ -346,26 +347,6 @@ export function normalizeKeySpeedIntensity(
     result.set(code, PALETTE_MIN_T + (1 - PALETTE_MIN_T) * normalized)
   }
   return result
-}
-
-/** Run `body` with `getProtocol()` temporarily set to `protocol` so
- * keycode string↔number conversion resolves against the snapshot's own
- * protocol version, then restore. Protocol-dependent keycodes (macros,
- * tap dance, QK_BOOT, …) map to different numeric values in v5 and v6,
- * and the bigram aggregate stores the numeric codes recorded under the
- * snapshot's protocol — resolving with the current global protocol
- * would mismatch a v5 snapshot viewed in a v6 session. Mirrors
- * `withImportProtocol` in `src/main/favorite-store.ts`; `undefined`
- * (older snapshots without `vialProtocol`) keeps the current default. */
-function withSnapshotProtocol<T>(protocol: number | undefined, body: () => T): T {
-  if (protocol === undefined) return body()
-  const prev = getProtocol()
-  setProtocol(protocol)
-  try {
-    return body()
-  } finally {
-    setProtocol(prev)
-  }
 }
 
 /** Resolves the Speed-mode fill for every physical position on one

--- a/src/renderer/components/analyze/use-keycode-finger-map.ts
+++ b/src/renderer/components/analyze/use-keycode-finger-map.ts
@@ -21,6 +21,6 @@ export function useKeycodeFingerMap(
     const layout = snapshot.layout as KeyboardLayout | null
     const keys = layout?.keys ?? []
     if (keys.length === 0) return new Map<number, FingerType>()
-    return buildKeycodeFingerMap(snapshot, keys, fingerOverrides)
+    return buildKeycodeFingerMap(snapshot, keys, fingerOverrides, snapshot.vialProtocol)
   }, [snapshot, fingerOverrides])
 }


### PR DESCRIPTION
## Summary

`buildKeycodeFingerMap` deserialized snapshot QMK ids with the session's global keycode protocol, so protocol-dependent keycodes from an older snapshot (e.g. `QK_BOOT`: 0x5c00 on v5 vs 0x7c00 on v6) never matched the recorded bigram codes and silently dropped out of the Finger IKI mapping.

## Changes

- Move `withSnapshotProtocol` (added for the speed heatmap in #247) into a neutral `analyze-protocol.ts` module shared by both consumers.
- `buildKeycodeFingerMap` accepts an optional `vialProtocol` and resolves keycodes under it; `useKeycodeFingerMap` passes `snapshot.vialProtocol`, covering both call sites (TypingProfileCard, BigramsChart finger quadrant).

## Tests

Regression tests with the v5/v6 `QK_BOOT` codes: unmapped without a protocol, mapped with `vialProtocol: 5`, and the global protocol restored afterward. Full renderer suite green.