### PR TITLE
fix(ui): keep the picker tab selection through mask-only filtering

### DIFF
--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -236,8 +236,26 @@ export function TabbedKeycodes({
     [lmMode, isVisible, revision],
   )
 
+  // Whether the special "keyboard" tab is currently shown at all. Kept as a
+  // plain boolean (not the keyboardPickerContent node itself) so effectiveTab
+  // below only recomputes when availability actually flips, not on every
+  // parent re-render that hands us a fresh JSX reference.
+  const keyboardTabAvailable = Boolean(keyboardPickerContent) && !maskOnly
+
+  // activeTab records only the tab the user last explicitly picked; it is
+  // never rewritten by availability changes. effectiveTab is the derived
+  // value actually used for rendering: if activeTab is temporarily
+  // unavailable (e.g. maskOnly narrowing categories, or the keyboard tab
+  // disappearing), it falls back to the first category, and automatically
+  // snaps back to activeTab once that tab becomes available again.
+  const effectiveTab = useMemo(() => {
+    const available = activeTab === 'keyboard' ? keyboardTabAvailable : categories.some((c) => c.id === activeTab)
+    if (available) return activeTab
+    return categories[0]?.id ?? activeTab
+  }, [activeTab, categories, keyboardTabAvailable])
+
   const { activeTabKeycodes, keycodeIndexMap } = useMemo(() => {
-    const cat = categories.find((c) => c.id === activeTab)
+    const cat = categories.find((c) => c.id === effectiveTab)
     if (!cat) return { activeTabKeycodes: [] as Keycode[], keycodeIndexMap: new Map<string, KeycodeIndexEntry>() }
 
     const indexMap = new Map<string, KeycodeIndexEntry>()
@@ -308,16 +326,22 @@ export function TabbedKeycodes({
 
     keycodes.forEach((kc, i) => indexMap.set(kc.qmkId, { baseIdx: i }))
     return { activeTabKeycodes: keycodes, keycodeIndexMap: indexMap }
-  }, [categories, activeTab, isVisible, revision, resolvedBasicViewType, maskOnly, lmMode, useSplit])
+  }, [categories, effectiveTab, isVisible, revision, resolvedBasicViewType, maskOnly, lmMode, useSplit])
 
-  // Reset active tab if it no longer exists in the filtered categories
+  // Clear any open tooltip whenever the rendered tab changes, whether from a
+  // user click or an automatic fallback/restore driven by effectiveTab.
   useEffect(() => {
-    const keyboardHidden = activeTab === 'keyboard' && maskOnly
-    if (categories.length > 0 && (keyboardHidden || (activeTab !== 'keyboard' && !categories.some((c) => c.id === activeTab)))) {
-      setActiveTab(categories[0].id)
+    setTooltip(null)
+  }, [effectiveTab])
+
+  const selectTab = useCallback(
+    (id: string) => {
+      onTabChange?.()
+      setActiveTab(id)
       setTooltip(null)
-    }
-  }, [categories, activeTab, maskOnly])
+    },
+    [onTabChange],
+  )
 
   const handleKeycodeHover = useCallback(
     (kc: Keycode, rect: DOMRect) => {
@@ -358,7 +382,7 @@ export function TabbedKeycodes({
   )
 
   function renderKeycodeGrid(keycodes: Keycode[], tabId?: string): React.ReactNode {
-    const isActive = !tabId || tabId === activeTab
+    const isActive = !tabId || tabId === effectiveTab
     return (
       <KeycodeGrid
         keycodes={keycodes}
@@ -398,7 +422,7 @@ export function TabbedKeycodes({
   }
 
   function renderCategoryContent(category: KeycodeCategory): React.ReactNode {
-    const isActive = category.id === activeTab
+    const isActive = category.id === effectiveTab
     // Keyboard view for basic tab (ANSI, ISO, or JIS)
     if (category.id === 'basic' && resolvedBasicViewType !== 'list' && resolvedBasicViewType != null && !lmMode) {
       return (
@@ -460,11 +484,11 @@ export function TabbedKeycodes({
               key={cat.id}
               type="button"
               className={`whitespace-nowrap px-3 py-1.5 text-xs transition-colors border-b-2 ${
-                activeTab === cat.id
+                effectiveTab === cat.id
                   ? 'border-b-accent text-accent font-semibold'
                   : 'border-b-transparent text-content-secondary hover:text-content'
               }`}
-              onClick={() => { onTabChange?.(); setActiveTab(cat.id); setTooltip(null) }}
+              onClick={() => selectTab(cat.id)}
             >
               {t(cat.labelKey)}
             </button>
@@ -474,11 +498,11 @@ export function TabbedKeycodes({
               key="keyboard"
               type="button"
               className={`whitespace-nowrap px-3 py-1.5 text-xs transition-colors border-b-2 ${
-                activeTab === 'keyboard'
+                effectiveTab === 'keyboard'
                   ? 'border-b-accent text-accent font-semibold'
                   : 'border-b-transparent text-content-secondary hover:text-content'
               }`}
-              onClick={() => { onTabChange?.(); setActiveTab('keyboard'); setTooltip(null) }}
+              onClick={() => selectTab('keyboard')}
             >
               {t('editor.keymap.keyboardTab')}
             </button>
@@ -511,7 +535,7 @@ export function TabbedKeycodes({
           {categories.map((cat) => (
             <div
               key={cat.id}
-              className={`col-start-1 row-start-1 overflow-y-auto ${cat.id === activeTab ? '' : 'invisible'}`}
+              className={`col-start-1 row-start-1 overflow-y-auto ${cat.id === effectiveTab ? '' : 'invisible'}`}
             >
               {renderCategoryContent(cat)}
             </div>
@@ -519,25 +543,25 @@ export function TabbedKeycodes({
           {keyboardPickerContent && !maskOnly && (
             <div
               key="keyboard"
-              className={`col-start-1 row-start-1 flex min-h-0 flex-col ${activeTab === 'keyboard' ? '' : 'invisible'}`}
+              className={`col-start-1 row-start-1 flex min-h-0 flex-col ${effectiveTab === 'keyboard' ? '' : 'invisible'}`}
             >
               {keyboardPickerContent}
             </div>
           )}
         </div>
 
-        {tabFooterContent?.[activeTab] && (
+        {tabFooterContent?.[effectiveTab] && (
           <div className="border-t border-edge-subtle px-3 py-2">
-            {tabFooterContent[activeTab]}
+            {tabFooterContent[effectiveTab]}
           </div>
         )}
 
-        {(showHint || (activeTab === 'basic' && onBasicViewTypeChange)) && (
+        {(showHint || (effectiveTab === 'basic' && onBasicViewTypeChange)) && (
           <div className="flex items-center justify-between px-3 pb-1.5">
             {showHint && (
               <p className="text-xs text-content-muted">{t('editor.keymap.pickerHint')}</p>
             )}
-            {activeTab === 'basic' && onBasicViewTypeChange && (
+            {effectiveTab === 'basic' && onBasicViewTypeChange && (
               <UpwardSelect
                 aria-label={t('editorSettings.basicViewType')}
                 value={resolvedBasicViewType}

--- a/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
@@ -161,4 +161,74 @@ describe('TabbedKeycodes', () => {
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }))
     expect(onConfirm).toHaveBeenCalledTimes(1)
   })
+
+  // Tab selection survives transient unavailability (issue #311). The
+  // "behavior" category stands in for a real "Modifiers" tab: it only
+  // contains QK_BOOT, which is non-basic, so it disappears entirely under
+  // maskOnly — exactly like a real category being narrowed out during mask
+  // inner-key selection. activeTab is derived (effectiveTab), so these tests
+  // only assert on what's visible, not on any internal stash/restore state.
+  describe('tab selection survives maskOnly toggling', () => {
+    it('falls back to Basic while the selected category is unavailable, and returns to it once available again', () => {
+      const { rerender } = render(<TabbedKeycodes maskOnly={false} />)
+      fireEvent.click(screen.getByText('Behavior'))
+      expect(screen.getByText('Behavior').className).toContain('text-accent')
+
+      // maskOnly removes "Behavior" from the filtered categories -> falls back to Basic
+      rerender(<TabbedKeycodes maskOnly />)
+      expect(screen.getByText('Basic').className).toContain('text-accent')
+      expect(screen.queryByText('Behavior')).not.toBeInTheDocument()
+
+      // maskOnly clears -> "Behavior" reappears -> back to it, with no extra click
+      rerender(<TabbedKeycodes maskOnly={false} />)
+      expect(screen.getByText('Behavior').className).toContain('text-accent')
+    })
+
+    it('falls back to Basic while the keyboard tab is unavailable, and returns to it once available again', () => {
+      const kb = <div>Keyboard Content</div>
+      const { rerender } = render(<TabbedKeycodes keyboardPickerContent={kb} maskOnly={false} />)
+      fireEvent.click(screen.getByText('editor.keymap.keyboardTab'))
+      expect(screen.getByText('editor.keymap.keyboardTab').className).toContain('text-accent')
+
+      // maskOnly hides the keyboard tab entirely -> falls back to Basic
+      rerender(<TabbedKeycodes keyboardPickerContent={kb} maskOnly />)
+      expect(screen.getByText('Basic').className).toContain('text-accent')
+      expect(screen.queryByText('editor.keymap.keyboardTab')).not.toBeInTheDocument()
+
+      // maskOnly clears -> keyboard tab reappears -> back to it
+      rerender(<TabbedKeycodes keyboardPickerContent={kb} maskOnly={false} />)
+      expect(screen.getByText('editor.keymap.keyboardTab').className).toContain('text-accent')
+    })
+
+    it('keeps a tab picked during maskOnly selected after maskOnly clears', () => {
+      const { rerender } = render(<TabbedKeycodes maskOnly={false} />)
+      fireEvent.click(screen.getByText('Behavior'))
+
+      // "Behavior" disappears under maskOnly -> falls back to Basic
+      rerender(<TabbedKeycodes maskOnly />)
+      expect(screen.getByText('Basic').className).toContain('text-accent')
+
+      // User deliberately picks another tab while maskOnly is still active
+      fireEvent.click(screen.getByText('System'))
+      expect(screen.getByText('System').className).toContain('text-accent')
+
+      // maskOnly clears -> "Behavior" becomes available again, but the
+      // user's later choice ("System") must not be overridden
+      rerender(<TabbedKeycodes maskOnly={false} />)
+      expect(screen.getByText('System').className).toContain('text-accent')
+    })
+
+    it('does not crash when categories is empty', () => {
+      // Hide every mock keycode so all categories are filtered out entirely
+      // (mirrors a real device exposing no visible keycodes at all).
+      const allKeycodes = [...mockBasicKeycodes, ...mockBehaviorKeycodes, ...mockSystemKeycodes]
+      allKeycodes.forEach((kc) => { kc.hidden = true })
+      try {
+        render(<TabbedKeycodes />)
+        expect(screen.queryByText('Basic')).not.toBeInTheDocument()
+      } finally {
+        allKeycodes.forEach((kc) => { kc.hidden = false })
+      }
+    })
+  })
 })


### PR DESCRIPTION
## Problem

The keycode picker reset its active tab whenever the filtered category list stopped containing it, and never went back.

Picking a mask key (mod-mask, mod-tap, LT, LM) with **Auto Move** on narrows the categories down to the mask-inner set, so the picker jumped to Basic to let you choose the inner key — and stayed on Basic after the inner key was confirmed and the original tab came back. Reported in issue #311 for modifiers; the same thing happened from the Layers tab.

## Fix

Split the tab state in two:

- `activeTab` records **only** the tab the user explicitly picked. Nothing else writes to it.
- `effectiveTab` is derived and decides what to render — it falls back to the first category while the picked tab is unavailable, and returns to it on its own once it becomes available again.

Because the selection is never destroyed, nothing has to stash and restore it. The earlier attempt at this used a ref to remember the tab across the reset; the derived form removes that machinery entirely along with the reset effect.

The keyboard tab now follows the same availability rule as its own render condition (`keyboardPickerContent && !maskOnly`), so a vanishing keyboard picker falls back to a real tab instead of leaving an empty panel behind. That part is a small behaviour improvement beyond the reported issue.

## Repro

Requires **Auto Move** enabled (default on).

1. Select a key in the keymap editor
2. Open the **Modifiers** tab in the picker
3. Click a **Mod Mask** (e.g. `LSFT()`) or **Mod-Tap** keycode
4. The picker switches to **Basic** for the inner key
5. Pick the inner key (e.g. `KC_A`)
6. Before: stays on Basic. After: returns to **Modifiers**

## Tests

Four behaviour-level cases added — falling back and returning for a category tab and for the keyboard tab, a manual tab pick during `maskOnly` not being overridden, and an empty category list not crashing.

`762` tests pass across `components/keycodes` and `components/editors`; eslint and typecheck are clean.