### PR TITLE
fix(ui): allow clearing a layer name back to its default label

### DIFF
--- a/src/renderer/components/editors/LayerListPanel.tsx
+++ b/src/renderer/components/editors/LayerListPanel.tsx
@@ -51,7 +51,10 @@ function LayerNumButton({ index, active, onLayerChange }: {
 
 export function LayerListPanel({ layers, currentLayer, onLayerChange, layerNames, onSetLayerName, collapsed, onToggleCollapse }: LayerListPanelProps) {
   const { t } = useTranslation()
-  const layerRename = useInlineRename<number>()
+  // Layer names fall back to a computed "Layer N" label when empty, so
+  // clearing the field is a valid rename (unlike stored layouts/packs/
+  // favorites, which require a non-empty name).
+  const layerRename = useInlineRename<number>({ allowEmpty: true })
 
   function commitLayerRename(layerIndex: number): void {
     const trimmed = layerRename.commitRename(layerIndex)

--- a/src/renderer/components/editors/__tests__/KeymapEditor.layerPanel.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor.layerPanel.test.tsx
@@ -257,6 +257,18 @@ describe('KeymapEditor — LayerListPanel', () => {
       expect(onSetLayerName).not.toHaveBeenCalled()
     })
 
+    it('saves an empty name on Enter when clearing a named layer', () => {
+      render(<KeymapEditor {...defaultProps} layerNames={['XXXXXX', 'Nav', '', 'Num']} />)
+
+      fireEvent.click(screen.getByTestId('layer-panel-layer-name-box-0'))
+
+      const input = screen.getByTestId('layer-panel-layer-name-input-0')
+      fireEvent.change(input, { target: { value: '' } })
+      fireEvent.keyDown(input, { key: 'Enter' })
+
+      expect(onSetLayerName).toHaveBeenCalledWith(0, '')
+    })
+
     it('shows confirm flash after Enter rename', () => {
       vi.useFakeTimers()
       render(<KeymapEditor {...defaultProps} />)

--- a/src/renderer/hooks/__tests__/useInlineRename.test.ts
+++ b/src/renderer/hooks/__tests__/useInlineRename.test.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act, renderHook, cleanup } from '@testing-library/react'
+import { useInlineRename } from '../useInlineRename'
+
+describe('useInlineRename', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  describe('default mode (allowEmpty: false)', () => {
+    it('commits a non-empty changed label', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBe('Renamed')
+      expect(result.current.editingId).toBeNull()
+    })
+
+    it('returns null and does not commit when cleared to empty', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel(''))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBeNull()
+    })
+
+    it('returns null when the value is unchanged', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBeNull()
+    })
+
+    it('trims surrounding whitespace before comparing and committing', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('  Renamed  '))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBe('Renamed')
+    })
+
+    it('treats a whitespace-only edit as empty and does not commit', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('   '))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBeNull()
+    })
+  })
+
+  describe('allowEmpty mode', () => {
+    it('commits an empty label when it differs from the original', () => {
+      const { result } = renderHook(() => useInlineRename<number>({ allowEmpty: true }))
+
+      act(() => result.current.startRename(0, 'XXXXXX'))
+      act(() => result.current.setEditLabel(''))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBe('')
+      expect(result.current.editingId).toBeNull()
+    })
+
+    it('returns null when the original was already empty and stays empty', () => {
+      const { result } = renderHook(() => useInlineRename<number>({ allowEmpty: true }))
+
+      act(() => result.current.startRename(0, ''))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBeNull()
+    })
+
+    it('still commits a non-empty changed label', () => {
+      const { result } = renderHook(() => useInlineRename<number>({ allowEmpty: true }))
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBe('Renamed')
+    })
+  })
+
+  describe('cancelRename / escape / blur guard', () => {
+    it('clears editingId without committing on cancelRename', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+      act(() => result.current.cancelRename())
+
+      expect(result.current.editingId).toBeNull()
+    })
+
+    it('guards a subsequent commitRename call (e.g. blur after Escape) from double-committing', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+      act(() => result.current.cancelRename())
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBeNull()
+    })
+
+    it('allows a fresh commitRename to proceed normally after the guard consumes one call', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+      act(() => result.current.cancelRename())
+      act(() => { result.current.commitRename(0) }) // consumes the guard
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('SecondRename'))
+
+      let commitResult: string | null = null
+      act(() => { commitResult = result.current.commitRename(0) })
+
+      expect(commitResult).toBe('SecondRename')
+    })
+  })
+
+  describe('scheduleFlash', () => {
+    it('sets confirmedId after a committed rename, then clears it after the flash duration', () => {
+      vi.useFakeTimers()
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+      act(() => result.current.setEditLabel('Renamed'))
+      act(() => { result.current.commitRename(0) })
+
+      act(() => { vi.advanceTimersByTime(0) })
+      expect(result.current.confirmedId).toBe(0)
+
+      act(() => { vi.advanceTimersByTime(1200) })
+      expect(result.current.confirmedId).toBeNull()
+
+      vi.useRealTimers()
+    })
+  })
+
+  describe('originalLabel / editLabel exposure', () => {
+    it('exposes the original label captured at startRename', () => {
+      const { result } = renderHook(() => useInlineRename<number>())
+
+      act(() => result.current.startRename(0, 'Base'))
+
+      expect(result.current.originalLabel).toBe('Base')
+      expect(result.current.editLabel).toBe('Base')
+    })
+  })
+})

