### PR TITLE
test(ui): cover the popover's Auto Move follow-along end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
           node-version: 24
           cache: pnpm
 
-      - name: Install Linux build dependencies for native modules
-        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev
+      - name: Install Linux build dependencies for native modules and Xvfb for the Electron E2E specs
+        run: sudo apt-get update && sudo apt-get install -y libusb-1.0-0-dev libudev-dev xvfb
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -35,6 +35,16 @@ jobs:
       - run: npx tsx scripts/check-hook-deps-tdz.ts
       - run: pnpm test
       - run: pnpm build
+
+      - name: Install Playwright OS dependencies for the Electron E2E specs
+        run: npx playwright install-deps
+
+      # Only specs tagged @virtual run in CI — they're self-contained against
+      # the software-emulated Virtual Keyboard device. Other e2e specs assume
+      # real hardware or a local Hub instance and can't run on a CI runner.
+      - name: Run @virtual-tagged E2E specs against the virtual device
+        run: xvfb-run -a npx playwright test --grep @virtual
+
       - run: pnpm run doc:guide
       - name: Verify docs/guide.html is up to date
         run: git diff --exit-code docs/guide.html || (echo "docs/guide.html is stale — run 'pnpm run doc:guide' and commit the result." && exit 1)

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out/
 *.tsbuildinfo
 test-results/
 playwright-report/
+e2e/screenshots/
 .playwright-cli/
 CLAUDE.md
 .claude/

