### PR TITLE
feat(ui): default romaji input on and remember it across language switches

### DIFF
--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -10,7 +10,7 @@ import { buildResultNameChips } from '../../typing-test/result-builder'
 import { PauseResumeModal } from '../../typing-test/PauseResumeModal'
 import { LanguageSelectorModal } from '../../typing-test/LanguageSelectorModal'
 import { TypingRecordingConsentModal } from '../../typing-test/TypingRecordingConsentModal'
-import { isRomajiCapable } from '../../typing-test/romaji-input'
+import { isRomajiCapable, carryRomajiFields } from '../../typing-test/romaji-input'
 import { useTypingHeatmap } from '../../typing-test/useTypingHeatmap'
 import { TYPING_HEATMAP_WINDOW_OPTIONS } from '../../../shared/types/app-config'
 import { KeyboardPane } from './KeyboardPane'
@@ -551,8 +551,8 @@ export function TypingTestPane({
               }
               void onLanguageChange(name)
             }}
-            onSelectImport={(textId) => onConfigChange({ mode: 'fileImport', textId })}
-            onSelectTatoeba={(language) => onConfigChange({ mode: 'tatoeba', language })}
+            onSelectImport={(textId) => onConfigChange({ mode: 'fileImport', textId, ...carryRomajiFields(typingTest.config) })}
+            onSelectTatoeba={(language) => onConfigChange({ mode: 'tatoeba', language, ...carryRomajiFields(typingTest.config) })}
             onCurrentTextDeleted={() => {
               // The selected imported text was deleted — fall back to
               // the default (words mode, English).

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useTypingTest } from '../../typing-test/useTypingTest'
 import { buildTypingTestResult, isPbForConfig, materialLabel } from '../../typing-test/result-builder'
+import { isRomajiInputActive } from '../../typing-test/romaji-input'
 import type { TypingTestConfig } from '../../typing-test/types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../typing-test/types'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
@@ -404,6 +405,7 @@ export function useInputModes({
         wpmHistory: typingTest.state.wpmHistory,
         fileImportTextName: typingTest.config.mode === 'fileImport' ? typingTest.state.currentQuote?.source : undefined,
         runId: typingTest.state.runId,
+        romajiActive: isRomajiInputActive(typingTest.config, typingTest.language, typingTest.state.romajiCapable),
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       if (saveUnnamed) {
@@ -429,7 +431,7 @@ export function useInputModes({
   }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
     typingTest.state.correctChars, typingTest.state.incorrectChars,
     typingTest.state.currentWordIndex, typingTest.state.wpmHistory,
-    typingTest.state.currentQuote, typingTest.state.runId,
+    typingTest.state.currentQuote, typingTest.state.runId, typingTest.state.romajiCapable,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
     typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult])

--- a/src/renderer/typing-test/RomajiSettingsModal.tsx
+++ b/src/renderer/typing-test/RomajiSettingsModal.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from '../components/ui/Tooltip'
 import { BASE_STYLES, type RomajiStyle } from './romaji-engine'
 import type { RomajiCaseStyle, RomajiDetailSettings, TypingTestConfig } from './types'
 import { optionButtonClass } from './TypingTestSettingsBar'
+import { isRomajiInputEnabled } from './romaji-input'
 
 // Display order matches the plan's spec ("大文字・先頭大文字・小文字"); the
 // i18n values for these keys are the fixed sample spellings ROMAJI / Romaji
@@ -78,7 +79,11 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
   }, [onClose])
 
   const romaji = config.romaji ?? {}
-  const enabled = config.romajiInput === true
+  // Default ON: undefined counts as opted-in, only an explicit false is off
+  // (see isRomajiInputEnabled). The toggle below writes the opposite boolean
+  // back — so turning a default-on config off persists `false`, and turning
+  // it back on persists `true`.
+  const enabled = isRomajiInputEnabled(config)
   const caseStyle = romaji.caseStyle ?? 'lower'
   const guideStyles = new Set(romaji.guideStyles ?? [])
   const disabledStyles = new Set(romaji.disabledStyles ?? [])

--- a/src/renderer/typing-test/TypingTestSettingsBar.tsx
+++ b/src/renderer/typing-test/TypingTestSettingsBar.tsx
@@ -11,7 +11,7 @@ import { useRef, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingTestConfig, TypingTestMode, QuoteLength, RomajiDetailSettings } from './types'
 import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS } from './types'
