### PR TITLE
refactor(ui): split KeymapEditor.tsx into focused modules (1383→528 lines)

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1,44 +1,23 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useEffect, useMemo, useRef, useImperativeHandle, forwardRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useImperativeHandle, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
-import { KeyPopover } from '../keycodes/KeyPopover'
-import { serialize, isMask, findKeycode } from '../../../shared/keycodes/keycodes'
 import { useTileContentOverride } from '../../hooks/useTileContentOverride'
-import { useUnlockGate } from '../../hooks/useUnlockGate'
-import type { Keycode } from '../../../shared/keycodes/keycodes'
-import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
-import { deserializeAllMacros, serializeAllMacros, type MacroAction } from '../../../preload/macro'
-import { TapDanceModal } from './TapDanceModal'
-import { MacroModal } from './MacroModal'
-import { TapDanceJsonEditor } from './TapDanceJsonEditor'
-import { JsonEditorModal } from './JsonEditorModal'
-import { comboToJson, parseCombo, keyOverrideToJson, parseKeyOverride, altRepeatKeyToJson, parseAltRepeatKey, macroToJson, parseMacro } from './json-entry-serializers'
 import { KeycodesOverlayPanel } from './KeycodesOverlayPanel'
-import { useViewMatrixMode } from './useViewMatrixMode'
 import { ViewMatrixPanel } from './ViewMatrixPanel'
-import { applyViewMatrixAxisToSelection, effectiveViewPos } from './view-matrix'
-import { KEY_DUPLICATE_COLOR } from '../keyboard/constants'
-import { ZoomIn, ZoomOut, SlidersHorizontal, Undo2, Redo2 } from 'lucide-react'
+import { ZoomIn, ZoomOut, SlidersHorizontal } from 'lucide-react'
 import { ICON_SM, ICON_MD } from '../../constants/ui-tokens'
-import { parseKle } from '../../../shared/kle/kle-parser'
-import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
-import { posKey } from '../../../shared/kle/pos-key'
-import { isVilFile, isVilFileV1, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
-import type { KeyboardLayout } from '../../../shared/kle/types'
-import type { StoredKeyboardInfo } from '../../../shared/types/sync'
-import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
 
 // Extracted modules
-import type { KeymapEditorProps as Props, PopoverState } from './keymap-editor-types'
-import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH, EMPTY_KEYCODES, EMPTY_REMAPPED, EMPTY_ENCODER_KEYCODES } from './keymap-editor-types'
+import type { KeymapEditorProps as Props } from './keymap-editor-types'
+import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export type { KeymapEditorHandle } from './keymap-editor-types'
 import { KeyboardPane } from './KeyboardPane'
 import { LayerListPanel } from './LayerListPanel'
-import { ScaleInput, toggleButtonClass } from './keymap-editor-toolbar'
+import { ScaleInput, ghostZoomButtonClass, KeymapToolbar } from './keymap-editor-toolbar'
+import { PopoverForState } from './keymap-editor-popover'
 import { Tooltip } from '../ui/Tooltip'
-import { QmkSettingsModals } from './QmkSettingsModal'
 import { useInputModes } from './useInputModes'
 import { useKeymapMultiSelect } from './useKeymapMultiSelect'
 import { useLayoutOptionsPanel } from './useLayoutOptionsPanel'
@@ -46,47 +25,12 @@ import { useKeymapSelectionHandlers } from './useKeymapSelectionHandlers'
 import { useKeymapHistory } from './useKeymapHistory'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { TypingTestPane } from './TypingTestPane'
+import { useLayoutPicker } from './useLayoutPicker'
+import { useKeymapJsonEditors } from './useKeymapJsonEditors'
+import { useViewMatrixEditing } from './useViewMatrixEditing'
+import { KeymapEditorModals } from './KeymapEditorModals'
+import { useLayerKeycodes } from './use-layer-keycodes'
 