--- a/e2e/popover-behavior.test.ts
+++ b/e2e/popover-behavior.test.ts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Regression coverage for PR #316: Auto Move carries the key popover to the
+// next key without unmounting it. This drives the real Auto Move path
+// through the software-emulated Virtual Keyboard device (no real hardware
+// required) and asserts against internal popover state that only resets on
+// a genuine remount — a plain `keymap`/props assertion would pass whether
+// or not the fix is in place, since the displayed value is always resolved
+// from the (correct) target position regardless of remount.
+
+import { test, expect } from '@playwright/test'
+import type { ElectronApplication, Page } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { launchApp } from './helpers/electron'
+import {
+  backupVirtualDeviceSettings,
+  connectToDevice,
+  dismissNotificationModal,
+  isAvailable,
+  nullifyLastDeviceConfig,
+  resetToEditorMode,
+  restoreLastDeviceConfig,
+  restoreVirtualDeviceSettings,
+  VIRTUAL_DEVICE_DISPLAY_NAME,
+  waitForUnlockDialog,
+  type LastDeviceBackup,
+  type VirtualDeviceSettingsBackup,
+} from './helpers/doc-capture-common'
+
+const SCREENSHOT_DIR = resolve(import.meta.dirname, 'screenshots')
+const DEVICE_NAME = VIRTUAL_DEVICE_DISPLAY_NAME
+
+let app: ElectronApplication
+let page: Page
+let lastDeviceBackup: LastDeviceBackup
+let virtualDeviceSettingsBackup: VirtualDeviceSettingsBackup
+
+test.beforeAll(async () => {
+  const launched = await launchApp({
+    env: { PIPETTE_VIRTUAL_DEVICE: 'only' },
+    // e2e Electron sessions share ~/.config/Electron across runs (unlike
+    // doc-capture's launchCaptureApp, which gets an isolated profile). A
+    // `lastDevice` persisted by an earlier run's `restoreLastSession` would
+    // otherwise skip the device-selector screen entirely and reconnect
+    // straight into the editor before we get a chance to pick "Virtual
+    // Keyboard" ourselves — see tray-start-unlock.test.ts for the same
+    // gotcha and doc-capture-common.ts's own doc comment on this helper.
+    onMainReady: async ({ userDataPath }) => {
+      lastDeviceBackup = nullifyLastDeviceConfig(userDataPath)
+      // ensureAutoMoveOn() below flips Auto Move on, and that toggle is
+      // persisted into the virtual device's pipette_settings.json (same
+      // store a real keyboard uses) — not just in-memory React state. Back
+      // it up here so afterAll can restore it and this run doesn't leave a
+      // real developer's Auto Move preference flipped on behind their back.
+      virtualDeviceSettingsBackup = backupVirtualDeviceSettings(userDataPath)
+    },
+  })
+  app = launched.app
+  page = launched.page
+
+  await dismissNotificationModal(page, { waitForAppearMs: 3_000 })
+
+  const connected = await connectToDevice(page, DEVICE_NAME)
+  if (!connected) throw new Error(`Device "${DEVICE_NAME}" not found`)
+
+  await dismissNotificationModal(page)
+  // Same defensive order as doc-capture-key-popover.ts: a viewMode
+  // persisted from an earlier run can surface the Unlock dialog via the
+  // auto-restore effect before we touch anything ourselves.
+  await waitForUnlockDialog(app, page)
+  await dismissNotificationModal(page)
+  await resetToEditorMode(page)
+
+  const editorContent = page.locator('[data-testid="editor-content"]')
+  const layer0Btn = editorContent.locator('button', { hasText: /^0$/ })
+  if (await isAvailable(layer0Btn)) {
+    await layer0Btn.first().click()
+    await page.waitForTimeout(300)
+  }
+  const basicBtn = editorContent.locator('button', { hasText: /^Basic$/ })
+  if (await isAvailable(basicBtn)) {
+    await basicBtn.first().click()
+    await page.waitForTimeout(300)
+  }
+})
+
+test.afterAll(async () => {
+  await app?.close()
+  // Restore after close — window-state saves on quit rewrite config.json,
+  // so restoring first would just be overwritten by that later write.
+  if (lastDeviceBackup) restoreLastDeviceConfig(lastDeviceBackup)
+  // Undo the Auto Move persistence from ensureAutoMoveOn() so this test run
+  // doesn't leave the virtual device's settings file changed on disk.
+  if (virtualDeviceSettingsBackup) restoreVirtualDeviceSettings(virtualDeviceSettingsBackup)
+})
+
+/** Saves a full-page screenshot for local visual review only. CI runners
+ *  don't upload these anywhere and there's no pixel comparison against
+ *  them, so writing them there is pure waste — skip on CI and keep the
+ *  local-inspection workflow. */
+async function capture(name: string): Promise<void> {
+  if (process.env.CI) return
+  mkdirSync(SCREENSHOT_DIR, { recursive: true })
+  await page.screenshot({ path: resolve(SCREENSHOT_DIR, `${name}.png`), fullPage: true })
+}
+
+/** Opens the keycode picker's Menu overlay and switches to the Tools tab —
+ *  same `aria-controls="keycodes-overlay-panel"` button doc-capture-overlay-
+ *  tools.ts and virtual-device.test.ts already rely on for this panel. */
+async function openToolsTab(): Promise<void> {
+  const menuButton = page.locator('button[aria-controls="keycodes-overlay-panel"]')
+  const isExpanded = await menuButton.getAttribute('aria-expanded')
+  if (isExpanded !== 'true') {
+    await menuButton.click()
+    await page.waitForTimeout(300)
+  }
+  await page.locator('[data-testid="overlay-tab-tools"]').click()
+  await page.waitForTimeout(200)
+}
+
+async function closeMenuIfOpen(): Promise<void> {
+  const menuButton = page.locator('button[aria-controls="keycodes-overlay-panel"]')
+  const isExpanded = await menuButton.getAttribute('aria-expanded')
+  if (isExpanded === 'true') {
+    await menuButton.click()
+    await page.waitForTimeout(300)
+  }
+}
+
+/** Turns Auto Move on if it isn't already — never writes the settings file
+ *  directly (virtual-device uid/userData layout is an implementation
+ *  detail the test shouldn't depend on). */
+async function ensureAutoMoveOn(): Promise<void> {
+  await openToolsTab()
+  const toggle = page.locator('[data-testid="overlay-auto-advance-toggle"]')
+  await expect(toggle).toBeVisible()
+  const checked = await toggle.getAttribute('aria-checked')
+  if (checked !== 'true') {
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-checked', 'true')
+  }
+  await closeMenuIfOpen()
+}
+
+async function openPopoverOnFirstKey(): Promise<void> {
+  const editorContent = page.locator('[data-testid="editor-content"]')
+  const keyLabel = editorContent.locator('svg text').first()
+  await expect(keyLabel).toBeVisible()
+  await page.evaluate(() => window.scrollTo(0, 0))
+  await keyLabel.evaluate((el) => {
+    el.dispatchEvent(new MouseEvent('dblclick', { bubbles: true, cancelable: true }))
+  })
+  await expect(page.locator('[data-testid="key-popover"]')).toBeVisible()
+}
+
+/** Closes the popover via its close button and confirms it's gone — the
+ *  standard teardown every test in this file ends with. */
+async function closePopover(): Promise<void> {
+  await page.locator('[data-testid="popover-close"]').click()
+  await expect(page.locator('[data-testid="key-popover"]')).not.toBeVisible()
+}
+
+test.describe('Key popover behavior', { tag: '@virtual' }, () => {
+  test('Auto Move does not carry the previous key\'s wrapper mode onto a plain landed key', async () => {
+    // Without the fix, `wrapperMode` is React state that survives the
+    // follow-along (no remount), so switching into Mod-Mask on the source
+    // key would still show the Mod-Mask checkbox strip after landing on a
+    // key whose own current keycode is plain — the exact "still showing
+    // the previous one" bug PR #316 describes, just on the mode-button
+    // wrapper instead of the Code-tab value (which is prop-driven and
+    // would look correct either way).
+    await ensureAutoMoveOn()
+    await openPopoverOnFirstKey()
+    const popover = page.locator('[data-testid="key-popover"]')
+    const startKey = await popover.getAttribute('data-popover-target-key')
+
+    // Switch the source key into Mod-Mask mode — a non-confirm raw call
+    // (see handleModeSwitch's `advance: false`), so the popover stays put
+    // and now shows the modifier checkbox strip.
+    await page.locator('[data-testid="popover-mode-mod-mask"]').click()
+    await expect(page.locator('[data-testid="modifier-checkbox-strip"]')).toBeVisible()
+
+    // Confirm a plain keycode pick while still in Mod-Mask mode (wraps it
+    // into a Mod-Mask keycode, a genuine confirm) — Auto Move advances to
+    // the next key.
+    const result = page.locator('[data-testid^="popover-result-"]').first()
+    await result.click()
+    await page.keyboard.press('Enter')
+    await expect
+      .poll(async () => popover.getAttribute('data-popover-target-key'))
+      .not.toBe(startKey)
+
+    // The landed key's own current keycode is plain (never touched by this
+    // test before now), so a fresh mount detects wrapperMode 'none' and
+    // hides the strip. A stale wrapperMode carried over from the source
+    // key would leave it visible.
+    await expect(page.locator('[data-testid="modifier-checkbox-strip"]')).not.toBeVisible()
+
+    await capture('auto-move-follow-along')
+    await closePopover()
+  })
+
+  test('layer sidebar keeps the Code tab active while the target layer changes', async () => {
+    await openPopoverOnFirstKey()
+
+    const popover = page.locator('[data-testid="key-popover"]')
+    const startLayer = await popover.getAttribute('data-popover-target-layer')
+
+    await page.locator('[data-testid="popover-tab-code"]').click()
+    const hexInput = page.locator('[data-testid="popover-hex-input"]')
+    await expect(hexInput).toBeVisible()
+
+    const layer1Btn = page.locator('[data-testid="popover-layer-1"]')
+    await expect(layer1Btn).toBeVisible()
+    await layer1Btn.click()
+
+    // Code tab must survive the layer switch (it's the same KeyPopover
+    // instance — only the layer sidebar effect re-derives state, it does
+    // not remount and reset activeTab).
+    await expect(hexInput).toBeVisible()
+
+    // The layer itself did switch (from whatever layer0Btn left us on in
+    // beforeAll, to layer 1).
+    expect(startLayer).not.toBe('1')
+    await expect(popover).toHaveAttribute('data-popover-target-layer', '1')
+
+    await capture('layer-sidebar-code-tab')
+    await closePopover()
+  })
+})

