### PR TITLE
feat(ui): tray residency toggles in the typing-view REC tab

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -939,6 +939,10 @@ export function App() {
             onTypingRecordingConsentAccepted={() => appConfig.set('typingRecordingConsentAccepted', true)}
             typingMonitorAppEnabled={appConfig.config.typingMonitorAppEnabled}
             onTypingMonitorAppEnabledChange={(enabled) => appConfig.set('typingMonitorAppEnabled', enabled)}
+            typingTrayResident={appConfig.config.trayResident}
+            onTypingTrayResidentChange={(enabled) => appConfig.set('trayResident', enabled)}
+            typingStartInTray={appConfig.config.startInTray}
+            onTypingStartInTrayChange={(enabled) => appConfig.set('startInTray', enabled)}
             typingViewMenuTab={devicePrefs.typingViewMenuTab}
             onTypingViewMenuTabChange={devicePrefs.setTypingViewMenuTab}
             onViewAnalytics={handleViewAnalytics}

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -68,6 +68,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
   typingHeatmapWindowMin, onTypingHeatmapWindowMinChange,
   typingMonitorAppEnabled, onTypingMonitorAppEnabledChange,
+  typingTrayResident, onTypingTrayResidentChange, typingStartInTray, onTypingStartInTrayChange,
   typingViewMenuTab, onTypingViewMenuTabChange,
   onViewAnalytics, onTypingTestRunningChange,
   tappingTermMs,
@@ -377,6 +378,10 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               onHeatmapWindowMinChange={onTypingHeatmapWindowMinChange}
               monitorAppEnabled={typingMonitorAppEnabled}
               onMonitorAppEnabledChange={onTypingMonitorAppEnabledChange}
+              trayResident={typingTrayResident}
+              onTrayResidentChange={onTypingTrayResidentChange}
+              startInTray={typingStartInTray}
+              onStartInTrayChange={onTypingStartInTrayChange}
               menuTab={typingViewMenuTab}
               onMenuTabChange={onTypingViewMenuTabChange}
               onViewAnalytics={onViewAnalytics}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -128,6 +128,18 @@ export interface TypingTestPaneProps {
    * controls one switch at a time. */
   monitorAppEnabled?: boolean
   onMonitorAppEnabledChange?: (enabled: boolean) => void
+  /** AppConfig flag — keeps Pipette running in the tray after the last
+   * window closes. Mirrors Settings > Tools; surfaced here too since the
+   * view-only window is often the last one open. */
+  trayResident?: boolean
+  onTrayResidentChange?: (enabled: boolean) => void
+  /** AppConfig flag — launch resident in the tray without opening a
+   * window. Disabled while trayResident is off; turning trayResident off
+   * also clears this when set, since a hidden window with no tray icon
+   * to reopen it would be unreachable. Same linked-clear logic as
+   * SettingsToolsTab — keep both in sync. */
+  startInTray?: boolean
+  onStartInTrayChange?: (enabled: boolean) => void
   /** Which tab of the view-only menu is currently open. Window shows
    * size / always-on-top controls; REC shows the recording toggle and
    * the entry point to the analytics page; Monitor App shows the
@@ -201,6 +213,10 @@ export function TypingTestPane({
   onHeatmapWindowMinChange,
   monitorAppEnabled,
   onMonitorAppEnabledChange,
+  trayResident,
+  onTrayResidentChange,
+  startInTray,
+  onStartInTrayChange,
   menuTab = 'window',
   onMenuTabChange,
   onViewAnalytics,
@@ -279,6 +295,18 @@ export function TypingTestPane({
     }
     onRecordEnabledChange(true)
   }, [onRecordEnabledChange, recordEnabled, recordingConsentAccepted])
+
+  const handleTrayResidentToggle = useCallback(() => {
+    if (!onTrayResidentChange) return
+    const next = !trayResident
+    onTrayResidentChange(next)
+    // Mirrors SettingsToolsTab: a hidden window with no tray icon to
+    // reopen it would be unreachable, so turning tray residency off
+    // also clears startInTray when it was on.
+    if (!next && startInTray) {
+      onStartInTrayChange?.(false)
+    }
+  }, [onTrayResidentChange, trayResident, startInTray, onStartInTrayChange])
 
   const handleConsentAccept = useCallback(() => {
     onRecordingConsentAccepted?.()
@@ -816,9 +844,10 @@ export function TypingTestPane({
 
             {/* Each tab body is wrapped in its own flex column so we can
                 pin a shared min-h. REC currently has the most controls
-                (Start/Stop, View Analytics, HeatMap window), so the
-                other tabs match its natural height. Keep this in sync
-                if any tab grows/shrinks meaningfully. */}
+                (Start/Stop, Monitor App, tray toggles, View Analytics,
+                HeatMap window), so the other tabs match its natural
+                height. Keep this in sync if any tab grows/shrinks
+                meaningfully. */}
             {menuTab === 'window' && (
               <div className="flex min-h-word-list flex-col gap-1.5">
                 <button
@@ -905,6 +934,42 @@ export function TypingTestPane({
                     }}
                   >
                     {t('editor.typingTest.monitorApp.label')}
+                  </button>
+                )}
+                {/* Tray toggles — same AppConfig fields and linked-clear
+                    semantics as Settings > Tools, surfaced here since the
+                    view-only window is often the last one open before the
+                    user reaches for the tray. */}
+                {onTrayResidentChange && (
+                  <button
+                    type="button"
+                    role="menuitemcheckbox"
+                    aria-checked={trayResident ?? false}
+                    data-testid="typing-tray-resident-toggle"
+                    className={`whitespace-nowrap ${trayResident ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`}
+                    onClick={handleTrayResidentToggle}
+                  >
+                    {t('settings.trayResident')}
+                  </button>
+                )}
+                {onStartInTrayChange && (
+                  <button
+                    type="button"
+                    role="menuitemcheckbox"
+                    aria-checked={startInTray ?? false}
+                    aria-disabled={!trayResident}
+                    data-testid="typing-start-in-tray-toggle"
+                    className={
+                      !trayResident
+                        ? 'whitespace-nowrap rounded border border-edge px-2 py-1 text-content-muted opacity-60 cursor-not-allowed'
+                        : `whitespace-nowrap ${startInTray ? BTN_TOGGLE_ACTIVE : BTN_TOGGLE_INACTIVE}`
+                    }
+                    onClick={() => {
+                      if (!trayResident) return
+                      onStartInTrayChange(!startInTray)
+                    }}
+                  >
+                    {t('settings.startInTray')}
                   </button>
                 )}
                 {onViewAnalytics && (

--- a/src/renderer/components/editors/__tests__/TypingTestPane.rec.test.tsx
+++ b/src/renderer/components/editors/__tests__/TypingTestPane.rec.test.tsx
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'editor.typingTest.tab.window': 'Window',
+        'editor.typingTest.tab.rec': 'REC',
+        'editor.typingTest.recordStart': 'Start',
+        'editor.typingTest.recordStop': 'Stop',
+        'settings.trayResident': 'Stay in System Tray',
+        'settings.startInTray': 'Start Hidden in Tray',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../keyboard/KeyboardWidget', () => ({
+  KeyboardWidget: () => <div data-testid="keyboard-widget">KeyboardWidget</div>,
+}))
+
+import { TypingTestPane, type TypingTestPaneProps } from '../TypingTestPane'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../../typing-test/types'
+import { createInitialState } from '../../../typing-test/run-state'
+
+beforeEach(() => {
+  window.vialAPI = {
+    ...window.vialAPI,
+    isAlwaysOnTopSupported: () => Promise.resolve(false),
+    setWindowCompactMode: () => Promise.resolve(null),
+    setWindowAspectRatio: () => Promise.resolve(),
+    setWindowAlwaysOnTop: () => Promise.resolve(),
+  } as typeof window.vialAPI
+})
+
+// Minimal stub of useTypingTest's return value — only the fields the REC
+// tab's rendering path (viewOnly + menuTab='rec') actually reads.
+const fakeTypingTest = {
+  state: createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE),
+  wpm: 0,
+  kpm: 0,
+  accuracy: 100,
+  romajiGuide: null,
+  elapsedSeconds: 0,
+  remainingSeconds: null,
+  config: DEFAULT_CONFIG,
+  language: DEFAULT_LANGUAGE,
+  isLanguageLoading: false,
+  baseLayer: 0,
+  effectiveLayer: 0,
+  windowFocused: true,
+  processMatrixFrame: vi.fn(),
+  resetMatrixPressTracking: vi.fn(),
+  processKeyEvent: vi.fn(),
+  processCompositionStart: vi.fn(),
+  processCompositionUpdate: vi.fn(),
+  processCompositionEnd: vi.fn(),
+  restart: vi.fn(),
+  restartWithCountdown: vi.fn(),
+  setConfig: vi.fn(),
+  setLanguage: vi.fn(),
+  setBaseLayer: vi.fn(),
+  setWindowFocused: vi.fn(),
+  captureMemory: vi.fn(),
+  pause: vi.fn(),
+  restoreState: vi.fn(),
+} as unknown as TypingTestPaneProps['typingTest']
+
+function renderRecTab(overrides: Partial<TypingTestPaneProps> = {}) {
+  const defaults: TypingTestPaneProps = {
+    typingTest: fakeTypingTest,
+    onConfigChange: vi.fn(),
+    onLanguageChange: vi.fn().mockResolvedValue(undefined),
+    layers: 1,
+    pressedKeys: new Set(),
+    keycodes: new Map(),
+    encoderKeycodes: new Map(),
+    remappedKeys: new Set(),
+    layoutOptions: new Map(),
+    scale: 1,
+    keys: [],
+    layerLabel: '',
+    viewOnly: true,
+    menuTab: 'rec',
+  }
+  return render(<TypingTestPane {...defaults} {...overrides} />)
+}
+
+describe('TypingTestPane — REC tab tray toggles', () => {
+  it('does not render the tray rows when their change handlers are not wired', () => {
+    renderRecTab()
+    expect(screen.queryByTestId('typing-tray-resident-toggle')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('typing-start-in-tray-toggle')).not.toBeInTheDocument()
+  })
+
+  it('renders both rows and reflects config values when off', () => {
+    const onTrayResidentChange = vi.fn()
+    const onStartInTrayChange = vi.fn()
+    renderRecTab({ trayResident: false, onTrayResidentChange, startInTray: false, onStartInTrayChange })
+
+    const trayRow = screen.getByTestId('typing-tray-resident-toggle')
+    const startRow = screen.getByTestId('typing-start-in-tray-toggle')
+    expect(trayRow).toHaveAttribute('aria-checked', 'false')
+    expect(startRow).toHaveAttribute('aria-checked', 'false')
+    expect(trayRow).toHaveTextContent('Stay in System Tray')
+    expect(startRow).toHaveTextContent('Start Hidden in Tray')
+  })
+
+  it('reflects config values when on', () => {
+    renderRecTab({
+      trayResident: true,
+      onTrayResidentChange: vi.fn(),
+      startInTray: true,
+      onStartInTrayChange: vi.fn(),
+    })
+    expect(screen.getByTestId('typing-tray-resident-toggle')).toHaveAttribute('aria-checked', 'true')
+    expect(screen.getByTestId('typing-start-in-tray-toggle')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('clicking the tray-resident row calls onTrayResidentChange', () => {
+    const onTrayResidentChange = vi.fn()
+    renderRecTab({ trayResident: false, onTrayResidentChange, startInTray: false, onStartInTrayChange: vi.fn() })
+
+    fireEvent.click(screen.getByTestId('typing-tray-resident-toggle'))
+    expect(onTrayResidentChange).toHaveBeenCalledWith(true)
+  })
+
+  it('disables the start-in-tray row while tray residency is off', () => {
+    const onStartInTrayChange = vi.fn()
+    renderRecTab({ trayResident: false, onTrayResidentChange: vi.fn(), startInTray: false, onStartInTrayChange })
+
+    const startRow = screen.getByTestId('typing-start-in-tray-toggle')
+    expect(startRow).toHaveAttribute('aria-disabled', 'true')
+    fireEvent.click(startRow)
+    expect(onStartInTrayChange).not.toHaveBeenCalled()
+  })
+
+  it('clicking the start-in-tray row calls onStartInTrayChange when tray residency is on', () => {
+    const onStartInTrayChange = vi.fn()
+    renderRecTab({ trayResident: true, onTrayResidentChange: vi.fn(), startInTray: false, onStartInTrayChange })
+
+    const startRow = screen.getByTestId('typing-start-in-tray-toggle')
+    expect(startRow).toHaveAttribute('aria-disabled', 'false')
+    fireEvent.click(startRow)
+    expect(onStartInTrayChange).toHaveBeenCalledWith(true)
+  })
+
+  it('turning tray residency off also clears start-in-tray when it was on', () => {
+    const onTrayResidentChange = vi.fn()
+    const onStartInTrayChange = vi.fn()
+    renderRecTab({ trayResident: true, onTrayResidentChange, startInTray: true, onStartInTrayChange })
+
+    fireEvent.click(screen.getByTestId('typing-tray-resident-toggle'))
+    expect(onTrayResidentChange).toHaveBeenCalledWith(false)
+    expect(onStartInTrayChange).toHaveBeenCalledWith(false)
+  })
+
+  it('turning tray residency off does not touch start-in-tray when it was already off', () => {
+    const onTrayResidentChange = vi.fn()
+    const onStartInTrayChange = vi.fn()
+    renderRecTab({ trayResident: true, onTrayResidentChange, startInTray: false, onStartInTrayChange })
+
+    fireEvent.click(screen.getByTestId('typing-tray-resident-toggle'))
+    expect(onTrayResidentChange).toHaveBeenCalledWith(false)
+    expect(onStartInTrayChange).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/editors/keymap-editor-types.ts
+++ b/src/renderer/components/editors/keymap-editor-types.ts
@@ -181,6 +181,12 @@ export interface KeymapEditorProps {
    * where data collection begins. */
   typingMonitorAppEnabled?: boolean
   onTypingMonitorAppEnabledChange?: (enabled: boolean) => void
+  /** AppConfig fields for the REC tab's tray toggles — same source and
+   * linked-clear semantics as Settings > Tools (SettingsToolsTab). */
+  typingTrayResident?: boolean
+  onTypingTrayResidentChange?: (enabled: boolean) => void
+  typingStartInTray?: boolean
+  onTypingStartInTrayChange?: (enabled: boolean) => void
   typingViewMenuTab?: TypingViewMenuTab
   onTypingViewMenuTabChange?: (tab: TypingViewMenuTab) => void
   /** Called when "View Analytics" is triggered, from either the compact


### PR DESCRIPTION
## Summary

- **Stay in System Tray** and **Start Hidden in Tray** join the REC tab below Monitor App, so tray behavior can be flipped without leaving the typing view
- Same semantics as Settings > Tools: Start Hidden in Tray is disabled without tray residency, and turning residency off clears it; wired through the same AppConfig prop chain the Monitor App toggle uses, in the REC tab's button-toggle idiom
- Reused the existing settings.* locale keys — no new i18n keys

## Test plan

- New TypingTestPane REC-tab test file (8 tests: render/absent-when-unwired/values/emit/disabled/linked-clear)
- Full suite green (6,331 tests); ESLint / tsc clean