### PR TITLE
test(sync): remove the same-millisecond flake window in the key-label reorder test

### DIFF
--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -317,9 +317,17 @@ describe('key-label-store', () => {
       const origA = a.data!.updatedAt
       const origB = b.data!.updatedAt
 
-      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000)
-      await reorderActive([b.data!.id, a.data!.id])
-      vi.mocked(Date.now).mockRestore()
+      // A Date.now spy never affects `new Date().toISOString()`, which is what the
+      // store actually calls, so freeze the clock and jump it forward instead.
+      // Freezing also removes the same-millisecond flake window when the real
+      // wall clock happens not to tick between saveRecord and reorderActive.
+      try {
+        vi.useFakeTimers()
+        vi.setSystemTime(Date.parse(origB) + 1000)
+        await reorderActive([b.data!.id, a.data!.id])
+      } finally {
+        vi.useRealTimers()
+      }
 
       const metas = await listMetas()
       const metaA = metas.find((m) => m.id === a.data!.id)!


### PR DESCRIPTION
## Summary

- The updatedAt-bump assertion in the key-label reorder test stubbed `Date.now`, which `new Date().toISOString()` — the store's actual clock read — never consults, so the test silently depended on the real wall clock ticking between `saveRecord` and `reorderActive` and failed whenever both landed in the same millisecond (observed once in a full-suite run; reruns passed)
- Freeze and advance the clock with vitest fake timers instead, which do patch the `Date` constructor, and restore real timers before the follow-up assertions

## Test plan

- The affected file passes 20 consecutive runs
- Full suite green (6,167 tests)