-import { isRomajiCapable } from './romaji-input'
+import { isRomajiCapable, isRomajiInputEnabled } from './romaji-input'
 import { RomajiSettingsModal } from './RomajiSettingsModal'
 
 const MODES: TypingTestMode[] = ['words', 'time', 'quote']
@@ -51,12 +51,14 @@ export function TypingTestSettingsBar({ config, onConfigChange, language, textRo
   // romajiInput/romaji are carried from every mode but quote, since tatoeba
   // and fileImport carry those fields too now (see TypingTestConfig).
   const togglesRef = useRef<{ punctuation: boolean; numbers: boolean; romajiInput: boolean; romaji?: RomajiDetailSettings }>(
-    { punctuation: false, numbers: false, romajiInput: false },
+    { punctuation: false, numbers: false, romajiInput: true },
   )
   if (config.mode !== 'quote') {
     togglesRef.current = {
       ...togglesRef.current,
-      romajiInput: config.romajiInput === true,
+      // Default ON: an undefined (not-yet-touched) romajiInput carries as
+      // true through a mode switch, matching isRomajiInputEnabled's default.
+      romajiInput: isRomajiInputEnabled(config),
       romaji: config.romaji,
       ...(config.mode === 'words' || config.mode === 'time'
         ? { punctuation: config.punctuation, numbers: config.numbers }
@@ -212,7 +214,7 @@ export function TypingTestSettingsBar({ config, onConfigChange, language, textRo
             <button
               type="button"
               data-testid="romaji-settings-toggle"
-              className={`${optionButtonClass(config.romajiInput === true)} w-full justify-center`}
+              className={`${optionButtonClass(isRomajiInputEnabled(config))} w-full justify-center`}
               onClick={() => setShowRomajiModal(true)}
               aria-haspopup="dialog"
               aria-expanded={showRomajiModal}

--- a/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
@@ -31,14 +31,19 @@ function renderModal(props: Partial<Parameters<typeof RomajiSettingsModal>[0]> =
 }
 
 describe('RomajiSettingsModal defaults', () => {
-  it('shows the master enable off when romajiInput is not set', () => {
+  it('shows the master enable on by default when romajiInput is not set', () => {
     renderModal()
-    expect(screen.getByTestId('romaji-settings-enabled')).toHaveAttribute('aria-checked', 'false')
+    expect(screen.getByTestId('romaji-settings-enabled')).toHaveAttribute('aria-checked', 'true')
   })
 
   it('shows the master enable on when romajiInput is true', () => {
     renderModal({ config: { ...BASE_CONFIG, romajiInput: true } })
     expect(screen.getByTestId('romaji-settings-enabled')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows the master enable off when romajiInput is explicitly false', () => {
+    renderModal({ config: { ...BASE_CONFIG, romajiInput: false } })
+    expect(screen.getByTestId('romaji-settings-enabled')).toHaveAttribute('aria-checked', 'false')
   })
 
   it('defaults the case selector to lower', () => {
@@ -82,9 +87,18 @@ describe('RomajiSettingsModal defaults', () => {
 })
 
 describe('RomajiSettingsModal edits', () => {
-  it('toggles the master enable', () => {
+  it('toggles the master enable off from the default-on state (writes an explicit false)', () => {
     const onConfigChange = vi.fn()
     renderModal({ onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-settings-enabled'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    expect(arg.mode).toBe('words')
+    if (arg.mode === 'words') expect(arg.romajiInput).toBe(false)
+  })
+
+  it('toggles the master enable back on from an explicit false', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ config: { ...BASE_CONFIG, romajiInput: false }, onConfigChange })
     fireEvent.click(screen.getByTestId('romaji-settings-enabled'))
     const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
     expect(arg.mode).toBe('words')

--- a/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
@@ -185,14 +185,20 @@ describe('TypingTestSettingsBar romaji settings button', () => {
     expect(screen.queryByTestId('romaji-settings-toggle')).not.toBeInTheDocument()
   })
 
-  it('highlights the romaji button when romajiInput is active', () => {
+  it('highlights the romaji button when romajiInput is explicitly true', () => {
     const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
     renderBar({ config, language: 'japanese_hiragana' })
     expect(screen.getByTestId('romaji-settings-toggle').className).toContain('text-accent')
   })
 
-  it('does not highlight the romaji button when romajiInput is inactive', () => {
+  it('highlights the romaji button by default (romajiInput undefined = on)', () => {
     const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    renderBar({ config, language: 'japanese_hiragana' })
+    expect(screen.getByTestId('romaji-settings-toggle').className).toContain('text-accent')
+  })
+
+  it('does not highlight the romaji button when romajiInput is explicitly false', () => {
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: false }
     renderBar({ config, language: 'japanese_hiragana' })
     expect(screen.getByTestId('romaji-settings-toggle').className).not.toContain('text-accent')
   })
@@ -207,9 +213,22 @@ describe('TypingTestSettingsBar romaji settings button', () => {
     expect(screen.getByTestId('romaji-settings-modal')).toBeInTheDocument()
   })
 
-  it('toggles romajiInput via the modal master enable switch', () => {
+  it('toggles romajiInput off via the modal master enable switch, from the default-on state', () => {
     const onConfigChange = vi.fn()
     const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    renderBar({ config, language: 'japanese_hiragana', onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-settings-toggle'))
+    fireEvent.click(screen.getByTestId('romaji-settings-enabled'))
+    expect(onConfigChange).toHaveBeenCalledTimes(1)
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') {
+      expect(arg.romajiInput).toBe(false)
+    }
+  })
+
+  it('toggles romajiInput back on via the modal master enable switch, from an explicit false', () => {
+    const onConfigChange = vi.fn()
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: false }
     renderBar({ config, language: 'japanese_hiragana', onConfigChange })
     fireEvent.click(screen.getByTestId('romaji-settings-toggle'))
     fireEvent.click(screen.getByTestId('romaji-settings-enabled'))

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -2,7 +2,8 @@
 
 import { describe, it, expect } from 'vitest'
 import { computeComparison, matchingResults, conditionKey, resultConditionKey } from '../comparison'
-import { buildTypingTestResult } from '../result-builder'
+import { buildTypingTestResult, configKey } from '../result-builder'
+import { isRomajiInputActive } from '../romaji-input'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../types'
 
@@ -99,8 +100,12 @@ describe('conditionKey', () => {
   })
 
   it('distinguishes a romaji run from a verbatim run of the same kana pack', () => {
+    // romajiInput defaults ON for a capable (kana) language, so a genuine
+    // "verbatim" run needs the explicit opt-out — an unset romajiInput on a
+    // kana language is itself the (default-active) romaji run.
+    const verbatimConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: false }
     const romajiConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
-    const a = conditionKey(wordsConfig, 'japanese_hiragana')
+    const a = conditionKey(verbatimConfig, 'japanese_hiragana')
     const b = conditionKey(romajiConfig, 'japanese_hiragana')
     expect(a).not.toBe(b)
   })
@@ -161,6 +166,11 @@ describe('conditionKey / resultConditionKey agreement', () => {
     language: 'english',
     wpmHistory: [60],
     fileImportTextName: 'novel.txt',
+    // Mirrors the real call site (useInputModes.ts): romajiActive is always
+    // the effective isRomajiInputActive state, not the raw config flag — a
+    // config with an explicit `romajiInput: true` on a non-capable language
+    // (as below) is still inactive, and conditionKey must agree.
+    romajiActive: isRomajiInputActive(config, 'english', undefined),
   })
 
   it('agrees for every mode', () => {
@@ -177,6 +187,30 @@ describe('conditionKey / resultConditionKey agreement', () => {
       const result = buildTypingTestResult(buildInput(config))
       expect(conditionKey(config, 'english')).toBe(resultConditionKey(result))
     }
+  })
+
+  it('groups a default-ON kana words run with its own saved result (regression)', () => {
+    // romajiInput is left unset — default-ON — on a kana-capable language.
+    // The live conditionKey must land on the same key as the result this
+    // exact run produces, or a fresh PB/comparison never finds its own history.
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    const language = 'japanese_hiragana'
+    const romajiActive = isRomajiInputActive(config, language, undefined)
+    expect(romajiActive).toBe(true)
+    const result = buildTypingTestResult({
+      correctChars: 100,
+      incorrectChars: 5,
+      wordCount: 20,
+      wpm: 60,
+      accuracy: 95,
+      elapsedMs: 20_000,
+      config,
+      language,
+      wpmHistory: [60],
+      romajiActive,
+    })
+    expect(conditionKey(config, language)).toBe(resultConditionKey(result))
+    expect(conditionKey(config, language)).toBe(configKey(result))
   })
 })
 

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -182,6 +182,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [55, 58, 60, 62],
+      romajiActive: false,
     })
 
     expect(result.wpm).toBe(60)
@@ -201,20 +202,35 @@ describe('buildTypingTestResult', () => {
     expect(result.date).toBeTruthy()
   })
 
-  it('stores romajiInput for words/time modes, and omits it for quote', () => {
+  it('records romajiInput from the romajiActive input, not the raw config flag', () => {
     const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
     const withRomaji = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [],
+      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: true,
     })
     expect(withRomaji.romajiInput).toBe(true)
+
+    const notActive = buildTypingTestResult({
+      correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
+      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: false,
+    })
+    expect(notActive.romajiInput).toBeUndefined()
 
     const quoteConfig: TypingTestConfig = { mode: 'quote', quoteLength: 'medium' }
     const quoteResult = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: quoteConfig, language: 'english', wpmHistory: [],
+      config: quoteConfig, language: 'english', wpmHistory: [], romajiActive: false,
     })
     expect(quoteResult.romajiInput).toBeUndefined()
+  })
+
+  it('records romajiInput for tatoeba/fileImport runs too, now that recording follows romajiActive', () => {
+    const tatoebaCfg: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana' }
+    const result = buildTypingTestResult({
+      correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
+      config: tatoebaCfg, language: 'english', wpmHistory: [], romajiActive: true,
+    })
+    expect(result.romajiInput).toBe(true)
   })
 
   it('derives mode2 from time config', () => {
@@ -229,6 +245,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [],
+      romajiActive: false,
     })
     expect(result.mode).toBe('time')
     expect(result.mode2).toBe(60)
@@ -246,6 +263,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [],
+      romajiActive: false,
     })
     expect(result.mode).toBe('quote')
     expect(result.mode2).toBe('medium')
@@ -264,6 +282,7 @@ describe('buildTypingTestResult', () => {
       // The top-level (MonkeyType) language is irrelevant for tatoeba.
       language: 'german',
       wpmHistory: [],
+      romajiActive: false,
     })
     expect(result.mode).toBe('tatoeba')
     expect(result.mode2).toBe('english')

--- a/src/renderer/typing-test/__tests__/romaji-input.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-input.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { isRomajiCapable, isRomajiInputActive, romajiDetail } from '../romaji-input'
+import { isRomajiCapable, isRomajiInputEnabled, isRomajiInputActive, romajiDetail, carryRomajiFields } from '../romaji-input'
 import type { RomajiDetailSettings, TypingTestConfig } from '../types'
 
 // Each helper takes `romaji` directly (rather than spreading its return
@@ -45,21 +45,46 @@ describe('isRomajiCapable', () => {
   })
 })
 
+describe('isRomajiInputEnabled', () => {
+  it('defaults to enabled when romajiInput is unset, regardless of capability', () => {
+    expect(isRomajiInputEnabled(wordsConfig())).toBe(true)
+    expect(isRomajiInputEnabled(timeConfig())).toBe(true)
+    expect(isRomajiInputEnabled(tatoebaConfig('english'))).toBe(true)
+    expect(isRomajiInputEnabled(fileImportConfig())).toBe(true)
+  })
+
+  it('an explicit false opts out, an explicit true stays opted in', () => {
+    expect(isRomajiInputEnabled(wordsConfig(false))).toBe(false)
+    expect(isRomajiInputEnabled(wordsConfig(true))).toBe(true)
+  })
+
+  it('quote never carries the field and is always disabled', () => {
+    expect(isRomajiInputEnabled(quoteConfig())).toBe(false)
+  })
+})
+
 describe('isRomajiInputActive', () => {
-  it('words/time: active only when romajiInput is true AND the language is capable', () => {
+  it('words/time: defaults to active (romajiInput undefined) when the language is capable, inactive when not capable', () => {
+    expect(isRomajiInputActive(wordsConfig(), 'japanese_hiragana', undefined)).toBe(true)
+    expect(isRomajiInputActive(wordsConfig(), 'english', undefined)).toBe(false)
+    expect(isRomajiInputActive(timeConfig(), 'japanese_hiragana', undefined)).toBe(true)
+  })
+
+  it('words/time: an explicit true stays active, an explicit false opts out, for a capable language', () => {
     expect(isRomajiInputActive(wordsConfig(true), 'japanese_hiragana', undefined)).toBe(true)
     expect(isRomajiInputActive(wordsConfig(true), 'english', undefined)).toBe(false)
     expect(isRomajiInputActive(wordsConfig(false), 'japanese_hiragana', undefined)).toBe(false)
-    expect(isRomajiInputActive(wordsConfig(), 'japanese_hiragana', undefined)).toBe(false)
   })
 
-  it('tatoeba: active only when romajiInput is true AND the pack language is a kana pack', () => {
+  it('tatoeba: defaults to active for a kana pack, and an explicit false opts out', () => {
+    expect(isRomajiInputActive(tatoebaConfig('japanese_hiragana'), 'english', undefined)).toBe(true)
     expect(isRomajiInputActive(tatoebaConfig('japanese_hiragana', true), 'english', undefined)).toBe(true)
     expect(isRomajiInputActive(tatoebaConfig('english', true), 'english', undefined)).toBe(false)
     expect(isRomajiInputActive(tatoebaConfig('japanese_hiragana', false), 'english', undefined)).toBe(false)
   })
 
-  it('fileImport: active only when romajiInput is true AND the loaded text is kana-pure', () => {
+  it('fileImport: defaults to active for a kana-pure text, and an explicit false opts out', () => {
+    expect(isRomajiInputActive(fileImportConfig(), 'english', true)).toBe(true)
     expect(isRomajiInputActive(fileImportConfig(true), 'english', true)).toBe(true)
     expect(isRomajiInputActive(fileImportConfig(true), 'english', false)).toBe(false)
     expect(isRomajiInputActive(fileImportConfig(false), 'english', true)).toBe(false)
@@ -67,6 +92,30 @@ describe('isRomajiInputActive', () => {
 
   it('quote: never active, even with romajiInput somehow set and a kana language active', () => {
     expect(isRomajiInputActive(quoteConfig(), 'japanese_hiragana', true)).toBe(false)
+  })
+})
+
+describe('carryRomajiFields', () => {
+  it('carries romajiInput and romaji from words/time/tatoeba/fileImport configs', () => {
+    const romaji = { caseStyle: 'capital' as const }
+    expect(carryRomajiFields(wordsConfig(false, romaji))).toEqual({ romajiInput: false, romaji })
+    expect(carryRomajiFields(timeConfig(true, romaji))).toEqual({ romajiInput: true, romaji })
+    expect(carryRomajiFields(tatoebaConfig('japanese_hiragana', true, romaji))).toEqual({ romajiInput: true, romaji })
+    expect(carryRomajiFields(fileImportConfig(false, romaji))).toEqual({ romajiInput: false, romaji })
+  })
+
+  it('returns {} for quote (no romaji fields at all)', () => {
+    expect(carryRomajiFields(quoteConfig())).toEqual({})
+  })
+
+  it('returns {} when the source config never set romajiInput/romaji', () => {
+    expect(carryRomajiFields(wordsConfig())).toEqual({})
+    expect(carryRomajiFields(tatoebaConfig('japanese_hiragana'))).toEqual({})
+    expect(carryRomajiFields(fileImportConfig())).toEqual({})
+  })
+
+  it('carries only romajiInput when romaji detail settings are absent', () => {
+    expect(carryRomajiFields(wordsConfig(true))).toEqual({ romajiInput: true })
   })
 })
 

--- a/src/renderer/typing-test/comparison.ts
+++ b/src/renderer/typing-test/comparison.ts
@@ -3,6 +3,7 @@
 import type { TypingTestResult, TypingTestComparisonBaseline } from '../../shared/types/pipette-settings'
 import type { TypingTestConfig } from './types'
 import { configKey, deriveMode2, resultKpm } from './result-builder'
+import { isRomajiInputActive } from './romaji-input'
 
 /** Headline metrics of the chosen baseline, compared against the live run. */
 export interface ComparisonStats {
@@ -37,13 +38,18 @@ export function resultConditionKey(result: TypingTestResult): string {
 export function conditionKey(config: TypingTestConfig, language: string): string {
   const hasToggles = config.mode === 'words' || config.mode === 'time'
   // resultConditionKey only reads these 5 fields, so a config-shaped partial is enough.
+  // romajiInput must be the effective active state (isRomajiInputActive), not the raw
+  // config flag — buildTypingTestResult records romajiActive (also isRomajiInputActive-
+  // derived), and the two need to land on the same key for a default-ON kana run to
+  // group with its own saved result. `undefined` for textRomajiCapable is exact here:
+  // hasToggles restricts this to words/time, whose isRomajiCapable branch never reads it.
   return resultConditionKey({
     mode: config.mode,
     mode2: deriveMode2(config),
     language,
     punctuation: hasToggles ? config.punctuation : undefined,
     numbers: hasToggles ? config.numbers : undefined,
-    romajiInput: hasToggles ? config.romajiInput : undefined,
+    romajiInput: hasToggles ? isRomajiInputActive(config, language, undefined) : undefined,
   } as TypingTestResult)
 }
 

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -118,12 +118,19 @@ export interface BuildTypingTestResultInput {
   fileImportTextName?: string
   /** Run id of the finished run, linking History to analytics keystrokes. */
   runId?: string
+  /** Whether romaji-keystroke judging was actually in effect for this run
+   *  (see `isRomajiInputActive`) — not the raw `config.romajiInput` flag,
+   *  since that now defaults to on and must still be gated by capability.
+   *  Recorded verbatim as `romajiInput` below, so a run under every mode
+   *  (including tatoeba/fileImport, which never recorded this before) is
+   *  now grouped/labeled consistently with words/time runs. */
+  romajiActive: boolean
 }
 
 /** Narrows to the 'words' / 'time' config variants — the only ones carrying
- * punctuation/numbers/romajiInput toggles. A plain `mode === 'words' ||
- * mode === 'time'` boolean stored in a separate variable doesn't narrow
- * `config` itself at the read site, so this needs to be a real type guard. */
+ * punctuation/numbers toggles. A plain `mode === 'words' || mode === 'time'`
+ * boolean stored in a separate variable doesn't narrow `config` itself at
+ * the read site, so this needs to be a real type guard. */
 function hasWordTimeToggles(
   config: TypingTestConfig,
 ): config is Extract<TypingTestConfig, { mode: 'words' | 'time' }> {
@@ -138,7 +145,6 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
   const wordTimeConfig = hasWordTimeToggles(config) ? config : undefined
   const hasPunctuation = wordTimeConfig?.punctuation
   const hasNumbers = wordTimeConfig?.numbers
-  const hasRomajiInput = wordTimeConfig?.romajiInput
 
   return {
     date: new Date().toISOString(),
@@ -158,7 +164,7 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     language: input.config.mode === 'tatoeba' ? input.config.language : input.language,
     punctuation: hasPunctuation,
     numbers: hasNumbers,
-    romajiInput: hasRomajiInput,
+    romajiInput: input.romajiActive ? true : undefined,
     consistency,
     wpmHistory: input.wpmHistory,
   }

--- a/src/renderer/typing-test/romaji-input.ts
+++ b/src/renderer/typing-test/romaji-input.ts
@@ -24,8 +24,8 @@ import { type TypingTestState, isSubmitKey, advanceAfterWord } from './run-state
  *    in run-state.ts).
  *  - quote: never capable — quotes are plain-language prose, not kana.
  *  Used both to gate the SettingsBar's Romaji button and, via
- *  `isRomajiInputActive`, to decide whether a persisted `romajiInput: true`
- *  is actually honored. */
+ *  `isRomajiInputActive`, to decide whether the (default-on) `romajiInput`
+ *  choice is actually honored. */
 export function isRomajiCapable(config: TypingTestConfig, language: string, textRomajiCapable: boolean | undefined): boolean {
   switch (config.mode) {
     case 'words':
@@ -40,22 +40,51 @@ export function isRomajiCapable(config: TypingTestConfig, language: string, text
   }
 }
 
-/** True when the config opts into sequential romaji-keystroke judging AND
- *  the mode/content combination is actually capable of it (see
- *  `isRomajiCapable`). `romajiInput` is persisted as-is regardless of
- *  capability — same as `punctuation`/`numbers` on words/time — and is
- *  simply not honored while its mode isn't currently capable (a non-kana
- *  language for words/time/tatoeba, or a non-kana-pure text for
- *  fileImport). This keeps the flag intact across any config/language/text
- *  sync order (e.g. a persisted config landing before the persisted
- *  language on mount), and it comes back into effect automatically once a
- *  capable language/text is selected again, without the user needing to
- *  re-toggle it. `config.mode === 'quote'` is checked first (rather than
- *  folded into `isRomajiCapable`'s boolean result) so the compiler can
- *  narrow `config` to the branches that actually carry `romajiInput`. */
+/** True when the config has opted into sequential romaji-keystroke judging,
+ *  independent of whether the mode/content combination is actually capable
+ *  of it (see `isRomajiCapable`) — the pure "user opted in" predicate, not
+ *  capability-gated. Defaults ON: `romajiInput === undefined` is treated as
+ *  opted-in, and only an explicit `false` opts out — mirroring how the
+ *  Romaji Settings modal's master toggle writes `false` rather than
+ *  deleting the field when the user turns it off (see `RomajiSettingsModal`).
+ *  `romajiInput` is persisted as-is regardless of capability — same as
+ *  `punctuation`/`numbers` on words/time — so this stays true across any
+ *  config/language/text sync order (e.g. a persisted config landing before
+ *  the persisted language on mount); capability gating happens separately
+ *  in `isRomajiInputActive`. `quote` never carries the field and is always
+ *  off. */
+export function isRomajiInputEnabled(config: TypingTestConfig): boolean {
+  return config.mode === 'quote' ? false : config.romajiInput !== false
+}
+
+/** True when the config opts into sequential romaji-keystroke judging
+ *  (`isRomajiInputEnabled`) AND the mode/content combination is actually
+ *  capable of it (`isRomajiCapable`). This is what actually gates whether
+ *  keystrokes are judged romaji-style — the flag itself is never stripped
+ *  while incapable (see `isRomajiInputEnabled`), and comes back into effect
+ *  automatically once a capable language/text is selected again, without
+ *  the user needing to re-toggle it. */
 export function isRomajiInputActive(config: TypingTestConfig, language: string, textRomajiCapable: boolean | undefined): boolean {
-  if (config.mode === 'quote') return false
-  return config.romajiInput === true && isRomajiCapable(config, language, textRomajiCapable)
+  return isRomajiInputEnabled(config) && isRomajiCapable(config, language, textRomajiCapable)
+}
+
+/** Carries a config's `romajiInput`/`romaji` choice into a freshly built
+ *  config of a different mode — used when switching tatoeba language or
+ *  importing a new file (`TypingTestPane`'s language selector), which each
+ *  build a brand-new config object from scratch rather than spreading the
+ *  previous one (unlike the Pattern row's mode switch, which already
+ *  carries these fields via `TypingTestSettingsBar`'s `togglesRef`).
+ *  Without this, the user's explicit opt-out (`romajiInput: false`) or
+ *  detail settings would silently reset to the default on every such
+ *  switch. Returns `{}` for `quote` (which has no romaji fields at all) or
+ *  when the source config never set them. */
+export function carryRomajiFields(config: TypingTestConfig): { romajiInput?: boolean; romaji?: RomajiDetailSettings } {
+  if (config.mode === 'quote') return {}
+  const fields: { romajiInput?: boolean; romaji?: RomajiDetailSettings } = {}
+  if (typeof config.romajiInput === 'boolean') fields.romajiInput = config.romajiInput
+  const romaji = romajiDetail(config)
+  if (romaji) fields.romaji = romaji
+  return fields
 }
 
 /** Rebuilds a matcher for `word` by replaying every keystroke accepted so

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -28,10 +28,12 @@ export interface RomajiDetailSettings {
 
 export type TypingTestConfig =
   // `romajiInput` opts into sequential romaji-keystroke judging for kana
-  // packs (japanese_hiragana / japanese_katakana); undefined/false keeps
-  // the existing verbatim-string matching behaviour. `romaji` holds the
-  // Romaji Settings modal's detail fields and is only ever read while
-  // `romajiInput` is honored (see `isRomajiInputActive`).
+  // packs (japanese_hiragana / japanese_katakana). Defaults ON when unset:
+  // an undefined value is treated as opted-in (subject to capability —
+  // see `isRomajiCapable`), and only an explicit `false` falls back to the
+  // verbatim-string matching behaviour. `romaji` holds the Romaji Settings
+  // modal's detail fields and is only ever read while `romajiInput` is
+  // honored (see `isRomajiInputActive`).
   | { mode: 'words'; wordCount: number; punctuation: boolean; numbers: boolean; romajiInput?: boolean; romaji?: RomajiDetailSettings }
   | { mode: 'time'; duration: number; punctuation: boolean; numbers: boolean; romajiInput?: boolean; romaji?: RomajiDetailSettings }
   | { mode: 'quote'; quoteLength: QuoteLength }
@@ -60,14 +62,14 @@ export const DEFAULT_LANGUAGE = 'english'
 
 /** Word-language packs the romaji-keystroke matcher supports (kana word
  *  lists only). Drives the SettingsBar toggle's visibility, and — via
- *  `isRomajiCapable` / `isRomajiInputActive` in romaji-input.ts — whether a
- *  persisted `romajiInput: true` is actually honored for words/time (by
- *  the active language) and tatoeba (by the pack's `language` id). The flag
- *  itself is never stripped from the config (same as `punctuation`/
- *  `numbers`): it stays saved across language switches, mount, and
- *  `setConfig` calls, and is simply inert whenever the relevant language
- *  isn't in this set. Selecting a kana pack again picks it back up
- *  automatically. */
+ *  `isRomajiCapable` / `isRomajiInputActive` in romaji-input.ts — whether the
+ *  (default-on, unless explicitly `false`) `romajiInput` choice is actually
+ *  honored for words/time (by the active language) and tatoeba (by the
+ *  pack's `language` id). The flag itself is never stripped from the config
+ *  (same as `punctuation`/`numbers`): it stays saved across language
+ *  switches, mount, and `setConfig` calls, and is simply inert whenever the
+ *  relevant language isn't in this set. Selecting a kana pack again picks it
+ *  back up automatically. */
 export const ROMAJI_INPUT_LANGUAGES = new Set(['japanese_hiragana', 'japanese_katakana'])
 
 /** Current word's confirmed romaji + canonical remaining spelling, plus the


### PR DESCRIPTION
## Summary

Romaji input for the Typing Test now **defaults on** for any romaji-capable config and **keeps the user's choice** when switching tatoeba language or importing a file. Previously it defaulted off and silently reset whenever you re-picked a Japanese pack or imported a text.

## Changes

- **Default on**: `romajiInput === undefined` is treated as on; only an explicit `false` opts out. A pure `isRomajiInputEnabled(config)` predicate centralizes the check, and `isRomajiInputActive` composes it with capability gating (so non-Japanese configs never become active).
- **Remember across switches**: `carryRomajiFields` carries the `romajiInput`/`romaji` choice into the freshly built config on tatoeba-language / file-import selection, matching what the Pattern row's mode switch already did via the settings bar's `togglesRef`.
- **Consistent history/comparison**: results now record the effective romaji-active state (all modes, not just words/time), and `conditionKey` derives its romaji component from the same `isRomajiInputActive` value, so a default-on kana run groups with its own saved result (keeps the documented `conditionKey`/`resultConditionKey` lockstep).

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6388 passed / 22 skipped, 0 failed
- Added tests: `isRomajiInputEnabled`, `carryRomajiFields`, effective-state result recording, and a regression test that a default-on kana run's `conditionKey` equals its saved result's `configKey`