-
-interface PopoverForStateProps {
-  popoverState: NonNullable<PopoverState>
-  keymap: Map<string, number>
-  encoderLayout: Map<string, number>
-  currentLayer: number
-  layers: number
-  onLayerChange?: (layer: number) => void
-  layerNames?: string[]
-  onKeycodeSelect: (kc: Keycode) => void
-  onRawKeycodeSelect: (code: number) => void
-  onModMaskChange?: (newMask: number) => void
-  onClose: () => void
-  quickSelect?: boolean
-  previousKeycode?: number
-  onUndo?: () => void
-  nextKeycode?: number
-  onRedo?: () => void
-}
-
-function PopoverForState({
-  popoverState, keymap, encoderLayout, currentLayer, layers,
-  onLayerChange, layerNames,
-  onKeycodeSelect, onRawKeycodeSelect, onModMaskChange, onClose,
-  quickSelect, previousKeycode, onUndo, nextKeycode, onRedo,
-}: PopoverForStateProps) {
-  const currentKeycode = popoverState.kind === 'key'
-    ? keymap.get(`${currentLayer},${popoverState.row},${popoverState.col}`) ?? 0
-    : encoderLayout.get(`${currentLayer},${popoverState.idx},${popoverState.dir}`) ?? 0
-  const maskOnly = popoverState.maskClicked && isMask(serialize(currentKeycode))
-  return (
-    <KeyPopover
-      anchorRect={popoverState.anchorRect} currentKeycode={currentKeycode} maskOnly={maskOnly} layers={layers}
-      currentLayer={currentLayer} onLayerChange={onLayerChange} layerNames={layerNames}
-      onKeycodeSelect={onKeycodeSelect} onRawKeycodeSelect={onRawKeycodeSelect} onModMaskChange={onModMaskChange}
-      onClose={onClose} quickSelect={quickSelect} previousKeycode={previousKeycode} onUndo={onUndo}
-      nextKeycode={nextKeycode} onRedo={onRedo}
-    />
-  )
-}
 
 export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEditorHandle, Props>(function KeymapEditor({
   keyboardUid, layout, layers, currentLayer, onLayerChange, keymap, encoderLayout, encoderCount,
@@ -134,36 +78,6 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 }, ref) {
   const { t } = useTranslation()
   const keyboardContentRef = useRef<HTMLDivElement>(null)
-  const [pickerLayer, setPickerLayer] = useState(0)
-  const [pickerSource, setPickerSource] = useState<'file' | 'device'>('device')
-  const [pickerFileData, setPickerFileData] = useState<{
-    layout: KeyboardLayout; keymap: Map<string, number>; layers: number
-    encoderKeycodes: Map<string, [string, string]>; layoutOptions: Map<number, number>
-    name: string; layerNames?: string[]; uid?: string
-  } | null>(null)
-  const [storedKeyboards, setStoredKeyboards] = useState<StoredKeyboardInfo[]>([])
-  const [selectedFileUid, setSelectedFileUid] = useState<string | null>(null)
-  const [storedEntries, setStoredEntries] = useState<SnapshotMeta[]>([])
-  const [fileBrowseView, setFileBrowseView] = useState<'list' | 'entries'>('list')
-  const [pickerLoadError, setPickerLoadError] = useState<string | null>(null)
-  const [probeStatus, setProbeStatus] = useState<'idle' | 'probing' | 'error'>('idle')
-  const [deviceBrowsing, setDeviceBrowsing] = useState(true)
-  const [pickerScale, setPickerScale] = useState<number | undefined>(undefined)
-  const [pickerTooltip, setPickerTooltip] = useState<{ keycode: string; top: number; left: number } | null>(null)
-  // pickerClickedPositions removed — now tracked via pickerSelectedIndices in useKeymapMultiSelect
-  const pickerContainerRef = useRef<HTMLDivElement>(null)
-
-  const handlePickerHover = useCallback((_key: import('../../../shared/kle/types').KleKey, keycode: string, rect: DOMRect) => {
-    const containerRect = pickerContainerRef.current?.getBoundingClientRect()
-    if (!containerRect) return
-    setPickerTooltip({
-      keycode,
-      top: rect.top - containerRect.top,
-      left: rect.left - containerRect.left + rect.width / 2,
-    })
-  }, [])
-
-  const handlePickerHoverEnd = useCallback(() => { setPickerTooltip(null) }, [])
 
   // --- Input modes (matrix tester + typing test) ---
   const {
@@ -204,20 +118,6 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   const { config: appCfg } = useAppConfig()
   const history = useKeymapHistory(appCfg.maxKeymapHistory)
 
-  // --- View Matrix mode ---
-  const viewMatrixMode = useViewMatrixMode()
-
-  // Clear history and exit View Matrix mode on keyboard/context switch or disconnect
-  const prevUidRef = useRef(keyboardUid)
-  const keymapSize = keymap.size
-  useEffect(() => {
-    if (keyboardUid !== prevUidRef.current || keymapSize === 0) {
-      prevUidRef.current = keyboardUid
-      history.clear()
-      viewMatrixMode.exit()
-    }
-  }, [keyboardUid, keymapSize, history.clear, viewMatrixMode.exit])
-
   // --- Selection + handlers ---
   const {
     selectedKey, selectedEncoder, selectedMaskPart, popoverState, setPopoverState,
@@ -241,131 +141,27 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   hasActiveSingleSelectionRef.current = !!(selectedKey || selectedEncoder)
   const { multiSelectedKeys, pickerSelectedIndices, handlePickerMultiSelect } = multiSelect
 
-  // --- View Matrix mode: entry/exit + per-key gating ---
-  // Entering the mode forces the matrix (Key Tester) tool off and clears
-  // any lingering selection so the blank R/C legend view starts clean.
-  const handleToggleViewMatrixMode = useCallback(() => {
-    if (!viewMatrixMode.active) {
-      if (matrixMode) handleMatrixToggle()
-      handleDeselect()
-    }
-    viewMatrixMode.toggle()
-    // Depend on the stable members, not the wrapper object (a fresh
-    // literal every render) — the object identity would churn this
-    // callback per render.
-  }, [viewMatrixMode.active, viewMatrixMode.toggle, matrixMode, handleMatrixToggle, handleDeselect])
+  // --- View Matrix mode ---
+  const {
+    viewMatrixMode, handleToggleViewMatrixMode, handleViewMatrixKeyClick,
+    viewMatrixSelectedPositions, viewMatrixEffectiveSingle, handleViewMatrixAxisChange,
+    viewMatrixAxisOptionCount, viewMatrixLabelOverrides, viewMatrixDuplicateKeyColors,
+    gatedHandleKeycodeSelect,
+  } = useViewMatrixEditing({
+    layout, viewMatrix, onViewMatrixChange, rows, cols, selectableKeys,
+    matrixMode, handleMatrixToggle, handleDeselect, handleKeycodeSelect,
+  })
 
-  // Clicking a key in the mode selects it for the panel's Row/Col selects
-  // — encoders and decals have no physical row/col to override, so they
-  // stay inert (unaffected) rather than gaining a click handler. Ctrl/Cmd
-  // toggles the key in/out of a multi-selection, Shift extends a
-  // contiguous range (mirrors the normal-mode keymap multi-select's
-  // modifier conventions — see `useKeymapMultiSelect`).
-  const handleViewMatrixKeyClick = useCallback((
-    key: import('../../../shared/kle/types').KleKey,
-    _maskClicked: boolean,
-    event?: { ctrlKey: boolean; shiftKey: boolean },
-  ) => {
-    if (key.decal || key.encoderIdx >= 0) return
-    if (event?.ctrlKey) { viewMatrixMode.toggleKeySelection(key.row, key.col); return }
-    if (event?.shiftKey) { viewMatrixMode.extendSelection(key.row, key.col, selectableKeys); return }
-    viewMatrixMode.selectKey(key.row, key.col)
-    // The hook's setters are useCallback-stable; depending on the wrapper
-    // object would defeat KeyboardWidget's memo on every render while the
-    // mode is active (80+ KeyWidget re-renders).
-  }, [viewMatrixMode.toggleKeySelection, viewMatrixMode.extendSelection, viewMatrixMode.selectKey, selectableKeys])
-
-  // Physical positions of the currently selected keys, parsed from the
-  // hook's "row,col" string set into the shape `applyViewMatrixAxisToSelection`
-  // expects.
-  const viewMatrixSelectedPositions = useMemo(() => [...viewMatrixMode.selectedKeys].map((pos) => {
-    const [row, col] = pos.split(',').map(Number)
-    return { row, col }
-  }), [viewMatrixMode.selectedKeys])
-
-  // Effective position of the single selected key — null with 0 or 2+ keys
-  // selected, where the panel's selects show a blank placeholder instead
-  // since a multi-selection's members may not share the same position.
-  const viewMatrixEffectiveSingle = useMemo(() => {
-    if (viewMatrixSelectedPositions.length !== 1) return null
-    const { row, col } = viewMatrixSelectedPositions[0]
-    return effectiveViewPos(viewMatrix, row, col)
-  }, [viewMatrixSelectedPositions, viewMatrix])
-
-  // Row/Col select handler — a single selected key writes just that key's
-  // override; 2+ selected keys bulk-apply the axis across the whole
-  // selection in one `onViewMatrixChange` write, each key keeping its own
-  // value on the other axis (see `applyViewMatrixAxisToSelection`).
-  const handleViewMatrixAxisChange = useCallback((axis: 'row' | 'col', value: number) => {
-    if (viewMatrixSelectedPositions.length === 0) return
-    onViewMatrixChange?.(applyViewMatrixAxisToSelection(viewMatrix, viewMatrixSelectedPositions, axis, value))
-  }, [viewMatrixSelectedPositions, viewMatrix, onViewMatrixChange])
-
-  // View positions are logical, not physical — they only need to sort keys
-  // into a 2D grid, not mirror the firmware's electrical matrix. Direct-pin
-  // keyboards declare degenerate physical matrices (1×N or N×1, one row/col
-  // per GPIO pin with no real electrical grid), so capping each select to
-  // its own physical dimension would collapse one axis to a single option
-  // and make 2D view ordering impossible. Both selects therefore share the
-  // same option count: the larger of the two physical dimensions.
-  const viewMatrixAxisOptionCount = Math.max(rows ?? 0, cols ?? 0)
-
-  // One pass over the layout builds both mode legend artifacts — they
-  // share the same inputs and always recompute together: the per-key R/C
-  // label override showing each non-decal, non-encoder key's effective
-  // position, and the fill colour map that flags keys whose effective
-  // position collides with another key's (the Auto Move order between
-  // colliding keys is ambiguous until resolved). The collision grouping
-  // happens in this same loop (rather than a second pass over the keys)
-  // so `effectiveViewPos` is computed once per key.
-  const { viewMatrixLabelOverrides, viewMatrixDuplicateKeyColors } = useMemo(() => {
-    if (!viewMatrixMode.active || !layout) {
-      return { viewMatrixLabelOverrides: undefined, viewMatrixDuplicateKeyColors: undefined }
-    }
-    const overrides = new Map<string, { outer: string; inner: string; masked: boolean }>()
-    // Effective position -> physical "row,col" keys resolving to it, used
-    // below to find every key involved in a collision (group size > 1).
-    const groups = new Map<string, string[]>()
-    for (const key of layout.keys) {
-      if (key.decal || key.encoderIdx >= 0) continue
-      const physPos = posKey(key.row, key.col)
-      const effective = effectiveViewPos(viewMatrix, key.row, key.col)
-      overrides.set(physPos, { outer: `R ${effective.row}\nC ${effective.col}`, inner: '', masked: false })
-      const effPos = posKey(effective.row, effective.col)
-      const group = groups.get(effPos)
-      if (group) group.push(physPos)
-      else groups.set(effPos, [physPos])
-    }
-    const duplicateKeyColors = new Map<string, string>()
-    for (const group of groups.values()) {
-      if (group.length <= 1) continue
-      for (const physPos of group) duplicateKeyColors.set(physPos, KEY_DUPLICATE_COLOR)
-    }
-    return {
-      viewMatrixLabelOverrides: overrides,
-      viewMatrixDuplicateKeyColors: duplicateKeyColors.size > 0 ? duplicateKeyColors : undefined,
-    }
-  }, [viewMatrixMode.active, layout, viewMatrix])
-
-  // Keycode palette selection is a no-op while in the mode — nothing is
-  // ever selected (selectedKey/selectedEncoder stay null), so this mostly
-  // guards TD/Macro tile clicks, which otherwise still open their modals.
-  const noopKeycodeSelect = useCallback(() => {}, [])
-  const gatedHandleKeycodeSelect = viewMatrixMode.active ? noopKeycodeSelect : handleKeycodeSelect
-
-  // --- Notify parent when device list browsing state changes ---
+  // Clear history and exit View Matrix mode on keyboard/context switch or disconnect
+  const prevUidRef = useRef(keyboardUid)
+  const keymapSize = keymap.size
   useEffect(() => {
-    onDeviceListActiveChange?.(pickerSource === 'device' && deviceBrowsing)
-  }, [pickerSource, deviceBrowsing, onDeviceListActiveChange])
-
-  // Save picker zoom back to target keyboard's settings
-  useEffect(() => {
-    const uid = pickerFileData?.uid
-    if (pickerScale == null || !uid) return
-    // PATCH only keymapScale so this can't clobber other fields on the
-    // target keyboard's settings.
-    window.vialAPI.pipetteSettingsPatch(uid, { keymapScale: pickerScale }).catch(() => {})
-  }, [pickerScale, pickerFileData?.uid])
+    if (keyboardUid !== prevUidRef.current || keymapSize === 0) {
+      prevUidRef.current = keyboardUid
+      history.clear()
+      viewMatrixMode.exit()
+    }
+  }, [keyboardUid, keymapSize, history.clear, viewMatrixMode.exit])
 
   // Surface the editor test's run state so the host can disable the
   // StatusBar "View Analytics" button mid-run (it lives in the footer, not
@@ -382,405 +178,69 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [pickerSelectedIndices.size, multiSelect])
 
-  // --- Layout picker: stored keyboards browsing ---
-  useEffect(() => {
-    if (pickerSource !== 'file') return
-    window.vialAPI.listStoredKeyboards().then(setStoredKeyboards).catch(() => {})
-  }, [pickerSource])
-
-  useEffect(() => {
-    if (!selectedFileUid) { setStoredEntries([]); return }
-    window.vialAPI.snapshotStoreList(selectedFileUid).then((r) => {
-      if (r.success && r.entries) setStoredEntries(r.entries.filter((e) => !e.deletedAt && e.vilVersion !== 1))
-    }).catch(() => {})
-  }, [selectedFileUid])
-
-  // --- Layout picker file loading ---
-  const loadPickerFromJson = useCallback((jsonStr: string) => {
-    try {
-      const parsed = JSON.parse(jsonStr)
-      if (!isVilFile(parsed)) {
-        setPickerLoadError(t('error.loadFailed'))
-        return false
-      }
-      if (isVilFileV1(parsed) || !parsed.definition) {
-        setPickerLoadError(t('error.vilV1NotSupported'))
-        return false
-      }
-      const fileLayout = parseKle(parsed.definition.layouts.keymap)
-      const fileKeymap = recordToMap(parsed.keymap)
-      const fileLayers = deriveLayerCount(parsed.keymap)
-      const remap = remapLabel ?? ((id: string) => id)
-      const encoderKeycodes = new Map<string, [string, string]>()
-      if (parsed.encoderLayout) {
-        const encMap = recordToMap(parsed.encoderLayout)
-        const encCount = new Set([...encMap.keys()].map((k) => k.split(',')[1])).size
-        for (let i = 0; i < encCount; i++) {
-          for (let layer = 0; layer < fileLayers; layer++) {
-            const cw = encMap.get(`${layer},${i},0`) ?? 0
-            const ccw = encMap.get(`${layer},${i},1`) ?? 0
-            encoderKeycodes.set(`${layer},${i}`, [remap(serialize(cw)), remap(serialize(ccw))])
-          }
-        }
-      }
-      const fileUid = typeof parsed.uid === 'string' ? parsed.uid : undefined
-      setPickerFileData({
-        layout: fileLayout, keymap: fileKeymap, layers: fileLayers, encoderKeycodes,
-        layoutOptions: parsed.definition.layouts?.labels
-          ? decodeLayoutOptions(parsed.layoutOptions ?? 0, parsed.definition.layouts.labels) : new Map(),
-        name: parsed.definition.name ?? 'File', layerNames: parsed.layerNames, uid: fileUid,
-      })
-      if (fileUid) {
-        window.vialAPI.pipetteSettingsGet(fileUid).then((prefs) => {
-          if (prefs?.keymapScale != null) setPickerScale(prefs.keymapScale)
-        }).catch(() => {})
-      } else {
-        setPickerScale(undefined)
-      }
-      setPickerLayer(0)
-      setFileBrowseView('list')
-      return true
-    } catch {
-      setPickerLoadError(t('error.loadFailed'))
-      return false
-    }
-  }, [remapLabel, t])
-
-  const handleLoadPickerFile = useCallback(async () => {
-    setPickerLoadError(null)
-    const result = await window.vialAPI.loadLayout(t('editor.keymap.pickerLoadFile'), ['.pipette', '.vil'])
-    if (!result.success || !result.data) {
-      if (result.error !== 'cancelled') setPickerLoadError(t('error.loadFailed'))
-      return
-    }
-    loadPickerFromJson(result.data)
-  }, [t, loadPickerFromJson])
-
-  const handleLoadSnapshotEntry = useCallback(async (uid: string, entryId: string) => {
-    setPickerLoadError(null)
-    const result = await window.vialAPI.snapshotStoreLoad(uid, entryId)
-    if (!result.success || !result.data) {
-      setPickerLoadError(t('error.loadFailed'))
-      return
-    }
-    loadPickerFromJson(result.data)
-  }, [t, loadPickerFromJson])
-
-  // --- Device probe handler ---
-  const handleProbeDevice = useCallback(async (vendorId: number, productId: number, serialNumber: string) => {
-    setProbeStatus('probing')
-    try {
-      const result = await window.vialAPI.probeDevice(vendorId, productId, serialNumber)
-      const fileLayout = parseKle(result.definition.layouts.keymap)
-      const fileKeymap = new Map<string, number>(Object.entries(result.keymap))
-      const remap = remapLabel ?? ((id: string) => id)
-      const encoderKeycodes = new Map<string, [string, string]>()
-      const encMap = new Map<string, number>(Object.entries(result.encoderLayout))
-      for (let i = 0; i < result.encoderCount; i++) {
-        for (let layer = 0; layer < result.layers; layer++) {
-          const cw = encMap.get(`${layer},${i},0`) ?? 0
-          const ccw = encMap.get(`${layer},${i},1`) ?? 0
-          encoderKeycodes.set(`${layer},${i}`, [remap(serialize(cw)), remap(serialize(ccw))])
-        }
-      }
-      let probeKeymapScale: number | undefined
-      if (result.uid) {
-        try {
-          const prefs = await window.vialAPI.pipetteSettingsGet(result.uid)
-          if (prefs?.keymapScale != null) probeKeymapScale = prefs.keymapScale
-        } catch { /* best-effort */ }
-      }
-      setPickerScale(probeKeymapScale)
-      setPickerFileData({
-        layout: fileLayout, keymap: fileKeymap, layers: result.layers, encoderKeycodes,
-        layoutOptions: result.definition.layouts?.labels
-          ? decodeLayoutOptions(result.layoutOptions, result.definition.layouts.labels) : new Map(),
-        name: result.name, uid: result.uid,
-      })
-      setPickerLayer(0)
-      setProbeStatus('idle')
-    } catch {
-      setProbeStatus('error')
-    }
-  }, [remapLabel])
-
-  // --- Device list for probe picker (includes connected device) ---
-  const isConnectedDevice = useCallback((d: import('../../../shared/types/protocol').DeviceInfo) => {
-    return !!connectedDevice && d.vendorId === connectedDevice.vendorId && d.productId === connectedDevice.productId && d.serialNumber === connectedDevice.serialNumber
-  }, [connectedDevice])
-
-  const handleDeviceSelect = useCallback((d: import('../../../shared/types/protocol').DeviceInfo) => {
-    if (isConnectedDevice(d)) {
-      // Connected device → use existing keymap/layout (clear pickerFileData)
-      setPickerFileData(null)
-      setPickerScale(undefined)
-      setPickerLayer(0)
-      setDeviceBrowsing(false)
-    } else {
-      setDeviceBrowsing(false)
-      handleProbeDevice(d.vendorId, d.productId, d.serialNumber)
-    }
-  }, [isConnectedDevice, handleProbeDevice])
-
-  // --- QMK settings modals ---
-  const [showSettings, setShowSettings] = useState<Record<string, boolean>>({})
-  const openSettings = useCallback((key: string) => setShowSettings((prev) => ({ ...prev, [key]: true })), [])
-  const closeSettings = useCallback((key: string) => setShowSettings((prev) => ({ ...prev, [key]: false })), [])
-
-  // --- Tap Dance JSON editor ---
-  const [showTdJsonEditor, setShowTdJsonEditor] = useState(false)
-  const tdJsonGate = useUnlockGate({ unlocked, onUnlock })
-  const handleTdJsonApply = useCallback(
-    async (entries: TapDanceEntry[]) => {
-      if (!onSetTapDanceEntry || !tapDanceEntries) return
-      const allCodes = entries.flatMap((e) => [e.onTap, e.onHold, e.onDoubleTap, e.onTapHold])
-      await tdJsonGate.guard(allCodes, async () => {
-        for (let i = 0; i < entries.length; i++) {
-          const prev = tapDanceEntries[i]
-          const next = entries[i]
-          if (prev.onTap !== next.onTap || prev.onHold !== next.onHold ||
-              prev.onDoubleTap !== next.onDoubleTap || prev.onTapHold !== next.onTapHold ||
-              prev.tappingTerm !== next.tappingTerm) {
-            await onSetTapDanceEntry(i, next)
-          }
-        }
-      })
-    },
-    [onSetTapDanceEntry, tapDanceEntries, tdJsonGate],
-  )
-
-  // --- Combo JSON editor ---
-  const [showComboJsonEditor, setShowComboJsonEditor] = useState(false)
-  const comboJsonGate = useUnlockGate({ unlocked, onUnlock })
-  const handleComboJsonApply = useCallback(
-    async (entries: ComboEntry[]) => {
-      if (!onSetComboEntry || !comboEntries) return
-      const allCodes = entries.flatMap((e) => [e.key1, e.key2, e.key3, e.key4, e.output])
-      await comboJsonGate.guard(allCodes, async () => {
-        for (let i = 0; i < entries.length; i++) {
-          const prev = comboEntries[i]
-          const next = entries[i]
-          if (prev.key1 !== next.key1 || prev.key2 !== next.key2 || prev.key3 !== next.key3 ||
-              prev.key4 !== next.key4 || prev.output !== next.output) {
-            await onSetComboEntry(i, next)
-          }
-        }
-      })
-    },
-    [onSetComboEntry, comboEntries, comboJsonGate],
-  )
-
-  // --- Key Override JSON editor ---
-  const [showKoJsonEditor, setShowKoJsonEditor] = useState(false)
-  const koJsonGate = useUnlockGate({ unlocked, onUnlock })
-  const handleKoJsonApply = useCallback(
-    async (entries: KeyOverrideEntry[]) => {
-      if (!onSetKeyOverrideEntry || !keyOverrideEntries) return
-      const allCodes = entries.flatMap((e) => [e.triggerKey, e.replacementKey])
-      await koJsonGate.guard(allCodes, async () => {
-        for (let i = 0; i < entries.length; i++) {
-          const prev = keyOverrideEntries[i]
-          const next = entries[i]
-          if (prev.triggerKey !== next.triggerKey || prev.replacementKey !== next.replacementKey ||
-              prev.layers !== next.layers || prev.triggerMods !== next.triggerMods ||
-              prev.negativeMods !== next.negativeMods || prev.suppressedMods !== next.suppressedMods ||
-              prev.options !== next.options || prev.enabled !== next.enabled) {
-            await onSetKeyOverrideEntry(i, next)
-          }
-        }
-      })
-    },
-    [onSetKeyOverrideEntry, keyOverrideEntries, koJsonGate],
-  )
-
-  // --- Alt Repeat Key JSON editor ---
-  const [showArkJsonEditor, setShowArkJsonEditor] = useState(false)
-  const arkJsonGate = useUnlockGate({ unlocked, onUnlock })
-  const handleArkJsonApply = useCallback(
-    async (entries: AltRepeatKeyEntry[]) => {
-      if (!onSetAltRepeatKeyEntry || !altRepeatKeyEntries) return
-      const allCodes = entries.flatMap((e) => [e.lastKey, e.altKey])
-      await arkJsonGate.guard(allCodes, async () => {
-        for (let i = 0; i < entries.length; i++) {
-          const prev = altRepeatKeyEntries[i]
-          const next = entries[i]
-          if (prev.lastKey !== next.lastKey || prev.altKey !== next.altKey ||
-              prev.allowedMods !== next.allowedMods || prev.options !== next.options ||
-              prev.enabled !== next.enabled) {
-            await onSetAltRepeatKeyEntry(i, next)
-          }
-        }
-      })
-    },
-    [onSetAltRepeatKeyEntry, altRepeatKeyEntries, arkJsonGate],
-  )
-
-  // --- Macro JSON editor ---
-  const [showMacroJsonEditor, setShowMacroJsonEditor] = useState(false)
-  const macroJsonGate = useUnlockGate({ unlocked, onUnlock })
-  const handleMacroJsonApply = useCallback(
-    async (macros: MacroAction[][]) => {
-      if (!onSaveMacros || !macroBufferSize) return
-      await macroJsonGate.guardAll(async () => {
-        const buffer = serializeAllMacros(macros, vialProtocol ?? 0)
-        if (buffer.length > macroBufferSize) {
-          throw new Error(t('editor.macro.memoryUsage', { used: buffer.length, total: macroBufferSize }))
-        }
-        await onSaveMacros(buffer, macros)
-      })
-    },
-    [onSaveMacros, macroBufferSize, vialProtocol, t, macroJsonGate],
-  )
-
-  const visibleModals = useMemo(() => ({
-    tapHold: !!showSettings.tapHold && !!tapHoldSupported,
-    mouseKeys: !!showSettings.mouseKeys && !!mouseKeysSupported,
-    magic: !!showSettings.magic && !!magicSupported,
-    graveEscape: !!showSettings.graveEscape && !!graveEscapeSupported,
-    autoShift: !!showSettings.autoShift && !!autoShiftSupported,
-    oneShotKeys: !!showSettings.oneShotKeys && !!oneShotKeysSupported,
-    combo: !!showSettings.combo && !!comboSettingsSupported,
-  }), [showSettings, tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported, autoShiftSupported, oneShotKeysSupported, comboSettingsSupported])
+  // --- QMK settings modals + Tap Dance / Combo / Key Override / Alt Repeat
+  // Key / Macro "Edit JSON" modals ---
+  const {
+    openSettings, closeSettings, visibleModals,
+    tdJson, comboJson, koJson, arkJson, macroJson,
+  } = useKeymapJsonEditors({
+    unlocked, onUnlock,
+    tapDanceEntries, onSetTapDanceEntry,
+    comboEntries, onSetComboEntry,
+    keyOverrideEntries, onSetKeyOverrideEntry,
+    altRepeatKeyEntries, onSetAltRepeatKeyEntry,
+    onSaveMacros, macroBufferSize, vialProtocol,
+    tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported,
+    autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
+  })
 
   // --- Layer panel ---
   const layerPanelCollapsed = layerPanelOpenProp === false
   const toggleLayerPanel = useCallback(() => { onLayerPanelOpenChange?.(!layerPanelOpenProp) }, [onLayerPanelOpenChange, layerPanelOpenProp])
-
-  // --- Macros ---
-  const deserializedMacros = useMemo(
-    () => parsedMacros ?? (macroBuffer && macroCount ? deserializeAllMacros(macroBuffer, vialProtocol ?? 0, macroCount) : undefined),
-    [parsedMacros, macroBuffer, macroCount, vialProtocol],
-  )
-
-  const configuredKeycodes = useMemo(() => {
-    const set = new Set<string>()
-    if (tapDanceEntries) {
-      for (let i = 0; i < tapDanceEntries.length; i++) {
-        const e = tapDanceEntries[i]
-        if (e.onTap || e.onHold || e.onDoubleTap || e.onTapHold) set.add(`TD(${i})`)
-      }
-    }
-    if (deserializedMacros) {
-      for (let i = 0; i < deserializedMacros.length; i++) {
-        if (deserializedMacros[i].length > 0) set.add(`M${i}`)
-      }
-    }
-    return set.size > 0 ? set : undefined
-  }, [tapDanceEntries, deserializedMacros])
-
-  const remap = remapLabel ?? ((id: string) => id)
 
   useImperativeHandle(ref, () => ({
     toggleMatrix: handleMatrixToggle, toggleTypingTest: handleTypingTestToggle,
     matrixMode, hasMatrixTester,
   }), [handleMatrixToggle, handleTypingTestToggle, matrixMode, hasMatrixTester])
 
-  // --- Build keycodes for layers ---
-  const buildKeycodesForLayer = useCallback((layer: number) => {
-    const keycodes = new Map<string, string>()
-    const remapped = new Set<string>()
-    const checkRemapped = isRemapped ?? (() => false)
-    for (const [key, code] of keymap) {
-      const [l, r, c] = key.split(',')
-      if (Number(l) === layer) {
-        const pos = posKey(Number(r), Number(c))
-        const qmkId = serialize(code)
-        keycodes.set(pos, remap(qmkId))
-        if (!isMask(qmkId) && checkRemapped(qmkId)) remapped.add(pos)
-      }
-    }
-    return { keycodes, remapped }
-  }, [keymap, remap, isRemapped])
+  // --- Layer keycode builders (current layer / typing test / picker) ---
+  const {
+    deserializedMacros, configuredKeycodes,
+    buildKeycodesForLayer, buildEncoderKeycodesForLayer,
+    layerKeycodes, remappedKeys, layerEncoderKeycodes,
+    typingTestKeycodes, typingTestRemapped, typingTestEncoderKeycodes,
+  } = useLayerKeycodes({
+    parsedMacros, macroBuffer, macroCount, vialProtocol, tapDanceEntries,
+    remapLabel, isRemapped, keymap, encoderLayout, encoderCount, currentLayer,
+    typingTestMode, typingTestEffectiveLayer: typingTest.effectiveLayer,
+  })
 
-  const buildEncoderKeycodesForLayer = useCallback((layer: number) => {
-    const map = new Map<string, [string, string]>()
-    for (let i = 0; i < encoderCount; i++) {
-      const cw = encoderLayout.get(`${layer},${i},0`) ?? 0
-      const ccw = encoderLayout.get(`${layer},${i},1`) ?? 0
-      map.set(String(i), [remap(serialize(cw)), remap(serialize(ccw))])
-    }
-    return map
-  }, [encoderLayout, encoderCount, remap])
-
-  const { keycodes: layerKeycodes, remapped: remappedKeys } = useMemo(() => buildKeycodesForLayer(currentLayer), [buildKeycodesForLayer, currentLayer])
-  const layerEncoderKeycodes = useMemo(() => buildEncoderKeycodesForLayer(currentLayer), [buildEncoderKeycodesForLayer, currentLayer])
-
-
-  const { keycodes: typingTestKeycodes, remapped: typingTestRemapped } = useMemo(
-    () => typingTestMode ? buildKeycodesForLayer(typingTest.effectiveLayer) : { keycodes: EMPTY_KEYCODES, remapped: EMPTY_REMAPPED },
-    [buildKeycodesForLayer, typingTest.effectiveLayer, typingTestMode])
-  const typingTestEncoderKeycodes = useMemo(
-    () => typingTestMode ? buildEncoderKeycodesForLayer(typingTest.effectiveLayer) : EMPTY_ENCODER_KEYCODES,
-    [buildEncoderKeycodesForLayer, typingTest.effectiveLayer, typingTestMode])
-
-  // --- Layout picker keycodes ---
-  const { keycodes: pickerKeycodes, remapped: pickerRemapped } = useMemo(
-    () => buildKeycodesForLayer(pickerLayer), [buildKeycodesForLayer, pickerLayer])
-  const pickerEncoderKeycodes = useMemo(
-    () => buildEncoderKeycodesForLayer(pickerLayer), [buildEncoderKeycodesForLayer, pickerLayer])
-
-  // Build ordered keycode numbers for picker multi-select (Shift+click range)
-  const pickerTabKeycodeNumbers = useMemo(() => {
-    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
-    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-    const numbers: number[] = []
-    for (const key of keys) {
-      if (key.row == null || key.col == null) continue
-      const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
-      if (code != null) numbers.push(code)
-    }
-    return numbers
-  }, [pickerFileData, keymap, pickerLayer, layout])
-
-  const handlePickerKeyClick = useCallback((key: import('../../../shared/kle/types').KleKey, _maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => {
-    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
-    const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
-    if (code == null) return
-    // Always assign the full composite keycode (e.g. LT1(KC_SPC) as-is)
-    const qmkId = serialize(code)
-    const kc = findKeycode(qmkId) ?? { qmkId, label: qmkId, keycode: code }
-    const isModified = event && (event.ctrlKey || event.shiftKey)
-    if (isModified && handlePickerMultiSelect) {
-      // Find the index of this key in the picker's ordered list
-      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-      let index = 0
-      for (const k of keys) {
-        if (k.row == null || k.col == null) continue
-        if (k.row === key.row && k.col === key.col) break
-        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
-      }
-      handlePickerMultiSelect(index, code, { ctrlKey: !!event.ctrlKey, shiftKey: !!event.shiftKey }, pickerTabKeycodeNumbers)
-    } else if (handlePickerMultiSelect && !selectedKey && !selectedEncoder) {
-      // Normal click (no key selected): select single key and set anchor
-      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-      let index = 0
-      for (const k of keys) {
-        if (k.row == null || k.col == null) continue
-        if (k.row === key.row && k.col === key.col) break
-        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
-      }
-      handlePickerMultiSelect(index, code, { ctrlKey: false, shiftKey: false }, pickerTabKeycodeNumbers)
-    } else {
-      handleKeycodeSelect(kc)
-    }
-  }, [keymap, pickerLayer, pickerFileData, layout, handleKeycodeSelect, handlePickerMultiSelect, pickerTabKeycodeNumbers])
+  // --- Layout picker (device browse / file browse / probe / keyboard view) ---
+  const { layoutPickerContent } = useLayoutPicker({
+    layout, layers, layerNames, keymap, effectiveLayoutOptions, remapLabel,
+    scale: scaleProp, onScaleChange,
+    devices, connectedDevice, onDeviceListActiveChange,
+    selectedKey, selectedEncoder, handleKeycodeSelect, handlePickerMultiSelect,
+    pickerSelectedIndices, clearPickerSelection: multiSelect.clearPickerSelection,
+    buildKeycodesForLayer, buildEncoderKeycodesForLayer,
+  })
 
   // --- Tab footer ---
   const tabFooterContent = useMemo(() => {
     const btnClass = 'rounded border border-edge px-3 py-1 text-xs text-content-secondary hover:text-content hover:bg-surface-dim'
     const buttonDefs = [
-      { tab: 'tapDance', key: 'tdJsonEditor', label: t('editor.tapDance.editJson'), onClick: () => setShowTdJsonEditor(true), testId: 'tap-dance-json-editor-btn', enabled: !!tapDanceEntries && tapDanceEntries.length > 0 },
+      { tab: 'tapDance', key: 'tdJsonEditor', label: t('editor.tapDance.editJson'), onClick: tdJson.open, testId: 'tap-dance-json-editor-btn', enabled: !!tapDanceEntries && tapDanceEntries.length > 0 },
       { tab: 'tapDance', key: 'tapHold', label: t('editor.keymap.tapHoldLabel'), onClick: () => openSettings('tapHold'), testId: 'tap-hold-settings-btn', enabled: tapHoldSupported },
       { tab: 'system', key: 'mouseKeys', label: t('editor.keymap.mouseKeysLabel'), onClick: () => openSettings('mouseKeys'), testId: 'mouse-keys-settings-btn', enabled: mouseKeysSupported },
       { tab: 'modifiers', key: 'graveEscape', label: t('editor.keymap.graveEscapeLabel'), onClick: () => openSettings('graveEscape'), testId: 'grave-escape-settings-btn', enabled: graveEscapeSupported },
       { tab: 'modifiers', key: 'oneShotKeys', label: t('editor.keymap.oneShotKeysLabel'), onClick: () => openSettings('oneShotKeys'), testId: 'one-shot-keys-settings-btn', enabled: oneShotKeysSupported },
       { tab: 'behavior', key: 'magic', label: t('editor.keymap.magicLabel'), onClick: () => openSettings('magic'), testId: 'magic-settings-btn', enabled: magicSupported },
       { tab: 'behavior', key: 'autoshift', label: t('editor.keymap.autoShiftLabel'), onClick: () => openSettings('autoShift'), testId: 'auto-shift-settings-btn', enabled: autoShiftSupported },
-      { tab: 'macro', key: 'macroJsonEditor', label: t('editor.tapDance.editJson'), onClick: () => void macroJsonGate.guardAll(async () => setShowMacroJsonEditor(true)), testId: 'macro-json-editor-btn', enabled: !!deserializedMacros && deserializedMacros.length > 0 },
-      { tab: 'combo', key: 'comboJsonEditor', label: t('editor.tapDance.editJson'), onClick: () => setShowComboJsonEditor(true), testId: 'combo-json-editor-btn', enabled: !!comboEntries && comboEntries.length > 0 },
+      { tab: 'macro', key: 'macroJsonEditor', label: t('editor.tapDance.editJson'), onClick: macroJson.openGated, testId: 'macro-json-editor-btn', enabled: !!deserializedMacros && deserializedMacros.length > 0 },
+      { tab: 'combo', key: 'comboJsonEditor', label: t('editor.tapDance.editJson'), onClick: comboJson.open, testId: 'combo-json-editor-btn', enabled: !!comboEntries && comboEntries.length > 0 },
       { tab: 'combo', key: 'combo', label: t('common.configuration'), onClick: () => openSettings('combo'), testId: 'combo-settings-btn', enabled: comboSettingsSupported },
-      { tab: 'keyOverride', key: 'koJsonEditor', label: t('editor.tapDance.editJson'), onClick: () => setShowKoJsonEditor(true), testId: 'ko-json-editor-btn', enabled: !!keyOverrideEntries && keyOverrideEntries.length > 0 },
-      { tab: 'altRepeatKey', key: 'arkJsonEditor', label: t('editor.tapDance.editJson'), onClick: () => setShowArkJsonEditor(true), testId: 'ark-json-editor-btn', enabled: !!altRepeatKeyEntries && altRepeatKeyEntries.length > 0 },
+      { tab: 'keyOverride', key: 'koJsonEditor', label: t('editor.tapDance.editJson'), onClick: koJson.open, testId: 'ko-json-editor-btn', enabled: !!keyOverrideEntries && keyOverrideEntries.length > 0 },
+      { tab: 'altRepeatKey', key: 'arkJsonEditor', label: t('editor.tapDance.editJson'), onClick: arkJson.open, testId: 'ark-json-editor-btn', enabled: !!altRepeatKeyEntries && altRepeatKeyEntries.length > 0 },
       { tab: 'lighting', key: 'lighting', label: t('common.configuration'), onClick: onOpenLighting, testId: 'lighting-settings-btn', enabled: !!onOpenLighting },
     ]
     const content: Record<string, React.ReactNode> = {}
@@ -795,7 +255,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
       )
     }
     return content
-  }, [tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros, tapHoldSupported, mouseKeysSupported, magicSupported, autoShiftSupported, graveEscapeSupported, oneShotKeysSupported, comboSettingsSupported, onOpenLighting, t, openSettings])
+  }, [tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros, tapHoldSupported, mouseKeysSupported, magicSupported, autoShiftSupported, graveEscapeSupported, oneShotKeysSupported, comboSettingsSupported, onOpenLighting, t, openSettings, tdJson.open, comboJson.open, koJson.open, arkJson.open, macroJson.openGated])
 
   const tabContentOverride = useTileContentOverride({
     tapDanceEntries,
@@ -804,261 +264,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     settings: { comboEntries, onOpenCombo, keyOverrideEntries, onOpenKeyOverride, altRepeatKeyEntries, onOpenAltRepeatKey },
   })
 
