### PR TITLE
feat(ui): import multiple pack files at once

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.40",
+  "version": "0.1.41",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -39,7 +39,9 @@
     "searchPlaceholder": "Pipette Hub を検索 (2 文字以上で入力)…",
     "sortByName": "名前",
     "importedNamed": "{{name}} をインポートしました",
-    "updatedNamed": "{{name}} を更新しました"
+    "updatedNamed": "{{name}} を更新しました",
+    "importBatchFailed_one": "{{count}} 件のファイルをインポートできませんでした：",
+    "importBatchFailed_other": "{{count}} 件のファイルをインポートできませんでした："
   },
   "app": {
     "title": "Pipette",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.40",
+  "version": "0.1.41",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -39,7 +39,9 @@
     "edit": "編集っしょ",
     "sortByName": "名前っ♡",
     "importedNamed": "{{name}} 入れたよん☆",
-    "updatedNamed": "{{name}} 更新したよん☆"
+    "updatedNamed": "{{name}} 更新したよん☆",
+    "importBatchFailed_one": "{{count}}個、入れられんかったよ…",
+    "importBatchFailed_other": "{{count}}個、入れられんかったよ…"
   },
   "app": {
     "title": "Pipette☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.40",
+  "version": "0.1.41",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -39,7 +39,9 @@
     "edit": "編集しますえ",
     "sortByName": "お名前どすえ",
     "importedNamed": "{{name}} を入れましたえ",
-    "updatedNamed": "{{name}} を更新しましたえ"
+    "updatedNamed": "{{name}} を更新しましたえ",
+    "importBatchFailed_one": "{{count}} 件、インポートできまへんでしたわ",
+    "importBatchFailed_other": "{{count}} 件、インポートできまへんでしたわ"
   },
   "app": {
     "title": "Pipette",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.40",
+  "version": "0.1.41",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -39,7 +39,9 @@
     "edit": "推敲",
     "sortByName": "御名前",
     "importedNamed": "{{name}} をお受け取りいたしました",
-    "updatedNamed": "{{name}} を更新いたしました"
+    "updatedNamed": "{{name}} を更新いたしました",
+    "importBatchFailed_one": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。",
+    "importBatchFailed_other": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。"
   },
   "app": {
     "title": "Pipette",

--- a/src/main/__tests__/i18n-pack-ipc.test.ts
+++ b/src/main/__tests__/i18n-pack-ipc.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Covers only the I18N_PACK_IMPORT dialog handler (multi-select read +
+// per-file parse). The store-backed handlers (savePack, renamePack, ...)
+// are covered in i18n-pack-store.test.ts; this suite stubs the store
+// module entirely so importing i18n-pack-ipc.ts does not construct
+// electron-store / app-config.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+vi.mock('electron', () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler)
+      }),
+      _handlers: handlers,
+    },
+    dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
+    BrowserWindow: { fromWebContents: vi.fn() },
+  }
+})
+
+vi.mock('../ipc-guard', async () => {
+  const { ipcMain } = await import('electron')
+  return { secureHandle: ipcMain.handle }
+})
+
+vi.mock('../i18n-pack-store', () => ({
+  listMetas: vi.fn(),
+  getPack: vi.fn(),
+  savePack: vi.fn(),
+  renamePack: vi.fn(),
+  setEnabled: vi.fn(),
+  deletePack: vi.fn(),
+  setHubPostId: vi.fn(),
+  hasActiveName: vi.fn(),
+  exportPackToDialog: vi.fn(),
+  reorderActive: vi.fn(),
+}))
+
+import { dialog, BrowserWindow, ipcMain } from 'electron'
+import { IpcChannels } from '../../shared/ipc/channels'
+import { setupI18nPackStore } from '../i18n-pack-ipc'
+
+interface FakeIpcMain {
+  _handlers: Map<string, (...args: unknown[]) => unknown>
+}
+
+interface ImportFileResult {
+  filePath: string
+  raw?: unknown
+  fileSizeBytes?: number
+  parseError?: string
+}
+
+interface ImportDialogResult {
+  canceled: boolean
+  files: ImportFileResult[]
+}
+
+function getImportHandler(): (event: unknown) => Promise<ImportDialogResult> {
+  const handlers = (ipcMain as unknown as FakeIpcMain)._handlers
+  const handler = handlers.get(IpcChannels.I18N_PACK_IMPORT)
+  if (!handler) throw new Error('I18N_PACK_IMPORT handler not registered')
+  return handler as (event: unknown) => Promise<ImportDialogResult>
+}
+
+describe('i18n-pack-ipc I18N_PACK_IMPORT', () => {
+  let dir = ''
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    dir = await mkdtemp(join(tmpdir(), 'i18n-pack-ipc-test-'))
+    setupI18nPackStore()
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ id: 1 } as unknown as Electron.BrowserWindow)
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('requests multiSelections and returns one entry per selected file', async () => {
+    const pathA = join(dir, 'a.json')
+    const pathB = join(dir, 'b.json')
+    await writeFile(pathA, JSON.stringify({ name: 'A', version: '0.1.0' }), 'utf-8')
+    await writeFile(pathB, JSON.stringify({ name: 'B', version: '0.1.0' }), 'utf-8')
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: [pathA, pathB] })
+
+    const result = await getImportHandler()({ sender: {} })
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ properties: expect.arrayContaining(['multiSelections']) }),
+    )
+    expect(result.canceled).toBe(false)
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0].raw).toEqual({ name: 'A', version: '0.1.0' })
+    expect(result.files[1].raw).toEqual({ name: 'B', version: '0.1.0' })
+  })
+
+  it('reports a parseError for one bad file without dropping the good one', async () => {
+    const goodPath = join(dir, 'good.json')
+    const badPath = join(dir, 'bad.json')
+    await writeFile(goodPath, JSON.stringify({ name: 'Good', version: '0.1.0' }), 'utf-8')
+    await writeFile(badPath, '{ not valid json', 'utf-8')
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: [badPath, goodPath] })
+
+    const result = await getImportHandler()({ sender: {} })
+
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0].parseError).toBeTruthy()
+    expect(result.files[0].raw).toBeUndefined()
+    expect(result.files[1].raw).toEqual({ name: 'Good', version: '0.1.0' })
+  })
+
+  it('returns canceled with no files when the dialog is dismissed', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: true, filePaths: [] })
+
+    const result = await getImportHandler()({ sender: {} })
+    expect(result).toEqual({ canceled: true, files: [] })
+  })
+
+  it('returns canceled with no files when there is no window for the sender', async () => {
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(null)
+
+    const result = await getImportHandler()({ sender: {} })
+    expect(result).toEqual({ canceled: true, files: [] })
+    expect(dialog.showOpenDialog).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -210,7 +210,7 @@ describe('key-label-store', () => {
   })
 
   describe('importFromDialog', () => {
-    it('imports a valid .json and returns the saved meta', async () => {
+    it('imports a valid .json and returns the saved meta in `imported`', async () => {
       const dir = join(mockUserDataPath, 'tmp-import')
       await mkdir(dir, { recursive: true })
       const importPath = join(dir, 'sample.json')
@@ -235,10 +235,25 @@ describe('key-label-store', () => {
 
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
-      expect(result.data?.name).toBe('Hebrew')
+      expect(result.data?.imported).toHaveLength(1)
+      expect(result.data?.imported[0].name).toBe('Hebrew')
+      expect(result.data?.rejections).toEqual([])
     })
 
-    it('rejects an invalid file shape', async () => {
+    it('requests multiSelections from the open dialog', async () => {
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: true,
+        filePaths: [],
+      })
+      const win = { id: 99 } as unknown as Electron.BrowserWindow
+      await importFromDialog(win)
+      expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+        win,
+        expect.objectContaining({ properties: expect.arrayContaining(['multiSelections']) }),
+      )
+    })
+
+    it('rejects an invalid file shape without failing the batch', async () => {
       const dir = join(mockUserDataPath, 'tmp-import')
       await mkdir(dir, { recursive: true })
       const importPath = join(dir, 'bad.json')
@@ -251,8 +266,11 @@ describe('key-label-store', () => {
 
       const win = { id: 2 } as unknown as Electron.BrowserWindow
       const result = await importFromDialog(win)
-      expect(result.success).toBe(false)
-      expect(result.errorCode).toBe('INVALID_FILE')
+      expect(result.success).toBe(true)
+      expect(result.data?.imported).toEqual([])
+      expect(result.data?.rejections).toEqual([
+        { fileName: 'bad.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' },
+      ])
     })
 
     it('returns IO_ERROR on cancel', async () => {
@@ -265,6 +283,82 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(false)
       expect(result.error).toBe('cancelled')
+    })
+
+    it('imports every file in a multi-select batch', async () => {
+      const dir = join(mockUserDataPath, 'tmp-import-multi')
+      await mkdir(dir, { recursive: true })
+      const pathA = join(dir, 'a.json')
+      const pathB = join(dir, 'b.json')
+      await writeFile(pathA, JSON.stringify({ name: 'Multi A', map: { KC_A: 'A' } }), 'utf-8')
+      await writeFile(pathB, JSON.stringify({ name: 'Multi B', map: { KC_B: 'B' } }), 'utf-8')
+
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [pathA, pathB],
+      })
+
+      const win = { id: 4 } as unknown as Electron.BrowserWindow
+      const result = await importFromDialog(win)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.imported.map((m) => m.name).sort()).toEqual(['Multi A', 'Multi B'])
+      expect(result.data?.rejections).toEqual([])
+    })
+
+    it('imports the good files and reports the bad ones in a mixed batch', async () => {
+      const dir = join(mockUserDataPath, 'tmp-import-mixed')
+      await mkdir(dir, { recursive: true })
+      const goodPath = join(dir, 'good.json')
+      const badPath = join(dir, 'bad.json')
+      await writeFile(goodPath, JSON.stringify({ name: 'Good Label', map: { KC_A: 'A' } }), 'utf-8')
+      await writeFile(badPath, JSON.stringify({ notAValidShape: true }), 'utf-8')
+
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [goodPath, badPath],
+      })
+
+      const win = { id: 5 } as unknown as Electron.BrowserWindow
+      const result = await importFromDialog(win)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.imported).toHaveLength(1)
+      expect(result.data?.imported[0].name).toBe('Good Label')
+      expect(result.data?.rejections).toEqual([
+        { fileName: 'bad.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' },
+      ])
+    })
+
+    it('overwrites the same entry when two files in one batch share a name', async () => {
+      const dir = join(mockUserDataPath, 'tmp-import-dup')
+      await mkdir(dir, { recursive: true })
+      const firstPath = join(dir, 'first.json')
+      const secondPath = join(dir, 'second.json')
+      await writeFile(firstPath, JSON.stringify({ name: 'Duplicate', map: { KC_A: 'A' } }), 'utf-8')
+      await writeFile(secondPath, JSON.stringify({ name: 'Duplicate', map: { KC_B: 'B' } }), 'utf-8')
+
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({
+        canceled: false,
+        filePaths: [firstPath, secondPath],
+      })
+
+      const win = { id: 6 } as unknown as Electron.BrowserWindow
+      const result = await importFromDialog(win)
+
+      expect(result.success).toBe(true)
+      expect(result.data?.imported).toHaveLength(2)
+      // Both entries resolve to the same id — the second overwrote the
+      // first in file-list order, which is the documented/acceptable
+      // behaviour for duplicate names within a single batch.
+      expect(result.data?.imported[0].id).toBe(result.data?.imported[1].id)
+
+      const metas = await listMetas()
+      const dup = metas.filter((m) => m.name === 'Duplicate')
+      expect(dup).toHaveLength(1)
+
+      const record = await getRecord(dup[0].id)
+      expect(record.data?.data.map).toEqual({ KC_B: 'B' })
     })
   })
 
@@ -403,7 +497,7 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
 
-      const record = await getRecord(result.data!.id)
+      const record = await getRecord(result.data!.imported[0].id)
       expect(record.data?.data.keymapApplicable).toBe(true)
     })
 
@@ -428,7 +522,7 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
 
-      const record = await getRecord(result.data!.id)
+      const record = await getRecord(result.data!.imported[0].id)
       expect(record.data?.data.keymapApplicable).toBeUndefined()
     })
   })

--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -236,7 +236,8 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
       expect(result.data?.imported).toHaveLength(1)
-      expect(result.data?.imported[0].name).toBe('Hebrew')
+      expect(result.data?.imported[0].fileName).toBe('sample.json')
+      expect(result.data?.imported[0].meta.name).toBe('Hebrew')
       expect(result.data?.rejections).toEqual([])
     })
 
@@ -302,7 +303,8 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
 
       expect(result.success).toBe(true)
-      expect(result.data?.imported.map((m) => m.name).sort()).toEqual(['Multi A', 'Multi B'])
+      expect(result.data?.imported.map((s) => s.meta.name).sort()).toEqual(['Multi A', 'Multi B'])
+      expect(result.data?.imported.map((s) => s.fileName).sort()).toEqual(['a.json', 'b.json'])
       expect(result.data?.rejections).toEqual([])
     })
 
@@ -324,7 +326,8 @@ describe('key-label-store', () => {
 
       expect(result.success).toBe(true)
       expect(result.data?.imported).toHaveLength(1)
-      expect(result.data?.imported[0].name).toBe('Good Label')
+      expect(result.data?.imported[0].fileName).toBe('good.json')
+      expect(result.data?.imported[0].meta.name).toBe('Good Label')
       expect(result.data?.rejections).toEqual([
         { fileName: 'bad.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' },
       ])
@@ -350,8 +353,11 @@ describe('key-label-store', () => {
       expect(result.data?.imported).toHaveLength(2)
       // Both entries resolve to the same id — the second overwrote the
       // first in file-list order, which is the documented/acceptable
-      // behaviour for duplicate names within a single batch.
-      expect(result.data?.imported[0].id).toBe(result.data?.imported[1].id)
+      // behaviour for duplicate names within a single batch. Each still
+      // carries its own originating filename.
+      expect(result.data?.imported[0].meta.id).toBe(result.data?.imported[1].meta.id)
+      expect(result.data?.imported[0].fileName).toBe('first.json')
+      expect(result.data?.imported[1].fileName).toBe('second.json')
 
       const metas = await listMetas()
       const dup = metas.filter((m) => m.name === 'Duplicate')
@@ -497,7 +503,7 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
 
-      const record = await getRecord(result.data!.imported[0].id)
+      const record = await getRecord(result.data!.imported[0].meta.id)
       expect(record.data?.data.keymapApplicable).toBe(true)
     })
 
@@ -522,7 +528,7 @@ describe('key-label-store', () => {
       const result = await importFromDialog(win)
       expect(result.success).toBe(true)
 
-      const record = await getRecord(result.data!.imported[0].id)
+      const record = await getRecord(result.data!.imported[0].meta.id)
       expect(record.data?.data.keymapApplicable).toBeUndefined()
     })
   })

