### PR TITLE
feat(ui): flash affected keys on undo/redo and unify flash timing

### DIFF
--- a/src/renderer/components/editors/KeyboardPane.tsx
+++ b/src/renderer/components/editors/KeyboardPane.tsx
@@ -25,8 +25,8 @@ export interface KeyboardPaneProps {
   pressedKeys?: Set<string>
   everPressedKeys?: Set<string>
   remappedKeys: Set<string>
-  /** Post-rewrite flash state after a bulk keymap rewrite — see
-   *  `KeyboardWidget`'s `flash`. */
+  /** Flash state after a bulk keymap rewrite or a successful undo/redo —
+   *  see `KeyboardWidget`'s `flash`. */
   flash?: KeyFlashState
   multiSelectedKeys?: Set<string>
   layoutOptions: Map<number, number>

--- a/src/renderer/components/editors/KeyboardPane.tsx
+++ b/src/renderer/components/editors/KeyboardPane.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { KeyboardWidget } from '../keyboard/KeyboardWidget'
-import type { KeyFlashState } from '../keyboard/KeyboardWidget'
+import type { KeyFlashState } from '../keyboard/key-flash'
 import type { KleKey } from '../../../shared/kle/types'
 import type { TypingHeatmapCell } from '../../../shared/types/typing-analytics'
 

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -14,7 +14,8 @@ import type { KeymapEditorProps as Props } from './keymap-editor-types'
 import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export type { KeymapEditorHandle } from './keymap-editor-types'
 import { KeyboardPane } from './KeyboardPane'
-import type { KeyFlashState } from '../keyboard/KeyboardWidget'
+import { KEY_FLASH_DURATION_MS } from '../keyboard/key-flash'
+import type { KeyFlashState } from '../keyboard/key-flash'
 import { LayerListPanel } from './LayerListPanel'
 import { ScaleInput, ghostZoomButtonClass, KeymapToolbar } from './keymap-editor-toolbar'
 import { PopoverForState } from './keymap-editor-popover'
@@ -252,8 +253,8 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   // timeline instead of restarting their own fade. `flashTimeoutRef` is
   // the single in-flight clear timer; a second successful apply (or
   // unmount) always clears it before scheduling/leaving so two windows
-  // never race. The 1300ms duration matches `key-flash`'s total animation
-  // length exactly, so the overlay is never unmounted mid-fade.
+  // never race. `KEY_FLASH_DURATION_MS` matches `key-flash`'s total
+  // animation length exactly, so the overlay is never unmounted mid-fade.
   const [flashBatch, setFlashBatch] = useState<{ entries: SingleHistoryEntry[]; generation: number; startedAt: number } | null>(null)
   const flashGenerationRef = useRef(0)
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -350,7 +351,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           flashTimeoutRef.current = setTimeout(() => {
             setFlashBatch(null)
             flashTimeoutRef.current = null
-          }, 1300)
+          }, KEY_FLASH_DURATION_MS)
         }
       }
       return { appliedCount: applied.length, error }

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useCallback, useEffect, useMemo, useRef, useState, useImperativeHandle, forwardRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useImperativeHandle, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
 import { useTileContentOverride } from '../../hooks/useTileContentOverride'
@@ -14,8 +14,6 @@ import type { KeymapEditorProps as Props } from './keymap-editor-types'
 import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export type { KeymapEditorHandle } from './keymap-editor-types'
 import { KeyboardPane } from './KeyboardPane'
-import { KEY_FLASH_DURATION_MS } from '../keyboard/key-flash'
-import type { KeyFlashState } from '../keyboard/key-flash'
 import { LayerListPanel } from './LayerListPanel'
 import { ScaleInput, ghostZoomButtonClass, KeymapToolbar } from './keymap-editor-toolbar'
 import { PopoverForState } from './keymap-editor-popover'
@@ -26,7 +24,7 @@ import { useLayoutOptionsPanel } from './useLayoutOptionsPanel'
 import { useKeymapSelectionHandlers } from './useKeymapSelectionHandlers'
 import { useKeymapHistory } from './useKeymapHistory'
 import type { SingleHistoryEntry } from './useKeymapHistory'
-import { posKey } from '../../../shared/kle/pos-key'
+import { useKeyFlash } from './useKeyFlash'
 import { rewriteNumericKeycode } from '../../../shared/keymap/keymap-apply'
 import type { KeymapRewriteTable, KeymapRewriteLayoutIds } from '../../../shared/keymap/keymap-apply'
 import type { KeymapApplyResult } from './keymap-editor-types'
@@ -127,6 +125,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   const { config: appCfg } = useAppConfig()
   const history = useKeymapHistory(appCfg.maxKeymapHistory)
 
+  // --- Key flash (Key Label "apply to keymap" bulk rewrite, and undo/redo)
+  // — must run before `useKeymapSelectionHandlers` below so `triggerFlash`
+  // exists to pass in as `onHistoryApplied`. ---
+  const { flash, triggerFlash } = useKeyFlash(currentLayer)
+
   // --- Selection + handlers ---
   const {
     selectedKey, selectedEncoder, selectedMaskPart, popoverState, setPopoverState,
@@ -144,6 +147,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     onSetKey, onSetKeysBulk, onSetEncoder, unlocked, onUnlock,
     multiSelect, history,
     onAppliedKeymapLayoutChange,
+    onHistoryApplied: triggerFlash,
     tapDanceEntries, onSetTapDanceEntry,
     macroCount, macroBufferSize, macroBuffer, onSaveMacros,
   })
@@ -240,28 +244,6 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     return () => { isMountedRef.current = false }
   }, [])
 
-  // Post-apply "flash" — briefly paints the just-rewritten positions in
-  // the selection colour (KeyWidget's `flashed`, a `key-flash` CSS
-  // keyframe overlay — see style.css). Holds the raw applied batch (not
-  // yet layer-filtered) so the derived `flash` memo below can re-slice it
-  // if the user switches layers during the window. `generation` bumps on
-  // every successful apply so KeyWidget remounts (and thus restarts) the
-  // overlay on a re-apply instead of reusing a DOM node whose animation
-  // may already be finished; `startedAt` is the wall-clock apply time so
-  // KeyWidget can compute a negative `animation-delay` for overlays that
-  // mount late (e.g. a layer switch mid-window), keeping them on the same
-  // timeline instead of restarting their own fade. `flashTimeoutRef` is
-  // the single in-flight clear timer; a second successful apply (or
-  // unmount) always clears it before scheduling/leaving so two windows
-  // never race. `KEY_FLASH_DURATION_MS` matches `key-flash`'s total
-  // animation length exactly, so the overlay is never unmounted mid-fade.
-  const [flashBatch, setFlashBatch] = useState<{ entries: SingleHistoryEntry[]; generation: number; startedAt: number } | null>(null)
-  const flashGenerationRef = useRef(0)
-  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  useEffect(() => () => {
-    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current)
-  }, [])
-
   const applyKeymapRewrite = useCallback(async (
     table: KeymapRewriteTable,
     layoutIds?: KeymapRewriteLayoutIds,
@@ -342,41 +324,17 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         // in sync afterwards via the same callback (useKeymapSelectionHandlers).
         if (bookkeepable) onAppliedKeymapLayoutChange?.(bookkeepable.after)
 
-        // Flash the rewritten positions — only for a clean, error-free
-        // pass. A partial failure leaves the keymap mixed, which isn't
-        // the "here's what changed" story this visual is telling.
-        if (error === undefined) {
-          if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current)
-          setFlashBatch({ entries: applied, generation: ++flashGenerationRef.current, startedAt: Date.now() })
-          flashTimeoutRef.current = setTimeout(() => {
-            setFlashBatch(null)
-            flashTimeoutRef.current = null
-          }, KEY_FLASH_DURATION_MS)
-        }
+        // Flash the rewritten positions (see `useKeyFlash`) — only for a
+        // clean, error-free pass. A partial failure leaves the keymap
+        // mixed, which isn't the "here's what changed" story this visual
+        // is telling.
+        if (error === undefined) triggerFlash(applied)
       }
       return { appliedCount: applied.length, error }
     } finally {
       isApplyingRewriteRef.current = false
     }
