### PR TITLE
feat(ui): make the romaji guide word count selectable (0-3)

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -324,6 +324,7 @@
           "capital": "Romaji",
           "lower": "romaji"
         },
+        "guideWordsLabel": "表示語数",
         "guideLabel": "表示パターン",
         "guideHint": "表示のみです。他の入力パターンでも正解になります",
         "inputLabel": "入力パターン",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -324,6 +324,7 @@
           "capital": "Romaji",
           "lower": "romaji"
         },
+        "guideWordsLabel": "表示語数っしょ",
         "guideLabel": "表示パターンっしょ",
         "guideHint": "表示だけだから、他の入力パターンでも正解になるよん☆",
         "inputLabel": "入力パターンっしょ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -324,6 +324,7 @@
           "capital": "Romaji",
           "lower": "romaji"
         },
+        "guideWordsLabel": "表示語数どす",
         "guideLabel": "表示パターン",
         "guideHint": "表示だけどすえ。他の入力パターンでも正解になりますえ",
         "inputLabel": "入力パターン",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -324,6 +324,7 @@
           "capital": "Romaji",
           "lower": "romaji"
         },
+        "guideWordsLabel": "表示語数",
         "guideLabel": "表示する綴りの型",
         "guideHint": "表示のみにございます。他の入力パターンでも正解となります",
         "inputLabel": "受理する入力の型",

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -846,6 +846,68 @@ describe('useDevicePrefs', () => {
       })
     })
 
+    it.each([0, 1, 2, 3])('round-trips a valid guideWordCount of %i', async (guideWordCount) => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: {
+          mode: 'words',
+          wordCount: 30,
+          punctuation: false,
+          numbers: false,
+          romaji: { guideWordCount },
+        },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romaji: { guideWordCount },
+      })
+    })
+
+    it.each([4, -1, 1.5, 'two'])('drops an out-of-range/non-integer guideWordCount (%p) but keeps the rest of romaji', async (guideWordCount) => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: {
+          mode: 'words',
+          wordCount: 30,
+          punctuation: false,
+          numbers: false,
+          romaji: { caseStyle: 'capital', guideWordCount },
+        },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romaji: { caseStyle: 'capital' },
+      })
+    })
+
     it('drops individually invalid romaji fields but keeps the ones that validate', async () => {
       setupMocks()
       mockPipetteSettingsGet.mockResolvedValue({

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -77,6 +77,14 @@ function validateRomajiDetailSettings(raw: unknown): RomajiDetailSettings | unde
     }
     if (styles.length > 0) result.disabledStyles = styles
   }
+  if (
+    typeof obj.guideWordCount === 'number'
+    && Number.isInteger(obj.guideWordCount)
+    && obj.guideWordCount >= 0
+    && obj.guideWordCount <= 3
+  ) {
+    result.guideWordCount = obj.guideWordCount
+  }
   return Object.keys(result).length > 0 ? result : undefined
 }
 

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.16",
+  "version": "0.1.17",
   "name": "English",
   "common": {
     "save": "Save",
@@ -324,6 +324,7 @@
           "capital": "Romaji",
           "lower": "romaji"
         },
+        "guideWordsLabel": "Words shown",
         "guideLabel": "Guide spelling pattern",
         "guideHint": "Display only — typing any accepted pattern is still correct",
         "inputLabel": "Accepted input patterns",

--- a/src/renderer/typing-test/RomajiSettingsModal.tsx
+++ b/src/renderer/typing-test/RomajiSettingsModal.tsx
@@ -26,6 +26,13 @@ import { isRomajiInputEnabled } from './romaji-input'
 // / romaji, identical in every locale (see english.json + the Japanese pack).
 const CASE_STYLES: readonly RomajiCaseStyle[] = ['upper', 'capital', 'lower']
 
+// Total word count offered by the guide row (current word included), 0-3:
+// 0 hides the row, 1 shows only the current word, 2/3 add one/two upcoming
+// words. Default 2 (see pruneRomaji) — one fewer than the fixed behaviour
+// before this setting existed (which always showed the current word plus
+// two upcoming).
+const GUIDE_WORD_OPTIONS = [0, 1, 2, 3] as const
+
 // Both the Guide and the Accepted input patterns sections share the same
 // Base/Options row split: BASE_STYLES (hepburn/kunrei) picks which base
 // spelling system is represented, and OPTION_STYLES are the independent
@@ -59,6 +66,7 @@ function pruneRomaji(next: RomajiDetailSettings): RomajiDetailSettings | undefin
   if (next.caseStyle !== undefined && next.caseStyle !== 'lower') pruned.caseStyle = next.caseStyle
   if (next.guideStyles !== undefined && next.guideStyles.length > 0) pruned.guideStyles = next.guideStyles
   if (next.disabledStyles !== undefined && next.disabledStyles.length > 0) pruned.disabledStyles = next.disabledStyles
+  if (next.guideWordCount !== undefined && next.guideWordCount !== 2) pruned.guideWordCount = next.guideWordCount
   return Object.keys(pruned).length > 0 ? pruned : undefined
 }
 
