### PR TITLE
chore(build): bump version to 0.4.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary

Version bump for the 0.4.12 release: the pack manager modal unification and its follow-ups (shared shell, drag reorder + Name sort everywhere, sorted insert + import feedback, orderable built-in English, ownership-gated delete cascade), the editor footer Analyze button, the keymap rewrite flash cue, the key-label keymap-apply feature set, and the new keymap-applicable sample packs.

## Test plan

- [x] package.json only, mirroring the 0.4.11 bump (#281)
- [x] CI (lint → test → build) gates the merge