-  }, [keymap, encoderLayout, onSetKey, onSetEncoder, history, onAppliedKeymapLayoutChange])
-
-  // Re-slice the raw flash batch down to the current layer's key positions
-  // on every layer change — switching layers during the window is
-  // intended to flash whatever the newly-visible layer had rewritten,
-  // rather than freezing the set at apply time. Encoder entries are
-  // omitted: flash isn't threaded to EncoderWidget (see KeyboardWidget's
-  // `KeyFlashState` comment). `generation`/`startedAt` pass through
-  // unchanged from the batch — they describe the apply event itself, not
-  // the per-layer position set.
-  const flash = useMemo<KeyFlashState | undefined>(() => {
-    if (!flashBatch) return undefined
-    const positions = new Set<string>()
-    for (const entry of flashBatch.entries) {
-      if (entry.kind === 'key' && entry.layer === currentLayer) positions.add(posKey(entry.row, entry.col))
-    }
-    if (positions.size === 0) return undefined
-    return { keys: positions, generation: flashBatch.generation, startedAt: flashBatch.startedAt }
-  }, [flashBatch, currentLayer])
+  }, [keymap, encoderLayout, onSetKey, onSetEncoder, history, onAppliedKeymapLayoutChange, triggerFlash])
 
   useImperativeHandle(ref, () => ({
     toggleMatrix: handleMatrixToggle, toggleTypingTest: handleTypingTestToggle,

--- a/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
@@ -429,7 +429,7 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       vi.useRealTimers()
     })
 
-    it('flashes the rewritten key positions on the current layer, then clears after the key-flash keyframe duration (1300ms)', async () => {
+    it('flashes the rewritten key positions on the current layer, then clears after the key-flash keyframe duration (700ms)', async () => {
       vi.useFakeTimers()
       const ref = createRef<KeymapEditorHandle>()
       render(<KeymapEditor ref={ref} {...defaultProps} />)
@@ -448,9 +448,9 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       // threaded to EncoderWidget (see KeyboardWidget's `KeyFlashState` doc).
       expect(lastFlashKeys()).toEqual(new Set(['0,0']))
 
-      // Matches style.css's `key-flash` keyframe (1300ms total) exactly,
+      // Matches style.css's `key-flash` keyframe (700ms total) exactly,
       // so the overlay is never unmounted mid-fade.
-      act(() => { vi.advanceTimersByTime(1300) })
+      act(() => { vi.advanceTimersByTime(700) })
       expect(lastFlash()).toBeUndefined()
     })
 
@@ -527,7 +527,7 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       // Let the first flash's timer fire, then advance the clock and
       // apply again — a fresh apply event must get its own generation
       // and its own wall-clock start time, not reuse the first one's.
-      act(() => { vi.advanceTimersByTime(1300) })
+      act(() => { vi.advanceTimersByTime(700) })
       expect(lastFlash()).toBeUndefined()
 
       // The mocked `onSetKey` doesn't mutate the `keymap` prop (this test

--- a/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
@@ -143,7 +143,7 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
     capturedCanRedo = false
   })
 
-  interface CapturedFlash { keys: Set<string>; generation: number; startedAt: number }
+  interface CapturedFlash { keys: Set<string>; encoders: Set<string>; generation: number; startedAt: number }
 
   function lastFlash(): CapturedFlash | undefined {
     const widget = capturedWidgetProps[capturedWidgetProps.length - 1]
@@ -460,7 +460,7 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       vi.useRealTimers()
     })
 
-    it('flashes the rewritten key positions on the current layer, then clears after the key-flash keyframe duration (700ms)', async () => {
+    it('flashes the rewritten key AND encoder positions on the current layer, then clears after the key-flash keyframe duration (700ms)', async () => {
       vi.useFakeTimers()
       const ref = createRef<KeymapEditorHandle>()
       render(<KeymapEditor ref={ref} {...defaultProps} />)
@@ -474,15 +474,30 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
         await ref.current!.applyKeymapRewrite(table)
       })
 
-      // [0,0,0] was rewritten — flash carries its "row,col" position.
-      // The encoder rewrite at [0,0,0] is NOT reflected here: flash isn't
-      // threaded to EncoderWidget (see KeyboardWidget's `KeyFlashState` doc).
+      // [0,0] key and the idx=0/dir=0 encoder were both rewritten.
       expect(lastFlashKeys()).toEqual(new Set(['0,0']))
+      expect(lastFlash()?.encoders).toEqual(new Set(['0,0']))
 
       // Matches style.css's `key-flash` keyframe (700ms total) exactly,
       // so the overlay is never unmounted mid-fade.
       act(() => { vi.advanceTimersByTime(700) })
       expect(lastFlash()).toBeUndefined()
+    })
+
+    it('flashes only the encoder position (keys empty) when the rewrite touches an encoder alone', async () => {
+      vi.useFakeTimers()
+      const ref = createRef<KeymapEditorHandle>()
+      render(<KeymapEditor ref={ref} {...defaultProps} />)
+
+      await act(async () => {
+        await ref.current!.applyKeymapRewrite(new Map([['KC_7', 'KC_70']]))
+      })
+
+      // An encoder-only rewrite must still open a flash window — `keys`
+      // staying empty must not suppress it.
+      expect(lastFlash()).not.toBeUndefined()
+      expect(lastFlashKeys()).toEqual(new Set())
+      expect(lastFlash()?.encoders).toEqual(new Set(['0,0']))
     })
 
     it('does not populate flash when the rewrite matches nothing', async () => {
@@ -539,7 +554,7 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       expect(lastFlash()).toBeUndefined()
 
       rerender(<KeymapEditor ref={ref} {...defaultProps} layers={2} currentLayer={0} />)
-      expect(lastFlash()).toEqual({ keys: new Set(['0,0']), generation, startedAt })
+      expect(lastFlash()).toEqual({ keys: new Set(['0,0']), encoders: new Set(), generation, startedAt })
     })
 
     it('bumps the generation and refreshes startedAt on a second successful apply', async () => {
@@ -602,6 +617,51 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       act(() => { vi.advanceTimersByTime(700) })
       return ref
     }
+
+    // Same shape as `renderWithRewrittenKey` above but rewrites only the
+    // idx=0/dir=0 encoder (KC_7 at defaultProps' `encoderLayout`), leaving
+    // no key entry on the pushed batch — proving an encoder-only undo/redo
+    // still opens a flash window (`keys` stays empty, `encoders` doesn't).
+    async function renderWithRewrittenEncoder() {
+      const ref = createRef<KeymapEditorHandle>()
+      render(<KeymapEditor ref={ref} {...defaultProps} />)
+      await act(async () => {
+        await ref.current!.applyKeymapRewrite(new Map([['KC_7', 'KC_70']]))
+      })
+      act(() => { vi.advanceTimersByTime(700) })
+      return ref
+    }
+
+    it('encoder-only undo flashes the encoder position (keys stays empty), then clears after 700ms', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenEncoder()
+      expect(lastFlash()).toBeUndefined()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+
+      expect(lastFlashKeys()).toEqual(new Set())
+      expect(lastFlash()?.encoders).toEqual(new Set(['0,0']))
+
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+    })
+
+    it('encoder-only redo flashes the encoder position likewise', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenEncoder()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true }) })
+
+      expect(lastFlashKeys()).toEqual(new Set())
+      expect(lastFlash()?.encoders).toEqual(new Set(['0,0']))
+
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+    })
 
     it('undo flashes the affected key position(s) on the current layer, then clears after 700ms', async () => {
       vi.useFakeTimers()

--- a/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-applyRewrite.test.tsx
@@ -23,6 +23,33 @@ vi.mock('../../keyboard/KeyboardWidget', () => ({
   },
 }))
 
+// Captures the toolbar's `onUndo`/`onRedo` (== `handleUndo`/`handleRedo`
+// from useKeymapSelectionHandlers) directly so the undo/redo-failure tests
+// below can `await` the call themselves. The real buttons wire these up as
+// `onClick={() => void onUndo()}` — fire-and-forget — so triggering a
+// rejection through a click or the Ctrl+Z window shortcut would leave an
+// unhandled rejection behind once the mocked device write rejects. Calling
+// the captured function directly and awaiting it here keeps the rejection
+// inside this test's own control flow instead.
+let capturedOnUndo: (() => Promise<void>) | undefined
+let capturedOnRedo: (() => Promise<void>) | undefined
+let capturedCanUndo = false
+let capturedCanRedo = false
+
+vi.mock('../keymap-editor-toolbar', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../keymap-editor-toolbar')>()
+  return {
+    ...actual,
+    KeymapToolbar: (props: { canUndo: boolean; canRedo: boolean; onUndo: () => Promise<void>; onRedo: () => Promise<void> }) => {
+      capturedOnUndo = props.onUndo
+      capturedOnRedo = props.onRedo
+      capturedCanUndo = props.canUndo
+      capturedCanRedo = props.canRedo
+      return <div data-testid="keymap-toolbar" />
+    },
+  }
+})
+
 vi.mock('../../keycodes/TabbedKeycodes', () => ({
   TabbedKeycodes: () => <div data-testid="tabbed-keycodes">TabbedKeycodes</div>,
 }))
@@ -110,6 +137,10 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
     onSetKeysBulk.mockResolvedValue(undefined)
     onSetEncoder.mockResolvedValue(undefined)
     capturedWidgetProps = []
+    capturedOnUndo = undefined
+    capturedOnRedo = undefined
+    capturedCanUndo = false
+    capturedCanRedo = false
   })
 
   interface CapturedFlash { keys: Set<string>; generation: number; startedAt: number }
