### PR TITLE
fix(ui): show unlock screen before tray residency when startup needs unlock

### DIFF
--- a/e2e/tray-start-unlock.test.ts
+++ b/e2e/tray-start-unlock.test.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Covers the boot-hidden Unlock dialog fix: with trayResident+startInTray
+// enabled and the app quit while in typing view, a relaunch with a locked
+// keyboard must (a) show the hidden window with the Unlock dialog instead
+// of staying tray-resident, and (b) hide the window back to the tray once
+// unlocked. Exercises both restore paths — typingView (dialog opened by
+// the view-mode restore in App.tsx) and plain editor (dialog auto-opened
+// by useBootHiddenWindow).
+//
+// Uses the virtual device (PIPETTE_VIRTUAL_DEVICE='only'), which relocks
+// on every launch so the Unlock dialog is guaranteed to appear on each
+// relaunch below. Mutates the Playwright userData dir (~/.config/Electron)
+// directly, with backup/restore around the whole run. Sessions launch
+// sequentially — the app's single-instance lock means each session must
+// fully exit before the next one starts, so there is no way to run these
+// three tests in parallel or out of order.
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication } from '@playwright/test'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+import { execSync } from 'node:child_process'
+import { launchApp } from './helpers/electron'
+import {
+  connectToDevice,
+  clickThroughUnlock,
+  waitForUnlockDialog,
+  unlockDialogHeading,
+  dismissNotificationModal,
+  backupFile,
+  restoreFile,
+  VIRTUAL_DEVICE_DISPLAY_NAME,
+  VIRTUAL_DEVICE_UID,
+  type FileBackup,
+} from './helpers/doc-capture-common'
+
+const USER_DATA = join(homedir(), '.config', 'Electron')
+const CONFIG_PATH = join(USER_DATA, 'config.json')
+const SETTINGS_PATH = join(USER_DATA, 'sync', 'keyboards', VIRTUAL_DEVICE_UID, 'pipette_settings.json')
+
+function readJson(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) return null
+  try { return JSON.parse(readFileSync(path, 'utf8')) as Record<string, unknown> } catch { return null }
+}
+
+// Reset flags a previous (crashed) run may have left behind so the setup
+// session starts as a normal visible launch with a device list.
+function cleanTestFlags(): void {
+  const cfg = readJson(CONFIG_PATH)
+  if (cfg) {
+    cfg.trayResident = false
+    cfg.startInTray = false
+    cfg.restoreLastSession = true
+    delete cfg.lastDevice
+    writeFileSync(CONFIG_PATH, JSON.stringify(cfg, null, 2))
+  }
+  // Also reset the persisted view mode from a previous run, otherwise the
+  // auto-restore path opens the Unlock dialog right after connecting and
+  // its overlay blocks the setup session's clicks.
+  const prefs = readJson(SETTINGS_PATH)
+  if (prefs && prefs.viewMode !== 'editor') {
+    prefs.viewMode = 'editor'
+    writeFileSync(SETTINGS_PATH, JSON.stringify(prefs, null, 2))
+  }
+}
+
+function electronRunning(): boolean {
+  try {
+    // [n] bracket trick: keeps this pgrep's own sh -c wrapper (whose
+    // command line contains the pattern text) from matching itself.
+    execSync('pgrep -f "electron/dist/electro[n].*out/main/index.js"', { stdio: 'pipe' })
+    return true
+  } catch { return false }
+}
+
+async function waitForElectronExit(timeoutMs = 30_000): Promise<void> {
+  const start = Date.now()
+  while (electronRunning()) {
+    if (Date.now() - start > timeoutMs) throw new Error('previous electron instance did not exit')
+    await new Promise((r) => setTimeout(r, 500))
+  }
+}
+
+async function quitApp(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ app: a }) => { a.quit() }).catch(() => {})
+  await new Promise((r) => setTimeout(r, 2000))
+  await app.close().catch(() => { /* already gone */ })
+  await waitForElectronExit()
+}
+
+let app: ElectronApplication | null = null
+let configBackup: FileBackup
+let settingsBackup: FileBackup
+
+test.describe.serial('tray start-in-tray unlock reveal', () => {
+  test.setTimeout(180_000)
+
+  test.beforeAll(() => {
+    if (electronRunning()) {
+      throw new Error('another electron instance is already running — aborting')
+    }
+    // Snapshot the files this run will mutate BEFORE any launch touches them.
+    configBackup = backupFile(CONFIG_PATH)
+    settingsBackup = backupFile(SETTINGS_PATH)
+    cleanTestFlags()
+  })
+
+  test.afterAll(async () => {
+    if (app) await quitApp(app).catch(() => {})
+    restoreFile(configBackup)
+    restoreFile(settingsBackup)
+  })
+
+  test('setup: connect, enter typing view, enable tray flags, quit while in typing view', async () => {
+    const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: 'only' } })
+    app = launched.app
+    const page = launched.page
+
+    const actualUserData = await app.evaluate(({ app: a }) => a.getPath('userData'))
+    expect(actualUserData).toBe(USER_DATA)
+
+    await dismissNotificationModal(page, { waitForAppearMs: 3_000 })
+
+    const connected = await connectToDevice(page, VIRTUAL_DEVICE_DISPLAY_NAME)
+    expect(connected).toBe(true)
+
+    // Enter view-only typing mode (unlock-gated on the freshly locked
+    // virtual device).
+    const viewOnlyBtn = page.locator('[data-testid="view-only-button"]')
+    await viewOnlyBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await clickThroughUnlock(app, page, viewOnlyBtn)
+    await page.waitForTimeout(2000)
+
+    // Enable tray-resident + start-in-tray (restoreLastSession already
+    // defaults to true).
+    await page.evaluate(async () => {
+      const api = (window as unknown as { vialAPI: { appConfigSet: (k: string, v: unknown) => Promise<void> } }).vialAPI
+      await api.appConfigSet('trayResident', true)
+      await api.appConfigSet('startInTray', true)
+    })
+    await page.waitForTimeout(800)
+
+    // Quit while still in typingView.
+    await quitApp(app)
+    app = null
+
+    const cfg = readJson(CONFIG_PATH)
+    const prefs = readJson(SETTINGS_PATH)
+    expect(cfg?.trayResident).toBe(true)
+    expect(cfg?.startInTray).toBe(true)
+    expect(prefs?.viewMode).toBe('typingView')
+  })
+
+  test('typingView restore path: relaunch reveals the Unlock dialog then hides back to tray', async () => {
+    const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: 'only' } })
+    app = launched.app
+    const page = launched.page
+
+    let dialogSeenVisible = false
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      const dialogUp = (await unlockDialogHeading(page).count()) > 0
+      if (dialogUp && winVisible.some(Boolean)) dialogSeenVisible = true
+      return dialogSeenVisible
+    }, { message: 'expected the Unlock dialog to appear in a visible window', timeout: 25_000, intervals: [1000] }).toBe(true)
+
+    await waitForUnlockDialog(app, page)
+
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      return winVisible.some(Boolean)
+    }, { message: 'expected the window to hide back to the tray after unlock', timeout: 15_000, intervals: [1000] }).toBe(false)
+    await expect(unlockDialogHeading(page)).toHaveCount(0)
+
+    await quitApp(app)
+    app = null
+  })
+
+  test('editor restore path: relaunch reveals the Unlock dialog then hides back to tray', async () => {
+    // Rewrite the persisted view mode to plain editor so this session
+    // exercises useBootHiddenWindow's auto-open path instead of the
+    // typingView restore effect in App.tsx.
+    const prefs = readJson(SETTINGS_PATH)
+    expect(prefs).not.toBeNull()
+    if (prefs) {
+      prefs.viewMode = 'editor'
+      writeFileSync(SETTINGS_PATH, JSON.stringify(prefs, null, 2))
+    }
+
+    const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: 'only' } })
+    app = launched.app
+    const page = launched.page
+
+    let dialogSeenVisible = false
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      const dialogUp = (await unlockDialogHeading(page).count()) > 0
+      if (dialogUp && winVisible.some(Boolean)) dialogSeenVisible = true
+      return dialogSeenVisible
+    }, { message: 'expected the Unlock dialog to appear in a visible window', timeout: 25_000, intervals: [1000] }).toBe(true)
+
+    await waitForUnlockDialog(app, page)
+
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      return winVisible.some(Boolean)
+    }, { message: 'expected the window to hide back to the tray after unlock', timeout: 15_000, intervals: [1000] }).toBe(false)
+    await expect(unlockDialogHeading(page)).toHaveCount(0)
+
+    await quitApp(app)
+    app = null
+  })
+})