-  // For file/device mode, build keycodes per-layer on the fly
-  const filePickerKeycodes = useMemo(() => {
-    if (!pickerFileData) return pickerKeycodes
-    const remap = remapLabel ?? ((id: string) => id)
-    const keycodes = new Map<string, string>()
-    for (const [key, code] of pickerFileData.keymap) {
-      const [l, r, c] = key.split(',')
-      if (Number(l) === pickerLayer) keycodes.set(posKey(Number(r), Number(c)), remap(serialize(code)))
-    }
-    return keycodes
-  }, [pickerFileData, pickerLayer, remapLabel, pickerKeycodes])
-
-  // Convert picker selected indices to position strings for keyboard widget highlight
-  const pickerHighlightPositions = useMemo(() => {
-    if (pickerSelectedIndices.size === 0) return undefined
-    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
-    const positions = new Set<string>()
-    let idx = 0
-    for (const key of keys) {
-      if (key.row == null || key.col == null) continue
-      if (!sourceKeymap.has(`${pickerLayer},${key.row},${key.col}`)) continue
-      if (pickerSelectedIndices.has(idx)) positions.add(`${key.row},${key.col}`)
-      idx++
-    }
-    return positions.size > 0 ? positions : undefined
-  }, [pickerSelectedIndices, pickerFileData, layout, keymap, pickerLayer])
-
   if (!layout) return <div className="p-4 text-content-muted">{t('common.loading')}</div>
 
   function layerLabel(layer: number): string {
     return layerNames?.[layer] || t('editor.keymap.layerN', { n: layer })
   }
