### PR TITLE
chore(build): bump version to 0.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
Bump the app version to 0.4.10 ahead of tagging the release.

The `v0.4.10` tag (pushed after this merges) triggers the release workflow, which verifies the tag matches `package.json`.