--- a/src/renderer/hooks/useInlineRename.ts
+++ b/src/renderer/hooks/useInlineRename.ts
@@ -37,6 +37,21 @@ interface InlineRenameActions<TId extends string | number> {
 
 export type InlineRename<TId extends string | number> = InlineRenameState<TId> & InlineRenameActions<TId>
 
+export interface UseInlineRenameOptions {
+  /**
+   * When true, clearing the input to an empty string counts as a real
+   * change and `commitRename` returns `''` instead of `null`.
+   *
+   * Defaults to false because most rename targets (stored layouts, packs,
+   * favorites, key labels) require a non-empty name — an empty trimmed
+   * value there just means "the user gave up on editing", so it should be
+   * treated as no change. Opt in only for targets that have a meaningful
+   * empty state with a computed fallback display (e.g. keymap layer names,
+   * which fall back to "Layer N" when empty).
+   */
+  allowEmpty?: boolean
+}
+
 /**
  * Encapsulates the inline-rename + confirm-flash pattern used by
  * LayoutStoreContent, FavoriteStoreModal, FavoriteTabContent, and HubPostRow.
@@ -44,7 +59,8 @@ export type InlineRename<TId extends string | number> = InlineRenameState<TId> &
  * The caller is responsible for actually performing the rename (sync or async)
  * when `commitRename` returns a non-null trimmed label.
  */
-export function useInlineRename<TId extends string | number>(): InlineRename<TId> {
+export function useInlineRename<TId extends string | number>(options?: UseInlineRenameOptions): InlineRename<TId> {
+  const allowEmpty = options?.allowEmpty ?? false
   const [editingId, setEditingId] = useState<TId | null>(null)
   const [editLabel, setEditLabel] = useState('')
   const [confirmedId, setConfirmedId] = useState<TId | null>(null)
@@ -86,7 +102,9 @@ export function useInlineRename<TId extends string | number>(): InlineRename<TId
       return null
     }
     const trimmed = editLabel.trim()
-    const changed = !!(trimmed && trimmed !== originalLabelRef.current)
+    const changed = allowEmpty
+      ? trimmed !== originalLabelRef.current
+      : !!(trimmed && trimmed !== originalLabelRef.current)
     closingRef.current = true
     setEditingId(null)
     if (changed) {


### PR DESCRIPTION
## Summary

Clearing a layer name did nothing: renaming a layer to `XXXXXX`, reopening the field, deleting the text and pressing Enter reverted the label to `XXXXXX`.

`useInlineRename`'s commit path treated an empty value as "no change" (`!!(trimmed && trimmed !== original)`), so it returned `null` and `LayerListPanel` never called `onSetLayerName` — the write never left the component. Everything below that already handles `''` as the canonical "no name" (setters pad arrays with it, the settings store's merge only skips `undefined`, `.vil` round-trips it, and the display falls back to `Layer N`).

Empty is rejected deliberately at the hook's eight other call sites — stored layouts, packs and favorites all need a name — so this adds an opt-in `allowEmpty` option (default `false`) and enables it only for layer names, which have a computed fallback label.

## Testing

- New `useInlineRename` unit tests covering both modes plus trimming, cancel/blur and flash behavior.
- New layer-panel case asserting Enter on a cleared field commits `(index, '')`.
- The seven other rename call sites' suites pass unchanged.
- 7095 tests pass; lint and typecheck clean.