### PR TITLE
refactor(ui): consolidate duplicate i18n keys for shared feature names

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -619,7 +619,6 @@
     "autoAdvance": "自動移動",
     "locked": "ロック中",
     "unlocked": "アンロック",
-    "keyTester": "キーテスター",
     "sync": {
       "pending": "同期待ち",
       "syncing": "同期中...",
@@ -749,7 +748,6 @@
     "defaultLayout": "キーラベル",
     "defaultAutoAdvance": "自動移動",
     "defaultLayerPanelOpen": "レイヤーリスト展開",
-    "defaultBasicViewType": "Basic タブ表示",
     "defaultSplitKeyMode": "キーピッカーでShiftキーを分離",
     "defaultQuickSelect": "キーの即時選択",
     "basicViewTypeList": "LIST",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -619,7 +619,6 @@
     "autoAdvance": "自動移動☆",
     "locked": "ロックちう",
     "unlocked": "アンロックっしょ",
-    "keyTester": "キーテスター☆",
     "sync": {
       "pending": "同期待ちっしょ",
       "syncing": "同期ちう…",
@@ -739,7 +738,6 @@
     "defaultLayout": "キーラベル☆",
     "defaultAutoAdvance": "自動移動っしょ",
     "defaultLayerPanelOpen": "レイヤーリスト広げる☆",
-    "defaultBasicViewType": "Basic タブ表示っしょ",
     "defaultSplitKeyMode": "Shiftキーを分離☆",
     "defaultQuickSelect": "速攻で選択！",
     "basicViewTypeList": "LIST",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -619,7 +619,6 @@
     "autoAdvance": "自動移動",
     "locked": "ロック中どすえ",
     "unlocked": "アンロックどすえ",
-    "keyTester": "キーテスター",
     "sync": {
       "pending": "同期待ちどすえ",
       "syncing": "同期してますえ…",
@@ -739,7 +738,6 @@
     "defaultLayout": "キーラベル",
     "defaultAutoAdvance": "自動移動",
     "defaultLayerPanelOpen": "レイヤーリスト展開",
-    "defaultBasicViewType": "Basic タブ表示",
     "defaultSplitKeyMode": "キーピッカーでShiftキーを分離",
     "defaultQuickSelect": "キーの即時選択",
     "basicViewTypeList": "LIST",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -619,7 +619,6 @@
     "autoAdvance": "自動巡回",
     "locked": "封印中",
     "unlocked": "開放済み",
-    "keyTester": "試打室",
     "sync": {
       "pending": "足並みの待ち",
       "syncing": "足並みを揃えております...",
@@ -739,7 +738,6 @@
     "defaultLayout": "名札",
     "defaultAutoAdvance": "自動巡回",
     "defaultLayerPanelOpen": "階層一覧の展開",
-    "defaultBasicViewType": "Basic の見栄え",
     "defaultSplitKeyMode": "Shift を別々に",
     "defaultQuickSelect": "即座の選択",
     "basicViewTypeList": "一覧",

--- a/src/renderer/components/StatusBar.tsx
+++ b/src/renderer/components/StatusBar.tsx
@@ -109,7 +109,7 @@ export function StatusBar({
         )}
         {matrixMode && !typingTestMode && (
           <>
-            <span data-testid="matrix-status">{t('statusBar.keyTester')}</span>
+            <span data-testid="matrix-status">{t('editor.keyTester.title')}</span>
             <span className="text-edge">|</span>
           </>
         )}

--- a/src/renderer/components/__tests__/StatusBar.test.tsx
+++ b/src/renderer/components/__tests__/StatusBar.test.tsx
@@ -10,7 +10,7 @@ const TRANSLATIONS: Record<string, string> = {
   'statusBar.autoAdvance': 'Auto Move',
   'statusBar.locked': 'Locked',
   'statusBar.unlocked': 'Unlocked',
-  'statusBar.keyTester': 'Key Tester',
+  'editor.keyTester.title': 'Key Tester',
   'app.analyzeTab': 'Analyze',
   'statusBar.sync.pending': 'Pending',
   'statusBar.sync.syncing': 'Syncing...',

--- a/src/renderer/components/settings-modal/SettingsToolsTab.tsx
+++ b/src/renderer/components/settings-modal/SettingsToolsTab.tsx
@@ -282,7 +282,7 @@ export function SettingsToolsTab({
         <div className="grid grid-cols-2 gap-3">
           <div className={ROW_CLASS} data-testid="settings-default-basic-view-type-row">
             <label htmlFor="settings-default-basic-view-type-selector" className="text-sm font-medium text-content">
-              {t('settings.defaultBasicViewType')}
+              {t('editorSettings.basicViewType')}
             </label>
             <select
               id="settings-default-basic-view-type-selector"

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -619,7 +619,6 @@
     "autoAdvance": "Auto Move",
     "locked": "Locked",
     "unlocked": "Unlocked",
-    "keyTester": "Key Tester",
     "sync": {
       "pending": "Pending",
       "syncing": "Syncing...",
@@ -749,7 +748,6 @@
     "defaultLayout": "Key Labels",
     "defaultAutoAdvance": "Auto Move",
     "defaultLayerPanelOpen": "Layer List Open",
-    "defaultBasicViewType": "Basic Tab View",
     "defaultSplitKeyMode": "Separate Shift in Key Picker",
     "defaultQuickSelect": "Instant Key Selection",
     "basicViewTypeList": "LIST",


### PR DESCRIPTION
## Summary

Follow-up to #287's key unification: consolidate the two remaining same-feature duplicate i18n key pairs so each feature name lives in exactly one key — a future rename cannot miss a surface.

- **Key Tester**: status bar label switches to `editor.keyTester.title` (feature-owning key); `statusBar.keyTester` removed from english + all four packs
- **Basic Tab View**: the Settings → Defaults row switches to `editorSettings.basicViewType`; `settings.defaultBasicViewType` removed. Verified the sibling default rows carry no "Default X" wording (the section heading provides that context), so the unified label reads naturally
- Key removals only — pack `version` stays 0.1.21 (no installed-pack invalidation); i18n coverage suite agrees
- Motivating evidence: the ギャル pack's two "Basic Tab View" values had already drifted (「っしょ」 vs 「☆」) — exactly the divergence this prevents

## Test plan

- [x] Full unit suite: 274 files / 6641 tests pass
- [x] i18n coverage suite passes, all five JSON files parse, versions unchanged
- [x] `pnpm typecheck` / ESLint clean
- [x] Operation guide grep: existing mentions already match; no doc changes needed