### PR TITLE
fix(ui): throttle hub sync during import and localize rate-limit errors

### DIFF
--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -28,6 +28,7 @@ import { MissingKeysModal } from './MissingKeysModal'
 import { downloadJson } from '../../utils/download-json'
 import { buildHubI18nPackUrl, HUB_CATEGORY } from '../../../shared/hub-urls'
 import { useHubFreshness } from '../../hooks/useHubFreshness'
+import { localizeHubError } from '../../utils/hub-error-i18n'
 import { PackManagerModal } from '../pack-modal/PackManagerModal'
 import { PackHubTab } from '../pack-modal/PackHubTab'
 import { PackSortButton } from '../pack-modal/PackSortButton'
@@ -364,7 +365,7 @@ export function LanguagePacksModal({
       await store.refresh()
       return { success: true }
     }
-    return { success: false, error: res.error ?? t('hub.updateFailed') }
+    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
   }, [store, t])
 
   const handleRenameCommit = useCallback(async (id: string): Promise<void> => {

--- a/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
+++ b/src/renderer/components/i18n-packs/__tests__/LanguagePacksModal.test.tsx
@@ -165,6 +165,7 @@ Object.defineProperty(window, 'vialAPI', { value: vialAPI, writable: true })
 
 import { LanguagePacksModal } from '../LanguagePacksModal'
 import { downloadJson } from '../../../utils/download-json'
+import { HUB_ERROR_RATE_LIMITED } from '../../../../shared/types/hub'
 
 function meta(over: Partial<{
   id: string
@@ -628,7 +629,10 @@ describe('LanguagePacksModal', () => {
       storeMetas = [...storeMetas, savedMeta]
       return { success: true, meta: savedMeta }
     })
-    vialAPI.hubUpdateI18nPost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    // A 429 from the Hub during the batch's hub-sync loop — surfaced as
+    // the bare `RATE_LIMITED` sentinel, exactly as the localization
+    // fix's target case arrives from main.
+    vialAPI.hubUpdateI18nPost.mockResolvedValueOnce({ success: false, error: HUB_ERROR_RATE_LIMITED })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 
     fireEvent.click(screen.getByTestId('language-packs-import-button'))
@@ -639,12 +643,13 @@ describe('LanguagePacksModal', () => {
     // failure) — 2 processed total.
     expect(screen.getByTestId('language-packs-import-feedback').textContent).toBe('common.importSummary:2:1:1')
 
-    // The hub-sync failure still shows up in the failure banner text,
-    // alongside the parse failure.
+    // The hub-sync failure shows up in the failure banner localized —
+    // the raw `RATE_LIMITED` sentinel must never reach the user.
     const banner = screen.getByTestId('language-packs-error')
     expect(banner.textContent).toContain('bad.json')
     expect(banner.textContent).toContain('my-upload.json')
-    expect(banner.textContent).toContain('network error')
+    expect(banner.textContent).toContain('hub.rateLimited')
+    expect(banner.textContent).not.toContain('RATE_LIMITED')
   })
 
   it('locks the Import button and existing row actions while a batch import is in flight', async () => {
@@ -757,6 +762,8 @@ describe('LanguagePacksModal', () => {
     })
     const savedMeta = meta({ id: 'e', name: 'Existing Pack', hubPostId: 'hub-1', matchedBaseVersion: '0.1.0' })
     applyImport.mockResolvedValueOnce({ success: true, meta: savedMeta })
+    // An unrecognized raw error string falls back to the generic
+    // localized "update failed" copy rather than leaking backend text.
     vialAPI.hubUpdateI18nPost.mockResolvedValueOnce({ success: false, error: 'network error' })
     render(<LanguagePacksModal open onClose={vi.fn()} />)
 
@@ -766,7 +773,7 @@ describe('LanguagePacksModal', () => {
     })
     const banner = screen.getByTestId('language-packs-error')
     expect(banner.textContent).toContain('my-upload.json')
-    expect(banner.textContent).toContain('network error')
+    expect(banner.textContent).toContain('hub.updateFailed')
   })
 
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {

--- a/src/renderer/components/key-labels/KeyLabelsModal.tsx
+++ b/src/renderer/components/key-labels/KeyLabelsModal.tsx
@@ -33,6 +33,7 @@ import { useImportBatch, type CollectedImportBatch } from '../pack-modal/useImpo
 import type { ImportBatchFailure } from '../pack-modal/import-batch-summary'
 import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
 import { isOwnPack } from '../pack-modal/ownership'
+import { localizeHubError } from '../../utils/hub-error-i18n'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
 import {
   InstalledTable,
@@ -521,7 +522,7 @@ function buildHubRows(items: HubKeyLabelItem[], metas: KeyLabelMeta[]): HubRow[]
 }
 
 function translateError(
-  t: (key: string) => string,
+  t: TFunction,
   code: string | undefined,
   error: string | undefined,
 ): string {
@@ -530,6 +531,10 @@ function translateError(
   }
   if (code === 'INVALID_FILE') return t('keyLabels.errorImportFailed')
   if (code === 'INVALID_NAME') return t('keyLabels.errorInvalidName')
-  return error ?? t('keyLabels.errorGeneric')
+  // Falls through to the shared Hub error mapper — covers RATE_LIMITED
+  // (429) and the other bare sentinels/HubHttpError shapes that a
+  // main-side hub call (upload/update/sync/delete) can surface, none of
+  // which the codes above account for.
+  return localizeHubError(error, 'keyLabels.errorGeneric', t)
 }
 

--- a/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
+++ b/src/renderer/components/key-labels/__tests__/KeyLabelsModal.test.tsx
@@ -102,6 +102,7 @@ vi.mock('../../../hooks/useKeyLabelLookup', () => ({
 }))
 
 import { KeyLabelsModal } from '../KeyLabelsModal'
+import { HUB_ERROR_RATE_LIMITED } from '../../../../shared/types/hub'
 
 function meta(over: Partial<{ id: string; name: string; uploaderName: string; hubPostId: string }> = {}) {
   return {
@@ -353,15 +354,17 @@ describe('KeyLabelsModal', () => {
     expect(hubDelete).not.toHaveBeenCalled()
   })
 
-  it('blocks the local delete and surfaces an error when the Hub delete rejects, leaving the entry intact', async () => {
+  it('blocks the local delete and surfaces a localized error when the Hub delete rejects, leaving the entry intact', async () => {
     metas = [meta({ id: 'linked2', name: 'Linked2', uploaderName: 'me', hubPostId: 'hub-2' })]
-    hubDelete.mockRejectedValueOnce(new Error('network error'))
+    // A 429 from the Hub — surfaced as the bare `RATE_LIMITED` sentinel,
+    // which must reach the row as the localized message, not raw text.
+    hubDelete.mockRejectedValueOnce(new Error(HUB_ERROR_RATE_LIMITED))
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-delete-linked2'))
     const confirm = await screen.findByTestId('key-labels-confirm-delete-linked2')
     fireEvent.click(confirm)
     await waitFor(() => expect(hubDelete).toHaveBeenCalledWith('linked2'))
-    await waitFor(() => expect(screen.getByTestId('key-labels-result-linked2').textContent).toBe('network error'))
+    await waitFor(() => expect(screen.getByTestId('key-labels-result-linked2').textContent).toBe('hub.rateLimited'))
     // A failed cascade must not proceed to the local delete — otherwise
     // the Hub post is orphaned under a name nobody can re-upload.
     expect(remove).not.toHaveBeenCalled()
@@ -372,13 +375,15 @@ describe('KeyLabelsModal', () => {
 
   it('blocks the local delete when the Hub delete resolves with success: false', async () => {
     metas = [meta({ id: 'linked3', name: 'Linked3', uploaderName: 'me', hubPostId: 'hub-3' })]
+    // An unrecognized raw error string falls back to the generic
+    // localized error copy rather than leaking backend text.
     hubDelete.mockResolvedValueOnce({ success: false, error: 'Hub rejected the delete' })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-delete-linked3'))
     const confirm = await screen.findByTestId('key-labels-confirm-delete-linked3')
     fireEvent.click(confirm)
     await waitFor(() => expect(hubDelete).toHaveBeenCalledWith('linked3'))
-    await waitFor(() => expect(screen.getByTestId('key-labels-result-linked3').textContent).toBe('Hub rejected the delete'))
+    await waitFor(() => expect(screen.getByTestId('key-labels-result-linked3').textContent).toBe('keyLabels.errorGeneric'))
     expect(remove).not.toHaveBeenCalled()
   })
 
@@ -640,7 +645,10 @@ describe('KeyLabelsModal', () => {
         rejections: [{ fileName: 'broken.json', errorCode: 'INVALID_FILE', error: 'Invalid key label file' }],
       },
     })
-    hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
+    // A 429 from the Hub during the batch's hub-sync loop — surfaced as
+    // the bare `RATE_LIMITED` sentinel, exactly as the localization
+    // fix's target case arrives from main.
+    hubUpdate.mockResolvedValueOnce({ success: false, error: HUB_ERROR_RATE_LIMITED })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
 
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
@@ -651,10 +659,13 @@ describe('KeyLabelsModal', () => {
     // rejection) — 2 processed total.
     await waitFor(() => expect(screen.getByTestId('key-labels-import-feedback').textContent).toBe('common.importSummary:2:1:1'))
 
+    // The hub-sync failure shows up in the failure banner localized —
+    // the raw `RATE_LIMITED` sentinel must never reach the user.
     const banner = screen.getByTestId('key-labels-error')
     expect(banner.textContent).toContain('broken.json')
     expect(banner.textContent).toContain('existing.json')
-    expect(banner.textContent).toContain('network error')
+    expect(banner.textContent).toContain('hub.rateLimited')
+    expect(banner.textContent).not.toContain('RATE_LIMITED')
   })
 
   it('locks the Import button and existing row actions while a batch import is in flight', async () => {
@@ -800,12 +811,14 @@ describe('KeyLabelsModal', () => {
   it('shows error when hub auto-sync fails after import, reported against the originating filename (P2a)', async () => {
     const importedMeta = meta({ id: 'existing', name: 'Existing', hubPostId: 'hub-55' })
     importFromFile.mockResolvedValueOnce({ success: true, data: { imported: [{ fileName: 'existing.json', meta: importedMeta }], rejections: [] } })
+    // An unrecognized raw error string falls back to the generic
+    // localized error copy rather than leaking backend text.
     hubUpdate.mockResolvedValueOnce({ success: false, error: 'network error' })
     render(<KeyLabelsModal open onClose={vi.fn()} currentDisplayName="me" hubCanWrite />)
     fireEvent.click(screen.getByTestId('key-labels-import-button'))
     await waitFor(() => expect(hubUpdate).toHaveBeenCalledWith('existing'))
     await waitFor(() => {
-      expect(screen.getByTestId('key-labels-error').textContent).toContain('network error')
+      expect(screen.getByTestId('key-labels-error').textContent).toContain('keyLabels.errorGeneric')
     })
     // P2a: the failure line reports the file the user picked, not the
     // label's internal display name (both happen to differ in this test).

--- a/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import type { TFunction } from 'i18next'
 import { useImportBatch, type CollectedImportBatch } from '../useImportBatch'
@@ -308,5 +308,127 @@ describe('useImportBatch', () => {
 
     act(() => { rerender({ open: false }) })
     expect(result.current.importSummary).toBeNull()
+  })
+
+  describe('hub-sync pacing', () => {
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('adds no delay when nothing in the batch has a hubPostId (zero hub-syncs)', async () => {
+      vi.useFakeTimers()
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      const placement = makePlacement()
+      const hubSync = vi.fn().mockResolvedValue({ success: true })
+      const collectResults = vi.fn().mockResolvedValue({
+        successes: [
+          { fileName: 'a.json', meta: { id: 'a', name: 'A' } },
+          { fileName: 'b.json', meta: { id: 'b', name: 'B' } },
+        ],
+        notSavedFailures: [],
+        snapshot: { entries: [], direction: 'asc' },
+      } satisfies CollectedImportBatch<FakeMeta>)
+
+      const { result } = renderHook(() => useImportBatch<FakeMeta>({
+        open: true,
+        placement,
+        setLastResult: vi.fn(),
+        setActionError: vi.fn(),
+        t,
+        collectResults,
+        hubSync,
+      }))
+
+      await act(async () => {
+        const p = result.current.runImport()
+        await vi.runAllTimersAsync()
+        await p
+      })
+
+      expect(hubSync).not.toHaveBeenCalled()
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 500)).toHaveLength(0)
+    })
+
+    it('adds no delay for a batch that hub-syncs exactly once', async () => {
+      vi.useFakeTimers()
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+      const placement = makePlacement()
+      const hubSync = vi.fn().mockResolvedValue({ success: true })
+      const collectResults = vi.fn().mockResolvedValue({
+        successes: [{ fileName: 'a.json', meta: { id: 'a', name: 'A', hubPostId: 'hp-a' } }],
+        notSavedFailures: [],
+        snapshot: { entries: [], direction: 'asc' },
+      } satisfies CollectedImportBatch<FakeMeta>)
+
+      const { result } = renderHook(() => useImportBatch<FakeMeta>({
+        open: true,
+        placement,
+        setLastResult: vi.fn(),
+        setActionError: vi.fn(),
+        t,
+        collectResults,
+        hubSync,
+      }))
+
+      await act(async () => {
+        const p = result.current.runImport()
+        await vi.runAllTimersAsync()
+        await p
+      })
+
+      expect(hubSync).toHaveBeenCalledTimes(1)
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 500)).toHaveLength(0)
+    })
+
+    it('spaces three consecutive hub-syncs by 500ms each, with no delay before the first or after the last', async () => {
+      vi.useFakeTimers()
+      const placement = makePlacement()
+      const hubSync = vi.fn().mockResolvedValue({ success: true })
+      const collectResults = vi.fn().mockResolvedValue({
+        successes: [
+          { fileName: 'a.json', meta: { id: 'a', name: 'A', hubPostId: 'hp-a' } },
+          { fileName: 'b.json', meta: { id: 'b', name: 'B', hubPostId: 'hp-b' } },
+          { fileName: 'c.json', meta: { id: 'c', name: 'C', hubPostId: 'hp-c' } },
+        ],
+        notSavedFailures: [],
+        snapshot: { entries: [], direction: 'asc' },
+      } satisfies CollectedImportBatch<FakeMeta>)
+
+      const { result } = renderHook(() => useImportBatch<FakeMeta>({
+        open: true,
+        placement,
+        setLastResult: vi.fn(),
+        setActionError: vi.fn(),
+        t,
+        collectResults,
+        hubSync,
+      }))
+
+      let runPromise!: Promise<void>
+      await act(async () => {
+        runPromise = result.current.runImport()
+        // Let collectResults resolve and the first, undelayed hub-sync
+        // fire — no timer has been scheduled yet at this point.
+        await vi.advanceTimersByTimeAsync(0)
+      })
+      expect(hubSync).toHaveBeenCalledTimes(1)
+
+      // Just under the delay window: the second hub-sync must not have
+      // fired yet.
+      await act(async () => { await vi.advanceTimersByTimeAsync(499) })
+      expect(hubSync).toHaveBeenCalledTimes(1)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+      expect(hubSync).toHaveBeenCalledTimes(2)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(499) })
+      expect(hubSync).toHaveBeenCalledTimes(2)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(1) })
+      expect(hubSync).toHaveBeenCalledTimes(3)
+
+      await act(async () => { await runPromise })
+      expect(result.current.importing).toBe(false)
+    })
   })
 })

--- a/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
+++ b/src/renderer/components/pack-modal/__tests__/useImportBatch.test.ts
@@ -346,7 +346,7 @@ describe('useImportBatch', () => {
       })
 
       expect(hubSync).not.toHaveBeenCalled()
-      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 500)).toHaveLength(0)
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 1100)).toHaveLength(0)
     })
 
     it('adds no delay for a batch that hub-syncs exactly once', async () => {
@@ -377,10 +377,10 @@ describe('useImportBatch', () => {
       })
 
       expect(hubSync).toHaveBeenCalledTimes(1)
-      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 500)).toHaveLength(0)
+      expect(setTimeoutSpy.mock.calls.filter(([, ms]) => ms === 1100)).toHaveLength(0)
     })
 
