### PR TITLE
fix(app): stop tray startup from forcing unlock on lock-free screens

### DIFF
--- a/e2e/tray-start-unlock.test.ts
+++ b/e2e/tray-start-unlock.test.ts
@@ -4,11 +4,12 @@
 // enabled and the app quit while in typing view, a relaunch with a locked
 // keyboard must (a) show the hidden window with the Unlock dialog instead
 // of staying tray-resident, and (b) hide the window back to the tray once
-// unlocked. Exercises both restore paths — typingView (dialog opened by
-// the view-mode restore in App.tsx, which is unlock-gated) and plain
-// editor (no view-mode restore requires unlocking, so the window must
-// stay hidden and no dialog must appear — useBootHiddenWindow no longer
-// opens the dialog on its own).
+// unlocked. Exercises three restore paths — typingView (dialog opened by
+// the view-mode restore effect in App.tsx), typingTest (dialog opened
+// through a different call site: KeymapEditor's toggleTypingTest ->
+// onUnlock) — both unlock-gated — and plain editor (no view-mode restore
+// requires unlocking, so the window must stay hidden and no dialog must
+// appear — useBootHiddenWindow no longer opens the dialog on its own).
 //
 // Uses the virtual device (PIPETTE_VIRTUAL_DEVICE='only'), which relocks
 // on every launch so the Unlock dialog is guaranteed to appear on each
@@ -16,7 +17,7 @@
 // directly, with backup/restore around the whole run. Sessions launch
 // sequentially — the app's single-instance lock means each session must
 // fully exit before the next one starts, so there is no way to run these
-// three tests in parallel or out of order.
+// tests in parallel or out of order.
 
 import { test, expect } from '@playwright/test'
 import type { ElectronApplication } from '@playwright/test'
@@ -182,10 +183,50 @@ test.describe.serial('tray start-in-tray unlock reveal', () => {
     app = null
   })
 