--- a/src/main/__tests__/app-behavior.test.ts
+++ b/src/main/__tests__/app-behavior.test.ts
@@ -214,7 +214,7 @@ describe('tray', () => {
   })
 
   it('Show menu item shows and focuses the window', () => {
-    const win = { show: vi.fn(), focus: vi.fn() }
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
     setupTray(() => win as unknown as Electron.BrowserWindow)
 
     const template = mockBuildFromTemplate.mock.calls[0][0]
@@ -243,7 +243,7 @@ describe('tray', () => {
   })
 
   it('tray click event shows and focuses the window, same as Show', () => {
-    const win = { show: vi.fn(), focus: vi.fn() }
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
     setupTray(() => win as unknown as Electron.BrowserWindow)
 
     const clickHandler = trayInstances[0].handlers.get('click')
@@ -328,7 +328,7 @@ describe('updateTrayStatus', () => {
   })
 
   it('the rebuilt Show item still shows and focuses the window', () => {
-    const win = { show: vi.fn(), focus: vi.fn() }
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
     const getWindow = () => win as unknown as Electron.BrowserWindow
     setupTray(getWindow)
     updateTrayStatus({ keyboardName: 'GPK-63R', recording: true, count: 1, kpm: 1 }, getWindow)
@@ -344,7 +344,7 @@ describe('updateTrayStatus', () => {
 
 describe('showWindow', () => {
   it('shows and focuses the window when one exists', () => {
-    const win = { show: vi.fn(), focus: vi.fn() }
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
     showWindow(() => win as unknown as Electron.BrowserWindow)
     expect(win.show).toHaveBeenCalled()
     expect(win.focus).toHaveBeenCalled()
@@ -352,6 +352,20 @@ describe('showWindow', () => {
 
   it('is a no-op when there is no window', () => {
     expect(() => showWindow(() => null)).not.toThrow()
+  })
+
+  it('returns false when there is no window', () => {
+    expect(showWindow(() => null)).toBe(false)
+  })
+
+  it('returns true when the window transitions from hidden to shown', () => {
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
+    expect(showWindow(() => win as unknown as Electron.BrowserWindow)).toBe(true)
+  })
+
+  it('returns false when the window was already visible', () => {
+    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(true) }
+    expect(showWindow(() => win as unknown as Electron.BrowserWindow)).toBe(false)
   })
 })
 

--- a/src/main/app-behavior.ts
+++ b/src/main/app-behavior.ts
@@ -85,12 +85,17 @@ let trayInstance: Tray | null = null
 
 /** Show and focus the given window. Shared by the tray menu/click
  * handlers and the WINDOW_SHOW IPC handler so a hidden (start-in-tray)
- * window and the tray icon reveal it the same way. */
-export function showWindow(getWindow: () => BrowserWindow | null): void {
+ * window and the tray icon reveal it the same way. Returns whether the
+ * window actually transitioned from hidden to shown, so callers that only
+ * want to act on a genuine hidden→visible edge (e.g. the boot-hidden Unlock
+ * dialog flow) can tell that apart from a window that was already visible. */
+export function showWindow(getWindow: () => BrowserWindow | null): boolean {
   const win = getWindow()
-  if (!win) return
+  if (!win) return false
+  const wasVisible = win.isVisible()
   win.show()
   win.focus()
+  return !wasVisible
 }
 
 const DEFAULT_TRAY_STATUS: TrayStatus = { keyboardName: null, recording: false, count: 0, kpm: 0 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -135,6 +135,16 @@ function createWindow(): void {
   setWindowStartedHidden(startHidden)
   const win = new BrowserWindow(winOpts)
 
+  // document.visibilityState is unreliable for windows created with
+  // show: false (notably on Linux, it still reports 'visible'), so the
+  // renderer needs main-process visibility truth pushed to it directly.
+  win.on('show', () => {
+    win.webContents.send(IpcChannels.WINDOW_VISIBILITY_CHANGED, true)
+  })
+  win.on('hide', () => {
+    win.webContents.send(IpcChannels.WINDOW_VISIBILITY_CHANGED, false)
+  })
+
   win.on('close', (e) => {
     if (normalWindowSize) {
       const bounds = win.getBounds()
@@ -337,8 +347,8 @@ function setupWindowIpc(): void {
     },
   )
 
-  secureHandle(IpcChannels.WINDOW_SHOW, () => {
-    showWindow(getFirstWindow)
+  secureHandle(IpcChannels.WINDOW_SHOW, (): boolean => {
+    return showWindow(getFirstWindow)
   })
 
   secureHandle(IpcChannels.WINDOW_HIDE, () => {
@@ -346,6 +356,8 @@ function setupWindowIpc(): void {
   })
 
   secureHandle(IpcChannels.WINDOW_STARTED_HIDDEN, (): boolean => getWindowStartedHidden())
+
+  secureHandle(IpcChannels.WINDOW_IS_VISIBLE, (): boolean => getFirstWindow()?.isVisible() ?? false)
 
   secureHandle(IpcChannels.TRAY_STATUS_UPDATE, (_event, status: unknown) => {
     if (!isValidTrayStatus(status)) return

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -758,12 +758,21 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.WINDOW_IS_ALWAYS_ON_TOP_SUPPORTED),
   setWindowZoom: (zoom: number): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.WINDOW_SET_ZOOM, zoom),
-  windowShow: (): Promise<void> =>
+  windowShow: (): Promise<boolean> =>
     ipcRenderer.invoke(IpcChannels.WINDOW_SHOW),
   windowHide: (): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.WINDOW_HIDE),
   windowStartedHidden: (): Promise<boolean> =>
     ipcRenderer.invoke(IpcChannels.WINDOW_STARTED_HIDDEN),
+  windowIsVisible: (): Promise<boolean> =>
+    ipcRenderer.invoke(IpcChannels.WINDOW_IS_VISIBLE),
+  onWindowVisibilityChanged: (callback: (visible: boolean) => void): (() => void) => {
+    const handler = (_event: Electron.IpcRendererEvent, visible: boolean): void => {
+      callback(visible)
+    }
+    ipcRenderer.on(IpcChannels.WINDOW_VISIBILITY_CHANGED, handler)
+    return () => ipcRenderer.removeListener(IpcChannels.WINDOW_VISIBILITY_CHANGED, handler)
+  },
 
   // --- Tray status ---
   trayStatusUpdate: (status: TrayStatus): Promise<void> =>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -263,10 +263,28 @@ export function App() {
     connect: lifecycle.handleConnect,
   })
 
+  // Whether the connected keyboard is confirmed locked, for the
+  // boot-hidden auto-unlock prompt below. Stays null (undetermined) until
+  // a real device is fully loaded with a known unlock status — a
+  // getUnlockStatus() failure must never be mistaken for "locked".
+  const bootKeyboardLocked: boolean | null =
+    (!device.connectedDevice || device.isDummy
+      || keyboard.loading || keyboard.uid === EMPTY_UID
+      || !keyboard.unlockStatusKnown)
+      ? null
+      : !keyboard.unlockStatus.unlocked
+
   // Show the window only for the Unlock dialog while a hidden launch
   // (startInTray) is restoring the last session; hide it again once the
-  // dialog resolves. No-ops entirely once the boot-hidden phase ends.
-  useBootHiddenWindow(editorUI.showUnlockDialog)
+  // dialog resolves. Also opens the dialog automatically, once per launch,
+  // if session restore reconnects a keyboard that is still locked (the
+  // typingView restore path below opens it itself, so this is idempotent
+  // with that path). No-ops entirely once the boot-hidden phase ends.
+  useBootHiddenWindow({
+    unlockDialogVisible: editorUI.showUnlockDialog,
+    keyboardLocked: bootKeyboardLocked,
+    onRequestUnlockDialog: () => editorUI.setShowUnlockDialog(true),
+  })
 
   const missingKeyLabel = useMissingKeyLabelNotice(keyboard.uid || null)
 
@@ -523,10 +541,12 @@ export function App() {
     } else if (mode === 'typingView') {
       if (keyboard.unlockStatus.unlocked) {
         enterTypingViewOnly()
-      } else {
+      } else if (keyboard.unlockStatusKnown) {
         pendingViewOnlyRef.current = true
         editorUI.setShowUnlockDialog(true)
       }
+      // Unknown unlock status (getUnlockStatus failed) — skip the restore
+      // rather than prompting for an unlock that may not be needed.
     }
   }, [
     device.connectedDevice,
@@ -534,6 +554,7 @@ export function App() {
     keyboard.loading,
     keyboard.uid,
     keyboard.unlockStatus.unlocked,
+    keyboard.unlockStatusKnown,
     devicePrefs.appliedUid,
     devicePrefs.viewMode,
     enterTypingViewOnly,

--- a/src/renderer/components/editors/UnlockDialog.tsx
+++ b/src/renderer/components/editors/UnlockDialog.tsx
@@ -108,7 +108,11 @@ export function UnlockDialog({
         if (cancelled) return
         intervalId = setInterval(() => void pollOnce(), UNLOCK_POLL_INTERVAL)
       } catch {
-        // failed to start unlock
+        // Failed to start unlock — clean up via the parent's disconnect
+        // handler so the dialog does not stay mounted with no poll loop
+        // ever running (e.g. this leaves a boot-hidden launch stuck with
+        // a hidden window otherwise).
+        if (!cancelled) onDisconnectRef.current?.()
       }
     }
 

--- a/src/renderer/components/editors/__tests__/UnlockDialog.test.tsx
+++ b/src/renderer/components/editors/__tests__/UnlockDialog.test.tsx
@@ -166,4 +166,25 @@ describe('UnlockDialog', () => {
     expect(warning).toBeInTheDocument()
     expect(screen.getByText('Click the macro key again after unlocking.')).toBeInTheDocument()
   })
+
+  it('calls onDisconnect when unlockStart rejects', async () => {
+    unlockStart.mockRejectedValue(new Error('failed to start unlock'))
+    const onDisconnect = vi.fn()
+
+    await act(async () => {
+      render(
+        <UnlockDialog
+          keys={keys}
+          unlockKeys={unlockKeys}
+          unlockStart={unlockStart}
+          unlockPoll={unlockPoll}
+          onComplete={onComplete}
+          onDisconnect={onDisconnect}
+        />,
+      )
+    })
+
+    expect(onDisconnect).toHaveBeenCalledTimes(1)
+    expect(unlockPoll).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
+++ b/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
@@ -11,87 +11,141 @@ async function flushMicrotasks() {
   })
 }
 
-function setVisibilityState(state: DocumentVisibilityState) {
-  Object.defineProperty(document, 'visibilityState', { value: state, configurable: true })
-}
-
 let windowShow: ReturnType<typeof vi.fn>
 let windowHide: ReturnType<typeof vi.fn>
 let windowStartedHidden: ReturnType<typeof vi.fn>
+let windowIsVisible: ReturnType<typeof vi.fn>
+let onWindowVisibilityChanged: ReturnType<typeof vi.fn>
+let unsubscribeSpy: ReturnType<typeof vi.fn>
+let visibilityCallback: ((visible: boolean) => void) | undefined
+
+// Simulates a main-process push (win.on('show') / win.on('hide')) arriving
+// at the renderer via onWindowVisibilityChanged.
+function pushWindowVisibility(visible: boolean) {
+  act(() => {
+    visibilityCallback?.(visible)
+  })
+}
 
 beforeEach(() => {
-  windowShow = vi.fn().mockResolvedValue(undefined)
+  windowShow = vi.fn().mockResolvedValue(true)
   windowHide = vi.fn().mockResolvedValue(undefined)
   windowStartedHidden = vi.fn().mockResolvedValue(true)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(window as any).vialAPI = { windowShow, windowHide, windowStartedHidden }
   // A boot-hidden launch means the BrowserWindow actually starts hidden,
-  // so document.visibilityState reports 'hidden' until this hook shows it.
-  setVisibilityState('hidden')
+  // so windowIsVisible() reports false until this hook shows it.
+  windowIsVisible = vi.fn().mockResolvedValue(false)
+  unsubscribeSpy = vi.fn()
+  visibilityCallback = undefined
+  onWindowVisibilityChanged = vi.fn((callback: (visible: boolean) => void) => {
+    visibilityCallback = callback
+    return unsubscribeSpy
+  })
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(window as any).vialAPI = {
+    windowShow,
+    windowHide,
+    windowStartedHidden,
+    windowIsVisible,
+    onWindowVisibilityChanged,
+  }
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
 
+interface Props {
+  visible: boolean
+  keyboardLocked: boolean | null
+  onRequestUnlockDialog: () => void
+}
+
+function renderBootHiddenWindow(initialProps: Partial<Props> = {}) {
+  const onRequestUnlockDialog = initialProps.onRequestUnlockDialog ?? vi.fn()
+  const utils = renderHook(
+    (props: Props) => useBootHiddenWindow({
+      unlockDialogVisible: props.visible,
+      keyboardLocked: props.keyboardLocked,
+      onRequestUnlockDialog: props.onRequestUnlockDialog,
+    }),
+    {
+      initialProps: {
+        visible: false,
+        keyboardLocked: null,
+        onRequestUnlockDialog,
+        ...initialProps,
+      },
+    },
+  )
+  return { ...utils, onRequestUnlockDialog }
+}
+
 describe('useBootHiddenWindow', () => {
   it('shows the window once on the unlock dialog rising edge during a boot-hidden launch', async () => {
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
 
     expect(windowShow).toHaveBeenCalledTimes(1)
     expect(windowHide).not.toHaveBeenCalled()
   })
 
   it('hides the window and ends the boot-hidden phase on the falling edge, with no second show later', async () => {
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).toHaveBeenCalledTimes(1)
 
-    rerender({ visible: false })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowHide).toHaveBeenCalledTimes(1)
 
     // A later dialog must not trigger auto-show again — the phase already ended.
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).toHaveBeenCalledTimes(1)
   })
 
-  it('ends the boot-hidden phase without hiding when a foreign visibilitychange shows the window first', async () => {
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+  it('ends the boot-hidden phase without hiding when a foreign visibility push shows the window first', async () => {
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    setVisibilityState('visible')
-    act(() => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    pushWindowVisibility(true)
 
     expect(windowHide).not.toHaveBeenCalled()
 
     // The boot-hidden phase already ended, so a later dialog does not auto-show.
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).not.toHaveBeenCalled()
+  })
+
+  it('never hides the window when windowShow reports the user beat it to the reveal', async () => {
+    // The user shows the window via the tray in the gap between the
+    // WINDOW_IS_VISIBLE snapshot and windowShow()'s invoke resolving.
+    // main reports transitioned=false, meaning it was already visible.
+    windowShow.mockResolvedValue(false)
+
+    const { rerender } = renderBootHiddenWindow()
+    await flushMicrotasks()
+
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    await flushMicrotasks()
+    expect(windowShow).toHaveBeenCalledTimes(1)
+
+    // The dialog resolves — ownership was rolled back, so this must not
+    // hide the window the user opened themselves.
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    expect(windowHide).not.toHaveBeenCalled()
   })
 
   it('never touches the window when the launch did not start hidden', async () => {
     windowStartedHidden.mockResolvedValue(false)
 
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true })
-    rerender({ visible: false })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
 
     expect(windowShow).not.toHaveBeenCalled()
     expect(windowHide).not.toHaveBeenCalled()
@@ -100,56 +154,173 @@ describe('useBootHiddenWindow', () => {
   it('never hides the window when an unlock dialog rises and falls during normal use after the window is already visible', async () => {
     // The window started hidden, but by the time the hook learns this the
     // window is already visible (e.g. the tray click happened first).
-    setVisibilityState('visible')
+    windowIsVisible.mockResolvedValue(true)
 
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
     // An unlock dialog cycles during normal use — must not hide the window
     // the user is actively looking at.
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).not.toHaveBeenCalled()
 
-    rerender({ visible: false })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowHide).not.toHaveBeenCalled()
 
     // Nor on a later cycle, since the phase already ended.
-    rerender({ visible: true })
-    rerender({ visible: false })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).not.toHaveBeenCalled()
     expect(windowHide).not.toHaveBeenCalled()
   })
 
   it('never hides the window when it is revealed before windowStartedHidden resolves (async race)', async () => {
     // Simulate the race: windowStartedHidden() has not resolved yet, but
-    // the user reveals the window (tray click → visibilitychange) first.
+    // the user reveals the window (tray click → visibility push) first.
     let resolveStartedHidden: (hidden: boolean) => void = () => {}
     windowStartedHidden.mockImplementation(
       () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
     )
 
-    const { rerender } = renderHook(({ visible }) => useBootHiddenWindow(visible), {
-      initialProps: { visible: false },
-    })
+    const { rerender } = renderBootHiddenWindow()
 
     // The user reveals the window before windowStartedHidden() resolves.
-    setVisibilityState('visible')
-    act(() => {
-      document.dispatchEvent(new Event('visibilitychange'))
-    })
+    pushWindowVisibility(true)
 
     // Now the promise resolves with hidden=true — this must not re-arm the
-    // boot-hidden phase, since the window is already visible.
+    // boot-hidden phase using the stale windowIsVisible() snapshot, since
+    // the live push already reported the window as visible.
     resolveStartedHidden(true)
     await flushMicrotasks()
 
     // A later unlock dialog cycle during normal use must not hide the window.
-    rerender({ visible: true })
+    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowShow).not.toHaveBeenCalled()
 
-    rerender({ visible: false })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
     expect(windowHide).not.toHaveBeenCalled()
+  })
+
+  it('requests the unlock dialog once when a boot-hidden launch reconnects a locked keyboard', async () => {
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+
+    // Further rerenders (even with locked still true) must not re-call it.
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('requests the unlock dialog even if keyboardLocked becomes true before windowStartedHidden resolves', async () => {
+    let resolveStartedHidden: (hidden: boolean) => void = () => {}
+    windowStartedHidden.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
+    )
+
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+
+    // keyboardLocked resolves to true before windowStartedHidden() does.
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+
+    resolveStartedHidden(true)
+    await flushMicrotasks()
+
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows the window for a dialog already visible when arming resolves, and hides it on the falling edge', async () => {
+    let resolveStartedHidden: (hidden: boolean) => void = () => {}
+    windowStartedHidden.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
+    )
+
+    // The typingView restore path opens the dialog before arming resolves.
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({
+      visible: true,
+      keyboardLocked: true,
+    })
+
+    resolveStartedHidden(true)
+    await flushMicrotasks()
+
+    expect(windowShow).toHaveBeenCalledTimes(1)
+    // The dialog was already visible, so this hook must not also request it.
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+
+    rerender({ visible: false, keyboardLocked: false, onRequestUnlockDialog })
+    expect(windowHide).toHaveBeenCalledTimes(1)
+  })
+
+  it('never requests the unlock dialog when windowStartedHidden resolves false', async () => {
+    windowStartedHidden.mockResolvedValue(false)
+
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+  })
+
+  it('never requests the unlock dialog when the user reveals the window first', async () => {
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    pushWindowVisibility(true)
+
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+  })
+
+  it('ends the phase on confirmed-unlocked without prompting, and ignores a later lock transition', async () => {
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    rerender({ visible: false, keyboardLocked: false, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+
+    // Startup-only: a later lock transition must not prompt or reveal.
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+
+    rerender({ visible: true, keyboardLocked: true, onRequestUnlockDialog })
+    expect(windowShow).not.toHaveBeenCalled()
+  })
+
+  it('never requests the unlock dialog while keyboardLocked stays unknown', async () => {
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
+
+    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
+  })
+
+  it('does not re-prompt on reconnect (locked → unknown → locked again)', async () => {
+    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+    await flushMicrotasks()
+
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+
+    // Disconnect: keyboardLocked goes back to unknown.
+    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+
+    // Reconnect: locked is confirmed true again — must not re-prompt.
+    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
+    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('unsubscribes from window visibility changes on unmount', async () => {
+    const { unmount } = renderBootHiddenWindow()
+    await flushMicrotasks()
+
+    unmount()
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/hooks/keyboard-types.ts
+++ b/src/renderer/hooks/keyboard-types.ts
@@ -48,6 +48,11 @@ export interface KeyboardState {
   keyOverrideEntries: KeyOverrideEntry[]
   altRepeatKeyEntries: AltRepeatKeyEntry[]
   unlockStatus: UnlockStatus
+  // True once unlockStatus reflects a real device answer (or a forced
+  // VIA-only/dummy/pipette-file unlocked state) rather than the initial
+  // placeholder. A failed getUnlockStatus() leaves this false, so callers
+  // must never treat "not known" as "confirmed locked".
+  unlockStatusKnown: boolean
   // QMK Backlight
   backlightBrightness: number
   backlightEffect: number
@@ -102,6 +107,7 @@ export function emptyState(): KeyboardState {
     keyOverrideEntries: [],
     altRepeatKeyEntries: [],
     unlockStatus: { unlocked: false, inProgress: false, keys: [] },
+    unlockStatusKnown: false,
     backlightBrightness: 0,
     backlightEffect: 0,
     rgblightBrightness: 0,

--- a/src/renderer/hooks/useBootHiddenWindow.ts
+++ b/src/renderer/hooks/useBootHiddenWindow.ts
@@ -1,77 +1,179 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+interface BootHiddenWindowOptions {
+  unlockDialogVisible: boolean
+  /**
+   * Whether the connected keyboard is currently locked, once known:
+   * true = confirmed locked, false = confirmed unlocked, null = not yet
+   * determined (still loading, no device, or unlock status unknown).
+   */
+  keyboardLocked: boolean | null
+  onRequestUnlockDialog: () => void
+}
 
 /**
  * Manages the window-visibility side of "start hidden in tray, but show
  * the window for the Unlock dialog." The main process starts the window
  * hidden (windowStartedHidden()); this hook shows it only while the
- * Unlock dialog opened during session restore is visible, then hides it
+ * Unlock dialog is visible during that boot-hidden phase, then hides it
  * again once the dialog resolves — but only if this hook is the one that
  * showed it. If the window is already visible (the user showed it
  * themselves, or the boot-hidden phase never really applied), later
  * unlock dialogs during normal use are left alone: the phase ends without
  * showing or hiding anything.
+ *
+ * It also owns opening the dialog in the first place: if session restore
+ * reconnects a keyboard that is still locked and nothing has opened the
+ * dialog yet (e.g. the plain keymap-editor restore path, as opposed to
+ * the typingView restore path which opens it itself), this hook requests
+ * it once per launch via onRequestUnlockDialog. If the keyboard turns out
+ * to already be unlocked, the boot-hidden phase ends without ever
+ * touching the window.
+ *
+ * Window visibility truth comes from the main process (windowIsVisible /
+ * onWindowVisibilityChanged), not from document.visibilityState: a
+ * BrowserWindow created with show: false can still report
+ * document.visibilityState === 'visible' on some platforms (observed on
+ * Linux Electron), which would silently prevent the boot-hidden phase
+ * from ever arming.
  */
-export function useBootHiddenWindow(unlockDialogVisible: boolean): void {
-  const bootHiddenRef = useRef(false)
+export function useBootHiddenWindow(opts: BootHiddenWindowOptions): void {
+  const { unlockDialogVisible, keyboardLocked, onRequestUnlockDialog } = opts
+
+  // Arming is reactive state, not a ref: windowStartedHidden() resolves
+  // asynchronously, and by the time it does, keyboardLocked may already be
+  // known or the dialog may already be visible (typingView restore path).
+  // Effects keyed on `armed` re-run when it flips true and pick up the
+  // current props, so none of those already-set signals are lost.
+  const [armed, setArmed] = useState(false)
+
   const weShowedRef = useRef(false)
-  const prevVisibleRef = useRef(unlockDialogVisible)
+  // Tracks unlockDialogVisible only while armed, starting at false so that
+  // a dialog already visible at the moment arming resolves is treated as
+  // a rising edge instead of being missed.
+  const prevVisibleRef = useRef(false)
+  // One-shot per launch: once we ask for the dialog, never ask again
+  // (disconnect → reconnect must not re-prompt).
+  const promptedRef = useRef(false)
+  const onRequestUnlockDialogRef = useRef(onRequestUnlockDialog)
+  onRequestUnlockDialogRef.current = onRequestUnlockDialog
+
+  // Live main-process window visibility, kept current by the
+  // onWindowVisibilityChanged subscription below. Read synchronously by
+  // the arming effect and the rising-edge check instead of the DOM's
+  // visibilityState.
+  const windowVisibleRef = useRef(false)
+  // True once a live onWindowVisibilityChanged push has updated
+  // windowVisibleRef — lets the arming effect know its own
+  // windowIsVisible() snapshot may already be stale by the time it
+  // resolves (e.g. the user revealed the window via the tray in the gap
+  // between the query being sent and it resolving) and defer to the ref
+  // instead of overwriting it with outdated data.
+  const windowVisibilityKnownRef = useRef(false)
+
+  // Subscribe to live visibility pushes once per mount. Two jobs: keep
+  // windowVisibleRef current, and end the boot-hidden phase the moment the
+  // user reveals the window themselves (tray Show / OS restore) rather
+  // than via our own windowShow() call. `armed` is not read from this
+  // effect's closure (it would be stale — this effect has no deps) so
+  // setArmed(false) is called unconditionally; that is a harmless no-op
+  // when the phase is already off.
+  useEffect(() => {
+    const unsubscribe = window.vialAPI.onWindowVisibilityChanged((visible) => {
+      windowVisibleRef.current = visible
+      windowVisibilityKnownRef.current = true
+      if (visible && !weShowedRef.current) {
+        setArmed(false)
+      }
+    })
+    return unsubscribe
+  }, [])
 
   // Learn whether this launch started hidden. Runs once; only arm the
   // phase if the window is still actually hidden by the time this
   // resolves — if the user (or the OS) already revealed it, the
-  // boot-hidden phase is already over and must never re-arm. A failure
-  // (or a launch that did not start hidden) also leaves the phase off.
+  // boot-hidden phase is already over and must never arm. A failure (or a
+  // launch that did not start hidden) also leaves the phase off.
   useEffect(() => {
     let cancelled = false
-    window.vialAPI.windowStartedHidden().then((hidden) => {
-      if (!cancelled) bootHiddenRef.current = hidden && document.visibilityState !== 'visible'
+    Promise.all([window.vialAPI.windowStartedHidden(), window.vialAPI.windowIsVisible()]).then(([hidden, visible]) => {
+      if (cancelled) return
+      // A live push may have already updated windowVisibleRef with more
+      // current data than this query's own snapshot — trust that over a
+      // possibly-stale `visible` value.
+      if (!windowVisibilityKnownRef.current) {
+        windowVisibleRef.current = visible
+      }
+      setArmed(hidden && !windowVisibleRef.current)
     }).catch(() => { /* best-effort — stay non-boot-hidden on failure */ })
     return () => { cancelled = true }
   }, [])
 
+  // Show/hide the window around the Unlock dialog's visible lifetime.
   useEffect(() => {
+    if (!armed) return
     const wasVisible = prevVisibleRef.current
     prevVisibleRef.current = unlockDialogVisible
-    if (!bootHiddenRef.current) return
 
     if (unlockDialogVisible && !wasVisible) {
-      if (document.visibilityState === 'visible') {
+      if (windowVisibleRef.current) {
         // The window is already visible (the user is actively using it) —
         // this is not the boot-hidden dialog. End the phase without
         // touching the window; later dialogs must not hide it either.
-        bootHiddenRef.current = false
+        setArmed(false)
         return
       }
       // Rising edge on a genuinely hidden window: show it for the dialog
       // and remember that we did so, so the falling edge only hides what
-      // we showed.
+      // we showed. weShowedRef must be set synchronously (not after the
+      // invoke resolves): Electron emits win 'show' from within win.show(),
+      // so the WINDOW_VISIBILITY_CHANGED push reaches the visibility
+      // subscription above BEFORE this invoke's promise resolves. If
+      // weShowedRef were still false at that point, that push would read as
+      // a foreign reveal and disarm the phase, breaking this very show.
+      //
+      // That leaves a window-ownership race: the user may have shown the
+      // window via the tray in the gap between the WINDOW_IS_VISIBLE
+      // snapshot (arming effect) and this call. windowShow() resolves with
+      // whether main actually transitioned the window from hidden to
+      // shown — false means the user beat us to it. Roll back ownership in
+      // that case so the falling edge does not hide a window the user
+      // opened themselves.
       weShowedRef.current = true
-      void window.vialAPI.windowShow().catch(() => {})
+      void window.vialAPI.windowShow().then((transitioned) => {
+        if (!transitioned) {
+          weShowedRef.current = false
+          setArmed(false)
+        }
+      }).catch(() => {})
     } else if (!unlockDialogVisible && wasVisible) {
-      // Falling edge: the dialog resolved (unlocked, or cancelled/
-      // disconnected). End the boot-hidden phase — later dialogs in this
-      // session no longer auto-show/hide — and hide the window again only
-      // if this hook is the one that showed it for this dialog.
-      bootHiddenRef.current = false
+      // Falling edge: the dialog resolved (unlocked, or disconnected).
+      // End the boot-hidden phase — later dialogs in this session no
+      // longer auto-show/hide — and hide the window again only if this
+      // hook is the one that showed it for this dialog.
+      setArmed(false)
       if (weShowedRef.current) {
         void window.vialAPI.windowHide().catch(() => {})
       }
     }
-  }, [unlockDialogVisible])
+  }, [armed, unlockDialogVisible])
 
+  // Auto-open the Unlock dialog once, if session restore reconnects a
+  // still-locked keyboard and nothing else has opened it yet. If the
+  // keyboard turns out to be unlocked instead, end the boot-hidden phase —
+  // this is startup-only behavior, so a later lock transition or
+  // reconnect must not reveal the window.
   useEffect(() => {
-    function handleVisibilityChange() {
-      if (!bootHiddenRef.current) return
-      if (document.visibilityState === 'visible' && !weShowedRef.current) {
-        // The user showed the window themselves (tray Show / OS restore)
-        // before we ever showed it for a dialog. Never auto-hide a window
-        // the user opened — just end the boot-hidden phase.
-        bootHiddenRef.current = false
-      }
+    if (!armed) return
+    if (unlockDialogVisible) return
+    if (promptedRef.current) return
+    if (keyboardLocked === true) {
+      promptedRef.current = true
+      onRequestUnlockDialogRef.current()
+    } else if (keyboardLocked === false) {
+      setArmed(false)
     }
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => document.removeEventListener('visibilitychange', handleVisibilityChange)
-  }, [])
+  }, [armed, keyboardLocked, unlockDialogVisible])
 }

--- a/src/renderer/hooks/useKeyboardLoaders.ts
+++ b/src/renderer/hooks/useKeyboardLoaders.ts
@@ -41,6 +41,7 @@ export function useKeyboardLoaders(
     newState.cols = definition.matrix.cols
     newState.layoutOptions = 0
     newState.unlockStatus = { unlocked: true, inProgress: false, keys: [] }
+    newState.unlockStatusKnown = true
 
     // Parse KLE layout
     const { layout, encoderCount } = parseDefinitionLayout(definition)
@@ -94,6 +95,7 @@ export function useKeyboardLoaders(
     newState.cols = definition.matrix.cols
     newState.layoutOptions = vil.layoutOptions
     newState.unlockStatus = { unlocked: true, inProgress: false, keys: [] }
+    newState.unlockStatusKnown = true
 
     // Parse KLE layout
     const { layout, encoderCount } = parseDefinitionLayout(definition)

--- a/src/renderer/hooks/useKeyboardPersistence.ts
+++ b/src/renderer/hooks/useKeyboardPersistence.ts
@@ -169,7 +169,7 @@ export function useKeyboardPersistence(
   const refreshUnlockStatus = useCallback(async () => {
     try {
       const unlockStatus = await window.vialAPI.getUnlockStatus()
-      setState((s) => ({ ...s, unlockStatus }))
+      setState((s) => ({ ...s, unlockStatus, unlockStatusKnown: true }))
     } catch (err) {
       console.error('[KB] unlock status refresh failed:', err)
     }

--- a/src/renderer/hooks/useKeyboardReload.ts
+++ b/src/renderer/hooks/useKeyboardReload.ts
@@ -331,12 +331,14 @@ export function useKeyboardReload(
       if (newState.vialProtocol >= 0) {
         try {
           newState.unlockStatus = await api.getUnlockStatus()
+          newState.unlockStatusKnown = true
         } catch (err) {
           console.error('[KB] unlock status fetch failed:', err)
         }
       } else {
         // VIA-only keyboards are always unlocked
         newState.unlockStatus = { unlocked: true, inProgress: false, keys: [] }
+        newState.unlockStatusKnown = true
       }
 
       newState.loading = false

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -306,6 +306,10 @@ export const IpcChannels = {
   WINDOW_SHOW: 'window:show',
   WINDOW_HIDE: 'window:hide',
   WINDOW_STARTED_HIDDEN: 'window:started-hidden',
+  WINDOW_IS_VISIBLE: 'window:is-visible',
+
+  // Window visibility (main → renderer)
+  WINDOW_VISIBILITY_CHANGED: 'window:visibility-changed',
 
   // Tray status (renderer → main)
   TRAY_STATUS_UPDATE: 'tray:status-update',

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -447,9 +447,11 @@ export interface VialAPI {
   setWindowMinSize(width: number, height: number): Promise<void>
   isAlwaysOnTopSupported(): Promise<boolean>
   setWindowZoom(zoom: number): Promise<void>
-  windowShow(): Promise<void>
+  windowShow(): Promise<boolean>
   windowHide(): Promise<void>
   windowStartedHidden(): Promise<boolean>
+  windowIsVisible(): Promise<boolean>
+  onWindowVisibilityChanged(callback: (visible: boolean) => void): () => void
 
   // Tray status
   trayStatusUpdate(status: TrayStatus): Promise<void>


### PR DESCRIPTION
## Summary
- A start-in-tray launch that restored a locked keyboard stayed tray-resident with the Unlock dialog mounted inside the hidden window, leaving the keyboard stuck locked with no visible prompt. Reproduced with the virtual device (`PIPETTE_VIRTUAL_DEVICE=only` + Playwright).
- Root cause 1: nothing opened the Unlock dialog on the plain keymap-editor restore path. `useBootHiddenWindow` now auto-opens it once per launch when a boot-hidden session restore connects a confirmed-locked keyboard. A new `unlockStatusKnown` state flag keeps a failed `getUnlockStatus()` fetch from being mistaken for "locked" (the initial placeholder is `unlocked: false`).
- Root cause 2: `document.visibilityState` reports `'visible'` for windows created with `show: false` on Linux, so the boot-hidden phase never armed — the whole show-for-unlock mechanism was dead. Window visibility truth now comes from the main process via new `window:is-visible` (invoke) and `window:visibility-changed` (push from `win.on('show'/'hide')`) IPC.
- `windowShow()` now returns whether it actually transitioned the window hidden→shown; if the user revealed the window from the tray first, the hook gives up ownership so the dialog's falling edge never hides a window the user opened.
- `UnlockDialog`: an `unlockStart()` rejection now routes through `onDisconnect` cleanup instead of leaving the dialog mounted with no poll loop running.

## Notes
- One-shot policy: the auto-prompt fires at most once per launch; disconnect → reconnect does not re-prompt, and a confirmed-unlocked startup ends the boot-hidden phase so later lock transitions never reveal the window.
- The typingView auto-restore path is now also gated on `unlockStatusKnown` (an unknown unlock status skips the restore instead of prompting).
- After unlock completes (or the device disconnects), the window hides back to the tray via the existing falling-edge logic.

## Testing
- `pnpm lint` / `pnpm typecheck` pass
- `pnpm test`: 6516 passed, 22 skipped
- New `e2e/tray-start-unlock.test.ts` (3/3, virtual device): quits mid-typingView with start-in-tray on, then verifies both restore paths show the unlock screen in a visible window and hide back to tray after unlock