### PR TITLE
feat(ui): typing mistake analysis (per-run tracking + history ranking)

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -494,7 +494,9 @@
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
-        "conditionTatoeba": "Tatoeba"
+        "conditionTatoeba": "Tatoeba",
+        "mistakeRankingTitle": "苦手な文字",
+        "mistakeRankingEmpty": "ミスの記録はまだありません"
       },
       "results": {
         "mistakesLabel": "ミス文字"

--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -495,6 +495,9 @@
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
         "conditionTatoeba": "Tatoeba"
+      },
+      "results": {
+        "mistakesLabel": "ミス文字"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -495,6 +495,9 @@
         "conditionNumbers": "+数字っしょ",
         "conditionRomaji": "+ローマ字入力☆",
         "conditionTatoeba": "Tatoeba"
+      },
+      "results": {
+        "mistakesLabel": "ミスった文字ｗ"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -494,7 +494,9 @@
         "conditionPunctuation": "+句読点☆",
         "conditionNumbers": "+数字っしょ",
         "conditionRomaji": "+ローマ字入力☆",
-        "conditionTatoeba": "Tatoeba"
+        "conditionTatoeba": "Tatoeba",
+        "mistakeRankingTitle": "苦手な文字☆",
+        "mistakeRankingEmpty": "まだミスってないっしょ"
       },
       "results": {
         "mistakesLabel": "ミスった文字ｗ"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -494,7 +494,9 @@
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
-        "conditionTatoeba": "Tatoeba"
+        "conditionTatoeba": "Tatoeba",
+        "mistakeRankingTitle": "苦手な文字どすえ",
+        "mistakeRankingEmpty": "ミスの記録はまだおへんなぁ"
       },
       "results": {
         "mistakesLabel": "ミス文字どすえ"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -495,6 +495,9 @@
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
         "conditionTatoeba": "Tatoeba"
+      },
+      "results": {
+        "mistakesLabel": "ミス文字どすえ"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -494,7 +494,9 @@
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
-        "conditionTatoeba": "Tatoeba"
+        "conditionTatoeba": "Tatoeba",
+        "mistakeRankingTitle": "苦手とする文字",
+        "mistakeRankingEmpty": "過ちの記録はまだございません"
       },
       "results": {
         "mistakesLabel": "過ちの文字"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -495,6 +495,9 @@
         "conditionNumbers": "+数字",
         "conditionRomaji": "+ローマ字入力",
         "conditionTatoeba": "Tatoeba"
+      },
+      "results": {
+        "mistakesLabel": "過ちの文字"
       }
     }
   },

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -406,6 +406,7 @@ export function useInputModes({
         fileImportTextName: typingTest.config.mode === 'fileImport' ? typingTest.state.currentQuote?.source : undefined,
         runId: typingTest.state.runId,
         romajiActive: isRomajiInputActive(typingTest.config, typingTest.language, typingTest.state.romajiCapable),
+        mistakes: typingTest.state.mistakes,
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       if (saveUnnamed) {

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -302,6 +302,63 @@ describe('useDevicePrefs', () => {
       expect(result.current.typingTestResults[1].wpm).toBe(80)
     })
 
+    it('round-trips a valid typingTestResults.mistakes field', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestResults: [
+          {
+            date: '2024-01-01', wpm: 60, accuracy: 95, wordCount: 30, correctChars: 100, incorrectChars: 5, durationSeconds: 30,
+            mistakes: { a: 2, shi: 1 },
+          },
+        ],
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestResults).toHaveLength(1)
+      expect(result.current.typingTestResults[0].mistakes).toEqual({ a: 2, shi: 1 })
+    })
+
+    it('drops a malformed typingTestResults.mistakes field but keeps the rest of the result', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestResults: [
+          {
+            date: '2024-01-01', wpm: 60, accuracy: 95, wordCount: 30, correctChars: 100, incorrectChars: 5, durationSeconds: 30,
+            mistakes: { a: 'not-a-number' },
+          },
+          {
+            date: '2024-01-02', wpm: 70, accuracy: 96, wordCount: 30, correctChars: 110, incorrectChars: 4, durationSeconds: 28,
+            mistakes: ['not', 'an', 'object'],
+          },
+        ],
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestResults).toHaveLength(2)
+      expect(result.current.typingTestResults[0].wpm).toBe(60)
+      expect(result.current.typingTestResults[0].mistakes).toBeUndefined()
+      expect(result.current.typingTestResults[1].wpm).toBe(70)
+      expect(result.current.typingTestResults[1].mistakes).toBeUndefined()
+    })
+
     it('falls back to defaults when IPC fails', async () => {
       setupMocks({ defaultKeyboardLayout: 'dvorak' })
       mockPipetteSettingsGet.mockRejectedValue(new Error('IPC error'))

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -186,6 +186,36 @@ function isValidTypingTestResult(item: unknown): item is TypingTestResult {
   return typeof r.date === 'string' && typeof r.wpm === 'number' && typeof r.accuracy === 'number'
 }
 
+/** Validates a result's optional `mistakes` field: a plain object mapping
+ *  every key to a finite number. Returns `undefined` for anything else
+ *  (absent, wrong shape, non-numeric/non-finite values) so a malformed
+ *  field degrades to "not set" rather than rejecting the whole result —
+ *  same treatment as the other optional fields on `TypingTestResult`. */
+function sanitizeMistakes(raw: unknown): Record<string, number> | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const entries = Object.entries(raw as Record<string, unknown>)
+  if (entries.length === 0) return undefined
+  const mistakes: Record<string, number> = {}
+  for (const [key, value] of entries) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+    mistakes[key] = value
+  }
+  return mistakes
+}
+
+/** Drops a malformed `mistakes` field without discarding the rest of an
+ *  already-`isValidTypingTestResult`-checked result. Applied after the
+ *  filter above so a persisted result with a corrupted `mistakes` blob
+ *  still survives (minus that one field) instead of vanishing from
+ *  History entirely. */
+function sanitizeTypingTestResult(result: TypingTestResult): TypingTestResult {
+  const mistakes = sanitizeMistakes(result.mistakes)
+  if (mistakes) return { ...result, mistakes }
+  if (result.mistakes === undefined) return result
+  const { mistakes: _dropped, ...rest } = result
+  return rest
+}
+
 const VALID_BASIC_VIEW_TYPES: ReadonlySet<string> = new Set(['ansi', 'iso', 'jis', 'list'])
 const LEGACY_BASIC_VIEW_MAP: Record<string, string> = { keyboard: 'ansi' }
 const VALID_SPLIT_KEY_MODES: ReadonlySet<string> = new Set(['split', 'flat'])
