### PR TITLE
feat(ui): tatoeba lines/time patterns, dynamic import unit labels, per-condition grouping

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -307,7 +307,8 @@
         "words": "単語",
         "time": "時間",
         "quote": "引用",
-        "fileImport": "テキスト"
+        "fileImport": "テキスト",
+        "lines": "行"
       },
       "punctuation": "句読点",
       "numbers": "数字",
@@ -395,6 +396,7 @@
       "units": "単位",
       "unitsWords": "単位(単語)",
       "unitsSec": "単位(秒)",
+      "unitsLines": "単位(行)",
       "optionLabel": "オプション",
       "baseLayerShort": "Base",
       "heatmapWindow": "ヒートマップの表示期間（分）",
@@ -426,6 +428,7 @@
         "available": "利用可能",
         "noResults": "一致する言語がありません",
         "words": "{{count}} 単語",
+        "lines": "{{count}} 行",
         "loadingLanguage": "言語を読み込み中...",
         "downloadFailed": "ダウンロードに失敗しました",
         "tabMonkeytype": "MonkeyType",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -307,7 +307,8 @@
         "words": "単語っしょ",
         "time": "タイム☆",
         "quote": "引用っしょ",
-        "fileImport": "テキストっしょ"
+        "fileImport": "テキストっしょ",
+        "lines": "行っしょ"
       },
       "punctuation": "句読点☆",
       "numbers": "数字っしょ",
@@ -395,6 +396,7 @@
       "units": "単位っしょ",
       "unitsWords": "単位(単語)☆",
       "unitsSec": "単位(秒)☆",
+      "unitsLines": "単位(行)☆",
       "optionLabel": "オプションっしょ",
       "baseLayerShort": "Base",
       "heatmapWindow": "ヒートマップ表示（分）☆",
@@ -426,6 +428,7 @@
         "available": "いけるっしょ",
         "noResults": "そんな言語なくね？",
         "words": "{{count}} 単語☆",
+        "lines": "{{count}} 行☆",
         "loadingLanguage": "言語読み込みちう…",
         "downloadFailed": "ダウンロード失敗…サゲ。。",
         "tabMonkeytype": "MonkeyType",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -307,7 +307,8 @@
         "words": "単語",
         "time": "時間",
         "quote": "引用",
-        "fileImport": "テキスト"
+        "fileImport": "テキスト",
+        "lines": "行"
       },
       "punctuation": "句読点",
       "numbers": "数字",
@@ -395,6 +396,7 @@
       "units": "単位",
       "unitsWords": "単位(単語)",
       "unitsSec": "単位(秒)",
+      "unitsLines": "単位(行)",
       "optionLabel": "オプション",
       "baseLayerShort": "Base",
       "heatmapWindow": "ヒートマップの表示期間（分）",
@@ -426,6 +428,7 @@
         "available": "使えますえ",
         "noResults": "合うのんがおへんなぁ",
         "words": "{{count}} 単語どすえ",
+        "lines": "{{count}} 行どすえ",
         "loadingLanguage": "言語を読み込んでますえ…",
         "downloadFailed": "ダウンロードがあきまへんでしたえ",
         "tabMonkeytype": "MonkeyType",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -307,7 +307,8 @@
         "words": "単語数",
         "time": "時間制限",
         "quote": "名句",
-        "fileImport": "文言"
+        "fileImport": "文言",
+        "lines": "行数"
       },
       "punctuation": "句読点",
       "numbers": "数字",
@@ -395,6 +396,7 @@
       "units": "単位",
       "unitsWords": "単位(語)",
       "unitsSec": "単位(秒)",
+      "unitsLines": "単位(行)",
       "optionLabel": "選択",
       "baseLayerShort": "Base",
       "heatmapWindow": "熱分布の期間（分）",
@@ -426,6 +428,7 @@
         "available": "入手可能",
         "noResults": "そのような言葉は見当たりません",
         "words": "{{count}} 語",
+        "lines": "{{count}} 行",
         "loadingLanguage": "言葉を紐解いております...",
         "downloadFailed": "お取り寄せに失敗いたしました",
         "tabMonkeytype": "MonkeyType",

--- a/src/main/__tests__/typing-test-text-store.test.ts
+++ b/src/main/__tests__/typing-test-text-store.test.ts
@@ -78,16 +78,25 @@ describe('typing-test-text-store', () => {
 
   describe('normalizeFileImportText', () => {
     it('canonicalizes with single spaces in a line and newline at breaks', () => {
-      expect(normalizeFileImportText('the  quick\nbrown   fox')).toEqual({ text: 'the quick\nbrown fox', wordCount: 4 })
+      expect(normalizeFileImportText('the  quick\nbrown   fox')).toEqual({ text: 'the quick\nbrown fox', wordCount: 4, lineCount: 2 })
     })
 
     it('preserves leading indentation per line (code structure)', () => {
-      expect(normalizeFileImportText('def f() {\n  val x = 1\n}')).toEqual({ text: 'def f() {\n  val x = 1\n}', wordCount: 8 })
+      expect(normalizeFileImportText('def f() {\n  val x = 1\n}')).toEqual({ text: 'def f() {\n  val x = 1\n}', wordCount: 8, lineCount: 3 })
     })
 
     it('round-trips through parseFileImportText', () => {
       const { text } = normalizeFileImportText('a b\nc\n\nd e f')
       expect(parseFileImportText(text)).toEqual(parseFileImportText('a b\nc\n\nd e f'))
+    })
+
+    it('counts non-empty lines, dropping blank lines from the count', () => {
+      // 3 non-blank lines; the blank line between "c" and "d e f" is dropped.
+      expect(normalizeFileImportText('a b\nc\n\nd e f').lineCount).toBe(3)
+    })
+
+    it('a single-line, no-space text has lineCount === wordCount (one "word" per line)', () => {
+      expect(normalizeFileImportText('こんにちは')).toEqual({ text: 'こんにちは', wordCount: 1, lineCount: 1 })
     })
   })
 
@@ -96,12 +105,14 @@ describe('typing-test-text-store', () => {
       const result = await saveRecord({ name: 'My Novel', text: 'the quick brown fox' })
       expect(result.success).toBe(true)
       expect(result.data?.wordCount).toBe(4)
+      expect(result.data?.lineCount).toBe(1)
       expect(result.data?.id).toBeTruthy()
       expect(notifyChange).toHaveBeenCalledWith(TYPING_TEST_TEXT_SYNC_UNIT)
 
       const metas = await listMetas()
       expect(metas).toHaveLength(1)
       expect(metas[0].name).toBe('My Novel')
+      expect(metas[0].lineCount).toBe(1)
     })
 
     it('rejects empty / whitespace-only text', async () => {

--- a/src/main/typing-test-text-store.ts
+++ b/src/main/typing-test-text-store.ts
@@ -208,7 +208,7 @@ export async function saveRecord(input: SaveTextInput): Promise<TypingTestTextSt
   }
   const name = validated.data
 
-  const { text, wordCount } = normalizeFileImportText(typeof input.text === 'string' ? input.text : '')
+  const { text, wordCount, lineCount } = normalizeFileImportText(typeof input.text === 'string' ? input.text : '')
   if (wordCount === 0) return fail('EMPTY_TEXT', 'Text has no typeable words')
 
   try {
@@ -226,6 +226,7 @@ export async function saveRecord(input: SaveTextInput): Promise<TypingTestTextSt
       id,
       name,
       wordCount,
+      lineCount,
       filename,
       savedAt: now.toISOString(),
       updatedAt: now.toISOString(),

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -552,7 +552,16 @@ export function TypingTestPane({
               void onLanguageChange(name)
             }}
             onSelectImport={(textId) => onConfigChange({ mode: 'fileImport', textId, ...carryRomajiFields(typingTest.config) })}
-            onSelectTatoeba={(language) => onConfigChange({ mode: 'tatoeba', language, ...carryRomajiFields(typingTest.config) })}
+            onSelectTatoeba={(language) => {
+              // Carry the previous tatoeba Pattern/Units forward (switching
+              // pack language shouldn't reset Lines/Time or their counts);
+              // default to Lines/5/30 when not already in tatoeba mode.
+              const cfg = typingTest.config
+              const { pattern, lineCount, duration } = cfg.mode === 'tatoeba'
+                ? cfg
+                : { pattern: 'lines' as const, lineCount: 5, duration: 30 }
+              onConfigChange({ mode: 'tatoeba', language, pattern, lineCount, duration, ...carryRomajiFields(cfg) })
+            }}
             onCurrentTextDeleted={() => {
               // The selected imported text was deleted — fall back to
               // the default (words mode, English).
@@ -606,11 +615,12 @@ export function TypingTestPane({
             </select>
           </div>
         </div>
-        {/* words/time/quote always get the full bar; tatoeba/fileImport only
-            get it (Option row only, see TypingTestSettingsBar) once their
-            content is actually romaji-capable — otherwise there is nothing
-            for the bar to show, same as before this mode's romaji support. */}
-        {(typingTest.config.mode !== 'fileImport' && typingTest.config.mode !== 'tatoeba'
+        {/* words/time/quote/tatoeba always get the full bar (tatoeba has its
+            own Pattern/Units, see TypingTestSettingsBar); fileImport only
+            gets it (Option row only) once its content is actually
+            romaji-capable — otherwise there is nothing for the bar to show,
+            same as before this mode's romaji support. */}
+        {(typingTest.config.mode !== 'fileImport'
           || isRomajiCapable(typingTest.config, typingTest.language, typingTest.state.romajiCapable)) && (
           <TypingTestSettingsBar
             config={typingTest.config}

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -439,7 +439,9 @@ describe('useDevicePrefs', () => {
         await result.current.applyDevicePrefs('0xAABB')
       })
 
-      expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30,
+      })
     })
 
     it('rejects a stale tatoeba value persisted in the MonkeyType fallback', async () => {
@@ -477,10 +479,12 @@ describe('useDevicePrefs', () => {
       })
       // Switch to tatoeba → the fallback must stay the last normal config.
       act(() => {
-        result.current.setTypingTestConfig({ mode: 'tatoeba', language: 'english' })
+        result.current.setTypingTestConfig({ mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 })
       })
 
-      expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30,
+      })
       expect(result.current.typingTestMonkeytypeConfig).toEqual({ mode: 'words', wordCount: 60, punctuation: false, numbers: false })
     })
 
@@ -1049,6 +1053,9 @@ describe('useDevicePrefs', () => {
       expect(result.current.typingTestConfig).toEqual({
         mode: 'tatoeba',
         language: 'japanese_hiragana',
+        pattern: 'lines',
+        lineCount: 5,
+        duration: 30,
         romajiInput: true,
         romaji: { caseStyle: 'capital' },
       })
@@ -1099,7 +1106,52 @@ describe('useDevicePrefs', () => {
         await result.current.applyDevicePrefs('0xAABB')
       })
 
-      expect(result.current.typingTestConfig).toEqual({ mode: 'tatoeba', language: 'english' })
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30,
+      })
+    })
+
+    it('defaults pattern/lineCount/duration on an old tatoeba config that predates them', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        // Pre-Pattern/Units tatoeba config, as saved by an older build.
+        typingTestConfig: { mode: 'tatoeba', language: 'french' },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'tatoeba', language: 'french', pattern: 'lines', lineCount: 5, duration: 30,
+      })
+    })
+
+    it('round-trips explicit pattern/lineCount/duration on a tatoeba config', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: { mode: 'tatoeba', language: 'french', pattern: 'time', lineCount: 20, duration: 120 },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'tatoeba', language: 'french', pattern: 'time', lineCount: 20, duration: 120,
+      })
     })
   })
 

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -104,9 +104,17 @@ function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
     case 'fileImport':
       if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
       return { mode: 'fileImport', textId: obj.textId, ...romajiInput, ...romajiDetail }
