### PR TITLE
feat(ui): confirm before loading a saved snapshot over the current keymap

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -27,6 +27,7 @@
     "exported": "エクスポート済み",
     "imported": "インポート済み",
     "load": "読み込み",
+    "confirmLoad": "読み込みますか？",
     "labelPlaceholder": "ラベル",
     "noLabel": "（ラベルなし）",
     "synced": "同期しました",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -27,6 +27,7 @@
     "exported": "書き出したよん！",
     "imported": "入れたよん！",
     "load": "読み込み☆",
+    "confirmLoad": "読み込んじゃう？",
     "labelPlaceholder": "ラベル",
     "noLabel": "（ラベルなし）",
     "synced": "同期おけ！",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -27,6 +27,7 @@
     "exported": "書き出しましたえ",
     "imported": "入れましたえ",
     "load": "読み込みますえ",
+    "confirmLoad": "読み込んでもよろしおすか？",
     "labelPlaceholder": "ラベル",
     "noLabel": "（ラベルおへん）",
     "synced": "同期しましたえ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -27,6 +27,7 @@
     "exported": "お届けいたしました",
     "imported": "お受け取りいたしました",
     "load": "拝読",
+    "confirmLoad": "こちらを読み込んでもよろしいでしょうか？",
     "labelPlaceholder": "名札",
     "noLabel": "（名札がございません）",
     "synced": "足並みが揃いました",