@@ -263,7 +293,7 @@ function validateIpcPrefs(
     ? data.layerNames.filter((n): n is string => typeof n === 'string')
     : []
   const typingTestResults = Array.isArray(data.typingTestResults)
-    ? data.typingTestResults.filter(isValidTypingTestResult)
+    ? data.typingTestResults.filter(isValidTypingTestResult).map(sanitizeTypingTestResult)
     : []
 
   // Legacy migration: { mode: 'viewOnly' } → separate boolean

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "English",
   "common": {
     "save": "Save",
@@ -495,6 +495,9 @@
         "conditionNumbers": "+nums",
         "conditionRomaji": "+romaji",
         "conditionTatoeba": "Tatoeba"
+      },
+      "results": {
+        "mistakesLabel": "Missed"
       }
     }
   },

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.19",
   "name": "English",
   "common": {
     "save": "Save",
@@ -494,7 +494,9 @@
         "conditionPunctuation": "+punct",
         "conditionNumbers": "+nums",
         "conditionRomaji": "+romaji",
-        "conditionTatoeba": "Tatoeba"
+        "conditionTatoeba": "Tatoeba",
+        "mistakeRankingTitle": "Most missed",
+        "mistakeRankingEmpty": "No mistakes recorded yet"
       },
       "results": {
         "mistakesLabel": "Missed"

--- a/src/renderer/typing-test/MistakeRankingSection.tsx
+++ b/src/renderer/typing-test/MistakeRankingSection.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+
+interface Props {
+  /** The active tab's full result set (see `AccuracyTrendSection`'s prop
+   *  doc — same `tabResults`, condition-scoped stays out of scope here
+   *  since a mistake ranking is meaningful across every condition mixed
+   *  together, unlike the accuracy trend line). */
+  results: TypingTestResult[]
+}
+
+interface MistakeRankEntry {
+  key: string
+  count: number
+}
+
+const MAX_MISTAKE_RANKING_ENTRIES = 15
+
+/** Sums each result's `mistakes` tally (key = canonical romaji unit or
+ *  verbatim target char, see `TypingTestResult.mistakes`) across the whole
+ *  set, then sorts by count DESC / key ASC (matches the completion
+ *  screen's `mistakeEntries` ordering in `TypingTestView.tsx` so the two
+ *  views read the same way) and caps to the top N. */
+function aggregateMistakes(results: TypingTestResult[]): MistakeRankEntry[] {
+  const totals = new Map<string, number>()
+  for (const r of results) {
+    if (!r.mistakes) continue
+    for (const [key, count] of Object.entries(r.mistakes)) {
+      totals.set(key, (totals.get(key) ?? 0) + count)
+    }
+  }
+  return Array.from(totals, ([key, count]) => ({ key, count }))
+    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
+    .slice(0, MAX_MISTAKE_RANKING_ENTRIES)
+}
+
+/** Most-missed-characters ranking — aggregates `mistakes` across every
+ *  result in the active tab (condition filter doesn't apply here, unlike
+ *  `AccuracyTrendSection`; a mistake tally is still meaningful mixed
+ *  across conditions). Hidden entirely when the tab has no results at
+ *  all; shows a subtle "no mistakes" line when there are results but
+ *  none of them recorded any mistakes. */
+export function MistakeRankingSection({ results }: Props) {
+  const { t } = useTranslation()
+
+  const ranked = useMemo(() => aggregateMistakes(results), [results])
+  const maxCount = ranked[0]?.count ?? 0
+
+  if (results.length === 0) return null
+
+  return (
+    <div className="flex flex-col gap-2" data-testid="typing-test-mistake-ranking">
+      <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+        {t('editor.typingTest.history.mistakeRankingTitle')}
+      </h3>
+      {ranked.length === 0 ? (
+        <p className="text-xs text-content-muted">
+          {t('editor.typingTest.history.mistakeRankingEmpty')}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-1">
+          {ranked.map(({ key, count }) => (
+            <div key={key} className="flex items-center gap-2 text-xs" data-testid={`mistake-rank-${key}`}>
+              <span className="w-12 shrink-0 truncate font-mono text-content">{key}</span>
+              <div className="h-1.5 flex-1 overflow-hidden rounded bg-surface-dim">
+                <div
+                  className="h-full rounded bg-accent"
+                  style={{ width: maxCount > 0 ? `${(count / maxCount) * 100}%` : '0%' }}
+                />
+              </div>
+              <span className="w-6 shrink-0 text-right font-mono text-content-muted">{count}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -9,6 +9,7 @@ import { buildCsv } from '../../shared/csv-export'
 import { computeStats } from './history-stats'
 import { WpmSparkline } from './WpmSparkline'
 import { AccuracyTrendSection } from './AccuracyTrendSection'
+import { MistakeRankingSection } from './MistakeRankingSection'
 import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
 import { resultKpm, buildResultNameChips } from './result-builder'
 import { formatConditionLabel } from './condition-label'
@@ -272,6 +273,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
       )}
 
       <AccuracyTrendSection results={tabResults} />
+      <MistakeRankingSection results={tabResults} />
 
       {/* Results table — fills remaining height */}
       <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-edge">

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -61,6 +61,12 @@ interface Props {
   hasSavedMemory?: boolean
 }
 
+// Completion screen's "missed characters" list (Phase 1 of mistake
+// analysis — see TypingTestState.mistakes) caps how many distinct
+// mistake keys are shown, so a run with many small errors doesn't turn
+// the results row into an unbounded wall of text.
+const MAX_MISTAKE_ENTRIES = 12
+
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
   const s = seconds % 60
@@ -165,6 +171,17 @@ export function TypingTestView({
     sum += Math.min(state.currentWordIndex, Math.max(0, state.words.length - 1)) // separators passed
     return Math.min(sum, totalChars)
   }, [charProgress, state.words, state.currentWordIndex, state.currentInput, totalChars])
+
+  // Completion screen's missed-characters list: sorted by count DESC then
+  // key ASC (ties break deterministically instead of on object insertion
+  // order), capped to the top MAX_MISTAKE_ENTRIES.
+  const mistakeEntries = useMemo(
+    () =>
+      Object.entries(state.mistakes)
+        .sort(([keyA, countA], [keyB, countB]) => countB - countA || keyA.localeCompare(keyB))
+        .slice(0, MAX_MISTAKE_ENTRIES),
+    [state.mistakes],
+  )
 
   function clearImeInput(): void {
     if (imeInputRef.current) imeInputRef.current.value = ''
@@ -513,6 +530,16 @@ export function TypingTestView({
             </span>
           )}
         </div>
+        {state.status === 'finished' && mistakeEntries.length > 0 && (
+          <div data-testid="typing-test-mistakes" className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-content-muted">
+            <span>{t('editor.typingTest.results.mistakesLabel')}:</span>
+            {mistakeEntries.map(([key, count]) => (
+              <span key={key} data-testid={`typing-test-mistake-${key}`} className="font-mono">
+                {key}:{count}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
       )}
 

--- a/src/renderer/typing-test/__tests__/MistakeRankingSection.test.tsx
+++ b/src/renderer/typing-test/__tests__/MistakeRankingSection.test.tsx
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { MistakeRankingSection } from '../MistakeRankingSection'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+
+function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+  return {
+    date: new Date().toISOString(),
+    wpm: 60,
+    accuracy: 95,
+    wordCount: 30,
+    correctChars: 100,
+    incorrectChars: 5,
+    durationSeconds: 30,
+    mode: 'words',
+    mode2: 30,
+    ...overrides,
+  }
+}
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+describe('MistakeRankingSection', () => {
+  it('renders nothing when there are no results at all', () => {
+    const { container } = renderWithI18n(<MistakeRankingSection results={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the empty state when there are results but none recorded mistakes', () => {
+    renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes: undefined })]} />)
+    expect(screen.getByTestId('typing-test-mistake-ranking')).toBeTruthy()
+    expect(screen.getByText(/no mistakes/i)).toBeTruthy()
+    expect(screen.queryByTestId(/^mistake-rank-/)).toBeNull()
+  })
+
+  it('aggregates the same key across multiple results and sums the counts', () => {
+    const results = [
+      makeResult({ mistakes: { shi: 2, a: 1 } }),
+      makeResult({ mistakes: { shi: 3 } }),
+    ]
+    renderWithI18n(<MistakeRankingSection results={results} />)
+    const shiRow = screen.getByTestId('mistake-rank-shi')
+    expect(shiRow.textContent).toContain('5')
+    const aRow = screen.getByTestId('mistake-rank-a')
+    expect(aRow.textContent).toContain('1')
+  })
+
+  it('sorts by count DESC then key ASC', () => {
+    const results = [
+      makeResult({ mistakes: { b: 3, a: 3, c: 5 } }),
+    ]
+    renderWithI18n(<MistakeRankingSection results={results} />)
+    const rows = screen.getByTestId('typing-test-mistake-ranking').querySelectorAll('[data-testid^="mistake-rank-"]')
+    const keys = Array.from(rows).map((r) => r.getAttribute('data-testid'))
+    expect(keys).toEqual(['mistake-rank-c', 'mistake-rank-a', 'mistake-rank-b'])
+  })
+
+  it('caps the ranking at the top 15 entries', () => {
+    const mistakes: Record<string, number> = {}
+    for (let i = 0; i < 20; i++) mistakes[`k${String(i).padStart(2, '0')}`] = 20 - i
+    renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes })]} />)
+    const rows = screen.getByTestId('typing-test-mistake-ranking').querySelectorAll('[data-testid^="mistake-rank-"]')
+    expect(rows.length).toBe(15)
+    // Highest counts (k00..k14) should be the ones kept.
+    expect(screen.getByTestId('mistake-rank-k00')).toBeTruthy()
+    expect(screen.queryByTestId('mistake-rank-k15')).toBeNull()
+  })
+
+  it('handles a result with an empty mistakes object without crashing', () => {
+    renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes: {} })]} />)
+    expect(screen.getByTestId('typing-test-mistake-ranking')).toBeTruthy()
+    expect(screen.getByText(/no mistakes/i)).toBeTruthy()
+  })
+})

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -29,6 +29,9 @@ function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
     lineIndents: [],
     romajiKeystrokes: '',
     romajiCapable: false,
