### PR TITLE
fix(ui): sync the typing-view heatmap legend with the window setting

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -375,7 +375,7 @@
         "label": "Monitor App"
       },
       "heatmap": {
-        "legend": "ヒートマップ: 直近 1 時間"
+        "legend": "ヒートマップ: 直近 {{minutes}} 分"
       },
       "closeHint": "クリックでメニューを開く",
       "recordingIndicator": "記録中",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -375,7 +375,7 @@
         "label": "Monitor App"
       },
       "heatmap": {
-        "legend": "ヒートマップ: 直近1時間っしょ☆"
+        "legend": "ヒートマップ: 直近{{minutes}}分っしょ☆"
       },
       "closeHint": "クリックでメニュー出るよん☆",
       "recordingIndicator": "記録なう☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -375,7 +375,7 @@
         "label": "Monitor App"
       },
       "heatmap": {
-        "legend": "ヒートマップ: ここ1時間どすえ"
+        "legend": "ヒートマップ: ここ{{minutes}}分どすえ"
       },
       "closeHint": "クリックしたらメニューが開きますえ",
       "recordingIndicator": "記録中どすえ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -375,7 +375,7 @@
         "label": "見守りアプリ"
       },
       "heatmap": {
-        "legend": "熱分布: この一刻"
+        "legend": "熱分布: 直近{{minutes}}分"
       },
       "closeHint": "触れて献立を開く",
       "recordingIndicator": "記録しております",

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -754,7 +754,7 @@ export function TypingTestPane({
               data-testid="typing-test-heatmap-legend"
               className="mt-1 text-center text-xs text-content-muted"
             >
-              {t('editor.typingTest.heatmap.legend')}
+              {t('editor.typingTest.heatmap.legend', { minutes: heatmapWindowMin ?? 5 })}
             </p>
           )}
           {/* Layer-tracking note describes the keymap, so hide it with the keymap. */}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -375,7 +375,7 @@
         "label": "Monitor App"
       },
       "heatmap": {
-        "legend": "Heatmap: last 1 hour"
+        "legend": "Heatmap: last {{minutes}} min"
       },
       "closeHint": "Click to open menu",
       "recordingIndicator": "Recording",


### PR DESCRIPTION
## Summary

- The typing-view heatmap legend was a fixed "Heatmap: last 1 hour" string left over from an earlier default, while the overlay itself already followed the REC tab's window-minutes setting (`typingHeatmapWindowMin`)
- Interpolate the configured value into the legend (`Heatmap: last {{minutes}} min`) in every locale, with the same 5-minute fallback the overlay uses

## Test plan

- Full suite green (6,242 tests); ESLint / tsc clean
- Value-only locale change (no new keys), so pack versions stay untouched