### PR TITLE
chore: isolate doc captures and drop the redundant apply lookup

### DIFF
--- a/e2e/helpers/doc-capture-common.ts
+++ b/e2e/helpers/doc-capture-common.ts
@@ -7,9 +7,10 @@
 
 import { _electron as electron } from '@playwright/test'
 import type { ElectronApplication, Locator, Page } from '@playwright/test'
-import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
-import { homedir } from 'node:os'
-import { join, resolve } from 'node:path'
+import type { ChildProcess } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir, tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
 
@@ -248,63 +249,145 @@ export function restoreLastDeviceConfig(backup: LastDeviceBackup): void {
 }
 
 /**
- * Default userData path for the real (non-isolated) installed-app profile,
- * used by capture helpers that launch Electron directly via `spawn()`
- * (doc-capture-key-labels.ts, doc-capture-theme-packs.ts) rather than
- * through `launchCaptureApp`'s Playwright-managed, always-fresh profile.
- * Linux-only, matching how these dev-only doc-capture scripts are actually
- * run (see e2e/helpers/wpm-screenshot.ts's `SRC_USER_DATA` for the same
- * hardcoded path). Honors `PIPETTE_CAPTURE_USER_DATA_DIR` so a caller that
- * opted into an isolated profile (see doc-capture-key-labels.ts's
- * `launchElectronApp`) resolves to that same directory instead.
+ * Entry names to skip when cloning a real userData profile for
+ * `cloneUserDataForCapture`. Two unrelated reasons to exclude something
+ * here:
+ *  - Chromium/Electron's own disk caches, which are gigabytes on a real
+ *    dev machine (`Cache` + `Code Cache` alone were ~1.7GB when this was
+ *    measured) and contribute nothing to a Key Labels / Theme Packs
+ *    Installed-tab screenshot. Excluding them is what keeps the clone
+ *    fast (tens of MB instead of ~2GB).
+ *  - `SingletonLock` / `SingletonSocket` / `SingletonCookie`: Chromium's
+ *    own single-instance-lock artifacts, written directly in userData
+ *    root (undotted — a plain dotfile filter does not catch these). If a
+ *    real Pipette session happens to be running when a capture script
+ *    starts, copying these into the clone could make the freshly-launched
+ *    clone-pointed instance see (or try to dial into) the REAL running
+ *    instance's lock/socket and refuse to open a window, or otherwise
+ *    misbehave — excluding them by name is required, not just defensive.
+ *
+ * See `cloneUserDataForCapture`'s own doc comment for why the clone
+ * exists at all.
  */
-export function resolveCaptureUserDataPath(): string {
-  return process.env.PIPETTE_CAPTURE_USER_DATA_DIR ?? join(homedir(), '.config', 'pipette-desktop')
-}
+const CAPTURE_CLONE_EXCLUDE_NAMES: ReadonlySet<string> = new Set([
+  'Cache', 'Code Cache', 'GPUCache', 'DawnGraphiteCache', 'DawnWebGPUCache', 'Crashpad', 'blob_storage',
+  'SingletonLock', 'SingletonSocket', 'SingletonCookie',
+])
 