+    mistakes: {},
+    romajiSegmentErred: false,
+    missedPositions: [],
     ...overrides,
   }
 }
@@ -280,6 +283,59 @@ describe('TypingTestView quote mode display', () => {
     })
     expect(screen.getByTestId('typing-test-results')).toBeInTheDocument()
     expect(screen.getByTestId('typing-test-quote-source').textContent).toContain('Test Book')
+  })
+})
+
+// Plan-typing-mistake-analysis Phase 1: the completion screen's "missed
+// characters" list, sourced from the just-finished run's state.mistakes.
+describe('TypingTestView mistakes list', () => {
+  it('renders the mistakes list, sorted by count DESC then key ASC, when the run finished with mistakes', () => {
+    renderView({
+      state: makeState({
+        status: 'finished',
+        mistakes: { a: 1, shi: 3, b: 3 },
+      }),
+      wpm: 50,
+      accuracy: 90,
+    })
+    const block = screen.getByTestId('typing-test-mistakes')
+    expect(block).toBeInTheDocument()
+    // count DESC first (shi/b tie at 3, broken by key ASC), then a (1).
+    expect(screen.getByTestId('typing-test-mistake-b').textContent).toBe('b:3')
+    expect(screen.getByTestId('typing-test-mistake-shi').textContent).toBe('shi:3')
+    expect(screen.getByTestId('typing-test-mistake-a').textContent).toBe('a:1')
+    const order = [...block.querySelectorAll('[data-testid^="typing-test-mistake-"]')].map((el) => el.getAttribute('data-testid'))
+    expect(order).toEqual(['typing-test-mistake-b', 'typing-test-mistake-shi', 'typing-test-mistake-a'])
+  })
+
+  it('renders nothing when the finished run had no mistakes', () => {
+    renderView({
+      state: makeState({ status: 'finished', mistakes: {} }),
+      wpm: 50,
+      accuracy: 100,
+    })
+    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+  })
+
+  it('does not render the mistakes list before the run finishes, even if mistakes were already tallied', () => {
+    renderView({
+      state: makeState({ status: 'running', mistakes: { a: 1 } }),
+      wpm: 50,
+      accuracy: 90,
+    })
+    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+  })
+
+  it('caps the list to the top 12 entries', () => {
+    const mistakes: Record<string, number> = {}
+    for (let i = 0; i < 20; i++) mistakes[`k${String(i).padStart(2, '0')}`] = 20 - i
+    renderView({
+      state: makeState({ status: 'finished', mistakes }),
+      wpm: 50,
+      accuracy: 90,
+    })
+    const block = screen.getByTestId('typing-test-mistakes')
+    expect(block.querySelectorAll('[data-testid^="typing-test-mistake-"]')).toHaveLength(12)
   })
 })
 

