### PR TITLE
feat(ui): follow Auto Move from the key popover

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -134,7 +134,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
   // --- Selection + handlers ---
   const {
-    selectedKey, selectedEncoder, selectedMaskPart, popoverState, setPopoverState,
+    selectedKey, selectedEncoder, selectedMaskPart, popoverState, closePopover,
     selectedKeycode, isMaskKey, isLMMask,
     handleKeyClick, handleEncoderClick, handleKeyDoubleClick, handleEncoderDoubleClick,
     handleKeycodeSelect, handlePopoverKeycodeSelect, handlePopoverRawKeycodeSelect,
@@ -146,7 +146,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   } = useKeymapSelectionHandlers({
     keymap, encoderLayout, currentLayer,
     selectableKeys, autoAdvance, viewMatrix,
-    onSetKey, onSetKeysBulk, onSetEncoder, unlocked, onUnlock,
+    onSetKey, onSetKeysBulk, onSetEncoder, keyboardContentRef, unlocked, onUnlock,
     multiSelect, history,
     onHistoryApplied: triggerFlash,
     tapDanceEntries, onSetTapDanceEntry,
@@ -788,7 +788,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           onLayerChange={onLayerChange} layerNames={layerNames}
           onKeycodeSelect={handlePopoverKeycodeSelect} onRawKeycodeSelect={handlePopoverRawKeycodeSelect}
           onModMaskChange={handlePopoverModMaskChange}
-          onClose={() => setPopoverState(null)} quickSelect={quickSelect}
+          onClose={closePopover} quickSelect={quickSelect}
           previousKeycode={popoverUndoKeycode} onUndo={handlePopoverUndo}
           nextKeycode={popoverRedoKeycode} onRedo={handlePopoverRedo}
           remapLabel={pickerRemapLabel}

--- a/src/renderer/components/editors/__tests__/KeymapEditor.autoAdvance.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor.autoAdvance.test.tsx
@@ -61,7 +61,7 @@ vi.mock('../../keycodes/TabbedKeycodes', () => ({
 vi.mock('../../keycodes/KeyPopover', () => ({
   KeyPopover: (props: {
     onKeycodeSelect?: (kc: { qmkId: string }) => void
-    onRawKeycodeSelect?: (code: number) => void
+    onRawKeycodeSelect?: (code: number, advance: boolean) => void
     onClose?: () => void
   }) => {
     return (
@@ -74,7 +74,10 @@ vi.mock('../../keycodes/KeyPopover', () => ({
         </button>
         <button
           data-testid="popover-raw-5"
-          onClick={() => props.onRawKeycodeSelect?.(5)}
+          // `advance: true` mirrors a genuine confirm (Code tab Apply, or
+          // a wrapped inner-key pick) — see `KeyPopover`'s `onRawKeycodeSelect`
+          // prop doc.
+          onClick={() => props.onRawKeycodeSelect?.(5, true)}
         >
           Popover Raw 5
         </button>
@@ -239,7 +242,16 @@ describe('KeymapEditor — auto advance', () => {
     expect(screen.getByText('[0,1]')).toBeInTheDocument()
   })
 
-  it('does NOT advance when keycode is selected via popover (onKeycodeSelect)', async () => {
+  it('closes the popover instead of advancing past a key with no on-screen element (onKeycodeSelect)', async () => {
+    // `KeyboardWidget` is mocked out above (a plain placeholder div), so no
+    // real `data-key-pos` element ever exists under `keyboardContentRef` in
+    // this file — the popover follow-along's next-key rect lookup always
+    // comes up empty here, which is exactly the "next key has no on-screen
+    // element" case: a genuine confirm that can't advance closes the
+    // popover instead of leaving it stranded open. `selectedKey` itself is
+    // untouched by that close. See
+    // `useKeymapSelectionHandlers.popoverAdvance.test.ts` for the real
+    // advance-with-a-live-DOM behavior.
     render(<KeymapEditor {...defaultProps} autoAdvance={true} />)
 
     // Double-click to open popover
@@ -252,11 +264,16 @@ describe('KeymapEditor — auto advance', () => {
       fireEvent.click(screen.getByTestId('popover-kc-a'))
     })
 
-    // Should NOT advance — popover is an intentional edit mode
+    // selectedKey never moves off [0,0] — there's no next-key element to
+    // measure a rect from — and the popover closes rather than staying open.
     expect(screen.getByText('[0,0]')).toBeInTheDocument()
+    expect(screen.queryByTestId('key-popover')).not.toBeInTheDocument()
   })
 
-  it('does NOT advance when raw keycode is selected via popover (onRawKeycodeSelect)', async () => {
+  it('closes the popover instead of advancing past a key with no on-screen element (onRawKeycodeSelect)', async () => {
+    // Same DOM-less setup as the onKeycodeSelect case above — a raw confirm
+    // (advance=true) also closes instead of advancing when the next key
+    // has no element to anchor to.
     render(<KeymapEditor {...defaultProps} autoAdvance={true} />)
 
     // Double-click to open popover
@@ -268,8 +285,9 @@ describe('KeymapEditor — auto advance', () => {
       fireEvent.click(screen.getByTestId('popover-raw-5'))
     })
 
-    // Should NOT advance
+    // Should NOT advance, and the popover should close.
     expect(screen.getByText('[0,0]')).toBeInTheDocument()
+    expect(screen.queryByTestId('key-popover')).not.toBeInTheDocument()
   })
 
   it('does NOT advance to next key when masked keycode is assigned with autoAdvance', async () => {

--- a/src/renderer/components/editors/__tests__/KeymapEditor.undo.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor.undo.test.tsx
@@ -240,12 +240,17 @@ describe('KeymapEditor — undo after single-click selection', () => {
     // No undo initially
     expect(screen.queryByTestId('popover-undo')).not.toBeInTheDocument()
 
-    // Select keycode via popover — triggers handlePopoverKeycodeSelect
+    // Select keycode via popover — triggers handlePopoverKeycodeSelect.
+    // Auto Move is off here, so a genuine confirm closes the popover
+    // (same as every popover confirm before Auto Move follow-along).
     await act(async () => {
       fireEvent.click(screen.getByTestId('popover-kc-a'))
     })
+    expect(screen.queryByTestId('key-popover')).not.toBeInTheDocument()
 
-    // Popover should still be open and now show undo
+    // Re-opening the popover on the same key shows undo for the entry
+    // the popover selection just recorded.
+    act(() => capturedOnKeyDoubleClick?.({ row: 0, col: 0 }, mockRect))
     expect(screen.getByTestId('key-popover')).toBeInTheDocument()
     expect(screen.getByTestId('popover-undo')).toBeInTheDocument()
     expect(capturedPreviousKeycode).toBe(5)

--- a/src/renderer/components/editors/__tests__/useKeymapSelectionHandlers.popoverAdvance.test.ts
+++ b/src/renderer/components/editors/__tests__/useKeymapSelectionHandlers.popoverAdvance.test.ts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { useRef } from 'react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useKeymapSelectionHandlers, nextAdvanceKey } from '../useKeymapSelectionHandlers'
+import { useKeymapMultiSelect } from '../useKeymapMultiSelect'
+import { useKeymapHistory } from '../useKeymapHistory'
+import type { UseKeymapSelectionOptions } from '../useKeymapSelectionHandlers'
+import type { KleKey } from '../../../../shared/kle/types'
+import type { Keycode } from '../../../../shared/keycodes/keycodes'
+
+// ---------------------------------------------------------------------------
+// nextAdvanceKey — pure function
+// ---------------------------------------------------------------------------
+
+describe('nextAdvanceKey', () => {
+  const keys = [{ row: 0, col: 0 }, { row: 0, col: 1 }, { row: 0, col: 2 }]
+
+  it('returns the next key in the walk', () => {
+    expect(nextAdvanceKey(keys, { row: 0, col: 0 })).toEqual({ row: 0, col: 1 })
+  })
+
+  it('returns null for the last key', () => {
+    expect(nextAdvanceKey(keys, { row: 0, col: 2 })).toBeNull()
+  })
+
+  it('returns null when `from` is not in the list', () => {
+    expect(nextAdvanceKey(keys, { row: 5, col: 5 })).toBeNull()
+  })
+
+  it('returns null for an empty list', () => {
+    expect(nextAdvanceKey([], { row: 0, col: 0 })).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useKeymapSelectionHandlers — popover Auto Move follow-along
+// ---------------------------------------------------------------------------
+
+const KEY_DEFAULTS: KleKey = {
+  x: 0, y: 0, width: 1, height: 1, row: 0, col: 0,
+  encoderIdx: -1, encoderDir: -1, layoutIndex: -1, layoutOption: -1,
+  decal: false, labels: [], x2: 0, y2: 0, width2: 1, height2: 1,
+  rotation: 0, rotationX: 0, rotationY: 0, color: '',
+  textColor: [], textSize: [], nub: false, stepped: false, ghost: false,
+}
+
+const makeKey = (row: number, col: number): KleKey => ({ ...KEY_DEFAULTS, row, col })
+
+// Three keys in a row: (0,0) -> (0,1) -> (0,2), matching the walk order
+// `sortKeysByViewMatrix` produces with no view-matrix overrides.
+const SELECTABLE_KEYS = [makeKey(0, 0), makeKey(0, 1), makeKey(0, 2)]
+
+// The rect passed to handleKeyDoubleClick when opening the popover — its
+// exact identity/value never matters to the tests below (it's immediately
+// superseded by a real measurement on the first advance), so one shared
+// stand-in rect is enough.
+const OPEN_RECT = { top: -1, left: -1, bottom: -1, right: -1, width: 0, height: 0, x: -1, y: -1, toJSON: () => ({}) } as DOMRect
+
+/** Builds the primary keymap pane's content container with real
+ *  `data-key-pos` child elements (mirroring `KeyWidget.tsx`), each with a
+ *  stubbed `getBoundingClientRect`/`scrollIntoView` — plus one duplicate
+ *  element OUTSIDE the container for a position that already has one
+ *  inside, mirroring the Keyboard tab's hidden layout picker (wall 2).
+ *  Rect objects are kept by reference in `rects` so assertions can check
+ *  identity instead of deep-equality (a struct with a function field like
+ *  `toJSON` never round-trips through `toEqual` cleanly). */
+function setupKeyboardDom(): { container: HTMLDivElement; rects: Record<string, DOMRect>; scrollSpies: Record<string, ReturnType<typeof vi.fn>>; cleanup: () => void } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const rects: Record<string, DOMRect> = {
+    '0,0': { top: 0, left: 0, bottom: 40, right: 60, width: 60, height: 40, x: 0, y: 0, toJSON: () => ({}) } as DOMRect,
+    '0,1': { top: 10, left: 10, bottom: 50, right: 70, width: 60, height: 40, x: 10, y: 10, toJSON: () => ({}) } as DOMRect,
+    '0,2': { top: 20, left: 20, bottom: 60, right: 80, width: 60, height: 40, x: 20, y: 20, toJSON: () => ({}) } as DOMRect,
+  }
+  const scrollSpies: Record<string, ReturnType<typeof vi.fn>> = {}
+  for (const [pos, rect] of Object.entries(rects)) {
+    const el = document.createElement('div')
+    el.setAttribute('data-key-pos', pos)
+    el.getBoundingClientRect = () => rect
+    const scrollSpy = vi.fn()
+    el.scrollIntoView = scrollSpy
+    scrollSpies[pos] = scrollSpy
+    container.appendChild(el)
+  }
+  const outsideDuplicate = document.createElement('div')
+  outsideDuplicate.setAttribute('data-key-pos', '0,1')
+  outsideDuplicate.getBoundingClientRect = () => ({ top: 999, left: 999, bottom: 999, right: 999, width: 0, height: 0, x: 999, y: 999, toJSON: () => ({}) }) as DOMRect
+  outsideDuplicate.scrollIntoView = vi.fn()
+  document.body.appendChild(outsideDuplicate)
+  return {
+    container,
+    rects,
+    scrollSpies,
+    cleanup: () => { container.remove(); outsideDuplicate.remove() },
+  }
+}
+
+type HarnessOverrides = Partial<Omit<UseKeymapSelectionOptions, 'multiSelect' | 'history'>>
+
+function useHarness(overrides: HarnessOverrides) {
+  const hasActiveSingleSelectionRef = useRef(false)
+  const multiSelect = useKeymapMultiSelect({ hasActiveSingleSelectionRef })
+  const history = useKeymapHistory(100)
+  return useKeymapSelectionHandlers({
+    keymap: new Map(),
+    encoderLayout: new Map(),
+    currentLayer: 0,
+    selectableKeys: SELECTABLE_KEYS,
+    autoAdvance: true,
+    onSetKey: vi.fn().mockResolvedValue(undefined),
+    onSetKeysBulk: vi.fn().mockResolvedValue(undefined),
+    onSetEncoder: vi.fn().mockResolvedValue(undefined),
+    multiSelect,
+    history,
+    ...overrides,
+  })
+}
+
+const BASIC_KC = { qmkId: 'KC_A' } as Keycode
+// A masked-template qmkId — `isMask` matches anything with a `(` whose
+// prefix is a known masked keycode. `LSFT(kc)` is one of the statically
+// registered modifier masks (module-load time, unlike LT/LM's per-layer
+// templates which only exist after `recreateKeyboardKeycodes`).
+const MASK_KC = { qmkId: 'LSFT(KC_A)' } as Keycode
+
+describe('useKeymapSelectionHandlers — popover Auto Move follow-along', () => {
+  let dom: ReturnType<typeof setupKeyboardDom>
+
+  beforeEach(() => { dom = setupKeyboardDom() })
+  afterEach(() => { dom.cleanup() })
+
+  function renderHarness(overrides: HarnessOverrides = {}) {
+    const containerRef = { current: dom.container }
+    return renderHook(() => useHarness({ keyboardContentRef: containerRef, ...overrides }))
+  }
+
+  it('moves popoverState and selectedKey to the next key on a normal confirm', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 1 })
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 1 })
+    expect(result.current.popoverState?.anchorRect).toBe(dom.rects['0,1'])
+  })
+
+  it('closes the popover when Auto Move is off — a genuine confirm still closes like every confirm did before this feature', async () => {
+    const { result } = renderHarness({ autoAdvance: false })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+    expect(result.current.popoverState).toBeNull()
+  })
+
+  it('does not advance when a mask-type keycode is selected — popover stays open in place', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(MASK_KC) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 0 })
+  })
+
+  it('does not advance on a raw LT/LM mode/layer/mod change (advance=false) — write happens, popover stays put', async () => {
+    const onSetKey = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHarness({ autoAdvance: true, onSetKey })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverRawKeycodeSelect(0x4104, false) })
+
+    expect(onSetKey).toHaveBeenCalledWith(0, 0, 0, 0x4104)
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 0 })
+  })
+
+  it('advances on a raw confirm (advance=true) — mirrors a wrapped inner key pick or Code tab Apply', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverRawKeycodeSelect(4, true) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 1 })
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 1 })
+  })
+
+  it('closes on a raw confirm (advance=true) when Auto Move is off', async () => {
+    const { result } = renderHarness({ autoAdvance: false })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverRawKeycodeSelect(4, true) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+    expect(result.current.popoverState).toBeNull()
+  })
+
+  it('closes the popover on the last key — nothing left to advance to', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[2], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 2 })
+    expect(result.current.popoverState).toBeNull()
+  })
+
+  it('closes the popover when the next key has no on-screen element to anchor to', async () => {
+    // Remove (0,1)'s element so the walk's next position can't be measured.
+    dom.container.querySelector('[data-key-pos="0,1"]')?.remove()
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 0 })
+    expect(result.current.popoverState).toBeNull()
+  })
+
+  it('uses the primary pane element, not the duplicate data-key-pos outside the container', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    // The container's own (0,1) rect must be used — the outside
+    // duplicate's stubbed rect (999,999) must never be picked up.
+    expect(result.current.popoverState?.anchorRect).toBe(dom.rects['0,1'])
+  })
+
+  it('encoders never advance — a confirm just closes the popover', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleEncoderDoubleClick(SELECTABLE_KEYS[0], 0, OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(result.current.popoverState).toBeNull()
+    expect(result.current.selectedEncoder).toEqual({ idx: -1, dir: 0 })
+  })
+
+  it('a stale write completing after a different key was opened does not resurrect or overwrite the new popover', async () => {
+    let resolveWrite: (() => void) | undefined
+    const onSetKey = vi.fn().mockImplementation(() => new Promise<void>((resolve) => { resolveWrite = resolve }))
+    const { result } = renderHarness({ autoAdvance: true, onSetKey })
+
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    let pending!: Promise<void>
+    act(() => { pending = result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    // While that write is still in flight, the user opens a different key.
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[2], OPEN_RECT, false))
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 2 })
+
+    // Now let the stale write resolve.
+    await act(async () => { resolveWrite?.(); await pending })
+
+    // The stale completion's advance must not have touched the popover
+    // the user already moved on to.
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 2 })
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 2 })
+  })
+
+  it('a stale completion never scrolls to the stale next key — the epoch guard runs before scrollIntoView', async () => {
+    let resolveWrite: (() => void) | undefined
+    const onSetKey = vi.fn().mockImplementation(() => new Promise<void>((resolve) => { resolveWrite = resolve }))
+    const { result } = renderHarness({ autoAdvance: true, onSetKey })
+
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    let pending!: Promise<void>
+    act(() => { pending = result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    // While that write is still in flight, the user opens a different key —
+    // this is the stale write's would-be next key, (0,1), that must never
+    // be scrolled to once the old write finally resolves.
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[2], OPEN_RECT, false))
+
+    // Now let the stale write resolve.
+    await act(async () => { resolveWrite?.(); await pending })
+
+    expect(dom.scrollSpies['0,1']).not.toHaveBeenCalled()
+  })
+
+  it('a normal confirm still scrolls the next key into view (regression check for the epoch guard reordering)', async () => {
+    const { result } = renderHarness({ autoAdvance: true })
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[0], OPEN_RECT, false))
+
+    await act(async () => { await result.current.handlePopoverKeycodeSelect(BASIC_KC) })
+
+    expect(dom.scrollSpies['0,1']).toHaveBeenCalledTimes(1)
+    expect(result.current.selectedKey).toEqual({ row: 0, col: 1 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useKeymapSelectionHandlers — runHistoryStep popover epoch guard
+// ---------------------------------------------------------------------------
+
+describe('useKeymapSelectionHandlers — runHistoryStep popover epoch guard', () => {
+  let dom: ReturnType<typeof setupKeyboardDom>
+
+  beforeEach(() => { dom = setupKeyboardDom() })
+  afterEach(() => { dom.cleanup() })
+
+  function renderHarness(overrides: HarnessOverrides = {}) {
+    const containerRef = { current: dom.container }
+    return renderHook(() => useHarness({ keyboardContentRef: containerRef, ...overrides }))
+  }
+
+  it('does not close a popover opened while an undo write is still in flight', async () => {
+    let resolveUndoWrite: (() => void) | undefined
+    const onSetKey = vi.fn()
+      .mockResolvedValueOnce(undefined) // the keycode-select write that seeds the undo entry
+      .mockImplementationOnce(() => new Promise<void>((resolve) => { resolveUndoWrite = resolve })) // the undo's own write
+
+    const { result } = renderHarness({ autoAdvance: false, onSetKey })
+
+    // Seed history: select (0,0), then pick a keycode to push an undo entry.
+    act(() => result.current.handleKeyClick(SELECTABLE_KEYS[0], false))
+    await act(async () => { await result.current.handleKeycodeSelect(BASIC_KC) })
+
+    // Start the undo — its device write is controlled and left pending.
+    let undoPending!: Promise<void>
+    act(() => { undoPending = result.current.handleUndo() })
+
+    // While the undo's write is in flight, the user opens a different key's
+    // popover — this must survive the undo completing later.
+    act(() => result.current.handleKeyDoubleClick(SELECTABLE_KEYS[2], OPEN_RECT, false))
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 2 })
+
+    // Let the undo's write resolve.
+    await act(async () => { resolveUndoWrite?.(); await undoPending })
+
+    // The undo completing must not close the popover the user opened in
+    // the meantime — only a still-current epoch may close it.
+    expect(result.current.popoverState).toMatchObject({ kind: 'key', row: 0, col: 2 })
+  })
+})