-/** Snapshot of the `language` key in userData/config.json (electron-store). */
-export interface LanguageConfigBackup {
-  path: string
-  hadKey: boolean
-  original: unknown
+/** Result of `cloneUserDataForCapture`: where the clone lives, and how to
+ *  discard it once the capture run is done. */
+export interface ClonedUserData {
+  userDataDir: string
+  /** Deletes the clone. Idempotent — safe to call even if the clone was
+   *  never fully populated (e.g. an earlier step in the same run threw). */
+  cleanup: () => void
 }
 
 /**
- * Force `language: 'builtin:en'` in the electron-store config file for the
- * duration of a capture run. Helpers that launch Electron directly against
- * the real userData profile (rather than through `launchCaptureApp`'s
- * isolated, always-English profile) would otherwise render every captured
- * screenshot in whatever i18n pack the developer's own app is set to.
- * Pass the result to `restoreLanguageConfig` in a `finally` block once the
- * Electron process has fully exited.
+ * Clone the real installed-app userData profile into a fresh, uniquely
+ * named temp directory and return its path plus a cleanup callback.
+ *
+ * WHY a clone instead of touching the real profile directly: an earlier
+ * version of `doc-capture-key-labels.ts` / `doc-capture-theme-packs.ts`
+ * launched Electron with `--user-data-dir` pointed straight at the real
+ * profile (needed for a *representative* Installed tab — see below) and
+ * patched `config.json`'s `language` key in place, restoring it
+ * afterward. That backup/restore was never actually safe for the user's
+ * real data: a SIGKILL/crash skips the `finally` that restores it, two
+ * concurrent runs would back up each other's already-forced value, and
+ * even the graceful path raced the still-shutting-down Electron process
+ * rewriting `config.json` after the restore already ran. A clone sidesteps
+ * all three at once — every write this run makes (including forcing
+ * `language: 'builtin:en'`) lands on the disposable copy, so the real
+ * profile is physically unwritable by this run and there is nothing left
+ * to back up or restore.
+ *
+ * The clone still needs to start from a copy of the real profile (not an
+ * empty directory, unlike `launchCaptureApp`'s Playwright-managed profile)
+ * because these two scripts' whole point is a screenshot that reflects
+ * actual locally-installed Key Label / Theme packs, and — for
+ * `doc-capture-key-labels.ts` — an existing Hub-authenticated session
+ * (Google OAuth token lives at `local/auth/` under userData, encrypted via
+ * `safeStorage`; excluded from `CAPTURE_CLONE_EXCLUDE_NAMES` on purpose so
+ * it copies along with everything else that isn't a disk cache or a
+ * singleton-lock artifact). Mirrors `e2e/helpers/wpm-screenshot.ts`'s own
+ * copy-before-launch idiom, plus the exclusions so this doesn't take
+ * multiple minutes / gigabytes, or clash with a real running session.
+ *
+ * Excludes dotfile entries too (in addition to the explicit Singleton*
+ * names in `CAPTURE_CLONE_EXCLUDE_NAMES` — those are undotted, so the
+ * dotfile filter does not cover them on its own): other lock/IPC-socket-
+ * style artifacts on Linux live as hidden files directly under userData.
+ *
+ * `PIPETTE_CAPTURE_USER_DATA_DIR` overrides which profile to clone FROM
+ * (e.g. a curated fixture profile instead of the live developer one) — the
+ * destination is always a fresh temp dir regardless, so unlike the old
+ * design this env var is no longer needed to dodge the single-instance
+ * lock (a temp dir can never collide with a running real session).
  */
-export function forceEnglishLanguage(userDataPath: string): LanguageConfigBackup {
-  const path = join(userDataPath, 'config.json')
+export function cloneUserDataForCapture(label: string): ClonedUserData {
+  const sourceDir = process.env.PIPETTE_CAPTURE_USER_DATA_DIR ?? join(homedir(), '.config', 'pipette-desktop')
+  const userDataDir = join(tmpdir(), `pipette-doc-capture-${label}-${process.pid}-${Date.now()}`)
+  if (existsSync(sourceDir)) {
+    cpSync(sourceDir, userDataDir, {
+      recursive: true,
+      filter: (src) => {
+        const name = basename(src)
+        if (name.startsWith('.')) return false
+        return !CAPTURE_CLONE_EXCLUDE_NAMES.has(name)
+      },
+    })
+  } else {
+    mkdirSync(userDataDir, { recursive: true })
+  }
+  return {
+    userDataDir,
+    cleanup: () => { rmSync(userDataDir, { recursive: true, force: true }) },
+  }
+}
+
+/**
+ * Force `language: 'builtin:en'` in `userDataDir`'s `config.json`. No
+ * backup/restore needed — `userDataDir` is always a disposable clone from
+ * `cloneUserDataForCapture`, never the real profile, so there is nothing
+ * to preserve. A plain read-modify-write (not a raw-bytes round trip) is
+ * fine here for the exact same reason.
+ */
+export function forceEnglishLanguageInClone(userDataDir: string): void {
+  const path = join(userDataDir, 'config.json')
   const config = existsSync(path)
     ? (JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>)
     : {}
-  const backup: LanguageConfigBackup = { path, hadKey: 'language' in config, original: config.language }
   config.language = 'builtin:en'
   writeFileSync(path, JSON.stringify(config, null, '\t'), 'utf-8')
-  return backup
 }
 
 /**
- * Restore the original `language` value snapshotted by
- * `forceEnglishLanguage`. Call only after the Electron process has fully
- * exited — the app can rewrite config.json on its own (window-state save
- * on quit, settings changes during the run), and restoring before that
- * would get clobbered by one of those late writes racing this one.
+ * Kill `child` and wait for it to actually exit before resolving — never
+ * assumes exit from a timeout alone (an earlier version of this helper,
+ * duplicated in doc-capture-key-labels.ts / doc-capture-theme-packs.ts,
+ * raced ahead after `graceMs` even if the process was still alive, which
+ * could let it rewrite files after a caller's own cleanup already ran).
+ * Escalates from SIGTERM to SIGKILL if the process hasn't exited within
+ * `graceMs`, then waits — unbounded — for the actual `'exit'` event; SIGKILL
+ * cannot be ignored on Linux, so that final wait is guaranteed to resolve.
+ * Clears the grace-period timer as soon as the race settles either way —
+ * left running, it would hold the event loop open (delaying the script's
+ * own exit by up to `graceMs`) even on the common path where the process
+ * already exited well before the timer fired.
  */
-export function restoreLanguageConfig(backup: LanguageConfigBackup): void {
-  if (!existsSync(backup.path)) return
-  const config = JSON.parse(readFileSync(backup.path, 'utf-8')) as Record<string, unknown>
-  if (!backup.hadKey) {
-    delete config.language
-  } else {
-    config.language = backup.original
-  }
-  writeFileSync(backup.path, JSON.stringify(config, null, '\t'), 'utf-8')
+export async function killAndWaitForExit(child: ChildProcess, graceMs = 5000): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  const exited = new Promise<void>((res) => { child.once('exit', () => res()) })
+  child.kill('SIGTERM')
+  let timer!: ReturnType<typeof setTimeout>
+  const timedOut = await Promise.race([
+    exited.then(() => false),
+    new Promise<boolean>((res) => { timer = setTimeout(() => res(true), graceMs) }),
+  ])
+  clearTimeout(timer)
+  if (timedOut) child.kill('SIGKILL')
+  await exited
 }
 
 /** Snapshot of the virtual device's saved-layout store, taken before a

--- a/e2e/helpers/doc-capture-common.ts
+++ b/e2e/helpers/doc-capture-common.ts
@@ -8,6 +8,7 @@
 import { _electron as electron } from '@playwright/test'
 import type { ElectronApplication, Locator, Page } from '@playwright/test'
 import { existsSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
@@ -242,6 +243,66 @@ export function restoreLastDeviceConfig(backup: LastDeviceBackup): void {
     delete config.lastDevice
   } else {
     config.lastDevice = backup.original
+  }
+  writeFileSync(backup.path, JSON.stringify(config, null, '\t'), 'utf-8')
+}
+
+/**
+ * Default userData path for the real (non-isolated) installed-app profile,
+ * used by capture helpers that launch Electron directly via `spawn()`
+ * (doc-capture-key-labels.ts, doc-capture-theme-packs.ts) rather than
+ * through `launchCaptureApp`'s Playwright-managed, always-fresh profile.
+ * Linux-only, matching how these dev-only doc-capture scripts are actually
+ * run (see e2e/helpers/wpm-screenshot.ts's `SRC_USER_DATA` for the same
+ * hardcoded path). Honors `PIPETTE_CAPTURE_USER_DATA_DIR` so a caller that
+ * opted into an isolated profile (see doc-capture-key-labels.ts's
+ * `launchElectronApp`) resolves to that same directory instead.
+ */
+export function resolveCaptureUserDataPath(): string {
+  return process.env.PIPETTE_CAPTURE_USER_DATA_DIR ?? join(homedir(), '.config', 'pipette-desktop')
+}
+
+/** Snapshot of the `language` key in userData/config.json (electron-store). */
+export interface LanguageConfigBackup {
+  path: string
+  hadKey: boolean
+  original: unknown
+}
+
+/**
+ * Force `language: 'builtin:en'` in the electron-store config file for the
+ * duration of a capture run. Helpers that launch Electron directly against
+ * the real userData profile (rather than through `launchCaptureApp`'s
+ * isolated, always-English profile) would otherwise render every captured
+ * screenshot in whatever i18n pack the developer's own app is set to.
+ * Pass the result to `restoreLanguageConfig` in a `finally` block once the
+ * Electron process has fully exited.
+ */
+export function forceEnglishLanguage(userDataPath: string): LanguageConfigBackup {
+  const path = join(userDataPath, 'config.json')
+  const config = existsSync(path)
+    ? (JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>)
+    : {}
+  const backup: LanguageConfigBackup = { path, hadKey: 'language' in config, original: config.language }
+  config.language = 'builtin:en'
+  writeFileSync(path, JSON.stringify(config, null, '\t'), 'utf-8')
+  return backup
+}
+
+/**
+ * Restore the original `language` value snapshotted by
+ * `forceEnglishLanguage`. Call only after the Electron process has fully
+ * exited — the app can rewrite config.json on its own (window-state save
+ * on quit, settings changes during the run), and restoring before that
+ * would get clobbered by one of those late writes racing this one.
+ */
+export function restoreLanguageConfig(backup: LanguageConfigBackup): void {
+  if (!existsSync(backup.path)) return
+  const config = JSON.parse(readFileSync(backup.path, 'utf-8')) as Record<string, unknown>
+  if (!backup.hadKey) {
+    delete config.language
+  } else {
+    config.language = backup.original
   }
   writeFileSync(backup.path, JSON.stringify(config, null, '\t'), 'utf-8')
 }

--- a/e2e/helpers/doc-capture-key-labels.ts
+++ b/e2e/helpers/doc-capture-key-labels.ts
@@ -19,7 +19,14 @@ import type { Page } from '@playwright/test'
 import { spawn } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { dismissNotificationModal, dismissOverlay, isAvailable } from './doc-capture-common'
+import {
+  dismissNotificationModal,
+  dismissOverlay,
+  forceEnglishLanguage,
+  isAvailable,
+  resolveCaptureUserDataPath,
+  restoreLanguageConfig,
+} from './doc-capture-common'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
 const SCREENSHOT_DIR = resolve(PROJECT_ROOT, 'docs/screenshots')
@@ -360,8 +367,21 @@ async function killAndWaitForExit(child: ReturnType<typeof spawn>, timeoutMs = 5
 async function main(): Promise<void> {
   mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
-  await runPhaseInFreshSession(captureInstalledTab)
-  await runPhaseInFreshSession(captureFindOnHubTab)
+  // This helper launches Electron directly against the real userData
+  // profile (see `launchElectronApp` below) rather than through
+  // `launchCaptureApp`'s isolated, always-English profile — force English
+  // for the run so a developer's own i18n pack setting can't leak into
+  // the captured screenshots.
+  const languageBackup = forceEnglishLanguage(resolveCaptureUserDataPath())
+  try {
+    await runPhaseInFreshSession(captureInstalledTab)
+    await runPhaseInFreshSession(captureFindOnHubTab)
+  } finally {
+    // Both phases above already wait for their Electron process to fully
+    // exit (`killAndWaitForExit`) before returning, so by the time this
+    // runs there's no running app left to race the restore.
+    restoreLanguageConfig(languageBackup)
+  }
 
   console.log(`\nKey Labels screenshots saved to: ${SCREENSHOT_DIR}`)
 }

--- a/e2e/helpers/doc-capture-key-labels.ts
+++ b/e2e/helpers/doc-capture-key-labels.ts
@@ -20,12 +20,12 @@ import { spawn } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
+  cloneUserDataForCapture,
   dismissNotificationModal,
   dismissOverlay,
-  forceEnglishLanguage,
+  forceEnglishLanguageInClone,
   isAvailable,
-  resolveCaptureUserDataPath,
-  restoreLanguageConfig,
+  killAndWaitForExit,
 } from './doc-capture-common'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
@@ -254,25 +254,21 @@ async function captureFindOnHubTab(page: Page): Promise<void> {
   await capture(page, 'key-labels-hub')
 }
 
-function launchElectronApp(): ReturnType<typeof spawn> {
+function launchElectronApp(userDataDir: string): ReturnType<typeof spawn> {
   const electronPath = resolve(PROJECT_ROOT, 'node_modules/.bin/electron')
   const args = [
     '.',
     '--no-sandbox',
     '--disable-gpu-sandbox',
     `--remote-debugging-port=${DEBUG_PORT}`,
+    // Always a disposable clone from `cloneUserDataForCapture` (see
+    // `main` below) — never the real profile. That also means the
+    // unconditional single-instance lock (since #278,
+    // `requestSingleInstanceLock` in src/main/index.ts) can no longer
+    // collide with an already-running real Pipette session; a fresh temp
+    // dir is never the same directory a live session owns.
+    `--user-data-dir=${userDataDir}`,
   ]
-  // Opt-in escape hatch for the (unconditional, since #278) single-instance
-  // lock: if a real Pipette session is already running against the default
-  // userData path, this helper's own launch silently no-ops instead of
-  // opening a window (see `requestSingleInstanceLock` in src/main/index.ts).
-  // Pass a copy of the real profile via this env var to capture against an
-  // isolated path instead — not the default, since the whole point of using
-  // the real userData path here (unlike doc-capture-language-packs.ts's
-  // isolated virtual-device profile) is a *representative* Installed tab.
-  if (process.env.PIPETTE_CAPTURE_USER_DATA_DIR) {
-    args.push(`--user-data-dir=${process.env.PIPETTE_CAPTURE_USER_DATA_DIR}`)
-  }
   return spawn(electronPath, args, {
     cwd: PROJECT_ROOT,
     stdio: 'ignore',
@@ -314,9 +310,9 @@ async function waitForDebugPort(port: number, timeoutMs = 15_000): Promise<void>
  * each phase its own process sidesteps the accumulation entirely,
  * at the cost of a second ~launch+relogin cycle.
  */
-async function runPhaseInFreshSession(phase: (page: Page) => Promise<void>): Promise<void> {
+async function runPhaseInFreshSession(userDataDir: string, phase: (page: Page) => Promise<void>): Promise<void> {
   console.log('Launching Electron app with remote debugging...')
-  const child = launchElectronApp()
+  const child = launchElectronApp(userDataDir)
 
   let browser: Awaited<ReturnType<typeof chromium.connectOverCDP>> | undefined
   try {
@@ -341,46 +337,30 @@ async function runPhaseInFreshSession(phase: (page: Page) => Promise<void>): Pro
     await phase(page)
   } finally {
     await browser?.close()
+    // Waits for the process to actually be gone (not just signaled) —
+    // without this, the next `runPhaseInFreshSession()` call can race the
+    // still-shutting-down previous instance and fail to bind
+    // `DEBUG_PORT` (`connectOverCDP: socket hang up`).
     await killAndWaitForExit(child)
   }
-}
-
-/**
- * `child.kill()` only sends the signal — it doesn't wait for the process
- * to actually exit and release `DEBUG_PORT`. Without waiting here, the
- * next `runPhaseInFreshSession()` call can race the still-shutting-down
- * previous instance and fail to bind the port (`connectOverCDP: socket
- * hang up`). Falls back to a fixed wait if 'exit' doesn't fire in time.
- */
-async function killAndWaitForExit(child: ReturnType<typeof spawn>, timeoutMs = 5000): Promise<void> {
-  if (child.exitCode !== null || child.killed) return
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, timeoutMs)
-    child.once('exit', () => {
-      clearTimeout(timer)
-      resolve()
-    })
-    child.kill()
-  })
 }
 
 async function main(): Promise<void> {
   mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
-  // This helper launches Electron directly against the real userData
-  // profile (see `launchElectronApp` below) rather than through
-  // `launchCaptureApp`'s isolated, always-English profile — force English
-  // for the run so a developer's own i18n pack setting can't leak into
-  // the captured screenshots.
-  const languageBackup = forceEnglishLanguage(resolveCaptureUserDataPath())
+  // Clone the real profile into a disposable temp dir and point every
+  // launch at the CLONE — see `cloneUserDataForCapture`'s doc comment for
+  // why (this used to patch the real config.json's `language` key in
+  // place with a backup/restore that could not fully protect the user's
+  // real data on a crash or concurrent run). Force English in the clone
+  // — no backup/restore needed since the clone is thrown away afterward.
+  const { userDataDir, cleanup } = cloneUserDataForCapture('key-labels')
   try {
-    await runPhaseInFreshSession(captureInstalledTab)
-    await runPhaseInFreshSession(captureFindOnHubTab)
+    forceEnglishLanguageInClone(userDataDir)
+    await runPhaseInFreshSession(userDataDir, captureInstalledTab)
+    await runPhaseInFreshSession(userDataDir, captureFindOnHubTab)
   } finally {
-    // Both phases above already wait for their Electron process to fully
-    // exit (`killAndWaitForExit`) before returning, so by the time this
-    // runs there's no running app left to race the restore.
-    restoreLanguageConfig(languageBackup)
+    cleanup()
   }
 
   console.log(`\nKey Labels screenshots saved to: ${SCREENSHOT_DIR}`)

--- a/e2e/helpers/doc-capture-theme-packs.ts
+++ b/e2e/helpers/doc-capture-theme-packs.ts
@@ -17,12 +17,12 @@ import { spawn } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
+  cloneUserDataForCapture,
   dismissNotificationModal,
   dismissOverlay,
-  forceEnglishLanguage,
+  forceEnglishLanguageInClone,
   isAvailable,
-  resolveCaptureUserDataPath,
-  restoreLanguageConfig,
+  killAndWaitForExit,
 } from './doc-capture-common'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
@@ -188,19 +188,21 @@ async function captureFindOnHubTab(page: Page): Promise<void> {
   await capture(page, 'theme-packs-hub')
 }
 
-function launchElectronApp(): ReturnType<typeof spawn> {
+function launchElectronApp(userDataDir: string): ReturnType<typeof spawn> {
   const electronPath = resolve(PROJECT_ROOT, 'node_modules/.bin/electron')
   const args = [
     '.',
     '--no-sandbox',
     '--disable-gpu-sandbox',
     `--remote-debugging-port=${DEBUG_PORT}`,
+    // Always a disposable clone from `cloneUserDataForCapture` (see
+    // `main` below) — see doc-capture-key-labels.ts's `launchElectronApp`
+    // for the full rationale (this used to touch the real profile
+    // directly, with an env-var escape hatch for the unconditional
+    // single-instance lock from #278 — no longer needed once the
+    // destination is always a fresh temp dir).
+    `--user-data-dir=${userDataDir}`,
   ]
-  // See doc-capture-key-labels.ts's `launchElectronApp` for why this
-  // escape hatch exists (the unconditional single-instance lock from #278).
-  if (process.env.PIPETTE_CAPTURE_USER_DATA_DIR) {
-    args.push(`--user-data-dir=${process.env.PIPETTE_CAPTURE_USER_DATA_DIR}`)
-  }
   return spawn(electronPath, args, {
     cwd: PROJECT_ROOT,
     stdio: 'ignore',
@@ -241,9 +243,9 @@ async function waitForDebugPort(port: number, timeoutMs = 15_000): Promise<void>
  * of a second launch cycle. See doc-capture-key-labels.ts's
  * `runPhaseInFreshSession` for the fuller investigation notes.
  */
-async function runPhaseInFreshSession(phase: (page: Page) => Promise<void>): Promise<void> {
+async function runPhaseInFreshSession(userDataDir: string, phase: (page: Page) => Promise<void>): Promise<void> {
   console.log('Launching Electron app with remote debugging...')
-  const child = launchElectronApp()
+  const child = launchElectronApp(userDataDir)
 
   let browser: Awaited<ReturnType<typeof chromium.connectOverCDP>> | undefined
   try {
@@ -268,40 +270,26 @@ async function runPhaseInFreshSession(phase: (page: Page) => Promise<void>): Pro
     await phase(page)
   } finally {
     await browser?.close()
+    // Waits for the process to actually be gone (not just signaled) —
+    // see doc-capture-key-labels.ts's `runPhaseInFreshSession` for why.
     await killAndWaitForExit(child)
   }
-}
-
-/** See doc-capture-key-labels.ts's `killAndWaitForExit` for why this exists. */
-async function killAndWaitForExit(child: ReturnType<typeof spawn>, timeoutMs = 5000): Promise<void> {
-  if (child.exitCode !== null || child.killed) return
-  await new Promise<void>((resolve) => {
-    const timer = setTimeout(resolve, timeoutMs)
-    child.once('exit', () => {
-      clearTimeout(timer)
-      resolve()
-    })
-    child.kill()
-  })
 }
 
 async function main(): Promise<void> {
   mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
-  // This helper launches Electron directly against the real userData
-  // profile (see `launchElectronApp` below) rather than through
-  // `launchCaptureApp`'s isolated, always-English profile — force English
-  // for the run so a developer's own i18n pack setting can't leak into
-  // the captured screenshots.
-  const languageBackup = forceEnglishLanguage(resolveCaptureUserDataPath())
+  // Clone the real profile into a disposable temp dir and point every
+  // launch at the CLONE — see `cloneUserDataForCapture`'s doc comment
+  // (doc-capture-common.ts) for why. Force English in the clone — no
+  // backup/restore needed since the clone is thrown away afterward.
+  const { userDataDir, cleanup } = cloneUserDataForCapture('theme-packs')
   try {
-    await runPhaseInFreshSession(captureInstalledTab)
-    await runPhaseInFreshSession(captureFindOnHubTab)
+    forceEnglishLanguageInClone(userDataDir)
+    await runPhaseInFreshSession(userDataDir, captureInstalledTab)
+    await runPhaseInFreshSession(userDataDir, captureFindOnHubTab)
   } finally {
-    // Both phases above already wait for their Electron process to fully
-    // exit (`killAndWaitForExit`) before returning, so by the time this
-    // runs there's no running app left to race the restore.
-    restoreLanguageConfig(languageBackup)
+    cleanup()
   }
 
   console.log(`\nTheme Packs screenshots saved to: ${SCREENSHOT_DIR}`)

--- a/e2e/helpers/doc-capture-theme-packs.ts
+++ b/e2e/helpers/doc-capture-theme-packs.ts
@@ -16,7 +16,14 @@ import type { Page } from '@playwright/test'
 import { spawn } from 'node:child_process'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { dismissNotificationModal, dismissOverlay, isAvailable } from './doc-capture-common'
+import {
+  dismissNotificationModal,
+  dismissOverlay,
+  forceEnglishLanguage,
+  isAvailable,
+  resolveCaptureUserDataPath,
+  restoreLanguageConfig,
+} from './doc-capture-common'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
 const SCREENSHOT_DIR = resolve(PROJECT_ROOT, 'docs/screenshots')
@@ -281,8 +288,21 @@ async function killAndWaitForExit(child: ReturnType<typeof spawn>, timeoutMs = 5
 async function main(): Promise<void> {
   mkdirSync(SCREENSHOT_DIR, { recursive: true })
 
-  await runPhaseInFreshSession(captureInstalledTab)
-  await runPhaseInFreshSession(captureFindOnHubTab)
+  // This helper launches Electron directly against the real userData
+  // profile (see `launchElectronApp` below) rather than through
+  // `launchCaptureApp`'s isolated, always-English profile — force English
+  // for the run so a developer's own i18n pack setting can't leak into
+  // the captured screenshots.
+  const languageBackup = forceEnglishLanguage(resolveCaptureUserDataPath())
+  try {
+    await runPhaseInFreshSession(captureInstalledTab)
+    await runPhaseInFreshSession(captureFindOnHubTab)
+  } finally {
+    // Both phases above already wait for their Electron process to fully
+    // exit (`killAndWaitForExit`) before returning, so by the time this
+    // runs there's no running app left to race the restore.
+    restoreLanguageConfig(languageBackup)
+  }
 
   console.log(`\nTheme Packs screenshots saved to: ${SCREENSHOT_DIR}`)
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -442,6 +442,8 @@ export function App() {
     onKeyboardLayoutChange: devicePrefs.setLayout,
     onApplyKeymapRewrite: handleApplyKeymapRewrite,
     keymapRestoreSeq: keyboard.keymapRestoreSeq,
+    activeRewriteTable: devicePrefs.activeRewriteTable,
+    activeLayoutName: devicePrefs.activeLayoutName,
   })
 
   const handleViewAnalytics = useCallback((origin: AnalyticsOrigin) => {

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -2059,4 +2059,99 @@ describe('useDevicePrefs', () => {
       expect(result.current.remapKind).toBe('actual')
     })
   })
+
+  // Task-kaw-requestApply-reuse: `activeRewriteTable` lets
+  // `useKeymapApplyPrompt.requestApply` skip its own async lookup/build —
+  // it must mirror `remapKind` exactly: defined (and matching
+  // `buildKeymapRewriteTable`'s own table) iff `remapKind === 'simulated'`,
+  // `undefined` in every 'actual' case.
+  describe('activeRewriteTable', () => {
+    const COLEMAK: Record<string, string> = {
+      KC_E: 'F', KC_R: 'P', KC_T: 'G', KC_Y: 'J', KC_U: 'L', KC_I: 'U', KC_O: 'Y',
+      KC_P: ';', KC_S: 'R', KC_D: 'S', KC_F: 'T', KC_G: 'D', KC_J: 'N', KC_K: 'E',
+      KC_L: 'I', KC_SCOLON: 'O', KC_N: 'K',
+    }
+    const JAPANESE_QWERTY: Record<string, string> = {
+      KC_LBRACKET: '`\n@',
+      KC_RBRACKET: '{\n[',
+      KC_2: '"\n2',
+    }
+
+    function mockKeyLabelPack(id: string, map: Record<string, string>, keymapApplicable = true): void {
+      const existing = vialAPIMock()
+      Object.defineProperty(window, 'vialAPI', {
+        value: {
+          ...existing,
+          keyLabelStoreGet: async (reqId: string) => {
+            if (reqId !== id) return { success: false, errorCode: 'NOT_FOUND' }
+            return {
+              success: true,
+              data: {
+                meta: { id, name: id, filename: `${id}.json`, savedAt: '', updatedAt: '' },
+                data: { name: id, map, keymapApplicable },
+              },
+            }
+          },
+        },
+        writable: true,
+        configurable: true,
+      })
+    }
+
+    it('is undefined for QWERTY (no pack loaded)', async () => {
+      setupMocks()
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      expect(result.current.activeRewriteTable).toBeUndefined()
+    })
+
+    it('mirrors remapKind === "simulated": the resolved table for a pure permutation pack (Colemak)', async () => {
+      setupMocks()
+      mockKeyLabelPack('colemak-id', COLEMAK)
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+      act(() => {
+        result.current.setLayout('colemak-id')
+      })
+      await act(async () => {})
+      expect(result.current.remapKind).toBe('simulated')
+      expect(result.current.activeRewriteTable).toBeDefined()
+      expect(result.current.activeRewriteTable?.get('KC_E')).toBe('KC_F')
+    })
+
+    it('is undefined for a JIS-type deviation pack that fails buildKeymapRewriteTable', async () => {
+      setupMocks()
+      mockKeyLabelPack('jis-id', JAPANESE_QWERTY)
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+      act(() => {
+        result.current.setLayout('jis-id')
+      })
+      await act(async () => {})
+      expect(result.current.remapKind).toBe('actual')
+      expect(result.current.activeRewriteTable).toBeUndefined()
+    })
+
+    it('is undefined for a pure permutation pack not flagged keymapApplicable (author opt-out)', async () => {
+      setupMocks()
+      mockKeyLabelPack('colemak-id', COLEMAK, false)
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+      act(() => {
+        result.current.setLayout('colemak-id')
+      })
+      await act(async () => {})
+      expect(result.current.remapKind).toBe('actual')
+      expect(result.current.activeRewriteTable).toBeUndefined()
+    })
+  })
 })

--- a/src/renderer/hooks/__tests__/useKeymapApplyPrompt.test.ts
+++ b/src/renderer/hooks/__tests__/useKeymapApplyPrompt.test.ts
@@ -46,6 +46,17 @@ function dvorakTable() {
   return result.table
 }
 
+// Computed ONCE and reused by identity everywhere a test passes
+// `activeRewriteTable` as a prop (as opposed to `.toEqual()`-comparing a
+// freshly-built one, where identity doesn't matter): the hook now watches
+// `activeRewriteTable`'s own identity (P2 fix below) to close the modal
+// when the active pack's data changes — calling `colemakTable()`/
+// `dvorakTable()` fresh at both `setup()` and a later `rerender()` for
+// what a test intends as "the same, unchanged pack" would produce two
+// different `Map` instances and spuriously trip that watcher.
+const COLEMAK_TABLE = colemakTable()
+const DVORAK_TABLE = dvorakTable()
+
 describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select-no-rewrite v7)', () => {
   const onKeyboardLayoutChange = vi.fn()
   const onApplyKeymapRewrite = vi.fn().mockResolvedValue({ appliedCount: 2 })
@@ -83,20 +94,20 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   })
 
   it('handleKeyboardLayoutChange switches straight to QWERTY too — no special-cased early return needed anymore', () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
     act(() => result.current.handleKeyboardLayoutChange(BUILTIN_QWERTY_LAYOUT_ID))
     expect(onKeyboardLayoutChange).toHaveBeenCalledWith(BUILTIN_QWERTY_LAYOUT_ID)
     expect(result.current.pendingApply).toBeNull()
   })
 
   it('handleKeyboardLayoutChange closes an already-open confirm modal (defensive, ahead of the layout-watch effect)', () => {
-    const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+    const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
 
     act(() => result.current.handleKeyboardLayoutChange('colemak-id'))
     expect(result.current.pendingApply).toBeNull()
-    rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+    rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
     expect(result.current.pendingApply).toBeNull()
   })
 
@@ -104,20 +115,20 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   // synchronously off the already-provided `activeRewriteTable` ---
 
   it('requestApply opens the modal for the current (rewrite-eligible) keyboardLayout', () => {
-    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
     expect(onKeyboardLayoutChange).not.toHaveBeenCalled()
   })
 
   it('requestApply falls back to the raw id when activeLayoutName is not provided', () => {
-    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable() })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'dvorak-id' })
   })
 
   it('requestApply is a no-op against QWERTY', () => {
-    const { result } = setup({ keyboardLayout: BUILTIN_QWERTY_LAYOUT_ID, activeRewriteTable: colemakTable() })
+    const { result } = setup({ keyboardLayout: BUILTIN_QWERTY_LAYOUT_ID, activeRewriteTable: COLEMAK_TABLE })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toBeNull()
   })
@@ -132,7 +143,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     const { result } = renderHook(() => useKeymapApplyPrompt({
       keymapEditable: false,
       keyboardLayout: 'dvorak-id',
-      activeRewriteTable: dvorakTable(),
+      activeRewriteTable: DVORAK_TABLE,
       activeLayoutName: 'Dvorak',
       onKeyboardLayoutChange,
       onApplyKeymapRewrite,
@@ -145,7 +156,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   // clean success (destructive one-shot) ---
 
   it('Confirm applies the current keyboardLayout\'s own table and resets the select to QWERTY on clean success', async () => {
-    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
 
@@ -157,7 +168,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   })
 
   it('re-requesting Apply for the pack the select already shows still offers a fresh Rewrite', async () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
 
@@ -168,7 +179,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   })
 
   it('Cancel closes the modal without touching the select or the keymap', () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).not.toBeNull()
 
@@ -182,7 +193,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   it('C1: partial failure leaves the select untouched (no forced QWERTY reset) and surfaces the error', async () => {
     onApplyKeymapRewrite.mockResolvedValueOnce({ appliedCount: 1, error: 'device write failed' })
-    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).not.toBeNull()
 
@@ -194,7 +205,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   it('C2: a zero-count success (keymap already matched the target — Apply intent satisfied) still resets the select to QWERTY', async () => {
     onApplyKeymapRewrite.mockResolvedValueOnce({ appliedCount: 0 })
-    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).not.toBeNull()
 
@@ -210,7 +221,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -235,7 +246,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -258,7 +269,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -284,7 +295,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   describe('layout-change race', () => {
     it('a layout change while the confirm modal is open for a DIFFERENT pack closes it (open Colemak, select Dvorak, Confirm must not fire)', () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
 
@@ -292,7 +303,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       // actually drives it: `keyboardLayout` (and its sibling
       // `activeRewriteTable`/`activeLayoutName`, always in sync with it via
       // `useDevicePrefs`) change out from under the hook.
-      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       expect(result.current.pendingApply).toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
@@ -300,11 +311,11 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     })
 
     it('an unchanged keyboardLayout value does not close an open modal', () => {
-      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       expect(result.current.pendingApply).not.toBeNull()
     })
 
@@ -318,7 +329,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -348,7 +359,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -366,7 +377,7 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     })
 
     it('FIX B control: an unchanged layout still resets to QWERTY on clean success (baseline, unaffected by the new guard)', async () => {
-      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
@@ -375,25 +386,72 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     })
   })
 
+  // --- P2 (external review): the active pack's OWN data can change while
+  // its confirm modal is open, without `keyboardLayout` itself changing —
+  // e.g. the same pack is edited or deleted (Key Labels modal, a Hub sync,
+  // or another window) while the modal is up. `activeRewriteTable` must be
+  // watched by its own identity so Confirm can never fire a table that no
+  // longer matches what `useDevicePrefs` currently resolves for this id. ---
+
+  describe('activeRewriteTable identity race (P2 fix)', () => {
+    it('the pack is deleted while the modal is open (activeRewriteTable becomes undefined): modal closes, Confirm cannot fire the stale table', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
+      act(() => { result.current.requestApply() })
+      expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
+
+      // Same id — only the pack's own resolved data changed underneath it.
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: undefined, activeLayoutName: 'Colemak' })
+      expect(result.current.pendingApply).toBeNull()
+
+      act(() => { result.current.handleApplyConfirm() })
+      expect(onApplyKeymapRewrite).not.toHaveBeenCalled()
+    })
+
+    it('the pack is edited while the modal is open (activeRewriteTable resolves to a new table instance): modal closes, Confirm cannot fire the stale table', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
+      act(() => { result.current.requestApply() })
+      expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
+
+      // Same id, same content even — but a freshly re-derived `Map`
+      // instance, matching how `useDevicePrefs`'s own `useMemo` would
+      // recompute a new object whenever the underlying pack data changes,
+      // regardless of whether the new content happens to be equivalent.
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
+      expect(result.current.pendingApply).toBeNull()
+
+      act(() => { result.current.handleApplyConfirm() })
+      expect(onApplyKeymapRewrite).not.toHaveBeenCalled()
+    })
+
+    it('an unchanged activeRewriteTable identity does not close the modal', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
+      act(() => { result.current.requestApply() })
+      expect(result.current.pendingApply).not.toBeNull()
+
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak' })
+      expect(result.current.pendingApply).not.toBeNull()
+    })
+  })
+
   // --- D3: keymapRestoreSeq defensively closes an open confirm modal
   // (Plan-qwerty-select-no-rewrite §snapshot/.vil 復元時のクリーンアップ) ---
 
   describe('keymapRestoreSeq (restore cleanup, D3)', () => {
     it('a change closes an open confirm modal', () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 2 })
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak', keymapRestoreSeq: 2 })
       expect(result.current.pendingApply).toBeNull()
     })
 
     it('an unchanged value does not close the modal', () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: COLEMAK_TABLE, activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       expect(result.current.pendingApply).not.toBeNull()
       expect(onKeyboardLayoutChange).not.toHaveBeenCalled()
     })