--- a/src/renderer/typing-test/__tests__/comparison.test.ts
+++ b/src/renderer/typing-test/__tests__/comparison.test.ts
@@ -179,6 +179,7 @@ describe('conditionKey / resultConditionKey agreement', () => {
     language: 'english',
     wpmHistory: [60],
     fileImportTextName: 'novel.txt',
+    mistakes: {},
     // Mirrors the real call site (useInputModes.ts): romajiActive is always
     // the effective isRomajiInputActive state, not the raw config flag — a
     // config with an explicit `romajiInput: true` on a non-capable language
@@ -221,6 +222,7 @@ describe('conditionKey / resultConditionKey agreement', () => {
       language,
       wpmHistory: [60],
       romajiActive,
+      mistakes: {},
     })
     expect(conditionKey(config, language)).toBe(resultConditionKey(result))
     expect(conditionKey(config, language)).toBe(configKey(result))

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -182,7 +182,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [55, 58, 60, 62],
-      romajiActive: false,
+      romajiActive: false, mistakes: {},
     })
 
     expect(result.wpm).toBe(60)
@@ -202,24 +202,38 @@ describe('buildTypingTestResult', () => {
     expect(result.date).toBeTruthy()
   })
 
+  it('includes mistakes when non-empty, and omits it entirely when empty', () => {
+    const config: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    const baseInput = {
+      correctChars: 20, incorrectChars: 2, wordCount: 5, wpm: 40, accuracy: 90, elapsedMs: 20000,
+      config, language: 'english', wpmHistory: [], romajiActive: false,
+    }
+
+    const withMistakes = buildTypingTestResult({ ...baseInput, mistakes: { a: 2, t: 1 } })
+    expect(withMistakes.mistakes).toEqual({ a: 2, t: 1 })
+
+    const withoutMistakes = buildTypingTestResult({ ...baseInput, mistakes: {} })
+    expect(withoutMistakes.mistakes).toBeUndefined()
+  })
+
   it('records romajiInput from the romajiActive input, not the raw config flag', () => {
     const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
     const withRomaji = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: true,
+      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: true, mistakes: {},
     })
     expect(withRomaji.romajiInput).toBe(true)
 
     const notActive = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: false,
+      config: wordsConfig, language: 'japanese_hiragana', wpmHistory: [], romajiActive: false, mistakes: {},
     })
     expect(notActive.romajiInput).toBeUndefined()
 
     const quoteConfig: TypingTestConfig = { mode: 'quote', quoteLength: 'medium' }
     const quoteResult = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: quoteConfig, language: 'english', wpmHistory: [], romajiActive: false,
+      config: quoteConfig, language: 'english', wpmHistory: [], romajiActive: false, mistakes: {},
     })
     expect(quoteResult.romajiInput).toBeUndefined()
   })
@@ -228,7 +242,7 @@ describe('buildTypingTestResult', () => {
     const tatoebaCfg: TypingTestConfig = { mode: 'tatoeba', language: 'japanese_hiragana', pattern: 'lines', lineCount: 5, duration: 30 }
     const result = buildTypingTestResult({
       correctChars: 20, incorrectChars: 1, wordCount: 5, wpm: 40, accuracy: 95, elapsedMs: 20000,
-      config: tatoebaCfg, language: 'english', wpmHistory: [], romajiActive: true,
+      config: tatoebaCfg, language: 'english', wpmHistory: [], romajiActive: true, mistakes: {},
     })
     expect(result.romajiInput).toBe(true)
   })
@@ -245,7 +259,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [],
-      romajiActive: false,
+      romajiActive: false, mistakes: {},
     })
     expect(result.mode).toBe('time')
     expect(result.mode2).toBe(60)
@@ -263,7 +277,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'english',
       wpmHistory: [],
-      romajiActive: false,
+      romajiActive: false, mistakes: {},
     })
     expect(result.mode).toBe('quote')
     expect(result.mode2).toBe('medium')
@@ -282,7 +296,7 @@ describe('buildTypingTestResult', () => {
       // The top-level (MonkeyType) language is irrelevant for tatoeba.
       language: 'german',
       wpmHistory: [],
-      romajiActive: false,
+      romajiActive: false, mistakes: {},
     })
     expect(result.mode).toBe('tatoeba')
     expect(result.mode2).toBe('english|lines|5')
@@ -302,7 +316,7 @@ describe('buildTypingTestResult', () => {
       config,
       language: 'japanese',
       wpmHistory: [],
-      romajiActive: false,
+      romajiActive: false, mistakes: {},
     })
     expect(result.mode2).toBe('japanese|time|30')
   })

--- a/src/renderer/typing-test/__tests__/romaji-engine.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-engine.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { createRomajiMatcher, KANA_TABLE, type RomajiAcceptResult } from '../romaji-engine'
+import { createRomajiMatcher, canonicalRomaji, KANA_TABLE, type RomajiAcceptResult } from '../romaji-engine'
 
 /** Types every character of `keys` into a fresh matcher for `word` and
  *  returns the matcher plus the per-keystroke result sequence. */
