### PR TITLE
chore(build): bump version to 0.4.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump version 0.4.10 → 0.4.11 for the next release.

## Included since v0.4.10
- #279 fix(ui): show unlock screen before tray residency when startup needs unlock
- #280 fix(build): package build/icon.png so tray and window icons load when packaged

## Testing
- Version bump only — CI `check` (lint → test → build) validates the tree