### PR TITLE
fix(ui): accept japanese punctuation in romaji typing mode

### DIFF
--- a/src/renderer/typing-test/__tests__/romaji-engine.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-engine.test.ts
@@ -431,6 +431,53 @@ describe('ん — mozc consonant-lookahead retroactive commit', () => {
   })
 })
 
+describe('punctuation — 。、？！ typed via their ASCII spelling', () => {
+  it('completes 。 via "."', () => {
+    const { matcher, results } = type('。', '.')
+    expect(results.at(-1)).toBe('complete')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.typedRomaji()).toBe('.')
+  })
+
+  it('completes 、 via ","', () => {
+    const { matcher, results } = type('、', ',')
+    expect(results.at(-1)).toBe('complete')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.typedRomaji()).toBe(',')
+  })
+
+  it('completes ？ via "?"', () => {
+    const { matcher, results } = type('？', '?')
+    expect(results.at(-1)).toBe('complete')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.typedRomaji()).toBe('?')
+  })
+
+  it('completes ！ via "!"', () => {
+    const { matcher, results } = type('！', '!')
+    expect(results.at(-1)).toBe('complete')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.typedRomaji()).toBe('!')
+  })
+
+  it('completes a mixed word end-to-end (はい、そうです。 as hai,soudesu.)', () => {
+    const { matcher, results } = type('はい、そうです。', 'hai,soudesu.')
+    expect(results.at(-1)).toBe('complete')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.typedRomaji()).toBe('hai,soudesu.')
+  })
+
+  it('remainingGuide shows the ASCII spelling for a word starting with punctuation, not the literal kana', () => {
+    const matcher = createRomajiMatcher('。です')
+    expect(matcher.remainingGuide()).toBe('.desu')
+  })
+
+  it('remainingGuide shows the ASCII spelling for punctuation mid-word', () => {
+    const matcher = createRomajiMatcher('はい、そうです。')
+    expect(matcher.remainingGuide()).toBe('hai,soudesu.')
+  })
+})
+
 describe('ねっこ — full pattern enumeration', () => {
   // Exhaustively walks every keystroke sequence the matcher accepts for
   // ねっこ (via DFS over a-z plus '-'), pruning as soon as a keystroke is

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -38,6 +38,7 @@
 // sweep against that table.
 
 import { toHiragana } from './kana-script'
+import { ROMAJI_PUNCTUATION, isRomajiPunctuation } from '../../shared/kana-purity'
 
 // Spelling-style groups used to let the Romaji settings modal (Step 2)
 // selectively disable alternate spellings while keeping every word
@@ -350,8 +351,10 @@ export const KANA_TABLE: Record<string, readonly string[]> = {
 // KANA_TABLE gains a non-kana key). mozc's own romaji table maps "."/","
 // to 。/、; ？/！ aren't part of that kana table, but "?"/"!" are their
 // natural direct-keystroke spelling. One canonical ASCII spelling each, no
-// style variants — see .claude/docs/ROMAJI-ENGINE.md.
-export const PUNCTUATION_TABLE: Record<string, readonly string[]> = {
+// style variants — see .claude/docs/ROMAJI-ENGINE.md. Keys are type-locked
+// to ROMAJI_PUNCTUATION (shared with isKanaOnlyText in shared/kana-purity)
+// so the two lists can't drift apart.
+export const PUNCTUATION_TABLE: Record<(typeof ROMAJI_PUNCTUATION)[number], readonly string[]> = {
   '。': ['.'],
   '、': [','],
   '？': ['?'],
@@ -774,9 +777,8 @@ function getSegmentOptions(
   const single = KANA_TABLE[current]
   if (single) options.push({ length: 1, patterns: filterByStyle(current, single, disabledStyles), scope: current })
 
-  if (options.length === 0) {
-    const punct = PUNCTUATION_TABLE[current]
-    if (punct) options.push({ length: 1, patterns: punct, scope: current })
+  if (options.length === 0 && isRomajiPunctuation(current)) {
+    options.push({ length: 1, patterns: PUNCTUATION_TABLE[current], scope: current })
   }
   if (options.length === 0) options.push({ length: 1, patterns: [current], scope: current })
   return options

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -343,6 +343,21 @@ export const KANA_TABLE: Record<string, readonly string[]> = {
   ずぉ: ['zwo'],
 }
 
+// Punctuation that appears in the Tatoeba japanese word packs and in kana
+// file-import texts, but is not kana — so it lives outside KANA_TABLE rather
+// than as a table entry, keeping KANA_TABLE in exact set correspondence
+// with mozc's kana rows (see the mozc compliance test, which fails if
+// KANA_TABLE gains a non-kana key). mozc's own romaji table maps "."/","
+// to 。/、; ？/！ aren't part of that kana table, but "?"/"!" are their
+// natural direct-keystroke spelling. One canonical ASCII spelling each, no
+// style variants — see .claude/docs/ROMAJI-ENGINE.md.
+export const PUNCTUATION_TABLE: Record<string, readonly string[]> = {
+  '。': ['.'],
+  '、': [','],
+  '？': ['?'],
+  '！': ['!'],
+}
+
 // Style tag per spelling, keyed by "<tableKey>|<spelling>" so spellings
 // that collide across different kana (e.g. "ji" is both じ's canonical and
 // ぢ's alternate) resolve independently per entry.
@@ -723,10 +738,11 @@ function sokuonOptions(
 }
 
 /** Every (kana-length, spellings) group that could start at `index`. Always
- *  returns at least one option while `index` is within the word (falling
- *  back to typing the raw character itself for anything outside the
- *  table, per the passthrough rule for未対応文字). `disabledStyles` prunes
- *  tagged alternate spellings out of each option's pattern list; canonical
+ *  returns at least one option while `index` is within the word: a
+ *  PUNCTUATION_TABLE entry (。、？！) is consulted before the final
+ *  passthrough, which falls back to typing the raw character itself for
+ *  anything still outside both tables. `disabledStyles` prunes tagged
+ *  alternate spellings out of each option's pattern list; canonical
  *  spellings are never tagged, so they always survive. */
 function getSegmentOptions(
   kana: readonly string[],
@@ -758,6 +774,10 @@ function getSegmentOptions(
   const single = KANA_TABLE[current]
   if (single) options.push({ length: 1, patterns: filterByStyle(current, single, disabledStyles), scope: current })
 
+  if (options.length === 0) {
+    const punct = PUNCTUATION_TABLE[current]
+    if (punct) options.push({ length: 1, patterns: punct, scope: current })
+  }
   if (options.length === 0) options.push({ length: 1, patterns: [current], scope: current })
   return options
 }

--- a/src/shared/__tests__/kana-purity.test.ts
+++ b/src/shared/__tests__/kana-purity.test.ts
@@ -28,12 +28,40 @@ describe('isKanaOnlyText', () => {
     expect(isKanaOnlyText('hello world')).toBe(false)
   })
 
-  it('rejects kana mixed with a full-width period', () => {
-    expect(isKanaOnlyText('こんにちは。')).toBe(false)
+  it('accepts kana mixed with a full-width period', () => {
+    expect(isKanaOnlyText('こんにちは。')).toBe(true)
   })
 
-  it('rejects kana mixed with a full-width comma', () => {
-    expect(isKanaOnlyText('こんにちは、げんきですか')).toBe(false)
+  it('accepts kana mixed with a full-width comma', () => {
+    expect(isKanaOnlyText('こんにちは、げんきですか')).toBe(true)
+  })
+
+  it('accepts kana mixed with a full-width question mark', () => {
+    expect(isKanaOnlyText('ですか？')).toBe(true)
+  })
+
+  it('accepts kana mixed with a full-width exclamation mark', () => {
+    expect(isKanaOnlyText('すごい！')).toBe(true)
+  })
+
+  it('rejects punctuation-only text', () => {
+    expect(isKanaOnlyText('。。。')).toBe(false)
+  })
+
+  it('rejects a single punctuation mark with no kana', () => {
+    expect(isKanaOnlyText('、')).toBe(false)
+  })
+
+  it('rejects punctuation and whitespace with no kana', () => {
+    expect(isKanaOnlyText('？ ！')).toBe(false)
+  })
+
+  it('rejects kana mixed with punctuation outside the allowed set (brackets)', () => {
+    expect(isKanaOnlyText('こんにちは「せかい」')).toBe(false)
+  })
+
+  it('rejects kana mixed with punctuation outside the allowed set (interpunct)', () => {
+    expect(isKanaOnlyText('あ・い')).toBe(false)
   })
 
   it('rejects empty text', () => {

--- a/src/shared/kana-purity.ts
+++ b/src/shared/kana-purity.ts
@@ -23,19 +23,39 @@ const KANA_CHAR_PATTERN = /^[ぁ-ゖー]$/
 // full-width space U+3000 (Unicode category Zs) alongside space/tab/CR/LF.
 const WHITESPACE_PATTERN = /^\s$/
 
+// The Japanese punctuation the romaji engine can type (see PUNCTUATION_TABLE
+// in renderer/typing-test/romaji-engine.ts, whose keys are type-locked to
+// this list). Allowed inside otherwise-kana text so imported sentences with
+// punctuation still qualify for romaji input, but a text of only these marks
+// is not "kana" and stays non-capable.
+export const ROMAJI_PUNCTUATION = ['。', '、', '？', '！'] as const
+
+const PUNCTUATION_SET: ReadonlySet<string> = new Set(ROMAJI_PUNCTUATION)
+
+/** Type guard narrowing `char` to one of ROMAJI_PUNCTUATION's members, so
+ *  callers indexing PUNCTUATION_TABLE (whose keys are locked to that list)
+ *  get a type-checked lookup instead of a manual cast. */
+export function isRomajiPunctuation(char: string): char is (typeof ROMAJI_PUNCTUATION)[number] {
+  return PUNCTUATION_SET.has(char)
+}
+
 /**
  * True when every non-whitespace character in `text` is typable by the
- * romaji engine's kana domain: hiragana, katakana (folded to hiragana), or
- * the long-vowel mark ー. Kanji, latin, digits, and punctuation (including
- * full-width punctuation like 、。「」！？・…) all return false. Empty or
- * whitespace-only text returns false — there is nothing to type.
+ * romaji engine's kana domain: hiragana, katakana (folded to hiragana), the
+ * long-vowel mark ー, or one of the four ROMAJI_PUNCTUATION marks (。、？！),
+ * which are permitted but don't count toward the required kana content on
+ * their own. Kanji, latin, digits, and other punctuation (full-width or
+ * half-width variants not in ROMAJI_PUNCTUATION, e.g. 「」・…) all return
+ * false. Empty, whitespace-only, or punctuation-only text returns false —
+ * there is nothing (or nothing but punctuation) to type as kana.
  */
 export function isKanaOnlyText(text: string): boolean {
-  let sawTypeableChar = false
+  let sawKana = false
   for (const char of text) {
     if (WHITESPACE_PATTERN.test(char)) continue
+    if (isRomajiPunctuation(char)) continue
     if (!KANA_CHAR_PATTERN.test(toHiragana(char))) return false
-    sawTypeableChar = true
+    sawKana = true
   }
-  return sawTypeableChar
+  return sawKana
 }


### PR DESCRIPTION
## Summary

In romaji-input mode, the Tatoeba japanese word packs contain the punctuation marks 。 、 ？ ！, but the romaji matcher had no spelling for them, so a word carrying punctuation could not be completed and the test stalled. Imported kana texts with punctuation were also never flagged romaji-capable.

## Changes

- **Engine**: add a `PUNCTUATION_TABLE` mapping each mark to its ASCII spelling (。→"." 、→"," ？→"?" ！→"!") and consult it in `getSegmentOptions` before the raw-character passthrough. Kept separate from `KANA_TABLE` so the mozc kana-row correspondence check is unaffected.
- **Imports**: `isKanaOnlyText` now permits the same four marks (they don't count as kana on their own, so punctuation-/whitespace-only text stays non-capable), so an imported kana file with punctuation is flagged romaji-capable.
- The four marks live in one shared constant `ROMAJI_PUNCTUATION` that type-locks `PUNCTUATION_TABLE`'s keys, so the purity check and the engine table can't drift.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6414 passed / 22 skipped, 0 failed
- Added tests for each mark's ASCII acceptance, an end-to-end mixed word (`はい、そうです。` → `hai,soudesu.`), guide spelling, and the `isKanaOnlyText` boundaries