--- a/src/renderer/components/editors/keymap-editor-popover.tsx
+++ b/src/renderer/components/editors/keymap-editor-popover.tsx
@@ -66,6 +66,7 @@ export function PopoverForState({
       // `useKeymapSelectionHandlers`'s popover handlers and the prop doc
       // on `KeyPopover.closeOnSelect`.
       closeOnSelect={false}
+      targetKey={popoverInstanceKey(popoverState)}
     />
   )
 }

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -63,6 +63,16 @@ interface KeyPopoverProps {
    *  so the Key tab's search index and result rows agree with what
    *  the keymap grid shows (issue #294). */
   remapLabel?: (qmkId: string) => string
+  /** Edit target identity, exposed as the `data-popover-target-key`
+   *  attribute on the root element so e2e tests can observe which
+   *  key/encoder is currently being edited. This is `popoverInstanceKey`
+   *  (`keymap-editor-popover.tsx`) itself — the same string that tells
+   *  React to remount this component — so the attribute answers exactly
+   *  "did the edit target change" rather than reimplementing that
+   *  identity separately. Only `KeymapEditor`'s `PopoverForState` passes
+   *  this; `MacroEditor` and `KeycodeEntryModalShell` have no edit-target
+   *  concept, so the attribute is omitted for them. */
+  targetKey?: string
 }
 
 const POPOVER_WIDTH = 320
@@ -90,6 +100,7 @@ export function KeyPopover({
   nextKeycode,
   onRedo,
   remapLabel,
+  targetKey,
 }: KeyPopoverProps) {
   const { t } = useTranslation()
   const [activeTab, setActiveTab] = useState<Tab>('key')
@@ -211,6 +222,8 @@ export function KeyPopover({
         paddingLeft: showLayerSidebar ? LAYER_SIDEBAR_WIDTH : undefined,
       }}
       data-testid="key-popover"
+      data-popover-target-key={targetKey}
+      data-popover-target-layer={targetKey != null ? currentLayer : undefined}
     >
       {showLayerSidebar && (
         <div


### PR DESCRIPTION
## Why

The regression in #316 slipped through because every test asserted the selection state *outside* the popover — nothing looked at what the popover itself was showing after a move. Unit tests now cover that, but they exercise the key builder and the remount separately, leaving the seam between them (the actual Auto Move path) unverified.

## What runs

Two specs, driven through the real app against the emulated device so no hardware is needed:

| Spec | Guards |
|---|---|
| Auto Move follow-along | A plain landed key does not inherit the previous key's wrapper mode |
| Layer sidebar | Switching layers leaves the Code tab open — the exception the remount key deliberately excludes the layer for |

**Both were written by reverting the fix and watching them fail**, so they are known to react to the mistake they describe rather than merely passing alongside it. The `currentLayer`-in-the-key mistake was reproduced too, and the second spec catches that one.

A third spec was written and then dropped: it asserted the Code tab's hex value, which is derived from `currentKeycode` via props and is therefore correct whether or not the popover remounts. It could not fail on this regression, and leaving it in would have implied coverage that did not exist.

## Observing the edit target

The popover now carries its edit target as a data attribute. It publishes the same string the remount key is built from rather than decomposing the position again, so the identity keeps one definition and encoders need no separate wiring. Callers that don't pass it — `MacroEditor`, `KeycodeEntryModalShell` — emit no attribute.

## CI

Specs run by tag (`--grep @virtual`), not by filename, so a new one is picked up without touching the workflow. The rest of the suite stays out: those specs assume real hardware or a local Hub. `xvfb` folded into the existing apt step rather than adding a second `apt-get update`.

Screenshots are written for local inspection only — under CI there is no artifact upload and no pixel comparison, so capturing them there would just write files the runner discards.

## Verification

`312` files / `7193` passed / `22` skipped unchanged; `2 passed` for the tagged e2e; eslint and typecheck clean.

Toggling Auto Move persists to the device's settings file, so the spec backs it up before launch and restores it after. Confirmed by forcing the setting off on disk, running the spec, and checking it stayed off.