@@ -524,5 +524,29 @@ describe('ねっこ — full pattern enumeration', () => {
       ].sort(),
     )
     expect(completions).toHaveLength(10)
+  })
+})
+
+// Plan-typing-mistake-analysis Phase 1: mistake tracking keys a mistyped
+// kana segment by its canonical romaji spelling, independent of which
+// alternate spelling the user actually typed.
+describe('canonicalRomaji', () => {
+  it('returns the canonical (first-listed) single-kana spelling', () => {
+    expect(canonicalRomaji('し')).toBe('shi')
+    expect(canonicalRomaji('き')).toBe('ki')
+  })
+
+  it('returns the canonical 2-kana digraph spelling', () => {
+    expect(canonicalRomaji('ぎゃ')).toBe('gya')
+    expect(canonicalRomaji('きょ')).toBe('kyo')
+  })
+
+  it('handles katakana input the same as its hiragana equivalent', () => {
+    expect(canonicalRomaji('シ')).toBe('shi')
+    expect(canonicalRomaji('ギャ')).toBe('gya')
+  })
+
+  it('handles a multi-kana word by concatenating each segment\'s canonical spelling', () => {
+    expect(canonicalRomaji('あい')).toBe('ai')
   })
 })

--- a/src/renderer/typing-test/__tests__/run-state.test.ts
+++ b/src/renderer/typing-test/__tests__/run-state.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Plan-typing-mistake-analysis Phase 1: verbatim mode's per-position mistake
+// attribution (Backspace tallies a wrong char immediately; word-submit
+// tallies whatever is still wrong/missing at that point, skipping positions
+// already tallied via Backspace).
+
+import { describe, it, expect } from 'vitest'
+import { handleBackspace, handleSpace, tryFinishLastWord, type TypingTestState } from '../run-state'
+import type { TypingTestConfig } from '../types'
+
+function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
+  return {
+    status: 'running',
+    runId: 'test-run',
+    words: ['cat', 'dog'],
+    currentWordIndex: 0,
+    currentInput: '',
+    compositionText: '',
+    wordResults: [],
+    startTime: Date.now(),
+    endTime: null,
+    correctChars: 0,
+    incorrectChars: 0,
+    currentQuote: null,
+    wpmHistory: [],
+    lineBreaks: new Set(),
+    lineIndents: [],
+    romajiKeystrokes: '',
+    romajiCapable: false,
+    mistakes: {},
+    romajiSegmentErred: false,
+    missedPositions: [],
+    ...overrides,
+  }
+}
+
+const config: TypingTestConfig = { mode: 'words', wordCount: 2, punctuation: false, numbers: false }
+
+describe('handleBackspace — verbatim mistake tracking', () => {
+  it('records 1 mistake for the target char when deleting a wrong character', () => {
+    // word 'cat', typed 'cx' — 'x' is wrong at position 1 ('a').
+    const state = makeState({ currentInput: 'cx' })
+    const next = handleBackspace(state)
+    expect(next.currentInput).toBe('c')
+    expect(next.mistakes).toEqual({ a: 1 })
+    expect(next.missedPositions).toEqual([1])
+  })
+
+  it('does not double-count when the same position is retyped wrong and deleted again', () => {
+    let state = makeState({ currentInput: 'cx' })
+    state = handleBackspace(state)
+    expect(state.mistakes).toEqual({ a: 1 })
+    state = { ...state, currentInput: state.currentInput + 'x' } // retype wrong again -> 'cx'
+    state = handleBackspace(state)
+    expect(state.mistakes).toEqual({ a: 1 })
+    expect(state.missedPositions).toEqual([1])
+  })
+
+  it('records nothing when deleting a correct character', () => {
+    const state = makeState({ currentInput: 'ca' })
+    const next = handleBackspace(state)
+    expect(next.mistakes).toEqual({})
+    expect(next.missedPositions).toEqual([])
+  })
+
+  it('records nothing when deleting a character typed past the end of the word', () => {
+    const state = makeState({ currentInput: 'catx' })
+    const next = handleBackspace(state)
+    expect(next.mistakes).toEqual({})
+    expect(next.missedPositions).toEqual([])
+  })
+
+  it('is a no-op on empty input', () => {
+    const state = makeState({ currentInput: '' })
+    const next = handleBackspace(state)
+    expect(next).toBe(state)
+  })
+})
+
+describe('handleSpace — verbatim mistake tracking', () => {
+  it('records 1 mistake for the target char when a wrong char is left in and submitted', () => {
+    const state = makeState({ currentInput: 'cxt' })
+    const next = handleSpace(state, config, 'english')
+    expect(next.mistakes).toEqual({ a: 1 })
+  })
+
+  it('records nothing for correct typing', () => {
+    const state = makeState({ currentInput: 'cat' })
+    const next = handleSpace(state, config, 'english')
+    expect(next.mistakes).toEqual({})
+  })
+
+  it('does not double-count a position already tallied via Backspace', () => {
+    let state = makeState({ currentInput: 'cx' })
+    state = handleBackspace(state) // tallies a:1, missedPositions [1]
+    // Retype 'x' at the same position (still wrong) and finish the rest
+    // correctly, then submit without deleting again.
+    state = { ...state, currentInput: 'cxt' }
+    const next = handleSpace(state, config, 'english')
+    expect(next.mistakes).toEqual({ a: 1 })
+  })
+
+  it('records a mistake for every missing char when submitted short', () => {
+    const state = makeState({ currentInput: 'c' })
+    const next = handleSpace(state, config, 'english')
+    // 'cat' vs 'c': positions 1 ('a') and 2 ('t') never typed at all.
+    expect(next.mistakes).toEqual({ a: 1, t: 1 })
+  })
+
+  it('resets missedPositions for the next word', () => {
+    let state = makeState({ currentInput: 'cx' })
+    state = handleBackspace(state)
+    const next = handleSpace(state, config, 'english')
+    expect(next.missedPositions).toEqual([])
+  })
+
+  it('accumulates mistakes across multiple words without resetting the tally', () => {
+    let state = makeState({ currentInput: 'cxt' })
+    state = handleSpace(state, config, 'english') // 'cat' -> a:1
+    state = { ...state, currentInput: 'dxg' }
+    state = handleSpace(state, config, 'english') // 'dog' -> o:1
+    expect(state.mistakes).toEqual({ a: 1, o: 1 })
+  })
+})
+
+describe('tryFinishLastWord — verbatim mistake tracking', () => {
+  it('carries through mistakes already recorded via Backspace without double-counting at finish', () => {
+    let state = makeState({ words: ['cat'], currentWordIndex: 0, currentInput: 'cx' })
+    state = handleBackspace(state) // a:1, missedPositions [1]
+    state = { ...state, currentInput: 'ca' }
+    // Not yet a full match ('ca' !== 'cat') — the word isn't finished yet.
+    expect(tryFinishLastWord(state)).toBeNull()
+
+    const full = tryFinishLastWord({ ...state, currentInput: 'cat' })
+    expect(full).not.toBeNull()
+    expect(full!.status).toBe('finished')
+    expect(full!.mistakes).toEqual({ a: 1 })
+    expect(full!.missedPositions).toEqual([])
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.fileImportText.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.fileImportText.test.ts
@@ -78,6 +78,50 @@ describe('useTypingTest — imported fileImport text (line breaks)', () => {
   })
 })
 
+// Plan-typing-mistake-analysis Phase 1: verbatim-mode mistake tracking
+// end-to-end through processKeyEvent (Backspace / Space), not just the
+// run-state reducers directly (see run-state.test.ts for the reducer-level
+// coverage of the same rules).
+describe('useTypingTest — verbatim mistake tracking', () => {
+  it('records a mistake for a wrong char typed then deleted, and does not double-count on resubmit', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't' }, data: { name: 'T', text: 'cat' } },
+    })
+    await getFileImportTextData('t')
+    const { result } = renderHook(() => useTypingTest({ mode: 'fileImport', textId: 't' }, 'english'))
+
+    type(result, 'c')
+    type(result, 'x') // wrong ('a' expected)
+    expect(result.current.state.mistakes).toEqual({})
+    type(result, 'Backspace')
+    expect(result.current.state.mistakes).toEqual({ a: 1 })
+
+    type(result, 'a')
+    type(result, 't')
+    expect(result.current.state.status).toBe('finished')
+    // Retyping correctly and finishing must not add a second tally for
+    // the same position.
+    expect(result.current.state.mistakes).toEqual({ a: 1 })
+  })
+
+  it('records nothing for correct typing', async () => {
+    mockGet.mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't' }, data: { name: 'T', text: 'cat' } },
+    })
+    await getFileImportTextData('t')
+    const { result } = renderHook(() => useTypingTest({ mode: 'fileImport', textId: 't' }, 'english'))
+
+    type(result, 'c')
+    type(result, 'a')
+    type(result, 't')
+
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.mistakes).toEqual({})
+  })
+})
+
 describe('useTypingTest — memory mode (pause / capture / restore)', () => {
   const setupFileImport = async () => {
     mockGet.mockResolvedValue({

--- a/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
@@ -377,6 +377,58 @@ describe('useTypingTest — romaji input mode', () => {
   })
 })
 
+// Plan-typing-mistake-analysis Phase 1: a rejected keystroke marks the
+// in-progress kana segment as erred; once that segment completes, one
+// mistake is tallied (keyed by the segment's canonical romaji spelling),
+// regardless of how many rejected keystrokes it took to get there.
+describe('useTypingTest — romaji mistake tracking', () => {
+  it('records exactly 1 mistake for a segment typed with a wrong key then corrected', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['か'])
+    const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
+
+    press(result, 'x') // not a valid start for か (ka/ca)
+    expect(result.current.state.incorrectChars).toBe(1)
+    type(result, 'ka')
+
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.mistakes).toEqual({ ka: 1 })
+  })
+
+  it('records nothing for a clean segment', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['か'])
+    const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
+
+    type(result, 'ka')
+
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.mistakes).toEqual({})
+  })
+
+  it('records 2 distinct keys for two separately erred segments', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['かき'])
+    const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
+
+    press(result, 'x') // not a valid start for か
+    type(result, 'ka')
+    press(result, 'x') // not a valid start for き (only ki)
+    type(result, 'ki')
+
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.mistakes).toEqual({ ka: 1, ki: 1 })
+  })
+
+  it('tallies only 1 mistake per segment regardless of how many keystrokes inside it were rejected', async () => {
+    await seedKanaLanguage(KANA_LANGUAGE, ['か'])
+    const { result } = renderHook(() => useTypingTest(wordsConfig(1), KANA_LANGUAGE))
+
+    press(result, 'x')
+    press(result, 'z')
+    type(result, 'ka')
+
+    expect(result.current.state.mistakes).toEqual({ ka: 1 })
+  })
+})
+
 // Plan-typing-romaji-settings-modal Step 2: `config.romaji`'s disabledStyles
 // / guideStyles wired into the matcher (via `romajiMatcherOptions`), and
 // caseStyle applied as a display-only transform to the guide row.

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -128,6 +128,9 @@ export interface BuildTypingTestResultInput {
    *  (including tatoeba/fileImport, which never recorded this before) is
    *  now grouped/labeled consistently with words/time runs. */
   romajiActive: boolean
+  /** Per-run mistake tally (see `TypingTestState.mistakes`). Stored on the
+   *  result only when non-empty — see `buildTypingTestResult`. */
+  mistakes: Record<string, number>
 }
 
 /** Narrows to the 'words' / 'time' config variants — the only ones carrying
@@ -170,5 +173,6 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     romajiInput: input.romajiActive ? true : undefined,
     consistency,
     wpmHistory: input.wpmHistory,
+    mistakes: Object.keys(input.mistakes).length > 0 ? input.mistakes : undefined,
   }
 }

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -867,6 +867,18 @@ function canonicalGuideFrom(
   return winner.pattern + canonicalGuideFrom(kana, index + winner.length, disabledStyles, guideStyles)
 }
 
+/** Canonical romaji spelling of a kana substring (e.g. a single completed
+ *  segment sliced from a word via `completedKanaCount()`'s before/after
+ *  positions) — the same first-listed/longest-match spelling
+ *  `canonicalGuideFrom` would show as the guide with no style preference
+ *  selected. Used to key mistake-tracking so the same kana always tallies
+ *  under one spelling regardless of which alternate the user actually
+ *  typed. Always lowercase, since `KANA_TABLE`'s spellings are. */
+export function canonicalRomaji(kana: string): string {
+  const kanaArr = [...kana].map(toHiragana)
+  return canonicalGuideFrom(kanaArr, 0, undefined, undefined)
+}
+
 /** The winning pattern that exactly matches `buffer` as a full spelling at
  *  `index`, or null when nothing does. Shared by the retroactive-commit
  *  path in `stepAt`/`tryConsume` and by `isComplete`, both of which need to

--- a/src/renderer/typing-test/romaji-input.ts
+++ b/src/renderer/typing-test/romaji-input.ts
@@ -4,7 +4,7 @@
  *  active for the current config/language, matcher construction/replay,
  *  and the key-event handler that dispatches into it. */
 
