### PR TITLE
feat(ui): preview the next words' romaji in the typing test guide

### DIFF
--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -353,20 +353,24 @@ export function TypingTestView({
       </div>
 
       {/* Romaji guide — the current word's confirmed/remaining romaji
-          spelling, plus an IME-on hint once a composition event proves
-          direct keystrokes aren't reaching the matcher. Rendered as its own
-          row below the reading window rather than inline per-word: the
-          words row is a single flex-wrap flow (word-flow modes have no
+          spelling, a fainter look-ahead preview of the next up-to-two
+          words' full spelling, plus an IME-on hint once a composition event
+          proves direct keystrokes aren't reaching the matcher. Rendered as
+          its own row below the reading window rather than inline per-word:
+          the words row is a single flex-wrap flow (word-flow modes have no
           per-line rows to anchor an inline guide under), so a fixed row
           here avoids overlapping whatever wraps below the current word.
-          The typed/remaining line tracks the Font setting via the same
-          --tt-font var as the reading window; the IME hint stays a fixed
-          small size since it's a hint, not reading content. */}
+          The typed/remaining/lookahead line tracks the Font setting via the
+          same --tt-font var as the reading window; the IME hint stays a
+          fixed small size since it's a hint, not reading content. */}
       {romajiGuide && (
         <div data-testid="typing-test-romaji-guide" className="flex w-full max-w-4xl flex-col items-start gap-1 font-mono" style={multilineStyle}>
           <p className="typing-romaji-guide-text break-all">
             <span className="text-success">{romajiGuide.typed}</span>
             <span className="text-content-muted">{romajiGuide.remaining}</span>
+            {romajiGuide.lookahead.map((word, i) => (
+              <span key={i} data-testid="typing-test-romaji-lookahead" className="text-content-muted/40">{' ' + word}</span>
+            ))}
           </p>
           {imeDetected && (
             <p data-testid="typing-test-romaji-ime-hint" className="text-xs text-warning">

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -468,7 +468,7 @@ describe('TypingTestView romaji guide', () => {
   it('renders typed and remaining romaji, and rewrites on prop changes', () => {
     const { rerender } = renderView({
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0 },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
     })
     let guide = screen.getByTestId('typing-test-romaji-guide')
     expect(guide.textContent).toBe('ai')
@@ -483,7 +483,7 @@ describe('TypingTestView romaji guide', () => {
           remainingSeconds={null}
           config={DEFAULT_CONFIG}
           paused={false}
-          romajiGuide={{ typed: 'a', remaining: 'i', kanaCompleted: 1 }}
+          romajiGuide={{ typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: [] }}
         />
       </I18nextProvider>,
     )
@@ -493,10 +493,31 @@ describe('TypingTestView romaji guide', () => {
     expect(guide.querySelector('.text-content-muted')?.textContent).toBe('i')
   })
 
+  it('renders the lookahead words, space-separated, after typed/remaining', () => {
+    renderView({
+      state: makeState({ status: 'running', words: ['あい', 'かめ', 'いぬ'] }),
+      romajiGuide: { typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: ['kame', 'inu'] },
+    })
+    const guide = screen.getByTestId('typing-test-romaji-guide')
+    const lookaheadSpans = screen.getAllByTestId('typing-test-romaji-lookahead')
+    expect(lookaheadSpans).toHaveLength(2)
+    expect(lookaheadSpans[0].textContent).toBe(' kame')
+    expect(lookaheadSpans[1].textContent).toBe(' inu')
+    expect(guide.textContent).toBe('ai kame inu')
+  })
+
+  it('does not render any lookahead span when lookahead is empty', () => {
+    renderView({
+      state: makeState({ status: 'running', words: ['あい'] }),
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
+    })
+    expect(screen.queryByTestId('typing-test-romaji-lookahead')).toBeNull()
+  })
+
   it('shows the IME hint once a composition event fires in romaji mode', () => {
     renderView({
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0 },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
     })
     expect(screen.queryByTestId('typing-test-romaji-ime-hint')).toBeNull()
     const textarea = screen.getByLabelText('IME input') as HTMLTextAreaElement
@@ -515,7 +536,7 @@ describe('TypingTestView romaji guide', () => {
     renderView({
       fontSize: 40,
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0 },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
     })
     const guide = screen.getByTestId('typing-test-romaji-guide')
     expect(guide.style.getPropertyValue('--tt-font')).toBe('40')

--- a/src/renderer/typing-test/__tests__/WordDisplay.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordDisplay.test.tsx
@@ -20,7 +20,7 @@ function renderWord(props: Partial<Parameters<typeof WordDisplay>[0]> = {}) {
 
 describe('WordDisplay romaji mode', () => {
   it('colors kana characters as success up through kanaCompleted', () => {
-    renderWord({ romajiGuide: { typed: 'de', remaining: 'xina-', kanaCompleted: 1 } })
+    renderWord({ romajiGuide: { typed: 'de', remaining: 'xina-', kanaCompleted: 1, lookahead: [] } })
     const word = screen.getByTestId('word-0')
     // First char (で) confirmed -> success; the rest stay muted.
     const successSpans = word.querySelectorAll('.text-success')
@@ -30,13 +30,13 @@ describe('WordDisplay romaji mode', () => {
   })
 
   it('shows every kana as muted before any keystroke is confirmed', () => {
-    renderWord({ romajiGuide: { typed: '', remaining: 'dhina-', kanaCompleted: 0 } })
+    renderWord({ romajiGuide: { typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [] } })
     const word = screen.getByTestId('word-0')
     expect(word.querySelector('.text-success')).toBeNull()
   })
 
   it('colors the full word as success once every kana is confirmed', () => {
-    renderWord({ word: 'あい', romajiGuide: { typed: 'ai', remaining: '', kanaCompleted: 2 } })
+    renderWord({ word: 'あい', romajiGuide: { typed: 'ai', remaining: '', kanaCompleted: 2, lookahead: [] } })
     const word = screen.getByTestId('word-0')
     const successSpans = word.querySelectorAll('.text-success')
     expect(successSpans.length).toBe(2)
@@ -45,7 +45,7 @@ describe('WordDisplay romaji mode', () => {
   it('renders no per-character error color even mid-word', () => {
     // Romaji mode never shows a red/danger char — rejected keystrokes leave
     // no trace, so only success/muted classes should ever appear.
-    renderWord({ word: 'かんじ', romajiGuide: { typed: 'ka', remaining: 'nji', kanaCompleted: 1 } })
+    renderWord({ word: 'かんじ', romajiGuide: { typed: 'ka', remaining: 'nji', kanaCompleted: 1, lookahead: [] } })
     const word = screen.getByTestId('word-0')
     expect(word.querySelector('.text-danger')).toBeNull()
   })
@@ -55,7 +55,7 @@ describe('WordDisplay romaji mode', () => {
       word: 'ねこ',
       wordIndex: 1,
       currentWordIndex: 0,
-      romajiGuide: { typed: 'a', remaining: '', kanaCompleted: 1 },
+      romajiGuide: { typed: 'a', remaining: '', kanaCompleted: 1, lookahead: [] },
     })
     const word = screen.getByTestId('word-1')
     // Future word — plain muted styling, unaffected by a guide meant for

--- a/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
@@ -5,7 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useTypingTest } from '../useTypingTest'
 import { clearLanguageCache, getLanguageData, clearFileImportTextCache } from '../word-generator'
-import type { TypingTestConfig } from '../types'
+import type { TypingTestConfig, RomajiGuide } from '../types'
+import { applyRomajiCaseStyle } from '../types'
 
 // A real kana pack id (see ROMAJI_INPUT_LANGUAGES) is required everywhere a
 // test wants the romaji matcher actually active: `romajiInput: true` alone
@@ -197,12 +198,34 @@ describe('useTypingTest — romaji input mode', () => {
     await seedKanaLanguage(KANA_LANGUAGE, ['でぃなー'])
     const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'dhina-', kanaCompleted: 0 })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [] })
 
     press(result, 'd')
     press(result, 'h')
     press(result, 'i') // commits でぃ as one 2-kana digraph segment
-    expect(result.current.romajiGuide).toEqual({ typed: 'dhi', remaining: 'na-', kanaCompleted: 2 })
+    expect(result.current.romajiGuide).toEqual({ typed: 'dhi', remaining: 'na-', kanaCompleted: 2, lookahead: [] })
+  })
+
+  it('previews the next up-to-two words\' canonical romaji as lookahead, shrinking near the end of the run', async () => {
+    // Single-word lists sample deterministically (see sampleWords), so a
+    // 3-word run against the same word gives full control over the queue
+    // without needing to control random word selection.
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const { result } = renderHook(() => useTypingTest(wordsConfig(3), KANA_LANGUAGE))
+    expect(result.current.state.words).toEqual(['あい', 'あい', 'あい'])
+
+    // At word 0: both word 1 and word 2 are upcoming.
+    expect(result.current.romajiGuide?.lookahead).toEqual(['ai', 'ai'])
+
+    type(result, 'ai')
+    expect(result.current.state.currentWordIndex).toBe(1)
+    // At word 1: only word 2 remains upcoming.
+    expect(result.current.romajiGuide?.lookahead).toEqual(['ai'])
+
+    type(result, 'ai')
+    expect(result.current.state.currentWordIndex).toBe(2)
+    // At the last word: nothing left to preview.
+    expect(result.current.romajiGuide?.lookahead).toEqual([])
   })
 
   it('keeps romajiInput saved but inactive once the language switches off a kana pack', async () => {
@@ -363,7 +386,7 @@ describe('useTypingTest — config.romaji wiring', () => {
       KANA_LANGUAGE,
     ))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'si', kanaCompleted: 0 })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'si', kanaCompleted: 0, lookahead: [] })
 
     // The canonical spelling is still accepted even though the guide shows 'si'.
     type(result, 'shi')
@@ -378,9 +401,9 @@ describe('useTypingTest — config.romaji wiring', () => {
       KANA_LANGUAGE,
     ))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'AI', kanaCompleted: 0 })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'AI', kanaCompleted: 0, lookahead: [] })
     press(result, 'a')
-    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'I', kanaCompleted: 1 })
+    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'I', kanaCompleted: 1, lookahead: [] })
     // Lowercase 'a' is still what's accepted — the transform never reaches acceptance.
     expect(result.current.state.incorrectChars).toBe(0)
   })
@@ -393,12 +416,28 @@ describe('useTypingTest — config.romaji wiring', () => {
     ))
 
     // Nothing typed yet — the capital lands on the first char of `remaining`.
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'Ai', kanaCompleted: 0 })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'Ai', kanaCompleted: 0, lookahead: [] })
 
     press(result, 'a')
     // Once something is typed, the capital moves onto `typed`'s first char
     // and `remaining` goes back to lowercase.