--- a/src/renderer/components/editors/LayoutStoreContent.tsx
+++ b/src/renderer/components/editors/LayoutStoreContent.tsx
@@ -87,8 +87,21 @@ export function LayoutStoreContent({
   const exportedTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const rename = useInlineRename<string>()
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+  const [confirmLoadId, setConfirmLoadId] = useState<string | null>(null)
   const [confirmHubRemoveId, setConfirmHubRemoveId] = useState<string | null>(null)
   const [confirmOverwriteId, setConfirmOverwriteId] = useState<string | null>(null)
+
+  // Delete and Load confirms are mutually exclusive within a row: opening one
+  // clears the other so a row never shows two confirm prompts at once.
+  function openDeleteConfirm(id: string | null): void {
+    setConfirmDeleteId(id)
+    if (id !== null) setConfirmLoadId(null)
+  }
+
+  function openLoadConfirm(id: string | null): void {
+    setConfirmLoadId(id)
+    if (id !== null) setConfirmDeleteId(null)
+  }
 
   function flashSaved(): void {
     setShowSaved(true)
@@ -335,7 +348,9 @@ export function LayoutStoreContent({
                     entryHubPostId={entryHubPostId}
                     rename={rename}
                     confirmDeleteId={confirmDeleteId}
-                    setConfirmDeleteId={setConfirmDeleteId}
+                    setConfirmDeleteId={openDeleteConfirm}
+                    confirmLoadId={confirmLoadId}
+                    setConfirmLoadId={openLoadConfirm}
                     onCommitRename={commitRename}
                     onHandleRenameKeyDown={handleRenameKeyDown}
                     onLoad={onLoad}

--- a/src/renderer/components/editors/LayoutStoreEntry.tsx
+++ b/src/renderer/components/editors/LayoutStoreEntry.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { FORMAT_BTN } from './layout-store-types'
 import type { HubEntryResult } from './layout-store-types'
 import { LayoutStoreHubRow } from './LayoutStoreHubActions'
-import { ACTION_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, formatDate } from './store-modal-shared'
+import { ACTION_BTN, CONFIRM_ACCENT_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, formatDate } from './store-modal-shared'
 import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
 import type { HubMyPost } from '../../../shared/types/hub'
 
@@ -74,6 +74,8 @@ interface LayoutStoreEntryProps {
   }
   confirmDeleteId: string | null
   setConfirmDeleteId: (id: string | null) => void
+  confirmLoadId?: string | null
+  setConfirmLoadId?: (id: string | null) => void
   onCommitRename?: (entryId: string) => void
   onHandleRenameKeyDown?: (e: React.KeyboardEvent, entryId: string) => void
   onLoad?: (entryId: string) => void
@@ -105,6 +107,8 @@ export function LayoutStoreEntry({
   rename,
   confirmDeleteId,
   setConfirmDeleteId,
+  confirmLoadId = null,
+  setConfirmLoadId = () => {},
   onCommitRename,
   onHandleRenameKeyDown,
   onLoad,
@@ -182,13 +186,32 @@ export function LayoutStoreEntry({
                 {t('common.cancel')}
               </button>
             </>
+          ) : confirmLoadId === entry.id ? (
+            <>
+              <button
+                type="button"
+                className={CONFIRM_ACCENT_BTN}
+                onClick={() => { onLoad?.(entry.id); setConfirmLoadId(null) }}
+                data-testid="layout-store-load-confirm"
+              >
+                {t('common.confirmLoad')}
+              </button>
+              <button
+                type="button"
+                className={ACTION_BTN}
+                onClick={() => setConfirmLoadId(null)}
+                data-testid="layout-store-load-cancel"
+              >
+                {t('common.cancel')}
+              </button>
+            </>
           ) : (
             <>
               {onLoad && (
                 <button
                   type="button"
                   className={ACTION_BTN}
-                  onClick={() => onLoad(entry.id)}
+                  onClick={() => setConfirmLoadId(entry.id)}
                   data-testid="layout-store-load-btn"
                 >
                   {t('common.load')}

--- a/src/renderer/components/editors/LayoutStoreEntry.tsx
+++ b/src/renderer/components/editors/LayoutStoreEntry.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { FORMAT_BTN } from './layout-store-types'
 import type { HubEntryResult } from './layout-store-types'
 import { LayoutStoreHubRow } from './LayoutStoreHubActions'
-import { ACTION_BTN, CONFIRM_ACCENT_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, formatDate } from './store-modal-shared'
+import { ACTION_BTN, CONFIRM_ACCENT_BTN, CONFIRM_DELETE_BTN, DELETE_BTN, LOAD_BTN, formatDate } from './store-modal-shared'
 import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
 import type { HubMyPost } from '../../../shared/types/hub'
 
@@ -210,7 +210,7 @@ export function LayoutStoreEntry({
               {onLoad && (
                 <button
                   type="button"
-                  className={ACTION_BTN}
+                  className={LOAD_BTN}
                   onClick={() => setConfirmLoadId(entry.id)}
                   data-testid="layout-store-load-btn"
                 >

--- a/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
@@ -76,8 +76,9 @@ describe('LayoutStoreModal', () => {
       />,
     )
 
-    // Click load
+    // Click load — initial button is accent-styled too, matching its confirm step
     const loadButtons = screen.getAllByTestId('layout-store-load-btn')
+    expect(loadButtons[0].className).toContain('text-accent')
     fireEvent.click(loadButtons[0])
 
     // Confirm — accent-styled (not danger/red), unlike the delete confirm

--- a/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
+++ b/src/renderer/components/editors/__tests__/LayoutStoreModal.test.tsx
@@ -66,7 +66,7 @@ describe('LayoutStoreModal', () => {
     expect(labels[1].textContent).toBe('common.noLabel')
   })
 
-  it('calls onLoad when load button clicked', () => {
+  it('shows load confirmation and calls onLoad', () => {
     const onLoad = vi.fn()
     render(
       <LayoutStoreModal
@@ -76,10 +76,64 @@ describe('LayoutStoreModal', () => {
       />,
     )
 
+    // Click load
     const loadButtons = screen.getAllByTestId('layout-store-load-btn')
     fireEvent.click(loadButtons[0])
 
+    // Confirm — accent-styled (not danger/red), unlike the delete confirm
+    const confirmBtn = screen.getByTestId('layout-store-load-confirm')
+    expect(confirmBtn.className).toContain('text-accent')
+    expect(confirmBtn.className).not.toContain('text-danger')
+    fireEvent.click(confirmBtn)
+
     expect(onLoad).toHaveBeenCalledWith('entry-1')
+  })
+
+  it('cancels load confirmation', () => {
+    const onLoad = vi.fn()
+    render(
+      <LayoutStoreModal
+        entries={MOCK_ENTRIES}
+        {...DEFAULT_PROPS}
+        onLoad={onLoad}
+      />,
+    )
+
+    // Click load
+    const loadButtons = screen.getAllByTestId('layout-store-load-btn')
+    fireEvent.click(loadButtons[0])
+
+    // Cancel
+    const cancelBtn = screen.getByTestId('layout-store-load-cancel')
+    fireEvent.click(cancelBtn)
+
+    expect(onLoad).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('layout-store-load-confirm')).not.toBeInTheDocument()
+  })
+
+  it('opening load confirm closes an open delete confirm on the same row, and vice versa', () => {
+    render(
+      <LayoutStoreModal
+        entries={MOCK_ENTRIES}
+        {...DEFAULT_PROPS}
+      />,
+    )
+
+    // Open delete confirm on entry 1
+    const deleteButtons = screen.getAllByTestId('layout-store-delete-btn')
+    fireEvent.click(deleteButtons[0])
+    expect(screen.getByTestId('layout-store-delete-confirm')).toBeInTheDocument()
+
+    // Opening load confirm on the same row closes the delete confirm
+    const loadButtons = screen.getAllByTestId('layout-store-load-btn')
+    fireEvent.click(loadButtons[0])
+    expect(screen.queryByTestId('layout-store-delete-confirm')).not.toBeInTheDocument()
+    expect(screen.getByTestId('layout-store-load-confirm')).toBeInTheDocument()
+
+    // Opening delete confirm again closes the load confirm
+    fireEvent.click(screen.getAllByTestId('layout-store-delete-btn')[0])
+    expect(screen.queryByTestId('layout-store-load-confirm')).not.toBeInTheDocument()
+    expect(screen.getByTestId('layout-store-delete-confirm')).toBeInTheDocument()
   })
 
   it('enters rename mode and submits on Enter', () => {

--- a/src/renderer/components/editors/store-modal-shared.tsx
+++ b/src/renderer/components/editors/store-modal-shared.tsx
@@ -25,6 +25,11 @@ export const ACTION_BTN =
   'text-xs font-medium text-content hover:text-content cursor-pointer bg-transparent border-none px-2 py-1 rounded'
 export const DELETE_BTN =
   'text-xs font-medium text-danger hover:text-danger cursor-pointer bg-transparent border-none px-2 py-1 rounded'
+// Accent-colored twin of DELETE_BTN — same initial-action row-button shape,
+// for actions that load/apply rather than delete (e.g. the initial Load
+// button), so it stays visually consistent with its own confirm step.
+export const LOAD_BTN =
+  'text-xs font-medium text-accent hover:text-accent cursor-pointer bg-transparent border-none px-2 py-1 rounded'
 export const CONFIRM_DELETE_BTN =
   'text-xs font-medium text-danger hover:bg-danger/10 px-2 py-1 rounded cursor-pointer bg-transparent border-none'
 // Accent-colored twin of CONFIRM_DELETE_BTN — same compact row-button shape,

--- a/src/renderer/components/editors/store-modal-shared.tsx
+++ b/src/renderer/components/editors/store-modal-shared.tsx
@@ -27,6 +27,11 @@ export const DELETE_BTN =
   'text-xs font-medium text-danger hover:text-danger cursor-pointer bg-transparent border-none px-2 py-1 rounded'
 export const CONFIRM_DELETE_BTN =
   'text-xs font-medium text-danger hover:bg-danger/10 px-2 py-1 rounded cursor-pointer bg-transparent border-none'
+// Accent-colored twin of CONFIRM_DELETE_BTN — same compact row-button shape,
+// for confirm-style actions that apply/overwrite rather than delete (e.g.
+// the Load confirm), so they read as distinct from the red delete confirm.
+export const CONFIRM_ACCENT_BTN =
+  'text-xs font-medium text-accent hover:bg-accent/10 px-2 py-1 rounded cursor-pointer bg-transparent border-none'
 
 function pad2(n: number): string {
   return String(n).padStart(2, '0')

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.39",
+  "version": "0.1.40",
   "name": "English",
   "common": {
     "save": "Save",
@@ -27,6 +27,7 @@
     "exported": "Exported",
     "imported": "Imported",
     "load": "Load",
+    "confirmLoad": "Load?",
     "labelPlaceholder": "Label",
     "noLabel": "(No label)",
     "synced": "Synced",


### PR DESCRIPTION
## Summary

The Save panel's **Load** applied a saved snapshot with a single click, replacing every layer of the current in-editor keymap and silently discarding unsaved edits — with no confirmation, unlike the neighbouring Delete which already asks first.

Load now takes the same inline two-step confirm as Delete: the first click swaps the button for **Load?** + Cancel, and only the second click applies. Opening either confirm closes the other, so a row never shows two prompts at once. The Load confirm is accent-coloured rather than red — it is an apply action, distinct from the destructive Delete.

## Testing

- The one-click Load test is updated to the two-step flow; added Load-cancel and Load/Delete mutual-exclusion cases.
- New `common.confirmLoad` string across all five locale files.
- 7091 tests pass; lint and typecheck clean.