### PR TITLE
feat: prevent multiple app instances from launching

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -52,6 +52,13 @@ const isDev = !!process.env.ELECTRON_RENDERER_URL
 
 app.setDesktopName('pipette')
 
+// Single-instance guard: a second launch exits immediately and silently
+// (app.exit skips before-quit/will-quit — nothing is set up yet at this
+// point); the running instance is left untouched.
+if (!app.requestSingleInstanceLock()) {
+  app.exit(0)
+}
+
 // Distinguishes a user-initiated quit from a plain window close so the
 // tray-resident close handler knows whether to hide the window instead of
 // letting it (and the app) close.


### PR DESCRIPTION
## Summary
- Acquire `app.requestSingleInstanceLock()` at the top of the main process; a duplicate launch calls `app.exit(0)` and terminates immediately and silently, leaving the running instance untouched.
- No `second-instance` handler on purpose: a duplicate launch should not surface, restore, or create any window.

## Notes
- `app.exit(0)` is safe at this point in module evaluation: nothing (HID, IPC, tray, quit finalizers) is set up yet, so skipping `before-quit`/`will-quit` has no teardown cost.

## Testing
- `pnpm lint` / `pnpm typecheck` pass
- `pnpm test`: 6502 passed, 22 skipped