### PR TITLE
fix(ui): stop Auto Move from landing on hidden layout-option keys

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -144,7 +144,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     handleDeselect, handleDeselectClick,
     tdModalIndex, macroModalIndex, handleTdModalSave, handleTdModalClose, handleMacroModalClose,
   } = useKeymapSelectionHandlers({
-    layout, keymap, encoderLayout, currentLayer,
+    keymap, encoderLayout, currentLayer,
     selectableKeys, autoAdvance, viewMatrix,
     onSetKey, onSetKeysBulk, onSetEncoder, unlocked, onUnlock,
     multiSelect, history,

--- a/src/renderer/components/editors/__tests__/KeymapEditor.autoAdvance.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor.autoAdvance.test.tsx
@@ -139,6 +139,20 @@ const makeLayout = () => ({
   keys: [makeKey(0, 0), makeKey(1, 1), makeKey(2, 2)],
 })
 
+// A layout option at layoutIndex 0 with two choices (0/1), each providing a
+// distinct key at col 1 — only one of the pair is ever visible at a time,
+// mirroring an ISO/ANSI-style split key. Col 0/2 keys have no layoutIndex
+// and are always shown.
+const makeVariantKey = (col: number, layoutOption: number): KleKey => ({
+  ...KEY_DEFAULTS, x: col, col, layoutIndex: 0, layoutOption,
+})
+
+const makeLayoutWithVariant = () => ({
+  keys: [makeKey(0, 0), makeVariantKey(1, 0), makeVariantKey(2, 1), makeKey(3, 3)],
+})
+
+const LAYOUT_LABELS = [['Split', 'Regular', 'Split']]
+
 // Column order a(0,0) < b(0,1) < c(0,2). Overriding c to logical (0,0) ties
 // it with a; the physical (row, col) tiebreak in sortKeysByViewMatrix then
 // keeps a first, pulling c ahead of the untouched b — see
@@ -359,5 +373,79 @@ describe('KeymapEditor — auto advance', () => {
     // Physical order would advance to (0,1); the view matrix override pulls
     // (0,2) ahead of it, so the walk lands there instead.
     expect(screen.getByText('[0,2]')).toBeInTheDocument()
+  })
+
+  it('skips a layout-option variant hidden by the current selection', async () => {
+    render(
+      <KeymapEditor
+        {...defaultProps}
+        layout={makeLayoutWithVariant()}
+        layoutLabels={LAYOUT_LABELS}
+        packedLayoutOptions={1}
+        autoAdvance={true}
+      />,
+    )
+
+    // Select the always-visible key at (0,0)
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    expect(screen.getByText('[0,0]')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('kc-a'))
+    })
+
+    // Option 1 is selected, so the variant at col 1 (option 0) is not
+    // rendered; Auto Move must skip it and land on the variant at col 2
+    // (option 1) instead.
+    expect(screen.getByText('[0,2]')).toBeInTheDocument()
+    expect(screen.queryByText('[0,1]')).not.toBeInTheDocument()
+  })
+
+  it('includes the currently visible layout-option variant in the walk', async () => {
+    render(
+      <KeymapEditor
+        {...defaultProps}
+        layout={makeLayoutWithVariant()}
+        layoutLabels={LAYOUT_LABELS}
+        packedLayoutOptions={0}
+        autoAdvance={true}
+      />,
+    )
+
+    // Select the always-visible key at (0,0)
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    expect(screen.getByText('[0,0]')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('kc-a'))
+    })
+
+    // Option 0 is selected, so the variant at col 1 is the visible one and
+    // is the very next key in the walk.
+    expect(screen.getByText('[0,1]')).toBeInTheDocument()
+  })
+
+  it('keeps decal and encoder keys excluded from the walk', async () => {
+    const layout = {
+      keys: [
+        makeKey(0, 0),
+        { ...KEY_DEFAULTS, x: 1, col: 1, decal: true },
+        { ...KEY_DEFAULTS, x: 2, col: 2, encoderIdx: 0 },
+        makeKey(3, 3),
+      ],
+    }
+
+    render(<KeymapEditor {...defaultProps} layout={layout} autoAdvance={true} />)
+
+    act(() => capturedOnKeyClick?.({ row: 0, col: 0 }))
+    expect(screen.getByText('[0,0]')).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('kc-a'))
+    })
+
+    // The decal (col 1) and encoder (col 2) keys are never selectable — the
+    // walk jumps straight to the next real key at col 3.
+    expect(screen.getByText('[0,3]')).toBeInTheDocument()
   })
 })

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -31,7 +31,6 @@ function matchPopoverEntry(
 
 export interface UseKeymapSelectionOptions {
   // Core data
-  layout: { keys: KleKey[] } | null
   keymap: Map<string, number>
   encoderLayout: Map<string, number>
   currentLayer: number
@@ -72,7 +71,6 @@ export interface UseKeymapSelectionOptions {
 }
 
 export function useKeymapSelectionHandlers({
-  layout,
   keymap,
   encoderLayout,
   currentLayer,
@@ -185,11 +183,14 @@ export function useKeymapSelectionHandlers({
   }
 
   // --- Auto-advance ---
-  const advancableKeys = useMemo(() => {
-    if (!layout) return []
-    const filtered = layout.keys.filter((k) => !k.decal && k.encoderIdx < 0)
-    return sortKeysByViewMatrix(filtered, viewMatrix)
-  }, [layout, viewMatrix])
+  // Walk `selectableKeys` (already layout-option/decal/encoder filtered),
+  // not raw `layout.keys` — otherwise Auto Move can land on a key hidden by
+  // the current layout option (e.g. the unselected ISO/ANSI or split
+  // spacebar variant), leaving the selection highlight invisible.
+  const advancableKeys = useMemo(
+    () => sortKeysByViewMatrix(selectableKeys, viewMatrix),
+    [selectableKeys, viewMatrix],
+  )
 
   const advanceToNextKey = useCallback(() => {
     if (!autoAdvance || !selectedKey || advancableKeys.length === 0) return


### PR DESCRIPTION
## Problem

Auto Move walked every key in the layout minus decals and encoders, so it never applied the layout-option filter.

On boards with variants — ISO/ANSI, split spacebar, split backspace — that meant the selection could land on a key belonging to the variant that is **not currently drawn**. The highlight ends up nowhere to be seen and the next keypress has no visible target.

The two lists had drifted apart:

| | built from | layout-option filter |
|---|---|---|
| `selectableKeys` (`useLayoutOptionsPanel.ts:120-131`) | `layout.keys` filtered by the active option, decal and encoder | yes |
| `advancableKeys` (`useKeymapSelectionHandlers.ts:188-192`) | `layout.keys` filtered by decal and encoder only | **no** |

## Fix

Walk `selectableKeys` instead. It already filters by the active layout option on top of the decal and encoder exclusions, and it is the same list selection itself uses, so the two can no longer drift apart.

The hook no longer reads the raw layout after this, so the parameter is dropped from its options and from the call site.

## Repro

Needs a board with layout options (ISO/ANSI or a split spacebar) and **Auto Move** enabled.

1. Pick a layout variant, leaving the other variant's keys undrawn
2. Select a key next to one of the hidden variant keys
3. Assign a keycode so Auto Move advances
4. Before: the selection can jump to an undrawn key and the highlight disappears. After: it skips to the next visible key

## Tests

Three cases added — a hidden variant being skipped, the visible variant being included, and a regression guard that decals and encoders stay excluded now that the exclusion is delegated to `selectableKeys`. Existing coverage already spans boards without layout options and the View Matrix ordering.

`633` tests pass across `components/editors`; eslint and typecheck are clean.

## Follow-up

Reviewing this surfaced a second, wider drift: `selectableKeys` hand-rolls the visibility rule that `shared/kle/filter-keys.ts` already owns as `filterVisibleKeys`, and the two disagree when no layout options are set. Filed separately rather than widened into this PR.