--- a/src/renderer/components/editors/keymap-editor-popover.tsx
+++ b/src/renderer/components/editors/keymap-editor-popover.tsx
@@ -18,7 +18,7 @@ interface PopoverForStateProps {
   onLayerChange?: (layer: number) => void
   layerNames?: string[]
   onKeycodeSelect: (kc: Keycode) => void
-  onRawKeycodeSelect: (code: number) => void
+  onRawKeycodeSelect: (code: number, advance: boolean) => void
   onModMaskChange?: (newMask: number) => void
   onClose: () => void
   quickSelect?: boolean
@@ -46,6 +46,11 @@ export function PopoverForState({
       onKeycodeSelect={onKeycodeSelect} onRawKeycodeSelect={onRawKeycodeSelect} onModMaskChange={onModMaskChange}
       onClose={onClose} quickSelect={quickSelect} previousKeycode={previousKeycode} onUndo={onUndo}
       nextKeycode={nextKeycode} onRedo={onRedo} remapLabel={remapLabel}
+      // The keymap editor decides close-vs-advance itself (Auto Move
+      // follow-along) instead of letting a confirm auto-close — see
+      // `useKeymapSelectionHandlers`'s popover handlers and the prop doc
+      // on `KeyPopover.closeOnSelect`.
+      closeOnSelect={false}
     />
   )
 }

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -14,7 +14,59 @@ import { hasModifierKey } from './KeyboardPane'
 import type { PopoverState } from './keymap-editor-types'
 import type { UseKeymapMultiSelectReturn } from './useKeymapMultiSelect'
 import type { UseKeymapHistoryReturn, SingleHistoryEntry, HistoryEntry } from './useKeymapHistory'
-import { sortKeysByViewMatrix } from './view-matrix'
+import { sortKeysByViewMatrix, type ViewMatrixKeyRef } from './view-matrix'
+
+/**
+ * Given the Auto Move walk order (already layout-option/decal/encoder
+ * filtered and view-matrix sorted — see `advancableKeys` below) and a
+ * starting position, returns the next key in the walk, or `null` when
+ * `from` isn't in the list at all or is already last. Pure — callers
+ * (both the left-panel picker and the popover follow-along) gate
+ * `autoAdvance` themselves before calling this.
+ */
+export function nextAdvanceKey<K extends ViewMatrixKeyRef>(
+  advancableKeys: readonly K[],
+  from: { row: number; col: number },
+): { row: number; col: number } | null {
+  const idx = advancableKeys.findIndex((k) => k.row === from.row && k.col === from.col)
+  if (idx < 0 || idx >= advancableKeys.length - 1) return null
+  const next = advancableKeys[idx + 1]
+  return { row: next.row, col: next.col }
+}
+
+/**
+ * Finds the on-screen rect for the key at physical `(row, col)`, scoped to
+ * `container` — never `document`. The Keyboard tab's hidden layout picker
+ * renders its own elements with the same `data-key-pos` attribute
+ * (`KeyWidget.tsx`), so an unscoped lookup can resolve to the wrong pane's
+ * key; `container` must be the primary keymap pane's own content ref.
+ *
+ * Scrolls the element into view first — `behavior: 'instant'` is required
+ * (not the default 'auto') so a key currently scrolled out of view is
+ * measured at its final position instead of mid smooth-scroll animation.
+ * Returns `null` when no matching element exists (e.g. a key hidden by the
+ * current layout option, or the container isn't mounted) — callers must
+ * not advance the popover in that case.
+ */
+function getKeyAnchorRect(container: HTMLElement | null, row: number, col: number): DOMRect | null {
+  if (!container) return null
+  const el = container.querySelector(`[data-key-pos="${row},${col}"]`)
+  if (!el) return null
+  el.scrollIntoView?.({ block: 'nearest', inline: 'nearest', behavior: 'instant' })
+  return el.getBoundingClientRect()
+}
+
+/** Partial write to the selection-state quartet (`selectedKey` /
+ *  `selectedMaskPart` / `selectedEncoder` / `popoverState`) that
+ *  `applySelectionChange` below accepts — only the fields present are
+ *  updated, the rest are left as-is. `popoverState` accepts a React
+ *  updater function too (see `handleKeyClick`). */
+interface SelectionPatch {
+  selectedKey?: { row: number; col: number } | null
+  selectedMaskPart?: boolean
+  selectedEncoder?: { idx: number; dir: 0 | 1 } | null
+  popoverState?: PopoverState | null | ((prev: PopoverState | null) => PopoverState | null)
+}
 
 /** Match a history entry against the current popover position, returning the keycode if matched. */
 function matchPopoverEntry(
@@ -44,6 +96,11 @@ export interface UseKeymapSelectionOptions {
   onSetKey: (layer: number, row: number, col: number, keycode: number) => Promise<void>
   onSetKeysBulk: (entries: BulkKeyEntry[]) => Promise<void>
   onSetEncoder: (layer: number, idx: number, dir: number, keycode: number) => Promise<void>
+  /** Ref to the primary keymap pane's content element (`KeymapEditor`'s
+   *  `keyboardContentRef`) — scopes the popover follow-along's next-key
+   *  rect lookup so it can never resolve to the Keyboard tab's hidden
+   *  layout picker, which renders the same `data-key-pos` attribute. */
+  keyboardContentRef?: React.RefObject<HTMLDivElement | null>
   // Auth
   unlocked?: boolean
   onUnlock?: (options?: { macroWarning?: boolean }) => void
@@ -80,6 +137,7 @@ export function useKeymapSelectionHandlers({
   onSetKey,
   onSetKeysBulk,
   onSetEncoder,
+  keyboardContentRef,
   unlocked,
   onUnlock,
   multiSelect,
@@ -109,12 +167,48 @@ export function useKeymapSelectionHandlers({
   const [selectedMaskPart, setSelectedMaskPart] = useState(false)
   const [popoverState, setPopoverState] = useState<PopoverState | null>(null)
 
+  // Generation counter guarding the popover follow-along's UI updates
+  // (selectedKey/selectedMaskPart/selectedEncoder/popoverState) against a
+  // stale async write resolving after something newer already took over
+  // — an explicit close, Escape, opening a different key, or a second
+  // popover-driven write starting. Every write to that state quartet
+  // bumps this ref; the popover write handlers snapshot its value at
+  // entry and re-check before touching any of that state (never before
+  // the device write/history push themselves, which always stand
+  // regardless).
+  const popoverAdvanceEpochRef = useRef(0)
+
+  const bumpPopoverEpoch = useCallback((): number => ++popoverAdvanceEpochRef.current, [])
+
+  /**
+   * Single entry point for writing any of the selection-state quartet.
+   * Bumps `popoverAdvanceEpochRef` first, unconditionally — every caller
+   * below goes through here instead of hand-rolling its own `++` next to
+   * a handful of setters, so a future confirm path can't add an 8th call
+   * site and forget the bump, letting the stale-write race this guards
+   * against creep back in. Returns the new epoch for callers that need
+   * to gate an async continuation on it (the popover confirm handlers).
+   */
+  const applySelectionChange = useCallback((patch: SelectionPatch): number => {
+    const epoch = bumpPopoverEpoch()
+    if ('selectedKey' in patch) setSelectedKey(patch.selectedKey ?? null)
+    if ('selectedMaskPart' in patch) setSelectedMaskPart(patch.selectedMaskPart ?? false)
+    if ('selectedEncoder' in patch) setSelectedEncoder(patch.selectedEncoder ?? null)
+    if ('popoverState' in patch) setPopoverState(patch.popoverState ?? null)
+    return epoch
+  }, [bumpPopoverEpoch])
+
   const clearSingleSelection = useCallback((): void => {
-    setSelectedKey(null)
-    setSelectedEncoder(null)
-    setSelectedMaskPart(false)
-    setPopoverState(null)
-  }, [])
+    applySelectionChange({ selectedKey: null, selectedEncoder: null, selectedMaskPart: false, popoverState: null })
+  }, [applySelectionChange])
+
+  /** Closes the popover from an explicit user action (close button,
+   *  outside click, resize, Escape) — bumps the epoch so a write that's
+   *  still in flight for the position being closed can't resurrect the
+   *  popover once it resolves. */
+  const closePopover = useCallback(() => {
+    applySelectionChange({ popoverState: null })
+  }, [applySelectionChange])
 
   // --- TD/Macro modal state ---
   const [tdModalIndex, setTdModalIndex] = useState<number | null>(null)
@@ -193,14 +287,51 @@ export function useKeymapSelectionHandlers({
   )
 
   const advanceToNextKey = useCallback(() => {
-    if (!autoAdvance || !selectedKey || advancableKeys.length === 0) return
-    const currentIdx = advancableKeys.findIndex((k) => k.row === selectedKey.row && k.col === selectedKey.col)
-    if (currentIdx >= 0 && currentIdx < advancableKeys.length - 1) {
-      const next = advancableKeys[currentIdx + 1]
-      setSelectedKey({ row: next.row, col: next.col })
-      setSelectedMaskPart(false)
-    }
+    if (!autoAdvance || !selectedKey) return
+    const next = nextAdvanceKey(advancableKeys, selectedKey)
+    if (!next) return
+    setSelectedKey(next)
+    setSelectedMaskPart(false)
   }, [autoAdvance, advancableKeys, selectedKey])
+
+  /** Moves the popover AND the shared single-selection state to `next`
+   *  together (wall 5) — a next key that happens to be a mask key must
+   *  never inherit a stale `selectedMaskPart`/`selectedEncoder` from
+   *  whatever was selected before. */
+  const advancePopoverAndSelection = useCallback((next: { row: number; col: number }, rect: DOMRect) => {
+    applySelectionChange({
+      selectedKey: next,
+      selectedMaskPart: false,
+      selectedEncoder: null,
+      popoverState: { anchorRect: rect, kind: 'key', row: next.row, col: next.col, maskClicked: false },
+    })
+  }, [applySelectionChange])
+
+  /**
+   * Follows the popover from `from` to the next key in the Auto Move
+   * walk. Checks `epoch` twice: once up front, before calling
+   * `getKeyAnchorRect` — which has the side effect of scrolling the next
+   * key into view — so a write that's already stale can't yank the
+   * viewport toward a key the user no longer cares about; and again
+   * right before touching any state (a stale write resolving after
+   * something newer took over must not clobber it — in that case this
+   * does nothing at all, scroll included). Otherwise it always resolves
+   * the confirm one way or another: advances to the next key when the
+   * walk has one and its on-screen element can be found, or closes the
+   * popover exactly like a confirm with no follow-along would (already
+   * on the last key, or the next key has no rect because it's hidden by
+   * the current layout option) — callers only reach here once they've
+   * decided this is a genuine confirm that must not leave the popover
+   * stranded open.
+   */
+  const tryAdvancePopover = useCallback((from: { row: number; col: number }, epoch: number) => {
+    if (popoverAdvanceEpochRef.current !== epoch) return
+    const next = nextAdvanceKey(advancableKeys, from)
+    const rect = next ? getKeyAnchorRect(keyboardContentRef?.current ?? null, next.row, next.col) : null
+    if (popoverAdvanceEpochRef.current !== epoch) return
+    if (next && rect) advancePopoverAndSelection(next, rect)
+    else applySelectionChange({ popoverState: null })
+  }, [advancableKeys, keyboardContentRef, advancePopoverAndSelection, applySelectionChange])
 
   // --- TD/Macro modal openers ---
   const openTdModal = useCallback((rawCode: number) => {
@@ -273,25 +404,41 @@ export function useKeymapSelectionHandlers({
         setSelectionSourcePane('primary'); setSelectionMode('shift'); return
       }
       setMultiSelectedKeys(new Set()); setSelectionAnchor({ row: key.row, col: key.col }); setSelectionSourcePane(null)
-      setPopoverState((prev) => { if (!prev) return null; if (prev.kind !== 'key' || prev.row !== key.row || prev.col !== key.col) return null; return { ...prev, maskClicked } })
-      setSelectedKey({ row: key.row, col: key.col }); setSelectedMaskPart(maskClicked); setSelectedEncoder(null)
+      // A different key's popover may be closing here (the updater below
+      // nulls it unless it's the same position) — routing through
+      // applySelectionChange bumps the epoch so an in-flight popover
+      // write for that other position can't resurrect it later.
+      applySelectionChange({
+        popoverState: (prev) => { if (!prev) return null; if (prev.kind !== 'key' || prev.row !== key.row || prev.col !== key.col) return null; return { ...prev, maskClicked } },
+        selectedKey: { row: key.row, col: key.col },
+        selectedMaskPart: maskClicked,
+        selectedEncoder: null,
+      })
     },
-    [selectedKey, selectionAnchor, selectableKeys, multiSelectedKeys, pickerSelected, handlePickerPaste, clearPickerSelection, setMultiSelectedKeys, setSelectionAnchor, setSelectionSourcePane, setSelectionMode],
+    [selectedKey, selectionAnchor, selectableKeys, multiSelectedKeys, pickerSelected, handlePickerPaste, clearPickerSelection, setMultiSelectedKeys, setSelectionAnchor, setSelectionSourcePane, setSelectionMode, applySelectionChange],
   )
 
   const handleEncoderClick = useCallback((_key: KleKey, dir: number, maskClicked: boolean) => {
-    setSelectedEncoder({ idx: _key.encoderIdx, dir: dir as 0 | 1 }); setSelectedKey(null); setSelectedMaskPart(maskClicked); setPopoverState(null)
-  }, [])
+    applySelectionChange({ selectedEncoder: { idx: _key.encoderIdx, dir: dir as 0 | 1 }, selectedKey: null, selectedMaskPart: maskClicked, popoverState: null })
+  }, [applySelectionChange])
 
   const handleKeyDoubleClick = useCallback((key: KleKey, rect: DOMRect, maskClicked: boolean) => {
-    setSelectedKey({ row: key.row, col: key.col }); setSelectedMaskPart(maskClicked); setSelectedEncoder(null)
-    setPopoverState({ anchorRect: rect, kind: 'key', row: key.row, col: key.col, maskClicked })
-  }, [])
+    applySelectionChange({
+      selectedKey: { row: key.row, col: key.col },
+      selectedMaskPart: maskClicked,
+      selectedEncoder: null,
+      popoverState: { anchorRect: rect, kind: 'key', row: key.row, col: key.col, maskClicked },
+    })
+  }, [applySelectionChange])
 
   const handleEncoderDoubleClick = useCallback((_key: KleKey, dir: number, rect: DOMRect, maskClicked: boolean) => {
-    setSelectedEncoder({ idx: _key.encoderIdx, dir: dir as 0 | 1 }); setSelectedKey(null); setSelectedMaskPart(maskClicked)
-    setPopoverState({ anchorRect: rect, kind: 'encoder', idx: _key.encoderIdx, dir: dir as 0 | 1, maskClicked })
-  }, [])
+    applySelectionChange({
+      selectedEncoder: { idx: _key.encoderIdx, dir: dir as 0 | 1 },
+      selectedKey: null,
+      selectedMaskPart: maskClicked,
+      popoverState: { anchorRect: rect, kind: 'encoder', idx: _key.encoderIdx, dir: dir as 0 | 1, maskClicked },
+    })
+  }, [applySelectionChange])
 
   // --- Deselect ---
   const handleDeselect = useCallback(() => {
@@ -328,38 +475,88 @@ export function useKeymapSelectionHandlers({
     }
   }, [selectedKey, selectedEncoder, currentLayer, keymap, encoderLayout, isMaskKey, autoAdvance, onSetKey, onSetEncoder, advanceToNextKey, openTdModal, openMacroModal, clearPending, clearPickerSelection, history])
 
+  /**
+   * Resolves what the popover does after a confirm's device write has
+   * landed — shared by the Key tab pick path (`handlePopoverKeycodeSelect`)
+   * and the raw/Code-tab path (`handlePopoverRawKeycodeSelect`), which
+   * otherwise differ only in how `stayOpen` is decided (picking a
+   * mask-type keycode vs. `advance === false`). Re-checks `epoch` first
+   * — a stale write resolving after something newer took over must
+   * leave the UI alone entirely (the write + history push already stood
+   * regardless, from the caller). Otherwise: `stayOpen` leaves the
+   * popover exactly as it was (a wrapper-mode pick awaiting its inner
+   * key, or a raw call that only reconfigured the wrapper itself);
+   * `kind === 'key'` with Auto Move on follows the walk to the next key;
+   * anything else — encoders never advance (no walk order over them),
+   * or Auto Move is off — closes exactly like every popover confirm did
+   * before this feature.
+   */
+  const resolvePopoverConfirm = useCallback((
+    kind: 'key' | 'encoder',
+    fromPos: { row: number; col: number } | null,
+    epoch: number,
+    stayOpen: boolean,
+  ): void => {
+    if (popoverAdvanceEpochRef.current !== epoch) return
+    if (stayOpen) return
+    if (kind === 'key' && autoAdvance && fromPos) {
+      tryAdvancePopover(fromPos, epoch)
+      return
+    }
+    applySelectionChange({ popoverState: null })
+  }, [autoAdvance, tryAdvancePopover, applySelectionChange])
+
   const handlePopoverKeycodeSelect = useCallback(async (kc: Keycode) => {
     clearPending()
     if (!popoverState) return
+    // A new popover-driven write always supersedes whatever the previous
+    // one was still waiting on — bump first so that older completion (if
+    // still in flight) is recognized as stale once it resolves.
+    const epoch = bumpPopoverEpoch()
     const code = deserialize(kc.qmkId)
     if (popoverState.kind === 'key') {
+      const fromPos = { row: popoverState.row, col: popoverState.col }
       const currentCode = keymap.get(`${currentLayer},${popoverState.row},${popoverState.col}`) ?? 0
       const popoverMask = popoverState.maskClicked && isMask(serialize(currentCode))
       const newCode = resolveKeycode(currentCode, code, popoverMask)
       await onSetKey(currentLayer, popoverState.row, popoverState.col, newCode)
       history.push({ kind: 'key', layer: currentLayer, row: popoverState.row, col: popoverState.col, oldKeycode: currentCode, newKeycode: newCode, maskPart: popoverMask ? 'inner' : undefined })
+      // Picking a mask-type keycode (unless already editing an existing
+      // mask's inner part) is the "stay open" case — mirrors the left
+      // panel's handleKeycodeSelect above.
+      resolvePopoverConfirm('key', fromPos, epoch, !popoverMask && isMask(kc.qmkId))
     } else {
       const currentCode = encoderLayout.get(`${currentLayer},${popoverState.idx},${popoverState.dir}`) ?? 0
       const popoverMask = popoverState.maskClicked && isMask(serialize(currentCode))
       const newCode = resolveKeycode(currentCode, code, popoverMask)
       await onSetEncoder(currentLayer, popoverState.idx, popoverState.dir, newCode)
       history.push({ kind: 'encoder', layer: currentLayer, idx: popoverState.idx, dir: popoverState.dir, oldKeycode: currentCode, newKeycode: newCode, maskPart: popoverMask ? 'inner' : undefined })
+      resolvePopoverConfirm('encoder', null, epoch, false)
     }
-  }, [popoverState, currentLayer, keymap, encoderLayout, onSetKey, onSetEncoder, clearPending, history])
+  }, [popoverState, currentLayer, keymap, encoderLayout, onSetKey, onSetEncoder, clearPending, history, bumpPopoverEpoch, resolvePopoverConfirm])
 
