### PR TITLE
fix(ui): reset the popover when Auto Move carries it to another key

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -16,7 +16,7 @@ export type { KeymapEditorHandle } from './keymap-editor-types'
 import { KeyboardPane } from './KeyboardPane'
 import { LayerListPanel } from './LayerListPanel'
 import { ScaleInput, ghostZoomButtonClass, KeymapToolbar } from './keymap-editor-toolbar'
-import { PopoverForState } from './keymap-editor-popover'
+import { PopoverForState, popoverInstanceKey } from './keymap-editor-popover'
 import { Tooltip } from '../ui/Tooltip'
 import { useInputModes } from './useInputModes'
 import { useKeymapMultiSelect } from './useKeymapMultiSelect'
@@ -783,6 +783,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
       {!typingTestMode && popoverState && (
         <PopoverForState
+          key={popoverInstanceKey(popoverState)}
           popoverState={popoverState} keymap={keymap} encoderLayout={encoderLayout}
           currentLayer={currentLayer} layers={layers}
           onLayerChange={onLayerChange} layerNames={layerNames}

--- a/src/renderer/components/editors/__tests__/keymap-editor-popover.test.ts
+++ b/src/renderer/components/editors/__tests__/keymap-editor-popover.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { popoverInstanceKey } from '../keymap-editor-popover'
+import type { PopoverState } from '../keymap-editor-types'
+
+const RECT_A = { top: 0, left: 0, bottom: 40, right: 60, width: 60, height: 40, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+const RECT_B = { top: 10, left: 10, bottom: 50, right: 70, width: 60, height: 40, x: 10, y: 10, toJSON: () => ({}) } as DOMRect
+
+describe('popoverInstanceKey', () => {
+  it('differs when the position (row/col) changes — this is what makes Auto Move advance remount the popover', () => {
+    const a: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 0, maskClicked: false }
+    const b: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 1, maskClicked: false }
+    expect(popoverInstanceKey(a)).not.toBe(popoverInstanceKey(b))
+  })
+
+  it('differs when maskClicked changes', () => {
+    const a: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 0, maskClicked: false }
+    const b: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 0, maskClicked: true }
+    expect(popoverInstanceKey(a)).not.toBe(popoverInstanceKey(b))
+  })
+
+  it('differs between a key target and an encoder target at the same position-like fields', () => {
+    const key: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 0, maskClicked: false }
+    const encoder: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'encoder', idx: 0, dir: 0, maskClicked: false }
+    expect(popoverInstanceKey(key)).not.toBe(popoverInstanceKey(encoder))
+  })
+
+  it('differs when the encoder idx/dir changes', () => {
+    const a: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'encoder', idx: 0, dir: 0, maskClicked: false }
+    const b: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'encoder', idx: 0, dir: 1, maskClicked: false }
+    const c: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'encoder', idx: 1, dir: 0, maskClicked: false }
+    expect(popoverInstanceKey(a)).not.toBe(popoverInstanceKey(b))
+    expect(popoverInstanceKey(a)).not.toBe(popoverInstanceKey(c))
+  })
+
+  it('stays the same when only anchorRect changes — position measurement is not part of the target identity', () => {
+    const a: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 0, col: 0, maskClicked: false }
+    const b: NonNullable<PopoverState> = { anchorRect: RECT_B, kind: 'key', row: 0, col: 0, maskClicked: false }
+    expect(popoverInstanceKey(a)).toBe(popoverInstanceKey(b))
+  })
+
+  it('is stable for the same target regardless of layer or anchorRect — the function takes no currentLayer ' +
+    'parameter at all, so a layer-only change at the call site (KeymapEditor) can never remount the popover; ' +
+    'that case is handled by usePopoverKeycodeWorkflow\'s own currentLayer effect instead, which lets activeTab survive it', () => {
+    const state: NonNullable<PopoverState> = { anchorRect: RECT_A, kind: 'key', row: 2, col: 3, maskClicked: false }
+    expect(popoverInstanceKey(state)).toBe(popoverInstanceKey({ ...state, anchorRect: RECT_B }))
+  })
+})