@@ -403,14 +461,14 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const applyPromise = new Promise<{ appliedCount: number; error?: string }>((res) => { resolveApply = res })
       onApplyKeymapRewrite.mockImplementationOnce(() => applyPromise)
 
-      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak', keymapRestoreSeq: 1 })
+      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
       expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(result.current.isApplying).toBe(true)
 
-      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak', keymapRestoreSeq: 2 })
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: DVORAK_TABLE, activeLayoutName: 'Dvorak', keymapRestoreSeq: 2 })
       expect(result.current.pendingApply).toBeNull()
 
       await act(async () => {

--- a/src/renderer/hooks/__tests__/useKeymapApplyPrompt.test.ts
+++ b/src/renderer/hooks/__tests__/useKeymapApplyPrompt.test.ts
@@ -13,8 +13,11 @@ import { BUILTIN_QWERTY_LAYOUT_ID } from '../../data/keyboard-layouts'
 // switch for every value, never a lookup or a modal. `requestApply` is the
 // ONLY entry point into the confirm modal now — called by KeymapEditor's
 // simulation-tab Apply button, which is only reachable while
-// `useDevicePrefs.remapKind === 'simulated'` (i.e. `keyboardLayout` is
-// already a rewrite-eligible pack).
+// `useDevicePrefs.remapKind === 'simulated'`. Task-kaw-requestApply-reuse:
+// the hook no longer resolves the target's map/table itself — callers pass
+// in `activeRewriteTable`/`activeLayoutName` (mirroring `useDevicePrefs`'s
+// own already-resolved values), so `requestApply` reads them synchronously
+// instead of running its own `useKeyLabelLookup` fetch + build.
 const COLEMAK: Record<string, string> = {
   KC_E: 'F', KC_R: 'P', KC_T: 'G', KC_Y: 'J', KC_U: 'L', KC_I: 'U', KC_O: 'Y',
   KC_P: ';', KC_S: 'R', KC_D: 'S', KC_F: 'T', KC_G: 'D', KC_J: 'N', KC_K: 'E',
@@ -30,30 +33,6 @@ const DVORAK: Record<string, string> = {
   KC_C: 'J', KC_V: 'K', KC_B: 'X', KC_N: 'B', KC_M: 'M', KC_COMMA: 'W',
   KC_DOT: 'V', KC_SLASH: 'Z', KC_MINUS: '[', KC_EQUAL: ']',
 }
-// A pack whose map is a shift-pair display style, not a permutation — fails
-// buildKeymapRewriteTable the same way sample-packs/key-labels' Japanese
-// QWERTY packs do (see shared/keymap/__tests__/keymap-apply.test.ts).
-const NOT_APPLICABLE: Record<string, string> = { KC_2: '"\n2' }
-
-interface FakeEntry {
-  name: string
-  map: Record<string, string>
-  keymapApplicable: boolean
-}
-
-const registry = new Map<string, FakeEntry>()
-
-const lookup = {
-  ensure: vi.fn(async (_id: string) => {}),
-  getName: vi.fn((id: string) => registry.get(id)?.name ?? id),
-  getMap: vi.fn((id: string) => registry.get(id)?.map),
-  getCompositeLabels: vi.fn(() => undefined),
-  getKeymapApplicable: vi.fn((id: string) => registry.get(id)?.keymapApplicable === true),
-}
-
-vi.mock('../useKeyLabelLookup', () => ({
-  useKeyLabelLookup: () => lookup,
-}))
 
 function colemakTable() {
   const result = buildKeymapRewriteTable(COLEMAK)
@@ -73,10 +52,6 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   beforeEach(() => {
     vi.clearAllMocks()
-    registry.clear()
-    registry.set('colemak-id', { name: 'Colemak', map: COLEMAK, keymapApplicable: true })
-    registry.set('dvorak-id', { name: 'Dvorak', map: DVORAK, keymapApplicable: true })
-    registry.set('not-applicable-id', { name: 'Not Applicable', map: NOT_APPLICABLE, keymapApplicable: true })
     onApplyKeymapRewrite.mockResolvedValue({ appliedCount: 2 })
   })
 
@@ -100,64 +75,69 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   // --- handleKeyboardLayoutChange: plain display switch for EVERY value ---
 
-  it('handleKeyboardLayoutChange never opens the modal or performs a lookup, for any value including a rewrite-eligible pack', async () => {
+  it('handleKeyboardLayoutChange never opens the modal, for any value including a rewrite-eligible pack', () => {
     const { result } = setup({ keyboardLayout: 'qwerty' })
     act(() => result.current.handleKeyboardLayoutChange('dvorak-id'))
     expect(onKeyboardLayoutChange).toHaveBeenCalledWith('dvorak-id')
     expect(result.current.pendingApply).toBeNull()
-    expect(lookup.ensure).not.toHaveBeenCalled()
   })
 
-  it('handleKeyboardLayoutChange switches straight to QWERTY too — no special-cased early return needed anymore', async () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id' })
+  it('handleKeyboardLayoutChange switches straight to QWERTY too — no special-cased early return needed anymore', () => {
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
     act(() => result.current.handleKeyboardLayoutChange(BUILTIN_QWERTY_LAYOUT_ID))
     expect(onKeyboardLayoutChange).toHaveBeenCalledWith(BUILTIN_QWERTY_LAYOUT_ID)
     expect(result.current.pendingApply).toBeNull()
   })
 
-  it('handleKeyboardLayoutChange closes an already-open confirm modal (defensive, ahead of the layout-watch effect)', async () => {
-    const { result, rerender } = setup({ keyboardLayout: 'dvorak-id' })
+  it('handleKeyboardLayoutChange closes an already-open confirm modal (defensive, ahead of the layout-watch effect)', () => {
+    const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+    expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
 
     act(() => result.current.handleKeyboardLayoutChange('colemak-id'))
     expect(result.current.pendingApply).toBeNull()
-    rerender({ keyboardLayout: 'colemak-id' })
+    rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
     expect(result.current.pendingApply).toBeNull()
   })
 
-  // --- requestApply: the only entry point into the modal ---
+  // --- requestApply: the only entry point into the modal, resolves
+  // synchronously off the already-provided `activeRewriteTable` ---
 
-  it('requestApply opens the modal for the current (rewrite-eligible) keyboardLayout', async () => {
-    const { result } = setup({ keyboardLayout: 'dvorak-id' })
+  it('requestApply opens the modal for the current (rewrite-eligible) keyboardLayout', () => {
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' }))
+    expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
     expect(onKeyboardLayoutChange).not.toHaveBeenCalled()
   })
 
-  it('requestApply is a no-op against QWERTY', async () => {
-    const { result } = setup({ keyboardLayout: BUILTIN_QWERTY_LAYOUT_ID })
+  it('requestApply falls back to the raw id when activeLayoutName is not provided', () => {
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable() })
     act(() => { result.current.requestApply() })
-    expect(lookup.ensure).not.toHaveBeenCalled()
+    expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'dvorak-id' })
+  })
+
+  it('requestApply is a no-op against QWERTY', () => {
+    const { result } = setup({ keyboardLayout: BUILTIN_QWERTY_LAYOUT_ID, activeRewriteTable: colemakTable() })
+    act(() => { result.current.requestApply() })
     expect(result.current.pendingApply).toBeNull()
   })
 
-  it('requestApply is a no-op against a pack that is not (or no longer) rewrite-eligible', async () => {
-    const { result } = setup({ keyboardLayout: 'not-applicable-id' })
+  it('requestApply is a no-op against a pack that is not (or no longer) rewrite-eligible', () => {
+    const { result } = setup({ keyboardLayout: 'not-applicable-id', activeRewriteTable: undefined })
     act(() => { result.current.requestApply() })
-    await act(async () => { await Promise.resolve(); await Promise.resolve() })
     expect(result.current.pendingApply).toBeNull()
   })
 
-  it('requestApply is a no-op when the keymap is not editable', async () => {
+  it('requestApply is a no-op when the keymap is not editable', () => {
     const { result } = renderHook(() => useKeymapApplyPrompt({
       keymapEditable: false,
       keyboardLayout: 'dvorak-id',
+      activeRewriteTable: dvorakTable(),
+      activeLayoutName: 'Dvorak',
       onKeyboardLayoutChange,
       onApplyKeymapRewrite,
     }))
     act(() => { result.current.requestApply() })
-    expect(lookup.ensure).not.toHaveBeenCalled()
     expect(result.current.pendingApply).toBeNull()
   })
 
@@ -165,9 +145,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   // clean success (destructive one-shot) ---
 
   it('Confirm applies the current keyboardLayout\'s own table and resets the select to QWERTY on clean success', async () => {
-    const { result } = setup({ keyboardLayout: 'dvorak-id' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' }))
+    expect(result.current.pendingApply).toEqual({ id: 'dvorak-id', name: 'Dvorak' })
 
     act(() => { result.current.handleApplyConfirm() })
     await waitFor(() => expect(onApplyKeymapRewrite).toHaveBeenCalledTimes(1))
@@ -177,9 +157,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   })
 
   it('re-requesting Apply for the pack the select already shows still offers a fresh Rewrite', async () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id' })
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' }))
+    expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
 
     act(() => { result.current.handleApplyConfirm() })
     await waitFor(() => expect(onApplyKeymapRewrite).toHaveBeenCalledTimes(1))
@@ -187,10 +167,10 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     expect(table).toEqual(colemakTable())
   })
 
-  it('Cancel closes the modal without touching the select or the keymap', async () => {
-    const { result } = setup({ keyboardLayout: 'colemak-id' })
+  it('Cancel closes the modal without touching the select or the keymap', () => {
+    const { result } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+    expect(result.current.pendingApply).not.toBeNull()
 
     act(() => result.current.handleApplyCancel())
     expect(result.current.pendingApply).toBeNull()
@@ -202,9 +182,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   it('C1: partial failure leaves the select untouched (no forced QWERTY reset) and surfaces the error', async () => {
     onApplyKeymapRewrite.mockResolvedValueOnce({ appliedCount: 1, error: 'device write failed' })
-    const { result } = setup({ keyboardLayout: 'dvorak-id' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+    expect(result.current.pendingApply).not.toBeNull()
 
     act(() => { result.current.handleApplyConfirm() })
     await waitFor(() => expect(result.current.applyError).toBe('device write failed'))
@@ -214,9 +194,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   it('C2: a zero-count success (keymap already matched the target — Apply intent satisfied) still resets the select to QWERTY', async () => {
     onApplyKeymapRewrite.mockResolvedValueOnce({ appliedCount: 0 })
-    const { result } = setup({ keyboardLayout: 'dvorak-id' })
+    const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
     act(() => { result.current.requestApply() })
-    await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+    expect(result.current.pendingApply).not.toBeNull()
 
     act(() => { result.current.handleApplyConfirm() })
     await waitFor(() => expect(onKeyboardLayoutChange).toHaveBeenCalledWith(BUILTIN_QWERTY_LAYOUT_ID))
@@ -230,9 +210,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(result.current.isApplying).toBe(true)
@@ -255,9 +235,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       act(() => { result.current.handleApplyConfirm() })
@@ -278,9 +258,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(result.current.isApplying).toBe(true)
@@ -298,44 +278,33 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
 
   // --- RACE (Plan-qwerty-select-no-rewrite v7, new/mandatory): the select
   // no longer routes through this hook's onChange-time lookup, so a
-  // `keyboardLayout` change can land at any time — while `requestApply`'s
-  // own lookup is in flight, or while the modal for a DIFFERENT pack is
-  // already open. Both must be caught by watching the value itself. ---
+  // `keyboardLayout` change can land at any time — while the modal for a
+  // DIFFERENT pack is already open. Must be caught by watching the value
+  // itself. ---
 
   describe('layout-change race', () => {
-    it('a layout change while the confirm modal is open for a DIFFERENT pack closes it (open Colemak, select Dvorak, Confirm must not fire)', async () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id' })
+    it('a layout change while the confirm modal is open for a DIFFERENT pack closes it (open Colemak, select Dvorak, Confirm must not fire)', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' }))
+      expect(result.current.pendingApply).toEqual({ id: 'colemak-id', name: 'Colemak' })
 
       // The select moves on to Dvorak — simulated here the same way App.tsx
-      // actually drives it: `keyboardLayout` changes out from under the hook.
-      rerender({ keyboardLayout: 'dvorak-id' })
+      // actually drives it: `keyboardLayout` (and its sibling
+      // `activeRewriteTable`/`activeLayoutName`, always in sync with it via
+      // `useDevicePrefs`) change out from under the hook.
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       expect(result.current.pendingApply).toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(onApplyKeymapRewrite).not.toHaveBeenCalled()
     })
 
-    it('a layout change while requestApply\'s own lookup is still in flight discards the result — no modal opens for the stale target', async () => {
-      let resolveEnsure!: () => void
-      lookup.ensure.mockImplementationOnce(() => new Promise<void>((res) => { resolveEnsure = res }))
-
-      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id' })
+    it('an unchanged keyboardLayout value does not close an open modal', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
+      expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'colemak-id' })
-      resolveEnsure()
-      await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve() })
-      expect(result.current.pendingApply).toBeNull()
-    })
-
-    it('an unchanged keyboardLayout value does not close an open modal', async () => {
-      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id' })
-      act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
-
-      rerender({ keyboardLayout: 'dvorak-id' })
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       expect(result.current.pendingApply).not.toBeNull()
     })
 
@@ -349,9 +318,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(result.current.isApplying).toBe(true)
@@ -379,9 +348,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const { promise, resolve } = pendingApplyResult()
       onApplyKeymapRewrite.mockImplementationOnce(() => promise)
 
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       act(() => { result.current.handleKeyboardLayoutChange(BUILTIN_QWERTY_LAYOUT_ID) })
@@ -397,9 +366,9 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
     })
 
     it('FIX B control: an unchanged layout still resets to QWERTY on clean success (baseline, unaffected by the new guard)', async () => {
-      const { result } = setup({ keyboardLayout: 'dvorak-id' })
+      const { result } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak' })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       await waitFor(() => expect(onKeyboardLayoutChange).toHaveBeenCalledWith(BUILTIN_QWERTY_LAYOUT_ID))
@@ -410,38 +379,23 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
   // (Plan-qwerty-select-no-rewrite §snapshot/.vil 復元時のクリーンアップ) ---
 
   describe('keymapRestoreSeq (restore cleanup, D3)', () => {
-    it('a change closes an open confirm modal', async () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 1 })
+    it('a change closes an open confirm modal', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 2 })
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 2 })
       expect(result.current.pendingApply).toBeNull()
     })
 
-    it('an unchanged value does not close the modal', async () => {
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 1 })
+    it('an unchanged value does not close the modal', () => {
+      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
-      rerender({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 1 })
+      rerender({ keyboardLayout: 'colemak-id', activeRewriteTable: colemakTable(), activeLayoutName: 'Colemak', keymapRestoreSeq: 1 })
       expect(result.current.pendingApply).not.toBeNull()
       expect(onKeyboardLayoutChange).not.toHaveBeenCalled()
-    })
-
-    it('restore race: a lookup already in flight before the restore must not re-open the modal once it resolves', async () => {
-      let resolveEnsure!: () => void
-      lookup.ensure.mockImplementationOnce(() => new Promise<void>((res) => { resolveEnsure = res }))
-
-      const { result, rerender } = setup({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 1 })
-      act(() => { result.current.requestApply() })
-
-      rerender({ keyboardLayout: 'colemak-id', keymapRestoreSeq: 2 })
-      expect(result.current.pendingApply).toBeNull()
-
-      resolveEnsure()
-      await act(async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve() })
-      expect(result.current.pendingApply).toBeNull()
     })
 
     it('restore race: a restore landing while Confirm is in flight discards the apply\'s own result entirely — only the modal close lands', async () => {
@@ -449,14 +403,14 @@ describe('useKeymapApplyPrompt — simulation tab Apply flow (Plan-qwerty-select
       const applyPromise = new Promise<{ appliedCount: number; error?: string }>((res) => { resolveApply = res })
       onApplyKeymapRewrite.mockImplementationOnce(() => applyPromise)
 
-      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', keymapRestoreSeq: 1 })
+      const { result, rerender } = setup({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak', keymapRestoreSeq: 1 })
       act(() => { result.current.requestApply() })
-      await waitFor(() => expect(result.current.pendingApply).not.toBeNull())
+      expect(result.current.pendingApply).not.toBeNull()
 
       act(() => { result.current.handleApplyConfirm() })
       expect(result.current.isApplying).toBe(true)
 
-      rerender({ keyboardLayout: 'dvorak-id', keymapRestoreSeq: 2 })
+      rerender({ keyboardLayout: 'dvorak-id', activeRewriteTable: dvorakTable(), activeLayoutName: 'Dvorak', keymapRestoreSeq: 2 })
       expect(result.current.pendingApply).toBeNull()
 
       await act(async () => {

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import type { KeyboardLayoutId } from '../data/keyboard-layouts'
 import { useKeyLabelLookup } from './useKeyLabelLookup'
-import { buildKeymapRewriteTable } from '../../shared/keymap/keymap-apply'
+import { buildKeymapRewriteTable, type KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
 import type { RemapKind } from '../components/keyboard/constants'
 import { useAppConfig } from './useAppConfig'
 import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
@@ -460,6 +460,12 @@ export interface UseDevicePrefsReturn {
    *  pack (irrelevant since no key is ever tinted there), and
    *  non-permutation deviation packs. */
   remapKind: RemapKind
+  /** The active pack's own rewrite table, already resolved and validated —
+   *  `undefined` unless `remapKind === 'simulated'`. Lets
+   *  `useKeymapApplyPrompt.requestApply` skip a second async lookup for
+   *  the exact table `remapKind` itself already required to build. See
+   *  the hook body's own doc comment for the full rationale. */
+  activeRewriteTable?: KeymapRewriteTable
   /** Display name of the active layout/pack — see `remapKind`'s sibling
    *  doc comment on `activeLayoutName` in the hook body for what feeds it. */
   activeLayoutName: string
@@ -960,6 +966,21 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     return hasActivePackMap && keymapApplicable && packIsPurePermutation ? 'simulated' : 'actual'
   }, [activeMap, keymapApplicable, packIsPurePermutation])
 
+  // The active pack's own rewrite table, exposed ONLY while it's actually
+  // eligible for a keymap Rewrite (`remapKind === 'simulated'` — the exact
+  // state `KeymapEditor` requires before it ever renders the simulation
+  // tab / Apply button in the first place). `useKeymapApplyPrompt
+  // .requestApply` reads this directly instead of re-resolving the same
+  // map through its own `useKeyLabelLookup` instance: by the time the
+  // Apply button is reachable at all, `rewriteTableResult` above has
+  // already built successfully for this exact `layout`, so there is
+  // nothing left to look up. `undefined` (not `remapKind !== 'simulated'`
+  // alone) is the guard `requestApply` no-ops on, mirroring the old
+  // resolver's own null-return contract.
+  const activeRewriteTable = remapKind === 'simulated' && rewriteTableResult?.ok
+    ? rewriteTableResult.table
+    : undefined
+
   // Display name for the active pack — used by `KeymapEditor`'s simulation
   // tab label when `remapKind === 'simulated'`. Falls back to the raw id
   // (same fallback `useKeyLabelLookup.getName` documents) so a not-yet-
@@ -1086,6 +1107,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     remapLabel,
     isRemapped,
     remapKind,
+    activeRewriteTable,
     activeLayoutName,
     pickerRemapLabel,
   }

--- a/src/renderer/hooks/useKeymapApplyPrompt.ts
+++ b/src/renderer/hooks/useKeymapApplyPrompt.ts
@@ -112,9 +112,10 @@ export function useKeymapApplyPrompt({
   const [isApplying, setIsApplying] = useState(false)
 
   // Bumped on every `requestApply`/`handleKeyboardLayoutChange` call and on
-  // every observed `keyboardLayout` change (see the watch effect below —
-  // the sibling `keymapRestoreSeq` watcher further down only needs to close
-  // the modal, not bump this, see its own comment). `handleApplyConfirm`
+  // every observed `keyboardLayout`/`activeRewriteTable` change (see the two
+  // watch effects below — the sibling `keymapRestoreSeq` watcher further
+  // down only needs to close the modal, not bump this, see its own
+  // comment). `handleApplyConfirm`
   // snapshots it at Confirm time and re-checks it after `onApplyKeymapRewrite`
   // settles, so a layout change mid-apply (the user picks a DIFFERENT pack,
   // or QWERTY, before the stale apply resolves) discards that apply's
@@ -142,6 +143,28 @@ export function useKeymapApplyPrompt({
     ++requestSeqRef.current
     setPendingApply(null)
   }, [keyboardLayout])
+
+  // Defensive close (external review finding): the active pack's OWN data
+  // can change out from under an open modal without `keyboardLayout`
+  // itself changing — e.g. the same pack is edited or deleted (via the
+  // Key Labels modal, a Hub sync, or another window) while its confirm
+  // modal is still open. `useDevicePrefs.activeRewriteTable` recomputes
+  // to a new object (or `undefined`) whenever that happens, even though
+  // `keyboardLayout` still names the same id — the `keyboardLayout`
+  // watcher above only fires on an actual id change, not a same-id data
+  // edit, so it can't catch this on its own. Comparing THIS value's own
+  // identity is what does. Bumps `requestSeqRef` too, same as the
+  // `keyboardLayout` watcher, so an in-flight Confirm built against the
+  // now-stale table is likewise superseded rather than driving the
+  // QWERTY-reset / error-surfacing branch once it settles.
+  const activeRewriteTableRef = useRef(activeRewriteTable)
+  useEffect(() => {
+    const prev = activeRewriteTableRef.current
+    activeRewriteTableRef.current = activeRewriteTable
+    if (activeRewriteTable === prev) return
+    ++requestSeqRef.current
+    setPendingApply(null)
+  }, [activeRewriteTable])
 
   // Defensive close (Plan-qwerty-select-no-rewrite §snapshot/.vil 復元時の
   // クリーンアップ, D3): the counter is monotonic for the session (disconnect

--- a/src/renderer/hooks/useKeymapApplyPrompt.ts
+++ b/src/renderer/hooks/useKeymapApplyPrompt.ts
@@ -2,9 +2,10 @@
 //
 // Owns the "does this Key Label pack want a keymap rewrite?" decision for
 // the simulation tab's Apply button (Plan-qwerty-select-no-rewrite v7 —
-// シミュレーションタブ方式): fetches the target's full payload, checks
-// `keymapApplicable`, and validates it with `buildKeymapRewriteTable`
-// before deciding whether to prompt with KeymapApplyConfirmModal.
+// シミュレーションタブ方式): reads `activeRewriteTable` — already resolved
+// and validated by `useDevicePrefs` (`keymapApplicable && buildKeymapRewrite
+// Table(map).ok`, the same predicate `remapKind === 'simulated'` gates on)
+// — before deciding whether to prompt with KeymapApplyConfirmModal.
 //
 // The footer's Keyboard Layout select never opens this modal itself
 // anymore — `handleKeyboardLayoutChange` is a plain display switch for
@@ -24,8 +25,7 @@
 // `remapKind` reverts to 'actual' for QWERTY.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { useKeyLabelLookup } from './useKeyLabelLookup'
-import { buildKeymapRewriteTable, type KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
+import type { KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
 import { BUILTIN_QWERTY_LAYOUT_ID } from '../data/keyboard-layouts'
 import type { KeyboardLayoutId } from './useKeyboardLayout'
 import type { KeymapApplyResult } from '../components/editors/keymap-editor-types'
@@ -34,10 +34,10 @@ export interface UseKeymapApplyPromptOptions {
   /** True when the connected device has a loaded keymap to rewrite. Without
    *  it, `requestApply` never opens the modal — there's nothing to write. */
   keymapEditable: boolean
-  /** The Keyboard Layout select's current value — `requestApply` builds its
-   *  rewrite table from this id, and the race-guard effect below watches it
-   *  to close a stale pending modal the instant it changes out from under
-   *  the request that opened it. */
+  /** The Keyboard Layout select's current value — `requestApply` reads
+   *  `activeRewriteTable`/`activeLayoutName` alongside this id, and the
+   *  race-guard effect below watches it to close a stale pending modal the
+   *  instant it changes out from under the request that opened it. */
   keyboardLayout: string
   onKeyboardLayoutChange?: (layout: KeyboardLayoutId) => void
   /** Bulk-rewrite the live keymap via `KeymapEditorHandle.applyKeymapRewrite`. */
@@ -49,15 +49,28 @@ export interface UseKeymapApplyPromptOptions {
    *  just replaced the whole keymap this modal's pending Apply would
    *  otherwise act against. */
   keymapRestoreSeq?: number
+  /** `useDevicePrefs.activeRewriteTable` — the CURRENT `keyboardLayout`'s
+   *  own rewrite table, already resolved and validated by `useDevicePrefs`
+   *  (the same `keymapApplicable && buildKeymapRewriteTable(map).ok`
+   *  predicate `remapKind === 'simulated'` itself gates on). `requestApply`
+   *  reads this synchronously instead of re-deriving it via its own
+   *  `useKeyLabelLookup` lookup — by the time the Apply button that calls
+   *  `requestApply` is even reachable, `remapKind` already required this
+   *  exact table to build. `undefined` means the active pack isn't (or is
+   *  no longer) rewrite-eligible — `requestApply` no-ops. */
+  activeRewriteTable?: KeymapRewriteTable
+  /** `useDevicePrefs.activeLayoutName` — display name for the CURRENT
+   *  `keyboardLayout`, shown in the confirm modal's title. */
+  activeLayoutName?: string
 }
 
 export interface UseKeymapApplyPromptReturn {
   /** Pass straight through as the Keyboard Layout select's `onChange` — a
    *  plain display switch for every value now, never a lookup/modal. */
   handleKeyboardLayoutChange: (v: string) => void
-  /** Start the "does the current selection want a Rewrite?" lookup and, if
-   *  so, open the confirm modal. Called by the simulation tab's Apply
-   *  button — see `KeymapEditor`'s `onRequestKeymapApply`. */
+  /** Check whether the current selection wants a Rewrite and, if so, open
+   *  the confirm modal. Called by the simulation tab's Apply button — see
+   *  `KeymapEditor`'s `onRequestKeymapApply`. */
   requestApply: () => void
   /** Non-null while the confirm modal should be open. */
   pendingApply: { id: string; name: string } | null
@@ -76,33 +89,15 @@ export interface UseKeymapApplyPromptReturn {
   isApplying: boolean
 }
 
-/** Resolve `id`'s own rewrite table when it's flagged `keymapApplicable`
- *  and its map actually builds — the same
- *  `keymapApplicable && buildKeymapRewriteTable(map).ok` predicate
- *  `useDevicePrefs.remapKind` uses to decide whether the simulation tabs
- *  (and thus the Apply button that calls this) are even showing. Returns
- *  `null` when `id` isn't rewrite-eligible at all (flag-less pack, failed
- *  build, or a pack that's missing/not yet loaded locally) — defensive
- *  only, since the Apply button shouldn't be reachable in that state. */
-async function resolveRewriteTable(
-  id: string,
-  keyLabelLookup: ReturnType<typeof useKeyLabelLookup>,
-): Promise<KeymapRewriteTable | null> {
-  await keyLabelLookup.ensure(id)
-  const map = keyLabelLookup.getMap(id)
-  if (!map || !keyLabelLookup.getKeymapApplicable(id)) return null
-  const result = buildKeymapRewriteTable(map)
-  return result.ok ? result.table : null
-}
-
 export function useKeymapApplyPrompt({
   keymapEditable,
   keyboardLayout,
   onKeyboardLayoutChange,
   onApplyKeymapRewrite,
   keymapRestoreSeq,
+  activeRewriteTable,
+  activeLayoutName,
 }: UseKeymapApplyPromptOptions): UseKeymapApplyPromptReturn {
-  const keyLabelLookup = useKeyLabelLookup()
   const [pendingApply, setPendingApply] = useState<{ id: string; name: string; table: KeymapRewriteTable } | null>(null)
   const [applyError, setApplyError] = useState<string | null>(null)
 
@@ -117,27 +112,28 @@ export function useKeymapApplyPrompt({
   const [isApplying, setIsApplying] = useState(false)
 
   // Bumped on every `requestApply`/`handleKeyboardLayoutChange` call and on
-  // every observed `keyboardLayout`/`keymapRestoreSeq` change (see the two
-  // watch effects below); the async lookup in `requestApply` re-checks it
-  // after each `await` so a superseded request can never open a modal after
-  // the user has already moved on. `handleApplyConfirm` also snapshots it at
-  // Confirm time and re-checks it after `onApplyKeymapRewrite` settles, so a
-  // layout change mid-apply (the user picks a DIFFERENT pack, or QWERTY,
-  // before the stale apply resolves) discards that apply's result instead
-  // of clobbering the new selection back to QWERTY.
+  // every observed `keyboardLayout` change (see the watch effect below —
+  // the sibling `keymapRestoreSeq` watcher further down only needs to close
+  // the modal, not bump this, see its own comment). `handleApplyConfirm`
+  // snapshots it at Confirm time and re-checks it after `onApplyKeymapRewrite`
+  // settles, so a layout change mid-apply (the user picks a DIFFERENT pack,
+  // or QWERTY, before the stale apply resolves) discards that apply's
+  // result instead of clobbering the new selection back to QWERTY.
+  // `requestApply` itself resolves synchronously off `activeRewriteTable`
+  // now (no lookup to supersede), but still bumps this on every call — see
+  // its own comment.
   const requestSeqRef = useRef(0)
 
   // RACE (Plan-qwerty-select-no-rewrite v7, new/mandatory): the select no
   // longer routes through this hook's own onChange-time lookup — a value
-  // change can now land at any time, including while `requestApply`'s own
-  // lookup is in flight or while the confirm modal for a DIFFERENT pack is
-  // already open (e.g. open Colemak's warning, then pick Dvorak from the
-  // select before confirming — the pending modal would otherwise go on to
-  // rewrite Colemak's table against a keymap the user has already moved
-  // away from). Watching the value itself — rather than only closing the
-  // modal inline inside `handleKeyboardLayoutChange` — catches every path
-  // that can change it, not just this hook's own setter call. Mirrors the
-  // `keymapRestoreSeq` watcher below exactly.
+  // change can now land at any time, including while the confirm modal for
+  // a DIFFERENT pack is already open (e.g. open Colemak's warning, then
+  // pick Dvorak from the select before confirming — the pending modal
+  // would otherwise go on to rewrite Colemak's table against a keymap the
+  // user has already moved away from). Watching the value itself — rather
+  // than only closing the modal inline inside `handleKeyboardLayoutChange`
+  // — catches every path that can change it, not just this hook's own
+  // setter call.
   const keyboardLayoutRef = useRef(keyboardLayout)
   useEffect(() => {
     const prev = keyboardLayoutRef.current
@@ -150,12 +146,7 @@ export function useKeymapApplyPrompt({
   // Defensive close (Plan-qwerty-select-no-rewrite §snapshot/.vil 復元時の
   // クリーンアップ, D3): the counter is monotonic for the session (disconnect
   // carries it forward rather than zeroing it, see keyboard-types.ts), so
-  // any change here means a new restore landed. Also bump `requestSeqRef`
-  // so a lookup already in flight from BEFORE the restore (started by
-  // `requestApply`, still awaiting `resolveRewriteTable`) fails its own
-  // `requestSeqRef.current !== seq` check when it resolves — otherwise it
-  // would re-open the modal via `setPendingApply` against the keymap the
-  // restore just replaced (restore race).
+  // any change here means a new restore landed.
   //
   // Deliberately does NOT touch `applyInFlightRef`/`isApplying`: if a
   // restore lands while a Confirm apply is still awaiting
@@ -165,24 +156,24 @@ export function useKeymapApplyPrompt({
   // guarantees the latch clears once it settles, regardless of whether
   // `pendingApply` was already nulled out from under it. That same in-
   // flight apply independently discards its own result against a fresh
-  // restore-seq snapshot taken at Confirm time (see `handleApplyConfirm`),
-  // so this effect does not need to coordinate with it beyond the modal
-  // close.
+  // restore-seq snapshot taken at Confirm time (see `handleApplyConfirm`'s
+  // own `keymapRestoreSeqRef` comparison) — a dedicated check, not routed
+  // through `requestSeqRef` — so this effect only needs to close the modal,
+  // nothing more.
   const keymapRestoreSeqRef = useRef(keymapRestoreSeq)
   useEffect(() => {
     const prev = keymapRestoreSeqRef.current
     keymapRestoreSeqRef.current = keymapRestoreSeq
     if (keymapRestoreSeq === undefined || prev === undefined || keymapRestoreSeq === prev) return
-    ++requestSeqRef.current
     setPendingApply(null)
   }, [keymapRestoreSeq])
 
   // Plain display switch for every value — QWERTY included, no more
   // per-value branching. The layout-watch effect above independently
-  // closes any pending modal / invalidates any in-flight lookup once
-  // `keyboardLayout` actually changes as a result of this call; the
-  // explicit reset here is belt-and-braces so the modal never flashes open
-  // for a single tick between this call and that effect's next run.
+  // closes any pending modal once `keyboardLayout` actually changes as a
+  // result of this call; the explicit reset here is belt-and-braces so the
+  // modal never flashes open for a single tick between this call and that
+  // effect's next run.
   const handleKeyboardLayoutChange = useCallback((v: string) => {
     setApplyError(null)
     ++requestSeqRef.current
@@ -190,24 +181,31 @@ export function useKeymapApplyPrompt({
     onKeyboardLayoutChange?.(v as KeyboardLayoutId)
   }, [onKeyboardLayoutChange])
 
-  // Entry point for the simulation tab's Apply button. Only meaningful
-  // while `keyboardLayout` is a rewrite-eligible pack — i.e. exactly the
-  // state in which `useDevicePrefs.remapKind === 'simulated'` and
-  // `KeymapEditor` renders the tabs/button in the first place — but stays
-  // defensive (falls through to a no-op) so a stray call against QWERTY or
-  // an ineligible pack can't open a bogus modal.
+  // Entry point for the simulation tab's Apply button. Resolves
+  // synchronously off `activeRewriteTable` — `useDevicePrefs` already built
+  // and validated it for this exact `keyboardLayout` as part of deriving
+  // `remapKind === 'simulated'`, which is the only state in which
+  // `KeymapEditor` renders the tabs/button that calls this at all — so
+  // there is nothing left to look up here. Stays defensive (falls through
+  // to a no-op) so a stray call against QWERTY, an ineligible pack, or a
+  // pack whose table hasn't resolved yet can't open a bogus modal. Still
+  // bumps `requestSeqRef` on every call (even though there's no longer an
+  // async gap for it to guard within THIS function): if a Confirm for a
+  // PRIOR request is somehow still in flight when this fires (the visible
+  // Apply button is disabled for that whole window, so not normally
+  // user-reachable), the bump makes that stale Confirm's eventual
+  // resolution skip the QWERTY-reset / error-surfacing branch instead of
+  // clobbering whatever this fresh request leads to — though its own
+  // unconditional `setPendingApply(null)` can still close a modal this
+  // fresh request opened in that same narrow window; see
+  // `handleApplyConfirm`'s resolution order below.
   const requestApply = useCallback(() => {
     setApplyError(null)
     const v = keyboardLayout
-    if (v === BUILTIN_QWERTY_LAYOUT_ID || !keymapEditable || !onApplyKeymapRewrite) return
-    const seq = ++requestSeqRef.current
-    void (async () => {
-      const targetTable = await resolveRewriteTable(v, keyLabelLookup)
-      if (requestSeqRef.current !== seq) return // superseded by a newer request/selection
-      if (!targetTable) return // not (or no longer) rewrite-eligible — nothing to prompt
-      setPendingApply({ id: v, name: keyLabelLookup.getName(v) ?? v, table: targetTable })
-    })()
-  }, [keyboardLayout, keymapEditable, onApplyKeymapRewrite, keyLabelLookup])
+    if (v === BUILTIN_QWERTY_LAYOUT_ID || !keymapEditable || !onApplyKeymapRewrite || !activeRewriteTable) return
+    ++requestSeqRef.current
+    setPendingApply({ id: v, name: activeLayoutName ?? v, table: activeRewriteTable })
+  }, [keyboardLayout, keymapEditable, onApplyKeymapRewrite, activeRewriteTable, activeLayoutName])
 
   // Cancel is a no-op while an apply is in flight — the modal disables its
   // button (via `isApplying`) as the primary defense, but this ref check is


### PR DESCRIPTION
## Summary

Two follow-ups deferred from #300.

### Doc captures no longer touch the real profile
`doc-capture-key-labels.ts` and `doc-capture-theme-packs.ts` launch Electron against the user's own userData directory, so a profile whose UI language is set to a translation pack produced non-English screenshots and required hand-editing `config.json` before and after each run.

Both scripts now clone the profile into a unique temporary directory and launch with `--user-data-dir` pointed at the copy, forcing `builtin:en` there. The real profile is never written, which also removes the crash and concurrency hazards an in-place edit would carry: an interrupted run leaves only a disposable temp directory, and parallel runs cannot clobber each other. Chromium's caches and singleton lock files are excluded from the clone so a live session cannot interfere with the captured one; the data the captures actually need (Hub credentials, key labels, themes) is preserved. `killAndWaitForExit` is now shared and awaits real process exit instead of a fixed timeout.

### `requestApply` reuses the memoized rewrite table
`useDevicePrefs` already builds and validates the active layout's rewrite table while deriving `remapKind`; it now exposes that result, and `useKeymapApplyPrompt` consumes it instead of resolving the pack and rebuilding the table itself. `requestApply` becomes synchronous and the hook no longer holds its own `useKeyLabelLookup` instance.

Race protections were reviewed individually rather than dropped wholesale: the restore-sequence and layout-change watchers and the double-confirm latch all remain, and a new watcher discards a pending apply when the active table's identity changes or disappears — a pack edited or deleted while the dialog is open previously left a stale table applicable. Only the restore watcher's request-sequence bump was removed, since confirm compares the restore sequence directly.

A hook-ownership move was also investigated (relocating `useKeymapApplyPrompt` from `App` into `KeymapEditor` to shed its prop chain) and abandoned: two of its outputs feed siblings under `App`, so the move trades a downward prop chain for upward callbacks and a co-mount assumption.

## Testing

- 7081 unit/component tests pass; lint and typecheck clean.
- Capture scripts run end to end against a real profile whose language is a translation pack: screenshots come out in English and `config.json` is byte-identical afterwards, including after killing the process tree mid-run.