-    it('spaces three consecutive hub-syncs by 500ms each, with no delay before the first or after the last', async () => {
+    it('spaces three consecutive hub-syncs by 1100ms each, with no delay before the first or after the last', async () => {
       vi.useFakeTimers()
       const placement = makePlacement()
       const hubSync = vi.fn().mockResolvedValue({ success: true })
@@ -415,13 +415,13 @@ describe('useImportBatch', () => {
 
       // Just under the delay window: the second hub-sync must not have
       // fired yet.
-      await act(async () => { await vi.advanceTimersByTimeAsync(499) })
+      await act(async () => { await vi.advanceTimersByTimeAsync(1099) })
       expect(hubSync).toHaveBeenCalledTimes(1)
 
       await act(async () => { await vi.advanceTimersByTimeAsync(1) })
       expect(hubSync).toHaveBeenCalledTimes(2)
 
-      await act(async () => { await vi.advanceTimersByTimeAsync(499) })
+      await act(async () => { await vi.advanceTimersByTimeAsync(1099) })
       expect(hubSync).toHaveBeenCalledTimes(2)
 
       await act(async () => { await vi.advanceTimersByTimeAsync(1) })

--- a/src/renderer/components/pack-modal/useImportBatch.ts
+++ b/src/renderer/components/pack-modal/useImportBatch.ts
@@ -70,10 +70,16 @@ interface ImportBatchMeta {
 /** Client-side pacing between consecutive Hub write requests fired by
  *  the multi-file import batch's hub-sync loop. The Hub's IP-layer
  *  rate limit allows roughly 120 requests per 60s (~500ms/request)
- *  before returning 429/RATE_LIMITED — spacing hub-sync calls by that
- *  same interval keeps a large batch under the limit instead of
- *  bursting one request per imported pack back-to-back. */
-const HUB_SYNC_DELAY_MS = 500
+ *  before returning 429/RATE_LIMITED. I18n and Theme pack updates each
+ *  fire TWO Hub requests per hub-sync call — the update PUT plus a
+ *  follow-up `/timestamps` call (see `src/main/hub/hub-ipc.ts` around
+ *  the i18n update handler and the theme update handler) — so a batch
+ *  of those effectively doubles the request rate per hub-sync
+ *  iteration. Spacing hub-sync calls by ~1100ms rather than ~500ms
+ *  keeps that worst case under the limit with a small safety margin
+ *  (Key Labels' single-request update stays comfortably under the
+ *  limit too at this spacing). */
+const HUB_SYNC_DELAY_MS = 1100
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))

--- a/src/renderer/components/pack-modal/useImportBatch.ts
+++ b/src/renderer/components/pack-modal/useImportBatch.ts
@@ -67,6 +67,18 @@ interface ImportBatchMeta {
   hubPostId?: string
 }
 
+/** Client-side pacing between consecutive Hub write requests fired by
+ *  the multi-file import batch's hub-sync loop. The Hub's IP-layer
+ *  rate limit allows roughly 120 requests per 60s (~500ms/request)
+ *  before returning 429/RATE_LIMITED — spacing hub-sync calls by that
+ *  same interval keeps a large batch under the limit instead of
+ *  bursting one request per imported pack back-to-back. */
+const HUB_SYNC_DELAY_MS = 500
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export interface CollectedImportBatch<TMeta> {
   successes: ImportBatchItem<TMeta>[]
   /** Files that never actually landed on disk (parse/validate/store
@@ -154,9 +166,18 @@ export function useImportBatch<TMeta extends ImportBatchMeta>({
 
       const hubSyncFailures: ImportBatchFailure[] = []
       const successBadges: PackActionResult[] = []
+      // Only actual Hub writes need spacing — a batch with zero
+      // hub-syncs (no `hubPostId` anywhere) or exactly one must add no
+      // delay at all. Tracking "did a previous hub-sync already fire"
+      // rather than the loop index means the delay lands strictly
+      // *between* real requests: never before the first one, never
+      // trailing after the last.
+      let hubSyncedBefore = false
       for (const { fileName, meta } of deduped) {
         let message = t('common.saved')
         if (meta.hubPostId && hubSync) {
+          if (hubSyncedBefore) await sleep(HUB_SYNC_DELAY_MS)
+          hubSyncedBefore = true
           const upd = await hubSync(meta)
           if (upd.success) {
             message = t('common.synced')

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -17,6 +17,7 @@ import type { ThemeColorScheme, ThemePackColors, ThemePackMeta } from '../../../
 import type { HubThemePostListItem, HubThemePackBody } from '../../../shared/types/hub'
 import { HUB_CATEGORY } from '../../../shared/hub-urls'
 import { useHubFreshness } from '../../hooks/useHubFreshness'
+import { localizeHubError } from '../../utils/hub-error-i18n'
 import type { ThemeMode, ThemeSelection } from '../../../shared/types/app-config'
 import { PackRow } from './ThemePackRow'
 import { PackManagerModal } from '../pack-modal/PackManagerModal'
@@ -232,7 +233,7 @@ export function ThemePacksModal({
       await store.refresh()
       return { success: true }
     }
-    return { success: false, error: res.error ?? t('hub.updateFailed') }
+    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
   }, [store, t])
 
   const handleTabChange = useCallback((tab: PackManagerTabId) => {

--- a/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
+++ b/src/renderer/components/theme-packs/__tests__/ThemePacksModal.test.tsx
@@ -114,6 +114,7 @@ const vialAPI = {
 Object.defineProperty(window, 'vialAPI', { value: vialAPI, writable: true })
 
 import { ThemePacksModal } from '../ThemePacksModal'
+import { HUB_ERROR_RATE_LIMITED } from '../../../../shared/types/hub'
 
 function meta(over: Partial<{
   id: string
@@ -568,7 +569,10 @@ describe('ThemePacksModal', () => {
         metas = [...metas, savedMeta]
         return { success: true, meta: savedMeta }
       })
-    vialAPI.hubUpdateThemePost.mockResolvedValueOnce({ success: false, error: 'network error' })
+    // A 429 from the Hub during the batch's hub-sync loop — surfaced as
+    // the bare `RATE_LIMITED` sentinel, exactly as the localization
+    // fix's target case arrives from main.
+    vialAPI.hubUpdateThemePost.mockResolvedValueOnce({ success: false, error: HUB_ERROR_RATE_LIMITED })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
     fireEvent.click(screen.getByTestId('theme-packs-import-button'))
@@ -579,10 +583,13 @@ describe('ThemePacksModal', () => {
     // validation failure) — 2 processed total.
     expect(screen.getByTestId('theme-packs-import-feedback').textContent).toBe('common.importSummary:2:1:1')
 
+    // The hub-sync failure shows up in the failure banner localized —
+    // the raw `RATE_LIMITED` sentinel must never reach the user.
     const banner = screen.getByTestId('theme-packs-error')
     expect(banner.textContent).toContain('bad.json')
     expect(banner.textContent).toContain('my-upload.json')
-    expect(banner.textContent).toContain('network error')
+    expect(banner.textContent).toContain('hub.rateLimited')
+    expect(banner.textContent).not.toContain('RATE_LIMITED')
   })
 
   it('locks the Import button and existing row actions while a batch import is in flight', async () => {
@@ -683,6 +690,8 @@ describe('ThemePacksModal', () => {
     })
     const savedMeta = meta({ id: 'e', name: 'Existing Pack', hubPostId: 'hub-1' })
     applyImport.mockResolvedValueOnce({ success: true, meta: savedMeta })
+    // An unrecognized raw error string falls back to the generic
+    // localized "update failed" copy rather than leaking backend text.
     vialAPI.hubUpdateThemePost.mockResolvedValueOnce({ success: false, error: 'network error' })
     render(<ThemePacksModal open onClose={vi.fn()} onThemeChange={vi.fn()} />)
 
@@ -692,7 +701,7 @@ describe('ThemePacksModal', () => {
     })
     const banner = screen.getByTestId('theme-packs-error')
     expect(banner.textContent).toContain('my-upload.json')
-    expect(banner.textContent).toContain('network error')
+    expect(banner.textContent).toContain('hub.updateFailed')
   })
 
   it('hub download parity: a new Hub download is inserted at its sorted position via reorder', async () => {


### PR DESCRIPTION
## Summary

Multi-file pack import synced each pack to the Hub back-to-back with no spacing, tripping the Hub's rate limit (429 / RATE_LIMITED) and surfacing the raw sentinel string in the failure banner.

- The batch hub-sync loop now waits 1100ms between successful Hub writes — only between actual requests (never before the first, after the last, or for packs with no `hubPostId`). The interval accounts for I18n/Theme updates issuing two Hub requests each (the update plus a `/timestamps` follow-up), keeping the effective rate under the Hub's IP limit of ~120 req/min.
- Hub-sync failures on the import path now run through `localizeHubError`, so a 429 shows the localized rate-limit message instead of the raw `RATE_LIMITED` sentinel. A per-day quota overrun (which pacing can't prevent) surfaces the same readable message.

## Testing

- Fake-timer tests assert the pacing (spacing between syncs, no delay for first/single/no-hub cases); modal tests assert RATE_LIMITED surfaces as `hub.rateLimited`.
- 7156 tests pass; lint and typecheck clean.