### PR TITLE
refactor(ui): share one idempotent helper for the keycode overlay in e2e

### DIFF
--- a/e2e/helpers/doc-capture-common.ts
+++ b/e2e/helpers/doc-capture-common.ts
@@ -653,6 +653,70 @@ export async function dismissOverlay(
   await page.waitForTimeout(500)
 }
 
+/** Selector for the keycode picker's Menu-overlay toggle button, shared by
+ *  every function below that opens/closes/inspects that overlay. */
+const KEYCODES_OVERLAY_TOGGLE_SELECTOR = 'button[aria-controls="keycodes-overlay-panel"]'
+
+/**
+ * Open the keycode picker's Menu overlay (`keycodes-overlay-panel`) if it's
+ * currently closed. Reads `aria-expanded` first so this is idempotent —
+ * the toggle button has no separate open/close affordance, just one button
+ * that flips state, so calling this on an already-open overlay must be a
+ * no-op rather than close it again. Returns false without throwing if the
+ * toggle isn't in the DOM at all: Typing Test and View Matrix mode unmount
+ * the whole keycode picker, overlay included (see KeymapEditor.tsx).
+ */
+export async function openKeycodesOverlay(page: Page): Promise<boolean> {
+  const toggle = page.locator(KEYCODES_OVERLAY_TOGGLE_SELECTOR)
+  if (!(await isAvailable(toggle))) return false
+  if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+    await toggle.click()
+    await page.waitForTimeout(500)
+  }
+  return true
+}
+
+/** Close the Menu overlay opened by `openKeycodesOverlay`, if it's open.
+ *  Same idempotent toggle-button read, mirrored for the close direction. */
+export async function closeKeycodesOverlay(page: Page): Promise<void> {
+  const toggle = page.locator(KEYCODES_OVERLAY_TOGGLE_SELECTOR)
+  if (!(await isAvailable(toggle))) return
+  if ((await toggle.getAttribute('aria-expanded')) === 'true') {
+    await toggle.click()
+    await page.waitForTimeout(300)
+  }
+}
+
+/** Standard "the overlay tab wasn't there" message body, shared by every
+ *  doc-capture call site that skips (log + return) or aborts (throw) when
+ *  `openOverlayTab` returns false. */
+export function overlayTabNotFoundMessage(tab: 'layout' | 'tools' | 'data'): string {
+  return `overlay-tab-${tab} not found`
+}
+
+/**
+ * Open the Menu overlay and switch to `tab`. Returns false immediately —
+ * without waiting out a timeout — when the toggle or the tab isn't
+ * available, so a misconfigured capture (e.g. a keyboard without layout
+ * options) fails fast instead of hanging on a locator that will never
+ * appear.
+ */
+export async function openOverlayTab(page: Page, tab: 'layout' | 'tools' | 'data'): Promise<boolean> {
+  if (!(await openKeycodesOverlay(page))) return false
+
+  const tabBtn = page.locator(`[data-testid="overlay-tab-${tab}"]`)
+  // The panel only renders a tab *bar* (and with it, `overlay-tab-tools`)
+  // once there are 2+ tabs. With `tools` as the sole tab there's no button
+  // to click, but its content is already the active one.
+  if ((await tabBtn.count()) === 0) return tab === 'tools'
+  // Already selected: skip the click (and its settle wait) so repeat calls
+  // in the same session don't re-trigger the tab's mount effects.
+  if ((await tabBtn.getAttribute('aria-selected')) === 'true') return true
+  await tabBtn.click()
+  await page.waitForTimeout(300)
+  return true
+}
+
 /**
  * Select a specific keyboard (by uid) through the Analyze staged filter
  * modal (chip -> Keyboard row -> Apply). Polls for the option's `<select>`

--- a/e2e/helpers/doc-capture-hub.ts
+++ b/e2e/helpers/doc-capture-hub.ts
@@ -20,6 +20,8 @@ import {
   isAvailable,
   isLocalHubUp,
   launchCaptureApp,
+  openOverlayTab,
+  overlayTabNotFoundMessage,
   resetToEditorMode,
   restoreHubEnabledConfig,
   restoreVirtualDeviceSnapshots,
@@ -296,29 +298,6 @@ async function waitForUploadButton(page: Page): Promise<{ available: boolean; lo
   }
 }
 
-async function ensureOverlayOpen(page: Page): Promise<boolean> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  if (!(await isAvailable(toggle))) return false
-
-  const isExpanded = await toggle.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await toggle.click()
-    await page.waitForTimeout(500)
-  }
-  return true
-}
-
-async function switchOverlayTab(page: Page, tabTestId: string): Promise<boolean> {
-  const tab = page.locator(`[data-testid="${tabTestId}"]`)
-  if (!(await isAvailable(tab))) {
-    console.log(`  [skip] ${tabTestId} not found`)
-    return false
-  }
-  await tab.click()
-  await page.waitForTimeout(300)
-  return true
-}
-
 async function captureEditorDataTab(page: Page): Promise<void> {
   console.log('\n--- Phase 5: Overlay Panel -> Data tab (Save & Upload) ---')
 
@@ -333,13 +312,8 @@ async function captureEditorDataTab(page: Page): Promise<void> {
     await page.waitForTimeout(300)
   }
 
-  if (!(await ensureOverlayOpen(page))) {
-    console.log('  [skip] overlay toggle not found')
-    return
-  }
-
-  if (!(await switchOverlayTab(page, 'overlay-tab-data'))) {
-    console.log('  [skip] data tab not found in overlay')
+  if (!(await openOverlayTab(page, 'data'))) {
+    console.log(`  [skip] ${overlayTabNotFoundMessage('data')}`)
     return
   }
 

--- a/e2e/helpers/doc-capture-layout-options.ts
+++ b/e2e/helpers/doc-capture-layout-options.ts
@@ -10,7 +10,7 @@ import { _electron as electron } from '@playwright/test'
 import type { ElectronApplication, Page } from '@playwright/test'
 import { mkdirSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { dismissNotificationModal } from './doc-capture-common'
+import { dismissNotificationModal, openOverlayTab } from './doc-capture-common'
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '../..')
 const SCREENSHOT_DIR = resolve(PROJECT_ROOT, 'docs/screenshots')
@@ -32,15 +32,6 @@ async function interceptFileDialog(app: ElectronApplication): Promise<void> {
     },
     FIXTURE_PATH,
   )
-}
-
-async function ensureOverlayOpen(page: Page): Promise<void> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  const isExpanded = await toggle.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await toggle.click()
-    await page.waitForTimeout(500)
-  }
 }
 
 async function main(): Promise<void> {
@@ -77,13 +68,13 @@ async function main(): Promise<void> {
     await dismissNotificationModal(page)
 
     // Open overlay panel and switch to Layout tab
-    await ensureOverlayOpen(page)
-    const layoutTab = page.locator('[data-testid="overlay-tab-layout"]')
-    if ((await layoutTab.count()) === 0) {
+    if (!(await openOverlayTab(page, 'layout'))) {
       throw new Error('Layout tab not found — keyboard definition may not have layout options')
     }
-    await layoutTab.click()
-    await page.waitForTimeout(500)
+    // Carried over from the pre-refactor capture, which waited 500ms here
+    // specifically for Layout (other tabs used the shorter default) — the
+    // reason Layout needed the longer wait isn't recorded anywhere.
+    await page.waitForTimeout(200)
     await capture(page, 'layout-options-open')
 
     // Change first visible option to capture the changed state.

--- a/e2e/helpers/doc-capture-overlay-tools.ts
+++ b/e2e/helpers/doc-capture-overlay-tools.ts
@@ -21,14 +21,15 @@
 // environments even though the page is fully interactive (see
 // doc-capture-language-packs.ts for the same workaround and rationale).
 
-import type { ElectronApplication, Page } from '@playwright/test'
+import type { ElectronApplication } from '@playwright/test'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import {
   connectToDevice,
   dismissNotificationModal,
-  isAvailable,
   launchCaptureApp,
+  openOverlayTab,
+  overlayTabNotFoundMessage,
   VIRTUAL_DEVICE_DISPLAY_NAME,
 } from './doc-capture-common'
 
@@ -52,17 +53,6 @@ async function capture(app: ElectronApplication, name: string): Promise<void> {
   const path = resolve(SCREENSHOT_DIR, `${name}.png`)
   writeFileSync(path, Buffer.from(dataUrl.replace(/^data:image\/png;base64,/, ''), 'base64'))
   console.log(`Saved: ${path}`)
-}
-
-async function ensureOverlayOpen(page: Page): Promise<boolean> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  if (!(await isAvailable(toggle))) return false
-  const isExpanded = await toggle.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await toggle.click()
-    await page.waitForTimeout(500)
-  }
-  return true
 }
 
 async function main(): Promise<void> {
@@ -90,15 +80,9 @@ async function main(): Promise<void> {
 
     // The Tools overlay tab isn't unlock-gated, so no clickThroughUnlock is
     // needed here — just open the keycodes overlay and select the tab.
-    if (!(await ensureOverlayOpen(page))) {
-      console.log('[skip] overlay toggle not found')
+    if (!(await openOverlayTab(page, 'tools'))) {
+      console.log(`  [skip] ${overlayTabNotFoundMessage('tools')}`)
       return
-    }
-
-    const tab = page.locator('[data-testid="overlay-tab-tools"]')
-    if (await isAvailable(tab)) {
-      await tab.click()
-      await page.waitForTimeout(300)
     }
 
     await capture(app, 'overlay-tools')

--- a/e2e/helpers/doc-capture-view-matrix.ts
+++ b/e2e/helpers/doc-capture-view-matrix.ts
@@ -19,6 +19,8 @@ import {
   connectToDevice,
   dismissNotificationModal,
   launchCaptureApp,
+  openOverlayTab,
+  overlayTabNotFoundMessage,
   resetToEditorMode,
   restoreVirtualDeviceSettings,
   VIRTUAL_DEVICE_DISPLAY_NAME,
@@ -50,28 +52,15 @@ async function interceptFileDialog(app: ElectronApplication): Promise<void> {
   )
 }
 
-async function ensureOverlayOpen(page: Page): Promise<void> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  const isExpanded = await toggle.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await toggle.click()
-    await page.waitForTimeout(500)
-  }
-}
-
 /** Open the Keycodes Overlay Panel and click the View Matrix row's Edit
  *  button, then wait for the mode's left pane to mount. Entering the mode
  *  unmounts the whole keycode picker (overlay included), so there is no
- *  panel to close afterwards. */
+ *  panel to close afterwards. The View Matrix row lives on the Tools tab;
+ *  openOverlayTab already handles the case where Tools is the panel's only
+ *  tab (tab bar absent, content already active). */
 async function enterViewMatrixMode(page: Page): Promise<void> {
-  await ensureOverlayOpen(page)
-  // The View Matrix row lives on the Tools tab; the panel may open on the
-  // Layout/Save tab instead when the keyboard has those (tab bar is absent
-  // when Tools is the only tab).
-  const toolsTab = page.locator('[data-testid="overlay-tab-tools"]')
-  if ((await toolsTab.count()) > 0) {
-    await toolsTab.click()
-    await page.waitForTimeout(300)
+  if (!(await openOverlayTab(page, 'tools'))) {
+    throw new Error(overlayTabNotFoundMessage('tools'))
   }
   await page.locator('[data-testid="overlay-view-matrix-edit-button"]').click()
   await page.locator('[data-testid="view-matrix-reset-panel"]').waitFor({ state: 'visible', timeout: 10_000 })

--- a/e2e/helpers/doc-capture.ts
+++ b/e2e/helpers/doc-capture.ts
@@ -8,12 +8,15 @@ import { resolve, join } from 'node:path'
 import {
   backupVirtualDeviceSettings,
   clickThroughUnlock,
+  closeKeycodesOverlay,
   connectToDevice,
   dismissNotificationModal,
   escapeRegex,
   isAvailable,
   launchCaptureApp,
   nullifyLastDeviceConfig,
+  openOverlayTab,
+  overlayTabNotFoundMessage,
   resetToEditorMode,
   resetVirtualDeviceKeyboardLayout,
   restoreLastDeviceConfig,
@@ -125,40 +128,6 @@ async function captureSegmentVariant(
     await offToggle.click()
     await page.waitForTimeout(500)
   }
-}
-
-async function ensureOverlayOpen(page: Page): Promise<boolean> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  if (!(await isAvailable(toggle))) return false
-
-  const isExpanded = await toggle.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await toggle.click()
-    await page.waitForTimeout(500)
-  }
-  return true
-}
-
-async function closeOverlay(page: Page): Promise<void> {
-  const toggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  if (await isAvailable(toggle)) {
-    const isExpanded = await toggle.getAttribute('aria-expanded')
-    if (isExpanded === 'true') {
-      await toggle.click()
-      await page.waitForTimeout(300)
-    }
-  }
-}
-
-async function switchOverlayTab(page: Page, tabTestId: string): Promise<boolean> {
-  const tab = page.locator(`[data-testid="${tabTestId}"]`)
-  if (!(await isAvailable(tab))) {
-    console.log(`  [skip] ${tabTestId} not found`)
-    return false
-  }
-  await tab.click()
-  await page.waitForTimeout(300)
-  return true
 }
 
 async function connectDevice(app: ElectronApplication, page: Page): Promise<boolean> {
@@ -1373,14 +1342,11 @@ async function captureJsonEditors(page: Page): Promise<void> {
 async function captureEditorSettings(page: Page): Promise<void> {
   console.log('\n--- Phase 7: Editor Settings (Save Panel) ---')
 
-  if (!(await ensureOverlayOpen(page))) {
-    console.log('  [skip] overlay toggle not found')
+  if (!(await openOverlayTab(page, 'data'))) {
+    console.log(`  [skip] ${overlayTabNotFoundMessage('data')}`)
     return
   }
-
-  if (await switchOverlayTab(page, 'overlay-tab-data')) {
-    await captureNamed(page, 'editor-settings-save', { fullPage: true })
-  }
+  await captureNamed(page, 'editor-settings-save', { fullPage: true })
 }
 
 // --- Phase 7.5: Overlay Panel ---
@@ -1388,20 +1354,20 @@ async function captureEditorSettings(page: Page): Promise<void> {
 async function captureOverlayPanel(page: Page): Promise<void> {
   console.log('\n--- Phase 7.5: Overlay Panel ---')
 
-  if (!(await ensureOverlayOpen(page))) {
-    console.log('  [skip] overlay toggle not found')
-    return
+  const tabs = [
+    ['tools', 'overlay-tools'],
+    ['data', 'overlay-save'],
+  ] as const
+
+  for (const [tab, shotName] of tabs) {
+    if (await openOverlayTab(page, tab)) {
+      await captureNamed(page, shotName, { fullPage: true })
+    } else {
+      console.log(`  [skip] ${overlayTabNotFoundMessage(tab)}`)
+    }
   }
 
-  if (await switchOverlayTab(page, 'overlay-tab-tools')) {
-    await captureNamed(page, 'overlay-tools', { fullPage: true })
-  }
-
-  if (await switchOverlayTab(page, 'overlay-tab-data')) {
-    await captureNamed(page, 'overlay-save', { fullPage: true })
-  }
-
-  await closeOverlay(page)
+  await closeKeycodesOverlay(page)
 }
 
 // --- Phase 8: Status Bar ---

--- a/e2e/hub-local.test.ts
+++ b/e2e/hub-local.test.ts
@@ -20,6 +20,7 @@ import {
   HUB_LOCAL_START_HINT,
   HUB_LOCAL_URL,
   isLocalHubUp,
+  openOverlayTab,
   resetToEditorMode,
   restoreHubEnabledConfig,
   restoreVirtualDeviceSnapshots,
@@ -143,11 +144,7 @@ test('connects the virtual device and reaches the hub upload UI', async () => {
   await resetToEditorMode(page)
 
   // Open the overlay panel's Data tab where saved layouts live.
-  const overlayToggle = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  if ((await overlayToggle.getAttribute('aria-expanded')) !== 'true') {
-    await overlayToggle.click()
-  }
-  await page.locator('[data-testid="overlay-tab-data"]').click()
+  expect(await openOverlayTab(page, 'data')).toBe(true)
 
   // Save a snapshot; its entry must expose the hub upload button.
   await page.locator('[data-testid="layout-store-save-input"]').fill(PUBLIC_LABEL)

--- a/e2e/popover-behavior.test.ts
+++ b/e2e/popover-behavior.test.ts
@@ -15,10 +15,12 @@ import { resolve } from 'node:path'
 import { launchApp } from './helpers/electron'
 import {
   backupVirtualDeviceSettings,
+  closeKeycodesOverlay,
   connectToDevice,
   dismissNotificationModal,
   isAvailable,
   nullifyLastDeviceConfig,
+  openOverlayTab,
   resetToEditorMode,
   restoreLastDeviceConfig,
   restoreVirtualDeviceSettings,
@@ -105,34 +107,11 @@ async function capture(name: string): Promise<void> {
   await page.screenshot({ path: resolve(SCREENSHOT_DIR, `${name}.png`), fullPage: true })
 }
 
-/** Opens the keycode picker's Menu overlay and switches to the Tools tab —
- *  same `aria-controls="keycodes-overlay-panel"` button doc-capture-overlay-
- *  tools.ts and virtual-device.test.ts already rely on for this panel. */
-async function openToolsTab(): Promise<void> {
-  const menuButton = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  const isExpanded = await menuButton.getAttribute('aria-expanded')
-  if (isExpanded !== 'true') {
-    await menuButton.click()
-    await page.waitForTimeout(300)
-  }
-  await page.locator('[data-testid="overlay-tab-tools"]').click()
-  await page.waitForTimeout(200)
-}
-
-async function closeMenuIfOpen(): Promise<void> {
-  const menuButton = page.locator('button[aria-controls="keycodes-overlay-panel"]')
-  const isExpanded = await menuButton.getAttribute('aria-expanded')
-  if (isExpanded === 'true') {
-    await menuButton.click()
-    await page.waitForTimeout(300)
-  }
-}
-
 /** Turns Auto Move on if it isn't already — never writes the settings file
  *  directly (virtual-device uid/userData layout is an implementation
  *  detail the test shouldn't depend on). */
 async function ensureAutoMoveOn(): Promise<void> {
-  await openToolsTab()
+  expect(await openOverlayTab(page, 'tools')).toBe(true)
   const toggle = page.locator('[data-testid="overlay-auto-advance-toggle"]')
   await expect(toggle).toBeVisible()
   const checked = await toggle.getAttribute('aria-checked')
@@ -140,7 +119,7 @@ async function ensureAutoMoveOn(): Promise<void> {
     await toggle.click()
     await expect(toggle).toHaveAttribute('aria-checked', 'true')
   }
-  await closeMenuIfOpen()
+  await closeKeycodesOverlay(page)
 }
 
 async function openPopoverOnFirstKey(): Promise<void> {

--- a/e2e/virtual-device.test.ts
+++ b/e2e/virtual-device.test.ts
@@ -12,7 +12,7 @@
 import { test, expect } from '@playwright/test'
 import type { ElectronApplication, Page } from '@playwright/test'
 import { launchApp } from './helpers/electron'
-import { dismissNotificationModal, escapeRegex, VIRTUAL_DEVICE_DISPLAY_NAME } from './helpers/doc-capture-common'
+import { dismissNotificationModal, escapeRegex, openOverlayTab, VIRTUAL_DEVICE_DISPLAY_NAME } from './helpers/doc-capture-common'
 import type { VirtualDeviceController } from './helpers/doc-capture-common'
 
 const VIRTUAL_DEVICE_NAME = VIRTUAL_DEVICE_DISPLAY_NAME
@@ -51,11 +51,7 @@ test('virtual device appears in the device list and connects to the editor', asy
 })
 
 test('enabling the matrix tester while locked prompts the unlock dialog, which clears after the combo is held', async () => {
-  const settingsButton = page.locator('[aria-controls="keycodes-overlay-panel"]')
-  await settingsButton.click()
-
-  const toolsTab = page.locator('[data-testid="overlay-tab-tools"]')
-  await toolsTab.click()
+  expect(await openOverlayTab(page, 'tools')).toBe(true)
 
   // Shorten the unlock countdown BEFORE the dialog's unlockStart() fires, so
   // the sequence completes in a few 200ms polls instead of the firmware's


### PR DESCRIPTION
## Why

Opening the keycode picker's Menu overlay and switching tabs was written out in **eight places**, and they had drifted apart:

| | reads `aria-expanded` | selector |
|---|---|---|
| `doc-capture-overlay-tools.ts` | yes | `button[aria-controls=…]` |
| `popover-behavior.test.ts` | yes | `button[aria-controls=…]` |
| **`virtual-device.test.ts`** | **no** | `[aria-controls=…]` |

Clicking the toggle unconditionally **closes** the panel when it is already open. That spec only worked because nothing before it happened to leave the panel open — a state dependency waiting to break as soon as the file grows or the order changes.

## What this does

Three idempotent helpers in `doc-capture-common.ts`: opening what is already open, or closing what is already closed, does nothing.

Switching tabs guarantees the overlay is open first, then reports whether the tab was there — because the right answer differs by caller:

| Caller | On a missing tab |
|---|---|
| `doc-capture.ts`, `-hub.ts`, `-overlay-tools.ts` | skip and log, keep going |
| `doc-capture-layout-options.ts` | throw — the fixture is meaningless without it |
| `hub-local.test.ts`, `virtual-device.test.ts`, `popover-behavior.test.ts` | assert |

Deciding that inside the helper would break one of them. Two callers were dropping the answer on the floor; `doc-capture-view-matrix.ts` would have waited out the full 30s action timeout before failing, so both now act on it.

## Two panel details the helpers encode

- A tab only exists when the keyboard has something to show there (`hasLayoutOptions` / `hasData`), so a missing tab returns immediately rather than waiting for something that will never appear.
- When Tools is the only tab, the tab bar isn't drawn at all — it is already selected, so there is nothing to click.

## Not changed

Every existing settle wait is preserved (500ms open, 300ms tab switch and close). The Layout capture kept its extra wait; the pre-refactor code waited longer there than for other tabs and left no record of why, so the comment says exactly that rather than inventing a reason.

## Verification

`312` files / `7193` passed / `22` skipped unchanged; `2 passed` for the tagged e2e; `doc-capture-layout-options.ts` run for real to exercise the required-tab path.

Net `-66` lines across 9 files.