-    case 'tatoeba':
+    case 'tatoeba': {
       if (typeof obj.language !== 'string' || obj.language.length === 0) return undefined
-      return { mode: 'tatoeba', language: obj.language, ...romajiInput, ...romajiDetail }
+      // Older configs (saved before Tatoeba gained its own Pattern/Units)
+      // lack pattern/lineCount/duration — default them rather than reject
+      // the whole config, same treatment as every other optional-carry-
+      // through field on this type.
+      const pattern = obj.pattern === 'time' ? 'time' : 'lines'
+      const lineCount = isFinitePositiveInt(obj.lineCount) ? obj.lineCount : 5
+      const duration = isFinitePositiveInt(obj.duration) ? obj.duration : 30
+      return { mode: 'tatoeba', language: obj.language, pattern, lineCount, duration, ...romajiInput, ...romajiDetail }
+    }
     default:
       return undefined
   }

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -396,7 +396,7 @@
       "units": "Units",
       "unitsWords": "Units(Words)",
       "unitsSec": "Units(Sec)",
-      "unitsLines": "Lines",
+      "unitsLines": "Units(Lines)",
       "optionLabel": "Option",
       "baseLayerShort": "Base",
       "heatmapWindow": "Heatmap window (minutes)",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "English",
   "common": {
     "save": "Save",
@@ -307,7 +307,8 @@
         "words": "words",
         "time": "time",
         "quote": "quote",
-        "fileImport": "text"
+        "fileImport": "text",
+        "lines": "Lines"
       },
       "punctuation": "punctuation",
       "numbers": "numbers",
@@ -395,6 +396,7 @@
       "units": "Units",
       "unitsWords": "Units(Words)",
       "unitsSec": "Units(Sec)",
+      "unitsLines": "Lines",
       "optionLabel": "Option",
       "baseLayerShort": "Base",
       "heatmapWindow": "Heatmap window (minutes)",
@@ -426,6 +428,7 @@
         "available": "Available",
         "noResults": "No matching languages",
         "words": "{{count}} words",
+        "lines": "{{count}} lines",
         "loadingLanguage": "Loading language...",
         "downloadFailed": "Download failed",
         "tabMonkeytype": "MonkeyType",

--- a/src/renderer/typing-test/LanguagePackTab.tsx
+++ b/src/renderer/typing-test/LanguagePackTab.tsx
@@ -139,6 +139,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
               <LanguageRow
                 key={lang.name}
                 lang={lang}
+                provider={provider}
                 isCurrent={lang.name === currentSelected}
                 isDownloading={downloading.has(lang.name)}
                 onSelect={onSelect}
@@ -155,6 +156,7 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
               <LanguageRow
                 key={lang.name}
                 lang={lang}
+                provider={provider}
                 isCurrent={false}
                 isDownloading={downloading.has(lang.name)}
                 onSelect={onSelect}