+  test('typingTest restore path: relaunch reveals the Unlock dialog then hides back to tray', async () => {
+    // Rewrite the persisted view mode to typingTest. This restore path opens
+    // the dialog through a different call site than typingView's own
+    // effect — App.tsx calls keymapEditorRef.current?.toggleTypingTest(),
+    // which (unlocked) delegates to useInputModes' handleTypingTestToggle,
+    // which calls the onUnlock callback wired to setShowUnlockDialog(true) —
+    // so it is worth its own regression coverage alongside typingView.
+    const prefs = readJson(SETTINGS_PATH)
+    expect(prefs).not.toBeNull()
+    if (prefs) {
+      prefs.viewMode = 'typingTest'
+      writeFileSync(SETTINGS_PATH, JSON.stringify(prefs, null, 2))
+    }
+
+    const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: 'only' } })
+    app = launched.app
+    const page = launched.page
+
+    let dialogSeenVisible = false
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      const dialogUp = (await unlockDialogHeading(page).count()) > 0
+      if (dialogUp && winVisible.some(Boolean)) dialogSeenVisible = true
+      return dialogSeenVisible
+    }, { message: 'expected the Unlock dialog to appear in a visible window', timeout: 25_000, intervals: [1000] }).toBe(true)
+
+    await waitForUnlockDialog(app, page)
+
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      return winVisible.some(Boolean)
+    }, { message: 'expected the window to hide back to the tray after unlock', timeout: 15_000, intervals: [1000] }).toBe(false)
+    await expect(unlockDialogHeading(page)).toHaveCount(0)
+
+    await quitApp(app)
+    app = null
+  })
+
   test('editor restore path: relaunch stays tray-resident with no Unlock dialog', async () => {
     // Rewrite the persisted view mode to plain editor so this session
     // restores into a view that does not require unlocking. Only the
-    // typingView (and typingTest/matrix-test) restore paths are allowed to
+    // typingView/typingTest (and matrix-test) restore paths are allowed to
     // open the Unlock dialog — a boot-hidden restore of the plain editor
     // must leave the window hidden and never show the dialog at all.
     const prefs = readJson(SETTINGS_PATH)
@@ -199,11 +240,23 @@ test.describe.serial('tray start-in-tray unlock reveal', () => {
     app = launched.app
     const page = launched.page
 
-    // Sample repeatedly over a window long enough for the fixed bug to have
-    // resurfaced (it used to fire this reveal shortly after the keyboard's
-    // unlock status resolved) — the window must stay hidden and the dialog
-    // must never appear.
-    for (let sample = 0; sample < 10; sample++) {
+    // Gate the start of the negative-assertion window on the same signal
+    // the positive restore tests above implicitly depend on: `keyboard.
+    // loading` (and, in the same reload() commit, `unlockStatusKnown`)
+    // flipping to known/false. `editor-content` only becomes visible once
+    // the keymap/definition payloads have resolved in that same commit —
+    // this is the established "connection complete" signal used elsewhere
+    // in this suite (see helpers/test-device.ts:connectTestDevice). Waiting
+    // for it here means sampling starts only AFTER the point where the old
+    // buggy auto-open effect would have fired, instead of racing it on a
+    // fixed wall-clock guess.
+    await page.locator('[data-testid="editor-content"]').waitFor({ state: 'visible', timeout: 25_000 })
+
+    // Sample repeatedly over a window matching the positive tests' ~25s
+    // dialog-appearance budget above, so timing skew on a slow environment
+    // cannot hide a late prompt — the window must stay hidden and the
+    // dialog must never appear at any point in this window.
+    for (let sample = 0; sample < 25; sample++) {
       const winVisible = await app!.evaluate(({ BrowserWindow }) =>
         BrowserWindow.getAllWindows().map((w) => w.isVisible()))
       const dialogUp = (await unlockDialogHeading(page).count()) > 0

--- a/e2e/tray-start-unlock.test.ts
+++ b/e2e/tray-start-unlock.test.ts
@@ -5,8 +5,10 @@
 // keyboard must (a) show the hidden window with the Unlock dialog instead
 // of staying tray-resident, and (b) hide the window back to the tray once
 // unlocked. Exercises both restore paths — typingView (dialog opened by
-// the view-mode restore in App.tsx) and plain editor (dialog auto-opened
-// by useBootHiddenWindow).
+// the view-mode restore in App.tsx, which is unlock-gated) and plain
+// editor (no view-mode restore requires unlocking, so the window must
+// stay hidden and no dialog must appear — useBootHiddenWindow no longer
+// opens the dialog on its own).
 //
 // Uses the virtual device (PIPETTE_VIRTUAL_DEVICE='only'), which relocks
 // on every launch so the Unlock dialog is guaranteed to appear on each
@@ -180,10 +182,12 @@ test.describe.serial('tray start-in-tray unlock reveal', () => {
     app = null
   })
 
-  test('editor restore path: relaunch reveals the Unlock dialog then hides back to tray', async () => {
+  test('editor restore path: relaunch stays tray-resident with no Unlock dialog', async () => {
     // Rewrite the persisted view mode to plain editor so this session
-    // exercises useBootHiddenWindow's auto-open path instead of the
-    // typingView restore effect in App.tsx.
+    // restores into a view that does not require unlocking. Only the
+    // typingView (and typingTest/matrix-test) restore paths are allowed to
+    // open the Unlock dialog — a boot-hidden restore of the plain editor
+    // must leave the window hidden and never show the dialog at all.
     const prefs = readJson(SETTINGS_PATH)
     expect(prefs).not.toBeNull()
     if (prefs) {
@@ -195,23 +199,18 @@ test.describe.serial('tray start-in-tray unlock reveal', () => {
     app = launched.app
     const page = launched.page
 
-    let dialogSeenVisible = false
-    await expect.poll(async () => {
+    // Sample repeatedly over a window long enough for the fixed bug to have
+    // resurfaced (it used to fire this reveal shortly after the keyboard's
+    // unlock status resolved) — the window must stay hidden and the dialog
+    // must never appear.
+    for (let sample = 0; sample < 10; sample++) {
       const winVisible = await app!.evaluate(({ BrowserWindow }) =>
         BrowserWindow.getAllWindows().map((w) => w.isVisible()))
       const dialogUp = (await unlockDialogHeading(page).count()) > 0
-      if (dialogUp && winVisible.some(Boolean)) dialogSeenVisible = true
-      return dialogSeenVisible
-    }, { message: 'expected the Unlock dialog to appear in a visible window', timeout: 25_000, intervals: [1000] }).toBe(true)
-
-    await waitForUnlockDialog(app, page)
-
-    await expect.poll(async () => {
-      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
-        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
-      return winVisible.some(Boolean)
-    }, { message: 'expected the window to hide back to the tray after unlock', timeout: 15_000, intervals: [1000] }).toBe(false)
-    await expect(unlockDialogHeading(page)).toHaveCount(0)
+      expect(winVisible.some(Boolean), `window became visible on sample ${sample}`).toBe(false)
+      expect(dialogUp, `Unlock dialog appeared on sample ${sample}`).toBe(false)
+      await page.waitForTimeout(1000)
+    }
 
     await quitApp(app)
     app = null

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -265,27 +265,15 @@ export function App() {
     connect: lifecycle.handleConnect,
   })
 
-  // Whether the connected keyboard is confirmed locked, for the
-  // boot-hidden auto-unlock prompt below. Stays null (undetermined) until
-  // a real device is fully loaded with a known unlock status — a
-  // getUnlockStatus() failure must never be mistaken for "locked".
-  const bootKeyboardLocked: boolean | null =
-    (!device.connectedDevice || device.isDummy
-      || keyboard.loading || keyboard.uid === EMPTY_UID
-      || !keyboard.unlockStatusKnown)
-      ? null
-      : !keyboard.unlockStatus.unlocked
-
   // Show the window only for the Unlock dialog while a hidden launch
   // (startInTray) is restoring the last session; hide it again once the
-  // dialog resolves. Also opens the dialog automatically, once per launch,
-  // if session restore reconnects a keyboard that is still locked (the
-  // typingView restore path below opens it itself, so this is idempotent
-  // with that path). No-ops entirely once the boot-hidden phase ends.
+  // dialog resolves. Opening the dialog itself is owned solely by the
+  // view-restore effects below (typingView restore, typingTest/matrix-test
+  // entry) — they are view-mode aware, so a boot-hidden restore into a
+  // view that does not require unlocking (e.g. the plain keymap editor)
+  // never forces a prompt. No-ops entirely once the boot-hidden phase ends.
   useBootHiddenWindow({
     unlockDialogVisible: editorUI.showUnlockDialog,
-    keyboardLocked: bootKeyboardLocked,
-    onRequestUnlockDialog: () => editorUI.setShowUnlockDialog(true),
   })
 
   const missingKeyLabel = useMissingKeyLabelNotice(keyboard.uid || null)

--- a/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
+++ b/src/renderer/hooks/__tests__/useBootHiddenWindow.test.ts
@@ -56,28 +56,21 @@ afterEach(() => {
 
 interface Props {
   visible: boolean
-  keyboardLocked: boolean | null
-  onRequestUnlockDialog: () => void
 }
 
 function renderBootHiddenWindow(initialProps: Partial<Props> = {}) {
-  const onRequestUnlockDialog = initialProps.onRequestUnlockDialog ?? vi.fn()
   const utils = renderHook(
     (props: Props) => useBootHiddenWindow({
       unlockDialogVisible: props.visible,
-      keyboardLocked: props.keyboardLocked,
-      onRequestUnlockDialog: props.onRequestUnlockDialog,
     }),
     {
       initialProps: {
         visible: false,
-        keyboardLocked: null,
-        onRequestUnlockDialog,
         ...initialProps,
       },
     },
   )
-  return { ...utils, onRequestUnlockDialog }
+  return utils
 }
 
 describe('useBootHiddenWindow', () => {
@@ -85,7 +78,7 @@ describe('useBootHiddenWindow', () => {
     const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
 
     expect(windowShow).toHaveBeenCalledTimes(1)
     expect(windowHide).not.toHaveBeenCalled()
@@ -95,14 +88,14 @@ describe('useBootHiddenWindow', () => {
     const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     expect(windowShow).toHaveBeenCalledTimes(1)
 
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false })
     expect(windowHide).toHaveBeenCalledTimes(1)
 
     // A later dialog must not trigger auto-show again — the phase already ended.
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     expect(windowShow).toHaveBeenCalledTimes(1)
   })
 
@@ -115,7 +108,7 @@ describe('useBootHiddenWindow', () => {
     expect(windowHide).not.toHaveBeenCalled()
 
     // The boot-hidden phase already ended, so a later dialog does not auto-show.
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     expect(windowShow).not.toHaveBeenCalled()
   })
 
@@ -128,13 +121,13 @@ describe('useBootHiddenWindow', () => {
     const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     await flushMicrotasks()
     expect(windowShow).toHaveBeenCalledTimes(1)
 
     // The dialog resolves — ownership was rolled back, so this must not
     // hide the window the user opened themselves.
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false })
     expect(windowHide).not.toHaveBeenCalled()
   })
 
@@ -144,8 +137,8 @@ describe('useBootHiddenWindow', () => {
     const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
+    rerender({ visible: false })
 
     expect(windowShow).not.toHaveBeenCalled()
     expect(windowHide).not.toHaveBeenCalled()
@@ -161,15 +154,15 @@ describe('useBootHiddenWindow', () => {
 
     // An unlock dialog cycles during normal use — must not hide the window
     // the user is actively looking at.
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     expect(windowShow).not.toHaveBeenCalled()
 
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false })
     expect(windowHide).not.toHaveBeenCalled()
 
     // Nor on a later cycle, since the phase already ended.
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
+    rerender({ visible: false })
     expect(windowShow).not.toHaveBeenCalled()
     expect(windowHide).not.toHaveBeenCalled()
   })
@@ -194,41 +187,11 @@ describe('useBootHiddenWindow', () => {
     await flushMicrotasks()
 
     // A later unlock dialog cycle during normal use must not hide the window.
-    rerender({ visible: true, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: true })
     expect(windowShow).not.toHaveBeenCalled()
 
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog: vi.fn() })
+    rerender({ visible: false })
     expect(windowHide).not.toHaveBeenCalled()
-  })
-
-  it('requests the unlock dialog once when a boot-hidden launch reconnects a locked keyboard', async () => {
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-    await flushMicrotasks()
-
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
-
-    // Further rerenders (even with locked still true) must not re-call it.
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
-  })
-
-  it('requests the unlock dialog even if keyboardLocked becomes true before windowStartedHidden resolves', async () => {
-    let resolveStartedHidden: (hidden: boolean) => void = () => {}
-    windowStartedHidden.mockImplementation(
-      () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
-    )
-
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-
-    // keyboardLocked resolves to true before windowStartedHidden() does.
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-
-    resolveStartedHidden(true)
-    await flushMicrotasks()
-
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
   })
 
   it('shows the window for a dialog already visible when arming resolves, and hides it on the falling edge', async () => {
@@ -237,82 +200,32 @@ describe('useBootHiddenWindow', () => {
       () => new Promise<boolean>((resolve) => { resolveStartedHidden = resolve }),
     )
 
-    // The typingView restore path opens the dialog before arming resolves.
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({
-      visible: true,
-      keyboardLocked: true,
-    })
+    // The typingView restore path (or a locked-mode entry in useInputModes)
+    // opens the dialog before arming resolves.
+    const { rerender } = renderBootHiddenWindow({ visible: true })
 
     resolveStartedHidden(true)
     await flushMicrotasks()
 
     expect(windowShow).toHaveBeenCalledTimes(1)
-    // The dialog was already visible, so this hook must not also request it.
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
 
-    rerender({ visible: false, keyboardLocked: false, onRequestUnlockDialog })
+    rerender({ visible: false })
     expect(windowHide).toHaveBeenCalledTimes(1)
   })
 
-  it('never requests the unlock dialog when windowStartedHidden resolves false', async () => {
-    windowStartedHidden.mockResolvedValue(false)
-
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
+  it('never calls windowShow for a boot-hidden launch with a locked keyboard when nothing opens the dialog', async () => {
+    // Regression guard: restoring a view that does not require unlocking
+    // (e.g. the plain keymap editor) must leave the window hidden — this
+    // hook must not infer a prompt from a locked keyboard on its own.
+    const { rerender } = renderBootHiddenWindow()
     await flushMicrotasks()
 
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-  })
+    // Simulate time passing / re-renders with the dialog never opening.
+    rerender({ visible: false })
+    rerender({ visible: false })
 
-  it('never requests the unlock dialog when the user reveals the window first', async () => {
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-    await flushMicrotasks()
-
-    pushWindowVisibility(true)
-
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-  })
-
-  it('ends the phase on confirmed-unlocked without prompting, and ignores a later lock transition', async () => {
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-    await flushMicrotasks()
-
-    rerender({ visible: false, keyboardLocked: false, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-
-    // Startup-only: a later lock transition must not prompt or reveal.
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-
-    rerender({ visible: true, keyboardLocked: true, onRequestUnlockDialog })
     expect(windowShow).not.toHaveBeenCalled()
-  })
-
-  it('never requests the unlock dialog while keyboardLocked stays unknown', async () => {
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-    await flushMicrotasks()
-
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
-
-    expect(onRequestUnlockDialog).not.toHaveBeenCalled()
-  })
-
-  it('does not re-prompt on reconnect (locked → unknown → locked again)', async () => {
-    const { rerender, onRequestUnlockDialog } = renderBootHiddenWindow({ keyboardLocked: null })
-    await flushMicrotasks()
-
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
-
-    // Disconnect: keyboardLocked goes back to unknown.
-    rerender({ visible: false, keyboardLocked: null, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
-
-    // Reconnect: locked is confirmed true again — must not re-prompt.
-    rerender({ visible: false, keyboardLocked: true, onRequestUnlockDialog })
-    expect(onRequestUnlockDialog).toHaveBeenCalledTimes(1)
+    expect(windowHide).not.toHaveBeenCalled()
   })
 
   it('unsubscribes from window visibility changes on unmount', async () => {

--- a/src/renderer/hooks/useBootHiddenWindow.ts
+++ b/src/renderer/hooks/useBootHiddenWindow.ts
@@ -4,13 +4,6 @@ import { useEffect, useRef, useState } from 'react'
 
 interface BootHiddenWindowOptions {
   unlockDialogVisible: boolean
-  /**
-   * Whether the connected keyboard is currently locked, once known:
-   * true = confirmed locked, false = confirmed unlocked, null = not yet
-   * determined (still loading, no device, or unlock status unknown).
-   */
-  keyboardLocked: boolean | null
-  onRequestUnlockDialog: () => void
 }
 
 /**
@@ -24,13 +17,13 @@ interface BootHiddenWindowOptions {
  * unlock dialogs during normal use are left alone: the phase ends without
  * showing or hiding anything.
  *
- * It also owns opening the dialog in the first place: if session restore
- * reconnects a keyboard that is still locked and nothing has opened the
- * dialog yet (e.g. the plain keymap-editor restore path, as opposed to
- * the typingView restore path which opens it itself), this hook requests
- * it once per launch via onRequestUnlockDialog. If the keyboard turns out
- * to already be unlocked, the boot-hidden phase ends without ever
- * touching the window.
+ * This hook does not decide whether the dialog should open — that is
+ * owned by the view-restore effects (App.tsx's typingView restore,
+ * useInputModes' typingTest/matrix-test entry), which are view-mode
+ * aware. This hook only reacts to `unlockDialogVisible` once something
+ * else has opened it, so a boot-hidden restore into a view that does not
+ * require unlocking (e.g. the plain keymap editor) never forces a
+ * prompt.
  *
  * Window visibility truth comes from the main process (windowIsVisible /
  * onWindowVisibilityChanged), not from document.visibilityState: a
@@ -40,13 +33,13 @@ interface BootHiddenWindowOptions {
  * from ever arming.
  */
 export function useBootHiddenWindow(opts: BootHiddenWindowOptions): void {
-  const { unlockDialogVisible, keyboardLocked, onRequestUnlockDialog } = opts
+  const { unlockDialogVisible } = opts
 
   // Arming is reactive state, not a ref: windowStartedHidden() resolves
-  // asynchronously, and by the time it does, keyboardLocked may already be
-  // known or the dialog may already be visible (typingView restore path).
-  // Effects keyed on `armed` re-run when it flips true and pick up the
-  // current props, so none of those already-set signals are lost.
+  // asynchronously, and by the time it does, the dialog may already be
+  // visible (typingView restore path). The reveal effect is keyed on
+  // `armed` and re-runs when it flips true, so an already-visible dialog
+  // at that moment is not lost.
   const [armed, setArmed] = useState(false)
 
   const weShowedRef = useRef(false)
@@ -54,11 +47,6 @@ export function useBootHiddenWindow(opts: BootHiddenWindowOptions): void {
   // a dialog already visible at the moment arming resolves is treated as
   // a rising edge instead of being missed.
   const prevVisibleRef = useRef(false)
-  // One-shot per launch: once we ask for the dialog, never ask again
-  // (disconnect → reconnect must not re-prompt).
-  const promptedRef = useRef(false)
-  const onRequestUnlockDialogRef = useRef(onRequestUnlockDialog)
-  onRequestUnlockDialogRef.current = onRequestUnlockDialog
 
   // Live main-process window visibility, kept current by the
   // onWindowVisibilityChanged subscription below. Read synchronously by
@@ -159,21 +147,4 @@ export function useBootHiddenWindow(opts: BootHiddenWindowOptions): void {
       }
     }
   }, [armed, unlockDialogVisible])
-
-  // Auto-open the Unlock dialog once, if session restore reconnects a
-  // still-locked keyboard and nothing else has opened it yet. If the
-  // keyboard turns out to be unlocked instead, end the boot-hidden phase —
-  // this is startup-only behavior, so a later lock transition or
-  // reconnect must not reveal the window.
-  useEffect(() => {
-    if (!armed) return
-    if (unlockDialogVisible) return
-    if (promptedRef.current) return
-    if (keyboardLocked === true) {
-      promptedRef.current = true
-      onRequestUnlockDialogRef.current()
-    } else if (keyboardLocked === false) {
-      setArmed(false)
-    }
-  }, [armed, keyboardLocked, unlockDialogVisible])
 }


### PR DESCRIPTION
## Summary

When the app started with tray-residency enabled, restoring a screen that doesn't need unlocking — the keymap editor — still forced the security Unlock dialog. Normal (non-tray) startup only prompts for the typing view, which is correct; the tray path carried a second, view-mode-blind prompt.

`useBootHiddenWindow` owned an auto-open effect that opened the Unlock dialog whenever the hidden-launch window was armed and the keyboard was locked, with no view-mode condition. The prompts that are actually needed already live elsewhere and are scoped to the modes that require an unlocked keyboard: the typing view opens the dialog on restore, and typing-test / matrix-test request unlock through their own lock guards.

This removes prompt ownership from the hook, leaving it as pure show/hide choreography for the hidden launch — it still reveals the window when a dialog becomes visible, it just no longer decides to open one. `bootKeyboardLocked`, which only fed the removed effect, is gone.

## Testing

- `useBootHiddenWindow` unit tests reworked: the auto-open assertions are gone, the reveal-on-dialog-visible behavior is kept, and a boot-hidden launch that opens no dialog now asserts the window is never shown.
- e2e: the editor-restore case is inverted — a boot-hidden editor restore of a locked keyboard keeps the window hidden with no Unlock dialog, sampled for 25s after connect completes (gated on `editor-content` becoming visible, i.e. after unlock status resolves, so a late prompt can't slip past). Verified it fails against the pre-fix code. The typing-view path stays as the positive guard and a typing-test restore case was added.
- 7089 tests pass; e2e 4/4 green with the virtual device; lint and typecheck clean.