-    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'i', kanaCompleted: 1 })
+    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'i', kanaCompleted: 1, lookahead: [] })
+  })
+
+  it('applies caseStyle to lookahead entries too, upper and capital alike', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const { result: upperResult } = renderHook(() => useTypingTest(
+      { mode: 'words', wordCount: 3, punctuation: false, numbers: false, romajiInput: true, romaji: { caseStyle: 'upper' } },
+      KANA_LANGUAGE,
+    ))
+    expect(upperResult.current.romajiGuide?.lookahead).toEqual(['AI', 'AI'])
+
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const { result: capitalResult } = renderHook(() => useTypingTest(
+      { mode: 'words', wordCount: 3, punctuation: false, numbers: false, romajiInput: true, romaji: { caseStyle: 'capital' } },
+      KANA_LANGUAGE,
+    ))
+    expect(capitalResult.current.romajiGuide?.lookahead).toEqual(['Ai', 'Ai'])
   })
 
   it('changing config.romaji via setConfig restarts the test, same as any other config field change', async () => {
@@ -420,6 +459,28 @@ describe('useTypingTest — config.romaji wiring', () => {
     expect(result.current.state.romajiKeystrokes).toBe('')
     expect(result.current.state.currentWordIndex).toBe(0)
     expect(result.current.state.status).toBe('waiting')
+  })
+})
+
+describe('applyRomajiCaseStyle — lookahead entries', () => {
+  const baseGuide: RomajiGuide = { typed: '', remaining: 'a', kanaCompleted: 0, lookahead: ['ai', 'ka'] }
+
+  it('leaves lookahead untouched for lower/undefined', () => {
+    expect(applyRomajiCaseStyle(baseGuide, undefined).lookahead).toEqual(['ai', 'ka'])
+    expect(applyRomajiCaseStyle(baseGuide, 'lower').lookahead).toEqual(['ai', 'ka'])
+  })
+
+  it('uppercases every lookahead word in full for upper', () => {
+    expect(applyRomajiCaseStyle(baseGuide, 'upper').lookahead).toEqual(['AI', 'KA'])
+  })
+
+  it('capitalizes only the first character of each lookahead word for capital', () => {
+    expect(applyRomajiCaseStyle(baseGuide, 'capital').lookahead).toEqual(['Ai', 'Ka'])
+  })
+
+  it('capitalizes lookahead even when the current word itself has nothing to capitalize', () => {
+    const emptyWordGuide: RomajiGuide = { typed: '', remaining: '', kanaCompleted: 0, lookahead: ['ai'] }
+    expect(applyRomajiCaseStyle(emptyWordGuide, 'capital').lookahead).toEqual(['Ai'])
   })
 })
 

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -74,35 +74,53 @@ export const ROMAJI_INPUT_LANGUAGES = new Set(['japanese_hiragana', 'japanese_ka
 
 /** Current word's confirmed romaji + canonical remaining spelling, plus the
  *  count of kana characters fully confirmed so far (romajiInput mode only).
- *  Produced by `useTypingTest`'s `romajiGuide` selector from a
- *  `RomajiMatcher` (see romaji-engine.ts), consumed by `WordDisplay` (kana
- *  coloring) and `TypingTestView` (the guide line below the reading
- *  window). */
+ *  `lookahead` holds the full canonical romaji spelling of up to the next
+ *  two upcoming words (empty entries once fewer remain), letting the guide
+ *  row preview what's coming after the current word. Produced by
+ *  `useTypingTest`'s `romajiGuide` selector from a `RomajiMatcher` (see
+ *  romaji-engine.ts), consumed by `WordDisplay` (kana coloring) and
+ *  `TypingTestView` (the guide line below the reading window). */
 export interface RomajiGuide {
   typed: string
   remaining: string
   kanaCompleted: number
+  lookahead: string[]
+}
+
+/** Capitalizes only the first character of a whole word (used for
+ *  lookahead entries, which have no typed/remaining split of their own). */
+function capitalizeWord(word: string): string {
+  return word.length > 0 ? word[0].toUpperCase() + word.slice(1) : word
 }
 
 /** Applies the Romaji Settings modal's display-only case transform to a
- *  guide's typed/remaining strings. Never touches acceptance/matching —
- *  `createRomajiMatcher` always works in lowercase; this only changes what
- *  `TypingTestView`'s guide row renders. 'upper' uppercases the whole
- *  string; 'capital' uppercases only the first character of the word as a
- *  whole (the first char of `typed` once anything is typed, otherwise the
- *  first char of `remaining`); 'lower'/undefined is a no-op. */
+ *  guide's typed/remaining strings, and to each `lookahead` entry. Never
+ *  touches acceptance/matching — `createRomajiMatcher` always works in
+ *  lowercase; this only changes what `TypingTestView`'s guide row renders.
+ *  'upper' uppercases the whole string (and each lookahead word in full);
+ *  'capital' uppercases only the first character of the word as a whole
+ *  (the first char of `typed` once anything is typed, otherwise the first
+ *  char of `remaining`; each lookahead word gets its own first character
+ *  capitalized, since each is a whole word with no typed portion);
+ *  'lower'/undefined is a no-op. */
 export function applyRomajiCaseStyle(guide: RomajiGuide, caseStyle: RomajiCaseStyle | undefined): RomajiGuide {
   if (!caseStyle || caseStyle === 'lower') return guide
   if (caseStyle === 'upper') {
-    return { ...guide, typed: guide.typed.toUpperCase(), remaining: guide.remaining.toUpperCase() }
+    return {
+      ...guide,
+      typed: guide.typed.toUpperCase(),
+      remaining: guide.remaining.toUpperCase(),
+      lookahead: guide.lookahead.map((word) => word.toUpperCase()),
+    }
   }
+  const lookahead = guide.lookahead.map(capitalizeWord)
   if (guide.typed.length > 0) {
-    return { ...guide, typed: guide.typed[0].toUpperCase() + guide.typed.slice(1) }
+    return { ...guide, typed: capitalizeWord(guide.typed), lookahead }
   }
   if (guide.remaining.length > 0) {
-    return { ...guide, remaining: guide.remaining[0].toUpperCase() + guide.remaining.slice(1) }
+    return { ...guide, remaining: capitalizeWord(guide.remaining), lookahead }
   }
-  return guide
+  return { ...guide, lookahead }
 }
 
 // Imported file-import-text display preferences (fileImport mode only).

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -556,14 +556,20 @@ export function useTypingTest(
 
   // Current word's romaji progress (romajiInput mode only), re-derived from
   // the accepted keystroke history on every change rather than stored on
-  // state directly — see `buildRomajiMatcher`.
+  // state directly — see `buildRomajiMatcher`. `lookahead` previews the
+  // full canonical spelling of up to the next two words (empty keystrokes
+  // -> remainingGuide() returns the whole word) so the guide row can show
+  // what's coming after the current word.
   const romajiGuide = useMemo(() => {
     if (!isRomajiInputActive(config, language, state.romajiCapable)) return null
     if (state.currentWordIndex >= state.words.length) return null
     const word = state.words[state.currentWordIndex]
     const detail = romajiDetail(config)
     const matcher = buildRomajiMatcher(word, state.romajiKeystrokes, detail)
-    const guide: RomajiGuide = { typed: matcher.typedRomaji(), remaining: matcher.remainingGuide(), kanaCompleted: matcher.completedKanaCount() }
+    const lookahead = state.words
+      .slice(state.currentWordIndex + 1, state.currentWordIndex + 3)
+      .map((w) => buildRomajiMatcher(w, '', detail).remainingGuide())
+    const guide: RomajiGuide = { typed: matcher.typedRomaji(), remaining: matcher.remainingGuide(), kanaCompleted: matcher.completedKanaCount(), lookahead }
     return applyRomajiCaseStyle(guide, detail?.caseStyle)
   }, [config, language, state.words, state.currentWordIndex, state.romajiKeystrokes, state.romajiCapable])
 


### PR DESCRIPTION
## Summary

In romaji-input mode, the guide line below the reading window showed only the current word's spelling. It now also previews the canonical romaji of the next up-to-two words in a fainter style, so the typist can read ahead. The current word's typed (green) / remaining (grey) coloring is unchanged, and the display case style applies to the preview words too.

## Changes

- `RomajiGuide` gains a `lookahead: string[]` field (full canonical romaji of the next up-to-2 words).
- `useTypingTest` fills it from the upcoming words via `buildRomajiMatcher(word, '', detail).remainingGuide()`.
- `TypingTestView` renders the lookahead words after the current word in `text-content-muted/40` (the file's existing de-emphasis convention), space-separated.
- `applyRomajiCaseStyle` transforms the lookahead entries too.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6400 passed / 22 skipped, 0 failed
- Added tests for lookahead computation, case-style transform, and rendering