@@ -542,6 +573,154 @@ describe('KeymapEditor — applyKeymapRewrite (Key Label apply-to-keymap)', () =
       const second = lastFlash()!
       expect(second.generation).toBe(2)
       expect(second.startedAt).toBe(1_010_000)
+    })
+  })
+
+  // --- Undo/redo flash (onHistoryApplied → triggerFlash, useKeyFlash) ---
+  // Reuses this file's rewrite harness to build a one-entry history batch
+  // (via `applyKeymapRewrite`) rather than driving the keycode picker —
+  // `KeymapEditor.undo.test.tsx`'s `KeyboardWidget` mock doesn't capture
+  // `flash`, so these live here alongside the rest of the flash coverage.
+
+  describe('undo/redo flash (onHistoryApplied → triggerFlash)', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    // Shared setup for every test below: mount the editor, apply a
+    // single-key rewrite (KC_5 at [0,0] -> KC_50), and let its own
+    // post-apply flash elapse — each test then starts from a clean flash
+    // state with exactly one entry sitting on the undo stack. Requires
+    // `vi.useFakeTimers()` to already be active (each test sets its own,
+    // since one needs `vi.setSystemTime` first).
+    async function renderWithRewrittenKey() {
+      const ref = createRef<KeymapEditorHandle>()
+      render(<KeymapEditor ref={ref} {...defaultProps} />)
+      await act(async () => {
+        await ref.current!.applyKeymapRewrite(new Map([['KC_5', 'KC_50']]))
+      })
+      act(() => { vi.advanceTimersByTime(700) })
+      return ref
+    }
+
+    it('undo flashes the affected key position(s) on the current layer, then clears after 700ms', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenKey()
+      expect(lastFlash()).toBeUndefined()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+
+      expect(lastFlashKeys()).toEqual(new Set(['0,0']))
+
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+    })
+
+    it('redo flashes the affected key position(s) likewise', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenKey()
+
+      // Undo, then let its own flash window elapse before checking redo.
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true }) })
+
+      expect(lastFlashKeys()).toEqual(new Set(['0,0']))
+
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+    })
+
+    it('a failed undo does not flash and does not advance history', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenKey()
+      expect(lastFlash()).toBeUndefined()
+      expect(capturedCanUndo).toBe(true)
+      expect(capturedCanRedo).toBe(false)
+
+      // The batch's single key entry is applied via `onSetKeysBulk` inside
+      // `applyHistoryEntry` — reject just that one call.
+      onSetKeysBulk.mockRejectedValueOnce(new Error('device write failed'))
+
+      // Call the toolbar's captured `onUndo` (== `handleUndo`) directly and
+      // await it ourselves — the real button/keyboard-shortcut paths both
+      // fire it as `void onUndo()`, which would otherwise leave this
+      // rejection as an unhandled promise once the mock rejects.
+      await act(async () => {
+        await expect(capturedOnUndo!()).rejects.toThrow('device write failed')
+      })
+
+      // The write failed before the history commit — nothing to flash.
+      expect(lastFlash()).toBeUndefined()
+      // History wasn't advanced: still undo-able, still nothing to redo.
+      expect(capturedCanUndo).toBe(true)
+      expect(capturedCanRedo).toBe(false)
+
+      // A retried undo (this time the write succeeds) still reverts the
+      // ORIGINAL entry — proving the failed attempt didn't silently pop it.
+      onSetKeysBulk.mockClear()
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+      expect(onSetKeysBulk).toHaveBeenCalledWith([{ layer: 0, row: 0, col: 0, keycode: 5 }])
+      expect(lastFlashKeys()).toEqual(new Set(['0,0']))
+    })
+
+    it('a failed redo does not flash and does not advance history', async () => {
+      vi.useFakeTimers()
+      await renderWithRewrittenKey()
+
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+      act(() => { vi.advanceTimersByTime(700) })
+      expect(lastFlash()).toBeUndefined()
+      expect(capturedCanUndo).toBe(false)
+      expect(capturedCanRedo).toBe(true)
+
+      onSetKeysBulk.mockRejectedValueOnce(new Error('device write failed'))
+
+      await act(async () => {
+        await expect(capturedOnRedo!()).rejects.toThrow('device write failed')
+      })
+
+      expect(lastFlash()).toBeUndefined()
+      // History wasn't advanced: still redo-able, still nothing to undo.
+      expect(capturedCanUndo).toBe(false)
+      expect(capturedCanRedo).toBe(true)
+
+      onSetKeysBulk.mockClear()
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true }) })
+      expect(onSetKeysBulk).toHaveBeenCalledWith([{ layer: 0, row: 0, col: 0, keycode: 50 }])
+      expect(lastFlashKeys()).toEqual(new Set(['0,0']))
+    })
+
+    it('undo followed quickly by redo within the flash window bumps the generation instead of the stale timer wiping the new flash', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(2_000_000)
+      await renderWithRewrittenKey()
+      expect(lastFlash()).toBeUndefined()
+
+      // Undo starts a flash window at T0.
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true }) })
+      const afterUndo = lastFlash()!
+      expect(afterUndo.keys).toEqual(new Set(['0,0']))
+
+      // Redo fires 200ms later — well within the undo's 700ms window.
+      act(() => { vi.advanceTimersByTime(200) })
+      await act(async () => { fireEvent.keyDown(window, { key: 'z', ctrlKey: true, shiftKey: true }) })
+      const afterRedo = lastFlash()!
+      expect(afterRedo.generation).toBeGreaterThan(afterUndo.generation)
+      expect(afterRedo.keys).toEqual(new Set(['0,0']))
+
+      // 500ms later lands at T0+700 — exactly when the undo's OWN timer
+      // would have cleared the flash had the redo's trigger not cancelled
+      // it. The redo's flash must still be showing, unchanged.
+      act(() => { vi.advanceTimersByTime(500) })
+      expect(lastFlash()).toEqual(afterRedo)
+
+      // The redo's own 700ms window (started at T0+200) ends at T0+900 —
+      // 200ms further from here.
+      act(() => { vi.advanceTimersByTime(200) })
+      expect(lastFlash()).toBeUndefined()
     })
   })
 })

--- a/src/renderer/components/editors/useKeyFlash.ts
+++ b/src/renderer/components/editors/useKeyFlash.ts
@@ -70,22 +70,25 @@ export function useKeyFlash(currentLayer: number): UseKeyFlashReturn {
     }, KEY_FLASH_DURATION_MS)
   }, [])
 
-  // Re-slice the raw flash batch down to the current layer's key positions
-  // on every layer change — switching layers during the window is
-  // intended to flash whatever the newly-visible layer had changed,
-  // rather than freezing the set at trigger time. Encoder entries are
-  // omitted: flash isn't threaded to EncoderWidget (see KeyboardWidget's
-  // `KeyFlashState` comment). `generation`/`startedAt` pass through
-  // unchanged from the batch — they describe the trigger event itself,
-  // not the per-layer position set.
+  // Re-slice the raw flash batch down to the current layer's key/encoder
+  // positions on every layer change — switching layers during the window
+  // is intended to flash whatever the newly-visible layer had changed,
+  // rather than freezing the set at trigger time. `generation`/`startedAt`
+  // pass through unchanged from the batch — they describe the trigger
+  // event itself, not the per-layer position set.
   const flash = useMemo<KeyFlashState | undefined>(() => {
     if (!flashBatch) return undefined
     const positions = new Set<string>()
+    const encoderPositions = new Set<string>()
     for (const entry of flashBatch.entries) {
-      if (entry.kind === 'key' && entry.layer === currentLayer) positions.add(posKey(entry.row, entry.col))
+      if (entry.layer !== currentLayer) continue
+      if (entry.kind === 'key') positions.add(posKey(entry.row, entry.col))
+      else encoderPositions.add(`${entry.idx},${entry.dir}`)
     }
-    if (positions.size === 0) return undefined
-    return { keys: positions, generation: flashBatch.generation, startedAt: flashBatch.startedAt }
+    // Either set alone is enough to open a flash window — an encoder-only
+    // undo/redo or rewrite must still flash even though `keys` is empty.
+    if (positions.size === 0 && encoderPositions.size === 0) return undefined
+    return { keys: positions, encoders: encoderPositions, generation: flashBatch.generation, startedAt: flashBatch.startedAt }
   }, [flashBatch, currentLayer])
 
   return { flash, triggerFlash }

--- a/src/renderer/components/editors/useKeyFlash.ts
+++ b/src/renderer/components/editors/useKeyFlash.ts
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { KEY_FLASH_DURATION_MS } from '../keyboard/key-flash'
 import type { KeyFlashState } from '../keyboard/key-flash'