@@ -85,6 +93,7 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
   // it back on persists `true`.
   const enabled = isRomajiInputEnabled(config)
   const caseStyle = romaji.caseStyle ?? 'lower'
+  const guideWordCount = romaji.guideWordCount ?? 2
   const guideStyles = new Set(romaji.guideStyles ?? [])
   const disabledStyles = new Set(romaji.disabledStyles ?? [])
 
@@ -178,6 +187,27 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
                   onClick={() => applyRomaji({ caseStyle: value })}
                 >
                   {t(`editor.typingTest.romajiSettings.case.${value}`)}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          {/* Guide word count — the total number of words shown in the
+              guide row, current word included (see useTypingTest's
+              romajiGuide selector). Same button-row pattern as Display case
+              above. */}
+          <section className="flex flex-col gap-1.5">
+            <span className="text-sm text-content-muted">{t('editor.typingTest.romajiSettings.guideWordsLabel')}</span>
+            <div className="flex flex-wrap gap-1">
+              {GUIDE_WORD_OPTIONS.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  data-testid={`romaji-guide-words-${n}`}
+                  className={optionButtonClass(guideWordCount === n, 'px-2.5')}
+                  onClick={() => applyRomaji({ guideWordCount: n })}
+                >
+                  {n}
                 </button>
               ))}
             </div>

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -353,25 +353,31 @@ export function TypingTestView({
       </div>
 
       {/* Romaji guide — the current word's confirmed/remaining romaji
-          spelling, a fainter look-ahead preview of the next up-to-two
-          words' full spelling, plus an IME-on hint once a composition event
-          proves direct keystrokes aren't reaching the matcher. Rendered as
-          its own row below the reading window rather than inline per-word:
-          the words row is a single flex-wrap flow (word-flow modes have no
+          spelling, a fainter look-ahead preview of the upcoming words' full
+          spelling, plus an IME-on hint once a composition event proves
+          direct keystrokes aren't reaching the matcher. Rendered as its own
+          row below the reading window rather than inline per-word: the
+          words row is a single flex-wrap flow (word-flow modes have no
           per-line rows to anchor an inline guide under), so a fixed row
           here avoids overlapping whatever wraps below the current word.
-          The typed/remaining/lookahead line tracks the Font setting via the
-          same --tt-font var as the reading window; the IME hint stays a
-          fixed small size since it's a hint, not reading content. */}
-      {romajiGuide && (
+          The spelling row is gated on `showRow` (guideWordCount === 0 hides
+          it), but the IME hint always shows once detected — it's a warning
+          about input not landing, which stays relevant even with the guide
+          row hidden. The typed/remaining/lookahead line tracks the Font
+          setting via the same --tt-font var as the reading window; the IME
+          hint stays a fixed small size since it's a hint, not reading
+          content. */}
+      {romajiGuide && (romajiGuide.showRow || imeDetected) && (
         <div data-testid="typing-test-romaji-guide" className="flex w-full max-w-4xl flex-col items-start gap-1 font-mono" style={multilineStyle}>
-          <p className="typing-romaji-guide-text break-all">
-            <span className="text-success">{romajiGuide.typed}</span>
-            <span className="text-content-muted">{romajiGuide.remaining}</span>
-            {romajiGuide.lookahead.map((word, i) => (
-              <span key={i} data-testid="typing-test-romaji-lookahead" className="text-content-muted/40">{' ' + word}</span>
-            ))}
-          </p>
+          {romajiGuide.showRow && (
+            <p className="typing-romaji-guide-text break-all">
+              <span className="text-success">{romajiGuide.typed}</span>
+              <span className="text-content-muted">{romajiGuide.remaining}</span>
+              {romajiGuide.lookahead.map((word, i) => (
+                <span key={i} data-testid="typing-test-romaji-lookahead" className="text-content-muted/40">{' ' + word}</span>
+              ))}
+            </p>
+          )}
           {imeDetected && (
             <p data-testid="typing-test-romaji-ime-hint" className="text-xs text-warning">
               {t('editor.typingTest.romaji.imeHint')}

--- a/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
@@ -52,6 +52,20 @@ describe('RomajiSettingsModal defaults', () => {
     expect(screen.getByTestId('romaji-case-upper').className).not.toContain('text-accent')
   })
 
+  it('defaults the guide word count selector to 2', () => {
+    renderModal()
+    expect(screen.getByTestId('romaji-guide-words-2').className).toContain('text-accent')
+    for (const n of [0, 1, 3]) {
+      expect(screen.getByTestId(`romaji-guide-words-${n}`).className).not.toContain('text-accent')
+    }
+  })
+
+  it('highlights the persisted guideWordCount instead of the default', () => {
+    renderModal({ config: { ...BASE_CONFIG, romaji: { guideWordCount: 0 } } })
+    expect(screen.getByTestId('romaji-guide-words-0').className).toContain('text-accent')
+    expect(screen.getByTestId('romaji-guide-words-2').className).not.toContain('text-accent')
+  })
+
   it('defaults the guide Base selector to Hepburn, with every Option off', () => {
     renderModal()
     expect(screen.getByTestId('romaji-guide-base-hepburn')).toHaveAttribute('aria-pressed', 'true')
@@ -121,6 +135,30 @@ describe('RomajiSettingsModal edits', () => {
     fireEvent.click(screen.getByTestId('romaji-case-capital'))
     const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
     if (arg.mode === 'words') expect(arg.romaji).toEqual({ caseStyle: 'capital' })
+  })
+
+  it('setting guideWordCount to 0 persists it explicitly', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-guide-words-0'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toEqual({ guideWordCount: 0 })
+  })
+
+  it('setting guideWordCount to 3 persists it explicitly', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-guide-words-3'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toEqual({ guideWordCount: 3 })
+  })
+
+  it('re-selecting the default guideWordCount of 2 prunes the field back to unset', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ config: { ...BASE_CONFIG, romaji: { guideWordCount: 0 } }, onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-guide-words-2'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toBeUndefined()
   })
 
   it('selecting Kunrei as the guide Base adds kunrei to guideStyles', () => {

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -468,7 +468,7 @@ describe('TypingTestView romaji guide', () => {
   it('renders typed and remaining romaji, and rewrites on prop changes', () => {
     const { rerender } = renderView({
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: true },
     })
     let guide = screen.getByTestId('typing-test-romaji-guide')
     expect(guide.textContent).toBe('ai')
@@ -483,7 +483,7 @@ describe('TypingTestView romaji guide', () => {
           remainingSeconds={null}
           config={DEFAULT_CONFIG}
           paused={false}
-          romajiGuide={{ typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: [] }}
+          romajiGuide={{ typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: [], showRow: true }}
         />
       </I18nextProvider>,
     )
@@ -496,7 +496,7 @@ describe('TypingTestView romaji guide', () => {
   it('renders the lookahead words, space-separated, after typed/remaining', () => {
     renderView({
       state: makeState({ status: 'running', words: ['あい', 'かめ', 'いぬ'] }),
-      romajiGuide: { typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: ['kame', 'inu'] },
+      romajiGuide: { typed: 'a', remaining: 'i', kanaCompleted: 1, lookahead: ['kame', 'inu'], showRow: true },
     })
     const guide = screen.getByTestId('typing-test-romaji-guide')
     const lookaheadSpans = screen.getAllByTestId('typing-test-romaji-lookahead')
@@ -509,7 +509,7 @@ describe('TypingTestView romaji guide', () => {
   it('does not render any lookahead span when lookahead is empty', () => {
     renderView({
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: true },
     })
     expect(screen.queryByTestId('typing-test-romaji-lookahead')).toBeNull()
   })
@@ -517,7 +517,7 @@ describe('TypingTestView romaji guide', () => {
   it('shows the IME hint once a composition event fires in romaji mode', () => {
     renderView({
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: true },
     })
     expect(screen.queryByTestId('typing-test-romaji-ime-hint')).toBeNull()
     const textarea = screen.getByLabelText('IME input') as HTMLTextAreaElement
@@ -536,7 +536,7 @@ describe('TypingTestView romaji guide', () => {
     renderView({
       fontSize: 40,
       state: makeState({ status: 'running', words: ['あい'] }),
-      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [] },
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: true },
     })
     const guide = screen.getByTestId('typing-test-romaji-guide')
     expect(guide.style.getPropertyValue('--tt-font')).toBe('40')
@@ -544,6 +544,26 @@ describe('TypingTestView romaji guide', () => {
     expect(typedRemaining).not.toBeNull()
     // The IME hint stays a fixed small size, not tied to --tt-font.
     expect(guide.querySelector('[data-testid="typing-test-romaji-ime-hint"]')).toBeNull()
+  })
+
+  it('hides the guide row entirely when showRow is false and no IME hint is active', () => {
+    renderView({
+      state: makeState({ status: 'running', words: ['あい'] }),
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: false },
+    })
+    expect(screen.queryByTestId('typing-test-romaji-guide')).toBeNull()
+  })
+
+  it('shows only the IME hint (no spelling row) when showRow is false but the IME is detected', () => {
+    renderView({
+      state: makeState({ status: 'running', words: ['あい'] }),
+      romajiGuide: { typed: '', remaining: 'ai', kanaCompleted: 0, lookahead: [], showRow: false },
+    })
+    const textarea = screen.getByLabelText('IME input') as HTMLTextAreaElement
+    fireEvent.compositionStart(textarea)
+    const guide = screen.getByTestId('typing-test-romaji-guide')
+    expect(screen.getByTestId('typing-test-romaji-ime-hint')).toBeInTheDocument()
+    expect(guide.querySelector('.typing-romaji-guide-text')).toBeNull()
   })
 
 })

--- a/src/renderer/typing-test/__tests__/WordDisplay.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordDisplay.test.tsx
@@ -20,7 +20,7 @@ function renderWord(props: Partial<Parameters<typeof WordDisplay>[0]> = {}) {
 
 describe('WordDisplay romaji mode', () => {
   it('colors kana characters as success up through kanaCompleted', () => {
-    renderWord({ romajiGuide: { typed: 'de', remaining: 'xina-', kanaCompleted: 1, lookahead: [] } })
+    renderWord({ romajiGuide: { typed: 'de', remaining: 'xina-', kanaCompleted: 1, lookahead: [], showRow: true } })
     const word = screen.getByTestId('word-0')
     // First char (で) confirmed -> success; the rest stay muted.
     const successSpans = word.querySelectorAll('.text-success')
@@ -30,13 +30,13 @@ describe('WordDisplay romaji mode', () => {
   })
 
   it('shows every kana as muted before any keystroke is confirmed', () => {
-    renderWord({ romajiGuide: { typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [] } })
+    renderWord({ romajiGuide: { typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [], showRow: true } })
     const word = screen.getByTestId('word-0')
     expect(word.querySelector('.text-success')).toBeNull()
   })
 
   it('colors the full word as success once every kana is confirmed', () => {
-    renderWord({ word: 'あい', romajiGuide: { typed: 'ai', remaining: '', kanaCompleted: 2, lookahead: [] } })
+    renderWord({ word: 'あい', romajiGuide: { typed: 'ai', remaining: '', kanaCompleted: 2, lookahead: [], showRow: true } })
     const word = screen.getByTestId('word-0')
     const successSpans = word.querySelectorAll('.text-success')
     expect(successSpans.length).toBe(2)
@@ -45,7 +45,7 @@ describe('WordDisplay romaji mode', () => {
   it('renders no per-character error color even mid-word', () => {
     // Romaji mode never shows a red/danger char — rejected keystrokes leave
     // no trace, so only success/muted classes should ever appear.
-    renderWord({ word: 'かんじ', romajiGuide: { typed: 'ka', remaining: 'nji', kanaCompleted: 1, lookahead: [] } })
+    renderWord({ word: 'かんじ', romajiGuide: { typed: 'ka', remaining: 'nji', kanaCompleted: 1, lookahead: [], showRow: true } })
     const word = screen.getByTestId('word-0')
     expect(word.querySelector('.text-danger')).toBeNull()
   })
@@ -55,7 +55,7 @@ describe('WordDisplay romaji mode', () => {
       word: 'ねこ',
       wordIndex: 1,
       currentWordIndex: 0,
-      romajiGuide: { typed: 'a', remaining: '', kanaCompleted: 1, lookahead: [] },
+      romajiGuide: { typed: 'a', remaining: '', kanaCompleted: 1, lookahead: [], showRow: true },
     })
     const word = screen.getByTestId('word-1')
     // Future word — plain muted styling, unaffected by a guide meant for

--- a/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
@@ -198,15 +198,15 @@ describe('useTypingTest — romaji input mode', () => {
     await seedKanaLanguage(KANA_LANGUAGE, ['でぃなー'])
     const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'dhina-', kanaCompleted: 0, lookahead: [], showRow: true })
 
     press(result, 'd')
     press(result, 'h')
     press(result, 'i') // commits でぃ as one 2-kana digraph segment
-    expect(result.current.romajiGuide).toEqual({ typed: 'dhi', remaining: 'na-', kanaCompleted: 2, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: 'dhi', remaining: 'na-', kanaCompleted: 2, lookahead: [], showRow: true })
   })
 
-  it('previews the next up-to-two words\' canonical romaji as lookahead, shrinking near the end of the run', async () => {
+  it('previews the next word as lookahead by default (guideWordCount 2 = current + 1), shrinking near the end of the run', async () => {
     // Single-word lists sample deterministically (see sampleWords), so a
     // 3-word run against the same word gives full control over the queue
     // without needing to control random word selection.
@@ -214,18 +214,50 @@ describe('useTypingTest — romaji input mode', () => {
     const { result } = renderHook(() => useTypingTest(wordsConfig(3), KANA_LANGUAGE))
     expect(result.current.state.words).toEqual(['あい', 'あい', 'あい'])
 
-    // At word 0: both word 1 and word 2 are upcoming.
-    expect(result.current.romajiGuide?.lookahead).toEqual(['ai', 'ai'])
+    // At word 0: only word 1 is upcoming (default guideWordCount 2 = current + 1 next).
+    expect(result.current.romajiGuide?.lookahead).toEqual(['ai'])
+    expect(result.current.romajiGuide?.showRow).toBe(true)
 
     type(result, 'ai')
     expect(result.current.state.currentWordIndex).toBe(1)
-    // At word 1: only word 2 remains upcoming.
+    // At word 1: word 2 remains upcoming.
     expect(result.current.romajiGuide?.lookahead).toEqual(['ai'])
 
     type(result, 'ai')
     expect(result.current.state.currentWordIndex).toBe(2)
     // At the last word: nothing left to preview.
     expect(result.current.romajiGuide?.lookahead).toEqual([])
+  })
+
+  it('hides the guide row and shows no lookahead when guideWordCount is 0', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const config = { ...wordsConfig(3), romaji: { guideWordCount: 0 } }
+    const { result } = renderHook(() => useTypingTest(config, KANA_LANGUAGE))
+
+    expect(result.current.romajiGuide?.lookahead).toEqual([])
+    expect(result.current.romajiGuide?.showRow).toBe(false)
+    // kanaCompleted still tracks progress even with the row hidden — the
+    // coloring in WordDisplay must keep working at guideWordCount 0.
+    expect(result.current.romajiGuide?.kanaCompleted).toBe(0)
+  })
+
+  it('shows the row with only the current word (no lookahead) when guideWordCount is 1', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const config = { ...wordsConfig(3), romaji: { guideWordCount: 1 } }
+    const { result } = renderHook(() => useTypingTest(config, KANA_LANGUAGE))
+
+    expect(result.current.romajiGuide?.lookahead).toEqual([])
+    expect(result.current.romajiGuide?.showRow).toBe(true)
+  })
+
+  it('previews up to 2 upcoming words when guideWordCount is 3 (current + next two)', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
+    const config = { ...wordsConfig(4), romaji: { guideWordCount: 3 } }
+    const { result } = renderHook(() => useTypingTest(config, KANA_LANGUAGE))
+    expect(result.current.state.words).toEqual(['あい', 'あい', 'あい', 'あい'])
+
+    expect(result.current.romajiGuide?.lookahead).toEqual(['ai', 'ai'])
+    expect(result.current.romajiGuide?.showRow).toBe(true)
   })
 
   it('keeps romajiInput saved but inactive once the language switches off a kana pack', async () => {
@@ -386,7 +418,7 @@ describe('useTypingTest — config.romaji wiring', () => {
       KANA_LANGUAGE,
     ))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'si', kanaCompleted: 0, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'si', kanaCompleted: 0, lookahead: [], showRow: true })
 
     // The canonical spelling is still accepted even though the guide shows 'si'.
     type(result, 'shi')
@@ -401,9 +433,9 @@ describe('useTypingTest — config.romaji wiring', () => {
       KANA_LANGUAGE,
     ))
 
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'AI', kanaCompleted: 0, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'AI', kanaCompleted: 0, lookahead: [], showRow: true })
     press(result, 'a')
-    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'I', kanaCompleted: 1, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'I', kanaCompleted: 1, lookahead: [], showRow: true })
     // Lowercase 'a' is still what's accepted — the transform never reaches acceptance.
     expect(result.current.state.incorrectChars).toBe(0)
   })
@@ -416,28 +448,30 @@ describe('useTypingTest — config.romaji wiring', () => {
     ))
 
     // Nothing typed yet — the capital lands on the first char of `remaining`.
-    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'Ai', kanaCompleted: 0, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: '', remaining: 'Ai', kanaCompleted: 0, lookahead: [], showRow: true })
 
     press(result, 'a')
     // Once something is typed, the capital moves onto `typed`'s first char
     // and `remaining` goes back to lowercase.
-    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'i', kanaCompleted: 1, lookahead: [] })
+    expect(result.current.romajiGuide).toEqual({ typed: 'A', remaining: 'i', kanaCompleted: 1, lookahead: [], showRow: true })
   })
 
   it('applies caseStyle to lookahead entries too, upper and capital alike', async () => {
+    // Default guideWordCount (2 = current + 1 next), so at word 0 only one
+    // upcoming word is previewed even with a 3-word run.
     await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
     const { result: upperResult } = renderHook(() => useTypingTest(
       { mode: 'words', wordCount: 3, punctuation: false, numbers: false, romajiInput: true, romaji: { caseStyle: 'upper' } },
       KANA_LANGUAGE,
     ))
-    expect(upperResult.current.romajiGuide?.lookahead).toEqual(['AI', 'AI'])
+    expect(upperResult.current.romajiGuide?.lookahead).toEqual(['AI'])
 
     await seedKanaLanguage(KANA_LANGUAGE, ['あい'])
     const { result: capitalResult } = renderHook(() => useTypingTest(
       { mode: 'words', wordCount: 3, punctuation: false, numbers: false, romajiInput: true, romaji: { caseStyle: 'capital' } },
       KANA_LANGUAGE,
     ))
-    expect(capitalResult.current.romajiGuide?.lookahead).toEqual(['Ai', 'Ai'])
+    expect(capitalResult.current.romajiGuide?.lookahead).toEqual(['Ai'])
   })
 
   it('changing config.romaji via setConfig restarts the test, same as any other config field change', async () => {
@@ -463,7 +497,7 @@ describe('useTypingTest — config.romaji wiring', () => {
 })
 
 describe('applyRomajiCaseStyle — lookahead entries', () => {
-  const baseGuide: RomajiGuide = { typed: '', remaining: 'a', kanaCompleted: 0, lookahead: ['ai', 'ka'] }
+  const baseGuide: RomajiGuide = { typed: '', remaining: 'a', kanaCompleted: 0, lookahead: ['ai', 'ka'], showRow: true }
 
   it('leaves lookahead untouched for lower/undefined', () => {
     expect(applyRomajiCaseStyle(baseGuide, undefined).lookahead).toEqual(['ai', 'ka'])
@@ -479,7 +513,7 @@ describe('applyRomajiCaseStyle — lookahead entries', () => {
   })
 
   it('capitalizes lookahead even when the current word itself has nothing to capitalize', () => {
-    const emptyWordGuide: RomajiGuide = { typed: '', remaining: '', kanaCompleted: 0, lookahead: ['ai'] }
+    const emptyWordGuide: RomajiGuide = { typed: '', remaining: '', kanaCompleted: 0, lookahead: ['ai'], showRow: true }
     expect(applyRomajiCaseStyle(emptyWordGuide, 'capital').lookahead).toEqual(['Ai'])
   })
 })

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -24,6 +24,10 @@ export interface RomajiDetailSettings {
   /** Alternate-spelling families excluded from acceptance. Passed straight
    *  through to `createRomajiMatcher`'s `disabledStyles` opt. */
   disabledStyles?: RomajiStyle[]
+  /** Total number of words shown in the guide row, 0-3: 0 hides the row
+   *  entirely, 1 shows only the current word, 2 shows the current word plus
+   *  the next one, 3 shows the current word plus the next two. Default: 2. */
+  guideWordCount?: number
 }
 
 export type TypingTestConfig =
@@ -102,9 +106,13 @@ export const ROMAJI_INPUT_LANGUAGES = new Set(['japanese_hiragana', 'japanese_ka
 
 /** Current word's confirmed romaji + canonical remaining spelling, plus the
  *  count of kana characters fully confirmed so far (romajiInput mode only).
- *  `lookahead` holds the full canonical romaji spelling of up to the next
- *  two upcoming words (empty entries once fewer remain), letting the guide
- *  row preview what's coming after the current word. Produced by
+ *  `lookahead` holds the full canonical romaji spelling of up to
+ *  `guideWordCount − 1` (default 1) upcoming words (fewer entries once fewer
+ *  remain), letting the guide row preview what's coming after the current
+ *  word. `showRow` is false when `guideWordCount` is 0 — the guide row
+ *  (typed/remaining/lookahead spelling) is hidden entirely, though
+ *  `kanaCompleted` still drives the current word's kana coloring and the
+ *  IME-on hint still shows independently of `showRow`. Produced by
  *  `useTypingTest`'s `romajiGuide` selector from a `RomajiMatcher` (see
  *  romaji-engine.ts), consumed by `WordDisplay` (kana coloring) and
  *  `TypingTestView` (the guide line below the reading window). */
@@ -113,6 +121,7 @@ export interface RomajiGuide {
   remaining: string
   kanaCompleted: number
   lookahead: string[]
+  showRow: boolean
 }
 
 /** Capitalizes only the first character of a whole word (used for

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -561,20 +561,30 @@ export function useTypingTest(
 
   // Current word's romaji progress (romajiInput mode only), re-derived from
   // the accepted keystroke history on every change rather than stored on
-  // state directly — see `buildRomajiMatcher`. `lookahead` previews the
-  // full canonical spelling of up to the next two words (empty keystrokes
-  // -> remainingGuide() returns the whole word) so the guide row can show
-  // what's coming after the current word.
+  // state directly — see `buildRomajiMatcher`. `guideWordCount` is the total
+  // number of words shown in the guide row (current word included), so the
+  // look-ahead word count is one fewer; the slice's end <= start for counts
+  // 0 and 1 naturally yields an empty `lookahead`. `showRow` is false only
+  // at count 0 — kanaCompleted (for WordDisplay's coloring) is always
+  // computed regardless, since it must keep working even when the row
+  // itself is hidden.
   const romajiGuide = useMemo(() => {
     if (!isRomajiInputActive(config, language, state.romajiCapable)) return null
     if (state.currentWordIndex >= state.words.length) return null
     const word = state.words[state.currentWordIndex]
     const detail = romajiDetail(config)
     const matcher = buildRomajiMatcher(word, state.romajiKeystrokes, detail)
+    const guideWordCount = detail?.guideWordCount ?? 2
     const lookahead = state.words
-      .slice(state.currentWordIndex + 1, state.currentWordIndex + 3)
+      .slice(state.currentWordIndex + 1, state.currentWordIndex + guideWordCount)
       .map((w) => buildRomajiMatcher(w, '', detail).remainingGuide())
-    const guide: RomajiGuide = { typed: matcher.typedRomaji(), remaining: matcher.remainingGuide(), kanaCompleted: matcher.completedKanaCount(), lookahead }
+    const guide: RomajiGuide = {
+      typed: matcher.typedRomaji(),
+      remaining: matcher.remainingGuide(),
+      kanaCompleted: matcher.completedKanaCount(),
+      lookahead,
+      showRow: guideWordCount > 0,
+    }
     return applyRomajiCaseStyle(guide, detail?.caseStyle)
   }, [config, language, state.words, state.currentWordIndex, state.romajiKeystrokes, state.romajiCapable])
 


### PR DESCRIPTION
## Summary

The romaji guide row below the reading window showed a fixed number of words. Add a 0/1/2/3 selector in the Romaji Settings modal (above the guide display pattern) controlling the total number of words shown:

- **0** — the guide row is hidden entirely
- **1** — only the current word being typed
- **2** (default) — current word + the next word
- **3** — current word + the next two words

The kana coloring in the reading window and the IME-on warning stay visible even when the row is hidden. The count is stored in `RomajiDetailSettings.guideWordCount`; the default (2) is dropped so existing configs are unchanged.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6467 passed / 22 skipped, 0 failed
- Added tests for the 0-3 slicing, `showRow` gating (row hidden at 0 while IME hint still shows), prune of the default, and validation