-
-  // Layout picker: keyboard-as-keycode-picker shown inside the picker panel
-  const pickerData = pickerFileData
-    ? { keys: pickerFileData.layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: pickerFileData.layoutOptions, totalLayers: pickerFileData.layers, names: pickerFileData.layerNames }
-    : { keys: layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: effectiveLayoutOptions, totalLayers: layers, names: layerNames }
-
-  const pickerEffectiveScale = pickerFileData ? (pickerScale ?? scaleProp) : scaleProp
-  const activPickerKeycodes = pickerFileData ? filePickerKeycodes : pickerKeycodes
-
-  const layerBtnClass = (active: boolean) =>
-    `min-w-7 max-w-20 shrink-0 truncate rounded-md border px-1.5 py-1 text-center text-xs font-semibold tabular-nums transition-colors ${
-      active ? 'border-accent bg-accent text-content-inverse' : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
-    }`
-  const sourceBtnClass = (active: boolean) =>
-    `rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-      active ? 'bg-surface-dim text-content' : 'text-content-muted hover:text-content hover:bg-surface-dim/50'
-    }`
-
-  const pickerBrowseMode = (pickerSource === 'device' && deviceBrowsing) || (pickerSource === 'file' && !pickerFileData)
-
-  // Ghost-style zoom button shared by the picker Keyboard tab and the
-  // View Matrix zoom row (kept identical so the two arrangements match).
-  const ghostZoomButtonClass = 'rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none'
-
-  const layoutPickerContent = (
-    <div className="flex min-h-0 flex-1 flex-col">
-      <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
-        {pickerSource === 'device' && deviceBrowsing ? (
-          /* --- Device browse view --- */
-          <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
-            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
-              <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerCurrentState')}</span>
-              {probeStatus === 'probing' ? (
-                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerProbing')}</p>
-              ) : probeStatus === 'error' ? (
-                <p className="py-4 text-center text-xs text-danger">{t('editor.keymap.pickerProbeError')}</p>
-              ) : devices?.length ? devices.map((d) => (
-                <button key={`${d.vendorId}:${d.productId}:${d.serialNumber}`} type="button"
-                  className={`flex items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim ${isConnectedDevice(d) ? 'border-accent/40 bg-accent/5' : 'border-edge'}`}
-                  onClick={() => handleDeviceSelect(d)}>
-                  <span className="font-medium text-content">{d.productName || `${d.vendorId.toString(16)}:${d.productId.toString(16)}`}</span>
-                  <span className="text-xs text-content-muted">›</span>
-                </button>
-              )) : (
-                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoDevices')}</p>
-              )}
-            </div>
-            <div className="mt-2 rounded-lg border border-dashed border-transparent px-3 py-2 text-center text-xs invisible">&#8203;</div>
-          </div>
-        ) : pickerSource === 'file' && !pickerFileData ? (
-          /* --- File browse view --- */
-          <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
-            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
-            {pickerLoadError && (
-              <div className="rounded-lg bg-danger/10 px-3 py-2 text-xs text-danger">
-                {pickerLoadError}
-              </div>
-            )}
-            {fileBrowseView === 'list' && (
-              <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerSavedFiles')}</span>
-            )}
-            {fileBrowseView === 'entries' && (
-              <button type="button" className="mb-2 self-start text-xs text-content-secondary hover:text-content"
-                onClick={() => { setFileBrowseView('list'); setSelectedFileUid(null); setPickerLoadError(null) }}>
-                ← {t('common.back')}
-              </button>
-            )}
-            {fileBrowseView === 'list' ? (
-              storedKeyboards.length > 0 ? storedKeyboards.map((kb) => (
-                <button key={kb.uid} type="button"
-                  className="flex items-center justify-between rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
-                  onClick={() => { setSelectedFileUid(kb.uid); setFileBrowseView('entries'); setPickerLoadError(null) }}>
-                  <span className="font-medium text-content">{kb.name}</span>
-                  <span className="text-xs text-content-muted">›</span>
-                </button>
-              )) : (
-                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoSavedFiles')}</p>
-              )
-            ) : (
-              storedEntries.length > 0 ? storedEntries.map((entry) => (
-                <button key={entry.id} type="button"
-                  className="flex flex-col rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
-                  onClick={() => handleLoadSnapshotEntry(selectedFileUid!, entry.id)}>
-                  <span className="font-medium text-content">{entry.label || entry.filename}</span>
-                  <span className="text-xs text-content-muted">{new Date(entry.savedAt).toLocaleString()}</span>
-                </button>
-              )) : (
-                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoEntries')}</p>
-              )
-            )}
-            </div>
-            <button type="button"
-              className="mt-2 rounded-lg border border-dashed border-edge px-3 py-2 text-center text-xs text-content-muted transition-colors hover:border-edge hover:bg-surface-dim hover:text-content"
-              onClick={handleLoadPickerFile}>
-              {t('editor.keymap.pickerLoadFile')}
-            </button>
-          </div>
-        ) : (
-          /* --- Keyboard view (current / loaded file / probed device) --- */
-          <div ref={pickerContainerRef} className="picker-hover-keys relative flex h-full min-h-0 items-center justify-center">
-            <KeyboardPane
-              paneId="secondary" isActive={true}              keys={pickerData.keys} keycodes={activPickerKeycodes} encoderKeycodes={pickerData.encoderKeycodes}
-              selectedKey={null} selectedEncoder={null} selectedMaskPart={false} selectedKeycode={null}
-              remappedKeys={pickerData.remapped} multiSelectedKeys={pickerHighlightPositions}
-              layoutOptions={pickerData.layoutOpts} scale={pickerEffectiveScale}
-              layerLabel={(pickerData.names?.[pickerLayer] || t('editor.keymap.layerN', { n: pickerLayer })) + (pickerFileData ? ` — ${pickerFileData.name}` : '')}
-              layerLabelTestId="picker-layer-label"
-              onKeyClick={handlePickerKeyClick}
-              onKeyHover={handlePickerHover}
-              onKeyHoverEnd={handlePickerHoverEnd}
-            />
-            {pickerTooltip && (
-              <div
-                className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
-                style={{ top: pickerTooltip.top - 4, left: pickerTooltip.left, transform: 'translate(-50%, -100%)' }}
-              >
-                <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">{pickerTooltip.keycode}</div>
-              </div>
-            )}
-          </div>
-        )}
-      </div>
-      <div className="flex shrink-0 items-center justify-between px-2 pb-1">
-        <div className="flex items-center gap-1">
-          <button type="button" className={sourceBtnClass(pickerSource === 'device')}
-            onClick={() => {
-              setPickerSource('device'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setDeviceBrowsing(true); setProbeStatus('idle'); setPickerLoadError(null)
-            }}>
-            {pickerSource === 'device' && !deviceBrowsing
-              ? t('editor.keymap.pickerBackToDevices')
-              : t('editor.keymap.pickerSourceDevice')}
-          </button>
-          <button type="button" className={sourceBtnClass(pickerSource === 'file')}
-            onClick={() => { setPickerSource('file'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setFileBrowseView('list'); setDeviceBrowsing(false); setPickerLoadError(null) }}>
-            {pickerSource === 'file' && pickerFileData ? t('editor.keymap.pickerBackToFiles') : t('editor.keymap.pickerSourceFile')}
-          </button>
-        </div>
-        <div className={`flex items-center gap-1 ${pickerBrowseMode ? 'invisible' : ''}`}>
-          <Tooltip content={t('editor.keymap.zoomOut')}>
-            <button type="button" aria-label={t('editor.keymap.zoomOut')}
-              className={ghostZoomButtonClass}
-              disabled={pickerEffectiveScale <= MIN_SCALE}
-              onClick={() => { if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, +(pickerEffectiveScale - 0.1).toFixed(1))); else onScaleChange?.(-0.1) }}>
-              <ZoomOut size={ICON_SM} aria-hidden="true" />
-            </button>
-          </Tooltip>
-          <ScaleInput scale={pickerEffectiveScale} onScaleChange={(delta) => {
-            if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, +(pickerEffectiveScale + delta).toFixed(1))))
-            else onScaleChange?.(delta)
-          }} />
-          <Tooltip content={t('editor.keymap.zoomIn')}>
-            <button type="button" aria-label={t('editor.keymap.zoomIn')}
-              className={ghostZoomButtonClass}
-              disabled={pickerEffectiveScale >= MAX_SCALE}
-              onClick={() => { if (pickerFileData) setPickerScale(Math.min(MAX_SCALE, +(pickerEffectiveScale + 0.1).toFixed(1))); else onScaleChange?.(0.1) }}>
-              <ZoomIn size={ICON_SM} aria-hidden="true" />
-            </button>
-          </Tooltip>
-        </div>
-        <div className={`flex min-w-0 items-center gap-1 overflow-x-auto ${pickerBrowseMode ? 'invisible' : ''}`}>
-          {Array.from({ length: pickerData.totalLayers }, (_, i) => {
-            const label = pickerData.names?.[i]?.trim()
-            return (
-              <Tooltip key={i} content={label} disabled={!label}>
-                <button type="button" className={layerBtnClass(pickerLayer === i)}
-                  onClick={() => { setPickerLayer(i); multiSelect.clearPickerSelection() }}>
-                  {label || i}
-                </button>
-              </Tooltip>
-            )
-          })}
-        </div>
-      </div>
-    </div>
-  )
-
-  const zoomButtonClass = `${toggleButtonClass(false)} disabled:opacity-30 disabled:pointer-events-none`
-
-  // Zoom controls are shared between two placements: the side toolbar in
-  // normal editing, and a row under the keymap pane while View Matrix mode
-  // is active (see the mode's layout below). Same elements/props/testids
-  // either way — only the wrapping layout differs.
-  const zoomControls = !typingTestMode && onScaleChange && (
-    <>
-      <Tooltip content={t('editor.keymap.zoomIn')} side="right">
-        <button type="button" data-testid="zoom-in-button" aria-label={t('editor.keymap.zoomIn')} className={zoomButtonClass} disabled={scaleProp >= MAX_SCALE} onClick={() => onScaleChange(0.1)}>
-          <ZoomIn size={ICON_MD} aria-hidden="true" />
-        </button>
-      </Tooltip>
-      <ScaleInput scale={scaleProp} onScaleChange={onScaleChange} />
-      <Tooltip content={t('editor.keymap.zoomOut')} side="right">
-        <button type="button" data-testid="zoom-out-button" aria-label={t('editor.keymap.zoomOut')} className={zoomButtonClass} disabled={scaleProp <= MIN_SCALE} onClick={() => onScaleChange(-0.1)}>
-          <ZoomOut size={ICON_MD} aria-hidden="true" />
-        </button>
-      </Tooltip>
-    </>
-  )
-
-  // Undo/redo act on keymap edits, which View Matrix mode disables for its
-  // duration — hide them while the mode is active rather than leave dead
-  // disabled buttons in the toolbar.
-  const toolbar = (
-    <div className="flex shrink-0 flex-col items-center gap-3 self-stretch" style={{ width: PANEL_COLLAPSED_WIDTH }}>
-      {!typingTestMode && !viewMatrixMode.active && (
-        <>
-          <Tooltip content={t('editor.keymap.undo')} side="right">
-            <button type="button" data-testid="undo-button" aria-label={t('editor.keymap.undo')} className={zoomButtonClass} disabled={!history.canUndo} onClick={() => void handleUndo()}>
-              <Undo2 size={ICON_MD} aria-hidden="true" />
-            </button>
-          </Tooltip>
-          <Tooltip content={t('editor.keymap.redo')} side="right">
-            <button type="button" data-testid="redo-button" aria-label={t('editor.keymap.redo')} className={zoomButtonClass} disabled={!history.canRedo} onClick={() => void handleRedo()}>
-              <Redo2 size={ICON_MD} aria-hidden="true" />
-            </button>
-          </Tooltip>
-        </>
-      )}
-      <div className="flex-1" />
-      {!viewMatrixMode.active && zoomControls}
-      <div className="flex-1" />
-    </div>
-  )
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${typingTestMode && typingTestViewOnly ? '' : 'gap-3'}`}>
@@ -1078,7 +288,14 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
             edits are disabled for the mode's duration) and zoom relocates
             to a row under the keymap pane (see below), so nothing would be
             left in the column. */}
-        {!typingTestMode && !viewMatrixMode.active && toolbar}
+        {!typingTestMode && !viewMatrixMode.active && (
+          <KeymapToolbar
+            typingTestMode={typingTestMode} viewMatrixActive={viewMatrixMode.active}
+            canUndo={history.canUndo} canRedo={history.canRedo}
+            onUndo={handleUndo} onRedo={handleRedo}
+            scale={scaleProp} onScaleChange={onScaleChange}
+          />
+        )}
         {/* View Matrix mode's left pane — replaces the layer selector slot
             that normally sits below, since this row is now the only one
             rendered (the keycode picker row is hidden for the mode's
@@ -1286,97 +503,25 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         </div>
       )}
 
-      {tdModalIndex !== null && tapDanceEntries && onSetTapDanceEntry && (
-        <TapDanceModal index={tdModalIndex} entry={tapDanceEntries[tdModalIndex]}
-          onSave={handleTdModalSave} onClose={handleTdModalClose} isDummy={isDummy}
-          tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
-          quickSelect={quickSelect} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
-          vialProtocol={vialProtocol ?? 0}
-          hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
-          hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
-          onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('tapDance', entryId) : undefined}
-          onUpdateOnHub={onFavUpdateOnHub ? (entryId) => onFavUpdateOnHub('tapDance', entryId) : undefined}
-          onRemoveFromHub={onFavRemoveFromHub ? (entryId) => onFavRemoveFromHub('tapDance', entryId) : undefined}
-          onRenameOnHub={onFavRenameOnHub} />
-      )}
-
-      {macroModalIndex !== null && macroBuffer && macroCount != null && onSaveMacros && (
-        <MacroModal index={macroModalIndex} macroCount={macroCount} macroBufferSize={macroBufferSize ?? 0}
-          macroBuffer={macroBuffer} vialProtocol={vialProtocol ?? 0} onSaveMacros={onSaveMacros}
-          parsedMacros={parsedMacros} onClose={handleMacroModalClose} unlocked={unlocked} onUnlock={onUnlock}
-          isDummy={isDummy} tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
-          quickSelect={quickSelect} autoAdvance={autoAdvance} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
-          layers={layers}
-          hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
-          hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
-          onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('macro', entryId) : undefined}
-          onUpdateOnHub={onFavUpdateOnHub ? (entryId) => onFavUpdateOnHub('macro', entryId) : undefined}
-          onRemoveFromHub={onFavRemoveFromHub ? (entryId) => onFavRemoveFromHub('macro', entryId) : undefined}
-          onRenameOnHub={onFavRenameOnHub} />
-      )}
-
-      {showTdJsonEditor && tapDanceEntries && tapDanceEntries.length > 0 && (
-        <TapDanceJsonEditor
-          entries={tapDanceEntries}
-          onApply={handleTdJsonApply}
-          onClose={() => setShowTdJsonEditor(false)}
-        />
-      )}
-
-      {showComboJsonEditor && comboEntries && comboEntries.length > 0 && (
-        <JsonEditorModal<ComboEntry[]>
-          title={t('editor.tapDance.editJson')}
-          initialText={comboToJson(comboEntries)}
-          parse={(text) => parseCombo(text, comboEntries.length, t)}
-          onApply={handleComboJsonApply}
-          onClose={() => setShowComboJsonEditor(false)}
-          testIdPrefix="combo-json-editor"
-          exportFileName="combo"
-        />
-      )}
-
-      {showKoJsonEditor && keyOverrideEntries && keyOverrideEntries.length > 0 && (
-        <JsonEditorModal<KeyOverrideEntry[]>
-          title={t('editor.tapDance.editJson')}
-          initialText={keyOverrideToJson(keyOverrideEntries)}
-          parse={(text) => parseKeyOverride(text, keyOverrideEntries.length, t)}
-          onApply={handleKoJsonApply}
-          onClose={() => setShowKoJsonEditor(false)}
-          testIdPrefix="ko-json-editor"
-          exportFileName="ko"
-        />
-      )}
-
-      {showArkJsonEditor && altRepeatKeyEntries && altRepeatKeyEntries.length > 0 && (
-        <JsonEditorModal<AltRepeatKeyEntry[]>
-          title={t('editor.tapDance.editJson')}
-          initialText={altRepeatKeyToJson(altRepeatKeyEntries)}
-          parse={(text) => parseAltRepeatKey(text, altRepeatKeyEntries.length, t)}
-          onApply={handleArkJsonApply}
-          onClose={() => setShowArkJsonEditor(false)}
-          testIdPrefix="ark-json-editor"
-          exportFileName="ark"
-        />
-      )}
-
-      {showMacroJsonEditor && deserializedMacros && deserializedMacros.length > 0 && (
-        <JsonEditorModal<MacroAction[][]>
-          title={t('editor.tapDance.editJson')}
-          initialText={macroToJson(deserializedMacros)}
-          parse={(text) => parseMacro(text, deserializedMacros.length, t)}
-          onApply={handleMacroJsonApply}
-          onClose={() => setShowMacroJsonEditor(false)}
-          testIdPrefix="macro-json-editor"
-          warning={t('editor.macro.unlockWarning')}
-          exportFileName="macro"
-        />
-      )}
-
-      {supportedQsids && qmkSettingsGet && qmkSettingsSet && qmkSettingsReset && (
-        <QmkSettingsModals supportedQsids={supportedQsids} qmkSettingsGet={qmkSettingsGet}
-          qmkSettingsSet={qmkSettingsSet} qmkSettingsReset={qmkSettingsReset}
-          onSettingsUpdate={onSettingsUpdate} visibleModals={visibleModals} onCloseModal={closeSettings} />
-      )}
+      <KeymapEditorModals
+        tdModalIndex={tdModalIndex} tapDanceEntries={tapDanceEntries} onSetTapDanceEntry={onSetTapDanceEntry}
+        handleTdModalSave={handleTdModalSave} handleTdModalClose={handleTdModalClose}
+        macroModalIndex={macroModalIndex} macroBuffer={macroBuffer} macroCount={macroCount}
+        macroBufferSize={macroBufferSize} vialProtocol={vialProtocol} onSaveMacros={onSaveMacros}
+        parsedMacros={parsedMacros} handleMacroModalClose={handleMacroModalClose}
+        unlocked={unlocked} onUnlock={onUnlock} autoAdvance={autoAdvance} layers={layers}
+        isDummy={isDummy} deserializedMacros={deserializedMacros} quickSelect={quickSelect}
+        splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+        favHubOrigin={favHubOrigin} favHubNeedsDisplayName={favHubNeedsDisplayName}
+        favHubUploading={favHubUploading} favHubUploadResult={favHubUploadResult}
+        onFavUploadToHub={onFavUploadToHub} onFavUpdateOnHub={onFavUpdateOnHub}
+        onFavRemoveFromHub={onFavRemoveFromHub} onFavRenameOnHub={onFavRenameOnHub}
+        comboEntries={comboEntries} keyOverrideEntries={keyOverrideEntries} altRepeatKeyEntries={altRepeatKeyEntries}
+        tdJson={tdJson} comboJson={comboJson} koJson={koJson} arkJson={arkJson} macroJson={macroJson}
+        supportedQsids={supportedQsids} qmkSettingsGet={qmkSettingsGet} qmkSettingsSet={qmkSettingsSet}
+        qmkSettingsReset={qmkSettingsReset} onSettingsUpdate={onSettingsUpdate}
+        visibleModals={visibleModals} closeSettings={closeSettings}
+      />
 
     </div>
   )

--- a/src/renderer/components/editors/KeymapEditorModals.tsx
+++ b/src/renderer/components/editors/KeymapEditorModals.tsx
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// The keymap editor's overlay modal collection — Tap Dance / Macro edit
+// modals, the five "Edit JSON" editors, and the QMK settings modal group.
+// Pure props in, JSX out; each modal's own show/apply state lives in the
+// hooks that own it (`useKeymapSelectionHandlers`, `useKeymapJsonEditors`).
+
+import { useTranslation } from 'react-i18next'
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
+import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
+import type { MacroAction } from '../../../preload/macro'
+import { TapDanceModal } from './TapDanceModal'
+import { MacroModal } from './MacroModal'
+import { TapDanceJsonEditor } from './TapDanceJsonEditor'
+import { JsonEditorModal } from './JsonEditorModal'
+import { comboToJson, parseCombo, keyOverrideToJson, parseKeyOverride, altRepeatKeyToJson, parseAltRepeatKey, macroToJson, parseMacro } from './json-entry-serializers'
+import { QmkSettingsModals } from './QmkSettingsModal'
+import type { FavHubEntryResult } from './FavoriteHubActions'
+import type { EntryJsonEditor, MacroJsonEditor, VisibleQmkModals } from './useKeymapJsonEditors'
+
+export interface KeymapEditorModalsProps {
+  // --- Tap Dance modal ---
+  tdModalIndex: number | null
+  tapDanceEntries?: TapDanceEntry[]
+  onSetTapDanceEntry?: (index: number, entry: TapDanceEntry) => Promise<void>
+  handleTdModalSave: (index: number, entry: TapDanceEntry) => Promise<void>
+  handleTdModalClose: () => void
+
+  // --- Macro modal ---
+  macroModalIndex: number | null
+  macroBuffer?: number[]
+  macroCount?: number
+  macroBufferSize?: number
+  vialProtocol?: number
+  onSaveMacros?: (buffer: number[], parsedMacros?: MacroAction[][]) => Promise<void>
+  parsedMacros?: MacroAction[][] | null
+  handleMacroModalClose: () => void
+  unlocked?: boolean
+  onUnlock?: (options?: { macroWarning?: boolean }) => void
+  autoAdvance?: boolean
+  layers: number
+
+  // --- Shared by Tap Dance / Macro modals ---
+  isDummy?: boolean
+  deserializedMacros?: MacroAction[][]
+  quickSelect?: boolean
+  splitKeyMode?: SplitKeyMode
+  basicViewType?: BasicViewType
+  favHubOrigin?: string
+  favHubNeedsDisplayName?: boolean
+  favHubUploading?: string | null
+  favHubUploadResult?: FavHubEntryResult | null
+  onFavUploadToHub?: (type: string, entryId: string) => void
+  onFavUpdateOnHub?: (type: string, entryId: string) => void
+  onFavRemoveFromHub?: (type: string, entryId: string) => void
+  onFavRenameOnHub?: (entryId: string, hubPostId: string, newLabel: string) => void
+
+  // --- "Edit JSON" modals ---
+  comboEntries?: ComboEntry[]
+  keyOverrideEntries?: KeyOverrideEntry[]
+  altRepeatKeyEntries?: AltRepeatKeyEntry[]
+  tdJson: EntryJsonEditor<TapDanceEntry>
+  comboJson: EntryJsonEditor<ComboEntry>
+  koJson: EntryJsonEditor<KeyOverrideEntry>
+  arkJson: EntryJsonEditor<AltRepeatKeyEntry>
+  macroJson: MacroJsonEditor
+
+  // --- QMK settings modals ---
+  supportedQsids?: Set<number>
+  qmkSettingsGet?: (qsid: number) => Promise<number[]>
+  qmkSettingsSet?: (qsid: number, data: number[]) => Promise<void>
+  qmkSettingsReset?: () => Promise<void>
+  onSettingsUpdate?: (qsid: number, data: number[]) => void
+  visibleModals: VisibleQmkModals
+  closeSettings: (key: string) => void
+}
+
+export function KeymapEditorModals({
+  tdModalIndex, tapDanceEntries, onSetTapDanceEntry, handleTdModalSave, handleTdModalClose,
+  macroModalIndex, macroBuffer, macroCount, macroBufferSize, vialProtocol, onSaveMacros,
+  parsedMacros, handleMacroModalClose, unlocked, onUnlock, autoAdvance, layers,
+  isDummy, deserializedMacros, quickSelect, splitKeyMode, basicViewType,
+  favHubOrigin, favHubNeedsDisplayName, favHubUploading, favHubUploadResult,
+  onFavUploadToHub, onFavUpdateOnHub, onFavRemoveFromHub, onFavRenameOnHub,
+  comboEntries, keyOverrideEntries, altRepeatKeyEntries,
+  tdJson, comboJson, koJson, arkJson, macroJson,
+  supportedQsids, qmkSettingsGet, qmkSettingsSet, qmkSettingsReset, onSettingsUpdate, visibleModals, closeSettings,
+}: KeymapEditorModalsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {tdModalIndex !== null && tapDanceEntries && onSetTapDanceEntry && (
+        <TapDanceModal index={tdModalIndex} entry={tapDanceEntries[tdModalIndex]}
+          onSave={handleTdModalSave} onClose={handleTdModalClose} isDummy={isDummy}
+          tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
+          quickSelect={quickSelect} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+          vialProtocol={vialProtocol ?? 0}
+          hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
+          hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
+          onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('tapDance', entryId) : undefined}
+          onUpdateOnHub={onFavUpdateOnHub ? (entryId) => onFavUpdateOnHub('tapDance', entryId) : undefined}
+          onRemoveFromHub={onFavRemoveFromHub ? (entryId) => onFavRemoveFromHub('tapDance', entryId) : undefined}
+          onRenameOnHub={onFavRenameOnHub} />
+      )}
+
+      {macroModalIndex !== null && macroBuffer && macroCount != null && onSaveMacros && (
+        <MacroModal index={macroModalIndex} macroCount={macroCount} macroBufferSize={macroBufferSize ?? 0}
+          macroBuffer={macroBuffer} vialProtocol={vialProtocol ?? 0} onSaveMacros={onSaveMacros}
+          parsedMacros={parsedMacros} onClose={handleMacroModalClose} unlocked={unlocked} onUnlock={onUnlock}
+          isDummy={isDummy} tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
+          quickSelect={quickSelect} autoAdvance={autoAdvance} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
+          layers={layers}
+          hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
+          hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
+          onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('macro', entryId) : undefined}
+          onUpdateOnHub={onFavUpdateOnHub ? (entryId) => onFavUpdateOnHub('macro', entryId) : undefined}
+          onRemoveFromHub={onFavRemoveFromHub ? (entryId) => onFavRemoveFromHub('macro', entryId) : undefined}
+          onRenameOnHub={onFavRenameOnHub} />
+      )}
+
+      {tdJson.show && tapDanceEntries && tapDanceEntries.length > 0 && (
+        <TapDanceJsonEditor
+          entries={tapDanceEntries}
+          onApply={tdJson.apply}
+          onClose={tdJson.close}
+        />
+      )}
+
+      {comboJson.show && comboEntries && comboEntries.length > 0 && (
+        <JsonEditorModal<ComboEntry[]>
+          title={t('editor.tapDance.editJson')}
+          initialText={comboToJson(comboEntries)}
+          parse={(text) => parseCombo(text, comboEntries.length, t)}
+          onApply={comboJson.apply}
+          onClose={comboJson.close}
+          testIdPrefix="combo-json-editor"
+          exportFileName="combo"
+        />
+      )}
+
+      {koJson.show && keyOverrideEntries && keyOverrideEntries.length > 0 && (
+        <JsonEditorModal<KeyOverrideEntry[]>
+          title={t('editor.tapDance.editJson')}
+          initialText={keyOverrideToJson(keyOverrideEntries)}
+          parse={(text) => parseKeyOverride(text, keyOverrideEntries.length, t)}
+          onApply={koJson.apply}
+          onClose={koJson.close}
+          testIdPrefix="ko-json-editor"
+          exportFileName="ko"
+        />
+      )}
+
+      {arkJson.show && altRepeatKeyEntries && altRepeatKeyEntries.length > 0 && (
+        <JsonEditorModal<AltRepeatKeyEntry[]>
+          title={t('editor.tapDance.editJson')}
+          initialText={altRepeatKeyToJson(altRepeatKeyEntries)}
+          parse={(text) => parseAltRepeatKey(text, altRepeatKeyEntries.length, t)}
+          onApply={arkJson.apply}
+          onClose={arkJson.close}
+          testIdPrefix="ark-json-editor"
+          exportFileName="ark"
+        />
+      )}
+
+      {macroJson.show && deserializedMacros && deserializedMacros.length > 0 && (
+        <JsonEditorModal<MacroAction[][]>
+          title={t('editor.tapDance.editJson')}
+          initialText={macroToJson(deserializedMacros)}
+          parse={(text) => parseMacro(text, deserializedMacros.length, t)}
+          onApply={macroJson.apply}
+          onClose={macroJson.close}
+          testIdPrefix="macro-json-editor"
+          warning={t('editor.macro.unlockWarning')}
+          exportFileName="macro"
+        />
+      )}
+
+      {supportedQsids && qmkSettingsGet && qmkSettingsSet && qmkSettingsReset && (
+        <QmkSettingsModals supportedQsids={supportedQsids} qmkSettingsGet={qmkSettingsGet}
+          qmkSettingsSet={qmkSettingsSet} qmkSettingsReset={qmkSettingsReset}
+          onSettingsUpdate={onSettingsUpdate} visibleModals={visibleModals} onCloseModal={closeSettings} />
+      )}
+    </>
+  )
+}

--- a/src/renderer/components/editors/LayoutPickerContent.tsx
+++ b/src/renderer/components/editors/LayoutPickerContent.tsx
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Presentational body of the picker panel's "Keyboard" tab — device/file
+// browse views plus the keyboard-as-keycode-picker itself. Pure props in,
+// JSX out; all state and handlers live in `useLayoutPicker`.
+
+import type { KleKey } from '../../../shared/kle/types'
+import type { DeviceInfo } from '../../../shared/types/protocol'
+import type { StoredKeyboardInfo } from '../../../shared/types/sync'
+import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
+import { KeyboardPane } from './KeyboardPane'
+import { Tooltip } from '../ui/Tooltip'
+import { ScaleInput, ghostZoomButtonClass } from './keymap-editor-toolbar'
+import { MIN_SCALE, MAX_SCALE } from './keymap-editor-types'
+import { ZoomIn, ZoomOut } from 'lucide-react'
+import { ICON_SM } from '../../constants/ui-tokens'
+import type { PickerData, PickerFileData } from './keymap-editor-types'
+import { useTranslation } from 'react-i18next'
+
+const layerBtnClass = (active: boolean) =>
+  `min-w-7 max-w-20 shrink-0 truncate rounded-md border px-1.5 py-1 text-center text-xs font-semibold tabular-nums transition-colors ${
+    active ? 'border-accent bg-accent text-content-inverse' : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
+  }`
+const sourceBtnClass = (active: boolean) =>
+  `rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+    active ? 'bg-surface-dim text-content' : 'text-content-muted hover:text-content hover:bg-surface-dim/50'
+  }`
+
+export interface LayoutPickerContentProps {
+  pickerSource: 'file' | 'device'
+  deviceBrowsing: boolean
+  probeStatus: 'idle' | 'probing' | 'error'
+  devices?: DeviceInfo[]
+  isConnectedDevice: (d: DeviceInfo) => boolean
+  handleDeviceSelect: (d: DeviceInfo) => void
+  pickerLoadError: string | null
+  fileBrowseView: 'list' | 'entries'
+  setFileBrowseView: (view: 'list' | 'entries') => void
+  setSelectedFileUid: (uid: string | null) => void
+  setPickerLoadError: (error: string | null) => void
+  storedKeyboards: StoredKeyboardInfo[]
+  selectedFileUid: string | null
+  storedEntries: SnapshotMeta[]
+  handleLoadSnapshotEntry: (uid: string, entryId: string) => void
+  handleLoadPickerFile: () => void
+  pickerContainerRef: React.RefObject<HTMLDivElement | null>
+  pickerData: PickerData
+  activPickerKeycodes: Map<string, string>
+  pickerHighlightPositions: Set<string> | undefined
+  pickerEffectiveScale: number
+  pickerLayer: number
+  pickerFileData: PickerFileData
+  handlePickerKeyClick: (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
+  handlePickerHover: (key: KleKey, keycode: string, rect: DOMRect) => void
+  handlePickerHoverEnd: () => void
+  pickerTooltip: { keycode: string; top: number; left: number } | null
+  setPickerSource: (source: 'file' | 'device') => void
+  setPickerLayer: (layer: number) => void
+  setPickerFileData: (data: PickerFileData) => void
+  setPickerScale: (scale: number | undefined) => void
+  setDeviceBrowsing: (browsing: boolean) => void
+  setProbeStatus: (status: 'idle' | 'probing' | 'error') => void
+  pickerBrowseMode: boolean
+  onScaleChange?: (delta: number) => void
+  clearPickerSelection: () => void
+}
+
+export function LayoutPickerContent({
+  pickerSource, deviceBrowsing, probeStatus, devices, isConnectedDevice, handleDeviceSelect,
+  pickerLoadError, fileBrowseView, setFileBrowseView, setSelectedFileUid, setPickerLoadError,
+  storedKeyboards, selectedFileUid, storedEntries, handleLoadSnapshotEntry, handleLoadPickerFile,
+  pickerContainerRef, pickerData, activPickerKeycodes, pickerHighlightPositions, pickerEffectiveScale,
+  pickerLayer, pickerFileData, handlePickerKeyClick, handlePickerHover, handlePickerHoverEnd, pickerTooltip,
+  setPickerSource, setPickerLayer, setPickerFileData, setPickerScale, setDeviceBrowsing, setProbeStatus,
+  pickerBrowseMode, onScaleChange, clearPickerSelection,
+}: LayoutPickerContentProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
+        {pickerSource === 'device' && deviceBrowsing ? (
+          /* --- Device browse view --- */
+          <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
+            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
+              <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerCurrentState')}</span>
+              {probeStatus === 'probing' ? (
+                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerProbing')}</p>
+              ) : probeStatus === 'error' ? (
+                <p className="py-4 text-center text-xs text-danger">{t('editor.keymap.pickerProbeError')}</p>
+              ) : devices?.length ? devices.map((d) => (
+                <button key={`${d.vendorId}:${d.productId}:${d.serialNumber}`} type="button"
+                  className={`flex items-center justify-between rounded-lg border px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim ${isConnectedDevice(d) ? 'border-accent/40 bg-accent/5' : 'border-edge'}`}
+                  onClick={() => handleDeviceSelect(d)}>
+                  <span className="font-medium text-content">{d.productName || `${d.vendorId.toString(16)}:${d.productId.toString(16)}`}</span>
+                  <span className="text-xs text-content-muted">›</span>
+                </button>
+              )) : (
+                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoDevices')}</p>
+              )}
+            </div>
+            <div className="mt-2 rounded-lg border border-dashed border-transparent px-3 py-2 text-center text-xs invisible">&#8203;</div>
+          </div>
+        ) : pickerSource === 'file' && !pickerFileData ? (
+          /* --- File browse view --- */
+          <div className="mx-auto flex w-full max-w-md flex-col px-3 py-3">
+            <div className="flex min-h-device-list max-h-device-list flex-col gap-1.5 overflow-y-auto pb-2 pr-1">
+            {pickerLoadError && (
+              <div className="rounded-lg bg-danger/10 px-3 py-2 text-xs text-danger">
+                {pickerLoadError}
+              </div>
+            )}
+            {fileBrowseView === 'list' && (
+              <span className="mb-1 text-xs text-content-secondary">{t('editor.keymap.pickerSavedFiles')}</span>
+            )}
+            {fileBrowseView === 'entries' && (
+              <button type="button" className="mb-2 self-start text-xs text-content-secondary hover:text-content"
+                onClick={() => { setFileBrowseView('list'); setSelectedFileUid(null); setPickerLoadError(null) }}>
+                ← {t('common.back')}
+              </button>
+            )}
+            {fileBrowseView === 'list' ? (
+              storedKeyboards.length > 0 ? storedKeyboards.map((kb) => (
+                <button key={kb.uid} type="button"
+                  className="flex items-center justify-between rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
+                  onClick={() => { setSelectedFileUid(kb.uid); setFileBrowseView('entries'); setPickerLoadError(null) }}>
+                  <span className="font-medium text-content">{kb.name}</span>
+                  <span className="text-xs text-content-muted">›</span>
+                </button>
+              )) : (
+                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoSavedFiles')}</p>
+              )
+            ) : (
+              storedEntries.length > 0 ? storedEntries.map((entry) => (
+                <button key={entry.id} type="button"
+                  className="flex flex-col rounded-lg border border-edge px-3 py-2 text-left text-sm transition-colors hover:bg-surface-dim"
+                  onClick={() => handleLoadSnapshotEntry(selectedFileUid!, entry.id)}>
+                  <span className="font-medium text-content">{entry.label || entry.filename}</span>
+                  <span className="text-xs text-content-muted">{new Date(entry.savedAt).toLocaleString()}</span>
+                </button>
+              )) : (
+                <p className="py-4 text-center text-xs text-content-muted">{t('editor.keymap.pickerNoEntries')}</p>
+              )
+            )}
+            </div>
+            <button type="button"
+              className="mt-2 rounded-lg border border-dashed border-edge px-3 py-2 text-center text-xs text-content-muted transition-colors hover:border-edge hover:bg-surface-dim hover:text-content"
+              onClick={handleLoadPickerFile}>
+              {t('editor.keymap.pickerLoadFile')}
+            </button>
+          </div>
+        ) : (
+          /* --- Keyboard view (current / loaded file / probed device) --- */
+          <div ref={pickerContainerRef} className="picker-hover-keys relative flex h-full min-h-0 items-center justify-center">
+            <KeyboardPane
+              paneId="secondary" isActive={true}              keys={pickerData.keys} keycodes={activPickerKeycodes} encoderKeycodes={pickerData.encoderKeycodes}
+              selectedKey={null} selectedEncoder={null} selectedMaskPart={false} selectedKeycode={null}
+              remappedKeys={pickerData.remapped} multiSelectedKeys={pickerHighlightPositions}
+              layoutOptions={pickerData.layoutOpts} scale={pickerEffectiveScale}
+              layerLabel={(pickerData.names?.[pickerLayer] || t('editor.keymap.layerN', { n: pickerLayer })) + (pickerFileData ? ` — ${pickerFileData.name}` : '')}
+              layerLabelTestId="picker-layer-label"
+              onKeyClick={handlePickerKeyClick}
+              onKeyHover={handlePickerHover}
+              onKeyHoverEnd={handlePickerHoverEnd}
+            />
+            {pickerTooltip && (
+              <div
+                className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
+                style={{ top: pickerTooltip.top - 4, left: pickerTooltip.left, transform: 'translate(-50%, -100%)' }}
+              >
+                <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">{pickerTooltip.keycode}</div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      <div className="flex shrink-0 items-center justify-between px-2 pb-1">
+        <div className="flex items-center gap-1">
+          <button type="button" className={sourceBtnClass(pickerSource === 'device')}
+            onClick={() => {
+              setPickerSource('device'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setDeviceBrowsing(true); setProbeStatus('idle'); setPickerLoadError(null)
+            }}>
+            {pickerSource === 'device' && !deviceBrowsing
+              ? t('editor.keymap.pickerBackToDevices')
+              : t('editor.keymap.pickerSourceDevice')}
+          </button>
+          <button type="button" className={sourceBtnClass(pickerSource === 'file')}
+            onClick={() => { setPickerSource('file'); setPickerLayer(0); setPickerFileData(null); setPickerScale(undefined); setFileBrowseView('list'); setDeviceBrowsing(false); setPickerLoadError(null) }}>
+            {pickerSource === 'file' && pickerFileData ? t('editor.keymap.pickerBackToFiles') : t('editor.keymap.pickerSourceFile')}
+          </button>
+        </div>
+        <div className={`flex items-center gap-1 ${pickerBrowseMode ? 'invisible' : ''}`}>
+          <Tooltip content={t('editor.keymap.zoomOut')}>
+            <button type="button" aria-label={t('editor.keymap.zoomOut')}
+              className={ghostZoomButtonClass}
+              disabled={pickerEffectiveScale <= MIN_SCALE}
+              onClick={() => { if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, +(pickerEffectiveScale - 0.1).toFixed(1))); else onScaleChange?.(-0.1) }}>
+              <ZoomOut size={ICON_SM} aria-hidden="true" />
+            </button>
+          </Tooltip>
+          <ScaleInput scale={pickerEffectiveScale} onScaleChange={(delta) => {
+            if (pickerFileData) setPickerScale(Math.max(MIN_SCALE, Math.min(MAX_SCALE, +(pickerEffectiveScale + delta).toFixed(1))))
+            else onScaleChange?.(delta)
+          }} />
+          <Tooltip content={t('editor.keymap.zoomIn')}>
+            <button type="button" aria-label={t('editor.keymap.zoomIn')}
+              className={ghostZoomButtonClass}
+              disabled={pickerEffectiveScale >= MAX_SCALE}
+              onClick={() => { if (pickerFileData) setPickerScale(Math.min(MAX_SCALE, +(pickerEffectiveScale + 0.1).toFixed(1))); else onScaleChange?.(0.1) }}>
+              <ZoomIn size={ICON_SM} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        </div>
+        <div className={`flex min-w-0 items-center gap-1 overflow-x-auto ${pickerBrowseMode ? 'invisible' : ''}`}>
+          {Array.from({ length: pickerData.totalLayers }, (_, i) => {
+            const label = pickerData.names?.[i]?.trim()
+            return (
+              <Tooltip key={i} content={label} disabled={!label}>
+                <button type="button" className={layerBtnClass(pickerLayer === i)}
+                  onClick={() => { setPickerLayer(i); clearPickerSelection() }}>
+                  {label || i}
+                </button>
+              </Tooltip>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/editors/keymap-editor-popover.tsx
+++ b/src/renderer/components/editors/keymap-editor-popover.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Bridges the keymap editor's popover state (`PopoverState` — key or
+// encoder target) to the KeyPopover widget, resolving the current keycode
+// for the clicked position and the mask-only editing flag.
+
+import { KeyPopover } from '../keycodes/KeyPopover'
+import { serialize, isMask } from '../../../shared/keycodes/keycodes'
+import type { Keycode } from '../../../shared/keycodes/keycodes'
+import type { PopoverState } from './keymap-editor-types'
+
+interface PopoverForStateProps {
+  popoverState: NonNullable<PopoverState>
+  keymap: Map<string, number>
+  encoderLayout: Map<string, number>
+  currentLayer: number
+  layers: number
+  onLayerChange?: (layer: number) => void
+  layerNames?: string[]
+  onKeycodeSelect: (kc: Keycode) => void
+  onRawKeycodeSelect: (code: number) => void
+  onModMaskChange?: (newMask: number) => void
+  onClose: () => void
+  quickSelect?: boolean
+  previousKeycode?: number
+  onUndo?: () => void
+  nextKeycode?: number
+  onRedo?: () => void
+}
+
+export function PopoverForState({
+  popoverState, keymap, encoderLayout, currentLayer, layers,
+  onLayerChange, layerNames,
+  onKeycodeSelect, onRawKeycodeSelect, onModMaskChange, onClose,
+  quickSelect, previousKeycode, onUndo, nextKeycode, onRedo,
+}: PopoverForStateProps) {
+  const currentKeycode = popoverState.kind === 'key'
+    ? keymap.get(`${currentLayer},${popoverState.row},${popoverState.col}`) ?? 0
+    : encoderLayout.get(`${currentLayer},${popoverState.idx},${popoverState.dir}`) ?? 0
+  const maskOnly = popoverState.maskClicked && isMask(serialize(currentKeycode))
+  return (
+    <KeyPopover
+      anchorRect={popoverState.anchorRect} currentKeycode={currentKeycode} maskOnly={maskOnly} layers={layers}
+      currentLayer={currentLayer} onLayerChange={onLayerChange} layerNames={layerNames}
+      onKeycodeSelect={onKeycodeSelect} onRawKeycodeSelect={onRawKeycodeSelect} onModMaskChange={onModMaskChange}
+      onClose={onClose} quickSelect={quickSelect} previousKeycode={previousKeycode} onUndo={onUndo}
+      nextKeycode={nextKeycode} onRedo={onRedo}
+    />
+  )
+}

--- a/src/renderer/components/editors/keymap-editor-toolbar.tsx
+++ b/src/renderer/components/editors/keymap-editor-toolbar.tsx
@@ -1,8 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useState, useCallback, useRef } from 'react'
-import { MIN_SCALE, MAX_SCALE } from './keymap-editor-types'
-import { TOOLBAR_BTN_ACTIVE, TOOLBAR_BTN_INACTIVE } from '../../constants/ui-tokens'
+import { useTranslation } from 'react-i18next'
+import { ZoomIn, ZoomOut, Undo2, Redo2 } from 'lucide-react'
+import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
+import { TOOLBAR_BTN_ACTIVE, TOOLBAR_BTN_INACTIVE, ICON_MD } from '../../constants/ui-tokens'
+import { Tooltip } from '../ui/Tooltip'
 
 export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleChange: (delta: number) => void }) {
   const display = `${Math.round(scale * 100)}`
@@ -49,4 +52,72 @@ export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleCha
 
 export function toggleButtonClass(active: boolean): string {
   return active ? TOOLBAR_BTN_ACTIVE : TOOLBAR_BTN_INACTIVE
+}
+
+// Ghost-style zoom button shared by the picker Keyboard tab and the
+// View Matrix zoom row (kept identical so the two arrangements match).
+export const ghostZoomButtonClass = 'rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content disabled:opacity-30 disabled:pointer-events-none'
+
+export interface KeymapToolbarProps {
+  typingTestMode?: boolean
+  viewMatrixActive: boolean
+  canUndo: boolean
+  canRedo: boolean
+  onUndo: () => Promise<void>
+  onRedo: () => Promise<void>
+  scale: number
+  onScaleChange?: (delta: number) => void
+}
+
+/** The editor's left side rail: undo/redo on top, zoom controls centered.
+ *  Undo/redo act on keymap edits, which View Matrix mode disables for its
+ *  duration — hide them while the mode is active rather than leave dead
+ *  disabled buttons in the toolbar. */
+export function KeymapToolbar({
+  typingTestMode, viewMatrixActive, canUndo, canRedo, onUndo, onRedo, scale, onScaleChange,
+}: KeymapToolbarProps) {
+  const { t } = useTranslation()
+  const zoomButtonClass = `${toggleButtonClass(false)} disabled:opacity-30 disabled:pointer-events-none`
+
+  // Zoom controls are shared between two placements: the side toolbar in
+  // normal editing, and a row under the keymap pane while View Matrix mode
+  // is active (see the mode's layout in KeymapEditor). Same
+  // elements/props/testids either way — only the wrapping layout differs.
+  const zoomControls = !typingTestMode && onScaleChange && (
+    <>
+      <Tooltip content={t('editor.keymap.zoomIn')} side="right">
+        <button type="button" data-testid="zoom-in-button" aria-label={t('editor.keymap.zoomIn')} className={zoomButtonClass} disabled={scale >= MAX_SCALE} onClick={() => onScaleChange(0.1)}>
+          <ZoomIn size={ICON_MD} aria-hidden="true" />
+        </button>
+      </Tooltip>
+      <ScaleInput scale={scale} onScaleChange={onScaleChange} />
+      <Tooltip content={t('editor.keymap.zoomOut')} side="right">
+        <button type="button" data-testid="zoom-out-button" aria-label={t('editor.keymap.zoomOut')} className={zoomButtonClass} disabled={scale <= MIN_SCALE} onClick={() => onScaleChange(-0.1)}>
+          <ZoomOut size={ICON_MD} aria-hidden="true" />
+        </button>
+      </Tooltip>
+    </>
+  )
+
+  return (
+    <div className="flex shrink-0 flex-col items-center gap-3 self-stretch" style={{ width: PANEL_COLLAPSED_WIDTH }}>
+      {!typingTestMode && !viewMatrixActive && (
+        <>
+          <Tooltip content={t('editor.keymap.undo')} side="right">
+            <button type="button" data-testid="undo-button" aria-label={t('editor.keymap.undo')} className={zoomButtonClass} disabled={!canUndo} onClick={() => void onUndo()}>
+              <Undo2 size={ICON_MD} aria-hidden="true" />
+            </button>
+          </Tooltip>
+          <Tooltip content={t('editor.keymap.redo')} side="right">
+            <button type="button" data-testid="redo-button" aria-label={t('editor.keymap.redo')} className={zoomButtonClass} disabled={!canRedo} onClick={() => void onRedo()}>
+              <Redo2 size={ICON_MD} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        </>
+      )}
+      <div className="flex-1" />
+      {!viewMatrixActive && zoomControls}
+      <div className="flex-1" />
+    </div>
+  )
 }

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -218,3 +218,28 @@ export interface KeymapEditorProps {
   /** Notify parent when device list browsing state changes (for polling control) */
   onDeviceListActiveChange?: (active: boolean) => void
 }
+
+// Layout picker (the picker "Keyboard" tab) data shapes — hoisted here so
+// LayoutPickerContent and useLayoutPicker share them without a type-only
+// import cycle between the two sibling modules.
+export interface PickerFileDataShape {
+  layout: KeyboardLayout
+  keymap: Map<string, number>
+  layers: number
+  encoderKeycodes: Map<string, [string, string]>
+  layoutOptions: Map<number, number>
+  name: string
+  layerNames?: string[]
+  uid?: string
+}
+export type PickerFileData = PickerFileDataShape | null
+
+export interface PickerData {
+  keys: KleKey[]
+  keycodes: Map<string, string>
+  encoderKeycodes: Map<string, [string, string]>
+  remapped: Set<string>
+  layoutOpts: Map<number, number>
+  totalLayers: number
+  names?: string[]
+}

--- a/src/renderer/components/editors/use-layer-keycodes.ts
+++ b/src/renderer/components/editors/use-layer-keycodes.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Builds the per-layer keycode/remapped-key maps the keymap editor renders
+// (current layer, typing-test's effective layer, and — via the returned
+// builder callbacks — the layout picker's browsed layer), plus the
+// deserialized macro buffer and the set of "configured" TD/Macro tiles to
+// highlight in the keycode palette.
+
+import { useCallback, useMemo } from 'react'
+import { serialize, isMask } from '../../../shared/keycodes/keycodes'
+import { posKey } from '../../../shared/kle/pos-key'
+import { deserializeAllMacros, type MacroAction } from '../../../preload/macro'
+import type { TapDanceEntry } from '../../../shared/types/protocol'
+import { EMPTY_KEYCODES, EMPTY_REMAPPED, EMPTY_ENCODER_KEYCODES } from './keymap-editor-types'
+
+export interface UseLayerKeycodesOptions {
+  parsedMacros?: MacroAction[][] | null
+  macroBuffer?: number[]
+  macroCount?: number
+  vialProtocol?: number
+  tapDanceEntries?: TapDanceEntry[]
+  remapLabel?: (qmkId: string) => string
+  isRemapped?: (qmkId: string) => boolean
+  keymap: Map<string, number>
+  encoderLayout: Map<string, number>
+  encoderCount: number
+  currentLayer: number
+  typingTestMode?: boolean
+  typingTestEffectiveLayer: number
+}
+
+export interface LayerKeycodes {
+  keycodes: Map<string, string>
+  remapped: Set<string>
+}
+
+export interface UseLayerKeycodesReturn {
+  deserializedMacros?: MacroAction[][]
+  /** Keycodes of currently-configured Tap Dance / Macro tiles (e.g.
+   *  `"TD(0)"`, `"M2"`), used to highlight them in the keycode palette. */
+  configuredKeycodes?: Set<string>
+  buildKeycodesForLayer: (layer: number) => LayerKeycodes
+  buildEncoderKeycodesForLayer: (layer: number) => Map<string, [string, string]>
+  layerKeycodes: Map<string, string>
+  remappedKeys: Set<string>
+  layerEncoderKeycodes: Map<string, [string, string]>
+  typingTestKeycodes: Map<string, string>
+  typingTestRemapped: Set<string>
+  typingTestEncoderKeycodes: Map<string, [string, string]>
+}
+
+export function useLayerKeycodes({
+  parsedMacros, macroBuffer, macroCount, vialProtocol, tapDanceEntries,
+  remapLabel, isRemapped, keymap, encoderLayout, encoderCount, currentLayer,
+  typingTestMode, typingTestEffectiveLayer,
+}: UseLayerKeycodesOptions): UseLayerKeycodesReturn {
+  // --- Macros ---
+  const deserializedMacros = useMemo(
+    () => parsedMacros ?? (macroBuffer && macroCount ? deserializeAllMacros(macroBuffer, vialProtocol ?? 0, macroCount) : undefined),
+    [parsedMacros, macroBuffer, macroCount, vialProtocol],
+  )
+
+  const configuredKeycodes = useMemo(() => {
+    const set = new Set<string>()
+    if (tapDanceEntries) {
+      for (let i = 0; i < tapDanceEntries.length; i++) {
+        const e = tapDanceEntries[i]
+        if (e.onTap || e.onHold || e.onDoubleTap || e.onTapHold) set.add(`TD(${i})`)
+      }
+    }
+    if (deserializedMacros) {
+      for (let i = 0; i < deserializedMacros.length; i++) {
+        if (deserializedMacros[i].length > 0) set.add(`M${i}`)
+      }
+    }
+    return set.size > 0 ? set : undefined
+  }, [tapDanceEntries, deserializedMacros])
+
+  const remap = remapLabel ?? ((id: string) => id)
+
+  // --- Build keycodes for layers ---
+  const buildKeycodesForLayer = useCallback((layer: number) => {
+    const keycodes = new Map<string, string>()
+    const remapped = new Set<string>()
+    const checkRemapped = isRemapped ?? (() => false)
+    for (const [key, code] of keymap) {
+      const [l, r, c] = key.split(',')
+      if (Number(l) === layer) {
+        const pos = posKey(Number(r), Number(c))
+        const qmkId = serialize(code)
+        keycodes.set(pos, remap(qmkId))
+        if (!isMask(qmkId) && checkRemapped(qmkId)) remapped.add(pos)
+      }
+    }
+    return { keycodes, remapped }
+  }, [keymap, remap, isRemapped])
+
+  const buildEncoderKeycodesForLayer = useCallback((layer: number) => {
+    const map = new Map<string, [string, string]>()
+    for (let i = 0; i < encoderCount; i++) {
+      const cw = encoderLayout.get(`${layer},${i},0`) ?? 0
+      const ccw = encoderLayout.get(`${layer},${i},1`) ?? 0
+      map.set(String(i), [remap(serialize(cw)), remap(serialize(ccw))])
+    }
+    return map
+  }, [encoderLayout, encoderCount, remap])
+
+  const { keycodes: layerKeycodes, remapped: remappedKeys } = useMemo(() => buildKeycodesForLayer(currentLayer), [buildKeycodesForLayer, currentLayer])
+  const layerEncoderKeycodes = useMemo(() => buildEncoderKeycodesForLayer(currentLayer), [buildEncoderKeycodesForLayer, currentLayer])
+
+  const { keycodes: typingTestKeycodes, remapped: typingTestRemapped } = useMemo(
+    () => typingTestMode ? buildKeycodesForLayer(typingTestEffectiveLayer) : { keycodes: EMPTY_KEYCODES, remapped: EMPTY_REMAPPED },
+    [buildKeycodesForLayer, typingTestEffectiveLayer, typingTestMode])
+  const typingTestEncoderKeycodes = useMemo(
+    () => typingTestMode ? buildEncoderKeycodesForLayer(typingTestEffectiveLayer) : EMPTY_ENCODER_KEYCODES,
+    [buildEncoderKeycodesForLayer, typingTestEffectiveLayer, typingTestMode])
+
+  return {
+    deserializedMacros, configuredKeycodes,
+    buildKeycodesForLayer, buildEncoderKeycodesForLayer,
+    layerKeycodes, remappedKeys, layerEncoderKeycodes,
+    typingTestKeycodes, typingTestRemapped, typingTestEncoderKeycodes,
+  }
+}

--- a/src/renderer/components/editors/useKeymapJsonEditors.ts
+++ b/src/renderer/components/editors/useKeymapJsonEditors.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Owns the "Edit JSON" modal state for Tap Dance / Combo / Key Override /
+// Alt Repeat Key / Macro, plus the QMK settings modal open/close state and
+// its derived `visibleModals` map. Each JSON editor's show/apply pair is
+// gated behind unlock (`useUnlockGate`) the same way the keymap itself is.
+
+import { useState, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useUnlockGate } from '../../hooks/useUnlockGate'
+import { serializeAllMacros, type MacroAction } from '../../../preload/macro'
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
+
+/** Extracts the raw keycodes an entry holds, for the QK_BOOT unlock check. */
+type ExtractCodes<T> = (entry: T) => number[]
+/** True when `next` differs from `prev` in any field the setter should push. */
+type HasChanged<T> = (prev: T, next: T) => boolean
+
+const tdExtractCodes: ExtractCodes<TapDanceEntry> = (e) => [e.onTap, e.onHold, e.onDoubleTap, e.onTapHold]
+const tdHasChanged: HasChanged<TapDanceEntry> = (prev, next) =>
+  prev.onTap !== next.onTap || prev.onHold !== next.onHold ||
+  prev.onDoubleTap !== next.onDoubleTap || prev.onTapHold !== next.onTapHold ||
+  prev.tappingTerm !== next.tappingTerm
+
+const comboExtractCodes: ExtractCodes<ComboEntry> = (e) => [e.key1, e.key2, e.key3, e.key4, e.output]
+const comboHasChanged: HasChanged<ComboEntry> = (prev, next) =>
+  prev.key1 !== next.key1 || prev.key2 !== next.key2 || prev.key3 !== next.key3 ||
+  prev.key4 !== next.key4 || prev.output !== next.output
+
+const koExtractCodes: ExtractCodes<KeyOverrideEntry> = (e) => [e.triggerKey, e.replacementKey]
+const koHasChanged: HasChanged<KeyOverrideEntry> = (prev, next) =>
+  prev.triggerKey !== next.triggerKey || prev.replacementKey !== next.replacementKey ||
+  prev.layers !== next.layers || prev.triggerMods !== next.triggerMods ||
+  prev.negativeMods !== next.negativeMods || prev.suppressedMods !== next.suppressedMods ||
+  prev.options !== next.options || prev.enabled !== next.enabled
+
+const arkExtractCodes: ExtractCodes<AltRepeatKeyEntry> = (e) => [e.lastKey, e.altKey]
+const arkHasChanged: HasChanged<AltRepeatKeyEntry> = (prev, next) =>
+  prev.lastKey !== next.lastKey || prev.altKey !== next.altKey ||
+  prev.allowedMods !== next.allowedMods || prev.options !== next.options ||
+  prev.enabled !== next.enabled
+
+interface UseEntryJsonEditorOptions<T> {
+  unlocked?: boolean
+  onUnlock?: (options?: { macroWarning?: boolean }) => void
+  entries?: T[]
+  onSetEntry?: (index: number, entry: T) => Promise<void>
+  extractCodes: ExtractCodes<T>
+  hasChanged: HasChanged<T>
+}
+
+export interface EntryJsonEditor<T> {
+  show: boolean
+  open: () => void
+  close: () => void
+  apply: (entries: T[]) => Promise<void>
+}
+
+export interface MacroJsonEditor {
+  show: boolean
+  /** Opening the macro editor always requires unlock (Vial protocol
+   *  gates macro saves unconditionally), unlike the other four editors
+   *  which only gate on apply if an entry contains QK_BOOT. */
+  openGated: () => void
+  close: () => void
+  apply: (macros: MacroAction[][]) => Promise<void>
+}
+
+/** Shared show/apply state machine behind Tap Dance / Combo / Key Override /
+ *  Alt Repeat Key's JSON editors — they differ only in entry type and which
+ *  fields count as "changed", threaded in via `extractCodes` / `hasChanged`. */
+function useEntryJsonEditor<T>({
+  unlocked, onUnlock, entries, onSetEntry, extractCodes, hasChanged,
+}: UseEntryJsonEditorOptions<T>): EntryJsonEditor<T> {
+  const [show, setShow] = useState(false)
+  const gate = useUnlockGate({ unlocked, onUnlock })
+
+  const open = useCallback(() => setShow(true), [])
+  const close = useCallback(() => setShow(false), [])
+
+  const apply = useCallback(
+    async (nextEntries: T[]) => {
+      if (!onSetEntry || !entries) return
+      const allCodes = nextEntries.flatMap(extractCodes)
+      await gate.guard(allCodes, async () => {
+        for (let i = 0; i < nextEntries.length; i++) {
+          const prev = entries[i]
+          const next = nextEntries[i]
+          if (hasChanged(prev, next)) await onSetEntry(i, next)
+        }
+      })
+    },
+    [onSetEntry, entries, gate, extractCodes, hasChanged],
+  )
+
+  return { show, open, close, apply }
+}
+
+export interface UseKeymapJsonEditorsOptions {
+  unlocked?: boolean
+  onUnlock?: (options?: { macroWarning?: boolean }) => void
+  tapDanceEntries?: TapDanceEntry[]
+  onSetTapDanceEntry?: (index: number, entry: TapDanceEntry) => Promise<void>
+  comboEntries?: ComboEntry[]
+  onSetComboEntry?: (index: number, entry: ComboEntry) => Promise<void>
+  keyOverrideEntries?: KeyOverrideEntry[]
+  onSetKeyOverrideEntry?: (index: number, entry: KeyOverrideEntry) => Promise<void>
+  altRepeatKeyEntries?: AltRepeatKeyEntry[]
+  onSetAltRepeatKeyEntry?: (index: number, entry: AltRepeatKeyEntry) => Promise<void>
+  onSaveMacros?: (buffer: number[], parsedMacros?: MacroAction[][]) => Promise<void>
+  macroBufferSize?: number
+  vialProtocol?: number
+  tapHoldSupported?: boolean
+  mouseKeysSupported?: boolean
+  magicSupported?: boolean
+  graveEscapeSupported?: boolean
+  autoShiftSupported?: boolean
+  oneShotKeysSupported?: boolean
+  comboSettingsSupported?: boolean
+}
+
+export interface VisibleQmkModals {
+  tapHold: boolean
+  mouseKeys: boolean
+  magic: boolean
+  graveEscape: boolean
+  autoShift: boolean
+  oneShotKeys: boolean
+  combo: boolean
+}
+
+export interface UseKeymapJsonEditorsReturn {
+  openSettings: (key: string) => void
+  closeSettings: (key: string) => void
+  visibleModals: VisibleQmkModals
+  tdJson: EntryJsonEditor<TapDanceEntry>
+  comboJson: EntryJsonEditor<ComboEntry>
+  koJson: EntryJsonEditor<KeyOverrideEntry>
+  arkJson: EntryJsonEditor<AltRepeatKeyEntry>
+  macroJson: MacroJsonEditor
+}
+
+export function useKeymapJsonEditors({
+  unlocked, onUnlock,
+  tapDanceEntries, onSetTapDanceEntry,
+  comboEntries, onSetComboEntry,
+  keyOverrideEntries, onSetKeyOverrideEntry,
+  altRepeatKeyEntries, onSetAltRepeatKeyEntry,
+  onSaveMacros, macroBufferSize, vialProtocol,
+  tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported,
+  autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
+}: UseKeymapJsonEditorsOptions): UseKeymapJsonEditorsReturn {
+  const { t } = useTranslation()
+
+  // --- QMK settings modals ---
+  const [showSettings, setShowSettings] = useState<Record<string, boolean>>({})
+  const openSettings = useCallback((key: string) => setShowSettings((prev) => ({ ...prev, [key]: true })), [])
+  const closeSettings = useCallback((key: string) => setShowSettings((prev) => ({ ...prev, [key]: false })), [])
+
+  const visibleModals = useMemo(() => ({
+    tapHold: !!showSettings.tapHold && !!tapHoldSupported,
+    mouseKeys: !!showSettings.mouseKeys && !!mouseKeysSupported,
+    magic: !!showSettings.magic && !!magicSupported,
+    graveEscape: !!showSettings.graveEscape && !!graveEscapeSupported,
+    autoShift: !!showSettings.autoShift && !!autoShiftSupported,
+    oneShotKeys: !!showSettings.oneShotKeys && !!oneShotKeysSupported,
+    combo: !!showSettings.combo && !!comboSettingsSupported,
+  }), [showSettings, tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported, autoShiftSupported, oneShotKeysSupported, comboSettingsSupported])
+
+  // --- Tap Dance / Combo / Key Override / Alt Repeat Key JSON editors ---
+  const tdJson = useEntryJsonEditor({
+    unlocked, onUnlock, entries: tapDanceEntries, onSetEntry: onSetTapDanceEntry,
+    extractCodes: tdExtractCodes, hasChanged: tdHasChanged,
+  })
+  const comboJson = useEntryJsonEditor({
+    unlocked, onUnlock, entries: comboEntries, onSetEntry: onSetComboEntry,
+    extractCodes: comboExtractCodes, hasChanged: comboHasChanged,
+  })
+  const koJson = useEntryJsonEditor({
+    unlocked, onUnlock, entries: keyOverrideEntries, onSetEntry: onSetKeyOverrideEntry,
+    extractCodes: koExtractCodes, hasChanged: koHasChanged,
+  })
+  const arkJson = useEntryJsonEditor({
+    unlocked, onUnlock, entries: altRepeatKeyEntries, onSetEntry: onSetAltRepeatKeyEntry,
+    extractCodes: arkExtractCodes, hasChanged: arkHasChanged,
+  })
+
+  // --- Macro JSON editor ---
+  const [showMacroJsonEditor, setShowMacroJsonEditor] = useState(false)
+  const macroJsonGate = useUnlockGate({ unlocked, onUnlock })
+  const openMacroJsonGated = useCallback(() => {
+    void macroJsonGate.guardAll(async () => setShowMacroJsonEditor(true))
+  }, [macroJsonGate])
+  const closeMacroJson = useCallback(() => setShowMacroJsonEditor(false), [])
+  const handleMacroJsonApply = useCallback(
+    async (macros: MacroAction[][]) => {
+      if (!onSaveMacros || !macroBufferSize) return
+      await macroJsonGate.guardAll(async () => {
+        const buffer = serializeAllMacros(macros, vialProtocol ?? 0)
+        if (buffer.length > macroBufferSize) {
+          throw new Error(t('editor.macro.memoryUsage', { used: buffer.length, total: macroBufferSize }))
+        }
+        await onSaveMacros(buffer, macros)
+      })
+    },
+    [onSaveMacros, macroBufferSize, vialProtocol, t, macroJsonGate],
+  )
+
+  return {
+    openSettings, closeSettings, visibleModals,
+    tdJson, comboJson, koJson, arkJson,
+    macroJson: { show: showMacroJsonEditor, openGated: openMacroJsonGated, close: closeMacroJson, apply: handleMacroJsonApply },
+  }
+}

--- a/src/renderer/components/editors/useLayoutPicker.tsx
+++ b/src/renderer/components/editors/useLayoutPicker.tsx
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Owns the picker panel's "Keyboard" tab state — browsing a connected
+// device, probing another detected device, or loading a saved/exported
+// layout file — plus the derived keycode data it renders. Returns the
+// fully-wired JSX (via `LayoutPickerContent`) so KeymapEditor only needs
+// to thread it into `TabbedKeycodes`' `keyboardPickerContent` prop.
+
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { serialize, findKeycode } from '../../../shared/keycodes/keycodes'
+import type { Keycode } from '../../../shared/keycodes/keycodes'
+import { parseKle } from '../../../shared/kle/kle-parser'
+import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
+import { posKey } from '../../../shared/kle/pos-key'
+import { isVilFile, isVilFileV1, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
+import type { KleKey, KeyboardLayout } from '../../../shared/kle/types'
+import type { DeviceInfo } from '../../../shared/types/protocol'
+import type { StoredKeyboardInfo } from '../../../shared/types/sync'
+import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
+import { LayoutPickerContent } from './LayoutPickerContent'
+import type { PickerData, PickerFileData } from './keymap-editor-types'
+
+export interface UseLayoutPickerOptions {
+  layout: KeyboardLayout | null
+  layers: number
+  layerNames?: string[]
+  keymap: Map<string, number>
+  effectiveLayoutOptions: Map<number, number>
+  remapLabel?: (qmkId: string) => string
+  scale: number
+  onScaleChange?: (delta: number) => void
+  devices?: DeviceInfo[]
+  connectedDevice?: DeviceInfo | null
+  onDeviceListActiveChange?: (active: boolean) => void
+  selectedKey: { row: number; col: number } | null
+  selectedEncoder: { idx: number; dir: number } | null
+  handleKeycodeSelect: (kc: Keycode) => Promise<void>
+  handlePickerMultiSelect?: (
+    index: number,
+    keycode: number,
+    event: { ctrlKey: boolean; shiftKey: boolean },
+    tabKeycodeNumbers: number[],
+  ) => void
+  pickerSelectedIndices: Set<number>
+  clearPickerSelection: () => void
+  buildKeycodesForLayer: (layer: number) => { keycodes: Map<string, string>; remapped: Set<string> }
+  buildEncoderKeycodesForLayer: (layer: number) => Map<string, [string, string]>
+}
+
+export interface UseLayoutPickerReturn {
+  layoutPickerContent: React.ReactNode
+}
+
+export function useLayoutPicker({
+  layout, layers, layerNames, keymap, effectiveLayoutOptions, remapLabel, scale, onScaleChange,
+  devices, connectedDevice, onDeviceListActiveChange,
+  selectedKey, selectedEncoder, handleKeycodeSelect, handlePickerMultiSelect,
+  pickerSelectedIndices, clearPickerSelection,
+  buildKeycodesForLayer, buildEncoderKeycodesForLayer,
+}: UseLayoutPickerOptions): UseLayoutPickerReturn {
+  const { t } = useTranslation()
+
+  const [pickerLayer, setPickerLayer] = useState(0)
+  const [pickerSource, setPickerSource] = useState<'file' | 'device'>('device')
+  const [pickerFileData, setPickerFileData] = useState<PickerFileData>(null)
+  const [storedKeyboards, setStoredKeyboards] = useState<StoredKeyboardInfo[]>([])
+  const [selectedFileUid, setSelectedFileUid] = useState<string | null>(null)
+  const [storedEntries, setStoredEntries] = useState<SnapshotMeta[]>([])
+  const [fileBrowseView, setFileBrowseView] = useState<'list' | 'entries'>('list')
+  const [pickerLoadError, setPickerLoadError] = useState<string | null>(null)
+  const [probeStatus, setProbeStatus] = useState<'idle' | 'probing' | 'error'>('idle')
+  const [deviceBrowsing, setDeviceBrowsing] = useState(true)
+  const [pickerScale, setPickerScale] = useState<number | undefined>(undefined)
+  const [pickerTooltip, setPickerTooltip] = useState<{ keycode: string; top: number; left: number } | null>(null)
+  // pickerClickedPositions removed — now tracked via pickerSelectedIndices in useKeymapMultiSelect
+  const pickerContainerRef = useRef<HTMLDivElement>(null)
+
+  const handlePickerHover = useCallback((_key: KleKey, keycode: string, rect: DOMRect) => {
+    const containerRect = pickerContainerRef.current?.getBoundingClientRect()
+    if (!containerRect) return
+    setPickerTooltip({
+      keycode,
+      top: rect.top - containerRect.top,
+      left: rect.left - containerRect.left + rect.width / 2,
+    })
+  }, [])
+
+  const handlePickerHoverEnd = useCallback(() => { setPickerTooltip(null) }, [])
+
+  // --- Notify parent when device list browsing state changes ---
+  useEffect(() => {
+    onDeviceListActiveChange?.(pickerSource === 'device' && deviceBrowsing)
+  }, [pickerSource, deviceBrowsing, onDeviceListActiveChange])
+
+  // Save picker zoom back to target keyboard's settings
+  useEffect(() => {
+    const uid = pickerFileData?.uid
+    if (pickerScale == null || !uid) return
+    // PATCH only keymapScale so this can't clobber other fields on the
+    // target keyboard's settings.
+    window.vialAPI.pipetteSettingsPatch(uid, { keymapScale: pickerScale }).catch(() => {})
+  }, [pickerScale, pickerFileData?.uid])
+
+  // --- Layout picker: stored keyboards browsing ---
+  useEffect(() => {
+    if (pickerSource !== 'file') return
+    window.vialAPI.listStoredKeyboards().then(setStoredKeyboards).catch(() => {})
+  }, [pickerSource])
+
+  useEffect(() => {
+    if (!selectedFileUid) { setStoredEntries([]); return }
+    window.vialAPI.snapshotStoreList(selectedFileUid).then((r) => {
+      if (r.success && r.entries) setStoredEntries(r.entries.filter((e) => !e.deletedAt && e.vilVersion !== 1))
+    }).catch(() => {})
+  }, [selectedFileUid])
+
+  // --- Layout picker file loading ---
+  const loadPickerFromJson = useCallback((jsonStr: string) => {
+    try {
+      const parsed = JSON.parse(jsonStr)
+      if (!isVilFile(parsed)) {
+        setPickerLoadError(t('error.loadFailed'))
+        return false
+      }
+      if (isVilFileV1(parsed) || !parsed.definition) {
+        setPickerLoadError(t('error.vilV1NotSupported'))
+        return false
+      }
+      const fileLayout = parseKle(parsed.definition.layouts.keymap)
+      const fileKeymap = recordToMap(parsed.keymap)
+      const fileLayers = deriveLayerCount(parsed.keymap)
+      const remap = remapLabel ?? ((id: string) => id)
+      const encoderKeycodes = new Map<string, [string, string]>()
+      if (parsed.encoderLayout) {
+        const encMap = recordToMap(parsed.encoderLayout)
+        const encCount = new Set([...encMap.keys()].map((k) => k.split(',')[1])).size
+        for (let i = 0; i < encCount; i++) {
+          for (let layer = 0; layer < fileLayers; layer++) {
+            const cw = encMap.get(`${layer},${i},0`) ?? 0
+            const ccw = encMap.get(`${layer},${i},1`) ?? 0
+            encoderKeycodes.set(`${layer},${i}`, [remap(serialize(cw)), remap(serialize(ccw))])
+          }
+        }
+      }
+      const fileUid = typeof parsed.uid === 'string' ? parsed.uid : undefined
+      setPickerFileData({
+        layout: fileLayout, keymap: fileKeymap, layers: fileLayers, encoderKeycodes,
+        layoutOptions: parsed.definition.layouts?.labels
+          ? decodeLayoutOptions(parsed.layoutOptions ?? 0, parsed.definition.layouts.labels) : new Map(),
+        name: parsed.definition.name ?? 'File', layerNames: parsed.layerNames, uid: fileUid,
+      })
+      if (fileUid) {
+        window.vialAPI.pipetteSettingsGet(fileUid).then((prefs) => {
+          if (prefs?.keymapScale != null) setPickerScale(prefs.keymapScale)
+        }).catch(() => {})
+      } else {
+        setPickerScale(undefined)
+      }
+      setPickerLayer(0)
+      setFileBrowseView('list')
+      return true
+    } catch {
+      setPickerLoadError(t('error.loadFailed'))
+      return false
+    }
+  }, [remapLabel, t])
+
+  const handleLoadPickerFile = useCallback(async () => {
+    setPickerLoadError(null)
+    const result = await window.vialAPI.loadLayout(t('editor.keymap.pickerLoadFile'), ['.pipette', '.vil'])
+    if (!result.success || !result.data) {
+      if (result.error !== 'cancelled') setPickerLoadError(t('error.loadFailed'))
+      return
+    }
+    loadPickerFromJson(result.data)
+  }, [t, loadPickerFromJson])
+
+  const handleLoadSnapshotEntry = useCallback(async (uid: string, entryId: string) => {
+    setPickerLoadError(null)
+    const result = await window.vialAPI.snapshotStoreLoad(uid, entryId)
+    if (!result.success || !result.data) {
+      setPickerLoadError(t('error.loadFailed'))
+      return
+    }
+    loadPickerFromJson(result.data)
+  }, [t, loadPickerFromJson])
+
+  // --- Device probe handler ---
+  const handleProbeDevice = useCallback(async (vendorId: number, productId: number, serialNumber: string) => {
+    setProbeStatus('probing')
+    try {
+      const result = await window.vialAPI.probeDevice(vendorId, productId, serialNumber)
+      const fileLayout = parseKle(result.definition.layouts.keymap)
+      const fileKeymap = new Map<string, number>(Object.entries(result.keymap))
+      const remap = remapLabel ?? ((id: string) => id)
+      const encoderKeycodes = new Map<string, [string, string]>()
+      const encMap = new Map<string, number>(Object.entries(result.encoderLayout))
+      for (let i = 0; i < result.encoderCount; i++) {
+        for (let layer = 0; layer < result.layers; layer++) {
+          const cw = encMap.get(`${layer},${i},0`) ?? 0
+          const ccw = encMap.get(`${layer},${i},1`) ?? 0
+          encoderKeycodes.set(`${layer},${i}`, [remap(serialize(cw)), remap(serialize(ccw))])
+        }
+      }
+      let probeKeymapScale: number | undefined
+      if (result.uid) {
+        try {
+          const prefs = await window.vialAPI.pipetteSettingsGet(result.uid)
+          if (prefs?.keymapScale != null) probeKeymapScale = prefs.keymapScale
+        } catch { /* best-effort */ }
+      }
+      setPickerScale(probeKeymapScale)
+      setPickerFileData({
+        layout: fileLayout, keymap: fileKeymap, layers: result.layers, encoderKeycodes,
+        layoutOptions: result.definition.layouts?.labels
+          ? decodeLayoutOptions(result.layoutOptions, result.definition.layouts.labels) : new Map(),
+        name: result.name, uid: result.uid,
+      })
+      setPickerLayer(0)
+      setProbeStatus('idle')
+    } catch {
+      setProbeStatus('error')
+    }
+  }, [remapLabel])
+
+  // --- Device list for probe picker (includes connected device) ---
+  const isConnectedDevice = useCallback((d: DeviceInfo) => {
+    return !!connectedDevice && d.vendorId === connectedDevice.vendorId && d.productId === connectedDevice.productId && d.serialNumber === connectedDevice.serialNumber
+  }, [connectedDevice])
+
+  const handleDeviceSelect = useCallback((d: DeviceInfo) => {
+    if (isConnectedDevice(d)) {
+      // Connected device → use existing keymap/layout (clear pickerFileData)
+      setPickerFileData(null)
+      setPickerScale(undefined)
+      setPickerLayer(0)
+      setDeviceBrowsing(false)
+    } else {
+      setDeviceBrowsing(false)
+      handleProbeDevice(d.vendorId, d.productId, d.serialNumber)
+    }
+  }, [isConnectedDevice, handleProbeDevice])
+
+  // --- Layout picker keycodes ---
+  const { keycodes: pickerKeycodes, remapped: pickerRemapped } = useMemo(
+    () => buildKeycodesForLayer(pickerLayer), [buildKeycodesForLayer, pickerLayer])
+  const pickerEncoderKeycodes = useMemo(
+    () => buildEncoderKeycodesForLayer(pickerLayer), [buildEncoderKeycodesForLayer, pickerLayer])
+
+  // Build ordered keycode numbers for picker multi-select (Shift+click range)
+  const pickerTabKeycodeNumbers = useMemo(() => {
+    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
+    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
+    const numbers: number[] = []
+    for (const key of keys) {
+      if (key.row == null || key.col == null) continue
+      const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
+      if (code != null) numbers.push(code)
+    }
+    return numbers
+  }, [pickerFileData, keymap, pickerLayer, layout])
+
+  const handlePickerKeyClick = useCallback((key: KleKey, _maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => {
+    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
+    const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
+    if (code == null) return
+    // Always assign the full composite keycode (e.g. LT1(KC_SPC) as-is)
+    const qmkId = serialize(code)
+    const kc = findKeycode(qmkId) ?? { qmkId, label: qmkId, keycode: code }
+    const isModified = event && (event.ctrlKey || event.shiftKey)
+    if (isModified && handlePickerMultiSelect) {
+      // Find the index of this key in the picker's ordered list
+      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
+      let index = 0
+      for (const k of keys) {
+        if (k.row == null || k.col == null) continue
+        if (k.row === key.row && k.col === key.col) break
+        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
+      }
+      handlePickerMultiSelect(index, code, { ctrlKey: !!event.ctrlKey, shiftKey: !!event.shiftKey }, pickerTabKeycodeNumbers)
+    } else if (handlePickerMultiSelect && !selectedKey && !selectedEncoder) {
+      // Normal click (no key selected): select single key and set anchor
+      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
+      let index = 0
+      for (const k of keys) {
+        if (k.row == null || k.col == null) continue
+        if (k.row === key.row && k.col === key.col) break
+        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
+      }
+      handlePickerMultiSelect(index, code, { ctrlKey: false, shiftKey: false }, pickerTabKeycodeNumbers)
+    } else {
+      handleKeycodeSelect(kc)
+    }
+  }, [keymap, pickerLayer, pickerFileData, layout, handleKeycodeSelect, handlePickerMultiSelect, pickerTabKeycodeNumbers])
+
+  // For file/device mode, build keycodes per-layer on the fly
+  const filePickerKeycodes = useMemo(() => {
+    if (!pickerFileData) return pickerKeycodes
+    const remap = remapLabel ?? ((id: string) => id)
+    const keycodes = new Map<string, string>()
+    for (const [key, code] of pickerFileData.keymap) {
+      const [l, r, c] = key.split(',')
+      if (Number(l) === pickerLayer) keycodes.set(posKey(Number(r), Number(c)), remap(serialize(code)))
+    }
+    return keycodes
+  }, [pickerFileData, pickerLayer, remapLabel, pickerKeycodes])
+
+  // Convert picker selected indices to position strings for keyboard widget highlight
+  const pickerHighlightPositions = useMemo(() => {
+    if (pickerSelectedIndices.size === 0) return undefined
+    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
+    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
+    const positions = new Set<string>()
+    let idx = 0
+    for (const key of keys) {
+      if (key.row == null || key.col == null) continue
+      if (!sourceKeymap.has(`${pickerLayer},${key.row},${key.col}`)) continue
+      if (pickerSelectedIndices.has(idx)) positions.add(`${key.row},${key.col}`)
+      idx++
+    }
+    return positions.size > 0 ? positions : undefined
+  }, [pickerSelectedIndices, pickerFileData, layout, keymap, pickerLayer])
+
+  // Layout picker: keyboard-as-keycode-picker shown inside the picker panel
+  const pickerData: PickerData = pickerFileData
+    ? { keys: pickerFileData.layout.keys, keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: pickerFileData.layoutOptions, totalLayers: pickerFileData.layers, names: pickerFileData.layerNames }
+    : { keys: layout?.keys ?? [], keycodes: pickerKeycodes, encoderKeycodes: pickerEncoderKeycodes, remapped: pickerRemapped, layoutOpts: effectiveLayoutOptions, totalLayers: layers, names: layerNames }
+
+  const pickerEffectiveScale = pickerFileData ? (pickerScale ?? scale) : scale
+  const activPickerKeycodes = pickerFileData ? filePickerKeycodes : pickerKeycodes
+
+  const pickerBrowseMode = (pickerSource === 'device' && deviceBrowsing) || (pickerSource === 'file' && !pickerFileData)
+
+  const layoutPickerContent = (
+    <LayoutPickerContent
+      pickerSource={pickerSource} deviceBrowsing={deviceBrowsing} probeStatus={probeStatus}
+      devices={devices} isConnectedDevice={isConnectedDevice} handleDeviceSelect={handleDeviceSelect}
+      pickerLoadError={pickerLoadError} fileBrowseView={fileBrowseView} setFileBrowseView={setFileBrowseView}
+      setSelectedFileUid={setSelectedFileUid} setPickerLoadError={setPickerLoadError}
+      storedKeyboards={storedKeyboards} selectedFileUid={selectedFileUid} storedEntries={storedEntries}
+      handleLoadSnapshotEntry={handleLoadSnapshotEntry} handleLoadPickerFile={handleLoadPickerFile}
+      pickerContainerRef={pickerContainerRef} pickerData={pickerData} activPickerKeycodes={activPickerKeycodes}
+      pickerHighlightPositions={pickerHighlightPositions} pickerEffectiveScale={pickerEffectiveScale}
+      pickerLayer={pickerLayer} pickerFileData={pickerFileData} handlePickerKeyClick={handlePickerKeyClick}
+      handlePickerHover={handlePickerHover} handlePickerHoverEnd={handlePickerHoverEnd} pickerTooltip={pickerTooltip}
+      setPickerSource={setPickerSource} setPickerLayer={setPickerLayer} setPickerFileData={setPickerFileData}
+      setPickerScale={setPickerScale} setDeviceBrowsing={setDeviceBrowsing} setProbeStatus={setProbeStatus}
+      pickerBrowseMode={pickerBrowseMode} onScaleChange={onScaleChange} clearPickerSelection={clearPickerSelection}
+    />
+  )
+
+  return { layoutPickerContent }
+}

--- a/src/renderer/components/editors/useViewMatrixEditing.ts
+++ b/src/renderer/components/editors/useViewMatrixEditing.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Wires `useViewMatrixMode`'s bare on/off + selection state into the
+// keymap editor: entry/exit gating (forces the matrix tester off, clears
+// selection), per-key click handling while the mode is active, the panel's
+// Row/Col axis edits, and the per-key legend/collision-color overlay drawn
+// on the primary pane.
+
+import { useCallback, useMemo } from 'react'
+import type { Keycode } from '../../../shared/keycodes/keycodes'
+import { posKey } from '../../../shared/kle/pos-key'
+import type { KleKey, KeyboardLayout } from '../../../shared/kle/types'
+import type { ViewMatrixCell } from '../../../shared/types/pipette-settings'
+import { KEY_DUPLICATE_COLOR } from '../keyboard/constants'
+import { applyViewMatrixAxisToSelection, effectiveViewPos } from './view-matrix'
+import { useViewMatrixMode, type UseViewMatrixModeReturn } from './useViewMatrixMode'
+
+export interface UseViewMatrixEditingOptions {
+  layout: KeyboardLayout | null
+  viewMatrix?: Record<string, ViewMatrixCell>
+  onViewMatrixChange?: (next: Record<string, ViewMatrixCell> | undefined) => void
+  rows?: number
+  cols?: number
+  selectableKeys: KleKey[]
+  matrixMode: boolean
+  handleMatrixToggle: () => void
+  handleDeselect: () => void
+  handleKeycodeSelect: (kc: Keycode) => Promise<void>
+}
+
+export interface UseViewMatrixEditingReturn {
+  viewMatrixMode: UseViewMatrixModeReturn
+  handleToggleViewMatrixMode: () => void
+  handleViewMatrixKeyClick: (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
+  viewMatrixSelectedPositions: { row: number; col: number }[]
+  viewMatrixEffectiveSingle: { row: number; col: number } | null
+  handleViewMatrixAxisChange: (axis: 'row' | 'col', value: number) => void
+  viewMatrixAxisOptionCount: number
+  viewMatrixLabelOverrides: Map<string, { outer: string; inner: string; masked: boolean }> | undefined
+  viewMatrixDuplicateKeyColors: Map<string, string> | undefined
+  /** Keycode palette selection is a no-op while the mode is active — see
+   *  the no-op wrapper below. */
+  gatedHandleKeycodeSelect: (kc: Keycode) => void
+}
+
+export function useViewMatrixEditing({
+  layout, viewMatrix, onViewMatrixChange, rows, cols, selectableKeys,
+  matrixMode, handleMatrixToggle, handleDeselect, handleKeycodeSelect,
+}: UseViewMatrixEditingOptions): UseViewMatrixEditingReturn {
+  const viewMatrixMode = useViewMatrixMode()
+
+  // --- View Matrix mode: entry/exit + per-key gating ---
+  // Entering the mode forces the matrix (Key Tester) tool off and clears
+  // any lingering selection so the blank R/C legend view starts clean.
+  const handleToggleViewMatrixMode = useCallback(() => {
+    if (!viewMatrixMode.active) {
+      if (matrixMode) handleMatrixToggle()
+      handleDeselect()
+    }
+    viewMatrixMode.toggle()
+    // Depend on the stable members, not the wrapper object (a fresh
+    // literal every render) — the object identity would churn this
+    // callback per render.
+  }, [viewMatrixMode.active, viewMatrixMode.toggle, matrixMode, handleMatrixToggle, handleDeselect])
+
+  // Clicking a key in the mode selects it for the panel's Row/Col selects
+  // — encoders and decals have no physical row/col to override, so they
+  // stay inert (unaffected) rather than gaining a click handler. Ctrl/Cmd
+  // toggles the key in/out of a multi-selection, Shift extends a
+  // contiguous range (mirrors the normal-mode keymap multi-select's
+  // modifier conventions — see `useKeymapMultiSelect`).
+  const handleViewMatrixKeyClick = useCallback((
+    key: KleKey,
+    _maskClicked: boolean,
+    event?: { ctrlKey: boolean; shiftKey: boolean },
+  ) => {
+    if (key.decal || key.encoderIdx >= 0) return
+    if (event?.ctrlKey) { viewMatrixMode.toggleKeySelection(key.row, key.col); return }
+    if (event?.shiftKey) { viewMatrixMode.extendSelection(key.row, key.col, selectableKeys); return }
+    viewMatrixMode.selectKey(key.row, key.col)
+    // The hook's setters are useCallback-stable; depending on the wrapper
+    // object would defeat KeyboardWidget's memo on every render while the
+    // mode is active (80+ KeyWidget re-renders).
+  }, [viewMatrixMode.toggleKeySelection, viewMatrixMode.extendSelection, viewMatrixMode.selectKey, selectableKeys])
+
+  // Physical positions of the currently selected keys, parsed from the
+  // hook's "row,col" string set into the shape `applyViewMatrixAxisToSelection`
+  // expects.
+  const viewMatrixSelectedPositions = useMemo(() => [...viewMatrixMode.selectedKeys].map((pos) => {
+    const [row, col] = pos.split(',').map(Number)
+    return { row, col }
+  }), [viewMatrixMode.selectedKeys])
+
+  // Effective position of the single selected key — null with 0 or 2+ keys
+  // selected, where the panel's selects show a blank placeholder instead
+  // since a multi-selection's members may not share the same position.
+  const viewMatrixEffectiveSingle = useMemo(() => {
+    if (viewMatrixSelectedPositions.length !== 1) return null
+    const { row, col } = viewMatrixSelectedPositions[0]
+    return effectiveViewPos(viewMatrix, row, col)
+  }, [viewMatrixSelectedPositions, viewMatrix])
+
+  // Row/Col select handler — a single selected key writes just that key's
+  // override; 2+ selected keys bulk-apply the axis across the whole
+  // selection in one `onViewMatrixChange` write, each key keeping its own
+  // value on the other axis (see `applyViewMatrixAxisToSelection`).
+  const handleViewMatrixAxisChange = useCallback((axis: 'row' | 'col', value: number) => {
+    if (viewMatrixSelectedPositions.length === 0) return
+    onViewMatrixChange?.(applyViewMatrixAxisToSelection(viewMatrix, viewMatrixSelectedPositions, axis, value))
+  }, [viewMatrixSelectedPositions, viewMatrix, onViewMatrixChange])
+
+  // View positions are logical, not physical — they only need to sort keys
+  // into a 2D grid, not mirror the firmware's electrical matrix. Direct-pin
+  // keyboards declare degenerate physical matrices (1×N or N×1, one row/col
+  // per GPIO pin with no real electrical grid), so capping each select to
+  // its own physical dimension would collapse one axis to a single option
+  // and make 2D view ordering impossible. Both selects therefore share the
+  // same option count: the larger of the two physical dimensions.
+  const viewMatrixAxisOptionCount = Math.max(rows ?? 0, cols ?? 0)
+
+  // One pass over the layout builds both mode legend artifacts — they
+  // share the same inputs and always recompute together: the per-key R/C
+  // label override showing each non-decal, non-encoder key's effective
+  // position, and the fill colour map that flags keys whose effective
+  // position collides with another key's (the Auto Move order between
+  // colliding keys is ambiguous until resolved). The collision grouping
+  // happens in this same loop (rather than a second pass over the keys)
+  // so `effectiveViewPos` is computed once per key.
+  const { viewMatrixLabelOverrides, viewMatrixDuplicateKeyColors } = useMemo(() => {
+    if (!viewMatrixMode.active || !layout) {
+      return { viewMatrixLabelOverrides: undefined, viewMatrixDuplicateKeyColors: undefined }
+    }
+    const overrides = new Map<string, { outer: string; inner: string; masked: boolean }>()
+    // Effective position -> physical "row,col" keys resolving to it, used
+    // below to find every key involved in a collision (group size > 1).
+    const groups = new Map<string, string[]>()
+    for (const key of layout.keys) {
+      if (key.decal || key.encoderIdx >= 0) continue
+      const physPos = posKey(key.row, key.col)
+      const effective = effectiveViewPos(viewMatrix, key.row, key.col)
+      overrides.set(physPos, { outer: `R ${effective.row}\nC ${effective.col}`, inner: '', masked: false })
+      const effPos = posKey(effective.row, effective.col)
+      const group = groups.get(effPos)
+      if (group) group.push(physPos)
+      else groups.set(effPos, [physPos])
+    }
+    const duplicateKeyColors = new Map<string, string>()
+    for (const group of groups.values()) {
+      if (group.length <= 1) continue
+      for (const physPos of group) duplicateKeyColors.set(physPos, KEY_DUPLICATE_COLOR)
+    }
+    return {
+      viewMatrixLabelOverrides: overrides,
+      viewMatrixDuplicateKeyColors: duplicateKeyColors.size > 0 ? duplicateKeyColors : undefined,
+    }
+  }, [viewMatrixMode.active, layout, viewMatrix])
+
+  // Keycode palette selection is a no-op while in the mode — nothing is
+  // ever selected (selectedKey/selectedEncoder stay null), so this mostly
+  // guards TD/Macro tile clicks, which otherwise still open their modals.
+  const noopKeycodeSelect = useCallback(() => {}, [])
+  const gatedHandleKeycodeSelect = viewMatrixMode.active ? noopKeycodeSelect : handleKeycodeSelect
+
+  return {
+    viewMatrixMode, handleToggleViewMatrixMode, handleViewMatrixKeyClick,
+    viewMatrixSelectedPositions, viewMatrixEffectiveSingle, handleViewMatrixAxisChange,
+    viewMatrixAxisOptionCount, viewMatrixLabelOverrides, viewMatrixDuplicateKeyColors,
+    gatedHandleKeycodeSelect,
+  }
+}

--- a/src/renderer/hooks/useUnlockGate.ts
+++ b/src/renderer/hooks/useUnlockGate.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useRef, useEffect, useCallback } from 'react'
+import { useRef, useEffect, useCallback, useMemo } from 'react'
 import { isResetKeycode } from '../../shared/keycodes/keycodes'
 
 interface UnlockGateOptions {
@@ -85,5 +85,8 @@ export function useUnlockGate({ unlocked, onUnlock }: UnlockGateOptions): Unlock
     [deferOrRun],
   )
 
-  return { guard, guardAll, clearPending }
+  // Stable wrapper identity: consumers list the gate object (or callbacks
+  // derived from it) in memo/callback deps, so a fresh literal per render
+  // would silently defeat their memoization.
+  return useMemo(() => ({ guard, guardAll, clearPending }), [guard, guardAll, clearPending])
 }


### PR DESCRIPTION
## Summary

- Extract the layout picker (state hook + presentational content), JSON-editor modal state (one generic helper behind an explicit surface), View Matrix wiring, the modal collection, layer keycode builders, the side toolbar, and the popover bridge into their own modules — the editor keeps composition and top-level layout only
- Code moved verbatim; two review fixes: `useUnlockGate` now returns a stable object (its per-render literal silently defeated consumers' memoization) and the picker data shapes moved to keymap-editor-types to break a type-only sibling import cycle

## Test plan

- Behavior-preserving: zero test-file edits, full suite green (6,323 tests)
- ESLint / tsc clean