@@ -170,6 +172,10 @@ export function LanguagePackTab({ provider, currentSelected, onSelect }: Props) 
 
 interface LanguageRowProps {
   lang: LanguageListEntry
+  /** Dataset provider this row belongs to — the tatoeba provider's
+   *  `wordCount` is a sentence (line) count, not a word count, so it's
+   *  shown with the "lines" unit label instead of "words". */
+  provider: string
   isCurrent: boolean
   isDownloading: boolean
   onSelect: (name: string) => void
@@ -177,7 +183,7 @@ interface LanguageRowProps {
   onDelete?: (name: string) => void
 }
 
-function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onDelete }: LanguageRowProps) {
+function LanguageRow({ lang, provider, isCurrent, isDownloading, onSelect, onDownload, onDelete }: LanguageRowProps) {
   const { t } = useTranslation()
   const canSelect = lang.status !== 'not-downloaded'
 
@@ -206,7 +212,9 @@ function LanguageRow({ lang, isCurrent, isDownloading, onSelect, onDownload, onD
       </div>
 
       <span className="shrink-0 text-xs text-content-muted">
-        {t('editor.typingTest.language.words', { count: lang.wordCount })}
+        {provider === 'tatoeba'
+          ? t('editor.typingTest.language.lines', { count: lang.wordCount })
+          : t('editor.typingTest.language.words', { count: lang.wordCount })}
       </span>
 
       {lang.status === 'not-downloaded' && onDownload && (

--- a/src/renderer/typing-test/LanguageSelectorModal.tsx
+++ b/src/renderer/typing-test/LanguageSelectorModal.tsx
@@ -351,6 +351,14 @@ interface ImportRowProps {
 
 function ImportRow({ meta, isCurrent, onSelect, onDelete }: ImportRowProps) {
   const { t } = useTranslation()
+  // Space-separated (English-like) content has more whitespace-delimited
+  // words than lines → show words. No-space content (e.g. Japanese) has
+  // wordCount === lineCount (one "word" per line) → show lines instead,
+  // where a word count would be meaningless. Older metas saved before
+  // `lineCount` existed (undefined) fall back to the words display.
+  const unit = meta.lineCount == null || meta.wordCount > meta.lineCount
+    ? t('editor.typingTest.language.words', { count: meta.wordCount })
+    : t('editor.typingTest.language.lines', { count: meta.lineCount })
   return (
     <div
       data-testid={`typing-text-row-${meta.id}`}
@@ -362,9 +370,7 @@ function ImportRow({ meta, isCurrent, onSelect, onDelete }: ImportRowProps) {
         <span className={`truncate ${isCurrent ? 'font-semibold text-accent' : 'text-content'}`}>{meta.name}</span>
         {meta.romajiCapable === true && <RomajiBadge />}
       </div>
-      <span className="shrink-0 text-xs text-content-muted">
-        {t('editor.typingTest.language.words', { count: meta.wordCount })}
-      </span>
+      <span className="shrink-0 text-xs text-content-muted">{unit}</span>
       <RowDeleteButton testId={`typing-text-delete-${meta.id}`} onClick={() => { void onDelete(meta.id) }} />
     </div>
   )

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -11,6 +11,7 @@ import { WpmSparkline } from './WpmSparkline'
 import { AccuracyTrendSection } from './AccuracyTrendSection'
 import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
 import { resultKpm, buildResultNameChips } from './result-builder'
+import { formatConditionLabel } from './condition-label'
 import { ResultNameModal } from './ResultNameModal'
 import { Tooltip } from '../components/ui/Tooltip'
 
@@ -49,7 +50,10 @@ function formatDuration(seconds: number): string {
 
 /** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
  *  name (falling back to the stable textId for legacy rows saved before the
- *  name was captured); every other mode shows its `mode2` value. */
+ *  name was captured); words/time/quote show their `mode2` value verbatim.
+ *  Tatoeba is NOT handled here — its `mode2` is a composite
+ *  `language|pattern|count` (see `deriveMode2`), so the Mode column renders
+ *  it via `formatConditionLabel` instead of this raw value. */
 function modeDetail(r: TypingTestResult): string {
   if (r.mode === 'fileImport') return r.fileImportTextName ?? (r.mode2 != null ? String(r.mode2) : '')
   return r.mode2 != null ? String(r.mode2) : ''
@@ -300,7 +304,12 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
                   <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
                     {isText
                       ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
-                      : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`}
+                      // Tatoeba's mode2 is a composite (language|pattern|count, see
+                      // deriveMode2) — formatConditionLabel already knows how to
+                      // render it (e.g. "Tatoeba 5 Lines (english)").
+                      : (r.mode === 'tatoeba'
+                        ? formatConditionLabel(r, t)
+                        : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)}
                   </td>
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">
                     {formatDuration(r.durationSeconds)}

--- a/src/renderer/typing-test/TypingTestSettingsBar.tsx
+++ b/src/renderer/typing-test/TypingTestSettingsBar.tsx
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Labeled test-config bar (Pattern / Units / Option) shown below the Mode row
-// in editor typing-test mode. Pattern/Units only render for words/time/quote
-// (the parent gates the whole bar on mode + romaji capability — tatoeba and
-// fileImport only ever see this bar's Option row, and only once their
-// content is romaji-capable, see isRomajiCapable). Extracted from
-// TypingTestView so the config controls live with the Mode / Base Layer row
-// rather than above the reading area.
+// in editor typing-test mode. The shared words/time/quote Pattern/Units
+// render for those three modes; tatoeba gets its own Pattern (Lines / Time)
+// + Units section (below, gated separately since it doesn't share the
+// words/time/quote mode-switch). fileImport has neither — the parent gates
+// the whole bar on mode + romaji capability, so fileImport only ever sees
+// this bar's Option row, and only once its content is romaji-capable (see
+// isRomajiCapable). Extracted from TypingTestView so the config controls
+// live with the Mode / Base Layer row rather than above the reading area.
 
 import { useRef, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingTestConfig, TypingTestMode, QuoteLength, RomajiDetailSettings } from './types'
-import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS } from './types'
+import { WORD_COUNT_OPTIONS, TIME_DURATION_OPTIONS, TATOEBA_LINE_OPTIONS } from './types'
 import { isRomajiCapable, isRomajiInputEnabled } from './romaji-input'
 import { RomajiSettingsModal } from './RomajiSettingsModal'
 
@@ -176,6 +178,66 @@ export function TypingTestSettingsBar({ config, onConfigChange, language, textRo
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {/* Tatoeba's own Pattern (Lines / Time) — separate from the shared
+          words/time/quote Pattern row above since tatoeba switches via the
+          Language selector, not this bar's mode-switch (see handleModeChange). */}
+      {config.mode === 'tatoeba' && (
+        <div className="flex w-full flex-col items-start gap-1">
+          <span className={LABEL}>{t('editor.typingTest.pattern')}</span>
+          <div className="flex h-8 w-full items-center gap-1 rounded-lg bg-surface-alt/50 px-1">
+            <button
+              type="button"
+              data-testid="tatoeba-pattern-lines"
+              className={`${optionButtonClass(config.pattern === 'lines')} flex-1 justify-center`}
+              onClick={() => onConfigChange({ ...config, pattern: 'lines' })}
+            >
+              {t('editor.typingTest.mode.lines')}
+            </button>
+            <button
+              type="button"
+              data-testid="tatoeba-pattern-time"
+              className={`${optionButtonClass(config.pattern === 'time')} flex-1 justify-center`}
+              onClick={() => onConfigChange({ ...config, pattern: 'time' })}
+            >
+              {t('editor.typingTest.mode.time')}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Tatoeba's own Units — Lines pattern picks the sampled sentence
+          count, Time pattern reuses TIME_DURATION_OPTIONS (same as the
+          monkeytype Time mode's Units row). */}
+      {config.mode === 'tatoeba' && (
+        <div className="flex w-full flex-col items-start gap-1">
+          <span className={LABEL}>{config.pattern === 'lines' ? t('editor.typingTest.unitsLines') : t('editor.typingTest.unitsSec')}</span>
+          <div className="flex w-full items-center gap-1">
+            {config.pattern === 'lines' && TATOEBA_LINE_OPTIONS.map((count) => (
+              <button
+                key={count}
+                type="button"
+                data-testid={`tatoeba-line-${count}`}
+                className={`${optionButtonClass(config.lineCount === count)} flex-1 justify-center`}
+                onClick={() => onConfigChange({ ...config, lineCount: count })}
+              >
+                {count}
+              </button>
+            ))}
+            {config.pattern === 'time' && TIME_DURATION_OPTIONS.map((dur) => (
+              <button
+                key={dur}
+                type="button"
+                data-testid={`tatoeba-sec-${dur}`}
+                className={`${optionButtonClass(config.duration === dur)} flex-1 justify-center`}
+                onClick={() => onConfigChange({ ...config, duration: dur })}
+              >
+                {dur}
+              </button>
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -8,7 +8,7 @@ import { ICON_SM, ICON_LG } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { RomajiGuide, TypingTestConfig } from './types'
 import type { ComparisonStats } from './comparison'
-import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
+import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, isTimeBoundedRun } from './types'
 import { WordDisplay } from './WordDisplay'
 import { ResultNameModal } from './ResultNameModal'
 
@@ -238,7 +238,7 @@ export function TypingTestView({
     // Font/line changes resize the window, so re-snap the scroll position.
   }, [state.currentWordIndex, state.lineBreaks, lines, fontSize, displayLines])
 
-  const displayTime = config.mode === 'time' && remainingSeconds !== null
+  const displayTime = isTimeBoundedRun(config) && remainingSeconds !== null
     ? formatTime(remainingSeconds)
     : formatTime(elapsedSeconds)
 

--- a/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/LanguageSelectorModal.test.tsx
@@ -513,6 +513,27 @@ describe('LanguageSelectorModal', () => {
     expect(screen.getByTestId('language-row-japanese_hiragana').textContent).toContain('Romaji')
   })
 
+  it('shows a word count for the monkeytype provider but a line count for the tatoeba provider', async () => {
+    renderWithI18n(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onSelectTatoeba={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('language-row-english').textContent).toContain('200 words')
+    })
+
+    fireEvent.click(screen.getByTestId('language-tab-tatoeba'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-row-english').textContent).toContain('200 lines')
+    })
+  })
+
   it('deleting the selected imported text then closing fires onCurrentTextDeleted', async () => {
     window.vialAPI = {
       ...window.vialAPI,
@@ -734,6 +755,40 @@ describe('LanguageSelectorModal', () => {
     await waitFor(() => expect(screen.getByTestId('typing-text-row-kana-id')).toBeInTheDocument())
     expect(screen.getByTestId('typing-text-row-kana-id').textContent).toContain('Romaji')
     expect(screen.getByTestId('typing-text-row-mixed-id').textContent).not.toContain('Romaji')
+  })
+
+  it('shows words for a spaced (English-like) import and lines for a no-space (e.g. Japanese) import', async () => {
+    window.vialAPI = {
+      ...window.vialAPI,
+      typingTestTextStoreList: vi.fn().mockResolvedValue({
+        success: true,
+        data: [
+          // Spaced content: more whitespace-delimited words than lines → words.
+          { id: 'spaced-id', name: 'Spaced Text', wordCount: 12, lineCount: 3, filename: 's.json', savedAt: '', updatedAt: '' },
+          // No-space content: one "word" per line (wordCount === lineCount) → lines.
+          { id: 'nospace-id', name: 'No Space Text', wordCount: 5, lineCount: 5, filename: 'n.json', savedAt: '', updatedAt: '' },
+          // Legacy meta saved before lineCount existed → falls back to words.
+          { id: 'legacy-id', name: 'Legacy Text', wordCount: 8, filename: 'l.json', savedAt: '', updatedAt: '' },
+        ],
+      }),
+    } as unknown as typeof window.vialAPI
+
+    renderWithI18n(
+      <LanguageSelectorModal
+        currentLanguage="english"
+        onSelectLanguage={vi.fn()}
+        onSelectImport={vi.fn()}
+        onSelectTatoeba={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-tab-import'))
+
+    await waitFor(() => expect(screen.getByTestId('typing-text-row-spaced-id')).toBeInTheDocument())
+    expect(screen.getByTestId('typing-text-row-spaced-id').textContent).toContain('12 words')
+    expect(screen.getByTestId('typing-text-row-nospace-id').textContent).toContain('5 lines')
+    expect(screen.getByTestId('typing-text-row-legacy-id').textContent).toContain('8 words')
   })
 
   it('does not fire onCurrentTextDeleted when nothing was deleted', async () => {

--- a/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestSettingsBar.test.tsx
@@ -158,16 +158,17 @@ describe('TypingTestSettingsBar romaji settings button', () => {
     expect(screen.queryByTestId('romaji-settings-toggle')).not.toBeInTheDocument()
   })
 
-  it('shows the romaji button (Option row only, no Pattern/Units) for a tatoeba kana pack', () => {
-    const config: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana' }
+  it('shows the romaji button (plus its own Pattern/Units, no words/time toggles) for a tatoeba kana pack', () => {
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana', pattern: 'lines', lineCount: 5, duration: 30 }
     renderBar({ config })
     expect(screen.getByTestId('romaji-settings-toggle')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-pattern-lines')).toBeInTheDocument()
     expect(screen.queryByTestId('mode-words')).not.toBeInTheDocument()
     expect(screen.queryByTestId('toggle-punctuation')).not.toBeInTheDocument()
   })
 
   it('hides the romaji button for a tatoeba non-kana pack', () => {
-    const config: TypingTestConfig = { mode: 'tatoeba', language: 'english' }
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 }
     renderBar({ config })
     expect(screen.queryByTestId('romaji-settings-toggle')).not.toBeInTheDocument()
   })
@@ -371,5 +372,55 @@ describe('TypingTestSettingsBar toggle preservation', () => {
     if (wordsConfig.mode === 'words') {
       expect(wordsConfig.romaji).toEqual({ guideStyles: ['kunrei'] })
     }
+  })
+})
+
+describe('TypingTestSettingsBar tatoeba Pattern/Units', () => {
+  const linesConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 10, duration: 60 }
+  const timeConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'time', lineCount: 10, duration: 60 }
+
+  it('shows the Lines/Time Pattern row and highlights the active pattern', () => {
+    renderBar({ config: linesConfig })
+    expect(screen.getByTestId('tatoeba-pattern-lines')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-pattern-time')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-pattern-lines').className).toContain('text-accent')
+    expect(screen.getByTestId('tatoeba-pattern-time').className).not.toContain('text-accent')
+  })
+
+  it('shows the line-count Units row (and not the seconds row) in Lines pattern', () => {
+    renderBar({ config: linesConfig })
+    expect(screen.getByTestId('tatoeba-line-5')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-line-40')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-line-10').className).toContain('text-accent')
+    expect(screen.queryByTestId('tatoeba-sec-30')).not.toBeInTheDocument()
+  })
+
+  it('shows the seconds Units row (and not the line-count row) in Time pattern', () => {
+    renderBar({ config: timeConfig })
+    expect(screen.getByTestId('tatoeba-sec-15')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-sec-120')).toBeInTheDocument()
+    expect(screen.getByTestId('tatoeba-sec-60').className).toContain('text-accent')
+    expect(screen.queryByTestId('tatoeba-line-10')).not.toBeInTheDocument()
+  })
+
+  it('clicking the Time pattern button switches config.pattern, preserving lineCount/duration', () => {
+    const onConfigChange = vi.fn()
+    renderBar({ config: linesConfig, onConfigChange })
+    fireEvent.click(screen.getByTestId('tatoeba-pattern-time'))
+    expect(onConfigChange).toHaveBeenCalledWith({ ...linesConfig, pattern: 'time' })
+  })
+
+  it('clicking a line-count option updates config.lineCount', () => {
+    const onConfigChange = vi.fn()
+    renderBar({ config: linesConfig, onConfigChange })
+    fireEvent.click(screen.getByTestId('tatoeba-line-40'))
+    expect(onConfigChange).toHaveBeenCalledWith({ ...linesConfig, lineCount: 40 })
+  })
+
+  it('clicking a duration option updates config.duration', () => {
+    const onConfigChange = vi.fn()
+    renderBar({ config: timeConfig, onConfigChange })
+    fireEvent.click(screen.getByTestId('tatoeba-sec-15'))
+    expect(onConfigChange).toHaveBeenCalledWith({ ...timeConfig, duration: 15 })
   })
 })

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -27,7 +27,7 @@ function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult
 
 const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false } as TypingTestConfig
 const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 't1' } as TypingTestConfig
-const tatoebaConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english' } as TypingTestConfig
+const tatoebaConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 }
 
 describe('matchingResults', () => {
   it('matches normal runs on mode + params + language + toggles', () => {
@@ -181,7 +181,7 @@ describe('conditionKey / resultConditionKey agreement', () => {
       { mode: 'time', duration: 30, punctuation: false, numbers: false },
       { mode: 'quote', quoteLength: 'medium' },
       { mode: 'fileImport', textId: 't1' },
-      { mode: 'tatoeba', language: 'japanese' },
+      { mode: 'tatoeba', language: 'japanese', pattern: 'lines', lineCount: 5, duration: 30 },
     ]
     for (const config of configs) {
       const result = buildTypingTestResult(buildInput(config))

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -52,12 +52,14 @@ describe('matchingResults', () => {
     expect(out.map((r) => r.wpm).sort()).toEqual([40, 45])
   })
 
-  it('matches tatoeba runs on the pack language (mode2), independent of word language', () => {
+  it('matches tatoeba runs on the pack language + pattern + unit (mode2), independent of word language', () => {
     const pool = [
-      makeResult({ wpm: 40, mode: 'tatoeba', mode2: 'english', language: 'english' }),  // match
-      makeResult({ wpm: 45, mode: 'tatoeba', mode2: 'english', language: 'german' }),   // same pack, stray lang → still match
-      makeResult({ wpm: 99, mode: 'tatoeba', mode2: 'french' }),                        // different pack
-      makeResult({ wpm: 12, mode: 'words', mode2: 'english' }),                         // different mode
+      makeResult({ wpm: 40, mode: 'tatoeba', mode2: 'english|lines|5', language: 'english' }),  // match
+      makeResult({ wpm: 45, mode: 'tatoeba', mode2: 'english|lines|5', language: 'german' }),   // same pack+pattern+count, stray lang → still match
+      makeResult({ wpm: 99, mode: 'tatoeba', mode2: 'english|lines|10' }),                       // different line count
+      makeResult({ wpm: 33, mode: 'tatoeba', mode2: 'english|time|30' }),                        // different pattern
+      makeResult({ wpm: 77, mode: 'tatoeba', mode2: 'french|lines|5' }),                         // different pack
+      makeResult({ wpm: 12, mode: 'words', mode2: 'english' }),                                  // different mode
     ]
     const out = matchingResults(pool, tatoebaConfig, 'german')
     expect(out.map((r) => r.wpm).sort((a, b) => a - b)).toEqual([40, 45])
@@ -86,9 +88,20 @@ describe('conditionKey', () => {
     expect(conditionKey(fileImportConfig, 'japanese')).toBe('fileImport|t1')
   })
 
-  it('keys tatoeba on the pack language only (word-language-independent)', () => {
-    expect(conditionKey(tatoebaConfig, 'german')).toBe('tatoeba|english')
-    expect(conditionKey(tatoebaConfig, 'japanese')).toBe('tatoeba|english')
+  it('keys tatoeba on the pack language + pattern + unit (word-language-independent)', () => {
+    expect(conditionKey(tatoebaConfig, 'german')).toBe('tatoeba|english|lines|5')
+    expect(conditionKey(tatoebaConfig, 'japanese')).toBe('tatoeba|english|lines|5')
+  })
+
+  it('distinguishes tatoeba configs that differ only in pattern or line count/duration', () => {
+    const lines5: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 }
+    const lines10: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 10, duration: 30 }
+    const time30: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'time', lineCount: 5, duration: 30 }
+    const lines5Again: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 60 }
+    const keys = [lines5, lines10, time30].map((c) => conditionKey(c, 'english'))
+    expect(new Set(keys).size).toBe(3)
+    // Same language + pattern + lineCount → same key, even if the unused duration field differs.
+    expect(conditionKey(lines5, 'english')).toBe(conditionKey(lines5Again, 'english'))
   })
 
   it('distinguishes different conditions', () => {
@@ -134,11 +147,11 @@ describe('resultConditionKey', () => {
     expect(resultConditionKey(r1)).toBe('fileImport|t1')
   })
 
-  it('keys tatoeba on the pack language (mode2) only', () => {
-    const r1 = makeResult({ mode: 'tatoeba', mode2: 'japanese', language: 'japanese' })
-    const r2 = makeResult({ mode: 'tatoeba', mode2: 'japanese', language: 'german' })
+  it('keys tatoeba on the pack language + pattern + unit (mode2) only', () => {
+    const r1 = makeResult({ mode: 'tatoeba', mode2: 'japanese|lines|5', language: 'japanese' })
+    const r2 = makeResult({ mode: 'tatoeba', mode2: 'japanese|lines|5', language: 'german' })
     expect(resultConditionKey(r1)).toBe(resultConditionKey(r2))
-    expect(resultConditionKey(r1)).toBe('tatoeba|japanese')
+    expect(resultConditionKey(r1)).toBe('tatoeba|japanese|lines|5')
   })
 
   it('falls back sensibly for legacy rows missing mode/mode2/language', () => {

--- a/src/renderer/typing-test/__tests__/condition-label.test.ts
+++ b/src/renderer/typing-test/__tests__/condition-label.test.ts
@@ -60,7 +60,17 @@ describe('formatConditionLabel', () => {
       .toBe('t1')
   })
 
-  it('formats tatoeba with the pack language', () => {
+  it('formats tatoeba with the pack language + line count', () => {
+    expect(formatConditionLabel(makeResult({ mode: 'tatoeba', mode2: 'japanese|lines|5', language: 'japanese' }), identityT))
+      .toBe('editor.typingTest.history.conditionTatoeba 5 editor.typingTest.mode.lines (japanese)')
+  })
+
+  it('formats tatoeba with the pack language + duration', () => {
+    expect(formatConditionLabel(makeResult({ mode: 'tatoeba', mode2: 'japanese|time|30', language: 'japanese' }), identityT))
+      .toBe('editor.typingTest.history.conditionTatoeba 30s (japanese)')
+  })
+
+  it('falls back to the legacy bare-language label for rows saved before the composite mode2', () => {
     expect(formatConditionLabel(makeResult({ mode: 'tatoeba', mode2: 'japanese', language: 'japanese' }), identityT))
       .toBe('editor.typingTest.history.conditionTatoeba (japanese)')
   })

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -225,7 +225,7 @@ describe('buildTypingTestResult', () => {
   })
 
   it('records romajiInput for tatoeba/fileImport runs too, now that recording follows romajiActive', () => {
-    const tatoebaCfg: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana' }
+    const tatoebaCfg: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana', pattern: 'lines', lineCount: 5, duration: 30 }
     const result = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
       config: tatoebaCfg, language: 'english', wpmHistory: [], romajiActive: true,
@@ -270,7 +270,7 @@ describe('buildTypingTestResult', () => {
   })
 
   it('stores the tatoeba pack language as language + mode2, not the input language', () => {
-    const config: TypingTestConfig = { mode: 'tatoeba', language: 'english' }
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 }
     const result = buildTypingTestResult({
       correctChars: 120,
       incorrectChars: 4,

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -269,7 +269,7 @@ describe('buildTypingTestResult', () => {
     expect(result.mode2).toBe('medium')
   })
 
-  it('stores the tatoeba pack language as language + mode2, not the input language', () => {
+  it('stores the tatoeba pack language as language, and a composite language|pattern|unit as mode2, not the input language', () => {
     const config: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 5, duration: 30 }
     const result = buildTypingTestResult({
       correctChars: 120,
@@ -285,9 +285,26 @@ describe('buildTypingTestResult', () => {
       romajiActive: false,
     })
     expect(result.mode).toBe('tatoeba')
-    expect(result.mode2).toBe('english')
+    expect(result.mode2).toBe('english|lines|5')
     expect(result.language).toBe('english')
     expect(typingTestResultMaterialLabel(result)).toBe('tatoeba-english')
+  })
+
+  it('derives the tatoeba mode2 unit from duration when pattern is time', () => {
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'japanese', pattern: 'time', lineCount: 5, duration: 30 }
+    const result = buildTypingTestResult({
+      correctChars: 120,
+      incorrectChars: 4,
+      wordCount: 20,
+      wpm: 65,
+      accuracy: 97,
+      elapsedMs: 40000,
+      config,
+      language: 'japanese',
+      wpmHistory: [],
+      romajiActive: false,
+    })
+    expect(result.mode2).toBe('japanese|time|30')
   })
 })
 

--- a/src/renderer/typing-test/__tests__/romaji-input.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-input.test.ts
@@ -13,7 +13,7 @@ const wordsConfig = (romajiInput?: boolean, romaji?: RomajiDetailSettings): Typi
 const timeConfig = (romajiInput?: boolean, romaji?: RomajiDetailSettings): TypingTestConfig =>
   ({ mode: 'time', duration: 30, punctuation: false, numbers: false, romajiInput, romaji })
 const tatoebaConfig = (language: string, romajiInput?: boolean, romaji?: RomajiDetailSettings): TypingTestConfig =>
-  ({ mode: 'tatoeba', language, romajiInput, romaji })
+  ({ mode: 'tatoeba', language, pattern: 'lines', lineCount: 5, duration: 30, romajiInput, romaji })
 const fileImportConfig = (romajiInput?: boolean, romaji?: RomajiDetailSettings): TypingTestConfig =>
   ({ mode: 'fileImport', textId: 't1', romajiInput, romaji })
 const quoteConfig = (): TypingTestConfig => ({ mode: 'quote', quoteLength: 'medium' })

--- a/src/renderer/typing-test/__tests__/types.test.ts
+++ b/src/renderer/typing-test/__tests__/types.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { isTimeBoundedRun, runDurationSeconds } from '../types'
+import type { TypingTestConfig } from '../types'
+
+const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+const timeConfig: TypingTestConfig = { mode: 'time', duration: 45, punctuation: false, numbers: false }
+const quoteConfig: TypingTestConfig = { mode: 'quote', quoteLength: 'medium' }
+const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 't1' }
+const tatoebaLinesConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'lines', lineCount: 10, duration: 60 }
+const tatoebaTimeConfig: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'time', lineCount: 10, duration: 60 }
+
+describe('isTimeBoundedRun', () => {
+  it('is true for monkeytype time mode', () => {
+    expect(isTimeBoundedRun(timeConfig)).toBe(true)
+  })
+
+  it('is true for tatoeba with the Time pattern', () => {
+    expect(isTimeBoundedRun(tatoebaTimeConfig)).toBe(true)
+  })
+
+  it('is false for tatoeba with the Lines pattern', () => {
+    expect(isTimeBoundedRun(tatoebaLinesConfig)).toBe(false)
+  })
+
+  it('is false for words/quote/fileImport', () => {
+    expect(isTimeBoundedRun(wordsConfig)).toBe(false)
+    expect(isTimeBoundedRun(quoteConfig)).toBe(false)
+    expect(isTimeBoundedRun(fileImportConfig)).toBe(false)
+  })
+})
+
+describe('runDurationSeconds', () => {
+  it('reads duration from monkeytype time mode', () => {
+    expect(runDurationSeconds(timeConfig)).toBe(45)
+  })
+
+  it('reads duration from tatoeba with the Time pattern', () => {
+    expect(runDurationSeconds(tatoebaTimeConfig)).toBe(60)
+  })
+
+  it('is null for tatoeba with the Lines pattern, even though duration is still stored', () => {
+    expect(runDurationSeconds(tatoebaLinesConfig)).toBeNull()
+  })
+
+  it('is null for words/quote/fileImport', () => {
+    expect(runDurationSeconds(wordsConfig)).toBeNull()
+    expect(runDurationSeconds(quoteConfig)).toBeNull()
+    expect(runDurationSeconds(fileImportConfig)).toBeNull()
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.tatoeba.test.ts
@@ -25,6 +25,17 @@ const type = (result: { current: { processKeyEvent: (k: string, c: boolean, a: b
   act(() => result.current.processKeyEvent(key, false, false, false))
 }
 
+/** Submits the current word with whichever key it actually expects — Enter
+ *  at a sentence-end word, Space elsewhere (see `state.lineBreaks`). Tatoeba
+ *  sentences don't all have the same word count, so a fixed Space/Enter
+ *  loop would silently get stuck partway through a multi-sentence sample. */
+const submitWord = (result: {
+  current: { state: { currentWordIndex: number; lineBreaks: Set<number> }; processKeyEvent: (k: string, c: boolean, a: boolean, m: boolean) => void }
+}): void => {
+  const key = result.current.state.lineBreaks.has(result.current.state.currentWordIndex) ? 'Enter' : ' '
+  type(result, key)
+}
+
 describe('useTypingTest — tatoeba mode', () => {
   it('plays a downloaded pack as word-flow (no line breaks) and finishes on the last char', async () => {
     // A single-sentence pack makes the sampled quote deterministic (the
@@ -33,7 +44,7 @@ describe('useTypingTest — tatoeba mode', () => {
     // Warm the cache so the hook's synchronous initial state has the words.
     await getTatoebaPack('english-x')
 
-    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-x' }, 'english'))
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-x', pattern: 'lines', lineCount: 5, duration: 30 }, 'english'))
 
     // Word-flow: sentence split into space-delimited tokens, no line breaks.
     expect(result.current.state.words).toEqual(['ab', 'cd'])
@@ -60,10 +71,10 @@ describe('useTypingTest — tatoeba mode', () => {
     const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
 
     await act(async () => {
-      await result.current.setConfig({ mode: 'tatoeba', language: 'english-y' })
+      await result.current.setConfig({ mode: 'tatoeba', language: 'english-y', pattern: 'lines', lineCount: 5, duration: 30 })
     })
 
-    expect(result.current.config).toEqual({ mode: 'tatoeba', language: 'english-y' })
+    expect(result.current.config).toEqual({ mode: 'tatoeba', language: 'english-y', pattern: 'lines', lineCount: 5, duration: 30 })
     expect(result.current.state.words).toEqual(['hi', 'yo'])
     expect(mockLangGet).toHaveBeenCalledWith('english-y', 'tatoeba')
   })
@@ -74,7 +85,7 @@ describe('useTypingTest — tatoeba mode', () => {
     const { result } = renderHook(() => useTypingTest({ mode: 'words', wordCount: 5, punctuation: false, numbers: false }, 'english'))
 
     await act(async () => {
-      await result.current.setConfig({ mode: 'tatoeba', language: 'missing' })
+      await result.current.setConfig({ mode: 'tatoeba', language: 'missing', pattern: 'lines', lineCount: 5, duration: 30 })
     })
 
     expect(result.current.state.words).toEqual([])
@@ -90,7 +101,7 @@ describe('useTypingTest — tatoeba mode', () => {
     })
     await getTatoebaPack('japanese-regression')
 
-    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'japanese-regression' }, 'english'))
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'japanese-regression', pattern: 'lines', lineCount: 5, duration: 30 }, 'english'))
 
     expect(result.current.state.words.join('')).not.toBe('0')
     expect(result.current.state.words.some((w) => w.includes('やばい'))).toBe(true)
@@ -103,7 +114,7 @@ describe('useTypingTest — tatoeba mode', () => {
     mockLangGet.mockResolvedValue({ name: 'english-z', words: ['ab cd', 'ef'] })
     await getTatoebaPack('english-z')
 
-    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-z' }, 'english'))
+    const { result } = renderHook(() => useTypingTest({ mode: 'tatoeba', language: 'english-z', pattern: 'lines', lineCount: 5, duration: 30 }, 'english'))
 
     expect(result.current.state.words).toEqual(['ab', 'cd', 'ef'])
     expect([...result.current.state.lineBreaks]).toEqual([1])
@@ -121,5 +132,90 @@ describe('useTypingTest — tatoeba mode', () => {
     expect(result.current.state.currentWordIndex).toBe(1)
     type(result, 'Enter')
     expect(result.current.state.currentWordIndex).toBe(2)
+  })
+})
+
+describe('useTypingTest — tatoeba Lines pattern is bounded to lineCount sentences', () => {
+  it('finishes once every sampled word is typed, never refilling', async () => {
+    // A pack far larger than lineCount — the Lines pattern must sample
+    // exactly lineCount sentences and finish there, not keep extending
+    // like the Time pattern does.
+    const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    mockLangGet.mockResolvedValue({ name: 'lines-bounded', words })
+    await getTatoebaPack('lines-bounded')
+
+    const { result } = renderHook(() => useTypingTest(
+      { mode: 'tatoeba', language: 'lines-bounded', pattern: 'lines', lineCount: 3, duration: 30 },
+      'english',
+    ))
+
+    expect(result.current.state.words).toHaveLength(3)
+
+    for (let i = 0; i < 2; i++) {
+      type(result, 'a')
+      submitWord(result)
+    }
+    expect(result.current.state.status).toBe('running')
+    expect(result.current.state.currentWordIndex).toBe(2)
+    expect(result.current.state.words).toHaveLength(3) // no refill
+
+    // Last word finishes on its final character (no trailing separator).
+    const lastWord = result.current.state.words[2]
+    for (const ch of lastWord) type(result, ch)
+    expect(result.current.state.status).toBe('finished')
+  })
+})
+
+describe('useTypingTest — tatoeba Time pattern', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('counts down and finishes at the configured duration', async () => {
+    const words = Array.from({ length: 30 }, (_, i) => `s${i}`)
+    mockLangGet.mockResolvedValue({ name: 'time-countdown', words })
+    await getTatoebaPack('time-countdown')
+
+    const { result } = renderHook(() => useTypingTest(
+      { mode: 'tatoeba', language: 'time-countdown', pattern: 'time', lineCount: 5, duration: 15 },
+      'english',
+    ))
+
+    expect(result.current.remainingSeconds).toBe(15)
+
+    act(() => result.current.processKeyEvent('s', false, false, false))
+    expect(result.current.state.status).toBe('running')
+
+    act(() => vi.advanceTimersByTime(15000))
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.remainingSeconds).toBe(0)
+  })
+
+  it('never finishes from completing all sampled words — only the timer ends it', async () => {
+    const words = ['s0a s0b', 's1a s1b', 's2a s2b']
+    mockLangGet.mockResolvedValue({ name: 'time-no-word-finish', words })
+    await getTatoebaPack('time-no-word-finish')
+
+    const { result } = renderHook(() => useTypingTest(
+      { mode: 'tatoeba', language: 'time-no-word-finish', pattern: 'time', lineCount: 5, duration: 120 },
+      'english',
+    ))
+
+    const initialWordCount = result.current.state.words.length
+    const submitCount = initialWordCount + 2
+    for (let i = 0; i < submitCount; i++) {
+      type(result, 'a')
+      submitWord(result)
+    }
+
+    // Ran clean through (and past) the initial batch — refilled, not finished.
+    expect(result.current.state.currentWordIndex).toBe(submitCount)
+    expect(result.current.state.status).toBe('running')
+    expect(result.current.state.words.length).toBeGreaterThan(initialWordCount)
   })
 })

--- a/src/renderer/typing-test/__tests__/word-supply.test.ts
+++ b/src/renderer/typing-test/__tests__/word-supply.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createWordsForConfigSync, createWordsForConfig, refillTimeModeWords } from '../word-supply'
+import { getTatoebaPack } from '../word-generator'
+import type { TypingTestConfig } from '../types'
+
+const mockLangGet = vi.fn()
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  window.vialAPI = {
+    ...(window.vialAPI ?? {}),
+    langGet: mockLangGet,
+  } as unknown as typeof window.vialAPI
+})
+
+afterEach(() => {
+  window.vialAPI = originalVialAPI
+})
+
+describe('createWordsForConfig(Sync) — tatoeba', () => {
+  it('Lines pattern samples exactly lineCount sentences', async () => {
+    // Single-word "sentences" so the sampled word count equals the sampled
+    // sentence count regardless of sampling order.
+    const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    mockLangGet.mockResolvedValue({ name: 'lines-pack', words })
+    await getTatoebaPack('lines-pack')
+
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'lines-pack', pattern: 'lines', lineCount: 10, duration: 30 }
+    expect(createWordsForConfigSync(config, 'english').words).toHaveLength(10)
+    expect((await createWordsForConfig(config, 'english')).words).toHaveLength(10)
+  })
+
+  it('a different lineCount samples a different count', async () => {
+    const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    mockLangGet.mockResolvedValue({ name: 'lines-pack-2', words })
+    await getTatoebaPack('lines-pack-2')
+
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'lines-pack-2', pattern: 'lines', lineCount: 40, duration: 30 }
+    expect(createWordsForConfigSync(config, 'english').words).toHaveLength(40)
+  })
+
+  it('Time pattern samples the fixed initial time batch, independent of lineCount', async () => {
+    const words = Array.from({ length: 100 }, (_, i) => `s${i}`)
+    mockLangGet.mockResolvedValue({ name: 'time-pack', words })
+    await getTatoebaPack('time-pack')
+
+    // lineCount is set to an unrelated value — the Time pattern must ignore
+    // it and sample its own fixed batch size (20, see TATOEBA_TIME_BATCH_SIZE
+    // in word-supply.ts).
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'time-pack', pattern: 'time', lineCount: 5, duration: 30 }
+    expect(createWordsForConfigSync(config, 'english').words).toHaveLength(20)
+    expect((await createWordsForConfig(config, 'english')).words).toHaveLength(20)
+  })
+})
+
+describe('refillTimeModeWords', () => {
+  it('returns null when the untyped tail is still above the low-water threshold', () => {
+    const config: TypingTestConfig = { mode: 'time', duration: 30, punctuation: false, numbers: false }
+    const words = Array.from({ length: 20 }, (_, i) => `w${i}`)
+    expect(refillTimeModeWords(words, 5, config, 'english')).toBeNull()
+  })
+
+  it('monkeytype time: extends with a fresh batch and no line breaks', () => {
+    const config: TypingTestConfig = { mode: 'time', duration: 30, punctuation: false, numbers: false }
+    const words = Array.from({ length: 10 }, (_, i) => `w${i}`)
+    const refill = refillTimeModeWords(words, 8, config, 'english')
+    expect(refill).not.toBeNull()
+    expect(refill!.words.length).toBeGreaterThan(words.length)
+    expect(refill!.words.slice(0, words.length)).toEqual(words)
+    expect(refill!.lineBreaks).toEqual([])
+  })
+
+  it('non-time-bounded configs (e.g. tatoeba Lines) never refill', () => {
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'x', pattern: 'lines', lineCount: 5, duration: 30 }
+    const words = Array.from({ length: 2 }, (_, i) => `w${i}`)
+    expect(refillTimeModeWords(words, 1, config, 'english')).toBeNull()
+  })
+
+  it('tatoeba time: returns null when the pack is not cached', () => {
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'not-cached', pattern: 'time', lineCount: 5, duration: 30 }
+    const words = Array.from({ length: 2 }, (_, i) => `w${i}`)
+    expect(refillTimeModeWords(words, 1, config, 'english')).toBeNull()
+  })
+
+  it('tatoeba time: extends with more sentences and stitches a seam line break at the old tail', async () => {
+    // A pack small enough that the sampler deterministically returns every
+    // sentence in order (see tatoeba-pack.test.ts's own coverage of that
+    // fallback) — makes the refill's exact shape predictable.
+    const words = ['s0a s0b', 's1a s1b', 's2a s2b']
+    mockLangGet.mockResolvedValue({ name: 'refill-pack', words })
+    await getTatoebaPack('refill-pack')
+
+    const config: TypingTestConfig = { mode: 'tatoeba', language: 'refill-pack', pattern: 'time', lineCount: 5, duration: 30 }
+    const initial = createWordsForConfigSync(config, 'english')
+    // TATOEBA_TIME_BATCH_SIZE (20) exceeds the pack's 3 sentences, so the
+    // initial batch is every sentence in order: 6 words, breaks after the
+    // first two sentences (1, 3), none after the last (5).
+    expect(initial.words).toEqual(['s0a', 's0b', 's1a', 's1b', 's2a', 's2b'])
+    expect(initial.lineBreaks).toEqual([1, 3])
+
+    const refill = refillTimeModeWords(initial.words, 1, config, 'english')
+    expect(refill).not.toBeNull()
+    // Same 3 sentences appended again (deterministic small-pack sampling).
+    expect(refill!.words).toEqual([
+      's0a', 's0b', 's1a', 's1b', 's2a', 's2b', 's0a', 's0b', 's1a', 's1b', 's2a', 's2b',
+    ])
+    // The seam (5, the old last word) plus the new batch's own internal
+    // breaks offset by 6 (7, 9).
+    expect(refill!.lineBreaks.slice().sort((a, b) => a - b)).toEqual([5, 7, 9])
+  })
+})

--- a/src/renderer/typing-test/comparison.ts
+++ b/src/renderer/typing-test/comparison.ts
@@ -17,7 +17,8 @@ export interface ComparisonStats {
  *  — no dedicated field needed, and it works for legacy rows too. This is
  *  the single source of truth for condition grouping:
  *  - fileImport: the imported text id (`mode2`), language-independent
- *  - tatoeba: the sentence-pack language (`mode2`), word-language-independent
+ *  - tatoeba: the sentence-pack language + pattern + active unit (`mode2`,
+ *    see `deriveMode2`), word-language-independent
  *  - normal (words/time/quote): mode + params + language + toggles (`configKey`)
  *  Rows missing some of these fields fall back the same way `configKey`
  *  already does for PB grouping, so old history entries group sensibly

--- a/src/renderer/typing-test/condition-label.ts
+++ b/src/renderer/typing-test/condition-label.ts
@@ -33,7 +33,22 @@ export function formatConditionLabel(result: TypingTestResult, t: (key: string) 
       // Text name takes priority; falls back to the stable textId for
       // legacy rows saved before the name was captured.
       return result.fileImportTextName || String(result.mode2 ?? '')
-    case 'tatoeba':
-      return `${t('editor.typingTest.history.conditionTatoeba')} (${String(result.mode2 ?? language)})`
+    case 'tatoeba': {
+      // mode2 is now a composite `language|pattern|lineCount-or-duration`
+      // (see deriveMode2) so the label distinguishes a 5-line run from a
+      // 120s run of the same pack. Legacy rows saved before this change
+      // stored the bare language in mode2 — fall back to the old label.
+      const raw = String(result.mode2 ?? language)
+      const parts = raw.split('|')
+      const tatoeba = t('editor.typingTest.history.conditionTatoeba')
+      if (parts.length === 3) {
+        const [lang, pattern, count] = parts
+        const unit = pattern === 'lines'
+          ? `${count} ${t('editor.typingTest.mode.lines')}`
+          : `${count}s`
+        return `${tatoeba} ${unit} (${lang})`
+      }
+      return `${tatoeba} (${raw})`
+    }
   }
 }

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -99,8 +99,11 @@ export function deriveMode2(config: TypingTestConfig): number | string {
       // Group PBs per imported text via its id.
       return config.textId
     case 'tatoeba':
-      // Group PBs per sentence-pack language.
-      return config.language
+      // Group PBs per sentence-pack language + pattern + active unit (line
+      // count or duration), mirroring how words/time bake their count/duration
+      // into mode2 — otherwise a 5-line run and a 120s run of the same pack
+      // would share one PB pool and condition label.
+      return `${config.language}|${config.pattern}|${config.pattern === 'lines' ? config.lineCount : config.duration}`
   }
 }
 

--- a/src/renderer/typing-test/run-state.ts
+++ b/src/renderer/typing-test/run-state.ts
@@ -4,6 +4,7 @@
  *  advance it on keystrokes, backspace, and word submits. */
 
 import type { TypingTestConfig, Quote } from './types'
+import { isTimeBoundedRun } from './types'
 import { type WordsForConfig, createWordsForConfigSync, refillTimeModeWords } from './word-supply'
 
 export type TypingTestStatus = 'countdown' | 'waiting' | 'running' | 'finished' | 'paused'
@@ -124,10 +125,15 @@ export function tryFinishLastWord(state: TypingTestState): TypingTestState | nul
 export function advanceAfterWord(base: TypingTestState, config: TypingTestConfig, language: string): TypingTestState {
   const nextIndex = base.currentWordIndex
 
-  // Time mode: extend words if running low, never finish from words
-  if (config.mode === 'time') {
+  // Time-bounded runs (monkeytype time mode, or tatoeba's Time pattern):
+  // extend words if running low, never finish from words.
+  if (isTimeBoundedRun(config)) {
     const refilled = refillTimeModeWords(base.words, nextIndex, config, language)
-    return refilled ? { ...base, words: refilled } : base
+    if (!refilled) return base
+    if (refilled.lineBreaks.length === 0) return { ...base, words: refilled.words }
+    const lineBreaks = new Set(base.lineBreaks)
+    for (const b of refilled.lineBreaks) lineBreaks.add(b)
+    return { ...base, words: refilled.words, lineBreaks }
   }
 
   // Words and quote modes: finish when all words typed

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -44,10 +44,14 @@ export type TypingTestConfig =
   | { mode: 'fileImport'; textId: string; romajiInput?: boolean; romaji?: RomajiDetailSettings }
   // Tatoeba sentence pack (Hub-distributed). Sentences are played verbatim
   // in order via the same char-count/word-flow path as fileImport. `language`
-  // selects the downloaded pack (e.g. 'english'). `romajiInput`/`romaji` are
-  // only meaningful when `language` is one of the kana packs — see
-  // `isRomajiCapable` in romaji-input.ts.
-  | { mode: 'tatoeba'; language: string; romajiInput?: boolean; romaji?: RomajiDetailSettings }
+  // selects the downloaded pack (e.g. 'english'). Like words/time, Tatoeba
+  // has its own Pattern (Lines / Time) with its own Units — `lineCount` and
+  // `duration` are both always stored (not just the active pattern's field)
+  // so switching Pattern preserves each independently, same as words/time
+  // keep their own counts. `romajiInput`/`romaji` are only meaningful when
+  // `language` is one of the kana packs — see `isRomajiCapable` in
+  // romaji-input.ts.
+  | { mode: 'tatoeba'; language: string; pattern: 'lines' | 'time'; lineCount: number; duration: number; romajiInput?: boolean; romaji?: RomajiDetailSettings }
 
 export interface Quote {
   id: number
@@ -58,7 +62,31 @@ export interface Quote {
 
 export const WORD_COUNT_OPTIONS = [15, 30, 60, 120] as const
 export const TIME_DURATION_OPTIONS = [15, 30, 60, 120] as const
+// Tatoeba's Lines pattern reuses the same 15/30/60/120 TIME_DURATION_OPTIONS
+// for its Time pattern — only Lines needs its own option set.
+export const TATOEBA_LINE_OPTIONS = [5, 10, 20, 40] as const
 export const DEFAULT_LANGUAGE = 'english'
+
+/** True for every "time-bounded" run — monkeytype time mode, or the tatoeba
+ *  Time pattern — the two config shapes whose word supply is an
+ *  ever-extending stream (see `refillTimeModeWords`) rather than a fixed
+ *  count, and whose run finishes on a countdown rather than on running out
+ *  of words (see `advanceAfterWord`). Centralizes the check so tatoeba+time
+ *  slots into the existing time logic without scattering
+ *  `mode === 'time' || (mode === 'tatoeba' && pattern === 'time')`
+ *  conditionals across run-state.ts / useTypingTest.ts. */
+export function isTimeBoundedRun(
+  config: TypingTestConfig,
+): config is Extract<TypingTestConfig, { mode: 'time' }> | (Extract<TypingTestConfig, { mode: 'tatoeba' }> & { pattern: 'time' }) {
+  return config.mode === 'time' || (config.mode === 'tatoeba' && config.pattern === 'time')
+}
+
+/** The configured duration (seconds) for a time-bounded run (see
+ *  `isTimeBoundedRun`), or null for every other mode/pattern. Derived from
+ *  the predicate so the two never disagree. */
+export function runDurationSeconds(config: TypingTestConfig): number | null {
+  return isTimeBoundedRun(config) ? config.duration : null
+}
 
 /** Word-language packs the romaji-keystroke matcher supports (kana word
  *  lists only). Drives the SettingsBar toggle's visibility, and — via

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -5,7 +5,7 @@ import { isTapKeycode } from './keycode-char-map'
 import { getLanguageData } from './word-generator'
 import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, RomajiGuide } from './types'
-import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, applyRomajiCaseStyle } from './types'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, applyRomajiCaseStyle, isTimeBoundedRun, runDurationSeconds } from './types'
 import type { TypingTestMemory } from '../../shared/types/pipette-settings'
 import type { TypingAnalyticsEventPayload, TypingMatrixAction } from '../../shared/types/typing-analytics'
 import { createWordsForConfig } from './word-supply'
@@ -434,8 +434,9 @@ export function useTypingTest(
           current = { ...current, status: 'running', startTime: Date.now() }
         }
         current = handleChar(current, key)
-        // Auto-finish when last char of last word is typed (words/quote modes only)
-        if (configRef.current.mode !== 'time') {
+        // Auto-finish when last char of last word is typed (words/quote modes,
+        // and tatoeba's Lines pattern — every mode but a time-bounded run).
+        if (!isTimeBoundedRun(configRef.current)) {
           return tryFinishLastWord(current) ?? current
         }
         return current
@@ -475,7 +476,7 @@ export function useTypingTest(
         current = { ...current, status: 'running', startTime: Date.now() }
       }
       current = { ...current, currentInput: current.currentInput + data, compositionText: '' }
-      if (configRef.current.mode !== 'time') {
+      if (!isTimeBoundedRun(configRef.current)) {
         return tryFinishLastWord(current) ?? current
       }
       return current
@@ -501,14 +502,17 @@ export function useTypingTest(
     return () => clearInterval(id)
   }, [state.status])
 
-  // Time mode countdown - finish when remaining reaches 0
+  // Time-bounded countdown (monkeytype time mode, or tatoeba's Time
+  // pattern) - finish when remaining reaches 0
   useEffect(() => {
     if (state.status !== 'running') return
-    if (config.mode !== 'time') return
+    if (!isTimeBoundedRun(config)) return
     if (!state.startTime) return
 
+    const duration = runDurationSeconds(config)
+    if (duration == null) return
     const elapsed = Math.floor((Date.now() - state.startTime) / 1000)
-    if (elapsed >= config.duration) {
+    if (elapsed >= duration) {
       setState((s) => {
         if (s.status !== 'running') return s
         return { ...s, status: 'finished', endTime: Date.now() }
@@ -547,11 +551,12 @@ export function useTypingTest(
   }, [state.startTime, state.endTime, tick])
 
   const remainingSeconds = useMemo(() => {
-    if (config.mode !== 'time') return null
-    if (!state.startTime) return config.duration
+    const duration = runDurationSeconds(config)
+    if (duration == null) return null
+    if (!state.startTime) return duration
     if (state.endTime) return 0
     const elapsed = Math.floor((Date.now() - state.startTime) / 1000)
-    return Math.max(0, config.duration - elapsed)
+    return Math.max(0, duration - elapsed)
   }, [config, state.startTime, state.endTime, tick])
 
   // Current word's romaji progress (romajiInput mode only), re-derived from

--- a/src/renderer/typing-test/word-generator/tatoeba-pack.ts
+++ b/src/renderer/typing-test/word-generator/tatoeba-pack.ts
@@ -69,9 +69,11 @@ export interface TatoebaRun {
  *  (Japanese, Cyrillic, accented Latin, etc. — most of the 72 Tatoeba
  *  languages). `quote` folds every sampled sentence into one string so the
  *  finished screen can label the source and char-based progress counting is
- *  reused verbatim. */
-export function tatoebaRun(pack: TatoebaPack): TatoebaRun {
-  const sentences = sampleSentences(pack.words, TATOEBA_SENTENCE_COUNT)
+ *  reused verbatim. `count` defaults to `TATOEBA_SENTENCE_COUNT` for
+ *  back-compat; callers with their own Pattern/Units (Lines pattern's
+ *  `lineCount`, Time pattern's batch size) pass it explicitly. */
+export function tatoebaRun(pack: TatoebaPack, count: number = TATOEBA_SENTENCE_COUNT): TatoebaRun {
+  const sentences = sampleSentences(pack.words, count)
   const { words, lineBreaks } = parseFileImportText(sentences.join('\n'))
   const text = words.join(' ')
   return { words, lineBreaks, quote: { id: 0, text, source: pack.name, length: text.length } }

--- a/src/renderer/typing-test/word-supply.ts
+++ b/src/renderer/typing-test/word-supply.ts
@@ -11,6 +11,10 @@ import type { TypingTestConfig, Quote } from './types'
 
 const TIME_MODE_BATCH_SIZE = 60
 const TIME_MODE_EXTEND_THRESHOLD = 10
+/** Sentences sampled for the tatoeba Time pattern's initial batch and every
+ *  refill — larger than a Lines-pattern run since a running clock chews
+ *  through many short sentences before the next low-water refill check. */
+const TATOEBA_TIME_BATCH_SIZE = 20
 
 /** Return the word count and generation options for word-based modes (words/time). */
 function wordGenParams(config: TypingTestConfig & { mode: 'words' | 'time' }): { count: number; opts: { punctuation: boolean; numbers: boolean } } {
@@ -20,21 +24,53 @@ function wordGenParams(config: TypingTestConfig & { mode: 'words' | 'time' }): {
   }
 }
 
-/** Time-mode word refill: when the untyped tail of `words` runs low,
- *  returns the list extended by one more generated batch (same
- *  punctuation/numbers opts as the initial supply); returns null when no
- *  refill is due, so the caller can keep its state object untouched. Keeps
- *  the batch/threshold policy private to this module. */
+/** Result of a time-bounded refill: `words` is the extended list; `lineBreaks`
+ *  are the NEW line-break indices (absolute, into the returned `words`)
+ *  contributed by this refill. Empty for monkeytype time mode (no line
+ *  concept); the caller merges these into the run's existing `lineBreaks`
+ *  set (see `advanceAfterWord`). */
+export interface WordsRefill {
+  words: string[]
+  lineBreaks: number[]
+}
+
+/** Time-bounded word refill — monkeytype time mode, or the tatoeba Time
+ *  pattern (see `isTimeBoundedRun`). Self-contained: every non-time-bounded
+ *  config (including tatoeba's Lines pattern) returns null on its own,
+ *  rather than trusting the caller to only invoke this once time-bounded.
+ *  When the untyped tail of `words` runs low, returns the list extended by
+ *  one more batch; returns null when no refill is due, or (tatoeba) the
+ *  pack isn't cached / sampled empty, so the caller can keep its state
+ *  object untouched. Keeps the batch/threshold policy private to this
+ *  module. */
 export function refillTimeModeWords(
   words: readonly string[],
   nextIndex: number,
-  config: TypingTestConfig & { mode: 'time' },
+  config: TypingTestConfig,
   language: string,
-): string[] | null {
+): WordsRefill | null {
   if (words.length - nextIndex >= TIME_MODE_EXTEND_THRESHOLD) return null
+
+  if (config.mode === 'tatoeba' && config.pattern === 'time') {
+    const pack = getTatoebaPackSync(config.language)
+    if (!pack) return null
+    const { words: moreWords, lineBreaks } = tatoebaRun(pack, TATOEBA_TIME_BATCH_SIZE)
+    if (moreWords.length === 0) return null
+    const offset = words.length
+    // The previous batch's final sentence never got a trailing break
+    // recorded (nothing followed it yet, by tatoebaRun's own convention) —
+    // the seam between it and this batch's first sentence needs one now,
+    // so Enter (not Space) still advances between them.
+    return {
+      words: [...words, ...moreWords],
+      lineBreaks: [offset - 1, ...lineBreaks.map((b) => b + offset)],
+    }
+  }
+
+  if (config.mode !== 'time') return null
   const { opts } = wordGenParams(config)
   const { words: moreWords } = generateWordsSync(TIME_MODE_BATCH_SIZE, opts, language)
-  return [...words, ...moreWords]
+  return { words: [...words, ...moreWords], lineBreaks: [] }
 }
 
 export interface WordsForConfig {
@@ -70,10 +106,18 @@ function fileImportTextToWords(data: FileImportTextData): WordsForConfig {
  *  is uncached / not downloaded). Reuses the quote path's char-based
  *  counting and carries the run's per-sentence `lineBreaks` through so each
  *  sampled sentence renders on its own line, same as imported fileImport
- *  text. */
-function tatoebaWordsForConfig(pack: { name: string; words: string[] } | undefined): WordsForConfig {
+ *  text. `count` is the Lines pattern's `lineCount`, or the Time pattern's
+ *  initial batch size — see the two `createWordsForConfig*` call sites. */
+function tatoebaWordsForConfig(pack: { name: string; words: string[] } | undefined, count: number): WordsForConfig {
   if (!pack) return { words: [], quote: null, lineBreaks: [], lineIndents: [], romajiCapable: false }
-  return { ...tatoebaRun(pack), lineIndents: [], romajiCapable: false }
+  return { ...tatoebaRun(pack, count), lineIndents: [], romajiCapable: false }
+}
+
+/** Sentence count to sample for a tatoeba config: the Lines pattern's own
+ *  `lineCount`, or the Time pattern's fixed initial batch (matching the
+ *  refill batch size — see `refillTimeModeWords`). */
+function tatoebaSampleCount(config: TypingTestConfig & { mode: 'tatoeba' }): number {
+  return config.pattern === 'time' ? TATOEBA_TIME_BATCH_SIZE : config.lineCount
 }
 
 export function createWordsForConfigSync(config: TypingTestConfig, language: string): WordsForConfig {
@@ -89,7 +133,7 @@ export function createWordsForConfigSync(config: TypingTestConfig, language: str
   }
   if (config.mode === 'tatoeba') {
     // Cache miss — the async path fills words once langGet resolves.
-    return tatoebaWordsForConfig(getTatoebaPackSync(config.language))
+    return tatoebaWordsForConfig(getTatoebaPackSync(config.language), tatoebaSampleCount(config))
   }
   const { count, opts } = wordGenParams(config)
   const { words } = generateWordsSync(count, opts, language)
@@ -106,7 +150,7 @@ export async function createWordsForConfig(config: TypingTestConfig, language: s
     return data ? fileImportTextToWords(data) : { words: [], quote: null, lineBreaks: [], lineIndents: [], romajiCapable: false }
   }
   if (config.mode === 'tatoeba') {
-    return tatoebaWordsForConfig(await getTatoebaPack(config.language))
+    return tatoebaWordsForConfig(await getTatoebaPack(config.language), tatoebaSampleCount(config))
   }
   const { count, opts } = wordGenParams(config)
   const { words } = await generateWords(count, opts, language)

--- a/src/shared/types/typing-test-text-store.ts
+++ b/src/shared/types/typing-test-text-store.ts
@@ -15,6 +15,13 @@ export interface TypingTestTextMeta {
   /** Number of whitespace-separated words stored (post word-cap). Shown
    *  in the Import list. */
   wordCount: number
+  /** Number of non-empty lines stored (post word-cap) — see
+   *  `parseFileImportText`'s line-break convention. Shown in the Import
+   *  list instead of `wordCount` for no-space content (e.g. Japanese),
+   *  where a word count is meaningless — see `ImportRow` in
+   *  LanguageSelectorModal.tsx. Optional so metas persisted before this
+   *  field existed fall back to the words display. */
+  lineCount?: number
   /** Internal filename (`{id}_{timestamp}.json`). */
   filename: string
   /** First save time (ISO 8601). */
@@ -136,7 +143,7 @@ export function parseFileImportText(text: string, maxWords: number = TYPING_TEST
  * space within a line and a newline at each line break. Round-trips
  * through `parseFileImportText` so storage and playback agree exactly.
  */
-export function normalizeFileImportText(raw: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): { text: string; wordCount: number } {
+export function normalizeFileImportText(raw: string, maxWords: number = TYPING_TEST_TEXT_MAX_WORDS): { text: string; wordCount: number; lineCount: number } {
   const { words, lineBreaks, indents } = parseFileImportText(raw, maxWords)
   const breakSet = new Set(lineBreaks)
   let text = ''
@@ -151,5 +158,7 @@ export function normalizeFileImportText(raw: string, maxWords: number = TYPING_T
     text += words[i]
     if (i < words.length - 1) text += breakSet.has(i) ? '\n' : ' '
   }
-  return { text, wordCount: words.length }
+  // `indents` has one entry per kept (non-empty, pre-cap) line — the same
+  // count `lineIdx` reaches once the loop above has walked every word.
+  return { text, wordCount: words.length, lineCount: indents.length }
 }


### PR DESCRIPTION
## Summary

Turns the Typing Test's Tatoeba data source into a full pattern source like the monkeytype modes, and fixes the imported-text unit labels.

- **Tatoeba Pattern (Lines / Time)** with its own Units: Lines samples 5/10/20/40 sentences; Time runs 15/30/60/120s and refills sentences from the pack as it goes. The config carries `pattern` + `lineCount` + `duration` (default lines/5/30), with backward-compatible validation for configs saved earlier.
- **Unified time-bounded logic**: `isTimeBoundedRun` / `runDurationSeconds` centralize the "time mode" concept so the Tatoeba Time pattern reuses the existing countdown, auto-finish, and word-refill paths.
- **Modal unit labels**: the Tatoeba tab shows "N lines"; the File Import list shows "words" for a space-separated text and "lines" otherwise (a new `lineCount` is stored per imported text). The english "Units(Lines)" label is aligned with "Units(Words)"/"Units(Sec)".
- **Per-condition grouping**: Tatoeba PBs / history / comparison now key on language + pattern + unit (composite `mode2`), so a 5-line run and a 120s run of the same pack no longer share one PB pool or condition label. Also fixes a latent bug where the History Mode column referenced a non-existent i18n key and would have leaked the raw composite.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6449 passed / 22 skipped, 0 failed
- Added tests for the config shape, predicates, word supply + refill, settings bar, useTypingTest lines/time runs, modal labels, and the composite grouping keys/labels