-import { posKey } from '../../../shared/kle/pos-key'
+import { posKey, encoderPosKey } from '../../../shared/kle/pos-key'
 import type { SingleHistoryEntry } from './useKeymapHistory'
 
 export interface UseKeyFlashReturn {
@@ -83,7 +83,7 @@ export function useKeyFlash(currentLayer: number): UseKeyFlashReturn {
     for (const entry of flashBatch.entries) {
       if (entry.layer !== currentLayer) continue
       if (entry.kind === 'key') positions.add(posKey(entry.row, entry.col))
-      else encoderPositions.add(`${entry.idx},${entry.dir}`)
+      else encoderPositions.add(encoderPosKey(entry.idx, entry.dir))
     }
     // Either set alone is enough to open a flash window — an encoder-only
     // undo/redo or rewrite must still flash even though `keys` is empty.

--- a/src/renderer/components/editors/useKeyFlash.ts
+++ b/src/renderer/components/editors/useKeyFlash.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { KEY_FLASH_DURATION_MS } from '../keyboard/key-flash'
+import type { KeyFlashState } from '../keyboard/key-flash'
+import { posKey } from '../../../shared/kle/pos-key'
+import type { SingleHistoryEntry } from './useKeymapHistory'
+
+export interface UseKeyFlashReturn {
+  /** Positions to flash on the current layer, or `undefined` when no flash
+   *  is in-window (or nothing landed on this layer — see the re-slice
+   *  memo below). Threaded straight through to `KeyboardPane`. */
+  flash: KeyFlashState | undefined
+  /** Start (or restart) a flash window over `entries`. Called after a Key
+   *  Label "apply to keymap" bulk rewrite AND after a successful undo/redo
+   *  (see `useKeymapSelectionHandlers`'s `onHistoryApplied`). No-op for an
+   *  empty array (nothing to flash) and for calls that arrive after the
+   *  owning component has unmounted. */
+  triggerFlash: (entries: SingleHistoryEntry[]) => void
+}
+
+/**
+ * Shared "flash" visual state for the Key Label "apply to keymap" bulk
+ * rewrite and for undo/redo: briefly paints the just-changed positions in
+ * the selection colour (KeyWidget's `flashed`, a `key-flash` CSS keyframe
+ * overlay — see style.css).
+ *
+ * Holds the raw triggered batch (not yet layer-filtered) so the derived
+ * `flash` memo below can re-slice it if the user switches layers during
+ * the window. `generation` bumps on every trigger so `KeyWidget` remounts
+ * (and thus restarts) the overlay on a re-trigger instead of reusing a DOM
+ * node whose animation may already be finished; `startedAt` is the
+ * wall-clock trigger time so `KeyWidget` can compute a negative
+ * `animation-delay` for overlays that mount late (e.g. a layer switch
+ * mid-window), keeping them on the same timeline instead of restarting
+ * their own fade. `flashTimeoutRef` is the single in-flight clear timer; a
+ * second trigger (or unmount) always clears it before scheduling/leaving
+ * so two flash windows never race. `KEY_FLASH_DURATION_MS` matches
+ * `key-flash`'s total animation length exactly, so the overlay is never
+ * unmounted mid-fade.
+ */
+export function useKeyFlash(currentLayer: number): UseKeyFlashReturn {
+  const [flashBatch, setFlashBatch] = useState<{ entries: SingleHistoryEntry[]; generation: number; startedAt: number } | null>(null)
+  const flashGenerationRef = useRef(0)
+  const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Unmount guard: undo/redo fires `triggerFlash` only after its awaited
+  // device writes resolve, which can land after the owning component
+  // (KeymapEditor) has already unmounted mid-navigation. A late trigger
+  // must be a no-op rather than scheduling a state update / timer that
+  // nobody will ever clear.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current)
+    }
+  }, [])
+
+  const triggerFlash = useCallback((entries: SingleHistoryEntry[]) => {
+    if (!isMountedRef.current) return
+    // Nothing to flash — don't open a window for an empty batch.
+    if (entries.length === 0) return
+    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current)
+    setFlashBatch({ entries, generation: ++flashGenerationRef.current, startedAt: Date.now() })
+    flashTimeoutRef.current = setTimeout(() => {
+      setFlashBatch(null)
+      flashTimeoutRef.current = null
+    }, KEY_FLASH_DURATION_MS)
+  }, [])
+
+  // Re-slice the raw flash batch down to the current layer's key positions
+  // on every layer change — switching layers during the window is
+  // intended to flash whatever the newly-visible layer had changed,
+  // rather than freezing the set at trigger time. Encoder entries are
+  // omitted: flash isn't threaded to EncoderWidget (see KeyboardWidget's
+  // `KeyFlashState` comment). `generation`/`startedAt` pass through
+  // unchanged from the batch — they describe the trigger event itself,
+  // not the per-layer position set.
+  const flash = useMemo<KeyFlashState | undefined>(() => {
+    if (!flashBatch) return undefined
+    const positions = new Set<string>()
+    for (const entry of flashBatch.entries) {
+      if (entry.kind === 'key' && entry.layer === currentLayer) positions.add(posKey(entry.row, entry.col))
+    }
+    if (positions.size === 0) return undefined
+    return { keys: positions, generation: flashBatch.generation, startedAt: flashBatch.startedAt }
+  }, [flashBatch, currentLayer])
+
+  return { flash, triggerFlash }
+}

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -443,8 +443,16 @@ export function useKeymapSelectionHandlers({
     // this line already guarantees the apply + commit succeeded — no flag
     // needed to gate it. Placement after the commit is what guarantees
     // `onHistoryApplied` can no longer un-commit the undo/redo or leave the
-    // in-flight guard stuck.
-    onHistoryApplied?.(entry.kind === 'batch' ? entry.entries : [entry])
+    // in-flight guard stuck. The flash it triggers is purely cosmetic, so a
+    // throw from the callback itself is swallowed here rather than
+    // rejecting `runHistoryStep`'s promise — the undo/redo already
+    // succeeded and must not be reported as failed just because the flash
+    // visual couldn't be shown.
+    try {
+      onHistoryApplied?.(entry.kind === 'batch' ? entry.entries : [entry])
+    } catch {
+      // Intentionally ignored — see comment above.
+    }
   }, [history, applyHistoryEntry, onHistoryApplied])
 
   const handleUndo = useCallback(() => runHistoryStep(true), [runHistoryStep])

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -430,19 +430,21 @@ export function useKeymapSelectionHandlers({
     const entry = isUndo ? history.peekUndo : history.peekRedo
     if (!entry) return
     undoRedoInFlightRef.current = true
-    let applied = false
     try {
       await applyHistoryEntry(entry, isUndo)
       // Commit only after successful apply.
       if (isUndo) history.undo()
       else history.redo()
-      applied = true
     } finally { undoRedoInFlightRef.current = false }
     setPopoverState(null)
-    // Fire outside the try/finally above: `onHistoryApplied` only runs once
-    // the apply + commit are already done, so a throw from it can no
-    // longer un-commit the undo/redo or leave the in-flight guard stuck.
-    if (applied) onHistoryApplied?.(entry.kind === 'batch' ? entry.entries : [entry])
+    // Fire outside the try/finally above: a throw from `applyHistoryEntry`
+    // or the commit call propagates out of the `try` (after `finally`
+    // resets the in-flight guard) and skips everything below, so reaching
+    // this line already guarantees the apply + commit succeeded — no flag
+    // needed to gate it. Placement after the commit is what guarantees
+    // `onHistoryApplied` can no longer un-commit the undo/redo or leave the
+    // in-flight guard stuck.
+    onHistoryApplied?.(entry.kind === 'batch' ? entry.entries : [entry])
   }, [history, applyHistoryEntry, onHistoryApplied])
 
   const handleUndo = useCallback(() => runHistoryStep(true), [runHistoryStep])

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -57,6 +57,16 @@ export interface UseKeymapSelectionOptions {
    *  (one carrying `appliedLayoutBefore`/`appliedLayoutAfter`) — every other
    *  batch/single entry has neither field, so this never fires for them. */
   onAppliedKeymapLayoutChange?: (id: string) => void
+  /** Fires the "flash" visual (see `useKeyFlash`) for the positions an
+   *  undo/redo just touched. Contract: called only after ALL of that
+   *  entry's device writes have succeeded AND the history stack has been
+   *  committed (`history.undo()` / `history.redo()`) — never on a failed
+   *  apply, and never before the commit. An exception thrown by this
+   *  callback must not retroactively mark the undo/redo as failed, so it
+   *  is invoked after `handleUndo`/`handleRedo`'s own try/finally has
+   *  already run to completion. Receives the normalized entry list
+   *  (`entry.kind === 'batch' ? entry.entries : [entry]`). */
+  onHistoryApplied?: (entries: SingleHistoryEntry[]) => void
   // TD/Macro
   tapDanceEntries?: TapDanceEntry[]
   onSetTapDanceEntry?: (index: number, entry: TapDanceEntry) => Promise<void>
@@ -82,6 +92,7 @@ export function useKeymapSelectionHandlers({
   multiSelect,
   history,
   onAppliedKeymapLayoutChange,
+  onHistoryApplied,
   tapDanceEntries,
   onSetTapDanceEntry,
   macroCount,
@@ -411,29 +422,31 @@ export function useKeymapSelectionHandlers({
   // In-flight guard to prevent concurrent undo/redo
   const undoRedoInFlightRef = useRef(false)
 
-  const handleUndo = useCallback(async () => {
+  // Undo and redo differ only in direction (which stack to peek/commit,
+  // and which side of the entry `applyHistoryEntry` restores) — shared here
+  // instead of duplicating the guard/apply/commit/notify sequence twice.
+  const runHistoryStep = useCallback(async (isUndo: boolean) => {
     if (undoRedoInFlightRef.current) return
-    const entry = history.peekUndo
+    const entry = isUndo ? history.peekUndo : history.peekRedo
     if (!entry) return
     undoRedoInFlightRef.current = true
+    let applied = false
     try {
-      await applyHistoryEntry(entry, true)
-      history.undo() // commit only after successful apply
+      await applyHistoryEntry(entry, isUndo)
+      // Commit only after successful apply.
+      if (isUndo) history.undo()
+      else history.redo()
+      applied = true
     } finally { undoRedoInFlightRef.current = false }
     setPopoverState(null)
-  }, [history, applyHistoryEntry])
+    // Fire outside the try/finally above: `onHistoryApplied` only runs once
+    // the apply + commit are already done, so a throw from it can no
+    // longer un-commit the undo/redo or leave the in-flight guard stuck.
+    if (applied) onHistoryApplied?.(entry.kind === 'batch' ? entry.entries : [entry])
+  }, [history, applyHistoryEntry, onHistoryApplied])
 
-  const handleRedo = useCallback(async () => {
-    if (undoRedoInFlightRef.current) return
-    const entry = history.peekRedo
-    if (!entry) return
-    undoRedoInFlightRef.current = true
-    try {
-      await applyHistoryEntry(entry, false)
-      history.redo() // commit only after successful apply
-    } finally { undoRedoInFlightRef.current = false }
-    setPopoverState(null)
-  }, [history, applyHistoryEntry])
+  const handleUndo = useCallback(() => runHistoryStep(true), [runHistoryStep])
+  const handleRedo = useCallback(() => runHistoryStep(false), [runHistoryStep])
 
   const handlePopoverUndo = useCallback(() => {
     if (popoverUndoKeycode == null) return

--- a/src/renderer/components/keyboard/EncoderWidget.tsx
+++ b/src/renderer/components/keyboard/EncoderWidget.tsx
@@ -95,39 +95,41 @@ function EncoderWidgetInner({
     ? flashAnimationDelayMs(flashStartedAt)
     : 0
 
+  // Flash overlay + border redraw (Key Label "apply to keymap" rewrite /
+  // undo/redo): shared by both the masked and non-masked branches below —
+  // painted on top of the outer fill/stroke but below the label text /
+  // inner mask rect, mirroring `KeyWidget`'s `key-flash-overlay`. The
+  // second circle redraws a stroke-only border on top since the overlay's
+  // opaque fill paints over the outer stroke too, keeping the border crisp
+  // for the whole flash (mirrors `KeyWidget`'s `flash-overlay-border`).
+  const flashOverlay = flashed ? (
+    <>
+      <circle
+        key={flashGeneration}
+        cx={cx} cy={cy} r={r}
+        data-testid="flash-overlay"
+        className="key-flash-overlay"
+        fill={KEY_SELECTED_COLOR}
+        style={{ pointerEvents: 'none', animationDelay: `-${flashElapsedMs}ms` }}
+      />
+      <circle
+        cx={cx} cy={cy} r={r}
+        data-testid="flash-overlay-border"
+        fill="none"
+        stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR}
+        strokeWidth={outerBorderActive ? 2 : 1}
+        style={{ pointerEvents: 'none' }}
+      />
+    </>
+  ) : null
+
   if (!masked) {
     const labelLines = keycodeLabel(keycode).split('\n')
     return (
       <g transform={groupTransform} onClick={handleClick} onDoubleClick={handleDoubleClick} style={{ cursor: onClick ? 'pointer' : 'default' }}>
         <circle cx={cx} cy={cy} r={r} fill={fillColor}
           stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR} strokeWidth={outerBorderActive ? 2 : 1} />
-        {/* Flash overlay (Key Label "apply to keymap" rewrite / undo/redo):
-            painted on top of the outer fill/stroke above but below the
-            label text, mirroring `KeyWidget`'s `key-flash-overlay`. */}
-        {flashed && (
-          <circle
-            key={flashGeneration}
-            cx={cx} cy={cy} r={r}
-            data-testid="flash-overlay"
-            className="key-flash-overlay"
-            fill={KEY_SELECTED_COLOR}
-            style={{ pointerEvents: 'none', animationDelay: `-${flashElapsedMs}ms` }}
-          />
-        )}
-        {/* Border redraw: the overlay above paints its opaque fill on top
-            of the outer stroke too, so redraw a stroke-only copy on top to
-            keep the border crisp for the whole flash (mirrors `KeyWidget`'s
-            `flash-overlay-border`). */}
-        {flashed && (
-          <circle
-            cx={cx} cy={cy} r={r}
-            data-testid="flash-overlay-border"
-            fill="none"
-            stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR}
-            strokeWidth={outerBorderActive ? 2 : 1}
-            style={{ pointerEvents: 'none' }}
-          />
-        )}
+        {flashOverlay}
         {labelLines.map((line, i) => (
           <text key={i} x={cx} y={cy + (i - (labelLines.length - 1) / 2) * (fontSize + 2)}
             textAnchor="middle" dominantBaseline="central" fill={labelColor} fontSize={fontSize} fontFamily="sans-serif">
@@ -175,30 +177,11 @@ function EncoderWidgetInner({
       {/* Outer circle */}
       <circle cx={cx} cy={cy} r={r} fill={fillColor}
         stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR} strokeWidth={outerBorderActive ? 2 : 1} />
-      {/* Flash overlay + border redraw: painted above the outer circle but
-          below the inner mask rect and labels (both rendered below), same
-          stacking as the non-masked branch and `KeyWidget`'s masked keys —
-          the inner rect and its label stay visible on top of the overlay. */}
-      {flashed && (
-        <circle
-          key={flashGeneration}
-          cx={cx} cy={cy} r={r}
-          data-testid="flash-overlay"
-          className="key-flash-overlay"
-          fill={KEY_SELECTED_COLOR}
-          style={{ pointerEvents: 'none', animationDelay: `-${flashElapsedMs}ms` }}
-        />
-      )}
-      {flashed && (
-        <circle
-          cx={cx} cy={cy} r={r}
-          data-testid="flash-overlay-border"
-          fill="none"
-          stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR}
-          strokeWidth={outerBorderActive ? 2 : 1}
-          style={{ pointerEvents: 'none' }}
-        />
-      )}
+      {/* Flash overlay: painted above the outer circle but below the inner
+          mask rect and labels (both rendered below), same stacking as the
+          non-masked branch and `KeyWidget`'s masked keys — the inner rect
+          and its label stay visible on top of the overlay. */}
+      {flashOverlay}
       {/* Inner rect clipped to circle — same style as KeyWidget (stroke-only selection) */}
       <rect x={innerRectX} y={innerRectY} width={innerRectW} height={innerRectH}
         rx={innerCorner} ry={innerCorner}

--- a/src/renderer/components/keyboard/EncoderWidget.tsx
+++ b/src/renderer/components/keyboard/EncoderWidget.tsx
@@ -13,12 +13,29 @@ import {
   KEY_INVERTED_TEXT_COLOR,
   KEY_MASK_RECT_COLOR,
 } from './constants'
+import { flashAnimationDelayMs } from './key-flash'
 
 interface Props {
   kleKey: KleKey
   keycode: string
   selected?: boolean
   selectedMaskPart?: boolean
+  /** True for one beat right after a bulk keymap rewrite (Key Label
+   *  "apply to keymap") or an undo/redo lands on this encoder position.
+   *  Mirrors `KeyWidget`'s `flashed` — renders an extra overlay (same fill
+   *  as `selected`, `KEY_SELECTED_COLOR`) on top of the encoder's normal
+   *  fill, fading via the declarative `key-flash` CSS keyframe (style.css)
+   *  once the caller clears the flag. */
+  flashed?: boolean
+  /** Bumped by the caller on every successful apply (`KeyFlashState.generation`
+   *  in `KeyboardWidget`). Used as the overlay element's React `key` so a
+   *  re-apply mid-flash remounts (and thus restarts) the overlay. */
+  flashGeneration?: number
+  /** `Date.now()` at the apply that produced this flash (`KeyFlashState.startedAt`).
+   *  Used to compute a negative `animation-delay` so a late-mounted overlay
+   *  joins the same global fade timeline instead of restarting from full
+   *  opacity. */
+  flashStartedAt?: number
   onClick?: (key: KleKey, direction: number, maskClicked: boolean) => void
   onDoubleClick?: (key: KleKey, direction: number, rect: DOMRect, maskClicked: boolean) => void
   scale?: number
@@ -29,6 +46,9 @@ function EncoderWidgetInner({
   keycode,
   selected,
   selectedMaskPart,
+  flashed,
+  flashGeneration,
+  flashStartedAt,
   onClick,
   onDoubleClick,
   scale = 1,
@@ -68,12 +88,46 @@ function EncoderWidgetInner({
     if (onDoubleClick) { e.stopPropagation(); onDoubleClick(kleKey, kleKey.encoderDir, e.currentTarget.getBoundingClientRect(), false) }
   }
 
+  // How far into the shared `key-flash` timeline this overlay is joining —
+  // same negative `animation-delay` trick as `KeyWidget` (see there for
+  // the full rationale).
+  const flashElapsedMs = flashed && flashStartedAt !== undefined
+    ? flashAnimationDelayMs(flashStartedAt)
+    : 0
+
   if (!masked) {
     const labelLines = keycodeLabel(keycode).split('\n')
     return (
       <g transform={groupTransform} onClick={handleClick} onDoubleClick={handleDoubleClick} style={{ cursor: onClick ? 'pointer' : 'default' }}>
         <circle cx={cx} cy={cy} r={r} fill={fillColor}
           stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR} strokeWidth={outerBorderActive ? 2 : 1} />
+        {/* Flash overlay (Key Label "apply to keymap" rewrite / undo/redo):
+            painted on top of the outer fill/stroke above but below the
+            label text, mirroring `KeyWidget`'s `key-flash-overlay`. */}
+        {flashed && (
+          <circle
+            key={flashGeneration}
+            cx={cx} cy={cy} r={r}
+            data-testid="flash-overlay"
+            className="key-flash-overlay"
+            fill={KEY_SELECTED_COLOR}
+            style={{ pointerEvents: 'none', animationDelay: `-${flashElapsedMs}ms` }}
+          />
+        )}
+        {/* Border redraw: the overlay above paints its opaque fill on top
+            of the outer stroke too, so redraw a stroke-only copy on top to
+            keep the border crisp for the whole flash (mirrors `KeyWidget`'s
+            `flash-overlay-border`). */}
+        {flashed && (
+          <circle
+            cx={cx} cy={cy} r={r}
+            data-testid="flash-overlay-border"
+            fill="none"
+            stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR}
+            strokeWidth={outerBorderActive ? 2 : 1}
+            style={{ pointerEvents: 'none' }}
+          />
+        )}
         {labelLines.map((line, i) => (
           <text key={i} x={cx} y={cy + (i - (labelLines.length - 1) / 2) * (fontSize + 2)}
             textAnchor="middle" dominantBaseline="central" fill={labelColor} fontSize={fontSize} fontFamily="sans-serif">
@@ -121,6 +175,30 @@ function EncoderWidgetInner({
       {/* Outer circle */}
       <circle cx={cx} cy={cy} r={r} fill={fillColor}
         stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR} strokeWidth={outerBorderActive ? 2 : 1} />
+      {/* Flash overlay + border redraw: painted above the outer circle but
+          below the inner mask rect and labels (both rendered below), same
+          stacking as the non-masked branch and `KeyWidget`'s masked keys —
+          the inner rect and its label stay visible on top of the overlay. */}
+      {flashed && (
+        <circle
+          key={flashGeneration}
+          cx={cx} cy={cy} r={r}
+          data-testid="flash-overlay"
+          className="key-flash-overlay"
+          fill={KEY_SELECTED_COLOR}
+          style={{ pointerEvents: 'none', animationDelay: `-${flashElapsedMs}ms` }}
+        />
+      )}
+      {flashed && (
+        <circle
+          cx={cx} cy={cy} r={r}
+          data-testid="flash-overlay-border"
+          fill="none"
+          stroke={outerBorderActive ? KEY_SELECTED_COLOR : KEY_BORDER_COLOR}
+          strokeWidth={outerBorderActive ? 2 : 1}
+          style={{ pointerEvents: 'none' }}
+        />
+      )}
       {/* Inner rect clipped to circle — same style as KeyWidget (stroke-only selection) */}
       <rect x={innerRectX} y={innerRectY} width={innerRectW} height={innerRectH}
         rx={innerCorner} ry={innerCorner}

--- a/src/renderer/components/keyboard/KeyWidget.tsx
+++ b/src/renderer/components/keyboard/KeyWidget.tsx
@@ -42,7 +42,7 @@ interface Props {
   pressed?: boolean
   highlighted?: boolean
   /** True for one beat right after a bulk keymap rewrite (Key Label
-   *  "apply to keymap") lands on this position. Renders an extra overlay
+   *  "apply to keymap") or an undo/redo lands on this position. Renders an extra overlay
    *  (same fill as `selected`, `KEY_SELECTED_COLOR`) on top of the key's
    *  normal fill so the user can see what changed, then fades via the
    *  declarative `key-flash` CSS keyframe (see `style.css`) once the

--- a/src/renderer/components/keyboard/KeyWidget.tsx
+++ b/src/renderer/components/keyboard/KeyWidget.tsx
@@ -30,12 +30,7 @@ import {
 import { shouldInvertText } from './fill-luminance'
 import type { EffectiveTheme } from '../../hooks/useEffectiveTheme'
 import { computeUnionPath } from '../../../shared/kle/rect-union'
-
-/** Must match the `key-flash` keyframe's total animation length in
- *  style.css — used to clamp the computed `animation-delay` so a stale
- *  `flashStartedAt` (e.g. a very late render) never produces a delay
- *  larger than the animation itself. */
-const FLASH_ANIMATION_DURATION_MS = 1300
+import { flashAnimationDelayMs } from './key-flash'
 
 interface Props {
   kleKey: KleKey
@@ -329,7 +324,7 @@ function KeyWidgetInner({
   // this same flash, instead of restarting its own fade from full
   // opacity.
   const flashElapsedMs = flashed && flashStartedAt !== undefined
-    ? Math.min(FLASH_ANIMATION_DURATION_MS, Math.max(0, Date.now() - flashStartedAt))
+    ? flashAnimationDelayMs(flashStartedAt)
     : 0
 
   return (

--- a/src/renderer/components/keyboard/KeyboardWidget.tsx
+++ b/src/renderer/components/keyboard/KeyboardWidget.tsx
@@ -3,14 +3,14 @@
 import { useMemo, memo } from 'react'
 import type { KleKey } from '../../../shared/kle/types'
 import { filterVisibleKeys, repositionLayoutKeys } from '../../../shared/kle/filter-keys'
-import { posKey } from '../../../shared/kle/pos-key'
+import { posKey, encoderPosKey } from '../../../shared/kle/pos-key'
 import { KeyWidget } from './KeyWidget'
 import { EncoderWidget } from './EncoderWidget'
 import { KEY_UNIT, KEY_SPACING, KEYBOARD_PADDING } from './constants'
 import { innerHeatmapFillForCell, outerHeatmapFillForCell } from './heatmap-fill'
 import type { TypingHeatmapCell } from '../../../shared/types/typing-analytics'
 import { useEffectiveTheme } from '../../hooks/useEffectiveTheme'
-import type { KeyFlashState } from './key-flash'
+import { flashPropsFor, type KeyFlashState } from './key-flash'
 
 /** Rotate point (px, py) by `angle` degrees around center (cx, cy). */
 export function rotatePoint(
@@ -215,9 +215,7 @@ function KeyboardWidgetInner({
               kleKey={key}
               keycode={kc}
               selected={false}
-              flashed={flash?.encoders.has(`${key.encoderIdx},${key.encoderDir}`)}
-              flashGeneration={flash?.generation}
-              flashStartedAt={flash?.startedAt}
+              {...flashPropsFor(flash, 'encoders', encoderPosKey(key.encoderIdx, key.encoderDir))}
               onClick={readOnly ? undefined : onEncoderClick}
               onDoubleClick={readOnly ? undefined : onEncoderDoubleClick}
               scale={scale}
@@ -236,9 +234,7 @@ function KeyboardWidgetInner({
             multiSelected={multiSelectedKeys?.has(pos)}
             pressed={pressedKeys?.has(pos)}
             highlighted={highlightedKeys?.has(pos)}
-            flashed={flash?.keys.has(pos)}
-            flashGeneration={flash?.generation}
-            flashStartedAt={flash?.startedAt}
+            {...flashPropsFor(flash, 'keys', pos)}
             everPressed={everPressedKeys?.has(pos)}
             remapped={remappedKeys?.has(pos)}
             heatmapOuterFill={outerHeatmapFillForCell(heatmapCells, heatmapMaxHold, heatmapMaxTotal, pos, effectiveTheme)}
@@ -274,9 +270,7 @@ function KeyboardWidgetInner({
               keycode={kc}
               selected
               selectedMaskPart={selectedMaskPart}
-              flashed={flash?.encoders.has(`${key.encoderIdx},${key.encoderDir}`)}
-              flashGeneration={flash?.generation}
-              flashStartedAt={flash?.startedAt}
+              {...flashPropsFor(flash, 'encoders', encoderPosKey(key.encoderIdx, key.encoderDir))}
               onClick={readOnly ? undefined : onEncoderClick}
               onDoubleClick={readOnly ? undefined : onEncoderDoubleClick}
               scale={scale}
@@ -296,9 +290,7 @@ function KeyboardWidgetInner({
             selectedMaskPart={selectedMaskPart}
             pressed={pressedKeys?.has(pos)}
             highlighted={highlightedKeys?.has(pos)}
-            flashed={flash?.keys.has(pos)}
-            flashGeneration={flash?.generation}
-            flashStartedAt={flash?.startedAt}
+            {...flashPropsFor(flash, 'keys', pos)}
             everPressed={everPressedKeys?.has(pos)}
             remapped={remappedKeys?.has(pos)}
             heatmapOuterFill={outerHeatmapFillForCell(heatmapCells, heatmapMaxHold, heatmapMaxTotal, pos, effectiveTheme)}

--- a/src/renderer/components/keyboard/KeyboardWidget.tsx
+++ b/src/renderer/components/keyboard/KeyboardWidget.tsx
@@ -72,10 +72,9 @@ interface Props {
   selectedEncoder?: { idx: number; dir: 0 | 1 } | null
   pressedKeys?: Set<string>
   highlightedKeys?: Set<string>
-  /** Post-rewrite flash state (Key Label "apply to keymap"). Not threaded
-   *  to `EncoderWidget`: it has no highlight-priority fill logic at all
-   *  today, so wiring flash there would mean redesigning its render path
-   *  rather than adding one prop. Encoders are skipped. */
+  /** Flash state after a Key Label "apply to keymap" bulk rewrite or a
+   *  successful undo/redo — threaded to both `KeyWidget` (`keys`) and
+   *  `EncoderWidget` (`encoders`). */
   flash?: KeyFlashState
   everPressedKeys?: Set<string>
   remappedKeys?: Set<string>
@@ -216,6 +215,9 @@ function KeyboardWidgetInner({
               kleKey={key}
               keycode={kc}
               selected={false}
+              flashed={flash?.encoders.has(`${key.encoderIdx},${key.encoderDir}`)}
+              flashGeneration={flash?.generation}
+              flashStartedAt={flash?.startedAt}
               onClick={readOnly ? undefined : onEncoderClick}
               onDoubleClick={readOnly ? undefined : onEncoderDoubleClick}
               scale={scale}
@@ -272,6 +274,9 @@ function KeyboardWidgetInner({
               keycode={kc}
               selected
               selectedMaskPart={selectedMaskPart}
+              flashed={flash?.encoders.has(`${key.encoderIdx},${key.encoderDir}`)}
+              flashGeneration={flash?.generation}
+              flashStartedAt={flash?.startedAt}
               onClick={readOnly ? undefined : onEncoderClick}
               onDoubleClick={readOnly ? undefined : onEncoderDoubleClick}
               scale={scale}

--- a/src/renderer/components/keyboard/KeyboardWidget.tsx
+++ b/src/renderer/components/keyboard/KeyboardWidget.tsx
@@ -10,28 +10,7 @@ import { KEY_UNIT, KEY_SPACING, KEYBOARD_PADDING } from './constants'
 import { innerHeatmapFillForCell, outerHeatmapFillForCell } from './heatmap-fill'
 import type { TypingHeatmapCell } from '../../../shared/types/typing-analytics'
 import { useEffectiveTheme } from '../../hooks/useEffectiveTheme'
-
-/** Post-rewrite key flash state (Key Label "apply to keymap" bulk
- *  rewrite). Bundles the flashed positions with the generation/start-time
- *  every `KeyWidget` overlay needs to stay synced to the SAME CSS-keyframe
- *  timeline (see `KeyWidget`'s `key-flash-overlay` element) — one prop
- *  instead of three loose ones so it threads cleanly through
- *  `KeyboardPane` -> `KeyboardWidget`. */
-export interface KeyFlashState {
-  /** Positions to flash, pos-keyed like `highlightedKeys`. */
-  keys: Set<string>
-  /** Bumped on every successful apply. Forwarded to `KeyWidget` as
-   *  `flashGeneration` so a re-apply mid-flash remounts (and thus
-   *  restarts) the overlay instead of reusing a DOM node whose CSS
-   *  animation may already be finished. */
-  generation: number
-  /** `Date.now()` at the apply that produced this batch. Forwarded to
-   *  `KeyWidget` as `flashStartedAt` so it can compute a negative
-   *  `animation-delay` — overlays that mount late (e.g. a layer switch
-   *  mid-window) join the same global timeline instead of restarting
-   *  the fade from full opacity. */
-  startedAt: number
-}
+import type { KeyFlashState } from './key-flash'
 
 /** Rotate point (px, py) by `angle` degrees around center (cx, cy). */
 export function rotatePoint(

--- a/src/renderer/components/keyboard/__tests__/EncoderWidget.test.tsx
+++ b/src/renderer/components/keyboard/__tests__/EncoderWidget.test.tsx
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { EncoderWidget } from '../EncoderWidget'
+import { KEY_SELECTED_COLOR, KEY_BG_COLOR } from '../constants'
+import type { KleKey } from '../../../../shared/kle/types'
+
+let mockIsMask = false
+let mockInnerKeycode: { qmkId: string } = { qmkId: 'KC_A' }
+
+vi.mock('../../../../shared/keycodes/keycodes', () => ({
+  keycodeLabel: (kc: string) => kc,
+  isMask: () => mockIsMask,
+  findInnerKeycode: () => mockInnerKeycode,
+}))
+
+function makeKey(overrides: Partial<KleKey> = {}): KleKey {
+  return {
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    x2: 0,
+    y2: 0,
+    width2: 1,
+    height2: 1,
+    rotation: 0,
+    rotationX: 0,
+    rotationY: 0,
+    color: '',
+    labels: [],
+    textColor: [],
+    textSize: [],
+    row: -1,
+    col: -1,
+    encoderIdx: 0,
+    encoderDir: 0,
+    layoutIndex: -1,
+    layoutOption: -1,
+    decal: false,
+    nub: false,
+    stepped: false,
+    ghost: false,
+    ...overrides,
+  }
+}
+
+describe('EncoderWidget', () => {
+  beforeEach(() => {
+    mockIsMask = false
+    mockInnerKeycode = { qmkId: 'KC_A' }
+  })
+
+  describe('flashed (post-rewrite / undo-redo flash)', () => {
+    it('does not render a flash overlay when flashed is unset', () => {
+      const { container } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" />
+        </svg>,
+      )
+      expect(container.querySelector('[data-testid="flash-overlay"]')).toBeNull()
+      expect(container.querySelector('[data-testid="flash-overlay-border"]')).toBeNull()
+    })
+
+    it('renders a flash overlay circle with the selected fill and the key-flash animation class when flashed=true', () => {
+      const { container } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed />
+        </svg>,
+      )
+      const overlay = container.querySelector('[data-testid="flash-overlay"]')!
+      expect(overlay).not.toBeNull()
+      expect(overlay.tagName).toBe('circle')
+      expect(overlay.getAttribute('fill')).toBe(KEY_SELECTED_COLOR)
+      expect(overlay.classList.contains('key-flash-overlay')).toBe(true)
+    })
+
+    it('leaves the outer circle fill untouched by flashed (overlay paints on top)', () => {
+      const { container } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed />
+        </svg>,
+      )
+      const circles = container.querySelectorAll('circle')
+      // First circle is the base outer circle, unaffected by `flashed`.
+      expect(circles[0].getAttribute('fill')).toBe(KEY_BG_COLOR)
+    })
+
+    it('removes the flash overlay once the caller clears flashed', () => {
+      const { container, rerender } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed />
+        </svg>,
+      )
+      expect(container.querySelector('[data-testid="flash-overlay"]')).not.toBeNull()
+
+      rerender(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" />
+        </svg>,
+      )
+      expect(container.querySelector('[data-testid="flash-overlay"]')).toBeNull()
+    })
+
+    it('does not let the flash overlay intercept clicks meant for the encoder', () => {
+      const { container } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed />
+        </svg>,
+      )
+      const overlay = container.querySelector('[data-testid="flash-overlay"]')! as SVGElement
+      expect(overlay.style.pointerEvents).toBe('none')
+    })
+
+    it('remounts the overlay (restarting its animation) when flashGeneration bumps on a re-apply', () => {
+      const { container, rerender } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed flashGeneration={1} />
+        </svg>,
+      )
+      const firstOverlay = container.querySelector('[data-testid="flash-overlay"]')!
+      expect(firstOverlay).not.toBeNull()
+
+      rerender(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed flashGeneration={2} />
+        </svg>,
+      )
+      const secondOverlay = container.querySelector('[data-testid="flash-overlay"]')!
+      expect(secondOverlay).not.toBeNull()
+      expect(secondOverlay).not.toBe(firstOverlay)
+    })
+
+    it('computes a negative animation-delay from flashStartedAt for a late-mounted overlay', () => {
+      const now = Date.now()
+      vi.useFakeTimers()
+      vi.setSystemTime(now + 500)
+      try {
+        const { container } = render(
+          <svg>
+            <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed flashStartedAt={now} />
+          </svg>,
+        )
+        const overlay = container.querySelector('[data-testid="flash-overlay"]')! as SVGElement
+        expect(overlay.style.animationDelay).toBe('-500ms')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('clamps animation-delay to the full animation length (700ms) for a stale flashStartedAt', () => {
+      const now = Date.now()
+      vi.useFakeTimers()
+      vi.setSystemTime(now + 5000)
+      try {
+        const { container } = render(
+          <svg>
+            <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed flashStartedAt={now} />
+          </svg>,
+        )
+        const overlay = container.querySelector('[data-testid="flash-overlay"]')! as SVGElement
+        expect(overlay.style.animationDelay).toBe('-700ms')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('renders a stroke-only border copy on top of the overlay while flashed, matching the outer border', () => {
+      const { container } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed selected />
+        </svg>,
+      )
+      const borderCopy = container.querySelector('[data-testid="flash-overlay-border"]')!
+      expect(borderCopy).not.toBeNull()
+      expect(borderCopy.getAttribute('fill')).toBe('none')
+      expect(borderCopy.getAttribute('stroke')).toBe(KEY_SELECTED_COLOR)
+      expect(borderCopy.getAttribute('stroke-width')).toBe('2')
+    })
+
+    it('removes the border copy once the caller clears flashed', () => {
+      const { container, rerender } = render(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" flashed />
+        </svg>,
+      )
+      expect(container.querySelector('[data-testid="flash-overlay-border"]')).not.toBeNull()
+
+      rerender(
+        <svg>
+          <EncoderWidget kleKey={makeKey()} keycode="KC_A" />
+        </svg>,
+      )
+      expect(container.querySelector('[data-testid="flash-overlay-border"]')).toBeNull()
+    })
+
+    describe('masked encoder (isMask=true)', () => {
+      beforeEach(() => {
+        mockIsMask = true
+      })
+
+      it('renders the flash overlay and border copy alongside the inner mask rect', () => {
+        const { container } = render(
+          <svg>
+            <EncoderWidget kleKey={makeKey()} keycode="LT0(KC_A)" flashed />
+          </svg>,
+        )
+        expect(container.querySelector('[data-testid="flash-overlay"]')).not.toBeNull()
+        expect(container.querySelector('[data-testid="flash-overlay-border"]')).not.toBeNull()
+        // The inner mask rect stays visible on top of the (opaque) overlay.
+        const innerRect = container.querySelector('rect')
+        expect(innerRect).not.toBeNull()
+      })
+
+      it('does not render a flash overlay for a masked encoder when flashed is unset', () => {
+        const { container } = render(
+          <svg>
+            <EncoderWidget kleKey={makeKey()} keycode="LT0(KC_A)" />
+          </svg>,
+        )
+        expect(container.querySelector('[data-testid="flash-overlay"]')).toBeNull()
+      })
+    })
+  })
+})

--- a/src/renderer/components/keyboard/__tests__/KeyWidget.test.tsx
+++ b/src/renderer/components/keyboard/__tests__/KeyWidget.test.tsx
@@ -300,7 +300,7 @@ describe('KeyWidget', () => {
           </svg>,
         )
         const overlay = container.querySelector('[data-testid="flash-overlay"]')! as SVGElement
-        expect(overlay.style.animationDelay).toBe('-1300ms')
+        expect(overlay.style.animationDelay).toBe('-700ms')
       } finally {
         vi.useRealTimers()
       }

--- a/src/renderer/components/keyboard/__tests__/KeyboardWidget.test.tsx
+++ b/src/renderer/components/keyboard/__tests__/KeyboardWidget.test.tsx
@@ -210,3 +210,38 @@ it('KEY_SPACING matches Python vial-gui ratio', () => {
   expect(KEY_SPACING).toBeCloseTo(expected)
   expect(KEY_SPACING / KEY_UNIT).toBeCloseTo(0.0588, 3)
 })
+
+describe('KeyboardWidget flash threading', () => {
+  const keys: KleKey[] = [
+    makeKey({ x: 0, y: 0, row: 0, col: 0 }),
+    makeKey({ x: 1, y: 0, row: -1, col: -1, encoderIdx: 0, encoderDir: 0 }),
+  ]
+  const keycodes = new Map([['0,0', 'KC_A']])
+  const encoderKeycodes = new Map<string, [string, string]>([['0', ['KC_B', 'KC_NO']]])
+
+  it('flashes the encoder when its "idx,dir" position is in flash.encoders', () => {
+    const { container } = render(
+      <KeyboardWidget
+        keys={keys}
+        keycodes={keycodes}
+        encoderKeycodes={encoderKeycodes}
+        flash={{ keys: new Set(), encoders: new Set(['0,0']), generation: 1, startedAt: Date.now() }}
+      />,
+    )
+    expect(container.querySelector('[data-testid="flash-overlay"]')).not.toBeNull()
+  })
+
+  it('does not flash the encoder when its position is absent from flash.encoders', () => {
+    const { container } = render(
+      <KeyboardWidget
+        keys={keys}
+        keycodes={keycodes}
+        encoderKeycodes={encoderKeycodes}
+        // `1,0` doesn't match the rendered encoder's own `idx=0,dir=0` —
+        // a non-empty `encoders` set that just doesn't cover this position.
+        flash={{ keys: new Set(), encoders: new Set(['1,0']), generation: 1, startedAt: Date.now() }}
+      />,
+    )
+    expect(container.querySelector('[data-testid="flash-overlay"]')).toBeNull()
+  })
+})

--- a/src/renderer/components/keyboard/key-flash.ts
+++ b/src/renderer/components/keyboard/key-flash.ts
@@ -46,3 +46,21 @@ export interface KeyFlashState {
 export function flashAnimationDelayMs(startedAt: number): number {
   return Math.min(KEY_FLASH_DURATION_MS, Math.max(0, Date.now() - startedAt))
 }
+
+/** Resolves the `flashed`/`flashGeneration`/`flashStartedAt` prop triple for
+ *  one `KeyWidget`/`EncoderWidget` instance from the shared `flash` state.
+ *  Non-members get back `{ flashed: false }` (the other two fields omitted,
+ *  i.e. `undefined`) instead of `flash.generation`/`flash.startedAt` passed
+ *  through unconditionally — `KeyboardWidget` renders 80+ of these widgets,
+ *  and threading the same `generation`/`startedAt` numbers to every one of
+ *  them regardless of membership would flip those props undefined<->number
+ *  for the WHOLE board every time a flash window opens or closes, busting
+ *  `React.memo` on every widget instead of just the flashed ones. */
+export function flashPropsFor(
+  flash: KeyFlashState | undefined,
+  member: 'keys' | 'encoders',
+  pos: string,
+): { flashed: boolean; flashGeneration?: number; flashStartedAt?: number } {
+  if (!flash || !flash[member].has(pos)) return { flashed: false }
+  return { flashed: true, flashGeneration: flash.generation, flashStartedAt: flash.startedAt }
+}

--- a/src/renderer/components/keyboard/key-flash.ts
+++ b/src/renderer/components/keyboard/key-flash.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Total length of the `key-flash` CSS keyframe (style.css): 500ms hold at
+ *  full opacity + 200ms fade out. Kept here as the single source of truth
+ *  shared by the editor's clear timer, the animation-delay clamp below,
+ *  and the keyframe's own percentage stops — all three must stay in sync
+ *  with this number. Lives in this neutral module (not KeyWidget) so
+ *  editor code doesn't have to depend on a display component just to read
+ *  a timing constant. */
+export const KEY_FLASH_DURATION_MS = 700
+
+/** Post-rewrite key flash state (Key Label "apply to keymap" bulk
+ *  rewrite, and undo/redo). Bundles the flashed positions with the
+ *  generation/start-time every `KeyWidget` overlay needs to stay synced to
+ *  the SAME CSS-keyframe timeline (see `KeyWidget`'s `key-flash-overlay`
+ *  element) — one prop instead of three loose ones so it threads cleanly
+ *  through `KeyboardPane` -> `KeyboardWidget`. */
+export interface KeyFlashState {
+  /** Positions to flash, pos-keyed like `highlightedKeys`. */
+  keys: Set<string>
+  /** Bumped on every successful apply. Forwarded to `KeyWidget` as
+   *  `flashGeneration` so a re-apply mid-flash remounts (and thus
+   *  restarts) the overlay instead of reusing a DOM node whose CSS
+   *  animation may already be finished. */
+  generation: number
+  /** `Date.now()` at the apply that produced this batch. Forwarded to
+   *  `KeyWidget` as `flashStartedAt` so it can compute a negative
+   *  `animation-delay` — overlays that mount late (e.g. a layer switch
+   *  mid-window) join the same global timeline instead of restarting
+   *  the fade from full opacity. */
+  startedAt: number
+}
+
+/** How far into the shared `key-flash` timeline an overlay starting at
+ *  `startedAt` is joining, clamped to `KEY_FLASH_DURATION_MS` so a stale
+ *  `startedAt` (e.g. a very late render) never produces a delay larger
+ *  than the animation itself. Fed to `animation-delay` as a NEGATIVE
+ *  value by callers — that starts the CSS animation already partway
+ *  through, so an overlay mounted late shows the correct mid-fade opacity
+ *  immediately and finishes at the same wall-clock moment as every other
+ *  overlay from this same flash, instead of restarting its own fade from
+ *  full opacity. */
+export function flashAnimationDelayMs(startedAt: number): number {
+  return Math.min(KEY_FLASH_DURATION_MS, Math.max(0, Date.now() - startedAt))
+}

--- a/src/renderer/components/keyboard/key-flash.ts
+++ b/src/renderer/components/keyboard/key-flash.ts
@@ -11,23 +11,26 @@ export const KEY_FLASH_DURATION_MS = 700
 
 /** Post-rewrite key flash state (Key Label "apply to keymap" bulk
  *  rewrite, and undo/redo). Bundles the flashed positions with the
- *  generation/start-time every `KeyWidget` overlay needs to stay synced to
- *  the SAME CSS-keyframe timeline (see `KeyWidget`'s `key-flash-overlay`
- *  element) — one prop instead of three loose ones so it threads cleanly
- *  through `KeyboardPane` -> `KeyboardWidget`. */
+ *  generation/start-time every `KeyWidget`/`EncoderWidget` overlay needs to
+ *  stay synced to the SAME CSS-keyframe timeline (see `KeyWidget`'s
+ *  `key-flash-overlay` element) — one prop instead of three loose ones so
+ *  it threads cleanly through `KeyboardPane` -> `KeyboardWidget`. */
 export interface KeyFlashState {
-  /** Positions to flash, pos-keyed like `highlightedKeys`. */
+  /** Key positions to flash, pos-keyed like `highlightedKeys`. */
   keys: Set<string>
-  /** Bumped on every successful apply. Forwarded to `KeyWidget` as
-   *  `flashGeneration` so a re-apply mid-flash remounts (and thus
+  /** Encoder positions to flash, keyed `'idx,dir'` (mirrors `keys`' pos-key
+   *  convention for regular keys). */
+  encoders: Set<string>
+  /** Bumped on every successful apply. Forwarded to `KeyWidget`/`EncoderWidget`
+   *  as `flashGeneration` so a re-apply mid-flash remounts (and thus
    *  restarts) the overlay instead of reusing a DOM node whose CSS
    *  animation may already be finished. */
   generation: number
   /** `Date.now()` at the apply that produced this batch. Forwarded to
-   *  `KeyWidget` as `flashStartedAt` so it can compute a negative
-   *  `animation-delay` — overlays that mount late (e.g. a layer switch
-   *  mid-window) join the same global timeline instead of restarting
-   *  the fade from full opacity. */
+   *  `KeyWidget`/`EncoderWidget` as `flashStartedAt` so it can compute a
+   *  negative `animation-delay` — overlays that mount late (e.g. a layer
+   *  switch mid-window) join the same global timeline instead of
+   *  restarting the fade from full opacity. */
   startedAt: number
 }
 

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -382,15 +382,16 @@ label:has(> input[type="radio"]:not(:disabled)) {
 }
 
 /* Keymap Editor: post-rewrite key flash overlay (KeyWidget's `flashed`,
-   `.key-flash-overlay`). Holds full opacity for ~1s so the just-rewritten
-   keys register, then eases out over the last ~300ms — expressed as
-   percentage stops over the 1300ms total so KeymapEditor's clear timer
-   (same duration) never unmounts the overlay mid-fade. */
+   `.key-flash-overlay`). Holds full opacity for 500ms so the just-rewritten
+   keys register, then eases out over the last 200ms — expressed as
+   percentage stops over the 700ms total (`KEY_FLASH_DURATION_MS` in
+   `key-flash.ts`) so KeymapEditor's clear timer (same duration) never
+   unmounts the overlay mid-fade. */
 @keyframes key-flash {
-  0%, 77% { opacity: 1; }
+  0%, 71.4% { opacity: 1; }
   100% { opacity: 0; }
 }
 
 .key-flash-overlay {
-  animation: key-flash 1300ms ease-out forwards;
+  animation: key-flash 700ms ease-out forwards;
 }

--- a/src/shared/kle/pos-key.ts
+++ b/src/shared/kle/pos-key.ts
@@ -11,3 +11,9 @@
 export function posKey(row: number, col: number): string {
   return `${row},${col}`
 }
+
+/** Format `(idx, dir)` as the project-wide `"idx,dir"` encoder position key
+ *  (the encoder analogue of `posKey`). */
+export function encoderPosKey(idx: number, dir: number): string {
+  return `${idx},${dir}`
+}


### PR DESCRIPTION
## Summary

- Unify the key-flash effect duration from 1300ms to 700ms (hold 500ms + fade 200ms) and centralize the timing constant, `KeyFlashState` type, and animation-delay helper in a new neutral module `key-flash.ts`
- Flash the affected key positions on undo/redo with the same visual used by the Key Label "apply to keymap" bulk rewrite (`useKeyFlash` hook extracted from `KeymapEditor`, fired via a new `onHistoryApplied` callback after device writes succeed and the history stack is committed)
- Extend the flash to encoders: `KeyFlashState.encoders`, `EncoderWidget` overlay + stroke redraw (masked and non-masked), threaded through both `EncoderWidget` render paths, with `encoderPosKey` keeping producer/consumer position keys in lockstep
- Keep non-flashed widgets' props stable during a flash window (`flashPropsFor`) so a flash no longer re-renders all 80+ memoized key widgets

## Behavior

- Undo/redo (shortcuts, toolbar, popover) highlights the changed keys/encoders on the visible layer for 500ms, then fades over 200ms
- Encoder-only changes flash too; a failed undo/redo neither flashes nor advances history
- The bulk-rewrite flash uses the same shortened 700ms window

## Testing

- Full suite: 294 files, 6904 tests passed (22 device-dependent skipped)
- New coverage: undo/redo flash (incl. failure and rapid undo→redo generation restart), `EncoderWidget` overlay/border/delay/remount, `KeyboardWidget` encoder flash threading, encoder-only rewrite and undo/redo
- lint / typecheck clean