-  const handlePopoverRawKeycodeSelect = useCallback(async (code: number) => {
+  const handlePopoverRawKeycodeSelect = useCallback(async (code: number, advance: boolean) => {
     clearPending()
     if (!popoverState) return
+    const epoch = bumpPopoverEpoch()
     if (popoverState.kind === 'key') {
+      const fromPos = { row: popoverState.row, col: popoverState.col }
       const currentCode = keymap.get(`${currentLayer},${popoverState.row},${popoverState.col}`) ?? 0
       await onSetKey(currentLayer, popoverState.row, popoverState.col, code)
       history.push({ kind: 'key', layer: currentLayer, row: popoverState.row, col: popoverState.col, oldKeycode: currentCode, newKeycode: code })
+      // `advance` is false for LT/LM layer changes, mode-button switches,
+      // and modifier-checkbox-strip changes (KeyPopover.tsx) — none of
+      // those are a "confirm", so `resolvePopoverConfirm` leaves the
+      // popover put.
+      resolvePopoverConfirm('key', fromPos, epoch, !advance)
     } else {
       const currentCode = encoderLayout.get(`${currentLayer},${popoverState.idx},${popoverState.dir}`) ?? 0
       await onSetEncoder(currentLayer, popoverState.idx, popoverState.dir, code)
       history.push({ kind: 'encoder', layer: currentLayer, idx: popoverState.idx, dir: popoverState.dir, oldKeycode: currentCode, newKeycode: code })
+      // Same "no advance for encoders" rule as the kc path above.
+      resolvePopoverConfirm('encoder', null, epoch, !advance)
     }
-  }, [popoverState, currentLayer, keymap, encoderLayout, onSetKey, onSetEncoder, clearPending, history])
+  }, [popoverState, currentLayer, keymap, encoderLayout, onSetKey, onSetEncoder, clearPending, history, bumpPopoverEpoch, resolvePopoverConfirm])
 
   const handlePopoverModMaskChange = useCallback(async (newMask: number) => {
     if (!popoverState) return
@@ -415,13 +612,22 @@ export function useKeymapSelectionHandlers({
     const entry = isUndo ? history.peekUndo : history.peekRedo
     if (!entry) return
     undoRedoInFlightRef.current = true
+    // Snapshot the epoch before the device writes below — which, for a
+    // batch entry, run as a sequence of awaited HID calls and can take
+    // long enough for the user to open a different popover in the
+    // meantime. `undoRedoInFlightRef` only blocks a second concurrent
+    // undo/redo; it does nothing to stop that other popover from opening.
+    // Re-checking the epoch here before closing the popover keeps this
+    // consistent with every other popover write handler in this file:
+    // a stale completion must never clobber something newer.
+    const epoch = popoverAdvanceEpochRef.current
     try {
       await applyHistoryEntry(entry, isUndo)
       // Commit only after successful apply.
       if (isUndo) history.undo()
       else history.redo()
     } finally { undoRedoInFlightRef.current = false }
-    setPopoverState(null)
+    if (popoverAdvanceEpochRef.current === epoch) applySelectionChange({ popoverState: null })
     // Fire outside the try/finally above: a throw from `applyHistoryEntry`
     // or the commit call propagates out of the `try` (after `finally`
     // resets the in-flight guard) and skips everything below, so reaching
@@ -438,7 +644,7 @@ export function useKeymapSelectionHandlers({
     } catch {
       // Intentionally ignored — see comment above.
     }
-  }, [history, applyHistoryEntry, onHistoryApplied])
+  }, [history, applyHistoryEntry, onHistoryApplied, applySelectionChange])
 
   const handleUndo = useCallback(() => runHistoryStep(true), [runHistoryStep])
   const handleRedo = useCallback(() => runHistoryStep(false), [runHistoryStep])
@@ -491,7 +697,7 @@ export function useKeymapSelectionHandlers({
     selectedEncoder,
     selectedMaskPart,
     popoverState,
-    setPopoverState,
+    closePopover,
     clearSingleSelection,
     // Derived
     selectedKeycode,

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -42,11 +42,25 @@ interface KeyPopoverProps {
   onLayerChange?: (layer: number) => void
   layerNames?: string[]
   onKeycodeSelect: (kc: Keycode) => void
-  onRawKeycodeSelect: (code: number) => void
+  /** `advance` distinguishes a genuine keycode confirm (Code tab Apply,
+   *  or a Key tab pick while a wrapper mode like LT/SH_T/LM/Mod-Tap/Mod-
+   *  Mask is active) from a raw call that merely reconfigures the
+   *  wrapper itself (mode-button switch, LT/LM layer change, modifier-
+   *  checkbox-strip change) — see the call sites below. Callers that
+   *  don't care (MacroEditor, KeycodeEntryModalShell) can ignore it. */
+  onRawKeycodeSelect: (code: number, advance: boolean) => void
   onModMaskChange?: (newMask: number) => void
   onClose: () => void
   onConfirm?: () => void // Enter / click-to-close: confirm and close the picker
   quickSelect?: boolean  // true: click applies + closes; false: buffer until Enter
+  /** When false, a confirmed keycode selection (quickSelect-immediate
+   *  apply, or Enter/close-hint confirming a buffered pick) does not call
+   *  onClose/onConfirm itself — the caller decides whether to close or
+   *  move the popover elsewhere instead (the keymap editor's Auto Move
+   *  follow-along). Defaults to true, matching every other caller's
+   *  existing "confirm closes" contract. Does not affect Escape/outside-
+   *  click/resize/the close button, which always close regardless. */
+  closeOnSelect?: boolean
   previousKeycode?: number // Previous keycode for undo (undefined = no undo available)
   onUndo?: () => void      // Revert to previousKeycode and close
   nextKeycode?: number     // Next keycode for redo (undefined = no redo available)
@@ -87,6 +101,7 @@ export function KeyPopover({
   onClose,
   onConfirm,
   quickSelect,
+  closeOnSelect = true,
   previousKeycode,
   onUndo,
   nextKeycode,
@@ -189,18 +204,18 @@ export function KeyPopover({
     return () => window.removeEventListener('resize', onClose)
   }, [onClose])
 
-  // Handle modifier strip changes — immediate keymap update
+  // Handle modifier strip changes — immediate keymap update, not a confirm (see the prop doc on `onRawKeycodeSelect`).
   const handleModStripChange = useCallback(
     (newMask: number) => {
       const basicKey = extractBasicKey(currentKeycode)
       if (wrapperMode === 'lm') {
-        onRawKeycodeSelect(buildLMKeycode(selectedLayer, newMask))
+        onRawKeycodeSelect(buildLMKeycode(selectedLayer, newMask), false)
       } else if (wrapperMode === 'modTap') {
-        onRawKeycodeSelect(buildModTapKeycode(newMask, basicKey))
+        onRawKeycodeSelect(buildModTapKeycode(newMask, basicKey), false)
       } else if (onModMaskChange) {
         onModMaskChange(newMask)
       } else {
-        onRawKeycodeSelect(buildModMaskKeycode(newMask, basicKey))
+        onRawKeycodeSelect(buildModMaskKeycode(newMask, basicKey), false)
       }
     },
     [wrapperMode, currentKeycode, selectedLayer, onRawKeycodeSelect, onModMaskChange],
@@ -222,11 +237,15 @@ export function KeyPopover({
     [currentModMask, selectedLayer, wrapperMode],
   )
 
-  // Apply a PendingAction to the keymap
+  // Apply a PendingAction to the keymap. Both branches represent a
+  // genuine keycode confirm (a plain pick, or a wrapper-mode pick whose
+  // inner key `wrapKeycode` folded into a raw build) — see the prop doc
+  // on `onRawKeycodeSelect` for the contrast with the non-confirm raw
+  // calls elsewhere in this file.
   const applyAction = useCallback(
     (action: PendingAction) => {
       if (action.kind === 'kc') onKeycodeSelect(action.kc)
-      else onRawKeycodeSelect(action.code)
+      else onRawKeycodeSelect(action.code, true)
     },
     [onKeycodeSelect, onRawKeycodeSelect],
   )
@@ -238,18 +257,20 @@ export function KeyPopover({
         setPendingAction(action)
       } else {
         applyAction(action)
-        // Auto-close after immediate apply when quickSelect is on
-        ;(onConfirm ?? onClose)()
+        // Auto-close after immediate apply when quickSelect is on — unless
+        // the caller wants to decide for itself (see `closeOnSelect`).
+        if (closeOnSelect) (onConfirm ?? onClose)()
       }
     },
-    [quickSelect, wrapKeycode, applyAction, onConfirm, onClose],
+    [quickSelect, wrapKeycode, applyAction, onConfirm, onClose, closeOnSelect],
   )
 
-  // Apply any buffered pending action then close the popover
+  // Apply any buffered pending action then close the popover (unless
+  // `closeOnSelect` is false — see its prop doc).
   const confirmAndClose = useCallback(() => {
     if (pendingAction) applyAction(pendingAction)
-    ;(onConfirm ?? onClose)()
-  }, [pendingAction, applyAction, onConfirm, onClose])
+    if (closeOnSelect) (onConfirm ?? onClose)()
+  }, [pendingAction, applyAction, onConfirm, onClose, closeOnSelect])
 
   // Refs so the keydown handler always sees latest values without re-subscribing
   const pendingRef = useRef(pendingAction)
@@ -275,21 +296,21 @@ export function KeyPopover({
     return () => window.removeEventListener('keydown', handler, true)
   }, [onClose])
 
-  // Handle layer selector changes — immediate keycode rebuild
+  // Handle layer selector changes — immediate keycode rebuild, not a confirm (see the prop doc on `onRawKeycodeSelect`).
   const handleLayerChange = useCallback(
     (layer: number) => {
       setSelectedLayer(layer)
       const basicKey = extractBasicKey(currentKeycode)
       if (wrapperMode === 'lt') {
-        onRawKeycodeSelect(buildLTKeycode(layer, basicKey))
+        onRawKeycodeSelect(buildLTKeycode(layer, basicKey), false)
       } else if (wrapperMode === 'lm') {
-        onRawKeycodeSelect(buildLMKeycode(layer, currentModMask))
+        onRawKeycodeSelect(buildLMKeycode(layer, currentModMask), false)
       }
     },
     [wrapperMode, currentKeycode, currentModMask, onRawKeycodeSelect],
   )
 
-  // Switching modes converts the keycode format (preserving basic key)
+  // Switching modes converts the keycode format (preserving basic key) — reconfigures the wrapper only, not a confirm (see the prop doc on `onRawKeycodeSelect`).
   const handleModeSwitch = useCallback(
     (newMode: WrapperMode) => {
       // Toggle off if clicking the active mode
@@ -301,29 +322,29 @@ export function KeyPopover({
       if (target === 'none') {
         // Turning off: revert to basic key
         if (basicKey !== currentKeycode) {
-          onRawKeycodeSelect(basicKey)
+          onRawKeycodeSelect(basicKey, false)
         }
       } else {
         // Switching to a new mode: rebuild keycode
         switch (target) {
           case 'lt':
-            onRawKeycodeSelect(buildLTKeycode(selectedLayer, basicKey))
+            onRawKeycodeSelect(buildLTKeycode(selectedLayer, basicKey), false)
             break
           case 'shT':
-            onRawKeycodeSelect(buildSHTKeycode(basicKey))
+            onRawKeycodeSelect(buildSHTKeycode(basicKey), false)
             break
           case 'lm':
-            onRawKeycodeSelect(buildLMKeycode(selectedLayer, 0))
+            onRawKeycodeSelect(buildLMKeycode(selectedLayer, 0), false)
             break
           case 'modTap': {
             // Only preserve mod mask when switching from another mod-based mode
             const mask = (wrapperMode === 'modMask' || wrapperMode === 'modTap') ? extractModMask(currentKeycode) : 0
-            onRawKeycodeSelect(buildModTapKeycode(mask, basicKey))
+            onRawKeycodeSelect(buildModTapKeycode(mask, basicKey), false)
             break
           }
           case 'modMask': {
             const mask = (wrapperMode === 'modMask' || wrapperMode === 'modTap') ? extractModMask(currentKeycode) : 0
-            onRawKeycodeSelect(buildModMaskKeycode(mask, basicKey))
+            onRawKeycodeSelect(buildModMaskKeycode(mask, basicKey), false)
             break
           }
         }
@@ -494,7 +515,8 @@ export function KeyPopover({
           <PopoverTabCode
             currentKeycode={currentKeycode}
             maskOnly={maskOnly}
-            onRawKeycodeSelect={onRawKeycodeSelect}
+            // Code tab Apply is a genuine confirm, same as a Key tab pick.
+            onRawKeycodeSelect={(code) => onRawKeycodeSelect(code, true)}
           />
         )}
       </div>

--- a/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
@@ -454,7 +454,7 @@ describe('PopoverTabCode — hex input', () => {
   it('calls onRawKeycodeSelect when apply is clicked (popover stays open)', () => {
     renderCodeTab('0005')
     fireEvent.click(screen.getByTestId('popover-code-apply'))
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(5)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(5, true)
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -516,7 +516,7 @@ describe('KeyPopover — maskOnly mode', () => {
     })
     fireEvent.click(screen.getByTestId('popover-code-apply'))
     // Should apply full code: 0x5100 | 0x2C = 0x512C (LT0(KC_SPACE))
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x512c)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x512c, true)
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -537,7 +537,7 @@ describe('KeyPopover — maskOnly mode', () => {
       target: { value: '2c' },
     })
     fireEvent.click(screen.getByTestId('popover-code-apply'))
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x512c)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x512c, true)
   })
 })
 
@@ -680,7 +680,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     // Switch to LM mode
     fireEvent.click(screen.getByTestId('popover-mode-lm'))
     // buildLMKeycode(0, 0) = 0x7000
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x7000)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x7000, false)
     // Search should be hidden, layer selector should appear
     expect(screen.queryByTestId('popover-search-input')).not.toBeInTheDocument()
     expect(screen.getByTestId('layer-selector')).toBeInTheDocument()
@@ -692,7 +692,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     fireEvent.click(screen.getByTestId('popover-mode-lm'))
     // LM keycodes store modifiers in lower bits, not basic keys.
     // Toggling off should produce KC_NO (0), not the modifier value.
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0, false)
   })
 
   it('clears search when switching from LM to another mode', () => {
@@ -709,28 +709,28 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     render(<KeyPopover {...defaultProps} currentKeycode={0x7002} layers={4} />)
     fireEvent.click(screen.getByTestId('popover-mode-lt'))
     // buildLTKeycode(0, 0) = 0x4000 — basicKey must be 0, not the modifier mask
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4000)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4000, false)
   })
 
   it('does not leak LM modifier bits as basic key when switching to SH_T', () => {
     render(<KeyPopover {...defaultProps} currentKeycode={0x7002} />)
     fireEvent.click(screen.getByTestId('popover-mode-sh-t'))
     // buildSHTKeycode(0) = 0x5600
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x5600)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x5600, false)
   })
 
   it('does not leak LM modifier bits as basic key when switching to modTap', () => {
     render(<KeyPopover {...defaultProps} currentKeycode={0x7002} />)
     fireEvent.click(screen.getByTestId('popover-mode-mod-tap'))
     // buildModTapKeycode(0, 0) = 0 (mask 0 returns basic key in mock)
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0, false)
   })
 
   it('does not leak LM modifier bits as basic key when switching to modMask', () => {
     render(<KeyPopover {...defaultProps} currentKeycode={0x7002} />)
     fireEvent.click(screen.getByTestId('popover-mode-mod-mask'))
     // buildModMaskKeycode(0, 0) = 0 (mask 0 returns basic key in mock)
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0, false)
   })
 
   it('builds LT keycode when selecting a key in LT mode', () => {
@@ -739,7 +739,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'B' } })
     fireEvent.click(screen.getByTestId('popover-result-KC_B'))
     // buildLTKeycode(0, 5) = 0x4000 | (0 << 8) | 5 = 0x4005
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4005)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4005, true)
   })
 
   it('changes layer in LT mode and rebuilds keycode', () => {
@@ -747,7 +747,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     // Click layer 2 button
     fireEvent.click(screen.getByTestId('layer-btn-2'))
     // buildLTKeycode(2, 4) = 0x4000 | (2 << 8) | 4 = 0x4204
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4204)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x4204, false)
   })
 
   it('builds SH_T keycode when selecting a key in SH_T mode', () => {
@@ -755,7 +755,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     render(<KeyPopover {...defaultProps} currentKeycode={4} />)
     fireEvent.click(screen.getByTestId('popover-mode-sh-t'))
     // Switching to SH_T mode: buildSHTKeycode(4) = 0x5600 | 4 = 0x5604
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x5604)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(0x5604, false)
   })
 
   it('reverts to basic key when toggling mode off', () => {
@@ -763,7 +763,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     // LT mode is auto-detected. Click LT button to toggle off
     fireEvent.click(screen.getByTestId('popover-mode-lt'))
     // Should revert to basic key: extractBasicKey(0x4004) = 4
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4, false)
   })
 
   it('resets modifier mask to 0 when switching from LT to modTap', () => {
@@ -773,7 +773,7 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     fireEvent.click(screen.getByTestId('popover-mode-mod-tap'))
     // Should build modTap with mask=0 (not extracting layer bits as mods)
     // buildModTapKeycode(0, 4) = 4 (mask 0 returns basic key)
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4, false)
   })
 
   it('resets modifier mask to 0 when switching from SH_T to modMask', () => {
@@ -783,6 +783,6 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     fireEvent.click(screen.getByTestId('popover-mode-mod-mask'))
     // Should build modMask with mask=0 (not extracting SH_T prefix as mods)
     // buildModMaskKeycode(0, 4) = 4 (mask 0 returns basic key)
-    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4)
+    expect(onRawKeycodeSelect).toHaveBeenCalledWith(4, false)
   })
 })