--- a/src/renderer/components/editors/keymap-editor-popover.tsx
+++ b/src/renderer/components/editors/keymap-editor-popover.tsx
@@ -9,6 +9,21 @@ import { serialize, isMask } from '../../../shared/keycodes/keycodes'
 import type { Keycode } from '../../../shared/keycodes/keycodes'
 import type { PopoverState } from './keymap-editor-types'
 
+/** Builds the `key` KeymapEditor assigns to `<PopoverForState>` so Auto
+ *  Move's follow-along (same call site, new target) remounts KeyPopover
+ *  like a close+reopen — see the contract on `KeyPopoverProps`.
+ *
+ *  `currentLayer` is excluded on purpose: a layer switch keeps the same
+ *  key/encoder open, so it's handled by `usePopoverKeycodeWorkflow`'s own
+ *  effect instead of a remount, which is what lets `activeTab` survive it.
+ *  `currentKeycode`/`anchorRect` are excluded too — mid-edit churn, not
+ *  target identity. */
+export function popoverInstanceKey(popoverState: NonNullable<PopoverState>): string {
+  return popoverState.kind === 'key'
+    ? `key:${popoverState.row},${popoverState.col}:${popoverState.maskClicked}`
+    : `encoder:${popoverState.idx},${popoverState.dir}:${popoverState.maskClicked}`
+}
+
 interface PopoverForStateProps {
   popoverState: NonNullable<PopoverState>
   keymap: Map<string, number>

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -12,6 +12,18 @@ import { usePopoverKeycodeWorkflow, type WrapperMode } from './use-popover-keyco
 
 type Tab = 'key' | 'code'
 
+/** Contract for callers that keep the same `<KeyPopover>` call site across
+ *  edit-target changes (e.g. `KeymapEditor`'s Auto Move follow-along, which
+ *  advances this same popover to a new key/encoder instead of unmounting
+ *  it): the caller must pass a React `key` derived from the new target
+ *  (kind, position, mask side — see `KeymapEditor`'s `popoverInstanceKey`)
+ *  so React remounts this component and its internal state (wrapper mode,
+ *  buffered pick, active tab, search box) resets like a close+reopen.
+ *  `currentLayer` changes are the one exception, handled internally instead
+ *  (see `usePopoverKeycodeWorkflow`'s `currentLayer` effect) so that
+ *  `activeTab` survives a layer-sidebar switch. `MacroEditor` and
+ *  `KeycodeEntryModalShell` don't need this — they mount a fresh instance
+ *  per open. */
 interface KeyPopoverProps {
   anchorRect: DOMRect
   currentKeycode: number

--- a/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
@@ -786,3 +786,112 @@ describe('KeyPopover — LT/SH_T/LM wrapper modes', () => {
     expect(onRawKeycodeSelect).toHaveBeenCalledWith(4, false)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Auto Move advance: KeymapEditor keeps the same call site but changes the
+// `key` it hands `<KeyPopover>` (via `popoverInstanceKey`) as the edit target
+// moves — layer is *not* part of that key (see the next describe block for
+// that case). These tests simulate the same `key` change directly on
+// `KeyPopover` and check the popover's own internal state — the regression
+// this closes left `wrapperMode`/`selectedLayer`/`pendingAction`/`activeTab`/
+// the search box behind on the previous target.
+// ---------------------------------------------------------------------------
+
+describe('KeyPopover — remount on Auto Move advance (key prop change)', () => {
+  it('shows the moved-to key\'s current value, not the previous key\'s — matches closing and reopening', () => {
+    const { rerender } = render(<KeyPopover key="0,0" {...defaultProps} currentKeycode={4} />)
+    expect((screen.getByTestId('popover-search-input') as HTMLInputElement).value).toBe('A')
+
+    // Auto Move advances to a key currently holding KC_B.
+    rerender(<KeyPopover key="0,1" {...defaultProps} currentKeycode={5} />)
+    expect((screen.getByTestId('popover-search-input') as HTMLInputElement).value).toBe('B')
+  })
+
+  it('re-detects wrapper mode for the moved-to key instead of keeping the previous key\'s mode', () => {
+    // Start on a plain basic key — no wrapper mode, no layer selector.
+    const { rerender } = render(<KeyPopover key="0,0" {...defaultProps} currentKeycode={4} layers={4} />)
+    expect(screen.queryByTestId('layer-selector')).not.toBeInTheDocument()
+
+    // Auto Move advances to a key that already holds an LT-wrapped keycode —
+    // LT mode must be auto-detected for it, not left at the previous key's 'none'.
+    rerender(<KeyPopover key="0,1" {...defaultProps} currentKeycode={0x4104} layers={4} />)
+    expect(screen.getByTestId('layer-selector')).toBeInTheDocument()
+  })
+
+  it('does not carry over a buffered pending action from the previous key', () => {
+    const { rerender } = render(<KeyPopover key="0,0" {...defaultProps} currentKeycode={4} quickSelect={false} />)
+    fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'B' } })
+    fireEvent.click(screen.getByTestId('popover-result-KC_B'))
+    // Buffered (quickSelect off), not applied yet.
+    expect(onKeycodeSelect).not.toHaveBeenCalled()
+
+    // Advance to the next key without confirming — the old key's buffered
+    // pick must not survive into the new instance.
+    rerender(<KeyPopover key="0,1" {...defaultProps} currentKeycode={4} quickSelect={false} />)
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    // Enter at the new key, with nothing picked there yet, must not apply
+    // the stale KC_B pick from the previous key.
+    expect(onKeycodeSelect).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('resets the active tab to Key after advance even if the Code tab was left open on the previous key', () => {
+    const { rerender } = render(<KeyPopover key="0,0" {...defaultProps} currentKeycode={4} />)
+    fireEvent.click(screen.getByTestId('popover-tab-code'))
+    expect(screen.getByTestId('popover-hex-input')).toBeInTheDocument()
+
+    rerender(<KeyPopover key="0,1" {...defaultProps} currentKeycode={5} />)
+    expect(screen.queryByTestId('popover-hex-input')).not.toBeInTheDocument()
+    expect(screen.getByTestId('popover-search-input')).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Layer sidebar click (`currentLayer` prop change, same `key` — no remount):
+// this is the existing "view another layer's value while the popover stays
+// open" workflow. Unlike an Auto Move advance, this must NOT reset
+// `activeTab` — that's the whole point of the layer sidebar. It still must
+// re-derive wrapper mode / selected layer / any buffered pick for the new
+// layer's keycode, via `usePopoverKeycodeWorkflow`'s own `currentLayer` effect.
+// ---------------------------------------------------------------------------
+
+describe('KeyPopover — layer sidebar change (currentLayer prop, same instance)', () => {
+  it('keeps the active tab on Code across a layer change', () => {
+    const { rerender } = render(
+      <KeyPopover {...defaultProps} currentKeycode={4} layers={4} currentLayer={0} onLayerChange={() => {}} />,
+    )
+    fireEvent.click(screen.getByTestId('popover-tab-code'))
+    expect(screen.getByTestId('popover-hex-input')).toBeInTheDocument()
+
+    // Same instance (no `key` change) — only `currentLayer` changes.
+    rerender(
+      <KeyPopover {...defaultProps} currentKeycode={5} layers={4} currentLayer={1} onLayerChange={() => {}} />,
+    )
+    expect(screen.getByTestId('popover-hex-input')).toBeInTheDocument()
+  })
+
+  it('re-detects wrapper mode and clears any buffered pick for the new layer\'s keycode', () => {
+    // LT1(KC_A) auto-detects LT mode with the layer selector shown.
+    const { rerender } = render(
+      <KeyPopover {...defaultProps} currentKeycode={0x4104} layers={4} currentLayer={0} onLayerChange={() => {}} quickSelect={false} />,
+    )
+    expect(screen.getByTestId('layer-selector')).toBeInTheDocument()
+    fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'B' } })
+    fireEvent.click(screen.getByTestId('popover-result-KC_B'))
+    expect(onKeycodeSelect).not.toHaveBeenCalled()
+
+    // Switch layer sidebar to a layer whose same position holds a plain
+    // basic key — wrapper mode must reset to 'none', not keep 'lt', and the
+    // buffered KC_B pick from the previous layer must not survive.
+    rerender(
+      <KeyPopover {...defaultProps} currentKeycode={4} layers={4} currentLayer={1} onLayerChange={() => {}} quickSelect={false} />,
+    )
+    expect(screen.queryByTestId('layer-selector')).not.toBeInTheDocument()
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    expect(onKeycodeSelect).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/keycodes/use-popover-keycode-workflow.ts
+++ b/src/renderer/components/keycodes/use-popover-keycode-workflow.ts
@@ -38,6 +38,13 @@ function detectWrapperMode(keycode: number, maskOnly?: boolean): WrapperMode {
 export interface UsePopoverKeycodeWorkflowOptions {
   currentKeycode: number
   maskOnly?: boolean
+  /** Layer shown in `KeyPopover`'s layer sidebar. A layer switch reuses the
+   *  same `KeyPopover` instance (unlike an edit-target change, which
+   *  remounts via `KeymapEditor`'s `popoverInstanceKey`) so that `activeTab`
+   *  survives it — but this hook's own picker state (wrapper mode, layer,
+   *  buffered pick, search) still needs to catch up to the new layer's
+   *  keycode. That catch-up is this hook's own effect below, not the
+   *  remount — see that effect for why the two are kept separate. */
   currentLayer?: number
   onKeycodeSelect: (kc: Keycode) => void
   /** `advance` distinguishes a genuine keycode confirm (Code tab Apply,
@@ -116,6 +123,11 @@ export function usePopoverKeycodeWorkflow({
   })()
 
   const prevCurrentLayerRef = useRef(currentLayer)
+  // Re-derives the picker state a remount would reset, without remounting —
+  // deliberately *not* folded into `popoverInstanceKey`'s target-change
+  // remount, because that would also reset `activeTab`, and the layer
+  // sidebar's whole point is viewing another layer's value without losing
+  // which tab you were on.
   useEffect(() => {
     if (currentLayer == null || currentLayer === prevCurrentLayerRef.current) return
     prevCurrentLayerRef.current = currentLayer


### PR DESCRIPTION
## Problem

Regression from #314. With Auto Move on, confirming a keycode in the popover carries it to the next key — but the popover arrived still showing the previous key.

With `Z` and `X` side by side: open `Z`, pick `A`, and the popover moves to `X` while still displaying `A`. Closing it and reopening on `X` showed the right thing, which is the state the move should have produced.

## Cause

Moving without closing is a state transition the popover had never seen. Until #314 the edit target only ever changed by closing and reopening, so React discarded the internal display state along with the instance — the wrapper mode, the layer selector, a buffered pick, the active tab, the search box. The only reset path that existed watched `currentLayer`, because that was the one thing that could change under a live popover.

Following along kept all of it.

## Fix

Derive a key from the edit target — kind, position, and which half of a mask was clicked — and let React remount the popover when that target changes. That is precisely what closing and reopening did.

**The layer sidebar deliberately stays on the existing effect.** Folding it into the key was tried and reverted: the effect re-derives the wrapper mode and clears the pending pick but leaves `activeTab` alone, so a Code tab stays open while you check what another layer holds. Remounting there would have taken the tab with it and quietly broken that workflow. Hence the split — target changes remount, layer changes re-derive.

`currentKeycode` is excluded from the key too, since it changes while editing the *same* target and must not reset anything mid-edit.

## Tests

The coverage added in #314 only asserted the selection state *outside* the popover, which is exactly why this slipped through. The new cases assert what the popover itself displays:

- the moved-to key's value is shown after an advance
- wrapper mode is re-detected for the new key
- a buffered pick does not carry over
- `activeTab` returns to the Key tab
- **a layer-only change keeps `activeTab`** while still resetting wrapper mode, selected layer, and the pending pick

Plus unit tests for the key builder itself: it differs by position, mask half, kind, and encoder direction, and stays stable across layer and anchor changes.

`312` files / `7193` passed / `22` skipped; eslint and typecheck clean.

## Follow-up

Key generation and the remount are verified separately; an integration test through the real Auto Move path would harden the seam between them. Not a blocker.