### PR TITLE
feat(ui): lock the pack list during import and summarize the outcome

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.41",
+  "version": "0.1.42",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -41,7 +41,9 @@
     "importedNamed": "{{name}} をインポートしました",
     "updatedNamed": "{{name}} を更新しました",
     "importBatchFailed_one": "{{count}} 件のファイルをインポートできませんでした：",
-    "importBatchFailed_other": "{{count}} 件のファイルをインポートできませんでした："
+    "importBatchFailed_other": "{{count}} 件のファイルをインポートできませんでした：",
+    "importSummary_one": "{{count}} 件インポートしました (成功 {{success}}, 失敗 {{failure}})",
+    "importSummary_other": "{{count}} 件インポートしました (成功 {{success}}, 失敗 {{failure}})"
   },
   "app": {
     "title": "Pipette",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.41",
+  "version": "0.1.42",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -41,7 +41,9 @@
     "importedNamed": "{{name}} 入れたよん☆",
     "updatedNamed": "{{name}} 更新したよん☆",
     "importBatchFailed_one": "{{count}}個、入れられんかったよ…",
-    "importBatchFailed_other": "{{count}}個、入れられんかったよ…"
+    "importBatchFailed_other": "{{count}}個、入れられんかったよ…",
+    "importSummary_one": "{{count}}個入れたよん☆(成功{{success}}、失敗{{failure}})",
+    "importSummary_other": "{{count}}個入れたよん☆(成功{{success}}、失敗{{failure}})"
   },
   "app": {
     "title": "Pipette☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.41",
+  "version": "0.1.42",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -41,7 +41,9 @@
     "importedNamed": "{{name}} を入れましたえ",
     "updatedNamed": "{{name}} を更新しましたえ",
     "importBatchFailed_one": "{{count}} 件、インポートできまへんでしたわ",
-    "importBatchFailed_other": "{{count}} 件、インポートできまへんでしたわ"
+    "importBatchFailed_other": "{{count}} 件、インポートできまへんでしたわ",
+    "importSummary_one": "{{count}} 件インポートしましたえ (成功{{success}}、失敗{{failure}})",
+    "importSummary_other": "{{count}} 件インポートしましたえ (成功{{success}}、失敗{{failure}})"
   },
   "app": {
     "title": "Pipette",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.41",
+  "version": "0.1.42",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -41,7 +41,9 @@
     "importedNamed": "{{name}} をお受け取りいたしました",
     "updatedNamed": "{{name}} を更新いたしました",
     "importBatchFailed_one": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。",
-    "importBatchFailed_other": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。"
+    "importBatchFailed_other": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。",
+    "importSummary_one": "{{count}} 件のファイルをお受け取りいたしました (成功 {{success}} 件、失敗 {{failure}} 件)。",
+    "importSummary_other": "{{count}} 件のファイルをお受け取りいたしました (成功 {{success}} 件、失敗 {{failure}} 件)。"
   },
   "app": {
     "title": "Pipette",

--- a/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
+++ b/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
@@ -183,6 +183,7 @@ export function LanguageInstalledRow({
           name={row.name}
           editing={editing}
           canRename={canRename}
+          locked={importing}
           editLabel={rename.editLabel}
           onEditLabelChange={rename.setEditLabel}
           onBlur={() => void onRenameCommit(row.packId as string)}

--- a/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
+++ b/src/renderer/components/i18n-packs/LanguageInstalledRow.tsx
@@ -56,6 +56,11 @@ export interface HubRow {
 export interface LanguageInstalledRowProps {
   row: InstalledRow
   pendingId: string | null
+  /** True while a multi-file import batch is in flight — locks every
+   *  row action, rename, drag and the select control so the list can't
+   *  be mutated out from under the batch's own placement/reorder call.
+   *  Wired the same way `pendingId` already gates a single op. */
+  importing: boolean
   confirmDeleteId: string | null
   setConfirmDeleteId: (id: string | null) => void
   confirmRemoveId: string | null
@@ -84,6 +89,7 @@ export interface LanguageInstalledRowProps {
 export function LanguageInstalledRow({
   row,
   pendingId,
+  importing,
   confirmDeleteId,
   setConfirmDeleteId,
   confirmRemoveId,
@@ -109,12 +115,12 @@ export function LanguageInstalledRow({
   onDragEnd,
 }: LanguageInstalledRowProps): JSX.Element {
   const { t } = useTranslation()
-  const busy = pendingId !== null && (pendingId === row.packId || pendingId === row.hubPostId)
+  const busy = (pendingId !== null && (pendingId === row.packId || pendingId === row.hubPostId)) || importing
   const freshness = row.packId ? hubFreshness.get(row.packId) : undefined
   const hasUpdateAvailable = hasUpdate(freshness, row.meta?.hubUpdatedAt)
   const hubRemoved = !!freshness && freshness.removed
   const editing = !!row.packId && rename.editingId === row.packId
-  const canRename = !row.isBuiltin && !!row.packId
+  const canRename = !row.isBuiltin && !!row.packId && !importing
   const updatedAt = row.updatedAt ? formatTimestamp(row.updatedAt) : ''
   const linkClass = 'text-xs font-medium hover:underline disabled:opacity-50'
 
@@ -139,7 +145,7 @@ export function LanguageInstalledRow({
     <PackListRow
       testid={`language-packs-row-${row.reactKey}`}
       active={row.active}
-      draggable={canDrag}
+      draggable={canDrag && !importing}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDragEnd={onDragEnd}
@@ -160,8 +166,9 @@ export function LanguageInstalledRow({
         <button
           type="button"
           aria-label={t('i18n.selectLanguage', { name: row.name })}
-          className="shrink-0 text-content-muted hover:text-accent transition-colors"
+          className="shrink-0 text-content-muted hover:text-accent transition-colors disabled:opacity-50"
           onClick={() => onSelectLanguage(row.internalId)}
+          disabled={busy}
           data-testid={`language-packs-select-${row.reactKey}`}
         >
           {row.active ? (
@@ -284,10 +291,14 @@ export function LanguageInstalledRow({
 export interface LanguageHubRowProps {
   row: HubRow
   pendingId: string | null
+  /** Defensive: the Hub tab isn't meant to be operable mid-import
+   *  either, even though its own actions don't touch the Installed
+   *  list directly. */
+  importing: boolean
   onDownload: (postId: string) => void
 }
 
-export function LanguageHubRow({ row, pendingId, onDownload }: LanguageHubRowProps): JSX.Element {
+export function LanguageHubRow({ row, pendingId, importing, onDownload }: LanguageHubRowProps): JSX.Element {
   return (
     <PackHubResultRow
       hubPostId={row.hubPostId}
@@ -296,7 +307,7 @@ export function LanguageHubRow({ row, pendingId, onDownload }: LanguageHubRowPro
       version={row.version}
       uploaderName={row.uploaderName}
       alreadyInstalled={row.alreadyInstalled}
-      busy={pendingId === row.hubPostId}
+      busy={pendingId === row.hubPostId || importing}
       onDownload={() => onDownload(row.hubPostId)}
     />
   )

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -12,7 +12,7 @@
 // reorder and Name sort include it like any imported entry (see
 // `ensureBuiltinEnglishEntry` in main/i18n-pack-store.ts).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -81,13 +81,6 @@ export function LanguagePacksModal({
   const [actionError, setActionError] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
-  // Mirrors `importing` (from `useImportBatch`, defined further below)
-  // into a ref so `handleRenameCommit` — defined earlier in this file,
-  // before the hook call — can read its latest value without a
-  // definition-order dependency. Kept current via a plain assignment
-  // during render (the same "adjust a ref during render" pattern
-  // `useImportPlacement.ts` uses for its own always-latest refs).
-  const importingRef = useRef(false)
 
   const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
   const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
@@ -375,16 +368,25 @@ export function LanguagePacksModal({
   }, [store, t])
 
   const handleRenameCommit = useCallback(async (id: string): Promise<void> => {
+    // Guards on `useImportBatch`'s own re-entrancy ref (destructured as
+    // `isImportingRef` below) rather than a locally-mirrored ref — a
+    // ref written only inside an event handler (`runImport`), never
+    // during render, so it can't go stale under a discarded/interrupted
+    // concurrent render the way `someRef.current = someState` could.
+    // Referencing `isImportingRef` here, even though it is destructured
+    // further down in this file, is safe: this callback's body only
+    // runs later, in response to a real blur/Enter event, by which time
+    // the whole render (including that destructure) has long finished.
+    //
     // A rename already committed its `store.rename` call the instant
     // the underlying input blurred — including the blur a click on the
     // Import button itself triggers, which fires before that click's
     // own handler runs — so this check cannot intercept that exact
     // call. It DOES catch every other path: a rename input left open
-    // when a batch was already running (this same check, read fresh
-    // every call via the ref) and any stray commit that slips through
-    // after the cancel-on-import-start effect below has already reset
-    // the editor for this render.
-    if (importingRef.current) return
+    // when a batch was already running, and any stray commit that
+    // slips through after the cancel-on-import-start effect below has
+    // already reset the editor for this render.
+    if (isImportingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)
@@ -677,7 +679,7 @@ export function LanguagePacksModal({
     return { successes, notSavedFailures, snapshot }
   }, [store, t, placement, importOnePack])
 
-  const { importing, importSummary, runImport } = useImportBatch<I18nPackMeta>({
+  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<I18nPackMeta>({
     open,
     placement,
     setLastResult,
@@ -687,12 +689,11 @@ export function LanguagePacksModal({
     hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
     onCollapsedToOne: (meta) => handleSelectLanguage(`pack:${meta.id}`),
   })
-  importingRef.current = importing
 
   // Closes any inline rename that was already open the moment a batch
   // starts, so its input unmounts instead of sitting there interactive
   // (and committable) for the whole duration of the import — see
-  // `handleRenameCommit`'s own `importingRef` guard above for the one
+  // `handleRenameCommit`'s own `isImportingRef` guard above for the one
   // race this cannot cover (a rename input's blur, and the click that
   // starts the batch, are the same user click; the blur's commit is
   // already in flight before `importing` ever flips true).

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -12,7 +12,7 @@
 // reorder and Name sort include it like any imported entry (see
 // `ensureBuiltinEnglishEntry` in main/i18n-pack-store.ts).
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -81,6 +81,13 @@ export function LanguagePacksModal({
   const [actionError, setActionError] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
+  // Mirrors `importing` (from `useImportBatch`, defined further below)
+  // into a ref so `handleRenameCommit` — defined earlier in this file,
+  // before the hook call — can read its latest value without a
+  // definition-order dependency. Kept current via a plain assignment
+  // during render (the same "adjust a ref during render" pattern
+  // `useImportPlacement.ts` uses for its own always-latest refs).
+  const importingRef = useRef(false)
 
   const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
   const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
@@ -368,6 +375,16 @@ export function LanguagePacksModal({
   }, [store, t])
 
   const handleRenameCommit = useCallback(async (id: string): Promise<void> => {
+    // A rename already committed its `store.rename` call the instant
+    // the underlying input blurred — including the blur a click on the
+    // Import button itself triggers, which fires before that click's
+    // own handler runs — so this check cannot intercept that exact
+    // call. It DOES catch every other path: a rename input left open
+    // when a batch was already running (this same check, read fresh
+    // every call via the ref) and any stray commit that slips through
+    // after the cancel-on-import-start effect below has already reset
+    // the editor for this render.
+    if (importingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)
@@ -670,6 +687,21 @@ export function LanguagePacksModal({
     hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
     onCollapsedToOne: (meta) => handleSelectLanguage(`pack:${meta.id}`),
   })
+  importingRef.current = importing
+
+  // Closes any inline rename that was already open the moment a batch
+  // starts, so its input unmounts instead of sitting there interactive
+  // (and committable) for the whole duration of the import — see
+  // `handleRenameCommit`'s own `importingRef` guard above for the one
+  // race this cannot cover (a rename input's blur, and the click that
+  // starts the batch, are the same user click; the blur's commit is
+  // already in flight before `importing` ever flips true).
+  useEffect(() => {
+    if (importing) rename.cancelRename()
+    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
+    // intentionally not in the deps array so this only re-fires when
+    // `importing` itself flips, not on every unrelated render.
+  }, [importing])
 
   const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
     setPendingId(postId)

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -12,7 +12,7 @@
 // reorder and Name sort include it like any imported entry (see
 // `ensureBuiltinEnglishEntry` in main/i18n-pack-store.ts).
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -37,7 +37,8 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, buildImportSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
+import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -80,22 +81,6 @@ export function LanguagePacksModal({
   const [actionError, setActionError] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
-  // Locks the Installed list (rows, drag, rename, the Import/Sort
-  // buttons) while a multi-file import batch is running, so nothing can
-  // mutate the list out from under `placement.placeMany`'s own reorder
-  // call. `importInFlightRef` is the actual re-entrancy guard (checked
-  // synchronously, mirroring the keymap-apply latch) — `importing` just
-  // mirrors it into render so the disabled UI reflects it a frame
-  // sooner than a double-click could slip through.
-  const [importing, setImporting] = useState(false)
-  const importInFlightRef = useRef(false)
-  // Toolbar headline shown only for a 2+ file batch (see
-  // `handleImportFile`) — supersedes `placement.feedback`'s per-name
-  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
-  // below. Cleared at the start of the next import and on modal close;
-  // no auto-clear timer (unlike `placement.feedback`) since it is meant
-  // to persist as the batch's final word until the user acts again.
-  const [importSummary, setImportSummary] = useState<string | null>(null)
 
   const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
   const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
@@ -310,7 +295,6 @@ export function LanguagePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
-      setImportSummary(null)
     }
   }, [open])
 
@@ -575,8 +559,8 @@ export function LanguagePacksModal({
 
   // Core validate + coverage + persist step, shared by the single-item
   // Hub-download path (`persistImportedPack` below) and the multi-file
-  // import batch (`handleImportFile`). Returns the outcome instead of
-  // touching state so each caller decides how to surface it (single
+  // import batch (`collectImportResults`). Returns the outcome instead
+  // of touching state so each caller decides how to surface it (single
   // banner vs. an accumulated batch summary).
   const importOnePack = useCallback(async (
     raw: unknown,
@@ -604,9 +588,9 @@ export function LanguagePacksModal({
 
   // Single-item import path: Hub download funnels through here (the
   // toolbar's own multi-file import now goes through `importOnePack`
-  // directly — see `handleImportFile` below). Failures surface through
-  // `setActionError` (the same banner KeyLabels uses) instead of
-  // opening a separate confirmation modal.
+  // directly — see `collectImportResults` below). Failures surface
+  // through `setActionError` (the same banner KeyLabels uses) instead
+  // of opening a separate confirmation modal.
   const persistImportedPack = useCallback(async (
     raw: unknown,
     extra: { hubPostId?: string } = {},
@@ -648,112 +632,44 @@ export function LanguagePacksModal({
   }, [importOnePack, t, pushPackToHub, handleSelectLanguage, placement])
 
   // Multi-file import batch: every selected file is parsed and saved
-  // independently, but the actual list placement happens in ONE call at
-  // the end via `placement.placeMany` — see the RAPID-INSERT RACE and
-  // DIRECTION RACE notes in useImportPlacement.ts for why calling
-  // `place()` once per file (the original approach) could compute a
-  // later file's position from a stale/inconsistent snapshot and
-  // silently drop an earlier file's id from the persisted order, or
-  // merge against a sort direction that changed mid-batch. Two files
-  // resolving to the same pack (same name,
-  // so main's auto-overwrite reuses the same id) are deduped, keeping
-  // only the last file's outcome — that's what actually ended up on
-  // disk — so hub-sync and the row badge only run/appear once per id.
-  // Successes each get their own row badge (accumulated into an array —
-  // `PackResultBadge` looks up its row's own entry); failures (parse
-  // errors + save failures + failed Hub auto-syncs) are aggregated into
-  // one banner via `buildImportBatchFailureSummary`, mirroring the
-  // typing-analytics import precedent, and always report the ACTUAL
-  // selected filename (never the pack's own internal `name`) plus the
-  // real underlying reason (never a generic placeholder when a real
-  // message is available).
-  const handleImportFile = useCallback(async (): Promise<void> => {
-    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
-    // on Import before React re-renders the now-disabled button must
-    // not queue a second concurrent batch on top of the first.
-    if (importInFlightRef.current) return
-    importInFlightRef.current = true
-    setImporting(true)
-    try {
-      setActionError(null)
-      setLastResult(null)
-      setImportSummary(null)
-      const dialogResult = await store.importFromDialog()
-      if (dialogResult.canceled) return
-      const beforeSnapshot = placement.snapshotEntries()
-      // Kept separate from `hubSyncFailures` below: these are files that
-      // never actually landed on disk (parse/validate/store failure),
-      // which is what the toolbar headline's "failure" count means —
-      // see `buildImportSummary`'s doc in import-batch-summary.ts.
-      const notSavedFailures: ImportBatchFailure[] = []
-      const rawSuccesses: { fileName: string; meta: I18nPackMeta }[] = []
-      for (const file of dialogResult.files) {
-        const fileName = basenameOf(file.filePath)
-        if (file.parseError || file.raw === undefined) {
-          notSavedFailures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
-          continue
-        }
-        const imported = await importOnePack(file.raw)
-        if (!imported.ok) {
-          notSavedFailures.push({ fileName, reason: imported.error })
-          continue
-        }
-        rawSuccesses.push({ fileName, meta: imported.meta })
+  // independently here; dedupe, hub-sync, placement and the toolbar
+  // summary/failure banner are handled by the shared `useImportBatch`
+  // hook below (see its module doc for the extraction rationale). The
+  // snapshot is taken right after the "canceled" check — before any
+  // per-file save runs — matching `placement.snapshotEntries()`'s
+  // "before the batch's own mutations begin" contract.
+  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<I18nPackMeta> | null> => {
+    const dialogResult = await store.importFromDialog()
+    if (dialogResult.canceled) return null
+    const snapshot = placement.snapshotEntries()
+    const notSavedFailures: ImportBatchFailure[] = []
+    const successes: ImportBatchItem<I18nPackMeta>[] = []
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        notSavedFailures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
+        continue
       }
-
-      // Dedupe by pack id, keeping the last file's outcome (see doc above).
-      const dedupedById = new Map<string, { fileName: string; meta: I18nPackMeta }>()
-      for (const success of rawSuccesses) {
-        dedupedById.delete(success.meta.id)
-        dedupedById.set(success.meta.id, success)
+      const imported = await importOnePack(file.raw)
+      if (!imported.ok) {
+        notSavedFailures.push({ fileName, reason: imported.error })
+        continue
       }
-      const deduped = [...dedupedById.values()]
-
-      const hubSyncFailures: ImportBatchFailure[] = []
-      const successBadges: PackActionResult[] = []
-      for (const { fileName, meta } of deduped) {
-        let message = t('common.saved')
-        if (meta.hubPostId) {
-          const upd = await pushPackToHub(meta.id, meta.hubPostId)
-          if (upd.success) {
-            message = t('common.synced')
-          } else {
-            hubSyncFailures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
-          }
-        }
-        successBadges.push({ id: meta.id, kind: 'success', message })
-      }
-
-      if (deduped.length > 0) {
-        await placement.placeMany(
-          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-          beforeSnapshot,
-        )
-        setLastResult(successBadges)
-        // Mirror the single-file behaviour of switching the active
-        // language to the freshly imported pack — only when the batch
-        // collapsed to a single result; a 2+ batch has no single "the"
-        // import to activate, so the active language is left untouched.
-        if (deduped.length === 1) {
-          handleSelectLanguage(`pack:${deduped[0].meta.id}`)
-        }
-      }
-
-      // Toolbar headline for a 2+ file batch only — a single-file
-      // import keeps its existing per-name "Imported {{name}}" /
-      // "Updated {{name}}" feedback via `placement.feedback` untouched.
-      const totalCount = deduped.length + notSavedFailures.length
-      if (totalCount >= 2) {
-        setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
-      }
-
-      const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
-      if (summary) setActionError(summary)
-    } finally {
-      importInFlightRef.current = false
-      setImporting(false)
+      successes.push({ fileName, meta: imported.meta })
     }
-  }, [store, t, placement, importOnePack, pushPackToHub, handleSelectLanguage])
+    return { successes, notSavedFailures, snapshot }
+  }, [store, t, placement, importOnePack])
+
+  const { importing, importSummary, runImport } = useImportBatch<I18nPackMeta>({
+    open,
+    placement,
+    setLastResult,
+    setActionError,
+    t,
+    collectResults: collectImportResults,
+    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
+    onCollapsedToOne: (meta) => handleSelectLanguage(`pack:${meta.id}`),
+  })
 
   const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
     setPendingId(postId)
@@ -801,7 +717,7 @@ export function LanguagePacksModal({
       searchButtonLabel={hubSearching ? t('keyLabels.searching') : t('i18n.search')}
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('i18n.import')}
-      onImport={() => void handleImportFile()}
+      onImport={() => void runImport()}
       importDisabled={importing}
       sortButton={(
         <PackSortButton

--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -12,7 +12,7 @@
 // reorder and Name sort include it like any imported entry (see
 // `ensureBuiltinEnglishEntry` in main/i18n-pack-store.ts).
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
@@ -37,7 +37,7 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { buildImportBatchFailureSummary, buildImportSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -80,6 +80,22 @@ export function LanguagePacksModal({
   const [actionError, setActionError] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
+  // Locks the Installed list (rows, drag, rename, the Import/Sort
+  // buttons) while a multi-file import batch is running, so nothing can
+  // mutate the list out from under `placement.placeMany`'s own reorder
+  // call. `importInFlightRef` is the actual re-entrancy guard (checked
+  // synchronously, mirroring the keymap-apply latch) — `importing` just
+  // mirrors it into render so the disabled UI reflects it a frame
+  // sooner than a double-click could slip through.
+  const [importing, setImporting] = useState(false)
+  const importInFlightRef = useRef(false)
+  // Toolbar headline shown only for a 2+ file batch (see
+  // `handleImportFile`) — supersedes `placement.feedback`'s per-name
+  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
+  // below. Cleared at the start of the next import and on modal close;
+  // no auto-clear timer (unlike `placement.feedback`) since it is meant
+  // to persist as the batch's final word until the user acts again.
+  const [importSummary, setImportSummary] = useState<string | null>(null)
 
   const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
   const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
@@ -294,6 +310,7 @@ export function LanguagePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
+      setImportSummary(null)
     }
   }, [open])
 
@@ -651,63 +668,91 @@ export function LanguagePacksModal({
   // real underlying reason (never a generic placeholder when a real
   // message is available).
   const handleImportFile = useCallback(async (): Promise<void> => {
-    setActionError(null)
-    setLastResult(null)
-    const dialogResult = await store.importFromDialog()
-    if (dialogResult.canceled) return
-    const beforeSnapshot = placement.snapshotEntries()
-    const failures: ImportBatchFailure[] = []
-    const rawSuccesses: { fileName: string; meta: I18nPackMeta }[] = []
-    for (const file of dialogResult.files) {
-      const fileName = basenameOf(file.filePath)
-      if (file.parseError || file.raw === undefined) {
-        failures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
-        continue
+    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
+    // on Import before React re-renders the now-disabled button must
+    // not queue a second concurrent batch on top of the first.
+    if (importInFlightRef.current) return
+    importInFlightRef.current = true
+    setImporting(true)
+    try {
+      setActionError(null)
+      setLastResult(null)
+      setImportSummary(null)
+      const dialogResult = await store.importFromDialog()
+      if (dialogResult.canceled) return
+      const beforeSnapshot = placement.snapshotEntries()
+      // Kept separate from `hubSyncFailures` below: these are files that
+      // never actually landed on disk (parse/validate/store failure),
+      // which is what the toolbar headline's "failure" count means —
+      // see `buildImportSummary`'s doc in import-batch-summary.ts.
+      const notSavedFailures: ImportBatchFailure[] = []
+      const rawSuccesses: { fileName: string; meta: I18nPackMeta }[] = []
+      for (const file of dialogResult.files) {
+        const fileName = basenameOf(file.filePath)
+        if (file.parseError || file.raw === undefined) {
+          notSavedFailures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
+          continue
+        }
+        const imported = await importOnePack(file.raw)
+        if (!imported.ok) {
+          notSavedFailures.push({ fileName, reason: imported.error })
+          continue
+        }
+        rawSuccesses.push({ fileName, meta: imported.meta })
       }
-      const imported = await importOnePack(file.raw)
-      if (!imported.ok) {
-        failures.push({ fileName, reason: imported.error })
-        continue
+
+      // Dedupe by pack id, keeping the last file's outcome (see doc above).
+      const dedupedById = new Map<string, { fileName: string; meta: I18nPackMeta }>()
+      for (const success of rawSuccesses) {
+        dedupedById.delete(success.meta.id)
+        dedupedById.set(success.meta.id, success)
       }
-      rawSuccesses.push({ fileName, meta: imported.meta })
-    }
+      const deduped = [...dedupedById.values()]
 
-    // Dedupe by pack id, keeping the last file's outcome (see doc above).
-    const dedupedById = new Map<string, { fileName: string; meta: I18nPackMeta }>()
-    for (const success of rawSuccesses) {
-      dedupedById.delete(success.meta.id)
-      dedupedById.set(success.meta.id, success)
-    }
-    const deduped = [...dedupedById.values()]
+      const hubSyncFailures: ImportBatchFailure[] = []
+      const successBadges: PackActionResult[] = []
+      for (const { fileName, meta } of deduped) {
+        let message = t('common.saved')
+        if (meta.hubPostId) {
+          const upd = await pushPackToHub(meta.id, meta.hubPostId)
+          if (upd.success) {
+            message = t('common.synced')
+          } else {
+            hubSyncFailures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+          }
+        }
+        successBadges.push({ id: meta.id, kind: 'success', message })
+      }
 
-    const successBadges: PackActionResult[] = []
-    for (const { fileName, meta } of deduped) {
-      let message = t('common.saved')
-      if (meta.hubPostId) {
-        const upd = await pushPackToHub(meta.id, meta.hubPostId)
-        if (upd.success) {
-          message = t('common.synced')
-        } else {
-          failures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+      if (deduped.length > 0) {
+        await placement.placeMany(
+          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+          beforeSnapshot,
+        )
+        setLastResult(successBadges)
+        // Mirror the single-file behaviour of switching the active
+        // language to the freshly imported pack — only when the batch
+        // collapsed to a single result; a 2+ batch has no single "the"
+        // import to activate, so the active language is left untouched.
+        if (deduped.length === 1) {
+          handleSelectLanguage(`pack:${deduped[0].meta.id}`)
         }
       }
-      successBadges.push({ id: meta.id, kind: 'success', message })
-    }
 
-    if (deduped.length > 0) {
-      await placement.placeMany(
-        deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-        beforeSnapshot,
-      )
-      setLastResult(successBadges)
-      // Mirror the single-file behaviour of switching the active
-      // language to the freshly imported pack, anchored on the last
-      // successfully imported (post-dedupe) file for a deterministic
-      // final state.
-      handleSelectLanguage(`pack:${deduped[deduped.length - 1].meta.id}`)
+      // Toolbar headline for a 2+ file batch only — a single-file
+      // import keeps its existing per-name "Imported {{name}}" /
+      // "Updated {{name}}" feedback via `placement.feedback` untouched.
+      const totalCount = deduped.length + notSavedFailures.length
+      if (totalCount >= 2) {
+        setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
+      }
+
+      const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
+      if (summary) setActionError(summary)
+    } finally {
+      importInFlightRef.current = false
+      setImporting(false)
     }
-    const summary = buildImportBatchFailureSummary(t, failures)
-    if (summary) setActionError(summary)
   }, [store, t, placement, importOnePack, pushPackToHub, handleSelectLanguage])
 
   const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
@@ -757,15 +802,16 @@ export function LanguagePacksModal({
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('i18n.import')}
       onImport={() => void handleImportFile()}
+      importDisabled={importing}
       sortButton={(
         <PackSortButton
           direction={nameSort.direction}
           onClick={handleSortByName}
-          disabled={nameSort.pending}
+          disabled={nameSort.pending || importing}
           testid="language-packs-sort-button"
         />
       )}
-      importFeedback={placement.feedback}
+      importFeedback={importSummary ?? placement.feedback}
       actionError={actionError}
       afterContent={(
         <MissingKeysModal
@@ -784,6 +830,7 @@ export function LanguagePacksModal({
               key={row.reactKey}
               row={row}
               pendingId={pendingId}
+              importing={importing}
               confirmDeleteId={confirmDeleteId}
               setConfirmDeleteId={setConfirmDeleteId}
               confirmRemoveId={confirmRemoveId}
@@ -823,6 +870,7 @@ export function LanguagePacksModal({
               key={row.reactKey}
               row={row}
               pendingId={pendingId}
+              importing={importing}
               onDownload={(postId) => void handleHubDownload(postId)}
             />
           )}

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -1174,6 +1174,37 @@ describe('LanguagePacksModal', () => {
     await waitFor(() => expect(renameFn).toHaveBeenCalledWith('r1', 'New Name'))
   })
 
+  it('P1-b: starting a rename then triggering an import cancels the edit instead of letting it commit mid-batch', async () => {
+    storeMetas = [meta({ id: 'r2', name: 'Old Name', matchedBaseVersion: '0.1.0' })]
+    let resolveDialog!: (value: { canceled: boolean; files: Array<{ filePath: string; raw?: unknown; parseError?: string }> }) => void
+    importFromDialog.mockImplementationOnce(() => new Promise((resolve) => { resolveDialog = resolve }))
+    render(
+      <LanguagePacksModal open onClose={vi.fn()} />,
+    )
+
+    fireEvent.click(screen.getByTestId('language-packs-name-r2'))
+    const input = screen.getByTestId('language-packs-rename-input-r2')
+    fireEvent.change(input, { target: { value: 'New Name' } })
+
+    // Trigger the import batch WITHOUT ever blurring the rename input —
+    // jsdom does not auto-blur an unrelated element on click the way a
+    // real browser does, so this specifically exercises the
+    // cancel-on-import-start effect rather than the (unpreventable)
+    // same-click blur race.
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+
+    // The edit was canceled, not left open and interactive for the
+    // duration of the batch.
+    expect(screen.queryByTestId('language-packs-rename-input-r2')).toBeNull()
+    expect(renameFn).not.toHaveBeenCalled()
+
+    resolveDialog({ canceled: true, files: [] })
+    await waitFor(() => expect((screen.getByTestId('language-packs-import-button') as HTMLButtonElement).disabled).toBe(false))
+    // Still never committed, even after the batch finished.
+    expect(renameFn).not.toHaveBeenCalled()
+  })
+
   it('open in browser calls openExternal for hub-linked row', async () => {
     storeMetas = [meta({ id: 'o1', name: 'Open Me', hubPostId: 'hp-o1' })]
     render(

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -7,6 +7,12 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       if (params && 'name' in params) return `${key}:${String(params.name)}`
+      // Surfaces the toolbar import summary's success/failure counts so
+      // tests can assert on them without a real i18next pluralization
+      // pipeline.
+      if (params && 'success' in params && 'failure' in params) {
+        return `${key}:${String(params.count)}:${String(params.success)}:${String(params.failure)}`
+      }
       return key
     },
   }),
@@ -560,6 +566,115 @@ describe('LanguagePacksModal', () => {
     fireEvent.click(screen.getByTestId('language-packs-import-button'))
     await waitFor(() => expect(screen.getByTestId('language-packs-result-b').textContent).toBe('common.saved'))
     expect(screen.getByTestId('language-packs-result-c').textContent).toBe('common.saved')
+  })
+
+  it('multi-file import (2+ files): does not auto-scroll, does not auto-select, and shows the toolbar summary instead of per-name feedback', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    const rawB = { name: 'Beta', version: '0.1.0', common: {} }
+    const rawC = { name: 'Gamma', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'gamma.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Gamma' })
+    applyImport
+      .mockImplementationOnce(async () => {
+        storeMetas = [...storeMetas, metaB]
+        return { success: true, meta: metaB }
+      })
+      .mockImplementationOnce(async () => {
+        storeMetas = [...storeMetas, metaC]
+        return { success: true, meta: metaC }
+      })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+    try {
+      fireEvent.click(screen.getByTestId('language-packs-import-button'))
+      await waitFor(() => expect(screen.getByTestId('language-packs-result-c').textContent).toBe('common.saved'))
+
+      // 2+ batch: no auto-scroll to an arbitrary one of the new rows.
+      expect(scrollIntoView).not.toHaveBeenCalled()
+      // 2+ batch: no auto-activation of an arbitrary one of the new packs.
+      expect(mockAppConfigSet).not.toHaveBeenCalled()
+      // The toolbar headline supersedes the per-name "Imported {{name}}"
+      // feedback for a 2+ batch: 2 processed, both saved, none failed.
+      expect(screen.getByTestId('language-packs-import-feedback').textContent).toBe('common.importSummary:2:2:0')
+    } finally {
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('partial-failure batch: a hub-sync failure still counts as a success in the summary headline, but appears in the failure banner', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    // `__invalid` triggers the mocked `validatePack`'s failure branch —
+    // this file never reaches `applyImport`, so it counts toward the
+    // headline's "failure" (not saved).
+    const rawBad = { name: 'Bad Pack', version: 'not-semver', __invalid: true }
+    const rawGood = { name: 'Existing Pack', version: '0.1.0', common: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'bad.json', raw: rawBad },
+        { filePath: 'my-upload.json', raw: rawGood },
+      ],
+    })
+    const savedMeta = meta({ id: 'e', name: 'Existing Pack', hubPostId: 'hub-1', matchedBaseVersion: '0.1.0' })
+    applyImport.mockImplementationOnce(async () => {
+      storeMetas = [...storeMetas, savedMeta]
+      return { success: true, meta: savedMeta }
+    })
+    vialAPI.hubUpdateI18nPost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('language-packs-result-e').textContent).toBe('common.saved'))
+
+    // Headline: 1 saved (the hub-sync failure doesn't reduce this — the
+    // file itself landed on disk) and 1 not-saved (the parse/validate
+    // failure) — 2 processed total.
+    expect(screen.getByTestId('language-packs-import-feedback').textContent).toBe('common.importSummary:2:1:1')
+
+    // The hub-sync failure still shows up in the failure banner text,
+    // alongside the parse failure.
+    const banner = screen.getByTestId('language-packs-error')
+    expect(banner.textContent).toContain('bad.json')
+    expect(banner.textContent).toContain('my-upload.json')
+    expect(banner.textContent).toContain('network error')
+  })
+
+  it('locks the Import button and existing row actions while a batch import is in flight', async () => {
+    storeMetas = [meta({ id: 'a', name: 'Alpha', matchedBaseVersion: '0.1.0' })]
+    let resolveDialog!: (value: { canceled: boolean; files: Array<{ filePath: string; raw?: unknown; parseError?: string }> }) => void
+    importFromDialog.mockImplementationOnce(() => new Promise((resolve) => { resolveDialog = resolve }))
+    render(<LanguagePacksModal open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+
+    // Mid-batch: the toolbar Import button and every existing row's
+    // controls lock via the `importing` prop propagating into `busy`.
+    expect((screen.getByTestId('language-packs-import-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('language-packs-sort-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('language-packs-select-a') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('language-packs-export-a') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('language-packs-delete-a') as HTMLButtonElement).disabled).toBe(true)
+    // `draggable={false}` renders with no `draggable` attribute at all
+    // (see `PackListRow`'s `dragProps`), same as the pre-load fallback's
+    // non-draggable row.
+    expect(screen.getByTestId('language-packs-row-a').getAttribute('draggable')).toBeNull()
+
+    // A second click while in flight is a no-op (the in-flight ref
+    // guard) — the dialog is not opened a second time.
+    fireEvent.click(screen.getByTestId('language-packs-import-button'))
+    expect(importFromDialog).toHaveBeenCalledTimes(1)
+
+    resolveDialog({ canceled: true, files: [] })
+    await waitFor(() => expect((screen.getByTestId('language-packs-import-button') as HTMLButtonElement).disabled).toBe(false))
   })
 
   it('partial-failure batch: the good file keeps its badge while the bad file is aggregated into one banner', async () => {

--- a/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
@@ -193,6 +193,7 @@ function InstalledRowView({
             name={row.name}
             editing={editing}
             canRename={canRename}
+            locked={importing}
             editLabel={rename.editLabel}
             onEditLabelChange={rename.setEditLabel}
             onBlur={() => void onRenameCommit(row.localId)}

--- a/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsInstalledTable.tsx
@@ -56,6 +56,11 @@ export interface HubRow {
 export interface InstalledTableProps {
   rows: InstalledRow[]
   pendingId: string | null
+  /** True while a multi-file import batch is in flight — locks every
+   *  row action, rename and drag so the list can't be mutated out from
+   *  under the batch's own placement/reorder call. Wired the same way
+   *  `pendingId` already gates a single op. */
+  importing: boolean
   confirmDeleteId: string | null
   setConfirmDeleteId: (id: string | null) => void
   confirmRemoveId: string | null
@@ -103,6 +108,7 @@ interface InstalledRowViewProps extends InstalledTableProps {
 function InstalledRowView({
   row,
   pendingId,
+  importing,
   confirmDeleteId,
   setConfirmDeleteId,
   confirmRemoveId,
@@ -128,12 +134,12 @@ function InstalledRowView({
   const { t } = useTranslation()
   const isMine = isOwnPack(row.hubPostId, row.author, currentDisplayName)
   const editing = rename.editingId === row.localId
-  const busy = pendingId !== null && pendingId === row.localId
+  const busy = (pendingId !== null && pendingId === row.localId) || importing
   const freshness = hubFreshness.get(row.localId)
   const hasUpdateAvailable = hasUpdate(freshness, row.meta?.hubUpdatedAt)
   const hubRemoved = !!freshness && freshness.removed
 
-  const canRename = isMine && !row.isQwerty
+  const canRename = isMine && !row.isQwerty && !importing
 
   const hubPostUrl = row.hubPostId && hubOrigin
     ? buildHubKeyLabelUrl(hubOrigin, row.hubPostId)
@@ -170,7 +176,7 @@ function InstalledRowView({
     <PackListRow
       testid={`key-labels-row-${row.localId}`}
       shape="sideColumn"
-      draggable
+      draggable={!importing}
       onDragStart={() => onDragStart(row.localId)}
       onDragOver={() => onDragOver(row.localId)}
       onDragEnd={() => { void onDragEnd() }}
@@ -290,16 +296,20 @@ export interface HubTableProps {
   rows: HubRow[]
   hubSearched: boolean
   pendingId: string | null
+  /** Defensive: the Hub tab isn't meant to be operable mid-import
+   *  either, even though its own actions don't touch the Installed
+   *  list directly. */
+  importing: boolean
   hubOrigin: string
   onDownload: (hubPostId: string) => void | Promise<void>
 }
 
-export function HubTable({ rows, hubSearched, pendingId, hubOrigin, onDownload }: HubTableProps): JSX.Element {
+export function HubTable({ rows, hubSearched, pendingId, importing, hubOrigin, onDownload }: HubTableProps): JSX.Element {
   const { t } = useTranslation()
   return (
     <div className="space-y-2 text-sm">
       {rows.map((row) => {
-        const busy = pendingId === row.hubPostId
+        const busy = pendingId === row.hubPostId || importing
         const openUrl = hubOrigin ? buildHubKeyLabelUrl(hubOrigin, row.hubPostId) : null
         return (
           <div

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -9,7 +9,7 @@
 // Wording (Upload/Update/Remove/Synced/Delete) mirrors the
 // favorite-store editors so the hub-aware modals stay consistent.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
@@ -73,14 +73,6 @@ export function KeyLabelsModal({
    * the start of the next operation.
    */
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
-  // Mirrors `importing` (from `useImportBatch`, defined further below)
-  // into a ref so `handleRenameCommit` can read its latest value the
-  // same way in all three pack modals — some of them define the rename
-  // handler before the `useImportBatch` call, where the `importing`
-  // state itself isn't in scope yet. Kept current via a plain
-  // assignment during render (the same "adjust a ref during render"
-  // pattern `useImportPlacement.ts` uses for its own always-latest refs).
-  const importingRef = useRef(false)
 
   // Key Labels fetches the Hub origin once on first mount, unlike the
   // i18n/theme pack modals which re-fetch each time the modal opens.
@@ -218,7 +210,7 @@ export function KeyLabelsModal({
     return null
   }, [labels, t, placement])
 
-  const { importing, importSummary, runImport } = useImportBatch<KeyLabelMeta>({
+  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<KeyLabelMeta>({
     open,
     placement,
     setLastResult,
@@ -235,12 +227,11 @@ export function KeyLabelsModal({
       return upd.success ? { success: true } : { success: false, error: translateError(t, upd.errorCode, upd.error) }
     },
   })
-  importingRef.current = importing
 
   // Closes any inline rename that was already open the moment a batch
   // starts, so its input unmounts instead of sitting there interactive
   // (and committable) for the whole duration of the import — see
-  // `handleRenameCommit`'s own `importingRef` guard below for the one
+  // `handleRenameCommit`'s own `isImportingRef` guard below for the one
   // race this cannot cover (a rename input's blur, and the click that
   // starts the batch, are the same user click; the blur's commit is
   // already in flight before `importing` ever flips true).
@@ -294,14 +285,23 @@ export function KeyLabelsModal({
   }, [labels, runWithPending, placement])
 
   const handleRenameCommit = useCallback(async (id: string) => {
-    // See the note above `importingRef`'s declaration: this cannot
-    // intercept a commit whose blur fired as part of the very click
-    // that started the batch (already in flight before `importing`
-    // flips true), but it does catch a rename left open from an
-    // already-running batch, and any stray commit that slips through
-    // after the cancel-on-import-start effect above has already reset
-    // the editor for this render.
-    if (importingRef.current) return
+    // Guards on `useImportBatch`'s own re-entrancy ref rather than a
+    // locally-mirrored one — written only inside an event handler
+    // (`runImport`), never during render, so it can't go stale under a
+    // discarded/interrupted concurrent render. Referencing
+    // `isImportingRef` here, defined further up via `useImportBatch`,
+    // is safe regardless: this callback's body only runs later, on a
+    // real blur/Enter event, well after the full render has finished.
+    //
+    // A rename already committed its `store.rename` call the instant
+    // the underlying input blurred — including the blur a click on the
+    // Import button itself triggers, which fires before that click's
+    // own handler runs — so this check cannot intercept that exact
+    // call. It DOES catch every other path: a rename input left open
+    // when a batch was already running, and any stray commit that
+    // slips through after the cancel-on-import-start effect above has
+    // already reset the editor for this render.
+    if (isImportingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -9,7 +9,7 @@
 // Wording (Upload/Update/Remove/Synced/Delete) mirrors the
 // favorite-store editors so the hub-aware modals stay consistent.
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
@@ -29,7 +29,7 @@ import { useNameSort } from '../pack-modal/useNameSort'
 import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { buildImportBatchFailureSummary, buildImportSummary, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { isOwnPack } from '../pack-modal/ownership'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
@@ -72,10 +72,30 @@ export function KeyLabelsModal({
    * the start of the next operation.
    */
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
+  // Locks the Installed list (rows, drag, rename, the Import/Sort
+  // buttons) while a multi-file import batch is running, so nothing can
+  // mutate the list out from under `placement.placeMany`'s own reorder
+  // call. `importInFlightRef` is the actual re-entrancy guard (checked
+  // synchronously, mirroring the keymap-apply latch) — `importing` just
+  // mirrors it into render so the disabled UI reflects it a frame
+  // sooner than a double-click could slip through.
+  const [importing, setImporting] = useState(false)
+  const importInFlightRef = useRef(false)
+  // Toolbar headline shown only for a 2+ file batch (see
+  // `handleImport`) — supersedes `placement.feedback`'s per-name
+  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
+  // below. Cleared at the start of the next import and on modal close;
+  // no auto-clear timer (unlike `placement.feedback`) since it is meant
+  // to persist as the batch's final word until the user acts again.
+  const [importSummary, setImportSummary] = useState<string | null>(null)
 
   // Key Labels fetches the Hub origin once on first mount, unlike the
   // i18n/theme pack modals which re-fetch each time the modal opens.
   const hubOrigin = useHubOrigin(open, { onlyOnce: true })
+
+  useEffect(() => {
+    if (!open) setImportSummary(null)
+  }, [open])
 
   const freshnessCandidates = useMemo(
     () => labels.metas
@@ -197,55 +217,81 @@ export function KeyLabelsModal({
   // up on disk — so hub-sync and the row badge only run/appear once
   // per id, not once per file.
   const handleImport = useCallback(async () => {
-    setActionError(null)
-    setLastResult(null)
-    const beforeSnapshot = placement.snapshotEntries()
-    const res = await labels.importFromFile()
-    if (res.success && res.data) {
-      const failures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
-        fileName: r.fileName,
-        reason: translateError(t, r.errorCode, r.error),
-      }))
+    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
+    // on Import before React re-renders the now-disabled button must
+    // not queue a second concurrent batch on top of the first.
+    if (importInFlightRef.current) return
+    importInFlightRef.current = true
+    setImporting(true)
+    try {
+      setActionError(null)
+      setLastResult(null)
+      setImportSummary(null)
+      const beforeSnapshot = placement.snapshotEntries()
+      const res = await labels.importFromFile()
+      if (res.success && res.data) {
+        // Kept separate from `hubSyncFailures` below: these are files
+        // that never actually landed on disk (main-side rejections),
+        // which is what the toolbar headline's "failure" count means —
+        // see `buildImportSummary`'s doc in import-batch-summary.ts.
+        const notSavedFailures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
+          fileName: r.fileName,
+          reason: translateError(t, r.errorCode, r.error),
+        }))
 
-      const dedupedById = new Map<string, { fileName: string; meta: KeyLabelMeta }>()
-      for (const success of res.data.imported) {
-        dedupedById.delete(success.meta.id)
-        dedupedById.set(success.meta.id, success)
-      }
-      const deduped = [...dedupedById.values()]
-
-      const successBadges: PackActionResult[] = []
-      for (const { fileName, meta } of deduped) {
-        let message = t('common.saved')
-        // Auto-sync overwrites of an already-uploaded entry so the Hub
-        // post stays consistent with the user's local edit. Promote the
-        // badge from "Saved" to "Synced" on success; a sync failure is
-        // folded into the same failure summary as import rejections
-        // (the file itself imported fine, only the Hub push failed) —
-        // reported against the originating filename, not the label's
-        // internal name.
-        if (meta.hubPostId) {
-          const upd = await labels.hubUpdate(meta.id)
-          if (upd.success) {
-            message = t('common.synced')
-          } else {
-            failures.push({ fileName, reason: translateError(t, upd.errorCode, upd.error) })
-          }
+        const dedupedById = new Map<string, { fileName: string; meta: KeyLabelMeta }>()
+        for (const success of res.data.imported) {
+          dedupedById.delete(success.meta.id)
+          dedupedById.set(success.meta.id, success)
         }
-        successBadges.push({ id: meta.id, kind: 'success', message })
-      }
+        const deduped = [...dedupedById.values()]
 
-      if (deduped.length > 0) {
-        await placement.placeMany(
-          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-          beforeSnapshot,
-        )
-        setLastResult(successBadges)
+        const hubSyncFailures: ImportBatchFailure[] = []
+        const successBadges: PackActionResult[] = []
+        for (const { fileName, meta } of deduped) {
+          let message = t('common.saved')
+          // Auto-sync overwrites of an already-uploaded entry so the Hub
+          // post stays consistent with the user's local edit. Promote the
+          // badge from "Saved" to "Synced" on success; a sync failure is
+          // folded into the same failure summary as import rejections
+          // (the file itself imported fine, only the Hub push failed) —
+          // reported against the originating filename, not the label's
+          // internal name.
+          if (meta.hubPostId) {
+            const upd = await labels.hubUpdate(meta.id)
+            if (upd.success) {
+              message = t('common.synced')
+            } else {
+              hubSyncFailures.push({ fileName, reason: translateError(t, upd.errorCode, upd.error) })
+            }
+          }
+          successBadges.push({ id: meta.id, kind: 'success', message })
+        }
+
+        if (deduped.length > 0) {
+          await placement.placeMany(
+            deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+            beforeSnapshot,
+          )
+          setLastResult(successBadges)
+        }
+
+        // Toolbar headline for a 2+ file batch only — a single-file
+        // import keeps its existing per-name "Imported {{name}}" /
+        // "Updated {{name}}" feedback via `placement.feedback` untouched.
+        const totalCount = deduped.length + notSavedFailures.length
+        if (totalCount >= 2) {
+          setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
+        }
+
+        const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
+        if (summary) setActionError(summary)
+      } else if (res.error && res.error !== 'cancelled') {
+        setActionError(translateError(t, res.errorCode, res.error))
       }
-      const summary = buildImportBatchFailureSummary(t, failures)
-      if (summary) setActionError(summary)
-    } else if (res.error && res.error !== 'cancelled') {
-      setActionError(translateError(t, res.errorCode, res.error))
+    } finally {
+      importInFlightRef.current = false
+      setImporting(false)
     }
   }, [labels, t, placement])
 
@@ -360,21 +406,23 @@ export function KeyLabelsModal({
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('keyLabels.import')}
       onImport={() => void handleImport()}
+      importDisabled={importing}
       sortButton={(
         <PackSortButton
           direction={nameSort.direction}
           onClick={handleSortByName}
-          disabled={nameSort.pending}
+          disabled={nameSort.pending || importing}
           testid="key-labels-sort-button"
         />
       )}
-      importFeedback={placement.feedback}
+      importFeedback={importSummary ?? placement.feedback}
       actionError={actionError}
     >
       {activeTab === 'installed' ? (
         <InstalledTable
           rows={installedRows}
           pendingId={pendingId}
+          importing={importing}
           confirmDeleteId={confirmDeleteId}
           setConfirmDeleteId={setConfirmDeleteId}
           confirmRemoveId={confirmRemoveId}
@@ -453,6 +501,7 @@ export function KeyLabelsModal({
           rows={hubRows}
           hubSearched={hubSearched}
           pendingId={pendingId}
+          importing={importing}
           hubOrigin={hubOrigin}
           onDownload={(hubPostId) => handleHubDownload(hubPostId)}
         />

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -9,7 +9,7 @@
 // Wording (Upload/Update/Remove/Synced/Delete) mirrors the
 // favorite-store editors so the hub-aware modals stay consistent.
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
@@ -73,6 +73,14 @@ export function KeyLabelsModal({
    * the start of the next operation.
    */
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
+  // Mirrors `importing` (from `useImportBatch`, defined further below)
+  // into a ref so `handleRenameCommit` can read its latest value the
+  // same way in all three pack modals — some of them define the rename
+  // handler before the `useImportBatch` call, where the `importing`
+  // state itself isn't in scope yet. Kept current via a plain
+  // assignment during render (the same "adjust a ref during render"
+  // pattern `useImportPlacement.ts` uses for its own always-latest refs).
+  const importingRef = useRef(false)
 
   // Key Labels fetches the Hub origin once on first mount, unlike the
   // i18n/theme pack modals which re-fetch each time the modal opens.
@@ -227,6 +235,21 @@ export function KeyLabelsModal({
       return upd.success ? { success: true } : { success: false, error: translateError(t, upd.errorCode, upd.error) }
     },
   })
+  importingRef.current = importing
+
+  // Closes any inline rename that was already open the moment a batch
+  // starts, so its input unmounts instead of sitting there interactive
+  // (and committable) for the whole duration of the import — see
+  // `handleRenameCommit`'s own `importingRef` guard below for the one
+  // race this cannot cover (a rename input's blur, and the click that
+  // starts the batch, are the same user click; the blur's commit is
+  // already in flight before `importing` ever flips true).
+  useEffect(() => {
+    if (importing) rename.cancelRename()
+    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
+    // intentionally not in the deps array so this only re-fires when
+    // `importing` itself flips, not on every unrelated render.
+  }, [importing])
 
   const runWithPending = useCallback(async <T,>(
     id: string,
@@ -271,6 +294,14 @@ export function KeyLabelsModal({
   }, [labels, runWithPending, placement])
 
   const handleRenameCommit = useCallback(async (id: string) => {
+    // See the note above `importingRef`'s declaration: this cannot
+    // intercept a commit whose blur fired as part of the very click
+    // that started the batch (already in flight before `importing`
+    // flips true), but it does catch a rename left open from an
+    // already-running batch, and any stray commit that slips through
+    // after the cancel-on-import-start effect above has already reset
+    // the editor for this render.
+    if (importingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -9,7 +9,7 @@
 // Wording (Upload/Update/Remove/Synced/Delete) mirrors the
 // favorite-store editors so the hub-aware modals stay consistent.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TFunction } from 'i18next'
 import { useEscapeClose } from '../../hooks/useEscapeClose'
@@ -29,7 +29,8 @@ import { useNameSort } from '../pack-modal/useNameSort'
 import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, buildImportSummary, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { useImportBatch, type CollectedImportBatch } from '../pack-modal/useImportBatch'
+import type { ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { isOwnPack } from '../pack-modal/ownership'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
@@ -72,30 +73,10 @@ export function KeyLabelsModal({
    * the start of the next operation.
    */
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
-  // Locks the Installed list (rows, drag, rename, the Import/Sort
-  // buttons) while a multi-file import batch is running, so nothing can
-  // mutate the list out from under `placement.placeMany`'s own reorder
-  // call. `importInFlightRef` is the actual re-entrancy guard (checked
-  // synchronously, mirroring the keymap-apply latch) — `importing` just
-  // mirrors it into render so the disabled UI reflects it a frame
-  // sooner than a double-click could slip through.
-  const [importing, setImporting] = useState(false)
-  const importInFlightRef = useRef(false)
-  // Toolbar headline shown only for a 2+ file batch (see
-  // `handleImport`) — supersedes `placement.feedback`'s per-name
-  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
-  // below. Cleared at the start of the next import and on modal close;
-  // no auto-clear timer (unlike `placement.feedback`) since it is meant
-  // to persist as the batch's final word until the user acts again.
-  const [importSummary, setImportSummary] = useState<string | null>(null)
 
   // Key Labels fetches the Hub origin once on first mount, unlike the
   // i18n/theme pack modals which re-fetch each time the modal opens.
   const hubOrigin = useHubOrigin(open, { onlyOnce: true })
-
-  useEffect(() => {
-    if (!open) setImportSummary(null)
-  }, [open])
 
   const freshnessCandidates = useMemo(
     () => labels.metas
@@ -201,99 +182,51 @@ export function KeyLabelsModal({
   )
 
   // Multi-file import batch. All of the batch's writes already land on
-  // disk in one `importFromFile()` IPC round trip, so `beforeSnapshot`
-  // (entries + sort direction) captured once up front is the correct
-  // "before the user's action" baseline for every result regardless of
-  // processing order — even if the user flips the Name-sort toggle
-  // while the batch is running. The actual list placement happens in
-  // ONE `placement.placeMany` call at the end — see the RAPID-INSERT
-  // RACE and DIRECTION RACE notes in useImportPlacement.ts for why
-  // calling `place()` once per file (the original approach) could
-  // compute a later file's position from a stale/inconsistent snapshot
-  // and silently drop an earlier file's id from the persisted order, or
-  // merge against the wrong direction. Two files resolving to the same
-  // label (main's overwrite-by-name reuses the same id) are deduped,
-  // keeping only the last file's outcome — that's what actually ended
-  // up on disk — so hub-sync and the row badge only run/appear once
-  // per id, not once per file.
-  const handleImport = useCallback(async () => {
-    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
-    // on Import before React re-renders the now-disabled button must
-    // not queue a second concurrent batch on top of the first.
-    if (importInFlightRef.current) return
-    importInFlightRef.current = true
-    setImporting(true)
-    try {
-      setActionError(null)
-      setLastResult(null)
-      setImportSummary(null)
-      const beforeSnapshot = placement.snapshotEntries()
-      const res = await labels.importFromFile()
-      if (res.success && res.data) {
-        // Kept separate from `hubSyncFailures` below: these are files
-        // that never actually landed on disk (main-side rejections),
-        // which is what the toolbar headline's "failure" count means —
-        // see `buildImportSummary`'s doc in import-batch-summary.ts.
-        const notSavedFailures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
-          fileName: r.fileName,
-          reason: translateError(t, r.errorCode, r.error),
-        }))
-
-        const dedupedById = new Map<string, { fileName: string; meta: KeyLabelMeta }>()
-        for (const success of res.data.imported) {
-          dedupedById.delete(success.meta.id)
-          dedupedById.set(success.meta.id, success)
-        }
-        const deduped = [...dedupedById.values()]
-
-        const hubSyncFailures: ImportBatchFailure[] = []
-        const successBadges: PackActionResult[] = []
-        for (const { fileName, meta } of deduped) {
-          let message = t('common.saved')
-          // Auto-sync overwrites of an already-uploaded entry so the Hub
-          // post stays consistent with the user's local edit. Promote the
-          // badge from "Saved" to "Synced" on success; a sync failure is
-          // folded into the same failure summary as import rejections
-          // (the file itself imported fine, only the Hub push failed) —
-          // reported against the originating filename, not the label's
-          // internal name.
-          if (meta.hubPostId) {
-            const upd = await labels.hubUpdate(meta.id)
-            if (upd.success) {
-              message = t('common.synced')
-            } else {
-              hubSyncFailures.push({ fileName, reason: translateError(t, upd.errorCode, upd.error) })
-            }
-          }
-          successBadges.push({ id: meta.id, kind: 'success', message })
-        }
-
-        if (deduped.length > 0) {
-          await placement.placeMany(
-            deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-            beforeSnapshot,
-          )
-          setLastResult(successBadges)
-        }
-
-        // Toolbar headline for a 2+ file batch only — a single-file
-        // import keeps its existing per-name "Imported {{name}}" /
-        // "Updated {{name}}" feedback via `placement.feedback` untouched.
-        const totalCount = deduped.length + notSavedFailures.length
-        if (totalCount >= 2) {
-          setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
-        }
-
-        const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
-        if (summary) setActionError(summary)
-      } else if (res.error && res.error !== 'cancelled') {
-        setActionError(translateError(t, res.errorCode, res.error))
-      }
-    } finally {
-      importInFlightRef.current = false
-      setImporting(false)
+  // disk in one `importFromFile()` IPC round trip, so the snapshot
+  // captured immediately before that call is the correct "before the
+  // user's action" baseline for every result regardless of processing
+  // order — even if the user flips the Name-sort toggle while the
+  // batch is running. Dedupe, hub-sync, placement and the toolbar
+  // summary/failure banner are handled by the shared `useImportBatch`
+  // hook below (see its module doc for the extraction rationale).
+  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<KeyLabelMeta> | null> => {
+    const snapshot = placement.snapshotEntries()
+    const res = await labels.importFromFile()
+    if (res.success && res.data) {
+      // Kept separate from the hook's own hub-sync failures: these are
+      // files that never actually landed on disk (main-side
+      // rejections), which is what the toolbar headline's "failure"
+      // count means — see `buildImportSummary`'s doc in
+      // import-batch-summary.ts.
+      const notSavedFailures: ImportBatchFailure[] = res.data.rejections.map((r) => ({
+        fileName: r.fileName,
+        reason: translateError(t, r.errorCode, r.error),
+      }))
+      return { successes: res.data.imported, notSavedFailures, snapshot }
     }
+    if (res.error && res.error !== 'cancelled') {
+      setActionError(translateError(t, res.errorCode, res.error))
+    }
+    return null
   }, [labels, t, placement])
+
+  const { importing, importSummary, runImport } = useImportBatch<KeyLabelMeta>({
+    open,
+    placement,
+    setLastResult,
+    setActionError,
+    t,
+    collectResults: collectImportResults,
+    // Auto-sync overwrites of an already-uploaded entry so the Hub post
+    // stays consistent with the user's local edit. A sync failure is
+    // folded into the same failure summary as import rejections (the
+    // file itself imported fine, only the Hub push failed) — reported
+    // against the originating filename, not the label's internal name.
+    hubSync: async (meta) => {
+      const upd = await labels.hubUpdate(meta.id)
+      return upd.success ? { success: true } : { success: false, error: translateError(t, upd.errorCode, upd.error) }
+    },
+  })
 
   const runWithPending = useCallback(async <T,>(
     id: string,
@@ -405,7 +338,7 @@ export function KeyLabelsModal({
       searchButtonLabel={hubSearching ? t('keyLabels.searching') : t('keyLabels.search')}
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('keyLabels.import')}
-      onImport={() => void handleImport()}
+      onImport={() => void runImport()}
       importDisabled={importing}
       sortButton={(
         <PackSortButton

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -9,6 +9,12 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       if (params && 'name' in params) return `${key}:${String(params.name)}`
+      // Surfaces the toolbar import summary's success/failure counts so
+      // tests can assert on them without a real i18next pluralization
+      // pipeline.
+      if (params && 'success' in params && 'failure' in params) {
+        return `${key}:${String(params.count)}:${String(params.success)}:${String(params.failure)}`
+      }
       return key
     },
   }),
@@ -559,6 +565,91 @@ describe('KeyLabelsModal', () => {
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => expect(screen.getByTestId('key-labels-result-b').textContent).toBe('common.saved'))
     expect(screen.getByTestId('key-labels-result-c').textContent).toBe('common.saved')
+  })
+
+  it('multi-file import (2+ files): does not auto-scroll and shows the toolbar summary instead of per-name feedback', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    const newMetaB = meta({ id: 'b', name: 'Beta' })
+    const newMetaC = meta({ id: 'c', name: 'Gamma' })
+    importFromFile.mockImplementationOnce(async () => {
+      metas = [...metas, newMetaB, newMetaC]
+      return {
+        success: true,
+        data: {
+          imported: [
+            { fileName: 'beta.json', meta: newMetaB },
+            { fileName: 'gamma.json', meta: newMetaC },
+          ],
+          rejections: [],
+        },
+      }
+    })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+    try {
+      fireEvent.click(screen.getByTestId('key-labels-import-button'))
+      await waitFor(() => expect(screen.getByTestId('key-labels-result-c').textContent).toBe('common.saved'))
+
+      // 2+ batch: no auto-scroll to an arbitrary one of the new rows.
+      expect(scrollIntoView).not.toHaveBeenCalled()
+      // The toolbar headline supersedes the per-name "Imported {{name}}"
+      // feedback for a 2+ batch: 2 processed, both saved, none rejected.
+      expect(screen.getByTestId('key-labels-import-feedback').textContent).toBe('common.importSummary:2:2:0')
+    } finally {
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('partial-failure batch: a hub-sync failure still counts as a success in the summary headline, but appears in the failure banner', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    const savedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
+    importFromFile.mockResolvedValueOnce({
+      success: true,
+      data: {
+        imported: [{ fileName: 'existing.json', meta: savedMeta }],
+        rejections: [{ fileName: 'broken.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' }],
+      },
+    })
+    hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
+
+    // Headline: 1 saved (the hub-sync failure doesn't reduce this — the
+    // file itself landed on disk) and 1 not-saved (the main-side
+    // rejection) — 2 processed total.
+    await waitFor(() => expect(screen.getByTestId('key-labels-import-feedback').textContent).toBe('common.importSummary:2:1:1'))
+
+    const banner = screen.getByTestId('key-labels-error')
+    expect(banner.textContent).toContain('broken.json')
+    expect(banner.textContent).toContain('existing.json')
+    expect(banner.textContent).toContain('network error')
+  })
+
+  it('locks the Import button and existing row actions while a batch import is in flight', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha', uploaderName: 'me' })]
+    let resolveImport!: (value: { success: boolean; data?: { imported: unknown[]; rejections: unknown[] } }) => void
+    importFromFile.mockImplementationOnce(() => new Promise((resolve) => { resolveImport = resolve }))
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(importFromFile).toHaveBeenCalled())
+
+    expect((screen.getByTestId('key-labels-import-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('key-labels-sort-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('key-labels-upload-a') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('key-labels-delete-a') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('key-labels-row-a').getAttribute('draggable')).toBeNull()
+
+    // A second click while in flight is a no-op (the in-flight ref
+    // guard) — the import dialog is not opened a second time.
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    expect(importFromFile).toHaveBeenCalledTimes(1)
+
+    resolveImport({ success: false, data: undefined })
+    await waitFor(() => expect((screen.getByTestId('key-labels-import-button') as HTMLButtonElement).disabled).toBe(false))
   })
 
   it('P1 fix: importing files that interleave with existing rows (existing A,D; import B,C) lands fully sorted A,B,C,D in one reorder call', async () => {

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -424,6 +424,35 @@ describe('KeyLabelsModal', () => {
     await waitFor(() => expect(importFromFile).toHaveBeenCalled())
   })
 
+  it('P1-b: starting a rename then triggering an import cancels the edit instead of letting it commit mid-batch', async () => {
+    metas = [meta({ id: 'r2', name: 'Old Name', uploaderName: 'me' })]
+    let resolveImport!: (value: { success: boolean; data?: { imported: unknown[]; rejections: unknown[] } }) => void
+    importFromFile.mockImplementationOnce(() => new Promise((resolve) => { resolveImport = resolve }))
+    render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
+
+    fireEvent.click(screen.getByTestId('key-labels-name-r2'))
+    const input = screen.getByTestId('key-labels-rename-input-r2')
+    fireEvent.change(input, { target: { value: 'New Name' } })
+
+    // Trigger the import batch WITHOUT ever blurring the rename input —
+    // jsdom does not auto-blur an unrelated element on click the way a
+    // real browser does, so this specifically exercises the
+    // cancel-on-import-start effect rather than the (unpreventable)
+    // same-click blur race.
+    fireEvent.click(screen.getByTestId('key-labels-import-button'))
+    await waitFor(() => expect(importFromFile).toHaveBeenCalled())
+
+    // The edit was canceled, not left open and interactive for the
+    // duration of the batch.
+    expect(screen.queryByTestId('key-labels-rename-input-r2')).toBeNull()
+    expect(renameFn).not.toHaveBeenCalled()
+
+    resolveImport({ success: false, data: undefined })
+    await waitFor(() => expect((screen.getByTestId('key-labels-import-button') as HTMLButtonElement).disabled).toBe(false))
+    // Still never committed, even after the batch finished.
+    expect(renameFn).not.toHaveBeenCalled()
+  })
+
   // --- Import/download placement + toolbar feedback + auto-scroll ---
 
   it('asc state: a new import is inserted at its sorted position via reorder, including QWERTY in scope', async () => {

--- a/src/renderer/components/pack-modal/PackManagerModal.tsx
+++ b/src/renderer/components/pack-modal/PackManagerModal.tsx
@@ -51,6 +51,10 @@ export interface PackManagerModalProps {
   searchDisabled: boolean
   importLabel: string
   onImport: () => void
+  /** Disables the Import button while a batch import is already in
+   *  flight — every modal passes its own `importing` state so a
+   *  double-click can't queue a second concurrent batch. */
+  importDisabled?: boolean
   /** "Name" sort toggle rendered at the left end of the Installed
    *  toolbar, opposite Import. Required — all three modals have one. */
   sortButton: ReactNode
@@ -82,6 +86,7 @@ export function PackManagerModal({
   searchDisabled,
   importLabel,
   onImport,
+  importDisabled,
   sortButton,
   importFeedback,
   actionError,
@@ -160,7 +165,8 @@ export function PackManagerModal({
             <button
               type="button"
               onClick={onImport}
-              className="shrink-0 rounded border border-edge bg-surface px-3 py-1.5 text-sm font-medium text-content hover:bg-surface-hover"
+              disabled={importDisabled}
+              className="shrink-0 rounded border border-edge bg-surface px-3 py-1.5 text-sm font-medium text-content hover:bg-surface-hover disabled:opacity-50"
               data-testid={testids.importButton}
             >
               {importLabel}

--- a/src/renderer/components/pack-modal/PackNameCell.tsx
+++ b/src/renderer/components/pack-modal/PackNameCell.tsx
@@ -8,6 +8,15 @@ export interface PackNameCellProps {
   /** True when this row supports the click-to-rename interaction
    * (false for built-in / QWERTY / not-mine rows). */
   canRename: boolean
+  /** True while a multi-file import batch is running. `canRename`
+   *  already stops a NEW rename from starting during import (each call
+   *  site ANDs its own condition with `!importing`), but an edit that
+   *  was already open when the batch started stays mounted — this
+   *  makes ITS input read-only for the duration, on top of the
+   *  modal-level guards that stop its commit from reaching the store
+   *  (see `handleRenameCommit`'s `importingRef` check and the
+   *  cancel-on-import-start effect in each pack modal). */
+  locked: boolean
   editLabel: string
   onEditLabelChange: (value: string) => void
   onBlur: () => void
@@ -27,6 +36,7 @@ export function PackNameCell({
   name,
   editing,
   canRename,
+  locked,
   editLabel,
   onEditLabelChange,
   onBlur,
@@ -46,6 +56,7 @@ export function PackNameCell({
         onBlur={onBlur}
         onKeyDown={onKeyDown}
         maxLength={maxLength}
+        readOnly={locked}
         className="w-full border-b border-edge bg-transparent px-1 text-sm text-content focus:outline-none focus:border-accent"
         data-testid={inputTestid}
       />

--- a/src/renderer/components/pack-modal/__tests__/PackManagerModal.test.tsx
+++ b/src/renderer/components/pack-modal/__tests__/PackManagerModal.test.tsx
@@ -123,6 +123,16 @@ describe('PackManagerModal', () => {
     expect(onImport).toHaveBeenCalled()
   })
 
+  it('disables the Import button when importDisabled is set (locks the toolbar mid-batch)', () => {
+    renderShell({ activeTab: 'installed', importDisabled: true })
+    expect((screen.getByTestId('test-import-button') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('leaves the Import button enabled when importDisabled is omitted', () => {
+    renderShell({ activeTab: 'installed' })
+    expect((screen.getByTestId('test-import-button') as HTMLButtonElement).disabled).toBe(false)
+  })
+
   it('shows the error banner with its testid when actionError is set', () => {
     renderShell({ actionError: 'Something broke' })
     expect(screen.getByTestId('test-error').textContent).toBe('Something broke')

--- a/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { TFunction } from 'i18next'
+import { useImportBatch, type CollectedImportBatch } from '../useImportBatch'
+import type { UseImportPlacementResult } from '../useImportPlacement'
+
+interface FakeMeta {
+  id: string
+  name: string
+  hubPostId?: string
+}
+
+// Mirrors the modal tests' fake `t`: surfaces the toolbar summary's
+// success/failure counts (and the interpolated `name`) without a real
+// i18next pluralization pipeline.
+const t = ((key: string, params?: Record<string, unknown>) => {
+  if (params && 'success' in params && 'failure' in params) {
+    return `${key}:${String(params.count)}:${String(params.success)}:${String(params.failure)}`
+  }
+  if (params && 'name' in params) return `${key}:${String(params.name)}`
+  return key
+}) as unknown as TFunction
+
+function makePlacement(): UseImportPlacementResult {
+  return {
+    feedback: null,
+    snapshotBeforeIds: () => new Set(),
+    snapshotEntries: () => ({ entries: [], direction: 'asc' }),
+    place: vi.fn().mockResolvedValue(undefined),
+    placeMany: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('useImportBatch', () => {
+  it('a batch that collapses to one result: hub-syncs, places, sets lastResult, and fires onCollapsedToOne — no toolbar summary', async () => {
+    const placement = makePlacement()
+    const setLastResult = vi.fn()
+    const setActionError = vi.fn()
+    const onCollapsedToOne = vi.fn()
+    const hubSync = vi.fn().mockResolvedValue({ success: true })
+    const collectResults = vi.fn().mockResolvedValue({
+      successes: [{ fileName: 'alpha.json', meta: { id: 'a', name: 'Alpha', hubPostId: 'hp1' } }],
+      notSavedFailures: [],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult,
+      setActionError,
+      t,
+      collectResults,
+      hubSync,
+      onCollapsedToOne,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    expect(hubSync).toHaveBeenCalledWith({ id: 'a', name: 'Alpha', hubPostId: 'hp1' })
+    expect(placement.placeMany).toHaveBeenCalledWith(
+      [{ id: 'a', name: 'Alpha' }],
+      { entries: [], direction: 'asc' },
+    )
+    expect(setLastResult).toHaveBeenCalledWith([{ id: 'a', kind: 'success', message: 'common.synced' }])
+    expect(onCollapsedToOne).toHaveBeenCalledWith({ id: 'a', name: 'Alpha', hubPostId: 'hp1' })
+    expect(setActionError).toHaveBeenCalledWith(null)
+    // Below the 2-file threshold — the per-name `placement.feedback`
+    // text (not exercised by this hook) is what the modal shows instead.
+    expect(result.current.importSummary).toBeNull()
+    expect(result.current.importing).toBe(false)
+  })
+
+  it('dedupes same-id results keeping the last file, shows the 2+ batch summary, and skips onCollapsedToOne', async () => {
+    const placement = makePlacement()
+    const setLastResult = vi.fn()
+    const onCollapsedToOne = vi.fn()
+    const collectResults = vi.fn().mockResolvedValue({
+      successes: [
+        { fileName: 'first.json', meta: { id: 'x', name: 'First' } },
+        // Same id as above (e.g. same name auto-overwrite) — only this
+        // later outcome should survive.
+        { fileName: 'second.json', meta: { id: 'x', name: 'Second' } },
+        { fileName: 'third.json', meta: { id: 'y', name: 'Third' } },
+      ],
+      notSavedFailures: [],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult,
+      setActionError: vi.fn(),
+      t,
+      collectResults,
+      onCollapsedToOne,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    expect(placement.placeMany).toHaveBeenCalledWith(
+      [{ id: 'x', name: 'Second' }, { id: 'y', name: 'Third' }],
+      { entries: [], direction: 'asc' },
+    )
+    expect(setLastResult).toHaveBeenCalledWith([
+      { id: 'x', kind: 'success', message: 'common.saved' },
+      { id: 'y', kind: 'success', message: 'common.saved' },
+    ])
+    expect(onCollapsedToOne).not.toHaveBeenCalled()
+    expect(result.current.importSummary).toBe('common.importSummary:2:2:0')
+  })
+
+  it('re-entrancy: a second call while a batch is in flight does not run collectResults again', async () => {
+    let resolveCollect!: (value: CollectedImportBatch<FakeMeta> | null) => void
+    const collectResults = vi.fn(() => new Promise<CollectedImportBatch<FakeMeta> | null>((resolve) => { resolveCollect = resolve }))
+    const placement = makePlacement()
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult: vi.fn(),
+      setActionError: vi.fn(),
+      t,
+      collectResults,
+    }))
+
+    let firstCall!: Promise<void>
+    let secondCall!: Promise<void>
+    act(() => {
+      firstCall = result.current.runImport()
+      secondCall = result.current.runImport()
+    })
+    expect(result.current.importing).toBe(true)
+    expect(collectResults).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveCollect(null)
+      await firstCall
+      await secondCall
+    })
+    expect(result.current.importing).toBe(false)
+  })
+
+  it('a canceled/empty batch (collectResults returns null) is a no-op: no placement, no lastResult, no summary', async () => {
+    const placement = makePlacement()
+    const setLastResult = vi.fn()
+    const setActionError = vi.fn()
+    const collectResults = vi.fn().mockResolvedValue(null)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult,
+      setActionError,
+      t,
+      collectResults,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    expect(placement.placeMany).not.toHaveBeenCalled()
+    // Only the "clear previous state" call at the start of the batch —
+    // never called again with an actual result.
+    expect(setLastResult).toHaveBeenCalledTimes(1)
+    expect(setLastResult).toHaveBeenCalledWith(null)
+    expect(result.current.importSummary).toBeNull()
+    expect(result.current.importing).toBe(false)
+  })
+
+  it('splits failures: a hub-sync failure still counts toward the summary\'s success total, but lands in the error banner, not the headline', async () => {
+    const placement = makePlacement()
+    const setActionError = vi.fn()
+    const hubSync = vi.fn().mockResolvedValue({ success: false, error: 'network down' })
+    const collectResults = vi.fn().mockResolvedValue({
+      successes: [{ fileName: 'good.json', meta: { id: 'g', name: 'Good', hubPostId: 'hp' } }],
+      notSavedFailures: [{ fileName: 'bad.json', reason: 'parse error' }],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult: vi.fn(),
+      setActionError,
+      t,
+      collectResults,
+      hubSync,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    // 1 saved (the hub-sync failure doesn't reduce this — the file
+    // itself landed on disk) + 1 not-saved (the parse failure).
+    expect(result.current.importSummary).toBe('common.importSummary:2:1:1')
+    const banner = setActionError.mock.calls.at(-1)?.[0] as string
+    expect(banner).toContain('bad.json')
+    expect(banner).toContain('parse error')
+    expect(banner).toContain('good.json')
+    expect(banner).toContain('network down')
+  })
+
+  it('a meta with no hubPostId never invokes hubSync, even when one is provided', async () => {
+    const placement = makePlacement()
+    const hubSync = vi.fn()
+    const collectResults = vi.fn().mockResolvedValue({
+      successes: [{ fileName: 'a.json', meta: { id: 'a', name: 'Alpha' } }],
+      notSavedFailures: [],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult: vi.fn(),
+      setActionError: vi.fn(),
+      t,
+      collectResults,
+      hubSync,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    expect(hubSync).not.toHaveBeenCalled()
+  })
+
+  it('clears the toolbar summary immediately on close, mirroring useImportPlacement\'s own open-gated resets', async () => {
+    const placement = makePlacement()
+    const collectResults = vi.fn().mockResolvedValue({
+      successes: [
+        { fileName: 'a.json', meta: { id: 'a', name: 'Alpha' } },
+        { fileName: 'b.json', meta: { id: 'b', name: 'Bravo' } },
+      ],
+      notSavedFailures: [],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) => useImportBatch<FakeMeta>({
+        open,
+        placement,
+        setLastResult: vi.fn(),
+        setActionError: vi.fn(),
+        t,
+        collectResults,
+      }),
+      { initialProps: { open: true } },
+    )
+
+    await act(async () => { await result.current.runImport() })
+    expect(result.current.importSummary).toBe('common.importSummary:2:2:0')
+
+    act(() => { rerender({ open: false }) })
+    expect(result.current.importSummary).toBeNull()
+  })
+})

--- a/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
@@ -61,9 +61,13 @@ describe('useImportBatch', () => {
     await act(async () => { await result.current.runImport() })
 
     expect(hubSync).toHaveBeenCalledWith({ id: 'a', name: 'Alpha', hubPostId: 'hp1' })
+    // Third arg is the pre-dedupe original success count (1 here) — see
+    // the P1 fix note: it drives `placeMany`'s own scroll suppression
+    // and must never be inferred from the deduped `results` array.
     expect(placement.placeMany).toHaveBeenCalledWith(
       [{ id: 'a', name: 'Alpha' }],
       { entries: [], direction: 'asc' },
+      1,
     )
     expect(setLastResult).toHaveBeenCalledWith([{ id: 'a', kind: 'success', message: 'common.synced' }])
     expect(onCollapsedToOne).toHaveBeenCalledWith({ id: 'a', name: 'Alpha', hubPostId: 'hp1' })
@@ -74,7 +78,7 @@ describe('useImportBatch', () => {
     expect(result.current.importing).toBe(false)
   })
 
-  it('dedupes same-id results keeping the last file, shows the 2+ batch summary, and skips onCollapsedToOne', async () => {
+  it('dedupes same-id results keeping the last file for placement/hub-sync, but the summary and scroll signal still use the original pre-dedupe count', async () => {
     const placement = makePlacement()
     const setLastResult = vi.fn()
     const onCollapsedToOne = vi.fn()
@@ -82,7 +86,7 @@ describe('useImportBatch', () => {
       successes: [
         { fileName: 'first.json', meta: { id: 'x', name: 'First' } },
         // Same id as above (e.g. same name auto-overwrite) — only this
-        // later outcome should survive.
+        // later outcome should survive in `deduped`.
         { fileName: 'second.json', meta: { id: 'x', name: 'Second' } },
         { fileName: 'third.json', meta: { id: 'y', name: 'Third' } },
       ],
@@ -102,15 +106,64 @@ describe('useImportBatch', () => {
 
     await act(async () => { await result.current.runImport() })
 
+    // Placement/reorder still operates on the deduped, one-per-id list
+    // — but the 3rd arg (originalCount) is 3, the true pre-dedupe file
+    // count, not `deduped.length` (2).
     expect(placement.placeMany).toHaveBeenCalledWith(
       [{ id: 'x', name: 'Second' }, { id: 'y', name: 'Third' }],
       { entries: [], direction: 'asc' },
+      3,
     )
     expect(setLastResult).toHaveBeenCalledWith([
       { id: 'x', kind: 'success', message: 'common.saved' },
       { id: 'y', kind: 'success', message: 'common.saved' },
     ])
     expect(onCollapsedToOne).not.toHaveBeenCalled()
+    // 3 successes (pre-dedupe), 0 failures — not "2:2:0" from
+    // `deduped.length`.
+    expect(result.current.importSummary).toBe('common.importSummary:3:3:0')
+  })
+
+  it('P1-a regression: two files that both overwrite the SAME existing pack still read as a genuine 2-file batch — summary shown, no auto-select, scroll suppressed via originalCount', async () => {
+    const placement = makePlacement()
+    const setLastResult = vi.fn()
+    const onCollapsedToOne = vi.fn()
+    const collectResults = vi.fn().mockResolvedValue({
+      // Both files independently overwrite the same pre-existing id 'x'
+      // — 2 real, successful saves that just happen to dedupe to 1
+      // placed entry.
+      successes: [
+        { fileName: 'first.json', meta: { id: 'x', name: 'Existing' } },
+        { fileName: 'second.json', meta: { id: 'x', name: 'Existing' } },
+      ],
+      notSavedFailures: [],
+      snapshot: { entries: [], direction: 'asc' },
+    } satisfies CollectedImportBatch<FakeMeta>)
+
+    const { result } = renderHook(() => useImportBatch<FakeMeta>({
+      open: true,
+      placement,
+      setLastResult,
+      setActionError: vi.fn(),
+      t,
+      collectResults,
+      onCollapsedToOne,
+    }))
+
+    await act(async () => { await result.current.runImport() })
+
+    // `deduped` is a single entry, but originalCount (3rd arg) is 2 —
+    // this is what makes `placeMany` suppress the scroll it would
+    // otherwise do for a lone result.
+    expect(placement.placeMany).toHaveBeenCalledWith(
+      [{ id: 'x', name: 'Existing' }],
+      { entries: [], direction: 'asc' },
+      2,
+    )
+    // No single "the" import to activate — a 2-file batch, even one
+    // that collapses to one id, must not auto-select.
+    expect(onCollapsedToOne).not.toHaveBeenCalled()
+    // success 2, failure 0 — never "success 1" from `deduped.length`.
     expect(result.current.importSummary).toBe('common.importSummary:2:2:0')
   })
 

--- a/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
@@ -401,6 +401,55 @@ describe('useImportPlacement', () => {
     expect(onReorderError).not.toHaveBeenCalled()
   })
 
+  it('placeMany does not scroll for a 2+ result batch, but still scrolls when the batch collapses to a single result', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError: vi.fn(),
+    }))
+
+    // The scroll effect looks these up by testid via
+    // `document.querySelector` — stand in for the real rows a modal
+    // would render.
+    const rowB = document.createElement('div')
+    rowB.setAttribute('data-testid', 'test-packs-row-b')
+    const rowC = document.createElement('div')
+    rowC.setAttribute('data-testid', 'test-packs-row-c')
+    const rowD = document.createElement('div')
+    rowD.setAttribute('data-testid', 'test-packs-row-d')
+    document.body.append(rowB, rowC, rowD)
+
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+    try {
+      // 2-result batch: no scroll, even though the last result's row exists.
+      await act(async () => {
+        const snapshot = result.current.snapshotEntries()
+        await result.current.placeMany(
+          [{ id: 'b', name: 'Bravo' }, { id: 'c', name: 'Charlie' }],
+          snapshot,
+        )
+      })
+      expect(scrollIntoView).not.toHaveBeenCalled()
+
+      // A batch that collapses to a single result behaves like place():
+      // it does scroll.
+      await act(async () => {
+        const snapshot = result.current.snapshotEntries()
+        await result.current.placeMany([{ id: 'd', name: 'Delta' }], snapshot)
+      })
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+    } finally {
+      scrollIntoView.mockRestore()
+      rowB.remove()
+      rowC.remove()
+      rowD.remove()
+    }
+  })
+
   it('single-file place() still behaves identically after placeMany was added (unaffected by the batch fix)', async () => {
     const reorder = vi.fn().mockResolvedValue({ success: true })
     const onReorderError = vi.fn()

--- a/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportPlacement.test.ts
@@ -450,6 +450,39 @@ describe('useImportPlacement', () => {
     }
   })
 
+  it('P1-a fix: an explicit originalCount overrides results.length for scroll suppression — a lone deduped result from a 2-file selection does not scroll', async () => {
+    const reorder = vi.fn().mockResolvedValue({ success: true })
+    const { result } = renderHook(() => useImportPlacement({
+      open: true,
+      entries: [{ id: 'a', name: 'Alpha' }],
+      direction: 'asc',
+      reorder,
+      rowTestidPrefix: 'test-packs',
+      onReorderError: vi.fn(),
+    }))
+
+    const rowD = document.createElement('div')
+    rowD.setAttribute('data-testid', 'test-packs-row-d')
+    document.body.append(rowD)
+
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+    try {
+      // `results` has collapsed to a single entry (e.g. two files both
+      // overwrote the same existing pack), but the caller passes the
+      // true pre-dedupe count (2) explicitly — this must suppress the
+      // scroll that a bare `results.length <= 1` inference would
+      // otherwise trigger (see useImportBatch.ts's P1 fix note).
+      await act(async () => {
+        const snapshot = result.current.snapshotEntries()
+        await result.current.placeMany([{ id: 'd', name: 'Delta' }], snapshot, 2)
+      })
+      expect(scrollIntoView).not.toHaveBeenCalled()
+    } finally {
+      scrollIntoView.mockRestore()
+      rowD.remove()
+    }
+  })
+
   it('single-file place() still behaves identically after placeMany was added (unaffected by the batch fix)', async () => {
     const reorder = vi.fn().mockResolvedValue({ success: true })
     const onReorderError = vi.fn()

--- a/src/renderer/components/pack-modal/import-batch-summary.ts
+++ b/src/renderer/components/pack-modal/import-batch-summary.ts
@@ -23,6 +23,22 @@ export function basenameOf(path: string): string {
   return segments[segments.length - 1] || path
 }
 
+/** Dedupes a batch's per-file results by id, keeping the last file's
+ *  outcome when two files resolve to the same id (e.g. two files with
+ *  the same name, so the store's auto-overwrite reuses the same id) —
+ *  that's what actually ended up on disk. `Map.delete` before `set`
+ *  moves a repeated id to the end, matching the last file's processing
+ *  order rather than the first's. */
+export function dedupeByIdKeepLast<T>(items: T[], getId: (item: T) => string): T[] {
+  const byId = new Map<string, T>()
+  for (const item of items) {
+    const id = getId(item)
+    byId.delete(id)
+    byId.set(id, item)
+  }
+  return [...byId.values()]
+}
+
 /**
  * Builds the "{{count}} file(s) could not be imported:" header plus one
  * `fileName: reason` line per failure. Returns null when there are no
@@ -40,20 +56,24 @@ export function buildImportBatchFailureSummary(
 
 /**
  * Builds the toolbar "Imported N file(s) (success N, failure N)"
- * headline shown for a multi-file import batch. `success` is the
- * number of files that actually landed on disk (post-dedupe); `failure`
- * is the number that never got saved (parse/validate/store failures) —
- * a saved file whose Hub auto-sync later failed still counts toward
- * `success` here (its failure is a separate concern surfaced by
- * `buildImportBatchFailureSummary`'s banner, not this headline). Callers
- * decide when to show this — see each modal's `handleImportFile` for
- * the "only for a 2+ batch" gate that keeps a single-file import's
- * existing per-name "Imported {{name}}" feedback intact.
+ * headline shown for a multi-file import batch, or `null` below the
+ * 2-file threshold — mirroring its sibling `buildImportBatchFailureSummary`'s
+ * self-gating null return, so call sites no longer need their own
+ * `totalCount >= 2` check. `deduped` is the batch's already-deduped
+ * successes (post-dedupe, one per saved id); `notSavedFailures` is the
+ * files that never got saved (parse/validate/store failures) — a saved
+ * file whose Hub auto-sync later failed still counts toward success
+ * here (its failure is a separate concern surfaced by
+ * `buildImportBatchFailureSummary`'s banner, not this headline).
  */
-export function buildImportSummary(
+export function buildImportSummary<T>(
   t: TFunction,
-  success: number,
-  failure: number,
-): string {
-  return t('common.importSummary', { count: success + failure, success, failure })
+  deduped: T[],
+  notSavedFailures: ImportBatchFailure[],
+): string | null {
+  const success = deduped.length
+  const failure = notSavedFailures.length
+  const total = success + failure
+  if (total < 2) return null
+  return t('common.importSummary', { count: total, success, failure })
 }

--- a/src/renderer/components/pack-modal/import-batch-summary.ts
+++ b/src/renderer/components/pack-modal/import-batch-summary.ts
@@ -37,3 +37,23 @@ export function buildImportBatchFailureSummary(
   const lines = failures.map((f) => `${f.fileName}: ${f.reason}`)
   return [header, ...lines].join('\n')
 }
+
+/**
+ * Builds the toolbar "Imported N file(s) (success N, failure N)"
+ * headline shown for a multi-file import batch. `success` is the
+ * number of files that actually landed on disk (post-dedupe); `failure`
+ * is the number that never got saved (parse/validate/store failures) —
+ * a saved file whose Hub auto-sync later failed still counts toward
+ * `success` here (its failure is a separate concern surfaced by
+ * `buildImportBatchFailureSummary`'s banner, not this headline). Callers
+ * decide when to show this — see each modal's `handleImportFile` for
+ * the "only for a 2+ batch" gate that keeps a single-file import's
+ * existing per-name "Imported {{name}}" feedback intact.
+ */
+export function buildImportSummary(
+  t: TFunction,
+  success: number,
+  failure: number,
+): string {
+  return t('common.importSummary', { count: success + failure, success, failure })
+}

--- a/src/renderer/components/pack-modal/import-batch-summary.ts
+++ b/src/renderer/components/pack-modal/import-batch-summary.ts
@@ -59,21 +59,26 @@ export function buildImportBatchFailureSummary(
  * headline shown for a multi-file import batch, or `null` below the
  * 2-file threshold — mirroring its sibling `buildImportBatchFailureSummary`'s
  * self-gating null return, so call sites no longer need their own
- * `totalCount >= 2` check. `deduped` is the batch's already-deduped
- * successes (post-dedupe, one per saved id); `notSavedFailures` is the
- * files that never got saved (parse/validate/store failures) — a saved
- * file whose Hub auto-sync later failed still counts toward success
- * here (its failure is a separate concern surfaced by
+ * `totalCount >= 2` check.
+ *
+ * `successCount` MUST be the original, pre-dedupe count of files that
+ * actually saved — never the post-dedupe count. Two files that both
+ * overwrote the same existing pack are still 2 successes here even
+ * though they collapse to a single placed entry (see the P1
+ * "count/scroll uses deduped set" fix note in useImportBatch.ts, the
+ * one caller of this function). `notSavedFailures` is the files that
+ * never got saved (parse/validate/store failures) — a saved file whose
+ * Hub auto-sync later failed still counts toward `successCount` (its
+ * failure is a separate concern surfaced by
  * `buildImportBatchFailureSummary`'s banner, not this headline).
  */
-export function buildImportSummary<T>(
+export function buildImportSummary(
   t: TFunction,
-  deduped: T[],
+  successCount: number,
   notSavedFailures: ImportBatchFailure[],
 ): string | null {
-  const success = deduped.length
   const failure = notSavedFailures.length
-  const total = success + failure
+  const total = successCount + failure
   if (total < 2) return null
-  return t('common.importSummary', { count: total, success, failure })
+  return t('common.importSummary', { count: total, success: successCount, failure })
 }

--- a/src/renderer/components/pack-modal/useImportBatch.ts
+++ b/src/renderer/components/pack-modal/useImportBatch.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Shared multi-file import batch handler for the three pack-management
+// modals (Language Packs, Theme Packs, Key Labels). Each modal's
+// `handleImportFile`/`handleImport` was ~80 lines, structurally
+// identical: an `importInFlightRef` latch → dedupe-by-id (keep-last) →
+// a hub-sync loop building per-row success badges + hub-sync failures
+// → `placement.placeMany` → single-result auto-select → a 2+ file
+// summary gate → failure-banner assembly. They differed only in:
+//
+//   (a) how the per-file raw results are obtained — Language/Theme run
+//       a `store.applyImport` loop over dialog-picked files; Key Labels
+//       reads a single main-side batch result (`imported`/`rejections`)
+//   (b) the hub-sync function (`pushPackToHub` vs `labels.hubUpdate`)
+//   (c) the optional single-result auto-select callback
+//       (`handleSelectLanguage`/`handleSelectTheme`; Key Labels has none)
+//
+// This hook owns everything else. `collectResults` is the seam for
+// (a): it runs the file-picker/save step (in whatever shape the
+// feature needs) and returns every per-file outcome plus the
+// placement snapshot, captured by the caller at the exact point its
+// own store mutation begins — see each modal's `collectResults` for
+// why that point differs (a per-file save loop vs. one batched IPC
+// call). Returning `null` means there is nothing to place: either the
+// user canceled, or the whole batch failed before any per-file outcome
+// existed (the callback is responsible for surfacing that failure
+// itself via `setActionError`, since it doesn't fit the per-file
+// success/failure shape below).
+//
+// RE-ENTRANCY (mirrors the keymap-apply latch, previously duplicated in
+// each modal): a double-click on Import before React re-renders the
+// now-disabled button must not queue a second concurrent batch on top
+// of the first. `importInFlightRef` is the actual guard, checked
+// synchronously; `importing` just mirrors it into render so the
+// disabled UI reflects it a frame sooner than a double-click could
+// slip through.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TFunction } from 'i18next'
+import type { BatchSnapshot, UseImportPlacementResult } from './useImportPlacement'
+import { buildImportBatchFailureSummary, buildImportSummary, dedupeByIdKeepLast, type ImportBatchFailure } from './import-batch-summary'
+import type { PackActionResult } from './pack-modal-types'
+
+/** One file's successfully-saved outcome within a batch: the
+ *  originating filename (for failure/summary reporting, never the
+ *  pack's own internal name) plus the store's own meta. */
+export interface ImportBatchItem<TMeta> {
+  fileName: string
+  meta: TMeta
+}
+
+/** Minimal shape `useImportBatch` needs from a feature's meta type —
+ *  satisfied by `I18nPackMeta` / `ThemePackMeta` / `KeyLabelMeta`. */
+interface ImportBatchMeta {
+  id: string
+  name: string
+  hubPostId?: string
+}
+
+export interface CollectedImportBatch<TMeta> {
+  successes: ImportBatchItem<TMeta>[]
+  /** Files that never actually landed on disk (parse/validate/store
+   *  failure) — what the toolbar headline's "failure" count means; see
+   *  `buildImportSummary`'s doc. */
+  notSavedFailures: ImportBatchFailure[]
+  snapshot: BatchSnapshot
+}
+
+export interface UseImportBatchOptions<TMeta extends ImportBatchMeta> {
+  /** Gates the `importSummary` reset on close, mirroring
+   *  `useImportPlacement`'s own `open`-gated resets. */
+  open: boolean
+  placement: UseImportPlacementResult
+  setLastResult: (result: PackActionResult[] | null) => void
+  setActionError: (error: string | null) => void
+  t: TFunction
+  /** Runs the file-picker + save step and returns every per-file
+   *  outcome, or `null` when there is nothing to place (see module doc). */
+  collectResults: () => Promise<CollectedImportBatch<TMeta> | null>
+  /** Pushes one freshly-saved item to its already-linked Hub post.
+   *  Called only when `meta.hubPostId` is set; omit for a feature with
+   *  no Hub auto-sync step. Any failure reason should already be
+   *  translated by the caller — this hook uses it verbatim in the
+   *  failure banner. */
+  hubSync?: (meta: TMeta) => Promise<{ success: boolean; error?: string }>
+  /** Mirrors the single-file behavior of activating the freshly
+   *  imported pack — called once, only when the batch collapses to
+   *  exactly one saved result. Omitted for Key Labels, which has no
+   *  such concept. */
+  onCollapsedToOne?: (meta: TMeta) => void
+}
+
+export interface UseImportBatchResult {
+  importing: boolean
+  /** Toolbar headline for a 2+ file batch, superseding
+   *  `placement.feedback`'s per-name text at each call site via
+   *  `importFeedback={importSummary ?? placement.feedback}`. */
+  importSummary: string | null
+  runImport: () => Promise<void>
+}
+
+export function useImportBatch<TMeta extends ImportBatchMeta>({
+  open,
+  placement,
+  setLastResult,
+  setActionError,
+  t,
+  collectResults,
+  hubSync,
+  onCollapsedToOne,
+}: UseImportBatchOptions<TMeta>): UseImportBatchResult {
+  const [importing, setImporting] = useState(false)
+  const [importSummary, setImportSummary] = useState<string | null>(null)
+  const importInFlightRef = useRef(false)
+
+  useEffect(() => {
+    if (!open) setImportSummary(null)
+  }, [open])
+
+  const runImport = useCallback(async (): Promise<void> => {
+    if (importInFlightRef.current) return
+    importInFlightRef.current = true
+    setImporting(true)
+    try {
+      setActionError(null)
+      setLastResult(null)
+      setImportSummary(null)
+
+      const collected = await collectResults()
+      if (!collected) return
+      const { successes, notSavedFailures, snapshot } = collected
+
+      // Two files resolving to the same pack (e.g. same name, so the
+      // store's auto-overwrite reuses the same id) are deduped, keeping
+      // only the last file's outcome — that's what actually ended up on
+      // disk — so hub-sync and the row badge only run/appear once per id.
+      const deduped = dedupeByIdKeepLast(successes, (item) => item.meta.id)
+
+      const hubSyncFailures: ImportBatchFailure[] = []
+      const successBadges: PackActionResult[] = []
+      for (const { fileName, meta } of deduped) {
+        let message = t('common.saved')
+        if (meta.hubPostId && hubSync) {
+          const upd = await hubSync(meta)
+          if (upd.success) {
+            message = t('common.synced')
+          } else {
+            hubSyncFailures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+          }
+        }
+        successBadges.push({ id: meta.id, kind: 'success', message })
+      }
+
+      if (deduped.length > 0) {
+        await placement.placeMany(
+          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+          snapshot,
+        )
+        setLastResult(successBadges)
+        // Mirror the single-file behaviour of activating the freshly
+        // imported pack — only when the batch collapsed to a single
+        // result; a 2+ batch has no single "the" import to activate.
+        if (deduped.length === 1) onCollapsedToOne?.(deduped[0].meta)
+      }
+
+      // Toolbar headline for a 2+ file batch only — a single-file
+      // import keeps its existing per-name "Imported {{name}}" /
+      // "Updated {{name}}" feedback via `placement.feedback` untouched.
+      // `buildImportSummary` self-gates below that threshold.
+      const summary = buildImportSummary(t, deduped, notSavedFailures)
+      if (summary) setImportSummary(summary)
+
+      const failureSummary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
+      if (failureSummary) setActionError(failureSummary)
+    } finally {
+      importInFlightRef.current = false
+      setImporting(false)
+    }
+  }, [collectResults, hubSync, onCollapsedToOne, placement, setActionError, setLastResult, t])
+
+  return { importing, importSummary, runImport }
+}

--- a/src/renderer/components/pack-modal/useImportBatch.ts
+++ b/src/renderer/components/pack-modal/useImportBatch.ts
@@ -151,23 +151,36 @@ export function useImportBatch<TMeta extends ImportBatchMeta>({
         successBadges.push({ id: meta.id, kind: 'success', message })
       }
 
+      // The "collapsed to one" decision (auto-select + auto-scroll) and
+      // the toolbar summary's success count both MUST read the original,
+      // pre-dedupe count of files that saved — never `deduped.length`.
+      // Two files that both overwrote the same existing pack are a
+      // genuine 2-file batch (no auto-select, no auto-scroll, summary
+      // shown) even though `deduped` collapses them to a single entry
+      // to place. `deduped` itself is still exactly right for the
+      // hub-sync loop, the row badges and what gets placed/reordered —
+      // syncing or placing the same id twice would be wrong regardless.
       if (deduped.length > 0) {
         await placement.placeMany(
           deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
           snapshot,
+          successes.length,
         )
         setLastResult(successBadges)
         // Mirror the single-file behaviour of activating the freshly
         // imported pack — only when the batch collapsed to a single
         // result; a 2+ batch has no single "the" import to activate.
-        if (deduped.length === 1) onCollapsedToOne?.(deduped[0].meta)
+        // `successes.length === 1` implies `deduped.length === 1` too
+        // (a single success can never need deduping), so indexing
+        // `deduped[0]` here is always safe.
+        if (successes.length === 1) onCollapsedToOne?.(deduped[0].meta)
       }
 
       // Toolbar headline for a 2+ file batch only — a single-file
       // import keeps its existing per-name "Imported {{name}}" /
       // "Updated {{name}}" feedback via `placement.feedback` untouched.
       // `buildImportSummary` self-gates below that threshold.
-      const summary = buildImportSummary(t, deduped, notSavedFailures)
+      const summary = buildImportSummary(t, successes.length, notSavedFailures)
       if (summary) setImportSummary(summary)
 
       const failureSummary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])

--- a/src/renderer/components/pack-modal/useImportBatch.ts
+++ b/src/renderer/components/pack-modal/useImportBatch.ts
@@ -34,8 +34,18 @@
 // synchronously; `importing` just mirrors it into render so the
 // disabled UI reflects it a frame sooner than a double-click could
 // slip through.
+//
+// This same ref is exposed as `isImportingRef` for callers that need a
+// concurrent-safe "is a batch in flight" read outside of render — e.g.
+// each pack modal's `handleRenameCommit` guards on it to stop an
+// in-progress rename from committing mid-batch. It is written ONLY
+// inside `runImport` (an event-handler-triggered async function), never
+// during render, so — unlike a ref kept in sync via a plain assignment
+// in the component body (`someRef.current = someState`) — an
+// interrupted/discarded React 19 concurrent render can never leave it
+// holding a value that doesn't match reality.
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type MutableRefObject } from 'react'
 import type { TFunction } from 'i18next'
 import type { BatchSnapshot, UseImportPlacementResult } from './useImportPlacement'
 import { buildImportBatchFailureSummary, buildImportSummary, dedupeByIdKeepLast, type ImportBatchFailure } from './import-batch-summary'
@@ -97,6 +107,12 @@ export interface UseImportBatchResult {
    *  `importFeedback={importSummary ?? placement.feedback}`. */
   importSummary: string | null
   runImport: () => Promise<void>
+  /** The same ref `runImport` uses for its own re-entrancy latch,
+   *  exposed read-only-in-spirit for callers that need to know "is a
+   *  batch in flight right now" from outside of render — see the
+   *  RE-ENTRANCY note above for why this is concurrent-safe where a
+   *  render-time `ref.current = someState` assignment is not. */
+  isImportingRef: MutableRefObject<boolean>
 }
 
 export function useImportBatch<TMeta extends ImportBatchMeta>({
@@ -191,5 +207,5 @@ export function useImportBatch<TMeta extends ImportBatchMeta>({
     }
   }, [collectResults, hubSync, onCollapsedToOne, placement, setActionError, setLastResult, t])
 
-  return { importing, importSummary, runImport }
+  return { importing, importSummary, runImport, isImportingRef: importInFlightRef }
 }

--- a/src/renderer/components/pack-modal/useImportPlacement.ts
+++ b/src/renderer/components/pack-modal/useImportPlacement.ts
@@ -326,15 +326,22 @@ export function useImportPlacement({
           if (!reorderResult.success) onReorderErrorRef.current(reorderResult.error)
         }
       }
-      // Feedback/scroll anchor on the last result processed — same
-      // "last one wins" convention the calling modals already use for
-      // e.g. switching the active language/theme after a batch import.
+      // Feedback anchors on the last result processed — same "last one
+      // wins" convention the calling modals already use for e.g.
+      // switching the active language/theme after a batch import.
       const last = results[results.length - 1]
       const lastIsInsert = !beforeIds.has(last.id)
       showFeedback(lastIsInsert
         ? tRef.current('common.importedNamed', { name: last.name })
         : tRef.current('common.updatedNamed', { name: last.name }))
-      scheduleScroll(`${rowTestidPrefixRef.current}-row-${last.id}`)
+      // Auto-scroll only when the batch collapsed to a single result —
+      // for a 2+ file batch there is no single "the" imported row to
+      // jump to (see the multi-import UX plan's no-auto-scroll
+      // requirement), so leave the user's scroll position alone rather
+      // than jumping to an arbitrary one of several new rows.
+      if (results.length <= 1) {
+        scheduleScroll(`${rowTestidPrefixRef.current}-row-${last.id}`)
+      }
     }
     const settled = queueRef.current.then(run, run)
     queueRef.current = settled.then(() => undefined, () => undefined)

--- a/src/renderer/components/pack-modal/useImportPlacement.ts
+++ b/src/renderer/components/pack-modal/useImportPlacement.ts
@@ -179,8 +179,20 @@ export interface UseImportPlacementResult {
    * issues at most one `reorder` call for the whole batch. See the
    * RAPID-INSERT RACE and DIRECTION RACE notes in the module doc for why
    * this differs from calling `place()` once per result.
+   *
+   * `originalCount` drives ONLY the auto-scroll suppression below — it
+   * is the true number of files the batch selected/processed BEFORE any
+   * same-id dedupe collapsed `results`, so a 2-file selection that
+   * happens to dedupe down to one placed result (both files overwrote
+   * the same existing pack) still reads as a batch and does not scroll.
+   * Defaults to `results.length` — a caller with no dedupe step of its
+   * own (there is currently only one caller, `useImportBatch`, and it
+   * always passes this explicitly) sees identical behavior to before
+   * this parameter existed. Never affects the reorder computation or
+   * the last-result feedback anchor, both of which still operate on the
+   * actual (deduped) `results`.
    */
-  placeMany: (results: NameSortEntry[], snapshot: BatchSnapshot) => Promise<void>
+  placeMany: (results: NameSortEntry[], snapshot: BatchSnapshot, originalCount?: number) => Promise<void>
 }
 
 export function useImportPlacement({
@@ -307,6 +319,7 @@ export function useImportPlacement({
   const placeMany = useCallback((
     results: NameSortEntry[],
     snapshot: BatchSnapshot,
+    originalCount: number = results.length,
   ): Promise<void> => {
     const run = async (): Promise<void> => {
       if (results.length === 0) return
@@ -338,8 +351,13 @@ export function useImportPlacement({
       // for a 2+ file batch there is no single "the" imported row to
       // jump to (see the multi-import UX plan's no-auto-scroll
       // requirement), so leave the user's scroll position alone rather
-      // than jumping to an arbitrary one of several new rows.
-      if (results.length <= 1) {
+      // than jumping to an arbitrary one of several new rows. Gated on
+      // `originalCount`, NOT `results.length`: two files that both
+      // overwrote the same existing pack still collapse `results` to a
+      // single entry, but the user genuinely selected 2 files, so this
+      // must still read as a batch (see the P1 "count/scroll uses
+      // deduped set" fix note in useImportBatch.ts).
+      if (originalCount <= 1) {
         scheduleScroll(`${rowTestidPrefixRef.current}-row-${last.id}`)
       }
     }

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -131,6 +131,7 @@ export function PackRow({
           name={meta.name}
           editing={editing}
           canRename={!importing}
+          locked={importing}
           editLabel={rename.editLabel}
           onEditLabelChange={rename.setEditLabel}
           onBlur={() => void onRenameCommit(meta.id)}

--- a/src/renderer/components/theme-packs/ThemePackRow.tsx
+++ b/src/renderer/components/theme-packs/ThemePackRow.tsx
@@ -21,6 +21,11 @@ export interface PackRowProps {
   meta: ThemePackMeta
   isActive: boolean
   pendingId: string | null
+  /** True while a multi-file import batch is in flight — locks every
+   *  row action, rename, drag and the select control so the list can't
+   *  be mutated out from under the batch's own placement/reorder call.
+   *  Wired the same way `pendingId` already gates a single op. */
+  importing: boolean
   confirmDeleteId: string | null
   setConfirmDeleteId: (id: string | null) => void
   rename: ReturnType<typeof useInlineRename<string>>
@@ -49,6 +54,7 @@ export function PackRow({
   meta,
   isActive,
   pendingId,
+  importing,
   confirmDeleteId,
   setConfirmDeleteId,
   rename,
@@ -73,7 +79,7 @@ export function PackRow({
   onDragEnd,
 }: PackRowProps): JSX.Element {
   const { t } = useTranslation()
-  const busy = pendingId === meta.id
+  const busy = pendingId === meta.id || importing
   const editing = rename.editingId === meta.id
   const isConfirmingDelete = confirmDeleteId === meta.id
 
@@ -91,7 +97,7 @@ export function PackRow({
     <PackListRow
       testid={`theme-packs-row-${meta.id}`}
       active={isActive}
-      draggable
+      draggable={!importing}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
       onDragEnd={onDragEnd}
@@ -108,8 +114,9 @@ export function PackRow({
         <button
           type="button"
           aria-label={t('themePacks.selectTheme', { name: meta.name })}
-          className="shrink-0 text-content-muted hover:text-accent transition-colors"
+          className="shrink-0 text-content-muted hover:text-accent transition-colors disabled:opacity-50"
           onClick={() => onSelect(`pack:${meta.id}`)}
+          disabled={busy}
           data-testid={`theme-packs-select-${meta.id}`}
         >
           {isActive ? (
@@ -123,7 +130,7 @@ export function PackRow({
         <PackNameCell
           name={meta.name}
           editing={editing}
-          canRename
+          canRename={!importing}
           editLabel={rename.editLabel}
           onEditLabelChange={rename.setEditLabel}
           onBlur={() => void onRenameCommit(meta.id)}

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -29,7 +29,7 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { buildImportBatchFailureSummary, buildImportSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -69,6 +69,22 @@ export function ThemePacksModal({
   const [pendingId, setPendingId] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [previewPostId, setPreviewPostId] = useState<string | null>(null)
+  // Locks the Installed list (rows, drag, rename, builtin theme bar, the
+  // Import/Sort buttons) while a multi-file import batch is running, so
+  // nothing can mutate the list out from under `placement.placeMany`'s
+  // own reorder call. `importInFlightRef` is the actual re-entrancy
+  // guard (checked synchronously, mirroring the keymap-apply latch) —
+  // `importing` just mirrors it into render so the disabled UI reflects
+  // it a frame sooner than a double-click could slip through.
+  const [importing, setImporting] = useState(false)
+  const importInFlightRef = useRef(false)
+  // Toolbar headline shown only for a 2+ file batch (see
+  // `handleImportFile`) — supersedes `placement.feedback`'s per-name
+  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
+  // below. Cleared at the start of the next import and on modal close;
+  // no auto-clear timer (unlike `placement.feedback`) since it is meant
+  // to persist as the batch's final word until the user acts again.
+  const [importSummary, setImportSummary] = useState<string | null>(null)
   const previewSeqRef = useRef(0)
   const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
   const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
@@ -205,6 +221,7 @@ export function ThemePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
+      setImportSummary(null)
       hubPreviewCacheRef.current.clear()
       activePackCacheRef.current = null
     }
@@ -316,66 +333,96 @@ export function ThemePacksModal({
   // internal `name`) plus the real underlying reason (never a generic
   // placeholder when a real message is available).
   const handleImportFile = useCallback(async () => {
-    setActionError(null)
-    setLastResult(null)
-    const dialogResult = await store.importFromDialog()
-    if (dialogResult.canceled) return
-    const beforeSnapshot = placement.snapshotEntries()
-    const failures: ImportBatchFailure[] = []
-    const rawSuccesses: { fileName: string; meta: ThemePackMeta }[] = []
-    for (const file of dialogResult.files) {
-      const fileName = basenameOf(file.filePath)
-      if (file.parseError || file.raw === undefined) {
-        failures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
-        continue
-      }
-      try {
-        const result = await store.applyImport(file.raw)
-        if (!result.success || !result.meta) {
-          failures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
+    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
+    // on Import before React re-renders the now-disabled button must
+    // not queue a second concurrent batch on top of the first.
+    if (importInFlightRef.current) return
+    importInFlightRef.current = true
+    setImporting(true)
+    try {
+      setActionError(null)
+      setLastResult(null)
+      setImportSummary(null)
+      const dialogResult = await store.importFromDialog()
+      if (dialogResult.canceled) return
+      const beforeSnapshot = placement.snapshotEntries()
+      // Kept separate from `hubSyncFailures` below: these are files that
+      // never actually landed on disk (parse/validate/store failure),
+      // which is what the toolbar headline's "failure" count means —
+      // see the module doc's REORDER-FAILURE-adjacent note in
+      // import-batch-summary.ts's `buildImportSummary`.
+      const notSavedFailures: ImportBatchFailure[] = []
+      const rawSuccesses: { fileName: string; meta: ThemePackMeta }[] = []
+      for (const file of dialogResult.files) {
+        const fileName = basenameOf(file.filePath)
+        if (file.parseError || file.raw === undefined) {
+          notSavedFailures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
           continue
         }
-        rawSuccesses.push({ fileName, meta: result.meta })
-      } catch {
-        failures.push({ fileName, reason: t('themePacks.parseError') })
-      }
-    }
-
-    // Dedupe by pack id, keeping the last file's outcome (see doc above).
-    const dedupedById = new Map<string, { fileName: string; meta: ThemePackMeta }>()
-    for (const success of rawSuccesses) {
-      dedupedById.delete(success.meta.id)
-      dedupedById.set(success.meta.id, success)
-    }
-    const deduped = [...dedupedById.values()]
-
-    const successBadges: PackActionResult[] = []
-    for (const { fileName, meta } of deduped) {
-      let message = t('common.saved')
-      if (meta.hubPostId) {
-        const upd = await pushPackToHub(meta.id, meta.hubPostId)
-        if (upd.success) {
-          message = t('common.synced')
-        } else {
-          failures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+        try {
+          const result = await store.applyImport(file.raw)
+          if (!result.success || !result.meta) {
+            notSavedFailures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
+            continue
+          }
+          rawSuccesses.push({ fileName, meta: result.meta })
+        } catch {
+          notSavedFailures.push({ fileName, reason: t('themePacks.parseError') })
         }
       }
-      successBadges.push({ id: meta.id, kind: 'success', message })
-    }
 
-    if (deduped.length > 0) {
-      await placement.placeMany(
-        deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-        beforeSnapshot,
-      )
-      setLastResult(successBadges)
-      // Mirror the single-file behaviour of switching the active theme
-      // to the freshly imported pack, anchored on the last successfully
-      // imported (post-dedupe) file for a deterministic final state.
-      handleSelectTheme(`pack:${deduped[deduped.length - 1].meta.id}`)
+      // Dedupe by pack id, keeping the last file's outcome (see doc above).
+      const dedupedById = new Map<string, { fileName: string; meta: ThemePackMeta }>()
+      for (const success of rawSuccesses) {
+        dedupedById.delete(success.meta.id)
+        dedupedById.set(success.meta.id, success)
+      }
+      const deduped = [...dedupedById.values()]
+
+      const hubSyncFailures: ImportBatchFailure[] = []
+      const successBadges: PackActionResult[] = []
+      for (const { fileName, meta } of deduped) {
+        let message = t('common.saved')
+        if (meta.hubPostId) {
+          const upd = await pushPackToHub(meta.id, meta.hubPostId)
+          if (upd.success) {
+            message = t('common.synced')
+          } else {
+            hubSyncFailures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
+          }
+        }
+        successBadges.push({ id: meta.id, kind: 'success', message })
+      }
+
+      if (deduped.length > 0) {
+        await placement.placeMany(
+          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
+          beforeSnapshot,
+        )
+        setLastResult(successBadges)
+        // Mirror the single-file behaviour of switching the active
+        // theme to the freshly imported pack — only when the batch
+        // collapsed to a single result; a 2+ batch has no single "the"
+        // import to activate, so the active theme is left untouched.
+        if (deduped.length === 1) {
+          handleSelectTheme(`pack:${deduped[0].meta.id}`)
+        }
+      }
+
+      // Toolbar headline for a 2+ file batch only — a single-file
+      // import keeps its existing per-name "Imported {{name}}" /
+      // "Updated {{name}}" feedback via `placement.feedback` untouched.
+      const totalCount = deduped.length + notSavedFailures.length
+      if (totalCount >= 2) {
+        setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
+      }
+
+      const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
+      if (summary) setActionError(summary)
+    } finally {
+      importInFlightRef.current = false
+      setImporting(false)
     }
-    const summary = buildImportBatchFailureSummary(t, failures)
-    if (summary) setActionError(summary)
   }, [store, t, pushPackToHub, handleSelectTheme, placement])
 
   const handleRenameCommit = useCallback(async (id: string) => {
@@ -559,15 +606,16 @@ export function ThemePacksModal({
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('i18n.import')}
       onImport={() => void handleImportFile()}
+      importDisabled={importing}
       sortButton={(
         <PackSortButton
           direction={nameSort.direction}
           onClick={handleSortByName}
-          disabled={nameSort.pending}
+          disabled={nameSort.pending || importing}
           testid="theme-packs-sort-button"
         />
       )}
-      importFeedback={placement.feedback}
+      importFeedback={importSummary ?? placement.feedback}
       actionError={actionError}
     >
       {activeTab === 'installed' ? (
@@ -580,12 +628,13 @@ export function ThemePacksModal({
                   key={mode}
                   type="button"
                   aria-label={t('themePacks.selectTheme', { name: t(`theme.${mode}`) })}
-                  className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                  className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors disabled:opacity-50 ${
                     isActive
                       ? 'bg-accent/15 text-accent'
                       : 'text-content-secondary hover:text-content'
                   }`}
                   onClick={() => handleSelectTheme(mode)}
+                  disabled={importing}
                   data-testid={`theme-packs-builtin-${mode}`}
                 >
                   {isActive ? (
@@ -606,6 +655,7 @@ export function ThemePacksModal({
               meta={meta}
               isActive={activeTheme === `pack:${meta.id}`}
               pendingId={pendingId}
+              importing={importing}
               confirmDeleteId={confirmDeleteId}
               setConfirmDeleteId={setConfirmDeleteId}
               rename={rename}
@@ -644,6 +694,7 @@ export function ThemePacksModal({
               key={row.hubPostId}
               row={row}
               pendingId={pendingId}
+              importing={importing}
               hubOrigin={hubOrigin}
               previewPostId={previewPostId}
               onPreview={(postId) => void handlePreview(postId)}
@@ -675,15 +726,19 @@ interface ThemeHubRowData {
 interface ThemeHubRowProps {
   row: ThemeHubRowData
   pendingId: string | null
+  /** Defensive: the Hub tab isn't meant to be operable mid-import
+   *  either, even though its own actions don't touch the Installed
+   *  list directly. */
+  importing: boolean
   hubOrigin: string
   previewPostId: string | null
   onPreview: (postId: string) => void
   onDownload: (postId: string) => void
 }
 
-function ThemeHubRow({ row, pendingId, previewPostId, onPreview, onDownload }: ThemeHubRowProps): JSX.Element {
+function ThemeHubRow({ row, pendingId, importing, previewPostId, onPreview, onDownload }: ThemeHubRowProps): JSX.Element {
   const { t } = useTranslation()
-  const busy = pendingId === row.hubPostId
+  const busy = pendingId === row.hubPostId || importing
   return (
     <PackHubResultRow
       hubPostId={row.hubPostId}

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -73,14 +73,6 @@ export function ThemePacksModal({
   const previewSeqRef = useRef(0)
   const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
   const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
-  // Mirrors `importing` (from `useImportBatch`, defined further below)
-  // into a ref so `handleRenameCommit` can read its latest value the
-  // same way in all three pack modals — some of them define the rename
-  // handler before the `useImportBatch` call, where the `importing`
-  // state itself isn't in scope yet. Kept current via a plain
-  // assignment during render (the same "adjust a ref during render"
-  // pattern `useImportPlacement.ts` uses for its own always-latest refs).
-  const importingRef = useRef(false)
 
   const activeTheme = appConfig.config.theme
   const hubOrigin = useHubOrigin(open)
@@ -338,7 +330,7 @@ export function ThemePacksModal({
     return { successes, notSavedFailures, snapshot }
   }, [store, t, placement])
 
-  const { importing, importSummary, runImport } = useImportBatch<ThemePackMeta>({
+  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<ThemePackMeta>({
     open,
     placement,
     setLastResult,
@@ -348,12 +340,11 @@ export function ThemePacksModal({
     hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
     onCollapsedToOne: (meta) => handleSelectTheme(`pack:${meta.id}`),
   })
-  importingRef.current = importing
 
   // Closes any inline rename that was already open the moment a batch
   // starts, so its input unmounts instead of sitting there interactive
   // (and committable) for the whole duration of the import — see
-  // `handleRenameCommit`'s own `importingRef` guard below for the one
+  // `handleRenameCommit`'s own `isImportingRef` guard below for the one
   // race this cannot cover (a rename input's blur, and the click that
   // starts the batch, are the same user click; the blur's commit is
   // already in flight before `importing` ever flips true).
@@ -365,14 +356,23 @@ export function ThemePacksModal({
   }, [importing])
 
   const handleRenameCommit = useCallback(async (id: string) => {
-    // See the module-level note above `importingRef`: this cannot
-    // intercept a commit whose blur fired as part of the very click
-    // that started the batch (already in flight before `importing`
-    // flips true), but it does catch a rename left open from an
-    // already-running batch, and any stray commit that slips through
-    // after the cancel-on-import-start effect above has already reset
-    // the editor for this render.
-    if (importingRef.current) return
+    // Guards on `useImportBatch`'s own re-entrancy ref rather than a
+    // locally-mirrored one — written only inside an event handler
+    // (`runImport`), never during render, so it can't go stale under a
+    // discarded/interrupted concurrent render. Referencing
+    // `isImportingRef` here, defined further up via `useImportBatch`,
+    // is safe regardless: this callback's body only runs later, on a
+    // real blur/Enter event, well after the full render has finished.
+    //
+    // A rename already committed its `store.rename` call the instant
+    // the underlying input blurred — including the blur a click on the
+    // Import button itself triggers, which fires before that click's
+    // own handler runs — so this check cannot intercept that exact
+    // call. It DOES catch every other path: a rename input left open
+    // when a batch was already running, and any stray commit that
+    // slips through after the cancel-on-import-start effect above has
+    // already reset the editor for this render.
+    if (isImportingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -29,7 +29,8 @@ import { useDragReorder } from '../pack-modal/useDragReorder'
 import { applyDragOrder } from '../pack-modal/drag-order'
 import { useNameSort } from '../pack-modal/useNameSort'
 import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { buildImportBatchFailureSummary, buildImportSummary, basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
+import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
 import { isOwnPack } from '../pack-modal/ownership'
@@ -69,22 +70,6 @@ export function ThemePacksModal({
   const [pendingId, setPendingId] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [previewPostId, setPreviewPostId] = useState<string | null>(null)
-  // Locks the Installed list (rows, drag, rename, builtin theme bar, the
-  // Import/Sort buttons) while a multi-file import batch is running, so
-  // nothing can mutate the list out from under `placement.placeMany`'s
-  // own reorder call. `importInFlightRef` is the actual re-entrancy
-  // guard (checked synchronously, mirroring the keymap-apply latch) —
-  // `importing` just mirrors it into render so the disabled UI reflects
-  // it a frame sooner than a double-click could slip through.
-  const [importing, setImporting] = useState(false)
-  const importInFlightRef = useRef(false)
-  // Toolbar headline shown only for a 2+ file batch (see
-  // `handleImportFile`) — supersedes `placement.feedback`'s per-name
-  // "Imported {{name}}" text via the `??` in the `importFeedback` prop
-  // below. Cleared at the start of the next import and on modal close;
-  // no auto-clear timer (unlike `placement.feedback`) since it is meant
-  // to persist as the batch's final word until the user acts again.
-  const [importSummary, setImportSummary] = useState<string | null>(null)
   const previewSeqRef = useRef(0)
   const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
   const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
@@ -221,7 +206,6 @@ export function ThemePacksModal({
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
-      setImportSummary(null)
       hubPreviewCacheRef.current.clear()
       activePackCacheRef.current = null
     }
@@ -312,118 +296,50 @@ export function ThemePacksModal({
   }, [store, activeTheme, onThemeChange, t, currentDisplayName])
 
   // Multi-file import batch: every selected file is saved independently
-  // (theme pack validation lives entirely main-side in `savePack`, so
-  // there is no renderer-side pre-check to run first, unlike Language
-  // Packs), but the actual list placement happens in ONE call at the
-  // end via `placement.placeMany` — see the RAPID-INSERT RACE and
-  // DIRECTION RACE notes in useImportPlacement.ts for why calling
-  // `place()` once per file (the original approach) could compute a
-  // later file's position from a stale/inconsistent snapshot and
-  // silently drop an earlier file's id from the persisted order, or
-  // merge against a sort direction that changed mid-batch. Two files
-  // resolving to the same pack (same name,
-  // so main's auto-overwrite reuses the same id) are deduped, keeping
-  // only the last file's outcome — that's what actually ended up on
-  // disk — so hub-sync and the row badge only run/appear once per id.
-  // Successes each get their own row badge (accumulated into an array —
-  // `PackResultBadge` looks up its row's own entry); failures (parse
-  // errors + save failures + failed Hub auto-syncs) are aggregated into
-  // one banner, mirroring the typing-analytics import precedent, and
-  // always report the ACTUAL selected filename (never the pack's own
-  // internal `name`) plus the real underlying reason (never a generic
-  // placeholder when a real message is available).
-  const handleImportFile = useCallback(async () => {
-    // Re-entrancy guard (mirrors the keymap-apply latch): a double-click
-    // on Import before React re-renders the now-disabled button must
-    // not queue a second concurrent batch on top of the first.
-    if (importInFlightRef.current) return
-    importInFlightRef.current = true
-    setImporting(true)
-    try {
-      setActionError(null)
-      setLastResult(null)
-      setImportSummary(null)
-      const dialogResult = await store.importFromDialog()
-      if (dialogResult.canceled) return
-      const beforeSnapshot = placement.snapshotEntries()
-      // Kept separate from `hubSyncFailures` below: these are files that
-      // never actually landed on disk (parse/validate/store failure),
-      // which is what the toolbar headline's "failure" count means —
-      // see the module doc's REORDER-FAILURE-adjacent note in
-      // import-batch-summary.ts's `buildImportSummary`.
-      const notSavedFailures: ImportBatchFailure[] = []
-      const rawSuccesses: { fileName: string; meta: ThemePackMeta }[] = []
-      for (const file of dialogResult.files) {
-        const fileName = basenameOf(file.filePath)
-        if (file.parseError || file.raw === undefined) {
-          notSavedFailures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
+  // here (theme pack validation lives entirely main-side in `savePack`,
+  // so there is no renderer-side pre-check to run first, unlike
+  // Language Packs); dedupe, hub-sync, placement and the toolbar
+  // summary/failure banner are handled by the shared `useImportBatch`
+  // hook below (see its module doc for the extraction rationale). The
+  // snapshot is taken right after the "canceled" check — before any
+  // per-file save runs — matching `placement.snapshotEntries()`'s
+  // "before the batch's own mutations begin" contract.
+  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<ThemePackMeta> | null> => {
+    const dialogResult = await store.importFromDialog()
+    if (dialogResult.canceled) return null
+    const snapshot = placement.snapshotEntries()
+    const notSavedFailures: ImportBatchFailure[] = []
+    const successes: ImportBatchItem<ThemePackMeta>[] = []
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        notSavedFailures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
+        continue
+      }
+      try {
+        const result = await store.applyImport(file.raw)
+        if (!result.success || !result.meta) {
+          notSavedFailures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
           continue
         }
-        try {
-          const result = await store.applyImport(file.raw)
-          if (!result.success || !result.meta) {
-            notSavedFailures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
-            continue
-          }
-          rawSuccesses.push({ fileName, meta: result.meta })
-        } catch {
-          notSavedFailures.push({ fileName, reason: t('themePacks.parseError') })
-        }
+        successes.push({ fileName, meta: result.meta })
+      } catch {
+        notSavedFailures.push({ fileName, reason: t('themePacks.parseError') })
       }
-
-      // Dedupe by pack id, keeping the last file's outcome (see doc above).
-      const dedupedById = new Map<string, { fileName: string; meta: ThemePackMeta }>()
-      for (const success of rawSuccesses) {
-        dedupedById.delete(success.meta.id)
-        dedupedById.set(success.meta.id, success)
-      }
-      const deduped = [...dedupedById.values()]
-
-      const hubSyncFailures: ImportBatchFailure[] = []
-      const successBadges: PackActionResult[] = []
-      for (const { fileName, meta } of deduped) {
-        let message = t('common.saved')
-        if (meta.hubPostId) {
-          const upd = await pushPackToHub(meta.id, meta.hubPostId)
-          if (upd.success) {
-            message = t('common.synced')
-          } else {
-            hubSyncFailures.push({ fileName, reason: upd.error ?? t('hub.updateFailed') })
-          }
-        }
-        successBadges.push({ id: meta.id, kind: 'success', message })
-      }
-
-      if (deduped.length > 0) {
-        await placement.placeMany(
-          deduped.map(({ meta }) => ({ id: meta.id, name: meta.name })),
-          beforeSnapshot,
-        )
-        setLastResult(successBadges)
-        // Mirror the single-file behaviour of switching the active
-        // theme to the freshly imported pack — only when the batch
-        // collapsed to a single result; a 2+ batch has no single "the"
-        // import to activate, so the active theme is left untouched.
-        if (deduped.length === 1) {
-          handleSelectTheme(`pack:${deduped[0].meta.id}`)
-        }
-      }
-
-      // Toolbar headline for a 2+ file batch only — a single-file
-      // import keeps its existing per-name "Imported {{name}}" /
-      // "Updated {{name}}" feedback via `placement.feedback` untouched.
-      const totalCount = deduped.length + notSavedFailures.length
-      if (totalCount >= 2) {
-        setImportSummary(buildImportSummary(t, deduped.length, notSavedFailures.length))
-      }
-
-      const summary = buildImportBatchFailureSummary(t, [...notSavedFailures, ...hubSyncFailures])
-      if (summary) setActionError(summary)
-    } finally {
-      importInFlightRef.current = false
-      setImporting(false)
     }
-  }, [store, t, pushPackToHub, handleSelectTheme, placement])
+    return { successes, notSavedFailures, snapshot }
+  }, [store, t, placement])
+
+  const { importing, importSummary, runImport } = useImportBatch<ThemePackMeta>({
+    open,
+    placement,
+    setLastResult,
+    setActionError,
+    t,
+    collectResults: collectImportResults,
+    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
+    onCollapsedToOne: (meta) => handleSelectTheme(`pack:${meta.id}`),
+  })
 
   const handleRenameCommit = useCallback(async (id: string) => {
     const newName = rename.commitRename(id)
@@ -605,7 +521,7 @@ export function ThemePacksModal({
       searchButtonLabel={hubSearching ? t('keyLabels.searching') : t('i18n.search')}
       searchDisabled={hubSearching || search.trim().length < 2}
       importLabel={t('i18n.import')}
-      onImport={() => void handleImportFile()}
+      onImport={() => void runImport()}
       importDisabled={importing}
       sortButton={(
         <PackSortButton

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -73,6 +73,14 @@ export function ThemePacksModal({
   const previewSeqRef = useRef(0)
   const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
   const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
+  // Mirrors `importing` (from `useImportBatch`, defined further below)
+  // into a ref so `handleRenameCommit` can read its latest value the
+  // same way in all three pack modals — some of them define the rename
+  // handler before the `useImportBatch` call, where the `importing`
+  // state itself isn't in scope yet. Kept current via a plain
+  // assignment during render (the same "adjust a ref during render"
+  // pattern `useImportPlacement.ts` uses for its own always-latest refs).
+  const importingRef = useRef(false)
 
   const activeTheme = appConfig.config.theme
   const hubOrigin = useHubOrigin(open)
@@ -340,8 +348,31 @@ export function ThemePacksModal({
     hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
     onCollapsedToOne: (meta) => handleSelectTheme(`pack:${meta.id}`),
   })
+  importingRef.current = importing
+
+  // Closes any inline rename that was already open the moment a batch
+  // starts, so its input unmounts instead of sitting there interactive
+  // (and committable) for the whole duration of the import — see
+  // `handleRenameCommit`'s own `importingRef` guard below for the one
+  // race this cannot cover (a rename input's blur, and the click that
+  // starts the batch, are the same user click; the blur's commit is
+  // already in flight before `importing` ever flips true).
+  useEffect(() => {
+    if (importing) rename.cancelRename()
+    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
+    // intentionally not in the deps array so this only re-fires when
+    // `importing` itself flips, not on every unrelated render.
+  }, [importing])
 
   const handleRenameCommit = useCallback(async (id: string) => {
+    // See the module-level note above `importingRef`: this cannot
+    // intercept a commit whose blur fired as part of the very click
+    // that started the batch (already in flight before `importing`
+    // flips true), but it does catch a rename left open from an
+    // already-running batch, and any stray commit that slips through
+    // after the cancel-on-import-start effect above has already reset
+    // the editor for this render.
+    if (importingRef.current) return
     const newName = rename.commitRename(id)
     if (!newName) return
     setActionError(null)

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -327,6 +327,37 @@ describe('ThemePacksModal', () => {
     await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
   })
 
+  it('P1-b: starting a rename then triggering an import cancels the edit instead of letting it commit mid-batch', async () => {
+    metas = [meta({ id: 'r2', name: 'Old Name' })]
+    let resolveDialog!: (value: { canceled: boolean; files: Array<{ filePath: string; raw?: unknown; parseError?: string }> }) => void
+    importFromDialog.mockImplementationOnce(() => new Promise((resolve) => { resolveDialog = resolve }))
+    render(
+      <ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />,
+    )
+
+    fireEvent.click(screen.getByTestId('theme-packs-name-r2'))
+    const input = screen.getByTestId('theme-packs-rename-input-r2')
+    fireEvent.change(input, { target: { value: 'New Name' } })
+
+    // Trigger the import batch WITHOUT ever blurring the rename input —
+    // jsdom does not auto-blur an unrelated element on click the way a
+    // real browser does, so this specifically exercises the
+    // cancel-on-import-start effect rather than the (unpreventable)
+    // same-click blur race.
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+
+    // The edit was canceled, not left open and interactive for the
+    // duration of the batch.
+    expect(screen.queryByTestId('theme-packs-rename-input-r2')).toBeNull()
+    expect(renameFn).not.toHaveBeenCalled()
+
+    resolveDialog({ canceled: true, files: [] })
+    await waitFor(() => expect((screen.getByTestId('theme-packs-import-button') as HTMLButtonElement).disabled).toBe(false))
+    // Still never committed, even after the batch finished.
+    expect(renameFn).not.toHaveBeenCalled()
+  })
+
   it('import applies the raw data when dialog returns a file', async () => {
     const raw = { name: 'Imported', version: '1', colorScheme: 'dark', colors: {} }
     importFromDialog.mockResolvedValueOnce({ canceled: false, files: [{ filePath: 'test.json', raw }] })

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -7,6 +7,12 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       if (params && 'name' in params) return `${key}:${String(params.name)}`
+      // Surfaces the toolbar import summary's success/failure counts so
+      // tests can assert on them without a real i18next pluralization
+      // pipeline.
+      if (params && 'success' in params && 'failure' in params) {
+        return `${key}:${String(params.count)}:${String(params.success)}:${String(params.failure)}`
+      }
       return key
     },
   }),
@@ -469,6 +475,109 @@ describe('ThemePacksModal', () => {
     fireEvent.click(screen.getByTestId('theme-packs-import-button'))
     await waitFor(() => expect(screen.getByTestId('theme-packs-result-b').textContent).toBe('common.saved'))
     expect(screen.getByTestId('theme-packs-result-c').textContent).toBe('common.saved')
+  })
+
+  it('multi-file import (2+ files): does not auto-scroll, does not auto-select, and shows the toolbar summary instead of per-name feedback', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    const rawB = { name: 'Beta', version: '1', colorScheme: 'dark', colors: {} }
+    const rawC = { name: 'Gamma', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'beta.json', raw: rawB },
+        { filePath: 'gamma.json', raw: rawC },
+      ],
+    })
+    const metaB = meta({ id: 'b', name: 'Beta' })
+    const metaC = meta({ id: 'c', name: 'Gamma' })
+    applyImport
+      .mockImplementationOnce(async () => {
+        metas = [...metas, metaB]
+        return { success: true, meta: metaB }
+      })
+      .mockImplementationOnce(async () => {
+        metas = [...metas, metaC]
+        return { success: true, meta: metaC }
+      })
+    const onThemeChange = vi.fn()
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={onThemeChange} />)
+
+    const scrollIntoView = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {})
+    try {
+      fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+      await waitFor(() => expect(screen.getByTestId('theme-packs-result-c').textContent).toBe('common.saved'))
+
+      // 2+ batch: no auto-scroll to an arbitrary one of the new rows.
+      expect(scrollIntoView).not.toHaveBeenCalled()
+      // 2+ batch: no auto-activation of an arbitrary one of the new themes.
+      expect(onThemeChange).not.toHaveBeenCalled()
+      // The toolbar headline supersedes the per-name "Imported {{name}}"
+      // feedback for a 2+ batch: 2 processed, both saved, none failed.
+      expect(screen.getByTestId('theme-packs-import-feedback').textContent).toBe('common.importSummary:2:2:0')
+    } finally {
+      scrollIntoView.mockRestore()
+    }
+  })
+
+  it('partial-failure batch: a hub-sync failure still counts as a success in the summary headline, but appears in the failure banner', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    const rawBad = { name: 'Bad Theme', version: '1', colorScheme: 'dark', colors: {} }
+    const rawGood = { name: 'Existing Theme', version: '1', colorScheme: 'dark', colors: {} }
+    importFromDialog.mockResolvedValueOnce({
+      canceled: false,
+      files: [
+        { filePath: 'bad.json', raw: rawBad },
+        { filePath: 'my-upload.json', raw: rawGood },
+      ],
+    })
+    const savedMeta = meta({ id: 'e', name: 'Existing Theme', hubPostId: 'hub-1' })
+    applyImport
+      .mockResolvedValueOnce({ success: false, error: 'Invalid theme colors' })
+      .mockImplementationOnce(async () => {
+        metas = [...metas, savedMeta]
+        return { success: true, meta: savedMeta }
+      })
+    vialAPI.hubUpdateThemePost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(screen.getByTestId('theme-packs-result-e').textContent).toBe('common.saved'))
+
+    // Headline: 1 saved (the hub-sync failure doesn't reduce this — the
+    // file itself landed on disk) and 1 not-saved (the store-side
+    // validation failure) — 2 processed total.
+    expect(screen.getByTestId('theme-packs-import-feedback').textContent).toBe('common.importSummary:2:1:1')
+
+    const banner = screen.getByTestId('theme-packs-error')
+    expect(banner.textContent).toContain('bad.json')
+    expect(banner.textContent).toContain('my-upload.json')
+    expect(banner.textContent).toContain('network error')
+  })
+
+  it('locks the Import button and existing row actions while a batch import is in flight', async () => {
+    metas = [meta({ id: 'a', name: 'Alpha' })]
+    let resolveDialog!: (value: { canceled: boolean; files: Array<{ filePath: string; raw?: unknown; parseError?: string }> }) => void
+    importFromDialog.mockImplementationOnce(() => new Promise((resolve) => { resolveDialog = resolve }))
+    render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    await waitFor(() => expect(importFromDialog).toHaveBeenCalled())
+
+    expect((screen.getByTestId('theme-packs-import-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('theme-packs-sort-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('theme-packs-builtin-system') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('theme-packs-select-a') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('theme-packs-export-a') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('theme-packs-delete-a') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('theme-packs-row-a').getAttribute('draggable')).toBeNull()
+
+    // A second click while in flight is a no-op (the in-flight ref
+    // guard) — the dialog is not opened a second time.
+    fireEvent.click(screen.getByTestId('theme-packs-import-button'))
+    expect(importFromDialog).toHaveBeenCalledTimes(1)
+
+    resolveDialog({ canceled: true, files: [] })
+    await waitFor(() => expect((screen.getByTestId('theme-packs-import-button') as HTMLButtonElement).disabled).toBe(false))
   })
 
   it('partial-failure batch: the good file keeps its badge while the bad file is aggregated into one banner', async () => {

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.41",
+  "version": "0.1.42",
   "name": "English",
   "common": {
     "save": "Save",
@@ -41,7 +41,9 @@
     "importedNamed": "Imported {{name}}",
     "updatedNamed": "Updated {{name}}",
     "importBatchFailed_one": "{{count}} file could not be imported:",
-    "importBatchFailed_other": "{{count}} files could not be imported:"
+    "importBatchFailed_other": "{{count}} files could not be imported:",
+    "importSummary_one": "Imported {{count}} file (success {{success}}, failure {{failure}})",
+    "importSummary_other": "Imported {{count}} files (success {{success}}, failure {{failure}})"
   },
   "app": {
     "title": "Pipette",


### PR DESCRIPTION
## Summary

Refines the multi-file import in the Language Packs, Theme Packs, and Key Labels modals.

- **List is locked while an import runs.** Row actions (delete, Hub download, rename, update/sync, the per-row select), drag-reorder, the sort button, and the Import button itself are all disabled for the duration, and a second Import click is a no-op. A rename left open when an import starts is cancelled, and its commit is guarded so it can't fire mid-import.
- **One-line outcome summary.** After a batch, the toolbar shows "Imported N files (success N, failure N)". A file whose save succeeds counts as success even if its later Hub auto-sync fails — that failure still appears, with its reason, in the failure banner. Single-file imports keep their existing per-name feedback.
- **No auto-scroll or auto-select for multi-file imports.** Picking two or more files no longer jumps the list to an arbitrary row; single-file import keeps scrolling to its row. The count that decides this is the number of files picked, so two files that overwrite the same pack still read as a batch.

The batch orchestration — previously duplicated across all three modals — is extracted into a shared `useImportBatch` hook alongside the existing `useImportPlacement`, trimming ~240 lines from the modals.

## Testing

- 7152 tests pass; lint and typecheck clean.
- New `useImportBatch` hook tests plus per-modal tests for the lock, the summary counts (including the same-pack-overwrite and hub-sync-failure cases), no-scroll on multi-file, and rename-cancelled-on-import. The modals' existing batch tests pass unchanged, confirming the extraction is behavior-preserving.