### PR DESCRIPTION
## Problem

Confirming a keycode in the key popover left the selection where it was, so **Auto Move only ever worked from the left-hand picker**. Auto Move is already an opt-in setting, so the popover should honour it too.

## Why it isn't a one-line call

The existing advance moves `selectedKey`. The popover renders from `popoverState` and anchors to a rect captured when the key was clicked. Moving one without the other strands the popover on the previous key.

Four more things had to be handled:

| | |
|---|---|
| **Wrong pane's rect** | The Keyboard tab's hidden picker publishes the same `data-key-pos` attribute, so an unscoped DOM lookup can anchor to the wrong pane. The lookup is scoped to the primary keymap pane's own ref. |
| **Raw callback overloading** | `onRawKeycodeSelect` fires for genuine confirms *and* for reconfiguring the wrapper (mode switch, LT/LM layer change, modifier toggle). The keycode alone can't tell them apart, so the callback now carries the caller's intent. |
| **Confirm always closed** | The popover closed itself on every confirm. It now leaves that decision to the caller for this call site only; every other caller keeps the old contract via a defaulted prop. |
| **Async writes** | Device writes are awaited, so a confirm can resolve after the user has moved on. |

## How a confirm resolves

| Case | Result |
|---|---|
| Auto Move on, next key exists with a measurable rect | advance |
| Mask key picked | stay open, so its inner byte can be set in place |
| Auto Move off / last key / next key has no rect | close, exactly as before |
| Encoder | close, exactly as before |
| Wrapper reconfigured (not a confirm) | leave the popover alone |

## Stale writes

An epoch guards every selection change. A single dispatcher owns the epoch bump — it is the only place the counter is mutated — and the async handlers re-check it before touching state, so a write that resolves late can neither move nor close a popover that has since been replaced.

Reviewing this surfaced a **pre-existing race in undo/redo**: `applyHistoryEntry` awaits real device writes, and `undoRedoInFlightRef` only blocks a second concurrent undo/redo — it never stopped the user opening a different popover mid-flight, which the trailing close would then wrongly dismiss. The same guard now covers it. That path is reachable and has a test that fails without the fix.

## Tests

`311` files / `7181` passed / `22` skipped. Coverage added for: advancing on confirm, Auto Move off, mask picks, wrapper reconfiguration, last key, missing next-key element, encoders, the duplicate `data-key-pos` between panes, and both stale-write races.

## Note on file size

`useKeymapSelectionHandlers.ts` is now `723` lines against the `600` guideline for hooks in `.claude/rules/file-splitting.md` (the `900` split-now threshold is not reached). Flagging rather than widening this PR with a split.