-import { createRomajiMatcher, type RomajiMatcher, type RomajiMatcherOptions } from './romaji-engine'
+import { createRomajiMatcher, canonicalRomaji, type RomajiMatcher, type RomajiMatcherOptions } from './romaji-engine'
 import type { TypingTestConfig, RomajiDetailSettings } from './types'
 import { ROMAJI_INPUT_LANGUAGES } from './types'
 import { type TypingTestState, isSubmitKey, advanceAfterWord } from './run-state'
@@ -140,19 +140,40 @@ export function processRomajiKeyEvent(state: TypingTestState, key: string, confi
  *  matcher's position untouched (nothing is appended to currentInput or
  *  the keystroke buffer). Completing the whole word auto-advances — the
  *  submit key is blocked in this mode (see `processKeyEvent`), so there is
- *  no separate Space-triggered finalize path to keep in sync. */
+ *  no separate Space-triggered finalize path to keep in sync.
+ *
+ *  Mistake tracking (romaji mode): a rejected keystroke marks
+ *  `romajiSegmentErred` true for the kana segment currently in progress,
+ *  without touching `mistakes` itself. Once that segment actually completes
+ *  (detected via `completedKanaCount()` advancing across the keystroke),
+ *  the flag decides whether to tally one mistake — keyed by the canonical
+ *  romaji spelling of the just-completed kana slice — before resetting the
+ *  flag for the next segment. This counts one mistake per erred segment
+ *  regardless of how many keystrokes inside it were rejected. */
 function handleRomajiChar(state: TypingTestState, char: string, config: TypingTestConfig, language: string): TypingTestState {
   if (state.currentWordIndex >= state.words.length) return state
 
   const word = state.words[state.currentWordIndex]
   const matcher = buildRomajiMatcher(word, state.romajiKeystrokes, romajiDetail(config))
+  const kanaBefore = matcher.completedKanaCount()
   const result = matcher.acceptChar(char)
 
   if (result === 'reject') {
-    return { ...state, incorrectChars: state.incorrectChars + 1 }
+    return { ...state, incorrectChars: state.incorrectChars + 1, romajiSegmentErred: true }
   }
 
   const correctChars = state.correctChars + 1
+  const kanaAfter = matcher.completedKanaCount()
+
+  let mistakes = state.mistakes
+  let romajiSegmentErred = state.romajiSegmentErred
+  if (kanaAfter > kanaBefore) {
+    if (romajiSegmentErred) {
+      const key = canonicalRomaji(word.slice(kanaBefore, kanaAfter))
+      mistakes = { ...mistakes, [key]: (mistakes[key] ?? 0) + 1 }
+    }
+    romajiSegmentErred = false
+  }
 
   if (result === 'complete' && matcher.isComplete()) {
     const base: TypingTestState = {
@@ -160,11 +181,14 @@ function handleRomajiChar(state: TypingTestState, char: string, config: TypingTe
       currentWordIndex: state.currentWordIndex + 1,
       currentInput: '',
       romajiKeystrokes: '',
+      romajiSegmentErred,
+      missedPositions: [],
       wordResults: [...state.wordResults, { word, typed: matcher.typedRomaji(), correct: true }],
       correctChars,
+      mistakes,
     }
     return advanceAfterWord(base, config, language)
   }
 
-  return { ...state, romajiKeystrokes: state.romajiKeystrokes + char, correctChars }
+  return { ...state, romajiKeystrokes: state.romajiKeystrokes + char, correctChars, mistakes, romajiSegmentErred }
 }

--- a/src/renderer/typing-test/run-state.ts
+++ b/src/renderer/typing-test/run-state.ts
@@ -59,6 +59,22 @@ export interface TypingTestState {
    *  produced `words`, never a stale value from a config/text mismatch
    *  mid-load. */
   romajiCapable: boolean
+  /** Per-run tally of mistyped characters, keyed by the target character
+   *  (verbatim mode — see `handleBackspace`/`handleSpace`) or the canonical
+   *  romaji spelling of the mistyped kana segment (romaji mode — see
+   *  `handleRomajiChar` in romaji-input.ts). Accumulates across the whole
+   *  run and is never reset on word advance, only on a fresh/restarted run.
+   *  Merged immutably (a new object is spread on every update). */
+  mistakes: Record<string, number>
+  /** Romaji mode only: true once any keystroke within the CURRENT kana
+   *  segment has been rejected, until that segment completes (at which
+   *  point it is tallied into `mistakes` and this resets to false). Reset
+   *  on word advance / new run alongside `romajiKeystrokes`. */
+  romajiSegmentErred: boolean
+  /** Verbatim mode only: positions within the CURRENT word already tallied
+   *  into `mistakes` via Backspace, so the word-submit pass doesn't
+   *  double-count them. Reset on word advance / new run. */
+  missedPositions: number[]
 }
 
 export function createInitialState(config: TypingTestConfig, language: string, status: TypingTestStatus = 'waiting'): TypingTestState {
@@ -84,6 +100,9 @@ export function freshState({ words, quote, lineBreaks, lineIndents, romajiCapabl
     lineIndents,
     romajiKeystrokes: '',
     romajiCapable,
+    mistakes: {},
+    romajiSegmentErred: false,
+    missedPositions: [],
   }
 }
 
@@ -114,6 +133,12 @@ export function tryFinishLastWord(state: TypingTestState): TypingTestState | nul
     incorrectChars: state.incorrectChars,
     status: 'finished',
     endTime: Date.now(),
+    // currentInput === currentWord here (checked above), so there is
+    // nothing left to tally at submit — mistakes already recorded via
+    // Backspace (if any) are carried through unchanged. Reset both
+    // word-scoped mistake flags at the boundary defensively.
+    missedPositions: [],
+    romajiSegmentErred: false,
   }
 }
 
