### PR TITLE
fix(ui): persist romaji input reliably and honour the guide font size

### DIFF
--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -676,6 +676,105 @@ describe('useDevicePrefs', () => {
         quoteLength: 'medium',
       })
     })
+
+    it('preserves romajiInput on a words config restored from IPC', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romajiInput: true,
+      })
+    })
+
+    it('preserves romajiInput on a time config restored from IPC', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: { mode: 'time', duration: 60, punctuation: true, numbers: false, romajiInput: true },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'time',
+        duration: 60,
+        punctuation: true,
+        numbers: false,
+        romajiInput: true,
+      })
+    })
+
+    it('drops a non-boolean romajiInput but keeps the rest of the config', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: 'yes' },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+      })
+    })
+
+    it('preserves romajiInput on the restored MonkeyType fallback config', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestMonkeytypeConfig: { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestMonkeytypeConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romajiInput: true,
+      })
+    })
   })
 
   describe('splitKeyMode', () => {

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -28,13 +28,18 @@ function hasBooleanFields(obj: Record<string, unknown>, ...keys: string[]): bool
 function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
   if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
   const obj = raw as Record<string, unknown>
+  // Optional carry-through: keep a persisted boolean romajiInput on
+  // words/time configs, drop any other type silently (the field is
+  // optional, so a malformed value degrades to "not set" rather than
+  // rejecting the whole config).
+  const romajiInput = typeof obj.romajiInput === 'boolean' ? { romajiInput: obj.romajiInput } : {}
   switch (obj.mode) {
     case 'words':
       if (!isFinitePositiveInt(obj.wordCount) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
-      return { mode: 'words', wordCount: obj.wordCount, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean }
+      return { mode: 'words', wordCount: obj.wordCount, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput }
     case 'time':
       if (!isFinitePositiveInt(obj.duration) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
-      return { mode: 'time', duration: obj.duration, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean }
+      return { mode: 'time', duration: obj.duration, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput }
     case 'quote':
       if (typeof obj.quoteLength !== 'string' || !VALID_QUOTE_LENGTHS.has(obj.quoteLength)) return undefined
       return { mode: 'quote', quoteLength: obj.quoteLength as 'short' | 'medium' | 'long' | 'all' }

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -70,6 +70,13 @@
   height: calc(var(--tt-font) * var(--tt-lines) * 1.5px);
 }
 
+/* Romaji guide line below the reading window tracks the same --tt-font
+   Font setting as the reading window itself (the IME hint next to it stays
+   a fixed small size — see TypingTestView.tsx). */
+.typing-romaji-guide-text {
+  font-size: calc(var(--tt-font) * 1px);
+}
+
 /* Interactive elements use pointer cursor */
 button:not(:disabled),
 a,

--- a/src/renderer/typing-test/TypingTestSettingsBar.tsx
+++ b/src/renderer/typing-test/TypingTestSettingsBar.tsx
@@ -36,19 +36,19 @@ export function TypingTestSettingsBar({ config, onConfigChange, language }: Prop
   const { t } = useTranslation()
 
   // Remember toggle state so it persists through quote modes (which have no toggles).
-  const togglesRef = useRef({ punctuation: false, numbers: false })
+  const togglesRef = useRef({ punctuation: false, numbers: false, romajiInput: false })
   if (config.mode === 'words' || config.mode === 'time') {
-    togglesRef.current = { punctuation: config.punctuation, numbers: config.numbers }
+    togglesRef.current = { punctuation: config.punctuation, numbers: config.numbers, romajiInput: config.romajiInput === true }
   }
 
   const handleModeChange = useCallback((mode: TypingTestMode) => {
-    const { punctuation, numbers } = togglesRef.current
+    const { punctuation, numbers, romajiInput } = togglesRef.current
     switch (mode) {
       case 'words':
-        onConfigChange({ mode: 'words', wordCount: config.mode === 'words' ? config.wordCount : 30, punctuation, numbers })
+        onConfigChange({ mode: 'words', wordCount: config.mode === 'words' ? config.wordCount : 30, punctuation, numbers, romajiInput })
         break
       case 'time':
-        onConfigChange({ mode: 'time', duration: config.mode === 'time' ? config.duration : 30, punctuation, numbers })
+        onConfigChange({ mode: 'time', duration: config.mode === 'time' ? config.duration : 30, punctuation, numbers, romajiInput })
         break
       case 'quote':
         onConfigChange({ mode: 'quote', quoteLength: config.mode === 'quote' ? config.quoteLength : 'medium' })

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -359,10 +359,13 @@ export function TypingTestView({
           row below the reading window rather than inline per-word: the
           words row is a single flex-wrap flow (word-flow modes have no
           per-line rows to anchor an inline guide under), so a fixed row
-          here avoids overlapping whatever wraps below the current word. */}
+          here avoids overlapping whatever wraps below the current word.
+          The typed/remaining line tracks the Font setting via the same
+          --tt-font var as the reading window; the IME hint stays a fixed
+          small size since it's a hint, not reading content. */}
       {romajiGuide && (
-        <div data-testid="typing-test-romaji-guide" className="flex w-full max-w-4xl flex-col items-start gap-1 font-mono text-sm">
-          <p className="break-all">
+        <div data-testid="typing-test-romaji-guide" className="flex w-full max-w-4xl flex-col items-start gap-1 font-mono" style={multilineStyle}>
+          <p className="typing-romaji-guide-text break-all">
             <span className="text-success">{romajiGuide.typed}</span>
             <span className="text-content-muted">{romajiGuide.remaining}</span>
           </p>

--- a/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
@@ -208,4 +208,48 @@ describe('TypingTestSettingsBar toggle preservation', () => {
       expect(timeConfig.numbers).toBe(true)
     }
   })
+
+  it('preserves romajiInput when switching words -> time', () => {
+    const onConfigChange = vi.fn()
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
+    renderBar({ config, language: 'japanese_hiragana', onConfigChange })
+
+    fireEvent.click(screen.getByTestId('mode-time'))
+
+    const timeConfig = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    expect(timeConfig.mode).toBe('time')
+    if (timeConfig.mode === 'time') {
+      expect(timeConfig.romajiInput).toBe(true)
+    }
+  })
+
+  it('preserves romajiInput through quote mode, same as punctuation/numbers', () => {
+    const onConfigChange = vi.fn()
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
+    const { rerender } = render(
+      <I18nextProvider i18n={i18n}>
+        <TypingTestSettingsBar config={config} onConfigChange={onConfigChange} language="japanese_hiragana" />
+      </I18nextProvider>,
+    )
+
+    // Switch to quote mode (romajiInput drops from the config but is remembered).
+    fireEvent.click(screen.getByTestId('mode-quote'))
+    const quoteConfig = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    expect(quoteConfig.mode).toBe('quote')
+
+    onConfigChange.mockClear()
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <TypingTestSettingsBar config={quoteConfig} onConfigChange={onConfigChange} language="japanese_hiragana" />
+      </I18nextProvider>,
+    )
+
+    // Switch back to words — romajiInput restored from before quote mode.
+    fireEvent.click(screen.getByTestId('mode-words'))
+    const wordsConfig = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    expect(wordsConfig.mode).toBe('words')
+    if (wordsConfig.mode === 'words') {
+      expect(wordsConfig.romajiInput).toBe(true)
+    }
+  })
 })

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -507,6 +507,20 @@ describe('TypingTestView romaji guide', () => {
     fireEvent.compositionStart(textarea)
     expect(screen.queryByTestId('typing-test-romaji-ime-hint')).toBeNull()
   })
+
+  it('tracks the Font setting via --tt-font, same as the reading window', () => {
+    renderView({
+      fontSize: 40,
+      state: makeState({ status: 'running', words: ['あい'] }),
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0 },
+    })
+    const guide = screen.getByTestId('typing-test-romaji-guide')
+    expect(guide.style.getPropertyValue('--tt-font')).toBe('40')
+    const typedRemaining = guide.querySelector('.typing-romaji-guide-text')
+    expect(typedRemaining).not.toBeNull()
+    // The IME hint stays a fixed small size, not tied to --tt-font.
+    expect(guide.querySelector('[data-testid="typing-test-romaji-ime-hint"]')).toBeNull()
+  })
 })
 
 describe('TypingTestView paused overlay', () => {

--- a/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
@@ -8,11 +8,11 @@ import { clearLanguageCache, getLanguageData } from '../word-generator'
 import type { TypingTestConfig } from '../types'
 
 // A real kana pack id (see ROMAJI_INPUT_LANGUAGES) is required everywhere a
-// test mounts with `romajiInput: true` already set: useTypingTest now
-// normalizes that pairing at mount (clearRomajiInputForLanguage), so an
-// arbitrary language name would have the flag dropped before the test body
-// runs. Every case below reseeds this same id with its own single-word
-// list via `seedKanaLanguage`, which evicts the previous entry first.
+// test wants the romaji matcher actually active: `romajiInput: true` alone
+// is not enough — `isRomajiInputActive` also requires the active language
+// to be a kana pack (see useTypingTest.ts). Every case below reseeds this
+// same id with its own single-word list via `seedKanaLanguage`, which
+// evicts the previous entry first.
 const KANA_LANGUAGE = 'japanese_hiragana'
 
 const mockLangGet = vi.fn()
@@ -199,7 +199,7 @@ describe('useTypingTest — romaji input mode', () => {
     expect(result.current.romajiGuide).toEqual({ typed: 'dhi', remaining: 'na-', kanaCompleted: 2 })
   })
 
-  it('clears romajiInput when the language switches off a kana pack', async () => {
+  it('keeps romajiInput saved but inactive once the language switches off a kana pack', async () => {
     await seedKanaLanguage(KANA_LANGUAGE, ['あ'])
     const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
     expect(result.current.config.mode === 'words' && result.current.config.romajiInput).toBe(true)
@@ -210,31 +210,32 @@ describe('useTypingTest — romaji input mode', () => {
 
     expect(result.current.language).toBe('english')
     expect(result.current.config.mode).toBe('words')
+    // The flag itself is preserved, same as punctuation/numbers — it's just
+    // not honored while a non-kana language is active.
     if (result.current.config.mode === 'words') {
-      expect(result.current.config.romajiInput).toBe(false)
+      expect(result.current.config.romajiInput).toBe(true)
     }
-    // The cleared flag also takes matching out of romaji mode immediately —
-    // a submitted word now goes through verbatim comparison, not the matcher.
+    // Inactive language takes matching out of romaji mode immediately — a
+    // submitted word now goes through verbatim comparison, not the matcher.
     expect(result.current.romajiGuide).toBeNull()
   })
 
-  it('normalizes a persisted romajiInput=true + non-kana language pair on mount', () => {
+  it('mounts with a persisted romajiInput=true + non-kana language pair inactive, not stripped', () => {
     // Mirrors a persisted config/language pair restored from device prefs
-    // (e.g. via sync) that is already out of sync — setLanguage was never
-    // the one that paired these two values, so the mount-time normalization
-    // has to catch it instead. See clearRomajiInputForLanguage.
+    // (e.g. via sync). The flag is kept as-is; isRomajiInputActive is what
+    // decides it isn't honored yet.
     const persistedConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
     const { result } = renderHook(() => useTypingTest(persistedConfig, 'english'))
 
     expect(result.current.language).toBe('english')
     expect(result.current.config.mode).toBe('words')
     if (result.current.config.mode === 'words') {
-      expect(result.current.config.romajiInput).toBe(false)
+      expect(result.current.config.romajiInput).toBe(true)
     }
     expect(result.current.romajiGuide).toBeNull()
   })
 
-  it('normalizes a config pushed in via setConfig against whichever language is already active', async () => {
+  it('keeps romajiInput from a config pushed via setConfig inactive against whichever language is already active', async () => {
     // Mirrors useInputModes.ts's device-prefs sync effect, which calls
     // setConfig directly with a persisted config rather than going through
     // setLanguage.
@@ -246,9 +247,46 @@ describe('useTypingTest — romaji input mode', () => {
 
     expect(result.current.config.mode).toBe('words')
     if (result.current.config.mode === 'words') {
-      expect(result.current.config.romajiInput).toBe(false)
+      expect(result.current.config.romajiInput).toBe(true)
     }
     expect(result.current.romajiGuide).toBeNull()
+  })
+
+  it('regression: honors romajiInput once the language sync catches up, even when the config sync landed first', async () => {
+    // Reproduces the reported bug: useInputModes.ts syncs the persisted
+    // config and language into useTypingTest via two independent effects.
+    // When the config effect resolves before the language effect (both can
+    // fire on the same mount, in either order), a config-first setConfig
+    // call must not lose romajiInput before setLanguage lands the kana
+    // pack that makes it meaningful again.
+    await seedKanaLanguage(KANA_LANGUAGE, ['あ'])
+    const { result } = renderHook(() => useTypingTest(undefined, undefined))
+
+    await act(async () => {
+      await result.current.setConfig(wordsConfig(1))
+    })
+    // Config landed while the default (non-kana) language was still active —
+    // the flag must survive this, not just carry through a same-order path.
+    expect(result.current.language).toBe('english')
+    if (result.current.config.mode === 'words') {
+      expect(result.current.config.romajiInput).toBe(true)
+    }
+    expect(result.current.romajiGuide).toBeNull()
+
+    await act(async () => {
+      await result.current.setLanguage(KANA_LANGUAGE)
+    })
+
+    expect(result.current.language).toBe(KANA_LANGUAGE)
+    if (result.current.config.mode === 'words') {
+      expect(result.current.config.romajiInput).toBe(true)
+    }
+    expect(result.current.romajiGuide).not.toBeNull()
+    expect(result.current.state.words).toEqual(['あ'])
+
+    press(result, 'a')
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.correctChars).toBe(1)
   })
 
   it('preserves romajiInput when switching between two kana languages', async () => {

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -31,13 +31,12 @@ export const DEFAULT_LANGUAGE = 'english'
 
 /** Word-language packs the romaji-keystroke matcher supports (kana word
  *  lists only). Drives the SettingsBar toggle's visibility, and — via
- *  `clearRomajiInputForLanguage` in `useTypingTest` — whether `romajiInput`
- *  is ever allowed to stay `true`: the flag is dropped the moment the
- *  active language isn't in this set, whether that happens by switching
- *  languages, restoring a persisted config/language pair on mount, or any
- *  other direct `setConfig` call. `isRomajiInputActive` therefore trusts
- *  `romajiInput: true` at face value without re-checking the language
- *  itself. */
+ *  `isRomajiInputActive` in `useTypingTest` — whether a persisted
+ *  `romajiInput: true` is actually honored. The flag itself is never
+ *  stripped from the config (same as `punctuation`/`numbers`): it stays
+ *  saved across language switches, mount, and `setConfig` calls, and is
+ *  simply inert whenever the active language isn't in this set. Selecting
+ *  a kana pack again picks it back up automatically. */
 export const ROMAJI_INPUT_LANGUAGES = new Set(['japanese_hiragana', 'japanese_katakana'])
 
 /** Current word's confirmed romaji + canonical remaining spelling, plus the

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -43,38 +43,18 @@ function isSubmitKey(key: string): boolean {
   return key === ' ' || key === '\u3000'
 }
 
-/** True when the config opts into sequential romaji-keystroke judging
- *  (only meaningful for the words/time kana packs — see types.ts).
- *  Language is deliberately not re-checked here: every path that can
- *  (re)pair `config` with `language` — `setLanguage`, `setConfig`, and the
- *  initial mount — runs the result through `clearRomajiInputForLanguage`,
- *  so by the time this runs `romajiInput: true` already implies a kana pack
- *  is selected. */
-function isRomajiInputActive(config: TypingTestConfig): boolean {
+/** True when the config opts into sequential romaji-keystroke judging AND
+ *  the active language is one of the kana packs the matcher supports (see
+ *  `ROMAJI_INPUT_LANGUAGES` in types.ts). `romajiInput` is persisted as-is
+ *  regardless of language — same as `punctuation`/`numbers` — and is simply
+ *  not honored while a non-kana language is active. This keeps the flag
+ *  intact across any config/language sync order (e.g. a persisted config
+ *  landing before the persisted language on mount), and it comes back into
+ *  effect automatically once a kana pack is selected again, without the
+ *  user needing to re-toggle it. */
+function isRomajiInputActive(config: TypingTestConfig, language: string): boolean {
   return (config.mode === 'words' || config.mode === 'time') && config.romajiInput === true
-}
-
-/** Config transform applied whenever `romajiInput` could end up paired with
- *  a non-kana language: quietly drops the flag so a stale value can't keep
- *  judging keystrokes against a word list the matcher no longer applies to.
- *  Called from every point that can (re)pair config with language —
- *  `setLanguage` (language changes on its own), `setConfig` (a new config
- *  arrives against whichever language is already active, including a
- *  persisted config pushed in from outside), and the initial mount (a
- *  persisted config/language pair can already be out of sync when it
- *  arrives) — so `isRomajiInputActive` can trust `romajiInput: true` at
- *  face value rather than re-checking the language itself, same as how the
- *  SettingsBar toggle simply disappears (gated on the same
- *  `ROMAJI_INPUT_LANGUAGES` check) instead of persisting hidden state.
- *  Re-enabling it requires opting back in once a kana pack is selected
- *  again, matching how the toggle is never restored automatically after
- *  leaving quote mode either. */
-function clearRomajiInputForLanguage(config: TypingTestConfig, language: string): TypingTestConfig {
-  if (ROMAJI_INPUT_LANGUAGES.has(language)) return config
-  if ((config.mode === 'words' || config.mode === 'time') && config.romajiInput) {
-    return { ...config, romajiInput: false }
-  }
-  return config
+    && ROMAJI_INPUT_LANGUAGES.has(language)
 }
 
 /** Rebuilds a matcher for `word` by replaying every keystroke accepted so
@@ -321,23 +301,17 @@ export function useTypingTest(
   initialLanguage?: string,
   options?: UseTypingTestOptions,
 ): UseTypingTestReturn {
-  // A persisted config/language pair (e.g. restored from device prefs) can
-  // arrive already out of sync — romajiInput true against a non-kana
-  // language — so normalize it here too, not just in setLanguage/setConfig.
-  // See clearRomajiInputForLanguage.
-  const [config, setConfigState] = useState<TypingTestConfig>(() =>
-    clearRomajiInputForLanguage(initialConfig ?? DEFAULT_CONFIG, initialLanguage ?? DEFAULT_LANGUAGE),
-  )
+  // A persisted config/language pair (e.g. restored from device prefs) is
+  // taken at face value — `romajiInput` is not paired with the language
+  // here; `isRomajiInputActive` gates whether it's honored.
+  const [config, setConfigState] = useState<TypingTestConfig>(() => initialConfig ?? DEFAULT_CONFIG)
   const [language, setLanguageState] = useState<string>(() => initialLanguage ?? DEFAULT_LANGUAGE)
   const [isLanguageLoading, setIsLanguageLoading] = useState(false)
   const [baseLayer, setBaseLayerState] = useState(0)
   const [effectiveLayer, setEffectiveLayer] = useState(0)
   const [windowFocused, setWindowFocusedState] = useState(true)
   const [state, setState] = useState<TypingTestState>(() =>
-    createInitialState(
-      clearRomajiInputForLanguage(initialConfig ?? DEFAULT_CONFIG, initialLanguage ?? DEFAULT_LANGUAGE),
-      initialLanguage ?? DEFAULT_LANGUAGE,
-    ),
+    createInitialState(initialConfig ?? DEFAULT_CONFIG, initialLanguage ?? DEFAULT_LANGUAGE),
   )
   const configRef = useRef(config)
   const stateRef = useRef(state)
@@ -389,36 +363,19 @@ export function useTypingTest(
   }, [state.status])
 
   const setConfig = useCallback(async (newConfig: TypingTestConfig) => {
-    // Normalize against whatever language is already active — a caller can
-    // push a config carrying a stale romajiInput straight in (e.g. a
-    // persisted config restored from device prefs), bypassing setLanguage
-    // entirely. See clearRomajiInputForLanguage.
-    const normalized = clearRomajiInputForLanguage(newConfig, languageRef.current)
-    setConfigState(normalized)
-    configRef.current = normalized
+    // Taken at face value — see isRomajiInputActive for why romajiInput
+    // doesn't need to be paired with the active language here.
+    setConfigState(newConfig)
+    configRef.current = newConfig
     const seq = ++seqRef.current
-    const result = await createWordsForConfig(normalized, languageRef.current)
+    const result = await createWordsForConfig(newConfig, languageRef.current)
     if (seqRef.current !== seq) return
     setState(freshState(result))
-  }, [])
-
-  // Applies clearRomajiInputForLanguage against `newLanguage` and, if it
-  // actually changed configRef.current, pushes the result into both the
-  // ref and React state. Shared by setLanguage's two config/language
-  // re-pairing points below: the normal switch, and the error-path
-  // fallback to DEFAULT_LANGUAGE.
-  const applyClearedConfigForLanguage = useCallback((newLanguage: string) => {
-    const cleared = clearRomajiInputForLanguage(configRef.current, newLanguage)
-    if (cleared !== configRef.current) {
-      configRef.current = cleared
-      setConfigState(cleared)
-    }
   }, [])
 
   const setLanguage = useCallback(async (newLanguage: string): Promise<string> => {
     setLanguageState(newLanguage)
     languageRef.current = newLanguage
-    applyClearedConfigForLanguage(newLanguage)
 
     setIsLanguageLoading(true)
     const seq = ++seqRef.current
@@ -433,7 +390,6 @@ export function useTypingTest(
       if (seqRef.current !== seq) return languageRef.current
       languageRef.current = DEFAULT_LANGUAGE
       setLanguageState(DEFAULT_LANGUAGE)
-      applyClearedConfigForLanguage(DEFAULT_LANGUAGE)
       setState(createInitialState(configRef.current, DEFAULT_LANGUAGE))
       return DEFAULT_LANGUAGE
     } finally {
@@ -441,7 +397,7 @@ export function useTypingTest(
         setIsLanguageLoading(false)
       }
     }
-  }, [applyClearedConfigForLanguage])
+  }, [])
 
   const setBaseLayer = useCallback(async (layer: number) => {
     setBaseLayerState(layer)
@@ -663,7 +619,7 @@ export function useTypingTest(
       // below (submit/Backspace no-ops, printable dispatched to the
       // matcher) — dispatch once here instead of re-checking
       // isRomajiInputActive in each branch.
-      if (isRomajiInputActive(configRef.current)) {
+      if (isRomajiInputActive(configRef.current, languageRef.current)) {
         return processRomajiKeyEvent(s, key, configRef.current, languageRef.current)
       }
 
@@ -726,7 +682,7 @@ export function useTypingTest(
       // Romaji mode is direct-keystroke only; IME composition input (which
       // implies IME is on, contrary to the mode's requirement) is ignored
       // entirely rather than fed into currentInput.
-      if (isRomajiInputActive(configRef.current)) return s
+      if (isRomajiInputActive(configRef.current, languageRef.current)) return s
       if (!data) {
         return { ...s, compositionText: '' }
       }
@@ -818,12 +774,12 @@ export function useTypingTest(
   // the accepted keystroke history on every change rather than stored on
   // state directly — see `buildRomajiMatcher`.
   const romajiGuide = useMemo(() => {
-    if (!isRomajiInputActive(config)) return null
+    if (!isRomajiInputActive(config, language)) return null
     if (state.currentWordIndex >= state.words.length) return null
     const word = state.words[state.currentWordIndex]
     const matcher = buildRomajiMatcher(word, state.romajiKeystrokes)
     return { typed: matcher.typedRomaji(), remaining: matcher.remainingGuide(), kanaCompleted: matcher.completedKanaCount() }
-  }, [config, state.words, state.currentWordIndex, state.romajiKeystrokes])
+  }, [config, language, state.words, state.currentWordIndex, state.romajiKeystrokes])
 
   return {
     state,


### PR DESCRIPTION
## Summary

Fixes the two user-reported issues with the Romaji option, plus two related persistence gaps found in review.

## Persistence (the toggle reset on restart)

Three compounding holes, all fixed:

- The mount-time normalization raced the config/language pref sync (config lands first, sees the default language, strips the flag). Replaced the strip-on-mismatch design with honour-at-read-time: `romajiInput` now persists exactly like punctuation/numbers and is simply inactive while a non-kana pack is selected — switching back to a kana pack re-activates the remembered setting.
- `validateTypingTestConfig` rebuilt words/time configs from known fields only, dropping the flag on every load (including the MonkeyType fallback restore path).
- The mode row rebuilt configs with just punctuation/numbers, losing the flag on words/time switches (and through quote).

## Guide font

The romaji guide line was hardcoded to a small size; it now follows the shared reading-window font variable (Settings › Font), while the IME hint stays small.

## Tests

Regression tests for the exact reported flow (config synced before language), validation carry-through (incl. rejecting non-boolean values), mode-switch preservation, and the guide font wiring. Full suite: 251 files / 5,022 green; lint and build clean.