### PR TITLE
fix(ui): stop the tray from swallowing the window on unlock during normal use

### DIFF
--- a/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
+++ b/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
@@ -25,7 +25,9 @@ beforeEach(() => {
   windowStartedHidden = vi.fn().mockResolvedValue(true)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(window as any).vialAPI = { windowShow, windowHide, windowStartedHidden }
-  setVisibilityState('visible')
+  // A boot-hidden launch means the BrowserWindow actually starts hidden,
+  // so document.visibilityState reports 'hidden' until this hook shows it.
+  setVisibilityState('hidden')
 })
 
 afterEach(() => {
@@ -92,6 +94,62 @@ describe('useBootHiddenWindow', () => {
     rerender({ visible: false })
 
     expect(windowShow).not.toHaveBeenCalled()
+    expect(windowHide).not.toHaveBeenCalled()
+  })
+
+  it('never hides the window when an unlock dialog rises and falls during normal use after the window is already visible', async () => {
+    // The window started hidden, but by the time the hook learns this the
+    // window is already visible (e.g. the tray click happened first).
+    setVisibilityState('visible')
+
+    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
+      initialProps: { visible: false },
+    })
+    await flushMicrotasks()
+
+    // An unlock dialog cycles during normal use — must not hide the window
+    // the user is actively looking at.
+    rerender({ visible: true })
+    expect(windowShow).not.toHaveBeenCalled()
+
+    rerender({ visible: false })
+    expect(windowHide).not.toHaveBeenCalled()
+
+    // Nor on a later cycle, since the phase already ended.
+    rerender({ visible: true })
+    rerender({ visible: false })
+    expect(windowShow).not.toHaveBeenCalled()
+    expect(windowHide).not.toHaveBeenCalled()
+  })
+
+  it('never hides the window when it is revealed before windowStartedHidden resolves (async race)', async () => {
+    // Simulate the race: windowStartedHidden() has not resolved yet, but
+    // the user reveals the window (tray click → visibilitychange) first.
+    let resolveStartedHidden: (hidden: boolean) => void = () => {}
+    windowStartedHidden.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
+    )
+
+    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
+      initialProps: { visible: false },
+    })
+
+    // The user reveals the window before windowStartedHidden() resolves.
+    setVisibilityState('visible')
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // Now the promise resolves with hidden=true — this must not re-arm the
+    // boot-hidden phase, since the window is already visible.
+    resolveStartedHidden(true)
+    await flushMicrotasks()
+
+    // A later unlock dialog cycle during normal use must not hide the window.
+    rerender({ visible: true })
+    expect(windowShow).not.toHaveBeenCalled()
+
+    rerender({ visible: false })
     expect(windowHide).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/useBootHiddenWindow.ts
+++ b/src/renderer/hooks/useBootHiddenWindow.ts
@@ -7,22 +7,26 @@ import { useEffect, useRef } from 'react'
  * the window for the Unlock dialog." The main process starts the window
  * hidden (windowStartedHidden()); this hook shows it only while the
  * Unlock dialog opened during session restore is visible, then hides it
- * again once the dialog resolves — unless the user has already shown the
- * window themselves (e.g. a tray click), in which case the boot-hidden
- * phase ends and the window is left alone.
+ * again once the dialog resolves — but only if this hook is the one that
+ * showed it. If the window is already visible (the user showed it
+ * themselves, or the boot-hidden phase never really applied), later
+ * unlock dialogs during normal use are left alone: the phase ends without
+ * showing or hiding anything.
  */
 export function useBootHiddenWindow(unlockDialogVisible: boolean): void {
   const bootHiddenRef = useRef(false)
   const weShowedRef = useRef(false)
   const prevVisibleRef = useRef(unlockDialogVisible)
 
-  // Learn whether this launch started hidden. Runs once; a failure (or a
-  // launch that did not start hidden) simply leaves the phase off, so the
-  // rest of this hook never touches the window.
+  // Learn whether this launch started hidden. Runs once; only arm the
+  // phase if the window is still actually hidden by the time this
+  // resolves — if the user (or the OS) already revealed it, the
+  // boot-hidden phase is already over and must never re-arm. A failure
+  // (or a launch that did not start hidden) also leaves the phase off.
   useEffect(() => {
     let cancelled = false
     window.vialAPI.windowStartedHidden().then((hidden) => {
-      if (!cancelled) bootHiddenRef.current = hidden
+      if (!cancelled) bootHiddenRef.current = hidden && document.visibilityState !== 'visible'
     }).catch(() => { /* best-effort — stay non-boot-hidden on failure */ })
     return () => { cancelled = true }
   }, [])
@@ -33,20 +37,27 @@ export function useBootHiddenWindow(unlockDialogVisible: boolean): void {
     if (!bootHiddenRef.current) return
 
     if (unlockDialogVisible && !wasVisible) {
-      // Rising edge: the unlock dialog just opened during the boot-hidden
-      // phase. Show the window for it and remember that we did so, so the
-      // visibilitychange listener below does not mistake this for the
-      // user showing the window themselves.
+      if (document.visibilityState === 'visible') {
+        // The window is already visible (the user is actively using it) —
+        // this is not the boot-hidden dialog. End the phase without
+        // touching the window; later dialogs must not hide it either.
+        bootHiddenRef.current = false
+        return
+      }
+      // Rising edge on a genuinely hidden window: show it for the dialog
+      // and remember that we did so, so the falling edge only hides what
+      // we showed.
       weShowedRef.current = true
       void window.vialAPI.windowShow().catch(() => {})
     } else if (!unlockDialogVisible && wasVisible) {
       // Falling edge: the dialog resolved (unlocked, or cancelled/
-      // disconnected). Hide the window again and end the boot-hidden
-      // phase — later dialogs in this session no longer auto-show/hide.
-      // (weShowedRef needs no reset: every read is gated on the
-      // boot-hidden flag that just went false for good.)
+      // disconnected). End the boot-hidden phase — later dialogs in this
+      // session no longer auto-show/hide — and hide the window again only
+      // if this hook is the one that showed it for this dialog.
       bootHiddenRef.current = false
-      void window.vialAPI.windowHide().catch(() => {})
+      if (weShowedRef.current) {
+        void window.vialAPI.windowHide().catch(() => {})
+      }
     }
   }, [unlockDialogVisible])
 


### PR DESCRIPTION
## Summary

With tray residency on, resolving an unlock dialog while the window was already visible (repro: keymap editor → typing test → re-lock → unlock) hid the window to the tray. Per spec, the window should auto-hide to the tray **only** on window close and on the start-hidden-in-tray launch — never just because an unlock dialog resolved during active use.

## Root cause

The boot-hidden phase in `useBootHiddenWindow` could linger into normal use:
- its "started hidden" flag is learned asynchronously (IPC round-trip), so a tray click that revealed the window *before* the flag resolved never ended the phase — the flag then flipped on and stayed armed;
- the falling edge (dialog resolved) then called `windowHide()` unconditionally.

## Fix

- Arm the boot-hidden phase only if the window is still hidden when the started-hidden flag resolves (closes the reveal-before-resolve race).
- On a dialog rising edge, bail if the window is already visible (the user is using it) instead of taking it over.
- On the falling edge, hide only the window this hook itself showed for that dialog.

The window-close auto-hide (`index.ts` close handler) and the start-hidden launch flow are untouched.

## Verification

- `pnpm typecheck` / `pnpm lint` clean
- `pnpm test`: 6374 passed / 22 skipped, 0 failed
- Adds regression tests for both the already-visible path and the async-race path