@@ -150,6 +175,7 @@ export function handleSpace(state: TypingTestState, config: TypingTestConfig, la
   const typed = state.currentInput
   const isCorrect = typed === currentWord
   const charCounts = computeWordCharCounts(currentWord, typed)
+  const mistakes = applyWordMistakes(currentWord, typed, state.missedPositions, state.mistakes)
 
   const nextIndex = state.currentWordIndex + 1
 
@@ -160,16 +186,63 @@ export function handleSpace(state: TypingTestState, config: TypingTestConfig, la
     wordResults: [...state.wordResults, { word: currentWord, typed, correct: isCorrect }],
     correctChars: state.correctChars + charCounts.correct,
     incorrectChars: state.incorrectChars + charCounts.incorrect,
+    mistakes,
+    missedPositions: [],
+    romajiSegmentErred: false,
   }
 
   return advanceAfterWord(base, config, language)
 }
 
+/** Verbatim mode's word-submit mistake pass: for every position `i` in
+ *  `word` where `typed[i] !== word[i]` (a wrong char, or a char never
+ *  typed at all when `typed` is shorter) and `i` is not already in
+ *  `missedPositions` (already tallied at Backspace time — see
+ *  `handleBackspace`), tallies one mistake keyed by the target char
+ *  `word[i]`. Never counts positions beyond `word.length` (extra typed
+ *  chars have no target char to attribute to). Returns `mistakes`
+ *  unchanged (no allocation) when nothing new is found. */
+function applyWordMistakes(
+  word: string,
+  typed: string,
+  missedPositions: readonly number[],
+  mistakes: Record<string, number>,
+): Record<string, number> {
+  let result = mistakes
+  for (let i = 0; i < word.length; i++) {
+    if (typed[i] === word[i]) continue
+    if (missedPositions.includes(i)) continue
+    if (result === mistakes) result = { ...mistakes }
+    const key = word[i]
+    result[key] = (result[key] ?? 0) + 1
+  }
+  return result
+}
+
+/** Verbatim mode: a Backspace that deletes a wrong character (one not
+ *  matching the target word at that position) tallies one mistake keyed by
+ *  the target char, immediately rather than waiting for word submit — and
+ *  marks the position in `missedPositions` so the eventual submit pass
+ *  (`applyWordMistakes`) doesn't double-count it even if the same wrong
+ *  char is retyped and deleted again, or the word is submitted with the
+ *  position still wrong. Deleting a correct char, or a char typed past the
+ *  end of the word, tallies nothing. */
 export function handleBackspace(state: TypingTestState): TypingTestState {
   if (state.currentInput.length === 0) return state
+  const pos = state.currentInput.length - 1
+  const word = state.words[state.currentWordIndex]
+  let mistakes = state.mistakes
+  let missedPositions = state.missedPositions
+  if (word !== undefined && pos < word.length && state.currentInput[pos] !== word[pos] && !missedPositions.includes(pos)) {
+    const key = word[pos]
+    mistakes = { ...mistakes, [key]: (mistakes[key] ?? 0) + 1 }
+    missedPositions = [...missedPositions, pos]
+  }
   return {
     ...state,
     currentInput: state.currentInput.slice(0, -1),
+    mistakes,
+    missedPositions,
   }
 }
 

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -256,6 +256,14 @@ export function useTypingTest(
       lineIndents,
       romajiKeystrokes: '',
       romajiCapable,
+      // Pause/resume memory doesn't carry per-run mistake tracking (it was
+      // never part of TypingTestMemory) — any mistakes tallied before the
+      // pause are lost on resume, same as they would be on any other field
+      // absent from the persisted snapshot. Acceptable: Phase 1 mistake
+      // tracking is best-effort per run, not a durable record.
+      mistakes: {},
+      romajiSegmentErred: false,
+      missedPositions: [],
     })
     return true
   }, [])

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -37,6 +37,13 @@ export interface TypingTestResult {
   consistency?: number
   isPb?: boolean
   wpmHistory?: number[]
+  /** Per-run tally of mistyped characters, keyed by the target character
+   *  (verbatim mode) or the canonical romaji spelling of the mistyped kana
+   *  segment (romaji mode — see `TypingTestState.mistakes` in run-state.ts
+   *  for the counting rules). Omitted when the run had no mistakes. Phase 1
+   *  of mistake analysis: stored on the result for the completion screen's
+   *  "missed characters" list; not yet surfaced in Analyze. */
+  mistakes?: Record<string, number>
 }
 
 /** A saved result tagged with the keyboard it belongs to. Returned by the


### PR DESCRIPTION
## Summary

Track and analyze per-character typing mistakes in the Typing Test.

**Counting rules** (agreed before implementing):
- **Romaji mode**: a kana segment with any rejected keystroke tallies one mistake, keyed by the segment's canonical romaji (し → "shi"), tallied when the segment completes — one per erred segment regardless of how many keystrokes were wrong (Backspace stays inert in romaji).
- **Verbatim mode**: a wrong character deleted with Backspace, or left wrong at word submit, tallies one mistake for the target character, deduped per position so a correction isn't double-counted.

**Storage & display**:
- Results carry a compact `mistakes: Record<string, number>` (dropped when empty).
- The completion screen shows a "Missed" list (count desc).
- The History view aggregates mistakes across the condition-filtered results into a "Most missed" Top-15 ranking with proportional bars.

## Verification

- `pnpm typecheck` / `pnpm lint` / `pnpm build` clean
- `pnpm test`: 6502 passed / 22 skipped, 0 failed
- Added tests for romaji + verbatim counting, `canonicalRomaji`, result storage + validation, completion display, and the ranking aggregation/sort/cap

Known minor limitation: a single keystroke that completes two kana at once (e.g. んー) keys the mistake by the combined slice; the count is still correct (1).