--- a/src/main/__tests__/theme-pack-ipc.test.ts
+++ b/src/main/__tests__/theme-pack-ipc.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Covers only the THEME_PACK_IMPORT dialog handler (multi-select read +
+// per-file parse). The store-backed handlers (savePack, renamePack, ...)
+// are covered in theme-pack-store.test.ts; this suite stubs the store
+// module entirely so importing theme-pack-ipc.ts does not construct
+// electron-store / app-config.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+vi.mock('electron', () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>()
+  return {
+    ipcMain: {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler)
+      }),
+      _handlers: handlers,
+    },
+    dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
+    BrowserWindow: {
+      fromWebContents: vi.fn(),
+      getAllWindows: vi.fn(() => []),
+    },
+  }
+})
+
+vi.mock('../ipc-guard', async () => {
+  const { ipcMain } = await import('electron')
+  return { secureHandle: ipcMain.handle }
+})
+
+vi.mock('../theme-pack-store', () => ({
+  listMetas: vi.fn(),
+  getPack: vi.fn(),
+  savePack: vi.fn(),
+  renamePack: vi.fn(),
+  deletePack: vi.fn(),
+  setHubPostId: vi.fn(),
+  hasActiveName: vi.fn(),
+  exportPackToDialog: vi.fn(),
+  reorderActive: vi.fn(),
+}))
+
+import { dialog, BrowserWindow, ipcMain } from 'electron'
+import { IpcChannels } from '../../shared/ipc/channels'
+import { setupThemePackStore } from '../theme-pack-ipc'
+
+interface FakeIpcMain {
+  _handlers: Map<string, (...args: unknown[]) => unknown>
+}
+
+interface ImportFileResult {
+  filePath: string
+  raw?: unknown
+  fileSizeBytes?: number
+  parseError?: string
+}
+
+interface ImportDialogResult {
+  canceled: boolean
+  files: ImportFileResult[]
+}
+
+function getImportHandler(): (event: unknown) => Promise<ImportDialogResult> {
+  const handlers = (ipcMain as unknown as FakeIpcMain)._handlers
+  const handler = handlers.get(IpcChannels.THEME_PACK_IMPORT)
+  if (!handler) throw new Error('THEME_PACK_IMPORT handler not registered')
+  return handler as (event: unknown) => Promise<ImportDialogResult>
+}
+
+describe('theme-pack-ipc THEME_PACK_IMPORT', () => {
+  let dir = ''
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    dir = await mkdtemp(join(tmpdir(), 'theme-pack-ipc-test-'))
+    setupThemePackStore()
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue({ id: 1 } as unknown as Electron.BrowserWindow)
+  })
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it('requests multiSelections and returns one entry per selected file', async () => {
+    const pathA = join(dir, 'a.json')
+    const pathB = join(dir, 'b.json')
+    await writeFile(pathA, JSON.stringify({ name: 'A', version: '1', colorScheme: 'dark', colors: {} }), 'utf-8')
+    await writeFile(pathB, JSON.stringify({ name: 'B', version: '1', colorScheme: 'dark', colors: {} }), 'utf-8')
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: [pathA, pathB] })
+
+    const result = await getImportHandler()({ sender: {} })
+
+    expect(dialog.showOpenDialog).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ properties: expect.arrayContaining(['multiSelections']) }),
+    )
+    expect(result.canceled).toBe(false)
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0].raw).toEqual({ name: 'A', version: '1', colorScheme: 'dark', colors: {} })
+    expect(result.files[1].raw).toEqual({ name: 'B', version: '1', colorScheme: 'dark', colors: {} })
+  })
+
+  it('reports a parseError for one bad file without dropping the good one', async () => {
+    const goodPath = join(dir, 'good.json')
+    const badPath = join(dir, 'bad.json')
+    await writeFile(goodPath, JSON.stringify({ name: 'Good', version: '1', colorScheme: 'dark', colors: {} }), 'utf-8')
+    await writeFile(badPath, '{ not valid json', 'utf-8')
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: [badPath, goodPath] })
+
+    const result = await getImportHandler()({ sender: {} })
+
+    expect(result.files).toHaveLength(2)
+    expect(result.files[0].parseError).toBeTruthy()
+    expect(result.files[0].raw).toBeUndefined()
+    expect(result.files[1].raw).toEqual({ name: 'Good', version: '1', colorScheme: 'dark', colors: {} })
+  })
+
+  it('returns canceled with no files when the dialog is dismissed', async () => {
+    vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: true, filePaths: [] })
+
+    const result = await getImportHandler()({ sender: {} })
+    expect(result).toEqual({ canceled: true, files: [] })
+  })
+
+  it('returns canceled with no files when there is no window for the sender', async () => {
+    vi.mocked(BrowserWindow.fromWebContents).mockReturnValue(null)
+
+    const result = await getImportHandler()({ sender: {} })
+    expect(result).toEqual({ canceled: true, files: [] })
+    expect(dialog.showOpenDialog).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/i18n-pack-ipc.ts
+++ b/src/main/i18n-pack-ipc.ts
@@ -6,10 +6,10 @@
 // process can keep treating pack JSON as opaque blobs that round-trip
 // via the dialog.
 
-import { BrowserWindow, dialog } from 'electron'
-import { readFile } from 'node:fs/promises'
+import { BrowserWindow } from 'electron'
 import { IpcChannels } from '../shared/ipc/channels'
 import { secureHandle } from './ipc-guard'
+import { readSelectedImportFiles } from './pack-import-dialog'
 import {
   listMetas,
   getPack,
@@ -27,25 +27,7 @@ import type {
   I18nPackRecord,
   I18nPackStoreResult,
   I18nPackImportDialogResult,
-  I18nPackImportFile,
 } from '../shared/types/i18n-store'
-
-/** Read + parse a single file selected via the multi-select import dialog.
- *  Never throws — a read or parse failure is reported via `parseError` so
- *  one bad file in the batch does not abort the rest. */
-async function readOneImportFile(filePath: string): Promise<I18nPackImportFile> {
-  try {
-    const raw = await readFile(filePath, 'utf-8')
-    try {
-      const parsed: unknown = JSON.parse(raw)
-      return { filePath, raw: parsed, fileSizeBytes: Buffer.byteLength(raw, 'utf-8') }
-    } catch (err) {
-      return { filePath, fileSizeBytes: Buffer.byteLength(raw, 'utf-8'), parseError: String(err) }
-    }
-  } catch (err) {
-    return { filePath, parseError: String(err) }
-  }
-}
 
 export function setupI18nPackStore(): void {
   secureHandle(
@@ -182,22 +164,14 @@ export function setupI18nPackStore(): void {
     IpcChannels.I18N_PACK_IMPORT,
     async (event): Promise<I18nPackImportDialogResult> => {
       const win = BrowserWindow.fromWebContents(event.sender)
-      if (!win) return { canceled: true, files: [] }
-      const result = await dialog.showOpenDialog(win, {
+      const files = await readSelectedImportFiles(win, {
         title: 'Import Language Pack',
         filters: [
           { name: 'JSON', extensions: ['json'] },
           { name: 'All Files', extensions: ['*'] },
         ],
-        properties: ['openFile', 'multiSelections'],
       })
-      if (result.canceled || result.filePaths.length === 0) {
-        return { canceled: true, files: [] }
-      }
-      const files: I18nPackImportFile[] = []
-      for (const filePath of result.filePaths) {
-        files.push(await readOneImportFile(filePath))
-      }
+      if (!files) return { canceled: true, files: [] }
       return { canceled: false, files }
     },
   )

--- a/src/main/i18n-pack-ipc.ts
+++ b/src/main/i18n-pack-ipc.ts
@@ -27,7 +27,25 @@ import type {
   I18nPackRecord,
   I18nPackStoreResult,
   I18nPackImportDialogResult,
+  I18nPackImportFile,
 } from '../shared/types/i18n-store'
+
+/** Read + parse a single file selected via the multi-select import dialog.
+ *  Never throws — a read or parse failure is reported via `parseError` so
+ *  one bad file in the batch does not abort the rest. */
+async function readOneImportFile(filePath: string): Promise<I18nPackImportFile> {
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      return { filePath, raw: parsed, fileSizeBytes: Buffer.byteLength(raw, 'utf-8') }
+    } catch (err) {
+      return { filePath, fileSizeBytes: Buffer.byteLength(raw, 'utf-8'), parseError: String(err) }
+    }
+  } catch (err) {
+    return { filePath, parseError: String(err) }
+  }
+}
 
 export function setupI18nPackStore(): void {
   secureHandle(
@@ -164,41 +182,23 @@ export function setupI18nPackStore(): void {
     IpcChannels.I18N_PACK_IMPORT,
     async (event): Promise<I18nPackImportDialogResult> => {
       const win = BrowserWindow.fromWebContents(event.sender)
-      if (!win) return { canceled: true }
+      if (!win) return { canceled: true, files: [] }
       const result = await dialog.showOpenDialog(win, {
         title: 'Import Language Pack',
         filters: [
           { name: 'JSON', extensions: ['json'] },
           { name: 'All Files', extensions: ['*'] },
         ],
-        properties: ['openFile'],
+        properties: ['openFile', 'multiSelections'],
       })
       if (result.canceled || result.filePaths.length === 0) {
-        return { canceled: true }
+        return { canceled: true, files: [] }
       }
-      const filePath = result.filePaths[0]
-      try {
-        const raw = await readFile(filePath, 'utf-8')
-        let parsed: unknown
-        try {
-          parsed = JSON.parse(raw)
-        } catch (err) {
-          return {
-            canceled: false,
-            filePath,
-            fileSizeBytes: Buffer.byteLength(raw, 'utf-8'),
-            parseError: String(err),
-          }
-        }
-        return {
-          canceled: false,
-          raw: parsed,
-          filePath,
-          fileSizeBytes: Buffer.byteLength(raw, 'utf-8'),
-        }
-      } catch (err) {
-        return { canceled: false, filePath, parseError: String(err) }
+      const files: I18nPackImportFile[] = []
+      for (const filePath of result.filePaths) {
+        files.push(await readOneImportFile(filePath))
       }
+      return { canceled: false, files }
     },
   )
 

--- a/src/main/key-label-ipc.ts
+++ b/src/main/key-label-ipc.ts
@@ -20,6 +20,7 @@ import type {
   KeyLabelMeta,
   KeyLabelRecord,
   KeyLabelStoreResult,
+  KeyLabelImportBatchResult,
 } from '../shared/types/key-label-store'
 
 export function setupKeyLabelStore(): void {
@@ -97,7 +98,7 @@ export function setupKeyLabelStore(): void {
 
   secureHandle(
     IpcChannels.KEY_LABEL_STORE_IMPORT,
-    async (event): Promise<KeyLabelStoreResult<KeyLabelMeta>> => {
+    async (event): Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>> => {
       const win = BrowserWindow.fromWebContents(event.sender)
       if (!win) return { success: false, errorCode: 'IO_ERROR', error: 'No window' }
       return importFromDialog(win)

--- a/src/main/key-label-store.ts
+++ b/src/main/key-label-store.ts
@@ -16,6 +16,7 @@ import type {
   KeyLabelStoreErrorCode,
   KeyLabelImportBatchResult,
   KeyLabelImportRejection,
+  KeyLabelImportSuccess,
 } from '../shared/types/key-label-store'
 
 export const KEY_LABEL_SYNC_UNIT = 'key-labels'
@@ -428,7 +429,7 @@ export async function importFromDialog(
       return fail('IO_ERROR', 'cancelled')
     }
 
-    const imported: KeyLabelMeta[] = []
+    const imported: KeyLabelImportSuccess[] = []
     const rejections: KeyLabelImportRejection[] = []
 
     for (const filePath of result.filePaths) {
@@ -463,7 +464,10 @@ export async function importFromDialog(
           keymapApplicable: parsed.keymapApplicable,
         })
         if (saved.success && saved.data) {
-          imported.push(saved.data)
+          // Carries the originating filename alongside the saved meta —
+          // the renderer needs it to report e.g. a Hub-sync failure
+          // against the file the user picked, not the label's name.
+          imported.push({ fileName, meta: saved.data })
         } else {
           rejections.push({
             fileName,

--- a/src/main/key-label-store.ts
+++ b/src/main/key-label-store.ts
@@ -2,7 +2,7 @@
 // Local store for Key Labels — mirrors favorite-store's index + per-entry layout.
 
 import { app, dialog, BrowserWindow } from 'electron'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
@@ -14,6 +14,8 @@ import type {
   KeyLabelRecord,
   KeyLabelStoreResult,
   KeyLabelStoreErrorCode,
+  KeyLabelImportBatchResult,
+  KeyLabelImportRejection,
 } from '../shared/types/key-label-store'
 
 export const KEY_LABEL_SYNC_UNIT = 'key-labels'
@@ -399,9 +401,19 @@ export async function setHubPostId(
   }
 }
 
+/**
+ * Import every file selected via the multi-select dialog. Each path is
+ * processed independently — a bad file (unreadable / invalid JSON / fails
+ * `saveRecord` validation) is recorded in `rejections` rather than aborting
+ * the rest of the batch, mirroring `importTypingDataFiles`'s
+ * per-file-independent contract. Two same-named files within one batch
+ * resolve in file-list order: the second finds the first's just-saved
+ * entry via `findActiveByName` and overwrites it — acceptable, since the
+ * user picked both files together.
+ */
 export async function importFromDialog(
   win: BrowserWindow,
-): Promise<KeyLabelStoreResult<KeyLabelMeta>> {
+): Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>> {
   try {
     const result = await dialog.showOpenDialog(win, {
       title: 'Import Key Label',
@@ -409,38 +421,62 @@ export async function importFromDialog(
         { name: 'JSON', extensions: ['json'] },
         { name: 'All Files', extensions: ['*'] },
       ],
-      properties: ['openFile'],
+      properties: ['openFile', 'multiSelections'],
     })
 
     if (result.canceled || result.filePaths.length === 0) {
       return fail('IO_ERROR', 'cancelled')
     }
 
-    const raw = await readFile(result.filePaths[0], 'utf-8')
-    const parsed = normalizeFile(JSON.parse(raw))
-    if (!parsed) return fail('INVALID_FILE', 'Invalid key label file')
+    const imported: KeyLabelMeta[] = []
+    const rejections: KeyLabelImportRejection[] = []
 
-    // Treat re-import of an entry with an existing name as an
-    // overwrite: the user explicitly opted in by picking the same
-    // file name back. We carry the existing id, uploaderName and
-    // hubPostId across so the entry stays linked to its Hub post
-    // (the user can detach via Remove if they want a fresh post).
-    const index = await readIndex()
-    const existing = findActiveByName(index.entries, parsed.name)
-    return saveRecord({
-      ...(existing
-        ? {
-          id: existing.id,
-          ...(existing.uploaderName ? { uploaderName: existing.uploaderName } : {}),
-          ...(existing.hubPostId ? { hubPostId: existing.hubPostId } : {}),
-          ...(existing.hubUpdatedAt ? { hubUpdatedAt: existing.hubUpdatedAt } : {}),
+    for (const filePath of result.filePaths) {
+      const fileName = basename(filePath)
+      try {
+        const raw = await readFile(filePath, 'utf-8')
+        const parsed = normalizeFile(JSON.parse(raw))
+        if (!parsed) {
+          rejections.push({ fileName, errorCode: 'INVALID_FILE', error: 'Invalid key label file' })
+          continue
         }
-        : {}),
-      name: parsed.name,
-      map: parsed.map,
-      compositeLabels: parsed.compositeLabels,
-      keymapApplicable: parsed.keymapApplicable,
-    })
+
+        // Treat re-import of an entry with an existing name as an
+        // overwrite: the user explicitly opted in by picking the same
+        // file name back. We carry the existing id, uploaderName and
+        // hubPostId across so the entry stays linked to its Hub post
+        // (the user can detach via Remove if they want a fresh post).
+        const index = await readIndex()
+        const existing = findActiveByName(index.entries, parsed.name)
+        const saved = await saveRecord({
+          ...(existing
+            ? {
+              id: existing.id,
+              ...(existing.uploaderName ? { uploaderName: existing.uploaderName } : {}),
+              ...(existing.hubPostId ? { hubPostId: existing.hubPostId } : {}),
+              ...(existing.hubUpdatedAt ? { hubUpdatedAt: existing.hubUpdatedAt } : {}),
+            }
+            : {}),
+          name: parsed.name,
+          map: parsed.map,
+          compositeLabels: parsed.compositeLabels,
+          keymapApplicable: parsed.keymapApplicable,
+        })
+        if (saved.success && saved.data) {
+          imported.push(saved.data)
+        } else {
+          rejections.push({
+            fileName,
+            errorCode: saved.errorCode ?? 'IO_ERROR',
+            error: saved.error ?? 'Import failed',
+          })
+        }
+      } catch (err) {
+        rejections.push({ fileName, errorCode: 'IO_ERROR', error: String(err) })
+      }
+    }
+
+    return ok({ imported, rejections })
   } catch (err) {
     return fail('IO_ERROR', String(err))
   }

--- a/src/main/pack-import-dialog.ts
+++ b/src/main/pack-import-dialog.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared multi-select import dialog for Language Packs and Theme Packs:
+// both used to define byte-identical "open dialog -> read -> JSON.parse
+// each selected file" logic inline in their own *-ipc.ts. Key Labels'
+// import is deliberately NOT folded in here — it saves each file in
+// main and returns saved metas rather than raw parsed bodies (see
+// `importFromDialog` in `key-label-store.ts`), so its shape and
+// behaviour genuinely differ from this read-only dialog.
+
+import type { BrowserWindow } from 'electron'
+import { dialog } from 'electron'
+import { readFile } from 'node:fs/promises'
+import type { PackImportFile } from '../shared/types/pack-import'
+
+/** Read + parse a single file selected via the multi-select import
+ *  dialog. Never throws — a read or parse failure is reported via
+ *  `parseError` so one bad file in the batch does not abort the rest. */
+async function readOneImportFile(filePath: string): Promise<PackImportFile> {
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      return { filePath, raw: parsed, fileSizeBytes: Buffer.byteLength(raw, 'utf-8') }
+    } catch (err) {
+      return { filePath, fileSizeBytes: Buffer.byteLength(raw, 'utf-8'), parseError: String(err) }
+    }
+  } catch (err) {
+    return { filePath, parseError: String(err) }
+  }
+}
+
+export interface ReadSelectedImportFilesOptions {
+  title: string
+  filters: { name: string; extensions: string[] }[]
+}
+
+/**
+ * Opens a multi-select "openFile" dialog anchored to `win` and reads +
+ * parses every selected file independently. Returns `null` when there is
+ * no window to anchor the dialog to, or the user cancels / selects
+ * nothing — the caller maps that to its own `{ canceled: true, files: [] }`
+ * response.
+ */
+export async function readSelectedImportFiles(
+  win: BrowserWindow | null,
+  opts: ReadSelectedImportFilesOptions,
+): Promise<PackImportFile[] | null> {
+  if (!win) return null
+  const result = await dialog.showOpenDialog(win, {
+    title: opts.title,
+    filters: opts.filters,
+    properties: ['openFile', 'multiSelections'],
+  })
+  if (result.canceled || result.filePaths.length === 0) return null
+
+  const files: PackImportFile[] = []
+  for (const filePath of result.filePaths) {
+    files.push(await readOneImportFile(filePath))
+  }
+  return files
+}

--- a/src/main/theme-pack-ipc.ts
+++ b/src/main/theme-pack-ipc.ts
@@ -5,10 +5,10 @@
 // and the main process treats pack JSON as opaque blobs that round-trip
 // via the dialog.
 
-import { BrowserWindow, dialog } from 'electron'
-import { readFile } from 'node:fs/promises'
+import { BrowserWindow } from 'electron'
 import { IpcChannels } from '../shared/ipc/channels'
 import { secureHandle } from './ipc-guard'
+import { readSelectedImportFiles } from './pack-import-dialog'
 import {
   listMetas,
   getPack,
@@ -25,29 +25,11 @@ import type {
   ThemePackRecord,
   ThemePackStoreResult,
   ThemePackImportDialogResult,
-  ThemePackImportFile,
 } from '../shared/types/theme-store'
 
 function broadcastChanged(): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(IpcChannels.THEME_PACK_CHANGED)
-  }
-}
-
-/** Read + parse a single file selected via the multi-select import dialog.
- *  Never throws — a read or parse failure is reported via `parseError` so
- *  one bad file in the batch does not abort the rest. */
-async function readOneImportFile(filePath: string): Promise<ThemePackImportFile> {
-  try {
-    const raw = await readFile(filePath, 'utf-8')
-    try {
-      const parsed: unknown = JSON.parse(raw)
-      return { filePath, raw: parsed, fileSizeBytes: Buffer.byteLength(raw, 'utf-8') }
-    } catch (err) {
-      return { filePath, fileSizeBytes: Buffer.byteLength(raw, 'utf-8'), parseError: String(err) }
-    }
-  } catch (err) {
-    return { filePath, parseError: String(err) }
   }
 }
 
@@ -164,22 +146,14 @@ export function setupThemePackStore(): void {
     IpcChannels.THEME_PACK_IMPORT,
     async (event): Promise<ThemePackImportDialogResult> => {
       const win = BrowserWindow.fromWebContents(event.sender)
-      if (!win) return { canceled: true, files: [] }
-      const result = await dialog.showOpenDialog(win, {
+      const files = await readSelectedImportFiles(win, {
         title: 'Import Theme Pack',
         filters: [
           { name: 'JSON', extensions: ['json'] },
           { name: 'All Files', extensions: ['*'] },
         ],
-        properties: ['openFile', 'multiSelections'],
       })
-      if (result.canceled || result.filePaths.length === 0) {
-        return { canceled: true, files: [] }
-      }
-      const files: ThemePackImportFile[] = []
-      for (const filePath of result.filePaths) {
-        files.push(await readOneImportFile(filePath))
-      }
+      if (!files) return { canceled: true, files: [] }
       return { canceled: false, files }
     },
   )

--- a/src/main/theme-pack-ipc.ts
+++ b/src/main/theme-pack-ipc.ts
@@ -25,11 +25,29 @@ import type {
   ThemePackRecord,
   ThemePackStoreResult,
   ThemePackImportDialogResult,
+  ThemePackImportFile,
 } from '../shared/types/theme-store'
 
 function broadcastChanged(): void {
   for (const win of BrowserWindow.getAllWindows()) {
     win.webContents.send(IpcChannels.THEME_PACK_CHANGED)
+  }
+}
+
+/** Read + parse a single file selected via the multi-select import dialog.
+ *  Never throws — a read or parse failure is reported via `parseError` so
+ *  one bad file in the batch does not abort the rest. */
+async function readOneImportFile(filePath: string): Promise<ThemePackImportFile> {
+  try {
+    const raw = await readFile(filePath, 'utf-8')
+    try {
+      const parsed: unknown = JSON.parse(raw)
+      return { filePath, raw: parsed, fileSizeBytes: Buffer.byteLength(raw, 'utf-8') }
+    } catch (err) {
+      return { filePath, fileSizeBytes: Buffer.byteLength(raw, 'utf-8'), parseError: String(err) }
+    }
+  } catch (err) {
+    return { filePath, parseError: String(err) }
   }
 }
 
@@ -146,41 +164,23 @@ export function setupThemePackStore(): void {
     IpcChannels.THEME_PACK_IMPORT,
     async (event): Promise<ThemePackImportDialogResult> => {
       const win = BrowserWindow.fromWebContents(event.sender)
-      if (!win) return { canceled: true }
+      if (!win) return { canceled: true, files: [] }
       const result = await dialog.showOpenDialog(win, {
         title: 'Import Theme Pack',
         filters: [
           { name: 'JSON', extensions: ['json'] },
           { name: 'All Files', extensions: ['*'] },
         ],
-        properties: ['openFile'],
+        properties: ['openFile', 'multiSelections'],
       })
       if (result.canceled || result.filePaths.length === 0) {
-        return { canceled: true }
+        return { canceled: true, files: [] }
       }
-      const filePath = result.filePaths[0]
-      try {
-        const raw = await readFile(filePath, 'utf-8')
-        let parsed: unknown
-        try {
-          parsed = JSON.parse(raw)
-        } catch (err) {
-          return {
-            canceled: false,
-            filePath,
-            fileSizeBytes: Buffer.byteLength(raw, 'utf-8'),
-            parseError: String(err),
-          }
-        }
-        return {
-          canceled: false,
-          raw: parsed,
-          filePath,
-          fileSizeBytes: Buffer.byteLength(raw, 'utf-8'),
-        }
-      } catch (err) {
-        return { canceled: false, filePath, parseError: String(err) }
+      const files: ThemePackImportFile[] = []
+      for (const filePath of result.filePaths) {
+        files.push(await readOneImportFile(filePath))
       }
+      return { canceled: false, files }
     },
   )
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,7 +13,7 @@ import type { TrayStatus } from '../shared/types/vial-api'
 import type { SnapshotMeta } from '../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from '../shared/types/analyze-filter-store'
 import type { SavedFavoriteMeta, FavoriteImportResult } from '../shared/types/favorite-store'
-import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from '../shared/types/key-label-store'
+import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult, KeyLabelImportBatchResult } from '../shared/types/key-label-store'
 import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from '../shared/types/typing-test-text-store'
 import type { HubKeyLabelItem, HubKeyLabelListResponse, HubKeyLabelListParams, HubKeyLabelTimestampsResponse } from '../shared/types/hub-key-label'
 import type {
@@ -278,7 +278,7 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_RENAME, id, newName),
   keyLabelStoreDelete: (id: string): Promise<KeyLabelStoreResult<void>> =>
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_DELETE, id),
-  keyLabelStoreImport: (): Promise<KeyLabelStoreResult<KeyLabelMeta>> =>
+  keyLabelStoreImport: (): Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>> =>
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_IMPORT),
   keyLabelStoreExport: (id: string): Promise<KeyLabelStoreResult<{ filePath: string }>> =>
     ipcRenderer.invoke(IpcChannels.KEY_LABEL_STORE_EXPORT, id),

--- a/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
+++ b/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
@@ -60,7 +60,7 @@ export interface LanguageInstalledRowProps {
   setConfirmDeleteId: (id: string | null) => void
   confirmRemoveId: string | null
   setConfirmRemoveId: (id: string | null) => void
-  lastResult: PackActionResult | null
+  lastResult: PackActionResult | PackActionResult[] | null
   currentDisplayName: string | null
   hubCanWrite: boolean
   hubFreshness: Map<string, HubFreshnessEntry>

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -18,11 +18,11 @@ import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useI18nPackStore } from '../../hooks/useI18nPackStore'
 import i18n from '../../i18n'
-import { validatePack } from '../../../shared/i18n/validate'
+import { validatePack, type ValidatePackResult } from '../../../shared/i18n/validate'
 import { computeCoverage } from '../../../shared/i18n/coverage'
 import { BASE_REVISION, ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
 import english from '../../i18n/locales/english.json'
-import { BUILTIN_ENGLISH_PACK_ID } from '../../../shared/types/i18n-store'
+import { BUILTIN_ENGLISH_PACK_ID, type I18nPackMeta } from '../../../shared/types/i18n-store'
 import type { HubI18nPostListItem } from '../../../shared/types/hub'
 import { MissingKeysModal } from './MissingKeysModal'
 import { downloadJson } from '../../utils/download-json'
@@ -37,6 +37,7 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
+import { buildImportBatchFailureSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -77,7 +78,7 @@ export function LanguagePacksModal({
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
-  const [lastResult, setLastResult] = useState<PackActionResult | null>(null)
+  const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
 
   const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
@@ -555,26 +556,21 @@ export function LanguagePacksModal({
     }
   }, [t])
 
-  // Inline import path: validate locally, compute coverage, then ask
-  // the store to persist. Failures surface through `setActionError`
-  // (the same banner KeyLabels uses) instead of opening a separate
-  // confirmation modal.
-  const persistImportedPack = useCallback(async (
+  // Core validate + coverage + persist step, shared by the single-item
+  // Hub-download path (`persistImportedPack` below) and the multi-file
+  // import batch (`handleImportFile`). Returns the outcome instead of
+  // touching state so each caller decides how to surface it (single
+  // banner vs. an accumulated batch summary).
+  const importOnePack = useCallback(async (
     raw: unknown,
-    extra: { hubPostId?: string } = {},
-  ): Promise<void> => {
-    setActionError(null)
-    setLastResult(null)
+  ): Promise<{ ok: true; meta: I18nPackMeta; validation: ValidatePackResult } | { ok: false; error: string }> => {
     const validation = validatePack(raw)
     if (!validation.ok) {
-      setActionError(validation.errors[0] ?? t('i18n.errorGeneric'))
-      return
+      return { ok: false, error: validation.errors[0] ?? t('i18n.errorGeneric') }
     }
     if (validation.dangerousKeys.length > 0) {
-      setActionError(t('i18n.preview.dangerousWarning'))
-      return
+      return { ok: false, error: t('i18n.preview.dangerousWarning') }
     }
-    const beforeIds = placement.snapshotBeforeIds()
     const coverage = computeCoverage(raw, ENGLISH_PACK_BODY)
     const result = await store.applyImport(raw, {
       enabled: true,
@@ -584,12 +580,32 @@ export function LanguagePacksModal({
       dangerousKeyCount: validation.dangerousKeys.length,
     })
     if (!result.success || !result.meta) {
-      setActionError(result.error ?? t('i18n.errorGeneric'))
+      return { ok: false, error: result.error ?? t('i18n.errorGeneric') }
+    }
+    return { ok: true, meta: result.meta, validation }
+  }, [store, t])
+
+  // Single-item import path: local file import via the toolbar (single
+  // selection legacy call sites/tests) and Hub download both funnel
+  // through here. Failures surface through `setActionError` (the same
+  // banner KeyLabels uses) instead of opening a separate confirmation
+  // modal.
+  const persistImportedPack = useCallback(async (
+    raw: unknown,
+    extra: { hubPostId?: string } = {},
+  ): Promise<void> => {
+    setActionError(null)
+    setLastResult(null)
+    const beforeIds = placement.snapshotBeforeIds()
+    const imported = await importOnePack(raw)
+    if (!imported.ok) {
+      setActionError(imported.error)
       return
     }
-    setLastResult({ id: result.meta.id, kind: 'success', message: t('common.saved') })
-    handleSelectLanguage(`pack:${result.meta.id}`)
-    await placement.place({ id: result.meta.id, name: result.meta.name }, { beforeIds })
+    const { meta, validation } = imported
+    setLastResult({ id: meta.id, kind: 'success', message: t('common.saved') })
+    handleSelectLanguage(`pack:${meta.id}`)
+    await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
 
     if (extra.hubPostId) {
       // Same Author/Updated enrichment as handleSync — the download
@@ -597,33 +613,78 @@ export function LanguagePacksModal({
       const enriched = validation.header
         ? await fetchHubPackMeta(window.vialAPI.hubListI18nPosts, validation.header.name, extra.hubPostId)
         : {}
-      void window.vialAPI.i18nPackSetHubPostId(result.meta.id, extra.hubPostId, enriched.uploaderName, enriched.hubUpdatedAt)
+      void window.vialAPI.i18nPackSetHubPostId(meta.id, extra.hubPostId, enriched.uploaderName, enriched.hubUpdatedAt)
       return
     }
     // Auto-sync to Hub when this overwrite landed on an entry that
     // already mirrors a Hub post. Promote the inline badge from
     // "Saved" to "Synced" so the user can see the second step
     // completed; failure surfaces inline without rolling back local.
-    if (result.meta.hubPostId) {
-      const upd = await pushPackToHub(result.meta.id, result.meta.hubPostId)
+    if (meta.hubPostId) {
+      const upd = await pushPackToHub(meta.id, meta.hubPostId)
       if (upd.success) {
-        setLastResult({ id: result.meta.id, kind: 'success', message: t('common.synced') })
+        setLastResult({ id: meta.id, kind: 'success', message: t('common.synced') })
       } else {
         setActionError(upd.error ?? t('hub.updateFailed'))
       }
     }
-  }, [store, t, pushPackToHub, handleSelectLanguage, placement])
+  }, [importOnePack, t, pushPackToHub, handleSelectLanguage, placement])
 
+  // Multi-file import batch: every selected file is processed
+  // independently. Successes each get their own row badge (accumulated
+  // into an array — `PackResultBadge` looks up its row's own entry);
+  // failures (parse errors + save failures + failed Hub auto-syncs) are
+  // aggregated into one banner via `buildImportBatchFailureSummary`,
+  // mirroring the typing-analytics import precedent.
   const handleImportFile = useCallback(async (): Promise<void> => {
     setActionError(null)
+    setLastResult(null)
     const dialogResult = await store.importFromDialog()
     if (dialogResult.canceled) return
-    if (dialogResult.parseError || dialogResult.raw === undefined) {
-      setActionError(t('i18n.errorInvalidJson'))
-      return
+    const successBadges: PackActionResult[] = []
+    const failures: ImportBatchFailure[] = []
+    let lastImportedPackId: string | null = null
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        failures.push({ fileName, reason: t('i18n.errorInvalidJson') })
+        continue
+      }
+      // Snapshot right before this file's own save rather than once for
+      // the whole batch: each `importOnePack` call below is its own IPC
+      // round trip that lands immediately, so an earlier file already
+      // placed in this same loop is reflected in `nameSortEntries` by
+      // the time a later file's insert position is computed.
+      const beforeIds = placement.snapshotBeforeIds()
+      const imported = await importOnePack(file.raw)
+      if (!imported.ok) {
+        failures.push({ fileName, reason: imported.error })
+        continue
+      }
+      const { meta } = imported
+      let message = t('common.saved')
+      if (meta.hubPostId) {
+        const upd = await pushPackToHub(meta.id, meta.hubPostId)
+        if (upd.success) {
+          message = t('common.synced')
+        } else {
+          failures.push({ fileName: meta.name, reason: upd.error ?? t('hub.updateFailed') })
+        }
+      }
+      successBadges.push({ id: meta.id, kind: 'success', message })
+      lastImportedPackId = meta.id
+      await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
     }
-    await persistImportedPack(dialogResult.raw)
-  }, [persistImportedPack, store, t])
+    if (successBadges.length > 0) {
+      setLastResult(successBadges)
+      // Mirror the single-file behaviour of switching the active
+      // language to the freshly imported pack, anchored on the last
+      // successfully imported file for a deterministic final state.
+      if (lastImportedPackId) handleSelectLanguage(`pack:${lastImportedPackId}`)
+    }
+    const summary = buildImportBatchFailureSummary(t, failures)
+    if (summary) setActionError(summary)
+  }, [store, t, placement, importOnePack, pushPackToHub, handleSelectLanguage])
 
   const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
     setPendingId(postId)

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -632,11 +632,13 @@ export function LanguagePacksModal({
 
   // Multi-file import batch: every selected file is parsed and saved
   // independently, but the actual list placement happens in ONE call at
-  // the end via `placement.placeMany` — see the RAPID-INSERT RACE note
-  // in useImportPlacement.ts for why calling `place()` once per file
-  // (the original approach) could compute a later file's position from
-  // a stale snapshot and silently drop an earlier file's id from the
-  // persisted order. Two files resolving to the same pack (same name,
+  // the end via `placement.placeMany` — see the RAPID-INSERT RACE and
+  // DIRECTION RACE notes in useImportPlacement.ts for why calling
+  // `place()` once per file (the original approach) could compute a
+  // later file's position from a stale/inconsistent snapshot and
+  // silently drop an earlier file's id from the persisted order, or
+  // merge against a sort direction that changed mid-batch. Two files
+  // resolving to the same pack (same name,
   // so main's auto-overwrite reuses the same id) are deduped, keeping
   // only the last file's outcome — that's what actually ended up on
   // disk — so hub-sync and the row badge only run/appear once per id.
@@ -653,7 +655,7 @@ export function LanguagePacksModal({
     setLastResult(null)
     const dialogResult = await store.importFromDialog()
     if (dialogResult.canceled) return
-    const beforeEntries = placement.snapshotEntries()
+    const beforeSnapshot = placement.snapshotEntries()
     const failures: ImportBatchFailure[] = []
     const rawSuccesses: { fileName: string; meta: I18nPackMeta }[] = []
     for (const file of dialogResult.files) {
@@ -695,7 +697,7 @@ export function LanguagePacksModal({
     if (deduped.length > 0) {
       await placement.placeMany(
         deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-        beforeEntries,
+        beforeSnapshot,
       )
       setLastResult(successBadges)
       // Mirror the single-file behaviour of switching the active

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -585,11 +585,11 @@ export function LanguagePacksModal({
     return { ok: true, meta: result.meta, validation }
   }, [store, t])
 
-  // Single-item import path: local file import via the toolbar (single
-  // selection legacy call sites/tests) and Hub download both funnel
-  // through here. Failures surface through `setActionError` (the same
-  // banner KeyLabels uses) instead of opening a separate confirmation
-  // modal.
+  // Single-item import path: Hub download funnels through here (the
+  // toolbar's own multi-file import now goes through `importOnePack`
+  // directly — see `handleImportFile` below). Failures surface through
+  // `setActionError` (the same banner KeyLabels uses) instead of
+  // opening a separate confirmation modal.
   const persistImportedPack = useCallback(async (
     raw: unknown,
     extra: { hubPostId?: string } = {},

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -630,57 +630,79 @@ export function LanguagePacksModal({
     }
   }, [importOnePack, t, pushPackToHub, handleSelectLanguage, placement])
 
-  // Multi-file import batch: every selected file is processed
-  // independently. Successes each get their own row badge (accumulated
-  // into an array — `PackResultBadge` looks up its row's own entry);
-  // failures (parse errors + save failures + failed Hub auto-syncs) are
-  // aggregated into one banner via `buildImportBatchFailureSummary`,
-  // mirroring the typing-analytics import precedent.
+  // Multi-file import batch: every selected file is parsed and saved
+  // independently, but the actual list placement happens in ONE call at
+  // the end via `placement.placeMany` — see the RAPID-INSERT RACE note
+  // in useImportPlacement.ts for why calling `place()` once per file
+  // (the original approach) could compute a later file's position from
+  // a stale snapshot and silently drop an earlier file's id from the
+  // persisted order. Two files resolving to the same pack (same name,
+  // so main's auto-overwrite reuses the same id) are deduped, keeping
+  // only the last file's outcome — that's what actually ended up on
+  // disk — so hub-sync and the row badge only run/appear once per id.
+  // Successes each get their own row badge (accumulated into an array —
+  // `PackResultBadge` looks up its row's own entry); failures (parse
+  // errors + save failures + failed Hub auto-syncs) are aggregated into
+  // one banner via `buildImportBatchFailureSummary`, mirroring the
+  // typing-analytics import precedent, and always report the ACTUAL
+  // selected filename (never the pack's own internal `name`) plus the
+  // real underlying reason (never a generic placeholder when a real
+  // message is available).
   const handleImportFile = useCallback(async (): Promise<void> => {
     setActionError(null)
     setLastResult(null)
     const dialogResult = await store.importFromDialog()
     if (dialogResult.canceled) return
-    const successBadges: PackActionResult[] = []
+    const beforeEntries = placement.snapshotEntries()
     const failures: ImportBatchFailure[] = []
-    let lastImportedPackId: string | null = null
+    const rawSuccesses: { fileName: string; meta: I18nPackMeta }[] = []
     for (const file of dialogResult.files) {
       const fileName = basenameOf(file.filePath)
       if (file.parseError || file.raw === undefined) {
-        failures.push({ fileName, reason: t('i18n.errorInvalidJson') })
+        failures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
         continue
       }
-      // Snapshot right before this file's own save rather than once for
-      // the whole batch: each `importOnePack` call below is its own IPC
-      // round trip that lands immediately, so an earlier file already
-      // placed in this same loop is reflected in `nameSortEntries` by
-      // the time a later file's insert position is computed.
-      const beforeIds = placement.snapshotBeforeIds()
       const imported = await importOnePack(file.raw)
       if (!imported.ok) {
         failures.push({ fileName, reason: imported.error })
         continue
       }
-      const { meta } = imported
+      rawSuccesses.push({ fileName, meta: imported.meta })
+    }
+
+    // Dedupe by pack id, keeping the last file's outcome (see doc above).
+    const dedupedById = new Map<string, { fileName: string; meta: I18nPackMeta }>()
+    for (const success of rawSuccesses) {
+      dedupedById.delete(success.meta.id)
+      dedupedById.set(success.meta.id, success)
+    }
+    const deduped = [...dedupedById.values()]
+
+    const successBadges: PackActionResult[] = []
+    for (const { fileName, meta } of deduped) {
       let message = t('common.saved')
       if (meta.hubPostId) {
         const upd = await pushPackToHub(meta.id, meta.hubPostId)
         if (upd.success) {
           message = t('common.synced')
         } else {
-          failures.push({ fileName: meta.name, reason: upd.error ?? t('hub.updateFailed') })
+          failures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
         }
       }
       successBadges.push({ id: meta.id, kind: 'success', message })
-      lastImportedPackId = meta.id
-      await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
     }
-    if (successBadges.length > 0) {
+
+    if (deduped.length > 0) {
+      await placement.placeMany(
+        deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+        beforeEntries,
+      )
       setLastResult(successBadges)
       // Mirror the single-file behaviour of switching the active
       // language to the freshly imported pack, anchored on the last
-      // successfully imported file for a deterministic final state.
-      if (lastImportedPackId) handleSelectLanguage(`pack:${lastImportedPackId}`)
+      // successfully imported (post-dedupe) file for a deterministic
+      // final state.
+      handleSelectLanguage(`pack:${deduped[deduped.length - 1].meta.id}`)
     }
     const summary = buildImportBatchFailureSummary(t, failures)
     if (summary) setActionError(summary)

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -333,8 +333,8 @@ describe('LanguagePacksModal', () => {
     await waitFor(() => expect(applyImport).toHaveBeenCalled())
   })
 
-  it('import shows error on parse failure', async () => {
-    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'bad.json', parseError: 'Bad format' }] })
+  it('import shows error on parse failure, using the actual parseError message (P2b)', async () => {
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'bad.json', parseError: 'EACCES: permission denied' }] })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
@@ -342,6 +342,11 @@ describe('LanguagePacksModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('language-packs-error')).toBeTruthy()
     })
+    // The real read/parse error is surfaced verbatim — not replaced by
+    // the generic "invalid JSON" placeholder, which would be wrong for
+    // e.g. a permission error.
+    expect(screen.getByTestId('language-packs-error').textContent).toContain('EACCES: permission denied')
+    expect(screen.getByTestId('language-packs-error').textContent).toContain('bad.json')
   })
 
   it('import shows error for invalid pack validation', async () => {
@@ -588,6 +593,57 @@ describe('LanguagePacksModal', () => {
     expect(applyImport).toHaveBeenCalledTimes(1)
     const banner = screen.getByTestId('language-packs-error')
     expect(banner.textContent).toContain('bad.json')
+  })
+
+  it('P1 fix: importing files that interleave with existing rows (existing A,D; import B,C) lands fully sorted A,B,C,D in one reorder call', async () => {
+    storeMetas = [
+      meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' }),
+      meta({ id: 'd', name: 'Delta', matchedBaseVersion: '0.1.0' }),
+    ]
+    const rawB = { name: 'Beta', version: '0.1.0', common: {} }
+    const rawC = { name: 'Charlie', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'charlie.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Charlie' })
+    applyImport
+      .mockResolvedValueOnce({ success: true, meta: metaB })
+      .mockResolvedValueOnce({ success: true, meta: metaC })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(reorderFn).toHaveBeenCalled())
+    // Without the fix, Charlie's position would be computed against a
+    // stale [Alpha, Delta] snapshot that never saw Beta's insert,
+    // persisting ['a', 'c', 'd'] and silently dropping Beta.
+    expect(reorderFn).toHaveBeenCalledTimes(1)
+    expect(reorderFn).toHaveBeenCalledWith(['a', 'b', 'c', 'd'])
+  })
+
+  it('hub-sync failure after import is reported against the originating filename, not the pack name (P2a)', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    const raw = { name: 'Existing Pack', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [{ filePath: 'my-upload.json', raw }],
+    })
+    const savedMeta = meta({ id: 'e', name: 'Existing Pack', hubPostId: 'hub-1', matchedBaseVersion: '0.1.0' })
+    applyImport.mockResolvedValueOnce({ success: true, meta: savedMeta })
+    vialAPI.hubUpdateI18nPost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('language-packs-error')).toBeTruthy()
+    })
+    const banner = screen.getByTestId('language-packs-error')
+    expect(banner.textContent).toContain('my-upload.json')
+    expect(banner.textContent).toContain('network error')
   })
 
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -202,7 +202,7 @@ describe('LanguagePacksModal', () => {
     removeFn.mockResolvedValue({ success: true })
     renameFn.mockResolvedValue({ success: true })
     reorderFn.mockResolvedValue({ success: true })
-    importFromDialog.mockResolvedValue({ canceled: true })
+    importFromDialog.mockResolvedValue({ canceled: true, files: [] })
     applyImport.mockResolvedValue({ success: true, meta: meta() })
     vialAPI.hubGetOrigin.mockResolvedValue('https://hub.example.com')
     vialAPI.hubListI18nPosts.mockResolvedValue({ success: true, data: { items: [] } })
@@ -324,7 +324,7 @@ describe('LanguagePacksModal', () => {
 
   it('import applies the raw data when dialog returns a file', async () => {
     const raw = { name: 'Imported', version: '0.1.0', common: { ok: 'OK' } }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'imp1', name: 'Imported' }) })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
@@ -334,7 +334,7 @@ describe('LanguagePacksModal', () => {
   })
 
   it('import shows error on parse failure', async () => {
-    importFromDialog.mockResolvedValueOnce({ canceled: false, parseError: 'Bad format' })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'bad.json', parseError: 'Bad format' }] })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
@@ -346,7 +346,7 @@ describe('LanguagePacksModal', () => {
 
   it('import shows error for invalid pack validation', async () => {
     const raw = { name: 'Bad', version: 'not-semver', __invalid: true }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
@@ -358,7 +358,7 @@ describe('LanguagePacksModal', () => {
 
   it('import shows error for dangerous keys', async () => {
     const raw = { name: 'Danger', version: '0.1.0', __dangerous: true }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
     )
@@ -370,7 +370,7 @@ describe('LanguagePacksModal', () => {
 
   it('overwrite import with hubPostId auto-syncs to Hub', async () => {
     const raw = { name: 'Synced', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 's1', name: 'Synced', hubPostId: 'hp1' }) })
     render(
       <LanguagePacksModal open onClose={vi.fn()} />,
@@ -398,7 +398,7 @@ describe('LanguagePacksModal', () => {
       meta({ id: 'z', name: 'Zeta', matchedBaseVersion: '0.1.0' }),
     ]
     const raw = { name: 'Mu', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'm', name: 'Mu' }) })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 
@@ -413,7 +413,7 @@ describe('LanguagePacksModal', () => {
       meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' }),
     ]
     const raw = { name: 'Mu', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'm', name: 'Mu' }) })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 
@@ -428,7 +428,7 @@ describe('LanguagePacksModal', () => {
       meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' }),
     ]
     const raw = { name: 'Beta', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'b', name: 'Beta' }) })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 
@@ -443,7 +443,7 @@ describe('LanguagePacksModal', () => {
       meta({ id: 'z', name: 'Zeta', matchedBaseVersion: '0.1.0' }),
     ]
     const raw = { name: 'Alpha', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     // Overwrite: the store reuses the existing 'a' id.
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'a', name: 'Alpha' }) })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
@@ -464,7 +464,7 @@ describe('LanguagePacksModal', () => {
     try {
       storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
       const raw = { name: 'Beta', version: '0.1.0', common: {} }
-      importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+      importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
       applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'b', name: 'Beta' }) })
       render(<LanguagePacksModal open onClose={vi.fn()} />)
 
@@ -482,8 +482,8 @@ describe('LanguagePacksModal', () => {
   it('a second import replaces the feedback message immediately instead of stacking', async () => {
     storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
     importFromDialog
-      .mockResolvedValueOnce({ canceled: false, raw: { name: 'Beta', version: '0.1.0', common: {} } })
-      .mockResolvedValueOnce({ canceled: false, raw: { name: 'Gamma', version: '0.1.0', common: {} } })
+      .mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'beta.json', raw: { name: 'Beta', version: '0.1.0', common: {} } }] })
+      .mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'gamma.json', raw: { name: 'Gamma', version: '0.1.0', common: {} } }] })
     applyImport
       .mockResolvedValueOnce({ success: true, meta: meta({ id: 'b', name: 'Beta' }) })
       .mockResolvedValueOnce({ success: true, meta: meta({ id: 'g', name: 'Gamma' }) })
@@ -499,7 +499,7 @@ describe('LanguagePacksModal', () => {
   it('scrolls the imported row into view', async () => {
     storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
     const raw = { name: 'Beta', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     // The mocked store doesn't simulate a metas re-fetch on its own —
     // append the new meta to `storeMetas` here so the row actually
     // renders (and can be found by testid) on the next render, the way
@@ -523,6 +523,71 @@ describe('LanguagePacksModal', () => {
     } finally {
       scrollIntoView.mockRestore()
     }
+  })
+
+  it('multi-file import: every selected file is saved and each row gets its own "Saved" badge', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    const rawB = { name: 'Beta', version: '0.1.0', common: {} }
+    const rawC = { name: 'Gamma', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'gamma.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Gamma' })
+    // The mocked store doesn't simulate a metas re-fetch on its own —
+    // append each new meta by hand so both rows actually render, the
+    // way a real `refresh()` would after each `applyImport` call.
+    applyImport
+      .mockImplementationOnce(async () => {
+        storeMetas = [...storeMetas, metaB]
+        return { success: true, meta: metaB }
+      })
+      .mockImplementationOnce(async () => {
+        storeMetas = [...storeMetas, metaC]
+        return { success: true, meta: metaC }
+      })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-result-b').textContent).toBe('common.saved'))
+    expect(screen.getByTestId('language-packs-result-c').textContent).toBe('common.saved')
+  })
+
+  it('partial-failure batch: the good file keeps its badge while the bad file is aggregated into one banner', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    const rawGood = { name: 'Good Pack', version: '0.1.0', common: {} }
+    // `__invalid` triggers the mocked `validatePack`'s failure branch —
+    // this file never reaches `applyImport`.
+    const rawBad = { name: 'Bad Pack', version: 'not-semver', __invalid: true }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'bad.json', raw: rawBad },
+        { filePath: 'good.json', raw: rawGood },
+      ],
+    })
+    // `matchedBaseVersion` matching BASE_REVISION keeps this pack out of
+    // the "stale pack auto-update" effect above — otherwise its own
+    // background `applyImport` call would double-count against the
+    // assertion below, which is unrelated to what this test verifies.
+    const goodMeta = meta({ id: 'g', name: 'Good Pack', matchedBaseVersion: '0.1.0' })
+    applyImport.mockImplementationOnce(async () => {
+      storeMetas = [...storeMetas, goodMeta]
+      return { success: true, meta: goodMeta }
+    })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-result-g').textContent).toBe('common.saved'))
+
+    // Only the good file ever reached the store.
+    expect(applyImport).toHaveBeenCalledTimes(1)
+    const banner = screen.getByTestId('language-packs-error')
+    expect(banner.textContent).toContain('bad.json')
   })
 
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {
@@ -1171,7 +1236,7 @@ describe('LanguagePacksModal', () => {
       meta({ id: 'z', name: 'Zeta', matchedBaseVersion: '0.1.0' }),
     ]
     const raw = { name: 'Charlie', version: '0.1.0', common: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'c', name: 'Charlie' }) })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 

--- a/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
@@ -60,7 +60,7 @@ export interface InstalledTableProps {
   setConfirmDeleteId: (id: string | null) => void
   confirmRemoveId: string | null
   setConfirmRemoveId: (id: string | null) => void
-  lastResult: PackActionResult | null
+  lastResult: PackActionResult | PackActionResult[] | null
   rename: ReturnType<typeof useInlineRename<string>>
   currentDisplayName: string | null
   hubCanWrite: boolean

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -181,22 +181,25 @@ export function KeyLabelsModal({
   )
 
   // Multi-file import batch. All of the batch's writes already land on
-  // disk in one `importFromFile()` IPC round trip, so `beforeEntries`
-  // captured once up front is the correct "before the user's action"
-  // baseline for every result regardless of processing order. The
-  // actual list placement happens in ONE `placement.placeMany` call at
-  // the end — see the RAPID-INSERT RACE note in useImportPlacement.ts
-  // for why calling `place()` once per file (the original approach)
-  // could compute a later file's position from a stale snapshot and
-  // silently drop an earlier file's id from the persisted order. Two
-  // files resolving to the same label (main's overwrite-by-name reuses
-  // the same id) are deduped, keeping only the last file's outcome —
-  // that's what actually ended up on disk — so hub-sync and the row
-  // badge only run/appear once per id, not once per file.
+  // disk in one `importFromFile()` IPC round trip, so `beforeSnapshot`
+  // (entries + sort direction) captured once up front is the correct
+  // "before the user's action" baseline for every result regardless of
+  // processing order — even if the user flips the Name-sort toggle
+  // while the batch is running. The actual list placement happens in
+  // ONE `placement.placeMany` call at the end — see the RAPID-INSERT
+  // RACE and DIRECTION RACE notes in useImportPlacement.ts for why
+  // calling `place()` once per file (the original approach) could
+  // compute a later file's position from a stale/inconsistent snapshot
+  // and silently drop an earlier file's id from the persisted order, or
+  // merge against the wrong direction. Two files resolving to the same
+  // label (main's overwrite-by-name reuses the same id) are deduped,
+  // keeping only the last file's outcome — that's what actually ended
+  // up on disk — so hub-sync and the row badge only run/appear once
+  // per id, not once per file.
   const handleImport = useCallback(async () => {
     setActionError(null)
     setLastResult(null)
-    const beforeEntries = placement.snapshotEntries()
+    const beforeSnapshot = placement.snapshotEntries()
     const res = await labels.importFromFile()
     if (res.success && res.data) {
       const failures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
@@ -235,7 +238,7 @@ export function KeyLabelsModal({
       if (deduped.length > 0) {
         await placement.placeMany(
           deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-          beforeEntries,
+          beforeSnapshot,
         )
         setLastResult(successBadges)
       }

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -29,6 +29,7 @@ import { useNameSort } from '../pack-modal/useNameSort'
 import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
+import { buildImportBatchFailureSummary, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { isOwnPack } from '../pack-modal/ownership'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
@@ -70,7 +71,7 @@ export function KeyLabelsModal({
    * under the affected row instead of hunting for a toast. Cleared at
    * the start of the next operation.
    */
-  const [lastResult, setLastResult] = useState<PackActionResult | null>(null)
+  const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
 
   // Key Labels fetches the Hub origin once on first mount, unlike the
   // i18n/theme pack modals which re-fetch each time the modal opens.
@@ -182,26 +183,44 @@ export function KeyLabelsModal({
   const handleImport = useCallback(async () => {
     setActionError(null)
     setLastResult(null)
+    // Single snapshot for the whole batch: every file's writes already
+    // landed on disk in one `importFromFile()` IPC round trip, so
+    // "was this id present before the user picked files" is the same
+    // answer for every result regardless of processing order within
+    // the batch.
     const beforeIds = placement.snapshotBeforeIds()
     const res = await labels.importFromFile()
     if (res.success && res.data) {
-      // The store returns the (possibly overwritten) entry meta —
-      // anchor the inline "Saved" badge on whatever id ended up on
-      // disk so a re-import of the same name lights up the existing
-      // row instead of orphaning the message.
-      setLastResult({ id: res.data.id, kind: 'success', message: t('common.saved') })
-      // Auto-sync overwrites of an already-uploaded entry so the Hub
-      // post stays consistent with the user's local edit. Promote the
-      // inline badge from "Saved" to "Synced" on success.
-      if (res.data.hubPostId) {
-        const upd = await labels.hubUpdate(res.data.id)
-        if (upd.success) {
-          setLastResult({ id: res.data.id, kind: 'success', message: t('common.synced') })
-        } else {
-          setActionError(translateError(t, upd.errorCode, upd.error))
+      const successBadges: PackActionResult[] = []
+      const failures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
+        fileName: r.fileName,
+        reason: translateError(t, r.errorCode, r.error),
+      }))
+      // Sequential await: each `place()` call is internally queued and
+      // reads the latest `entries` ref, so processing one at a time
+      // lets a later file's sorted-insert position see the earlier
+      // file's already-placed row instead of racing it.
+      for (const meta of res.data.imported) {
+        let message = t('common.saved')
+        // Auto-sync overwrites of an already-uploaded entry so the Hub
+        // post stays consistent with the user's local edit. Promote the
+        // badge from "Saved" to "Synced" on success; a sync failure is
+        // folded into the same failure summary as import rejections
+        // (the file itself imported fine, only the Hub push failed).
+        if (meta.hubPostId) {
+          const upd = await labels.hubUpdate(meta.id)
+          if (upd.success) {
+            message = t('common.synced')
+          } else {
+            failures.push({ fileName: meta.name, reason: translateError(t, upd.errorCode, upd.error) })
+          }
         }
+        successBadges.push({ id: meta.id, kind: 'success', message })
+        await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
       }
-      await placement.place({ id: res.data.id, name: res.data.name }, { beforeIds })
+      if (successBadges.length > 0) setLastResult(successBadges)
+      const summary = buildImportBatchFailureSummary(t, failures)
+      if (summary) setActionError(summary)
     } else if (res.error && res.error !== 'cancelled') {
       setActionError(translateError(t, res.errorCode, res.error))
     }
@@ -303,6 +322,7 @@ export function KeyLabelsModal({
         searchButton: 'key-labels-search-button',
         importButton: 'key-labels-import-button',
         importFeedback: 'key-labels-import-feedback',
+        errorBanner: 'key-labels-error',
       }}
       activeTab={activeTab}
       onTabChange={setActiveTab}

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -180,45 +180,65 @@ export function KeyLabelsModal({
     [hubResults, labels.metas],
   )
 
+  // Multi-file import batch. All of the batch's writes already land on
+  // disk in one `importFromFile()` IPC round trip, so `beforeEntries`
+  // captured once up front is the correct "before the user's action"
+  // baseline for every result regardless of processing order. The
+  // actual list placement happens in ONE `placement.placeMany` call at
+  // the end — see the RAPID-INSERT RACE note in useImportPlacement.ts
+  // for why calling `place()` once per file (the original approach)
+  // could compute a later file's position from a stale snapshot and
+  // silently drop an earlier file's id from the persisted order. Two
+  // files resolving to the same label (main's overwrite-by-name reuses
+  // the same id) are deduped, keeping only the last file's outcome —
+  // that's what actually ended up on disk — so hub-sync and the row
+  // badge only run/appear once per id, not once per file.
   const handleImport = useCallback(async () => {
     setActionError(null)
     setLastResult(null)
-    // Single snapshot for the whole batch: every file's writes already
-    // landed on disk in one `importFromFile()` IPC round trip, so
-    // "was this id present before the user picked files" is the same
-    // answer for every result regardless of processing order within
-    // the batch.
-    const beforeIds = placement.snapshotBeforeIds()
+    const beforeEntries = placement.snapshotEntries()
     const res = await labels.importFromFile()
     if (res.success && res.data) {
-      const successBadges: PackActionResult[] = []
       const failures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
         fileName: r.fileName,
         reason: translateError(t, r.errorCode, r.error),
       }))
-      // Sequential await: each `place()` call is internally queued and
-      // reads the latest `entries` ref, so processing one at a time
-      // lets a later file's sorted-insert position see the earlier
-      // file's already-placed row instead of racing it.
-      for (const meta of res.data.imported) {
+
+      const dedupedById = new Map<string, { fileName: string; meta: KeyLabelMeta }>()
+      for (const success of res.data.imported) {
+        dedupedById.delete(success.meta.id)
+        dedupedById.set(success.meta.id, success)
+      }
+      const deduped = [...dedupedById.values()]
+
+      const successBadges: PackActionResult[] = []
+      for (const { fileName, meta } of deduped) {
         let message = t('common.saved')
         // Auto-sync overwrites of an already-uploaded entry so the Hub
         // post stays consistent with the user's local edit. Promote the
         // badge from "Saved" to "Synced" on success; a sync failure is
         // folded into the same failure summary as import rejections
-        // (the file itself imported fine, only the Hub push failed).
+        // (the file itself imported fine, only the Hub push failed) —
+        // reported against the originating filename, not the label's
+        // internal name.
         if (meta.hubPostId) {
           const upd = await labels.hubUpdate(meta.id)
           if (upd.success) {
             message = t('common.synced')
           } else {
-            failures.push({ fileName: meta.name, reason: translateError(t, upd.errorCode, upd.error) })
+            failures.push({ fileName, reason: translateError(t, upd.errorCode, upd.error) })
           }
         }
         successBadges.push({ id: meta.id, kind: 'success', message })
-        await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
       }
-      if (successBadges.length > 0) setLastResult(successBadges)
+
+      if (deduped.length > 0) {
+        await placement.placeMany(
+          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+          beforeEntries,
+        )
+        setLastResult(successBadges)
+      }
       const summary = buildImportBatchFailureSummary(t, failures)
       if (summary) setActionError(summary)
     } else if (res.error && res.error !== 'cancelled') {

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -114,7 +114,7 @@ describe('KeyLabelsModal', () => {
     vi.clearAllMocks()
     metas = []
     keyLabelRegistry.clear()
-    importFromFile.mockResolvedValue({ success: true, data: { imported: [meta()], rejections: [] } })
+    importFromFile.mockResolvedValue({ success: true, data: { imported: [{ fileName: 'a.json', meta: meta() }], rejections: [] } })
     exportEntry.mockResolvedValue({ success: true, data: { filePath: '/tmp/x.json' } })
     reorder.mockResolvedValue({ success: true })
     renameFn.mockResolvedValue({ success: true, data: meta() })
@@ -428,7 +428,7 @@ describe('KeyLabelsModal', () => {
       meta({ id: 'qwerty', name: 'QWERTY', uploaderName: 'pipette' }),
       meta({ id: 'z', name: 'Zeta', uploaderName: 'me' }),
     ]
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'm', name: 'Mu' })], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'mu.json', meta: meta({ id: 'm', name: 'Mu' }) }], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -441,7 +441,7 @@ describe('KeyLabelsModal', () => {
       meta({ id: 'z', name: 'Zeta', uploaderName: 'me' }),
       meta({ id: 'a', name: 'Alpha', uploaderName: 'me' }),
     ]
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'b', name: 'Beta' })], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'beta.json', meta: meta({ id: 'b', name: 'Beta' }) }], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -452,7 +452,7 @@ describe('KeyLabelsModal', () => {
   it('overwrite (same id already installed) keeps its position — no reorder call, "Updated" feedback', async () => {
     metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' }), meta({ id: 'z', name: 'Zeta', uploaderName: 'me' })]
     // Overwrite: the store reuses the existing 'a' id.
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'a', name: 'Alpha' })], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'alpha.json', meta: meta({ id: 'a', name: 'Alpha' }) }], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -463,7 +463,7 @@ describe('KeyLabelsModal', () => {
 
   it('new import shows "Imported {{name}}" feedback next to the Name button', async () => {
     metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'b', name: 'Beta' })], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'beta.json', meta: meta({ id: 'b', name: 'Beta' }) }], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -475,7 +475,7 @@ describe('KeyLabelsModal', () => {
     const newMeta = meta({ id: 'b', name: 'Beta' })
     importFromFile.mockImplementationOnce(async () => {
       metas = [...metas, newMeta]
-      return { success: true, data: { imported: [newMeta], rejections: [] } }
+      return { success: true, data: { imported: [{ fileName: 'beta.json', meta: newMeta }], rejections: [] } }
     })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
@@ -543,13 +543,76 @@ describe('KeyLabelsModal', () => {
     // into view" test's pattern above.
     importFromFile.mockImplementationOnce(async () => {
       metas = [...metas, newMetaB, newMetaC]
-      return { success: true, data: { imported: [newMetaB, newMetaC], rejections: [] } }
+      return {
+        success: true,
+        data: {
+          imported: [
+            { fileName: 'beta.json', meta: newMetaB },
+            { fileName: 'gamma.json', meta: newMetaC },
+          ],
+          rejections: [],
+        },
+      }
     })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => expect(screen.getByTestId('key-labels-result-b').textContent).toBe('common.saved'))
     expect(screen.getByTestId('key-labels-result-c').textContent).toBe('common.saved')
+  })
+
+  it('P1 fix: importing files that interleave with existing rows (existing A,D; import B,C) lands fully sorted A,B,C,D in one reorder call', async () => {
+    metas = [
+      meta({ id: 'a', name: 'Alpha', uploaderName: 'me' }),
+      meta({ id: 'd', name: 'Delta', uploaderName: 'me' }),
+    ]
+    const newMetaB = meta({ id: 'b', name: 'Beta' })
+    const newMetaC = meta({ id: 'c', name: 'Charlie' })
+    importFromFile.mockResolvedValueOnce({
+      success: true,
+      data: {
+        imported: [
+          { fileName: 'beta.json', meta: newMetaB },
+          { fileName: 'charlie.json', meta: newMetaC },
+        ],
+        rejections: [],
+      },
+    })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(reorder).toHaveBeenCalled())
+    // Without the fix (per-file `place()` calls hoping a re-render lands
+    // between them), this could compute Charlie's position from a stale
+    // pre-batch [A,D] snapshot and persist ['a','c','d'] — silently
+    // dropping Beta. `placeMany` merges both in one pure pass instead.
+    expect(reorder).toHaveBeenCalledTimes(1)
+    expect(reorder).toHaveBeenCalledWith(['a', 'b', 'c', 'd'])
+  })
+
+  it('dedupes a batch where two files resolve to the same id: hub-sync and badge run only once', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    // Two files sharing a name both overwrite the same entry — main
+    // resolves this in file-list order (see key-label-store.ts's
+    // importFromDialog), so `imported` legitimately contains the same
+    // id twice.
+    const overwritten = meta({ id: 'dup', name: 'Duplicate', hubPostId: 'hub-1' })
+    importFromFile.mockResolvedValueOnce({
+      success: true,
+      data: {
+        imported: [
+          { fileName: 'first.json', meta: overwritten },
+          { fileName: 'second.json', meta: overwritten },
+        ],
+        rejections: [],
+      },
+    })
+    hubUpdate.mockResolvedValue({ success: true, data: overwritten })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('dup'))
+    expect(hubUpdate).toHaveBeenCalledTimes(1)
   })
 
   it('partial-failure batch: good files keep their badges while bad files are aggregated into one banner', async () => {
@@ -560,7 +623,7 @@ describe('KeyLabelsModal', () => {
       return {
         success: true,
         data: {
-          imported: [newMetaB],
+          imported: [{ fileName: 'beta.json', meta: newMetaB }],
           rejections: [
             { fileName: 'broken.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' },
             { fileName: 'dup.json', errorCode: 'DUPLICATE_NAME', error: 'A label with the same name already exists' },
@@ -598,16 +661,16 @@ describe('KeyLabelsModal', () => {
 
   it('auto-pushes to Hub when importing over an entry with hubPostId', async () => {
     const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [importedMeta], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'existing.json', meta: importedMeta }], rejections: [] } })
     hubUpdate.mockResolvedValueOnce({ success: true, data: importedMeta })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
   })
 
-  it('shows error when hub auto-sync fails after import', async () => {
+  it('shows error when hub auto-sync fails after import, reported against the originating filename (P2a)', async () => {
     const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
-    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [importedMeta], rejections: [] } })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'existing.json', meta: importedMeta }], rejections: [] } })
     hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -615,6 +678,9 @@ describe('KeyLabelsModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('key-labels-error').textContent).toContain('network error')
     })
+    // P2a: the failure line reports the file the user picked, not the
+    // label's internal display name (both happen to differ in this test).
+    expect(screen.getByTestId('key-labels-error').textContent).toContain('existing.json')
   })
 
   // --- Phase 2: Name sort (drag reorder itself predates this phase) -------

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -114,7 +114,7 @@ describe('KeyLabelsModal', () => {
     vi.clearAllMocks()
     metas = []
     keyLabelRegistry.clear()
-    importFromFile.mockResolvedValue({ success: true, data: meta() })
+    importFromFile.mockResolvedValue({ success: true, data: { imported: [meta()], rejections: [] } })
     exportEntry.mockResolvedValue({ success: true, data: { filePath: '/tmp/x.json' } })
     reorder.mockResolvedValue({ success: true })
     renameFn.mockResolvedValue({ success: true, data: meta() })
@@ -428,7 +428,7 @@ describe('KeyLabelsModal', () => {
       meta({ id: 'qwerty', name: 'QWERTY', uploaderName: 'pipette' }),
       meta({ id: 'z', name: 'Zeta', uploaderName: 'me' }),
     ]
-    importFromFile.mockResolvedValueOnce({ success: true, data: meta({ id: 'm', name: 'Mu' }) })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'm', name: 'Mu' })], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -441,7 +441,7 @@ describe('KeyLabelsModal', () => {
       meta({ id: 'z', name: 'Zeta', uploaderName: 'me' }),
       meta({ id: 'a', name: 'Alpha', uploaderName: 'me' }),
     ]
-    importFromFile.mockResolvedValueOnce({ success: true, data: meta({ id: 'b', name: 'Beta' }) })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'b', name: 'Beta' })], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -452,7 +452,7 @@ describe('KeyLabelsModal', () => {
   it('overwrite (same id already installed) keeps its position — no reorder call, "Updated" feedback', async () => {
     metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' }), meta({ id: 'z', name: 'Zeta', uploaderName: 'me' })]
     // Overwrite: the store reuses the existing 'a' id.
-    importFromFile.mockResolvedValueOnce({ success: true, data: meta({ id: 'a', name: 'Alpha' }) })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'a', name: 'Alpha' })], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -463,7 +463,7 @@ describe('KeyLabelsModal', () => {
 
   it('new import shows "Imported {{name}}" feedback next to the Name button', async () => {
     metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
-    importFromFile.mockResolvedValueOnce({ success: true, data: meta({ id: 'b', name: 'Beta' }) })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [meta({ id: 'b', name: 'Beta' })], rejections: [] } })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -475,7 +475,7 @@ describe('KeyLabelsModal', () => {
     const newMeta = meta({ id: 'b', name: 'Beta' })
     importFromFile.mockImplementationOnce(async () => {
       metas = [...metas, newMeta]
-      return { success: true, data: newMeta }
+      return { success: true, data: { imported: [newMeta], rejections: [] } }
     })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
@@ -509,17 +509,75 @@ describe('KeyLabelsModal', () => {
     await waitFor(() => expect(reorder).toHaveBeenCalledWith(['a', 'hub-m', 'z']))
   })
 
-  it('shows duplicate-name error when import fails with DUPLICATE_NAME', async () => {
+  it('shows duplicate-name error when a file in the batch is rejected with DUPLICATE_NAME', async () => {
     importFromFile.mockResolvedValueOnce({
-      success: false,
-      errorCode: 'DUPLICATE_NAME',
-      error: 'KEY_LABEL_DUPLICATE',
+      success: true,
+      data: {
+        imported: [],
+        rejections: [{ fileName: 'dup.json', errorCode: 'DUPLICATE_NAME', error: 'A label with the same name already exists' }],
+      },
     })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => {
-      expect(screen.getByText('keyLabels.errorDuplicate')).toBeTruthy()
+      expect(screen.getByTestId('key-labels-error').textContent).toContain('keyLabels.errorDuplicate')
     })
+    expect(screen.getByTestId('key-labels-error').textContent).toContain('dup.json')
+  })
+
+  it('cancelling the dialog (no files selected) does not touch feedback or error state', async () => {
+    importFromFile.mockResolvedValueOnce({ success: false, errorCode: 'IO_ERROR', error: 'cancelled' })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(importFromFile).toHaveBeenCalled())
+    expect(screen.queryByTestId('key-labels-error')).toBeNull()
+  })
+
+  it('multi-file import: every selected file is saved and each row gets its own "Saved" badge', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    const newMetaB = meta({ id: 'b', name: 'Beta' })
+    const newMetaC = meta({ id: 'c', name: 'Gamma' })
+    // `refresh` is a no-op mock (like every other test in this file) so the
+    // module-level `metas` array is updated by hand to mimic the real
+    // store's post-import state, matching the "scrolls the imported row
+    // into view" test's pattern above.
+    importFromFile.mockImplementationOnce(async () => {
+      metas = [...metas, newMetaB, newMetaC]
+      return { success: true, data: { imported: [newMetaB, newMetaC], rejections: [] } }
+    })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(screen.getByTestId('key-labels-result-b').textContent).toBe('common.saved'))
+    expect(screen.getByTestId('key-labels-result-c').textContent).toBe('common.saved')
+  })
+
+  it('partial-failure batch: good files keep their badges while bad files are aggregated into one banner', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    const newMetaB = meta({ id: 'b', name: 'Beta' })
+    importFromFile.mockImplementationOnce(async () => {
+      metas = [...metas, newMetaB]
+      return {
+        success: true,
+        data: {
+          imported: [newMetaB],
+          rejections: [
+            { fileName: 'broken.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' },
+            { fileName: 'dup.json', errorCode: 'DUPLICATE_NAME', error: 'A label with the same name already exists' },
+          ],
+        },
+      }
+    })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(screen.getByTestId('key-labels-result-b').textContent).toBe('common.saved'))
+
+    const banner = screen.getByTestId('key-labels-error')
+    expect(banner.textContent).toContain('broken.json')
+    expect(banner.textContent).toContain('keyLabels.errorImportFailed')
+    expect(banner.textContent).toContain('dup.json')
+    expect(banner.textContent).toContain('keyLabels.errorDuplicate')
   })
 
   it('disables hub-write actions when hubCanWrite is false', () => {
@@ -540,7 +598,7 @@ describe('KeyLabelsModal', () => {
 
   it('auto-pushes to Hub when importing over an entry with hubPostId', async () => {
     const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
-    importFromFile.mockResolvedValueOnce({ success: true, data: importedMeta })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [importedMeta], rejections: [] } })
     hubUpdate.mockResolvedValueOnce({ success: true, data: importedMeta })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -549,13 +607,13 @@ describe('KeyLabelsModal', () => {
 
   it('shows error when hub auto-sync fails after import', async () => {
     const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
-    importFromFile.mockResolvedValueOnce({ success: true, data: importedMeta })
+    importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [importedMeta], rejections: [] } })
     hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
     await waitFor(() => {
-      expect(screen.getByText('network error')).toBeTruthy()
+      expect(screen.getByTestId('key-labels-error').textContent).toContain('network error')
     })
   })
 

--- a/src/renderer/components/pack-modal/PackManagerModal.tsx
+++ b/src/renderer/components/pack-modal/PackManagerModal.tsx
@@ -170,7 +170,7 @@ export function PackManagerModal({
 
         {actionError && (
           <div
-            className="mx-4 my-2 rounded border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-700"
+            className="mx-4 my-2 whitespace-pre-wrap rounded border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-700"
             data-testid={testids.errorBanner}
           >
             {actionError}

--- a/src/renderer/components/pack-modal/PackResultBadge.tsx
+++ b/src/renderer/components/pack-modal/PackResultBadge.tsx
@@ -3,7 +3,10 @@
 import type { PackActionResult } from './pack-modal-types'
 
 export interface PackResultBadgeProps {
-  result: PackActionResult | null
+  /** A single-row action (rename, upload, delete, ...) sets one result.
+   *  A multi-file import batch sets an array so every successfully
+   *  imported row can show its own badge at the same time. */
+  result: PackActionResult | PackActionResult[] | null
   /** Row (or hub post) id this badge is anchored to — matches `result.id`. */
   rowId: string
   testid: string
@@ -16,13 +19,16 @@ export interface PackResultBadgeProps {
  * Key Labels so the feedback stays visually identical.
  */
 export function PackResultBadge({ result, rowId, testid }: PackResultBadgeProps): JSX.Element | null {
-  if (!result || result.id !== rowId) return null
+  const match = Array.isArray(result)
+    ? result.find((r) => r.id === rowId)
+    : (result && result.id === rowId ? result : null)
+  if (!match) return null
   return (
     <span
-      className={`text-xs font-medium ${result.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
+      className={`text-xs font-medium ${match.kind === 'success' ? 'text-accent' : 'text-rose-600'}`}
       data-testid={testid}
     >
-      {result.message}
+      {match.message}
     </span>
   )
 }

--- a/src/renderer/components/pack-modal/__tests__/sorted-insert.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/sorted-insert.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { computeSortedInsertOrder } from '../sorted-insert'
+import { computeSortedInsertOrder, computeSortedInsertOrderMany } from '../sorted-insert'
 
 describe('computeSortedInsertOrder', () => {
   it('returns null for the free state — the store appends new entries at the bottom on its own', () => {
@@ -46,5 +46,46 @@ describe('computeSortedInsertOrder', () => {
   it('is case-insensitive/locale-aware (sensitivity: base), matching compareNames', () => {
     const existing = [{ id: 'lower', name: 'alpha' }]
     expect(computeSortedInsertOrder(existing, { id: 'upper', name: 'BETA' }, 'asc')).toEqual(['lower', 'upper'])
+  })
+})
+
+describe('computeSortedInsertOrderMany', () => {
+  it('interleaves multiple new entries among existing rows in one pass (P1 batch race regression)', () => {
+    // existing A,D ascending; import B then C (in that processing
+    // order) — must land fully sorted A,B,C,D, not A,C,D,B (the
+    // per-item bug: C computed from a stale [A,D] snapshot that never
+    // saw B's insert).
+    const existing = [{ id: 'a', name: 'Alpha' }, { id: 'd', name: 'Delta' }]
+    const newEntries = [{ id: 'b', name: 'Bravo' }, { id: 'c', name: 'Charlie' }]
+    expect(computeSortedInsertOrderMany(existing, newEntries, 'asc')).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('interleaves in descending order too', () => {
+    const existing = [{ id: 'd', name: 'Delta' }, { id: 'a', name: 'Alpha' }]
+    const newEntries = [{ id: 'c', name: 'Charlie' }, { id: 'b', name: 'Bravo' }]
+    expect(computeSortedInsertOrderMany(existing, newEntries, 'desc')).toEqual(['d', 'c', 'b', 'a'])
+  })
+
+  it('is order-independent: processing [C, B] yields the same final order as [B, C]', () => {
+    const existing = [{ id: 'a', name: 'Alpha' }, { id: 'd', name: 'Delta' }]
+    const inOrder = computeSortedInsertOrderMany(existing, [{ id: 'b', name: 'Bravo' }, { id: 'c', name: 'Charlie' }], 'asc')
+    const reversed = computeSortedInsertOrderMany(existing, [{ id: 'c', name: 'Charlie' }, { id: 'b', name: 'Bravo' }], 'asc')
+    expect(inOrder).toEqual(['a', 'b', 'c', 'd'])
+    expect(reversed).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('handles an empty existing list (first entries ever)', () => {
+    const newEntries = [{ id: 'b', name: 'Bravo' }, { id: 'a', name: 'Alpha' }]
+    expect(computeSortedInsertOrderMany([], newEntries, 'asc')).toEqual(['a', 'b'])
+  })
+
+  it('returns null for the free state', () => {
+    const existing = [{ id: 'a', name: 'Alpha' }]
+    expect(computeSortedInsertOrderMany(existing, [{ id: 'b', name: 'Bravo' }], 'free')).toBeNull()
+  })
+
+  it('returns null when there is nothing to insert', () => {
+    const existing = [{ id: 'a', name: 'Alpha' }]
+    expect(computeSortedInsertOrderMany(existing, [], 'asc')).toBeNull()
   })
 })

--- a/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
@@ -250,6 +250,124 @@ describe('useImportPlacement', () => {
     expect(result.current.feedback).toBeNull()
   })
 
+  it('placeMany (P1 batch race fix): existing A,D; importing B then C lands fully sorted A,B,C,D in one reorder call, with no rerender in between', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const onReorderError = vi.fn()
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }, { id: 'd', name: 'Delta' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError,
+    }))
+
+    await act(async () => {
+      const beforeEntries = result.current.snapshotEntries()
+      // Deliberately no rerender() between "processing" B and C — the
+      // whole point of placeMany is that it does not need one.
+      await result.current.placeMany(
+        [{ id: 'b', name: 'Bravo' }, { id: 'c', name: 'Charlie' }],
+        beforeEntries,
+      )
+    })
+
+    expect(reorder).toHaveBeenCalledTimes(1)
+    expect(reorder).toHaveBeenCalledWith(['a', 'b', 'c', 'd'])
+    expect(onReorderError).not.toHaveBeenCalled()
+    expect(result.current.feedback).toBe('Imported Charlie')
+  })
+
+  it('placeMany: an id already present in beforeEntries is treated as an overwrite (no position change), last-result feedback reflects that', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }, { id: 'd', name: 'Delta' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError: vi.fn(),
+    }))
+
+    await act(async () => {
+      const beforeEntries = result.current.snapshotEntries()
+      // 'b' is a new insert; 'a' is an overwrite (already in beforeEntries).
+      await result.current.placeMany(
+        [{ id: 'b', name: 'Bravo' }, { id: 'a', name: 'Alpha' }],
+        beforeEntries,
+      )
+    })
+
+    // Only the genuinely-new 'b' is merged into the persisted order.
+    expect(reorder).toHaveBeenCalledWith(['a', 'b', 'd'])
+    expect(result.current.feedback).toBe('Updated Alpha')
+  })
+
+  it('placeMany: a free (unsorted) direction skips reorder entirely but still shows feedback for the last result', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }],
+      direction: 'free',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError: vi.fn(),
+    }))
+
+    await act(async () => {
+      const beforeEntries = result.current.snapshotEntries()
+      await result.current.placeMany(
+        [{ id: 'b', name: 'Bravo' }, { id: 'c', name: 'Charlie' }],
+        beforeEntries,
+      )
+    })
+
+    expect(reorder).not.toHaveBeenCalled()
+    expect(result.current.feedback).toBe('Imported Charlie')
+  })
+
+  it('placeMany: an empty results array is a no-op', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError: vi.fn(),
+    }))
+
+    await act(async () => {
+      const beforeEntries = result.current.snapshotEntries()
+      await result.current.placeMany([], beforeEntries)
+    })
+
+    expect(reorder).not.toHaveBeenCalled()
+    expect(result.current.feedback).toBeNull()
+  })
+
+  it('single-file place() still behaves identically after placeMany was added (unaffected by the batch fix)', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const onReorderError = vi.fn()
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }, { id: 'z', name: 'Zeta' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError,
+    }))
+
+    await act(async () => {
+      const beforeIds = result.current.snapshotBeforeIds()
+      await result.current.place({ id: 'm', name: 'Mu' }, { beforeIds })
+    })
+
+    expect(reorder).toHaveBeenCalledWith(['a', 'm', 'z'])
+    expect(onReorderError).not.toHaveBeenCalled()
+    expect(result.current.feedback).toBe('Imported Mu')
+  })
+
   it('auto-clears feedback after the timeout while still open', async () => {
     const reorder = vi.fn().mockResolvedValue({ success: true })
     const { result } = renderHook(() => useImportPlacement({

--- a/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import '../../../i18n'
 import { useImportPlacement } from '../useImportPlacement'
+import type { SortDirection } from '../useNameSort'
 
 describe('useImportPlacement', () => {
   beforeEach(() => {
@@ -352,7 +353,7 @@ describe('useImportPlacement', () => {
     const onReorderError = vi.fn()
 
     const { result, rerender } = renderHook(
-      ({ direction }: { direction: 'asc' | 'desc' | 'free' }) => useImportPlacement({
+      ({ direction }: { direction: SortDirection }) => useImportPlacement({
         open: true,
         entries: [{ id: 'a', name: 'Alpha' }, { id: 'z', name: 'Zeta' }],
         direction,
@@ -360,7 +361,7 @@ describe('useImportPlacement', () => {
         rowTestidPrefix: 'test-packs',
         onReorderError,
       }),
-      { initialProps: { direction: 'asc' as const } },
+      { initialProps: { direction: 'asc' as SortDirection } },
     )
 
     let placeManyPromise!: Promise<void>

--- a/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
@@ -346,6 +346,60 @@ describe('useImportPlacement', () => {
     expect(result.current.feedback).toBeNull()
   })
 
+  it('DIRECTION RACE fix: a Name-sort toggle (asc -> desc) landing mid-batch does not affect the batch\'s frozen placement', async () => {
+    let resolveReorder!: (value: { success: boolean }) => void
+    const reorder = vi.fn().mockImplementation(() => new Promise<{ success: boolean }>((resolve) => { resolveReorder = resolve }))
+    const onReorderError = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ direction }: { direction: 'asc' | 'desc' | 'free' }) => useImportPlacement({
+        open: true,
+        entries: [{ id: 'a', name: 'Alpha' }, { id: 'z', name: 'Zeta' }],
+        direction,
+        reorder,
+        rowTestidPrefix: 'test-packs',
+        onReorderError,
+      }),
+      { initialProps: { direction: 'asc' as const } },
+    )
+
+    let placeManyPromise!: Promise<void>
+    await act(async () => {
+      // Freezes direction='asc' into the snapshot, before anything else
+      // can change it.
+      const snapshot = result.current.snapshotEntries()
+      placeManyPromise = result.current.placeMany(
+        [{ id: 'b', name: 'Beta' }, { id: 'c', name: 'Charlie' }],
+        snapshot,
+      )
+      // Let placeMany's queued `run()` actually start (a microtask hop
+      // off `queueRef.current.then(...)`) so it reaches its `await
+      // reorder(...)` call and captures `resolveReorder` below.
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(resolveReorder).toBeDefined()
+
+    // The Name-sort toggle flips to descending WHILE the batch's own
+    // reorder call is still in flight — e.g. the user clicked it, or a
+    // concurrent op changed it, before this batch's save loop finished.
+    act(() => { rerender({ direction: 'desc' }) })
+
+    await act(async () => {
+      resolveReorder({ success: true })
+      await placeManyPromise
+    })
+
+    // Still fully ascending — frozen to the 'asc' snapshot taken at
+    // batch start, not the live 'desc' direction that landed mid-flight.
+    // Without the fix, merging `toInsert` against the live direction
+    // while `beforeEntries` reflects the old one would produce a
+    // garbled, neither-direction order (e.g. ['c', 'b', 'a', 'z']).
+    expect(reorder).toHaveBeenCalledTimes(1)
+    expect(reorder).toHaveBeenCalledWith(['a', 'b', 'c', 'z'])
+    expect(onReorderError).not.toHaveBeenCalled()
+  })
+
   it('single-file place() still behaves identically after placeMany was added (unaffected by the batch fix)', async () => {
     const reorder = vi.fn().mockResolvedValue({ success: true })
     const onReorderError = vi.fn()

--- a/src/renderer/components/pack-modal/import-batch-summary.ts
+++ b/src/renderer/components/pack-modal/import-batch-summary.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared multi-line failure summary for the three pack-management
+// modals' (Language Packs, Theme Packs, Key Labels) multi-file import
+// batches. Mirrors the typing-analytics import precedent
+// (`src/main/typing-analytics/import-export.ts`'s `ImportRejection[]`)
+// but surfaces through the modals' existing single-string `actionError`
+// banner instead of a dedicated list component — `PackManagerModal`'s
+// error banner renders `white-space: pre-wrap` so the newline-joined
+// lines below actually break visually.
+
+import type { TFunction } from 'i18next'
+
+export interface ImportBatchFailure {
+  fileName: string
+  reason: string
+}
+
+/** Strips a filesystem path down to its final segment for display in the
+ *  failure summary — the full absolute path is noise to the user. */
+export function basenameOf(path: string): string {
+  const segments = path.split(/[\\/]/)
+  return segments[segments.length - 1] || path
+}
+
+/**
+ * Builds the "{{count}} file(s) could not be imported:" header plus one
+ * `fileName: reason` line per failure. Returns null when there are no
+ * failures so callers can leave `actionError` untouched in that case.
+ */
+export function buildImportBatchFailureSummary(
+  t: TFunction,
+  failures: ImportBatchFailure[],
+): string | null {
+  if (failures.length === 0) return null
+  const header = t('common.importBatchFailed', { count: failures.length })
+  const lines = failures.map((f) => `${f.fileName}: ${f.reason}`)
+  return [header, ...lines].join('\n')
+}

--- a/src/renderer/components/pack-modal/sorted-insert.ts
+++ b/src/renderer/components/pack-modal/sorted-insert.ts
@@ -38,3 +38,43 @@ export function computeSortedInsertOrder(
   ids.splice(insertAt, 0, newEntry.id)
   return ids
 }
+
+/**
+ * Batch variant of `computeSortedInsertOrder` for a multi-file import:
+ * positions every entry in `newEntries` into its sorted slot among
+ * `existingEntries` AND each other, in one pure pass over the two input
+ * arrays. This is deliberately NOT "call `computeSortedInsertOrder` once
+ * per new entry, feeding each result back into `existingEntries`" done by
+ * the *caller* across separate async steps — see `placeMany` in
+ * `useImportPlacement.ts` for why a real caller can't safely do that
+ * (the "existing" list a later step would read may not yet reflect an
+ * earlier step's insert, or may already reflect it from an unrelated
+ * background refresh, either of which corrupts the merge). Here the
+ * fold happens synchronously across `newEntries` with no I/O and no
+ * React state in between, so it can't observe anything but its own
+ * arguments.
+ *
+ * `newEntries` must not overlap `existingEntries`' ids (same "genuinely
+ * new, not overwrite" contract as `computeSortedInsertOrder`) and must
+ * not contain duplicate ids itself — callers dedupe a batch's results
+ * before calling this. Returns `null` when `direction` is 'free' or
+ * there is nothing to insert.
+ */
+export function computeSortedInsertOrderMany(
+  existingEntries: NameSortEntry[],
+  newEntries: NameSortEntry[],
+  direction: SortDirection,
+): string[] | null {
+  if (direction === 'free' || newEntries.length === 0) return null
+  let current: NameSortEntry[] = existingEntries
+  for (const entry of newEntries) {
+    // `direction` is never 'free' here, so `computeSortedInsertOrder`
+    // always returns a real list — the fallback only exists to satisfy
+    // the compiler's `string[] | null` return type.
+    const ids = computeSortedInsertOrder(current, entry, direction) ?? [...current.map((e) => e.id), entry.id]
+    const byId = new Map(current.map((e) => [e.id, e] as const))
+    byId.set(entry.id, entry)
+    current = ids.map((id) => byId.get(id) as NameSortEntry)
+  }
+  return current.map((e) => e.id)
+}

--- a/src/renderer/components/pack-modal/useImportPlacement.ts
+++ b/src/renderer/components/pack-modal/useImportPlacement.ts
@@ -48,8 +48,27 @@
 // every render — never the closure captured when `place` itself was
 // created — and placements are serialized through an internal promise
 // chain (`queueRef`) so the second one's order computation only runs
-// after the first's `reorder` call has resolved and the caller has
+// after the first's `reorder` call has resolved AND the caller has
 // re-rendered with the refreshed entries.
+//
+// That second half of the guarantee is the part `place()` cannot
+// actually make on its own: the store's `reorder`/`refresh` functions
+// resolve once `setState` has been *called*, not once the component has
+// *re-rendered* with the new state — React schedules that separately,
+// on its own timer. A multi-file import batch that calls `place()` once
+// per file in a tight loop has no guarantee a render lands between
+// iterations, so a later file's sorted-insert position can be computed
+// against a snapshot that is missing an earlier file's insert (or, if
+// some unrelated background refresh raced in, one that already contains
+// an id the caller is about to insert a second time). `placeMany` below
+// exists for exactly this case: it takes every result in a batch at
+// once and positions them as a group with a single pure computation
+// (`computeSortedInsertOrderMany`) against a snapshot taken once before
+// the batch started — no dependency on any render happening in between,
+// and at most one `reorder` call for the whole batch. `place()` itself
+// is untouched and still used for every single-item flow (Hub download,
+// rename auto-sync, etc.), where the race does not apply in practice —
+// those are separate user-triggered actions with real time between them.
 //
 // REORDER-FAILURE VISIBILITY (P2): a failed sorted-insert `reorder`
 // call is surfaced via `onReorderError` (each site's existing
@@ -70,7 +89,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { NameSortEntry, SortDirection } from './useNameSort'
-import { computeSortedInsertOrder } from './sorted-insert'
+import { computeSortedInsertOrder, computeSortedInsertOrderMany } from './sorted-insert'
 
 const AUTO_CLEAR_MS = 5000
 
@@ -109,12 +128,32 @@ export interface UseImportPlacementResult {
    *  import/download store call. */
   snapshotBeforeIds: () => Set<string>
   /**
+   * Call synchronously once, right before starting a multi-file import
+   * batch's store calls. Returns the full entries list (not just ids)
+   * as it stood before any file in the batch was saved — pass it to
+   * `placeMany` as `beforeEntries` so the batch's merge computation
+   * never depends on `entriesRef` (which can drift mid-batch; see the
+   * RAPID-INSERT RACE note in the module doc).
+   */
+  snapshotEntries: () => NameSortEntry[]
+  /**
    * Call after the store operation resolves with the placed entry's
    * `{ id, name }`. Serialized — queues behind any in-flight placement
    * so both compute their sorted-insert position against up-to-date
    * data (see the P1 note in the module doc).
    */
   place: (result: NameSortEntry, opts?: PlacementOptions) => Promise<void>
+  /**
+   * Batch-aware counterpart to `place()` for a multi-file import: pass
+   * every processed result (successes only — the caller already
+   * dedupes by id and skips failures) plus the `beforeEntries` snapshot
+   * captured via `snapshotEntries()` before the batch started. Positions
+   * every newly-inserted result as a group in one pure computation and
+   * issues at most one `reorder` call for the whole batch — see the
+   * RAPID-INSERT RACE note in the module doc for why this differs from
+   * calling `place()` once per result.
+   */
+  placeMany: (results: NameSortEntry[], beforeEntries: NameSortEntry[]) => Promise<void>
 }
 
 export function useImportPlacement({
@@ -202,6 +241,10 @@ export function useImportPlacement({
     return new Set(entriesRef.current.map((entry) => entry.id))
   }, [])
 
+  const snapshotEntries = useCallback((): NameSortEntry[] => {
+    return entriesRef.current
+  }, [])
+
   // Serializes placements so a second one's order computation always
   // sees the first's already-settled insert. `queueRef` holds a
   // "settle regardless" tail so one placement's failure never wedges
@@ -234,5 +277,39 @@ export function useImportPlacement({
     return settled
   }, [showFeedback, scheduleScroll])
 
-  return { feedback, snapshotBeforeIds, place }
+  const placeMany = useCallback((
+    results: NameSortEntry[],
+    beforeEntries: NameSortEntry[],
+  ): Promise<void> => {
+    const run = async (): Promise<void> => {
+      if (results.length === 0) return
+      const beforeIds = new Set(beforeEntries.map((entry) => entry.id))
+      const toInsert = results.filter((r) => !beforeIds.has(r.id))
+      if (toInsert.length > 0) {
+        // Merged purely from `beforeEntries` + `toInsert` — never from
+        // `entriesRef.current` — so this cannot be corrupted by a
+        // background refresh landing partway through the batch (see the
+        // RAPID-INSERT RACE note in the module doc).
+        const orderedIds = computeSortedInsertOrderMany(beforeEntries, toInsert, directionRef.current)
+        if (orderedIds) {
+          const reorderResult = await reorderRef.current(orderedIds)
+          if (!reorderResult.success) onReorderErrorRef.current(reorderResult.error)
+        }
+      }
+      // Feedback/scroll anchor on the last result processed — same
+      // "last one wins" convention the calling modals already use for
+      // e.g. switching the active language/theme after a batch import.
+      const last = results[results.length - 1]
+      const lastIsInsert = !beforeIds.has(last.id)
+      showFeedback(lastIsInsert
+        ? tRef.current('common.importedNamed', { name: last.name })
+        : tRef.current('common.updatedNamed', { name: last.name }))
+      scheduleScroll(`${rowTestidPrefixRef.current}-row-${last.id}`)
+    }
+    const settled = queueRef.current.then(run, run)
+    queueRef.current = settled.then(() => undefined, () => undefined)
+    return settled
+  }, [showFeedback, scheduleScroll])
+
+  return { feedback, snapshotBeforeIds, snapshotEntries, place, placeMany }
 }

--- a/src/renderer/components/pack-modal/useImportPlacement.ts
+++ b/src/renderer/components/pack-modal/useImportPlacement.ts
@@ -85,6 +85,21 @@
 // an `open` ref at the moment it would actually display something, not
 // when the placement started; the auto-clear timer is also torn down
 // immediately on close so it cannot fire into a since-reopened session.
+//
+// DIRECTION RACE (batch): `placeMany`'s merge computation must not read
+// `directionRef.current` at execution time either — a batch's file-save
+// loop can take a while (several IPC round trips), and the user is free
+// to click the Name-sort toggle (asc <-> desc) while it runs. Reading
+// live direction there would merge `toInsert` against one direction
+// while `beforeEntries` (captured at batch start) reflects the other,
+// producing a persisted order that is sorted in neither direction.
+// `snapshotEntries()` therefore captures direction alongside entries in
+// one `BatchSnapshot`, and `placeMany` uses only that frozen value —
+// the whole batch is placed consistently against the state that existed
+// when it began, exactly like `beforeEntries` already was. `place()`
+// (single-item) is untouched and keeps reading live direction: those
+// are separate user-triggered actions with no long-running loop for a
+// toggle to land inside of.
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -110,6 +125,16 @@ export interface UseImportPlacementOptions {
   onReorderError: (error: string | undefined) => void
 }
 
+/** Frozen pre-batch state for `placeMany`: both the entries list and the
+ *  sort direction as they stood when the batch started, captured
+ *  together by `snapshotEntries()` so neither can drift independently
+ *  while the batch's file-save loop runs (see the DIRECTION RACE note
+ *  in the module doc). */
+export interface BatchSnapshot {
+  entries: NameSortEntry[]
+  direction: SortDirection
+}
+
 export interface PlacementOptions {
   /** From `snapshotBeforeIds()`, called before the store operation.
    *  Omit only when `alwaysInsert` is set. */
@@ -129,13 +154,14 @@ export interface UseImportPlacementResult {
   snapshotBeforeIds: () => Set<string>
   /**
    * Call synchronously once, right before starting a multi-file import
-   * batch's store calls. Returns the full entries list (not just ids)
-   * as it stood before any file in the batch was saved — pass it to
-   * `placeMany` as `beforeEntries` so the batch's merge computation
-   * never depends on `entriesRef` (which can drift mid-batch; see the
-   * RAPID-INSERT RACE note in the module doc).
+   * batch's store calls. Returns the entries list AND sort direction
+   * (not just ids) as they stood before any file in the batch was saved
+   * — pass the result to `placeMany` so the batch's merge computation
+   * never depends on `entriesRef`/`directionRef` (which can drift
+   * mid-batch; see the RAPID-INSERT RACE and DIRECTION RACE notes in
+   * the module doc).
    */
-  snapshotEntries: () => NameSortEntry[]
+  snapshotEntries: () => BatchSnapshot
   /**
    * Call after the store operation resolves with the placed entry's
    * `{ id, name }`. Serialized — queues behind any in-flight placement
@@ -146,14 +172,15 @@ export interface UseImportPlacementResult {
   /**
    * Batch-aware counterpart to `place()` for a multi-file import: pass
    * every processed result (successes only — the caller already
-   * dedupes by id and skips failures) plus the `beforeEntries` snapshot
-   * captured via `snapshotEntries()` before the batch started. Positions
-   * every newly-inserted result as a group in one pure computation and
-   * issues at most one `reorder` call for the whole batch — see the
-   * RAPID-INSERT RACE note in the module doc for why this differs from
-   * calling `place()` once per result.
+   * dedupes by id and skips failures) plus the `BatchSnapshot` captured
+   * via `snapshotEntries()` before the batch started. Positions every
+   * newly-inserted result as a group in one pure computation — against
+   * the snapshot's frozen entries AND direction, never live state — and
+   * issues at most one `reorder` call for the whole batch. See the
+   * RAPID-INSERT RACE and DIRECTION RACE notes in the module doc for why
+   * this differs from calling `place()` once per result.
    */
-  placeMany: (results: NameSortEntry[], beforeEntries: NameSortEntry[]) => Promise<void>
+  placeMany: (results: NameSortEntry[], snapshot: BatchSnapshot) => Promise<void>
 }
 
 export function useImportPlacement({
@@ -241,8 +268,8 @@ export function useImportPlacement({
     return new Set(entriesRef.current.map((entry) => entry.id))
   }, [])
 
-  const snapshotEntries = useCallback((): NameSortEntry[] => {
-    return entriesRef.current
+  const snapshotEntries = useCallback((): BatchSnapshot => {
+    return { entries: entriesRef.current, direction: directionRef.current }
   }, [])
 
   // Serializes placements so a second one's order computation always
@@ -279,18 +306,21 @@ export function useImportPlacement({
 
   const placeMany = useCallback((
     results: NameSortEntry[],
-    beforeEntries: NameSortEntry[],
+    snapshot: BatchSnapshot,
   ): Promise<void> => {
     const run = async (): Promise<void> => {
       if (results.length === 0) return
+      const { entries: beforeEntries, direction: beforeDirection } = snapshot
       const beforeIds = new Set(beforeEntries.map((entry) => entry.id))
       const toInsert = results.filter((r) => !beforeIds.has(r.id))
       if (toInsert.length > 0) {
-        // Merged purely from `beforeEntries` + `toInsert` — never from
-        // `entriesRef.current` — so this cannot be corrupted by a
-        // background refresh landing partway through the batch (see the
-        // RAPID-INSERT RACE note in the module doc).
-        const orderedIds = computeSortedInsertOrderMany(beforeEntries, toInsert, directionRef.current)
+        // Merged purely from `beforeEntries` + `toInsert` + the
+        // snapshot's own `beforeDirection` — never from
+        // `entriesRef.current`/`directionRef.current` — so this cannot
+        // be corrupted by a background refresh, or a Name-sort toggle,
+        // landing partway through the batch (see the RAPID-INSERT RACE
+        // and DIRECTION RACE notes in the module doc).
+        const orderedIds = computeSortedInsertOrderMany(beforeEntries, toInsert, beforeDirection)
         if (orderedIds) {
           const reorderResult = await reorderRef.current(orderedIds)
           if (!reorderResult.success) onReorderErrorRef.current(reorderResult.error)

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -33,7 +33,7 @@ export interface PackRowProps {
   currentDisplayName: string | null
   hubCanWrite: boolean
   hubFreshness: Map<string, HubFreshnessEntry>
-  lastResult: PackActionResult | null
+  lastResult: PackActionResult | PackActionResult[] | null
   confirmRemoveId: string | null
   setConfirmRemoveId: (id: string | null) => void
   onUpload: (id: string) => void

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -298,11 +298,13 @@ export function ThemePacksModal({
   // (theme pack validation lives entirely main-side in `savePack`, so
   // there is no renderer-side pre-check to run first, unlike Language
   // Packs), but the actual list placement happens in ONE call at the
-  // end via `placement.placeMany` — see the RAPID-INSERT RACE note in
-  // useImportPlacement.ts for why calling `place()` once per file (the
-  // original approach) could compute a later file's position from a
-  // stale snapshot and silently drop an earlier file's id from the
-  // persisted order. Two files resolving to the same pack (same name,
+  // end via `placement.placeMany` — see the RAPID-INSERT RACE and
+  // DIRECTION RACE notes in useImportPlacement.ts for why calling
+  // `place()` once per file (the original approach) could compute a
+  // later file's position from a stale/inconsistent snapshot and
+  // silently drop an earlier file's id from the persisted order, or
+  // merge against a sort direction that changed mid-batch. Two files
+  // resolving to the same pack (same name,
   // so main's auto-overwrite reuses the same id) are deduped, keeping
   // only the last file's outcome — that's what actually ended up on
   // disk — so hub-sync and the row badge only run/appear once per id.
@@ -318,7 +320,7 @@ export function ThemePacksModal({
     setLastResult(null)
     const dialogResult = await store.importFromDialog()
     if (dialogResult.canceled) return
-    const beforeEntries = placement.snapshotEntries()
+    const beforeSnapshot = placement.snapshotEntries()
     const failures: ImportBatchFailure[] = []
     const rawSuccesses: { fileName: string; meta: ThemePackMeta }[] = []
     for (const file of dialogResult.files) {
@@ -364,7 +366,7 @@ export function ThemePacksModal({
     if (deduped.length > 0) {
       await placement.placeMany(
         deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-        beforeEntries,
+        beforeSnapshot,
       )
       setLastResult(successBadges)
       // Mirror the single-file behaviour of switching the active theme

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -29,6 +29,7 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
+import { buildImportBatchFailureSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -66,7 +67,7 @@ export function ThemePacksModal({
   const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
   const [pendingId, setPendingId] = useState<string | null>(null)
-  const [lastResult, setLastResult] = useState<PackActionResult | null>(null)
+  const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [previewPostId, setPreviewPostId] = useState<string | null>(null)
   const previewSeqRef = useRef(0)
   const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
@@ -293,38 +294,66 @@ export function ThemePacksModal({
     }
   }, [store, activeTheme, onThemeChange, t, currentDisplayName])
 
+  // Multi-file import batch: every selected file is processed
+  // independently (theme pack validation lives entirely main-side in
+  // `savePack`, so there is no renderer-side pre-check to run first,
+  // unlike Language Packs). Successes each get their own row badge
+  // (accumulated into an array — `PackResultBadge` looks up its row's
+  // own entry); failures (parse errors + save failures + failed Hub
+  // auto-syncs) are aggregated into one banner, mirroring the
+  // typing-analytics import precedent.
   const handleImportFile = useCallback(async () => {
     setActionError(null)
     setLastResult(null)
-    try {
-      const dialogResult = await store.importFromDialog()
-      if (dialogResult.canceled) return
-      if (dialogResult.parseError) {
-        setActionError(dialogResult.parseError)
-        return
+    const dialogResult = await store.importFromDialog()
+    if (dialogResult.canceled) return
+    const successBadges: PackActionResult[] = []
+    const failures: ImportBatchFailure[] = []
+    let lastImportedPackId: string | null = null
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        failures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
+        continue
       }
-      if (!dialogResult.raw) return
-      const beforeIds = placement.snapshotBeforeIds()
-      const result = await store.applyImport(dialogResult.raw)
-      if (!result.success || !result.meta) {
-        if (result.error) setActionError(result.error)
-        return
-      }
-      setLastResult({ id: result.meta.id, kind: 'success', message: t('common.saved') })
-      handleSelectTheme(`pack:${result.meta.id}`)
-      await placement.place({ id: result.meta.id, name: result.meta.name }, { beforeIds })
-
-      if (result.meta.hubPostId) {
-        const upd = await pushPackToHub(result.meta.id, result.meta.hubPostId)
-        if (upd.success) {
-          setLastResult({ id: result.meta.id, kind: 'success', message: t('common.synced') })
-        } else {
-          setActionError(upd.error ?? t('hub.updateFailed'))
+      try {
+        // Snapshot right before this file's own save rather than once
+        // for the whole batch: `applyImport` below is its own IPC round
+        // trip that lands immediately, so an earlier file already
+        // placed in this same loop is reflected in `nameSortEntries` by
+        // the time a later file's insert position is computed.
+        const beforeIds = placement.snapshotBeforeIds()
+        const result = await store.applyImport(file.raw)
+        if (!result.success || !result.meta) {
+          failures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
+          continue
         }
+        const meta = result.meta
+        let message = t('common.saved')
+        if (meta.hubPostId) {
+          const upd = await pushPackToHub(meta.id, meta.hubPostId)
+          if (upd.success) {
+            message = t('common.synced')
+          } else {
+            failures.push({ fileName: meta.name, reason: upd.error ?? t('hub.updateFailed') })
+          }
+        }
+        successBadges.push({ id: meta.id, kind: 'success', message })
+        lastImportedPackId = meta.id
+        await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
+      } catch {
+        failures.push({ fileName, reason: t('themePacks.parseError') })
       }
-    } catch {
-      setActionError(t('themePacks.parseError'))
     }
+    if (successBadges.length > 0) {
+      setLastResult(successBadges)
+      // Mirror the single-file behaviour of switching the active theme
+      // to the freshly imported pack, anchored on the last successfully
+      // imported file for a deterministic final state.
+      if (lastImportedPackId) handleSelectTheme(`pack:${lastImportedPackId}`)
+    }
+    const summary = buildImportBatchFailureSummary(t, failures)
+    if (summary) setActionError(summary)
   }, [store, t, pushPackToHub, handleSelectTheme, placement])
 
   const handleRenameCommit = useCallback(async (id: string) => {

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -13,7 +13,7 @@ import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useThemePackStore } from '../../hooks/useThemePackStore'
 import { applyPackColors, clearPackColors, isPackTheme, extractPackId } from '../../hooks/useTheme'
-import type { ThemeColorScheme, ThemePackColors } from '../../../shared/types/theme-store'
+import type { ThemeColorScheme, ThemePackColors, ThemePackMeta } from '../../../shared/types/theme-store'
 import type { HubThemePostListItem, HubThemePackBody } from '../../../shared/types/hub'
 import { HUB_CATEGORY } from '../../../shared/hub-urls'
 import { useHubFreshness } from '../../hooks/useHubFreshness'
@@ -294,22 +294,33 @@ export function ThemePacksModal({
     }
   }, [store, activeTheme, onThemeChange, t, currentDisplayName])
 
-  // Multi-file import batch: every selected file is processed
-  // independently (theme pack validation lives entirely main-side in
-  // `savePack`, so there is no renderer-side pre-check to run first,
-  // unlike Language Packs). Successes each get their own row badge
-  // (accumulated into an array — `PackResultBadge` looks up its row's
-  // own entry); failures (parse errors + save failures + failed Hub
-  // auto-syncs) are aggregated into one banner, mirroring the
-  // typing-analytics import precedent.
+  // Multi-file import batch: every selected file is saved independently
+  // (theme pack validation lives entirely main-side in `savePack`, so
+  // there is no renderer-side pre-check to run first, unlike Language
+  // Packs), but the actual list placement happens in ONE call at the
+  // end via `placement.placeMany` — see the RAPID-INSERT RACE note in
+  // useImportPlacement.ts for why calling `place()` once per file (the
+  // original approach) could compute a later file's position from a
+  // stale snapshot and silently drop an earlier file's id from the
+  // persisted order. Two files resolving to the same pack (same name,
+  // so main's auto-overwrite reuses the same id) are deduped, keeping
+  // only the last file's outcome — that's what actually ended up on
+  // disk — so hub-sync and the row badge only run/appear once per id.
+  // Successes each get their own row badge (accumulated into an array —
+  // `PackResultBadge` looks up its row's own entry); failures (parse
+  // errors + save failures + failed Hub auto-syncs) are aggregated into
+  // one banner, mirroring the typing-analytics import precedent, and
+  // always report the ACTUAL selected filename (never the pack's own
+  // internal `name`) plus the real underlying reason (never a generic
+  // placeholder when a real message is available).
   const handleImportFile = useCallback(async () => {
     setActionError(null)
     setLastResult(null)
     const dialogResult = await store.importFromDialog()
     if (dialogResult.canceled) return
-    const successBadges: PackActionResult[] = []
+    const beforeEntries = placement.snapshotEntries()
     const failures: ImportBatchFailure[] = []
-    let lastImportedPackId: string | null = null
+    const rawSuccesses: { fileName: string; meta: ThemePackMeta }[] = []
     for (const file of dialogResult.files) {
       const fileName = basenameOf(file.filePath)
       if (file.parseError || file.raw === undefined) {
@@ -317,40 +328,49 @@ export function ThemePacksModal({
         continue
       }
       try {
-        // Snapshot right before this file's own save rather than once
-        // for the whole batch: `applyImport` below is its own IPC round
-        // trip that lands immediately, so an earlier file already
-        // placed in this same loop is reflected in `nameSortEntries` by
-        // the time a later file's insert position is computed.
-        const beforeIds = placement.snapshotBeforeIds()
         const result = await store.applyImport(file.raw)
         if (!result.success || !result.meta) {
           failures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
           continue
         }
-        const meta = result.meta
-        let message = t('common.saved')
-        if (meta.hubPostId) {
-          const upd = await pushPackToHub(meta.id, meta.hubPostId)
-          if (upd.success) {
-            message = t('common.synced')
-          } else {
-            failures.push({ fileName: meta.name, reason: upd.error ?? t('hub.updateFailed') })
-          }
-        }
-        successBadges.push({ id: meta.id, kind: 'success', message })
-        lastImportedPackId = meta.id
-        await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
+        rawSuccesses.push({ fileName, meta: result.meta })
       } catch {
         failures.push({ fileName, reason: t('themePacks.parseError') })
       }
     }
-    if (successBadges.length > 0) {
+
+    // Dedupe by pack id, keeping the last file's outcome (see doc above).
+    const dedupedById = new Map<string, { fileName: string; meta: ThemePackMeta }>()
+    for (const success of rawSuccesses) {
+      dedupedById.delete(success.meta.id)
+      dedupedById.set(success.meta.id, success)
+    }
+    const deduped = [...dedupedById.values()]
+
+    const successBadges: PackActionResult[] = []
+    for (const { fileName, meta } of deduped) {
+      let message = t('common.saved')
+      if (meta.hubPostId) {
+        const upd = await pushPackToHub(meta.id, meta.hubPostId)
+        if (upd.success) {
+          message = t('common.synced')
+        } else {
+          failures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+        }
+      }
+      successBadges.push({ id: meta.id, kind: 'success', message })
+    }
+
+    if (deduped.length > 0) {
+      await placement.placeMany(
+        deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+        beforeEntries,
+      )
       setLastResult(successBadges)
       // Mirror the single-file behaviour of switching the active theme
       // to the freshly imported pack, anchored on the last successfully
-      // imported file for a deterministic final state.
-      if (lastImportedPackId) handleSelectTheme(`pack:${lastImportedPackId}`)
+      // imported (post-dedupe) file for a deterministic final state.
+      handleSelectTheme(`pack:${deduped[deduped.length - 1].meta.id}`)
     }
     const summary = buildImportBatchFailureSummary(t, failures)
     if (summary) setActionError(summary)

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -143,7 +143,7 @@ describe('ThemePacksModal', () => {
     mockTheme = 'system'
     removeFn.mockResolvedValue({ success: true })
     renameFn.mockResolvedValue({ success: true })
-    importFromDialog.mockResolvedValue({ canceled: true })
+    importFromDialog.mockResolvedValue({ canceled: true, files: [] })
     applyImport.mockResolvedValue({ success: true, meta: meta() })
     exportPack.mockResolvedValue({ success: true })
     reorderFn.mockResolvedValue({ success: true })
@@ -323,7 +323,7 @@ describe('ThemePacksModal', () => {
 
   it('import applies the raw data when dialog returns a file', async () => {
     const raw = { name: 'Imported', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'new1', name: 'Imported' }) })
     render(
       <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
@@ -333,20 +333,19 @@ describe('ThemePacksModal', () => {
   })
 
   it('import shows error on parse failure', async () => {
-    importFromDialog.mockResolvedValueOnce({ canceled: false, parseError: 'Bad format' })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'bad.json', parseError: 'Bad format' }] })
     render(
       <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
     )
     fireEvent.click(screen.getByTestId('theme-packs-import-button'))
     await waitFor(() => {
-      expect(screen.getByTestId('theme-packs-error')).toBeTruthy()
-      expect(screen.getByText('Bad format')).toBeTruthy()
+      expect(screen.getByTestId('theme-packs-error').textContent).toContain('Bad format')
     })
   })
 
   it('import with hubPostId auto-syncs to hub', async () => {
     const raw = { name: 'Synced', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 's1', name: 'Synced', hubPostId: 'hp1' }) })
     render(
       <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
@@ -361,7 +360,7 @@ describe('ThemePacksModal', () => {
     // Already ascending — detected as 'asc' on open, no click needed.
     metas = [meta({ id: 'a', name: 'Alpha' }), meta({ id: 'z', name: 'Zeta' })]
     const raw = { name: 'Mu', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'm', name: 'Mu' }) })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
@@ -373,7 +372,7 @@ describe('ThemePacksModal', () => {
     // Already descending — detected as 'desc' on open, no click needed.
     metas = [meta({ id: 'z', name: 'Zeta' }), meta({ id: 'a', name: 'Alpha' })]
     const raw = { name: 'Mu', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'm', name: 'Mu' }) })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
@@ -384,7 +383,7 @@ describe('ThemePacksModal', () => {
   it('free state (shuffled list): a new import does not call reorder — the store appends it at the bottom on its own', async () => {
     metas = [meta({ id: 'm', name: 'Mu' }), meta({ id: 'z', name: 'Zeta' }), meta({ id: 'a', name: 'Alpha' })]
     const raw = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'b', name: 'Beta' }) })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
@@ -396,7 +395,7 @@ describe('ThemePacksModal', () => {
   it('overwrite (same id already installed) keeps its position — no reorder call, "Updated" feedback', async () => {
     metas = [meta({ id: 'a', name: 'Alpha' }), meta({ id: 'z', name: 'Zeta' })]
     const raw = { name: 'Alpha', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     // Overwrite: the store reuses the existing 'a' id.
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'a', name: 'Alpha' }) })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
@@ -410,7 +409,7 @@ describe('ThemePacksModal', () => {
   it('new import shows "Imported {{name}}" feedback next to the Name button', async () => {
     metas = [meta({ id: 'a', name: 'Alpha' })]
     const raw = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     applyImport.mockResolvedValueOnce({ success: true, meta: meta({ id: 'b', name: 'Beta' }) })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
@@ -421,7 +420,7 @@ describe('ThemePacksModal', () => {
   it('scrolls the imported row into view', async () => {
     metas = [meta({ id: 'a', name: 'Alpha' })]
     const raw = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
-    importFromDialog.mockResolvedValueOnce({ canceled: false, raw })
+    importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })
     const newMeta = meta({ id: 'b', name: 'Beta' })
     applyImport.mockImplementationOnce(async () => {
       metas = [...metas, newMeta]
@@ -438,6 +437,66 @@ describe('ThemePacksModal', () => {
     } finally {
       scrollIntoView.mockRestore()
     }
+  })
+
+  it('multi-file import: every selected file is saved and each row gets its own "Saved" badge', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    const rawB = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
+    const rawC = { name: 'Gamma', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'gamma.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Gamma' })
+    // The mocked store doesn't simulate a metas re-fetch on its own —
+    // append each new meta by hand so both rows actually render, the
+    // way a real `refresh()` would after each `applyImport` call.
+    applyImport
+      .mockImplementationOnce(async () => {
+        metas = [...metas, metaB]
+        return { success: true, meta: metaB }
+      })
+      .mockImplementationOnce(async () => {
+        metas = [...metas, metaC]
+        return { success: true, meta: metaC }
+      })
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-result-b').textContent).toBe('common.saved'))
+    expect(screen.getByTestId('theme-packs-result-c').textContent).toBe('common.saved')
+  })
+
+  it('partial-failure batch: the good file keeps its badge while the bad file is aggregated into one banner', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    const rawGood = { name: 'Good Theme', version: '1', colorScheme: 'dark', colors: {} }
+    const rawBad = { name: 'Bad Theme', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'bad.json', raw: rawBad },
+        { filePath: 'good.json', raw: rawGood },
+      ],
+    })
+    const goodMeta = meta({ id: 'g', name: 'Good Theme' })
+    applyImport
+      .mockResolvedValueOnce({ success: false, error: 'Invalid theme colors' })
+      .mockImplementationOnce(async () => {
+        metas = [...metas, goodMeta]
+        return { success: true, meta: goodMeta }
+      })
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-result-g').textContent).toBe('common.saved'))
+
+    const banner = screen.getByTestId('theme-packs-error')
+    expect(banner.textContent).toContain('bad.json')
+    expect(banner.textContent).toContain('Invalid theme colors')
   })
 
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -499,6 +499,54 @@ describe('ThemePacksModal', () => {
     expect(banner.textContent).toContain('Invalid theme colors')
   })
 
+  it('P1 fix: importing files that interleave with existing rows (existing A,D; import B,C) lands fully sorted A,B,C,D in one reorder call', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' }), meta({ id: 'd', name: 'Delta' })]
+    const rawB = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
+    const rawC = { name: 'Charlie', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'charlie.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Charlie' })
+    applyImport
+      .mockResolvedValueOnce({ success: true, meta: metaB })
+      .mockResolvedValueOnce({ success: true, meta: metaC })
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(reorderFn).toHaveBeenCalled())
+    // Without the fix, Charlie's position would be computed against a
+    // stale [Alpha, Delta] snapshot that never saw Beta's insert,
+    // persisting ['a', 'c', 'd'] and silently dropping Beta.
+    expect(reorderFn).toHaveBeenCalledTimes(1)
+    expect(reorderFn).toHaveBeenCalledWith(['a', 'b', 'c', 'd'])
+  })
+
+  it('hub-sync failure after import is reported against the originating filename, not the pack name (P2a)', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    const raw = { name: 'Existing Pack', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [{ filePath: 'my-upload.json', raw }],
+    })
+    const savedMeta = meta({ id: 'e', name: 'Existing Pack', hubPostId: 'hub-1' })
+    applyImport.mockResolvedValueOnce({ success: true, meta: savedMeta })
+    vialAPI.hubUpdateThemePost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => {
+      expect(screen.getByTestId('theme-packs-error')).toBeTruthy()
+    })
+    const banner = screen.getByTestId('theme-packs-error')
+    expect(banner.textContent).toContain('my-upload.json')
+    expect(banner.textContent).toContain('network error')
+  })
+
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {
     // Already ascending — detected as 'asc' on open, no click needed.
     metas = [meta({ id: 'a', name: 'Alpha' }), meta({ id: 'z', name: 'Zeta' })]

--- a/src/renderer/hooks/__tests__/useKeyLabels.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyLabels.test.ts
@@ -53,7 +53,7 @@ describe('useKeyLabels', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockList.mockResolvedValue({ success: true, data: [meta({ id: 'b', name: 'B' }), meta({ id: 'a', name: 'A' })] })
-    mockImport.mockResolvedValue({ success: true, data: meta({ id: 'c', name: 'C' }) })
+    mockImport.mockResolvedValue({ success: true, data: { imported: [meta({ id: 'c', name: 'C' })], rejections: [] } })
     mockExport.mockResolvedValue({ success: true, data: { filePath: '/tmp/c.json' } })
     mockReorder.mockResolvedValue({ success: true })
     mockRename.mockResolvedValue({ success: true, data: meta({ id: 'a', name: 'A2' }) })
@@ -279,7 +279,7 @@ describe('useKeyLabels', () => {
     expect(mockList).toHaveBeenCalled()
   })
 
-  it('importFromFile returns the import result data', async () => {
+  it('importFromFile returns the batch import result data', async () => {
     const { result } = renderHook(() => useKeyLabels())
     await waitFor(() => expect(result.current.metas).toHaveLength(2))
 
@@ -289,6 +289,7 @@ describe('useKeyLabels', () => {
     })
 
     expect(res!.success).toBe(true)
-    expect(res!.data).toEqual(expect.objectContaining({ id: 'c', name: 'C' }))
+    expect(res!.data?.imported).toEqual([expect.objectContaining({ id: 'c', name: 'C' })])
+    expect(res!.data?.rejections).toEqual([])
   })
 })

--- a/src/renderer/hooks/__tests__/useKeyLabels.test.ts
+++ b/src/renderer/hooks/__tests__/useKeyLabels.test.ts
@@ -53,7 +53,7 @@ describe('useKeyLabels', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockList.mockResolvedValue({ success: true, data: [meta({ id: 'b', name: 'B' }), meta({ id: 'a', name: 'A' })] })
-    mockImport.mockResolvedValue({ success: true, data: { imported: [meta({ id: 'c', name: 'C' })], rejections: [] } })
+    mockImport.mockResolvedValue({ success: true, data: { imported: [{ fileName: 'c.json', meta: meta({ id: 'c', name: 'C' }) }], rejections: [] } })
     mockExport.mockResolvedValue({ success: true, data: { filePath: '/tmp/c.json' } })
     mockReorder.mockResolvedValue({ success: true })
     mockRename.mockResolvedValue({ success: true, data: meta({ id: 'a', name: 'A2' }) })
@@ -289,7 +289,9 @@ describe('useKeyLabels', () => {
     })
 
     expect(res!.success).toBe(true)
-    expect(res!.data?.imported).toEqual([expect.objectContaining({ id: 'c', name: 'C' })])
+    expect(res!.data?.imported).toEqual([
+      { fileName: 'c.json', meta: expect.objectContaining({ id: 'c', name: 'C' }) },
+    ])
     expect(res!.data?.rejections).toEqual([])
   })
 })

--- a/src/renderer/hooks/useKeyLabels.ts
+++ b/src/renderer/hooks/useKeyLabels.ts
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useState } from 'react'
 import type {
   KeyLabelMeta,
   KeyLabelStoreResult,
+  KeyLabelImportBatchResult,
 } from '../../shared/types/key-label-store'
 import type {
   HubKeyLabelListParams,
@@ -36,7 +37,7 @@ export interface UseKeyLabelsReturn {
   error: string | null
   refresh: () => Promise<void>
 
-  importFromFile: () => Promise<KeyLabelStoreResult<KeyLabelMeta>>
+  importFromFile: () => Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>>
   exportEntry: (id: string) => Promise<KeyLabelStoreResult<{ filePath: string }>>
   reorder: (orderedIds: string[]) => Promise<KeyLabelStoreResult<void>>
   rename: (id: string, newName: string) => Promise<KeyLabelStoreResult<KeyLabelMeta>>
@@ -97,7 +98,7 @@ export function useKeyLabels(): UseKeyLabelsReturn {
     return () => window.removeEventListener(REFRESH_EVENT, handler)
   }, [refresh])
 
-  const importFromFile = useCallback(async (): Promise<KeyLabelStoreResult<KeyLabelMeta>> => {
+  const importFromFile = useCallback(async (): Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>> => {
     const result = await window.vialAPI.keyLabelStoreImport()
     if (result.success) {
       await refresh()

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.40",
+  "version": "0.1.41",
   "name": "English",
   "common": {
     "save": "Save",
@@ -39,7 +39,9 @@
     "findOnHubHint": "Browse uploaded files on <hub>Pipette Hub</hub>.",
     "sortByName": "Name",
     "importedNamed": "Imported {{name}}",
-    "updatedNamed": "Updated {{name}}"
+    "updatedNamed": "Updated {{name}}",
+    "importBatchFailed_one": "{{count}} file could not be imported:",
+    "importBatchFailed_other": "{{count}} files could not be imported:"
   },
   "app": {
     "title": "Pipette",

--- a/src/shared/types/i18n-store.ts
+++ b/src/shared/types/i18n-store.ts
@@ -128,13 +128,21 @@ export interface I18nPackRecord {
   pack: unknown
 }
 
-/** Shape returned by the I18N_PACK_IMPORT IPC handler. */
-export interface I18nPackImportDialogResult {
-  canceled: boolean
+/** One file selected via the multi-select I18N_PACK_IMPORT dialog. Parsing
+ *  happens per-file in main; `parseError` is set instead of `raw` when the
+ *  file could not be read or was not valid JSON. */
+export interface I18nPackImportFile {
+  filePath: string
   raw?: unknown
   fileSizeBytes?: number
-  filePath?: string
   parseError?: string
+}
+
+/** Shape returned by the I18N_PACK_IMPORT IPC handler. `files` is empty
+ *  when `canceled` is true. */
+export interface I18nPackImportDialogResult {
+  canceled: boolean
+  files: I18nPackImportFile[]
 }
 
 /** Optional flags forwarded with I18N_PACK_IMPORT_APPLY. */

--- a/src/shared/types/i18n-store.ts
+++ b/src/shared/types/i18n-store.ts
@@ -128,22 +128,13 @@ export interface I18nPackRecord {
   pack: unknown
 }
 
-/** One file selected via the multi-select I18N_PACK_IMPORT dialog. Parsing
- *  happens per-file in main; `parseError` is set instead of `raw` when the
- *  file could not be read or was not valid JSON. */
-export interface I18nPackImportFile {
-  filePath: string
-  raw?: unknown
-  fileSizeBytes?: number
-  parseError?: string
-}
-
-/** Shape returned by the I18N_PACK_IMPORT IPC handler. `files` is empty
- *  when `canceled` is true. */
-export interface I18nPackImportDialogResult {
-  canceled: boolean
-  files: I18nPackImportFile[]
-}
+/** Structurally identical to Theme Packs' `ThemePackImportFile` /
+ *  `ThemePackImportDialogResult` — both alias the shared shape in
+ *  `pack-import.ts` (see `readSelectedImportFiles` in
+ *  `src/main/pack-import-dialog.ts`, which both IPC handlers call).
+ *  Aliased (not just re-exported) under the domain-specific name so
+ *  existing call sites don't need to change what they import. */
+export type { PackImportFile as I18nPackImportFile, PackImportDialogResult as I18nPackImportDialogResult } from './pack-import'
 
 /** Optional flags forwarded with I18N_PACK_IMPORT_APPLY. */
 export interface I18nPackImportApplyOptions {

--- a/src/shared/types/key-label-store.ts
+++ b/src/shared/types/key-label-store.ts
@@ -74,3 +74,18 @@ export interface KeyLabelStoreResult<T> {
   errorCode?: KeyLabelStoreErrorCode
   error?: string
 }
+
+/** One file's failure within a multi-file `importFromDialog` batch. */
+export interface KeyLabelImportRejection {
+  fileName: string
+  errorCode: KeyLabelStoreErrorCode
+  error: string
+}
+
+/** Result of importing a batch of files selected via the multi-select
+ *  file dialog. Every selected file is processed independently — a bad
+ *  file is recorded in `rejections` rather than aborting the rest. */
+export interface KeyLabelImportBatchResult {
+  imported: KeyLabelMeta[]
+  rejections: KeyLabelImportRejection[]
+}

--- a/src/shared/types/key-label-store.ts
+++ b/src/shared/types/key-label-store.ts
@@ -82,10 +82,21 @@ export interface KeyLabelImportRejection {
   error: string
 }
 
+/** One file's success within a multi-file `importFromDialog` batch.
+ *  Carries the originating filename alongside the saved meta so the
+ *  renderer can report a failure (e.g. a Hub-sync failure after the
+ *  save itself succeeded) against the file the user picked, not the
+ *  label's internal display name — the main process is the only side
+ *  that knows which `filePaths[i]` produced a given saved entry. */
+export interface KeyLabelImportSuccess {
+  fileName: string
+  meta: KeyLabelMeta
+}
+
 /** Result of importing a batch of files selected via the multi-select
  *  file dialog. Every selected file is processed independently — a bad
  *  file is recorded in `rejections` rather than aborting the rest. */
 export interface KeyLabelImportBatchResult {
-  imported: KeyLabelMeta[]
+  imported: KeyLabelImportSuccess[]
   rejections: KeyLabelImportRejection[]
 }

--- a/src/shared/types/pack-import.ts
+++ b/src/shared/types/pack-import.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared shapes for the multi-select import dialog used by Language
+// Packs (I18N_PACK_IMPORT) and Theme Packs (THEME_PACK_IMPORT). Both
+// handlers open the same kind of dialog and read+parse each selected
+// file the same way — see `src/main/pack-import-dialog.ts`'s
+// `readSelectedImportFiles`, which both call. Key Labels' import is
+// deliberately NOT part of this — it saves each file in main and
+// returns saved metas rather than raw parsed bodies (the renderer
+// validates/persists i18n and theme packs itself).
+
+/** One file selected via the dialog. Parsing happens per-file in main;
+ *  `parseError` is set instead of `raw` when the file could not be read
+ *  or was not valid JSON. */
+export interface PackImportFile {
+  filePath: string
+  raw?: unknown
+  fileSizeBytes?: number
+  parseError?: string
+}
+
+/** Shape returned by the import IPC handler. `files` is empty when
+ *  `canceled` is true. */
+export interface PackImportDialogResult {
+  canceled: boolean
+  files: PackImportFile[]
+}

--- a/src/shared/types/theme-store.ts
+++ b/src/shared/types/theme-store.ts
@@ -93,12 +93,21 @@ export interface ThemePackStoreResult<T> {
   error?: string
 }
 
-export interface ThemePackImportDialogResult {
-  canceled: boolean
+/** One file selected via the multi-select THEME_PACK_IMPORT dialog. Parsing
+ *  happens per-file in main; `parseError` is set instead of `raw` when the
+ *  file could not be read or was not valid JSON. */
+export interface ThemePackImportFile {
+  filePath: string
   raw?: unknown
   fileSizeBytes?: number
-  filePath?: string
   parseError?: string
+}
+
+/** Shape returned by the THEME_PACK_IMPORT IPC handler. `files` is empty
+ *  when `canceled` is true. */
+export interface ThemePackImportDialogResult {
+  canceled: boolean
+  files: ThemePackImportFile[]
 }
 
 export interface ThemePackImportApplyOptions {

--- a/src/shared/types/theme-store.ts
+++ b/src/shared/types/theme-store.ts
@@ -93,22 +93,13 @@ export interface ThemePackStoreResult<T> {
   error?: string
 }
 
-/** One file selected via the multi-select THEME_PACK_IMPORT dialog. Parsing
- *  happens per-file in main; `parseError` is set instead of `raw` when the
- *  file could not be read or was not valid JSON. */
-export interface ThemePackImportFile {
-  filePath: string
-  raw?: unknown
-  fileSizeBytes?: number
-  parseError?: string
-}
-
-/** Shape returned by the THEME_PACK_IMPORT IPC handler. `files` is empty
- *  when `canceled` is true. */
-export interface ThemePackImportDialogResult {
-  canceled: boolean
-  files: ThemePackImportFile[]
-}
+/** Structurally identical to Language Packs' `I18nPackImportFile` /
+ *  `I18nPackImportDialogResult` — both alias the shared shape in
+ *  `pack-import.ts` (see `readSelectedImportFiles` in
+ *  `src/main/pack-import-dialog.ts`, which both IPC handlers call).
+ *  Aliased (not just re-exported) under the domain-specific name so
+ *  existing call sites don't need to change what they import. */
+export type { PackImportFile as ThemePackImportFile, PackImportDialogResult as ThemePackImportDialogResult } from './pack-import'
 
 export interface ThemePackImportApplyOptions {
   id?: string

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -16,7 +16,7 @@ import type {
 import type { SnapshotMeta } from './snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from './analyze-filter-store'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteImportResult } from './favorite-store'
-import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from './key-label-store'
+import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult, KeyLabelImportBatchResult } from './key-label-store'
 import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from './typing-test-text-store'
 import type { HubKeyLabelItem, HubKeyLabelListResponse, HubKeyLabelListParams, HubKeyLabelTimestampsResponse } from './hub-key-label'
 import type {
@@ -184,7 +184,7 @@ export interface VialAPI {
   keyLabelStoreGet(id: string): Promise<KeyLabelStoreResult<KeyLabelRecord>>
   keyLabelStoreRename(id: string, newName: string): Promise<KeyLabelStoreResult<KeyLabelMeta>>
   keyLabelStoreDelete(id: string): Promise<KeyLabelStoreResult<void>>
-  keyLabelStoreImport(): Promise<KeyLabelStoreResult<KeyLabelMeta>>
+  keyLabelStoreImport(): Promise<KeyLabelStoreResult<KeyLabelImportBatchResult>>
   keyLabelStoreExport(id: string): Promise<KeyLabelStoreResult<{ filePath: string }>>
   keyLabelStoreReorder(orderedIds: string[]): Promise<KeyLabelStoreResult<void>>
   keyLabelStoreSetHubPostId(id: string, hubPostId: string | null): Promise<KeyLabelStoreResult<KeyLabelMeta>>


### PR DESCRIPTION
## Summary

The Import buttons in the Language Packs, Theme Packs, and Key Labels modals accepted one file per click. They now allow selecting several files and import them all in one action.

- Each dialog opens with multi-selection. Every file that validates is imported and gets its usual per-row "Saved" (or "Synced") badge; files that fail are collected into a single banner listing each filename and its reason, so a mixed batch imports the good ones instead of aborting.
- Failure lines report the file the user actually chose (its filename), including when a Hub auto-sync fails, and a read error reports the real error rather than a generic "invalid JSON".
- A batch is placed into the name-sorted list as a group against one snapshot taken when the batch starts — the sort direction is frozen for its duration — so interleaving names land in order regardless of per-file save timing or a mid-import sort toggle. Two selected files that resolve to the same pack are de-duplicated so its import runs once.

The two parse-to-raw dialog handlers (Language, Theme) now share one `readSelectedImportFiles` helper and a common `PackImportFile` type; Key Labels keeps its own path since it saves in the main process. Single-file behaviour — Hub download, rename auto-sync — is unchanged.

## Testing

- Per modal: multi-file success, partial-failure banner, duplicate-id de-dup, and interleaved-name ordering (including the direction-flip race) are covered; single-file paths keep their existing tests.
- New IPC-handler tests for the Language and Theme dialogs, which previously had none.
- 7128 tests pass; lint and typecheck clean.