### PR TITLE
fix(build): package build/icon.png so tray and window icons load when packaged

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     },
     "files": [
       "out/**/*",
-      "package.json"
+      "package.json",
+      "build/icon.png"
     ],
     "artifactName": "${productName}-${os}-${arch}.${ext}",
     "generateUpdatesFilesForAllChannels": false,


### PR DESCRIPTION
## Summary
- The packaged AppImage showed a blank tray icon while pnpm-launched runs looked fine. `appIconPath()` (`src/main/app-behavior.ts`) resolves to `<app.asar>/build/icon.png`, but `build.files` only packaged `out/**` and `package.json`, so `nativeImage.createFromPath()` returned an empty image at runtime.
- Add `build/icon.png` to `build.files` so the asset ships inside the asar. Electron reads asar paths transparently, so no code change is needed.
- The `BrowserWindow` icon (`src/main/index.ts`) shares the same path and is fixed by the same change.

## Notes
- `extraResources` + `process.resourcesPath` was considered and rejected: it would add packaging/path branching for no benefit over a single asar asset.
- Linux StatusNotifier receives the decoded `NativeImage`, not the source path, so an asar-backed image is fine; the 1024×1024 PNG is downscaled by the tray host.

## Testing
- `electron-builder --linux dir`: `asar list` now contains `/build/icon.png`, byte-identical to the source (`asar extract-file` + `cmp`)
- Packaged-context runtime check (unpacked binary, isolated `XDG_CONFIG_HOME`, virtual device): `app.isPackaged === true` and `nativeImage.createFromPath(<appPath>/build/icon.png)` loads a non-empty 1024×1024 image
- No source code changes — lint / typecheck / test unaffected