### PR TITLE
feat(ui): break bigram intervals down by hand alternation

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -1127,7 +1127,8 @@
       "quadrant": {
         "top": "頻出ペア",
         "slow": "ペア間隔",
-        "fingerIki": "指間隔"
+        "fingerIki": "指間隔",
+        "classes": "交互打鍵ベネフィット"
       },
       "cappedNotice": "頻度上位 {{limit}} 件のペアから算出しています — 低頻度のペアは含まれない場合があります",
       "gramToggle": {
@@ -1137,6 +1138,7 @@
       },
       "column": {
         "pair": "ペア",
+        "class": "分類",
         "count": "回数",
         "avgIki": "平均間隔",
         "avgIkiTrigramTooltip": "3キー間にある2つの間隔の平均です。3キー全体の所要時間ではありません",
@@ -1150,6 +1152,19 @@
           "desc": "遅い順",
           "asc": "早い順"
         }
+      },
+      "classes": {
+        "noSnapshot": "交互打鍵ベネフィットには keymap snapshot が必要です。Record セッションを開始するか snapshot のある期間を選択してください",
+        "className": {
+          "left": "左手",
+          "right": "右手",
+          "alternation": "交互打鍵",
+          "repetition": "同指連打"
+        },
+        "coverage": "{{percent}}% のペアを分類できました",
+        "deltaLeft": "ΔLeft",
+        "deltaRight": "ΔRight",
+        "deltaTooltip": "プラスなら、同じ手を使い続けるより手を交互に使う方が速かったことを示します"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -1117,7 +1117,8 @@
       "quadrant": {
         "top": "頻出ペア☆",
         "slow": "ペア間隔っしょ",
-        "fingerIki": "指間隔☆"
+        "fingerIki": "指間隔☆",
+        "classes": "交互打鍵ベネフィット☆"
       },
       "cappedNotice": "頻度上位 {{limit}} 件から出してるよん — レアなペアは入ってないかもっしょ",
       "gramToggle": {
@@ -1127,6 +1128,7 @@
       },
       "column": {
         "pair": "ペア☆",
+        "class": "分類☆",
         "count": "回数っしょ",
         "avgIki": "平均間隔☆",
         "avgIkiTrigramTooltip": "3キー間にある2つの間隔の平均だよ。3キー全体の時間じゃないから注意っしょ",
@@ -1140,6 +1142,19 @@
           "desc": "遅い順ｗ",
           "asc": "速い順☆"
         }
+      },
+      "classes": {
+        "noSnapshot": "交互打鍵ベネフィットもスナップショットないと無理っしょ☆REC開始して！",
+        "className": {
+          "left": "左手☆",
+          "right": "右手☆",
+          "alternation": "交互っしょ☆",
+          "repetition": "連打ｗ"
+        },
+        "coverage": "{{percent}}%のペア分類できたっしょ☆",
+        "deltaLeft": "ΔLeft",
+        "deltaRight": "ΔRight",
+        "deltaTooltip": "プラスなら交互に手動かした方が速かったってことっしょ☆"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -1117,7 +1117,8 @@
       "quadrant": {
         "top": "よう出るペア",
         "slow": "ペア間隔",
-        "fingerIki": "指間隔"
+        "fingerIki": "指間隔",
+        "classes": "交互打鍵ベネフィット"
       },
       "cappedNotice": "頻度上位 {{limit}} 件のペアから出してますえ — 珍しいペアは入っとらんこともありますえ",
       "gramToggle": {
@@ -1127,6 +1128,7 @@
       },
       "column": {
         "pair": "ペア",
+        "class": "分類",
         "count": "回数",
         "avgIki": "平均間隔",
         "avgIkiTrigramTooltip": "3キー間にある2つの間隔の平均どす。3キー全体の時間とは違いますえ",
@@ -1140,6 +1142,19 @@
           "desc": "遅い順どすえ",
           "asc": "速い順どすえ"
         }
+      },
+      "classes": {
+        "noSnapshot": "交互打鍵ベネフィットにはスナップショットが要りますえ。Record を始めるかスナップショットのある期間を選んでおくれやす",
+        "className": {
+          "left": "左手どすえ",
+          "right": "右手どすえ",
+          "alternation": "交互打鍵どすえ",
+          "repetition": "同指連打どすえ"
+        },
+        "coverage": "{{percent}}% のペアを分類できましたえ",
+        "deltaLeft": "ΔLeft",
+        "deltaRight": "ΔRight",
+        "deltaTooltip": "プラスやったら、片手だけよりも両手交互の方が速かったいうことどすえ"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -1117,7 +1117,8 @@
       "quadrant": {
         "top": "頻出ペア",
         "slow": "ペア間隔",
-        "fingerIki": "指間隔"
+        "fingerIki": "指間隔",
+        "classes": "交互打鍵の恩恵"
       },
       "cappedNotice": "頻度上位 {{limit}} 件の組より算出しております — 稀な組は含まれぬこともございます",
       "gramToggle": {
@@ -1127,6 +1128,7 @@
       },
       "column": {
         "pair": "ペア",
+        "class": "分類",
         "count": "回数",
         "avgIki": "平均間隔",
         "avgIkiTrigramTooltip": "三つの打鍵の間にある二つの間隔の平均にございます。三つ全体の所要時間ではございません",
@@ -1140,6 +1142,19 @@
           "desc": "遅い順",
           "asc": "早い順"
         }
+      },
+      "classes": {
+        "noSnapshot": "交互打鍵の恩恵にも地図の写しが必要でございます",
+        "className": {
+          "left": "左手",
+          "right": "右手",
+          "alternation": "交互打鍵",
+          "repetition": "同指連打"
+        },
+        "coverage": "{{percent}}% の組を分類できましてございます",
+        "deltaLeft": "ΔLeft",
+        "deltaRight": "ΔRight",
+        "deltaTooltip": "正の値であれば、片手のみより両手を交互に用いた方が速かったことを意味いたします"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/src/renderer/components/analyze/AnalyzeExportModal.tsx
+++ b/src/renderer/components/analyze/AnalyzeExportModal.tsx
@@ -319,7 +319,9 @@ function pickBuilders(
     out.push(buildByAppCsv(scope))
   }
   if (selected.bigrams) {
-    out.push(buildBigramsCsv({ ...scope, gram: ctx.bigrams.gram }))
+    out.push(buildBigramsCsv({
+      ...scope, gram: ctx.bigrams.gram, snapshot: ctx.snapshot, fingerOverrides: ctx.fingerOverrides,
+    }))
   }
   if (selected.layoutComparison && ctx.snapshot !== null && ctx.layoutComparison.targetLayoutId !== null) {
     out.push(buildLayoutComparisonCsv({

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -31,10 +31,19 @@ import {
 } from './analyze-bigram-finger'
 import { useKeycodeFingerMap } from './use-keycode-finger-map'
 import {
+  aggregateBigramClasses,
+  CLASSIFIED_CLASSES,
+  type BigramClassAggregate,
+  type BigramClassTotal,
+  type ClassifiedBigramClass,
+} from './analyze-bigram-classes'
+import {
   avgIkiAtOrAboveThreshold,
+  avgIkiFromHist,
   percentileFromHist,
 } from './analyze-bigram-heatmap'
-import { ALL_PAIRS_LIMIT } from './analyze-constants'
+import { BIGRAM_MIN_COUNT } from './analyze-typing-profile'
+import { ALL_PAIRS_LIMIT, EMPTY_STAT_VALUE } from './analyze-constants'
 import { fmtMs } from './analyze-format'
 import { FILTER_SELECT, LIST_LIMIT_OPTIONS } from './analyze-filter-styles'
 import { SegmentedToggle } from './SegmentedToggle'
@@ -74,6 +83,12 @@ interface BigramsChartProps {
 }
 
 type FingerSort = 'desc' | 'asc'
+
+// Stable empty-array reference so the classes aggregate's useMemo dep
+// doesn't churn every render while the Classes quadrant is hidden
+// (gram === 3) — a fresh `[]` literal would defeat the memo instead of
+// skipping the computation.
+const EMPTY_CLASSES_ENTRIES: readonly TypingBigramTopEntry[] = []
 
 export function BigramsChart({
   uid,
@@ -160,6 +175,21 @@ export function BigramsChart({
   const gridClass = showFingerIki
     ? 'grid h-full min-h-0 grid-cols-2 grid-rows-2 gap-3'
     : 'grid h-full min-h-0 grid-cols-2 grid-rows-1 gap-3'
+
+  // Classes (hand-usage) aggregate — computed once here rather than
+  // separately inside BigramClassesCoverage and BigramClassesTable,
+  // which used to each run useKeycodeFingerMap + aggregateBigramClasses
+  // on their own, doubling the work whenever either sibling quadrant
+  // re-rendered. Both `snapshot` and `entries` fall back to a stable
+  // empty value while the quadrant is hidden (gram === 3) so the memo
+  // below settles on an empty aggregate instead of doing the fold for a
+  // quadrant nobody sees.
+  const classesFingerMap = useKeycodeFingerMap(showFingerIki ? snapshot : null, fingerOverrides)
+  const classesEntries = showFingerIki ? entries : EMPTY_CLASSES_ENTRIES
+  const classesAggregate = useMemo(
+    () => aggregateBigramClasses(classesEntries, classesFingerMap),
+    [classesEntries, classesFingerMap],
+  )
 
   const body = loading ? (
     <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-loading">
@@ -251,6 +281,19 @@ export function BigramsChart({
           gram={gram}
         />
       </Quadrant>
+      {showFingerIki && (
+        <Quadrant
+          title={t('analyze.bigrams.quadrant.classes')}
+          notice={
+            <>
+              {cappedNotice('analyze-bigrams-classes-capped-notice')}
+              <BigramClassesCoverage aggregate={classesAggregate} hasSnapshot={snapshot !== null} />
+            </>
+          }
+        >
+          <BigramClassesTable aggregate={classesAggregate} hasSnapshot={snapshot !== null} />
+        </Quadrant>
+      )}
     </div>
   )
 
@@ -627,8 +670,12 @@ function SortHeader({ label, indicator, align, active, onClick, title }: SortHea
   )
 }
 
-function EmptyQuadrant({ text }: { text: string }): JSX.Element {
-  return <div className="py-4 text-center text-xs text-content-muted">{text}</div>
+function EmptyQuadrant({ text, testId }: { text: string; testId?: string }): JSX.Element {
+  return (
+    <div className="py-4 text-center text-xs text-content-muted" data-testid={testId}>
+      {text}
+    </div>
+  )
 }
 
 interface FingerBarChartProps {
@@ -677,9 +724,10 @@ function BigramFingerBarChart({
 
   if (snapshot === null) {
     return (
-      <div className="py-4 text-center text-xs text-content-muted" data-testid="analyze-bigrams-finger-no-snapshot">
-        {t('analyze.bigrams.fingerIki.noSnapshot')}
-      </div>
+      <EmptyQuadrant
+        text={t('analyze.bigrams.fingerIki.noSnapshot')}
+        testId="analyze-bigrams-finger-no-snapshot"
+      />
     )
   }
   if (data.length === 0) {
@@ -694,6 +742,109 @@ function BigramFingerBarChart({
 
 const BAR_LEFT = 'var(--color-accent-hover)'
 const BAR_RIGHT = 'var(--color-danger)'
+
+interface BigramClassesQuadrantProps {
+  /** Classes aggregate computed once by the parent `BigramsChart` and
+   * shared with the sibling quadrant below — see the "1 calculation, 2
+   * consumers" note at the call site. */
+  aggregate: BigramClassAggregate
+  hasSnapshot: boolean
+}
+
+/** Coverage line rendered in the classes quadrant's notice slot —
+ * "N% of pairs classified" — so a low value (heavy `unknown` bucket)
+ * is visible instead of the 4-class table silently under-representing
+ * the period. Hidden while there's no snapshot since the table already
+ * explains that state. */
+function BigramClassesCoverage({ aggregate, hasSnapshot }: BigramClassesQuadrantProps): JSX.Element | null {
+  const { t } = useTranslation()
+  if (!hasSnapshot || aggregate.totalCount === 0) return null
+  const percent = Math.round(((aggregate.totalCount - aggregate.unknownCount) / aggregate.totalCount) * 100)
+  return (
+    <div className="text-xs text-content-muted" data-testid="analyze-bigrams-classes-coverage">
+      {t('analyze.bigrams.classes.coverage', { percent })}
+    </div>
+  )
+}
+
+/** Per-class avgIki, `null` (renders "—") whenever the class's sample
+ * falls below `BIGRAM_MIN_COUNT` — the same floor the Typing Profile
+ * card uses to suppress its Hand balance / SFB labels on thin data. */
+function classAvgOrNull(total: BigramClassTotal): number | null {
+  if (total.count < BIGRAM_MIN_COUNT) return null
+  return avgIkiFromHist(total.hist)
+}
+
+/** Signed `+N ms` / `-N ms` delta, `'—'` when either side is `null`.
+ * Positive means alternating hands was faster than staying on the
+ * class's hand — the CHI 2018 headline result. */
+function fmtDelta(value: number | null): string {
+  if (value === null) return EMPTY_STAT_VALUE
+  const rounded = Math.round(value)
+  return `${rounded > 0 ? '+' : ''}${rounded} ms`
+}
+
+/** Left / Right / Alternation / Repetition IKI quadrant — the
+ * CHI 2018 Table 3 hand-usage classes. Each row's average comes from
+ * `avgIkiFromHist` on that class's own folded histogram (never a mean
+ * of two other classes' averages), and ΔLeft / ΔRight compare each
+ * same-hand class directly against Alternation. */
+function BigramClassesTable({ aggregate, hasSnapshot }: BigramClassesQuadrantProps): JSX.Element {
+  const { t } = useTranslation()
+
+  if (!hasSnapshot) {
+    return (
+      <EmptyQuadrant
+        text={t('analyze.bigrams.classes.noSnapshot')}
+        testId="analyze-bigrams-classes-no-snapshot"
+      />
+    )
+  }
+
+  const avgByClass: Record<ClassifiedBigramClass, number | null> = {
+    left: classAvgOrNull(aggregate.totals.left),
+    right: classAvgOrNull(aggregate.totals.right),
+    alternation: classAvgOrNull(aggregate.totals.alternation),
+    repetition: classAvgOrNull(aggregate.totals.repetition),
+  }
+  const deltaLeft = avgByClass.left !== null && avgByClass.alternation !== null
+    ? avgByClass.left - avgByClass.alternation
+    : null
+  const deltaRight = avgByClass.right !== null && avgByClass.alternation !== null
+    ? avgByClass.right - avgByClass.alternation
+    : null
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2" data-testid="analyze-bigrams-classes-table">
+      <table className="w-full text-xs">
+        <thead className="text-content-muted">
+          <tr>
+            <th className="px-2 py-1 text-left font-medium">{t('analyze.bigrams.column.class')}</th>
+            <th className="px-2 py-1 text-right font-medium">{t('analyze.bigrams.column.avgIki')}</th>
+            <th className="px-2 py-1 text-right font-medium">{t('analyze.bigrams.column.count')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {CLASSIFIED_CLASSES.map((cls) => (
+            <tr key={cls} className="border-t border-surface-dim">
+              <td className="px-2 py-1">{t(`analyze.bigrams.classes.className.${cls}`)}</td>
+              <td className="px-2 py-1 text-right tabular-nums">{fmtMs(avgByClass[cls])}</td>
+              <td className="px-2 py-1 text-right tabular-nums">{aggregate.totals[cls].count.toLocaleString()}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div
+        className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-content-muted"
+        data-testid="analyze-bigrams-classes-delta"
+        title={t('analyze.bigrams.classes.deltaTooltip')}
+      >
+        <span>{t('analyze.bigrams.classes.deltaLeft')}: {fmtDelta(deltaLeft)}</span>
+        <span>{t('analyze.bigrams.classes.deltaRight')}: {fmtDelta(deltaRight)}</span>
+      </div>
+    </div>
+  )
+}
 
 interface BarDatum {
   id: string

--- a/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
@@ -5,9 +5,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { BigramsChart } from '../BigramsChart'
 import { ALL_PAIRS_LIMIT } from '../analyze-constants'
+import { deserialize } from '../../../../shared/keycodes/keycodes'
+import { parseKle } from '../../../../shared/kle/kle-parser'
+import type { FingerType } from '../../../../shared/kle/kle-ergonomics'
 import type {
   TypingBigramAggregateResult,
   TypingBigramTopEntry,
+  TypingKeymapSnapshot,
 } from '../../../../shared/types/typing-analytics'
 
 vi.mock('react-i18next', () => ({
@@ -454,6 +458,153 @@ describe('BigramsChart', () => {
     expect(screen.getByTestId('analyze-bigrams-slow-capped-notice')).toBeTruthy()
     expect(screen.queryByTestId('analyze-bigrams-finger-capped-notice')).toBeNull()
     expect(screen.queryByText('analyze.bigrams.quadrant.fingerIki')).toBeNull()
+  })
+
+  describe('classes quadrant (alternation benefit)', () => {
+    // Two single-key positions, "0,0" and "0,1", each explicitly
+    // overridden to a finger so the test doesn't depend on the
+    // geometry estimator. keyA/keyB resolve under whatever protocol
+    // is active when the suite runs, matching how the component itself
+    // resolves keycodes via `snapshot.vialProtocol`.
+    const layout = parseKle([['0,0', '0,1']])
+    const keyA = deserialize('KC_A')
+    const keyB = deserialize('KC_B')
+
+    function buildSnapshot(): TypingKeymapSnapshot {
+      return {
+        uid: '0x00',
+        machineHash: 'h',
+        productName: 'Test',
+        savedAt: 0,
+        layers: 1,
+        matrix: { rows: 1, cols: 2 },
+        keymap: [[['KC_A', 'KC_B']]],
+        layout,
+      }
+    }
+
+    const alternationOverrides: Record<string, FingerType> = {
+      '0,0': 'left-index',
+      '0,1': 'right-index',
+    }
+    // Two different keys sharing one finger — a same-finger bigram
+    // (SFB), not a letter repeat, so it classifies as `left`.
+    const sameFingerOverrides: Record<string, FingerType> = {
+      '0,0': 'left-index',
+      '0,1': 'left-index',
+    }
+
+    it('hides the classes quadrant for trigrams', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}_${keyA}`, count: 10, hist: [1, 2, 3, 1, 1, 1, 1, 0], avgIki: 100, sd: 25 }],
+        truncated: false,
+      })
+      renderChart({ gram: 3, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-content')).toBeTruthy()
+      })
+      expect(screen.queryByText('analyze.bigrams.quadrant.classes')).toBeNull()
+    })
+
+    it('shows the no-snapshot message when there is no keymap snapshot', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: null })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-no-snapshot')).toBeTruthy()
+      })
+    })
+
+    it('classifies an alternation pair and renders its avgIki + count', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      const table = screen.getByTestId('analyze-bigrams-classes-table')
+      // Bucket center for index 2 is 125ms (see HIST_BUCKETS centers),
+      // so the alternation row shows the folded-hist average, not the
+      // raw entry.avgIki from the wire payload.
+      expect(within(table).getByText('analyze.bigrams.classes.className.alternation')).toBeTruthy()
+      expect(within(table).getByText('125 ms')).toBeTruthy()
+      expect(within(table).getByText('2,000')).toBeTruthy()
+    })
+
+    it('is exclusive: two keys sharing one finger classify as left, not repetition', async () => {
+      // keyA and keyB are different keycodes, so even though both are
+      // pinned to the same finger this is a same-finger bigram (SFB) —
+      // a same-hand pair — not a letter repeat.
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: sameFingerOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      const table = screen.getByTestId('analyze-bigrams-classes-table')
+      const rows = table.querySelectorAll('tbody tr')
+      const leftRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.left'))
+      const repetitionRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.repetition'))
+      expect(repetitionRow?.textContent).toContain('—')
+      expect(leftRow?.textContent).toContain('125 ms')
+      expect(leftRow?.textContent).toContain('2,000')
+    })
+
+    it('classifies a same-key repeat (letter repetition) as repetition', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyA}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: { '0,0': 'left-index', '0,1': 'left-index' } })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      const table = screen.getByTestId('analyze-bigrams-classes-table')
+      const rows = table.querySelectorAll('tbody tr')
+      const repetitionRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.repetition'))
+      expect(repetitionRow?.textContent).toContain('125 ms')
+      expect(repetitionRow?.textContent).toContain('2,000')
+    })
+
+    it('shows "—" for a class whose sample is below BIGRAM_MIN_COUNT', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 5, hist: [0, 0, 5, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      const table = screen.getByTestId('analyze-bigrams-classes-table')
+      const rows = table.querySelectorAll('tbody tr')
+      const alternationRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.alternation'))
+      expect(alternationRow?.textContent).toContain('—')
+      expect(alternationRow?.textContent).toContain('5')
+    })
+
+    it('shows classification coverage and hides it when there is no snapshot', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-coverage')).toBeTruthy()
+      })
+    })
   })
 })
 

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-classes.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-classes.test.ts
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { aggregateBigramClasses, classifyBigram } from '../analyze-bigram-classes'
+import type { FingerType } from '../../../../shared/kle/kle-ergonomics'
+import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
+
+function entry(
+  ngramId: string,
+  count: number,
+  hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0],
+): TypingBigramTopEntry {
+  return { ngramId, count, hist, avgIki: null, sd: null }
+}
+
+describe('classifyBigram', () => {
+  it('classifies the same keycode struck twice as repetition (letter repeat)', () => {
+    expect(classifyBigram('left-index', 'left-index', true)).toBe('repetition')
+  })
+
+  it('classifies two different keys sharing one finger as left/right, not repetition', () => {
+    // e.g. two thumb-cluster keys both mapped to left-thumb — a
+    // same-finger bigram (SFB), which is still a same-hand pair per
+    // the CHI 2018 definition, not a letter repeat.
+    expect(classifyBigram('left-thumb', 'left-thumb', false)).toBe('left')
+  })
+
+  it('classifies same-hand, different-finger pairs as left / right', () => {
+    expect(classifyBigram('left-index', 'left-middle', false)).toBe('left')
+    expect(classifyBigram('right-ring', 'right-pinky', false)).toBe('right')
+  })
+
+  it('classifies cross-hand pairs as alternation', () => {
+    expect(classifyBigram('left-index', 'right-index', false)).toBe('alternation')
+    expect(classifyBigram('right-pinky', 'left-thumb', false)).toBe('alternation')
+  })
+
+  it('classifies as unknown when either finger is unresolved, even for the same keycode', () => {
+    expect(classifyBigram(undefined, 'left-index', false)).toBe('unknown')
+    expect(classifyBigram('left-index', undefined, false)).toBe('unknown')
+    expect(classifyBigram(undefined, undefined, false)).toBe('unknown')
+    // Unresolved fingers take priority over the same-keycode check.
+    expect(classifyBigram(undefined, undefined, true)).toBe('unknown')
+  })
+})
+
+describe('aggregateBigramClasses', () => {
+  const fingerMap = new Map<number, FingerType>([
+    [1, 'left-index'],
+    [2, 'left-index'], // shares a finger with keycode 1 but is a different key
+    [3, 'right-middle'],
+    [4, 'left-middle'],
+  ])
+
+  it('returns zeroed totals for empty entries', () => {
+    const result = aggregateBigramClasses([], fingerMap)
+    expect(result.totals.left).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.totals.right).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.totals.alternation).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.totals.repetition).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.unknownCount).toBe(0)
+    expect(result.totalCount).toBe(0)
+  })
+
+  it('folds a same-key repeat into repetition', () => {
+    const result = aggregateBigramClasses(
+      [entry('1_1', 4, [4, 0, 0, 0, 0, 0, 0, 0])],
+      fingerMap,
+    )
+    expect(result.totals.repetition).toEqual({ count: 4, hist: [4, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.totals.left.count).toBe(0)
+  })
+
+  it('is exclusive: a same-finger, different-key pair folds into left, never repetition', () => {
+    // keycodes 1 and 2 both resolve to left-index -> same hand AND same
+    // finger, but they're different keys. A pre-fix implementation
+    // that classified by finger equality would have counted this as
+    // repetition; the correct (keycode-equality) definition puts it in
+    // `left` instead.
+    const result = aggregateBigramClasses(
+      [entry('1_2', 4, [4, 0, 0, 0, 0, 0, 0, 0])],
+      fingerMap,
+    )
+    expect(result.totals.left).toEqual({ count: 4, hist: [4, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.totals.repetition.count).toBe(0)
+    expect(result.totals.right.count).toBe(0)
+    expect(result.totals.alternation.count).toBe(0)
+  })
+
+  it('folds same-hand different-finger pairs into left', () => {
+    const result = aggregateBigramClasses(
+      [entry('1_4', 3, [0, 3, 0, 0, 0, 0, 0, 0])],
+      fingerMap,
+    )
+    expect(result.totals.left).toEqual({ count: 3, hist: [0, 3, 0, 0, 0, 0, 0, 0] })
+  })
+
+  it('folds cross-hand pairs into alternation and sums hist across entries', () => {
+    const result = aggregateBigramClasses(
+      [
+        entry('1_3', 2, [2, 0, 0, 0, 0, 0, 0, 0]),
+        entry('4_3', 1, [0, 1, 0, 0, 0, 0, 0, 0]),
+      ],
+      fingerMap,
+    )
+    expect(result.totals.alternation).toEqual({ count: 3, hist: [2, 1, 0, 0, 0, 0, 0, 0] })
+  })
+
+  it('counts unmapped keycodes and malformed ids as unknown without dropping them from totalCount', () => {
+    const result = aggregateBigramClasses(
+      [
+        entry('99_3', 5), // 99 unmapped
+        entry('bad', 2), // malformed ngramId
+        entry('1_3', 1, [1, 0, 0, 0, 0, 0, 0, 0]),
+      ],
+      fingerMap,
+    )
+    expect(result.unknownCount).toBe(7)
+    expect(result.totalCount).toBe(8)
+    expect(result.totals.alternation.count).toBe(1)
+  })
+
+  it('counts a same-keycode pair with an unmapped finger as unknown, not repetition', () => {
+    const result = aggregateBigramClasses(
+      [entry('99_99', 3)], // same keycode, but 99 has no mapped finger
+      fingerMap,
+    )
+    expect(result.unknownCount).toBe(3)
+    expect(result.totals.repetition.count).toBe(0)
+  })
+})

--- a/src/renderer/components/analyze/analyze-bigram-classes.ts
+++ b/src/renderer/components/analyze/analyze-bigram-classes.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Bigram -> Left / Right / Alternation / Repetition classification,
+// the four hand-usage classes from CHI 2018 Table 3 (Dhakal et al.,
+// "Observations on Typing from 136 Million Keystrokes"). `repetition`
+// is the paper's `letter repetition` (Table 2: ll, cc, aa, nn, ...) —
+// the same key struck twice in a row — and is decided from keycode
+// equality, not finger equality; two different keys sharing a finger
+// (a same-finger bigram) fall through to `left`/`right` like any other
+// same-hand pair. The rest of the classification is derived from the
+// finger used by each of the bigram's two keys — no fixed key list, no
+// independent geometry estimate. Reuses the finger map built by
+// `analyze-bigram-finger.ts` so a user's Finger Assignment overrides
+// apply here exactly as they do in the Finger IKI quadrant.
+
+import { HAND_OF_FINGER, type FingerType } from '../../../shared/kle/kle-ergonomics'
+import type { TypingBigramTopEntry } from '../../../shared/types/typing-analytics'
+import { resolvePairFingers } from './analyze-bigram-finger'
+import { emptyHistTotal, foldHist, type HistTotal } from './analyze-bigram-heatmap'
+
+export type BigramClass = 'left' | 'right' | 'alternation' | 'repetition' | 'unknown'
+
+/** The four classes `classifyBigram` can resolve to — every `BigramClass`
+ * value except `unknown`. Exported so renderer callers (the classes
+ * table's row order) share the same list instead of re-declaring it. */
+export const CLASSIFIED_CLASSES = ['left', 'right', 'alternation', 'repetition'] as const
+export type ClassifiedBigramClass = (typeof CLASSIFIED_CLASSES)[number]
+
+/**
+ * Classify a bigram from the finger used by its previous and current
+ * key, plus whether the two keycodes are the same key. Exclusive —
+ * checked in this order so a letter repeat never also gets counted as
+ * `left`/`right`, and a same-finger-different-key bigram never gets
+ * counted as `repetition`:
+ *
+ *   1. either finger unresolved -> `unknown`
+ *   2. same keycode (the same key struck twice) -> `repetition`
+ *   3. the two fingers are on different hands -> `alternation`
+ *   4. both left -> `left`, both right -> `right` (this also covers a
+ *      same-finger bigram — two different keys sharing one finger,
+ *      e.g. a thumb cluster — since it's still a same-hand pair)
+ */
+export function classifyBigram(
+  prevFinger: FingerType | undefined,
+  currFinger: FingerType | undefined,
+  sameKeycode: boolean,
+): BigramClass {
+  if (!prevFinger || !currFinger) return 'unknown'
+  if (sameKeycode) return 'repetition'
+  const prevHand = HAND_OF_FINGER[prevFinger]
+  const currHand = HAND_OF_FINGER[currFinger]
+  if (prevHand !== currHand) return 'alternation'
+  return prevHand === 'left' ? 'left' : 'right'
+}
+
+/** Per-class running total — see `HistTotal` (shared with
+ * `FingerPairTotal`, the finger-pair sibling) for the shape. */
+export type BigramClassTotal = HistTotal
+
+export interface BigramClassAggregate {
+  totals: Record<ClassifiedBigramClass, BigramClassTotal>
+  /** Keystroke-pair count that couldn't be classified — malformed
+   * ngram id or either key's finger unresolved. Kept separate rather
+   * than folded into any class so the renderer can show classification
+   * coverage instead of silently dropping the gap. */
+  unknownCount: number
+  /** Sum of every entry's `count`, classified or not — the coverage
+   * denominator (`(totalCount - unknownCount) / totalCount`). */
+  totalCount: number
+}
+
+/**
+ * Aggregate bigram entries into the four CHI 2018 hand-usage classes.
+ * Mirrors `aggregateFingerPairs`'s fold-then-average approach: per
+ * class, `{count, hist}` accumulate and the caller derives the average
+ * with `avgIkiFromHist` — never average two classes' pre-computed
+ * averages together, since that isn't the same number as folding their
+ * histograms first.
+ *
+ * No SD is produced here (nor should one be approximated from the
+ * hist): the wire entries only carry a per-pair `sd`, and re-combining
+ * per-pair SDs into a per-class variance needs sum/sumsq, which
+ * `TypingBigramTopEntry` doesn't have.
+ */
+export function aggregateBigramClasses(
+  entries: readonly TypingBigramTopEntry[],
+  keycodeFinger: ReadonlyMap<number, FingerType>,
+): BigramClassAggregate {
+  const totals: Record<ClassifiedBigramClass, BigramClassTotal> = {
+    left: emptyHistTotal(),
+    right: emptyHistTotal(),
+    alternation: emptyHistTotal(),
+    repetition: emptyHistTotal(),
+  }
+  let unknownCount = 0
+  let totalCount = 0
+  for (const entry of entries) {
+    totalCount += entry.count
+    const { prevFinger, currFinger, sameKeycode } = resolvePairFingers(entry.ngramId, keycodeFinger)
+    const cls = classifyBigram(prevFinger, currFinger, sameKeycode)
+    if (cls === 'unknown') {
+      unknownCount += entry.count
+      continue
+    }
+    const bucket = totals[cls]
+    bucket.count += entry.count
+    foldHist(bucket.hist, entry.hist)
+  }
+  return { totals, unknownCount, totalCount }
+}

--- a/src/renderer/components/analyze/analyze-bigram-finger.ts
+++ b/src/renderer/components/analyze/analyze-bigram-finger.ts
@@ -16,7 +16,7 @@ import type {
   TypingBigramTopEntry,
   TypingKeymapSnapshot,
 } from '../../../shared/types/typing-analytics'
-import { foldHist, HIST_BUCKETS, parseBigramId } from './analyze-bigram-heatmap'
+import { emptyHistTotal, foldHist, parseBigramId, type HistTotal } from './analyze-bigram-heatmap'
 import { withSnapshotProtocol } from './analyze-protocol'
 
 /** Build a numeric-keycode → finger lookup from the snapshot's layer-0
@@ -67,9 +67,32 @@ export function buildKeycodeFingerMap(
   })
 }
 
-export interface FingerPairTotal {
-  count: number
-  hist: number[]
+/** Per-finger-pair running total — see `HistTotal` (shared with
+ * `BigramClassTotal`, the hand-usage-class sibling) for the shape. */
+export type FingerPairTotal = HistTotal
+
+/** Resolves the (prev, curr) finger pair for a bigram id via the
+ * keycodeFinger map, plus whether the pair's two keycodes are the same
+ * key (needed by `classifyBigram` to detect a letter repeat). Either
+ * finger comes back `undefined` when the id is malformed or that
+ * half's keycode has no mapped finger; `sameKeycode` is `false` for a
+ * malformed id. Shared by every aggregator that needs a bigram's
+ * finger pair, so the parse-then-look-up pair isn't duplicated at each
+ * call site. */
+export function resolvePairFingers(
+  ngramId: string,
+  keycodeFinger: ReadonlyMap<number, FingerType>,
+): {
+  prevFinger: FingerType | undefined
+  currFinger: FingerType | undefined
+  sameKeycode: boolean
+} {
+  const pair = parseBigramId(ngramId)
+  return {
+    prevFinger: pair ? keycodeFinger.get(pair.prev) : undefined,
+    currFinger: pair ? keycodeFinger.get(pair.curr) : undefined,
+    sameKeycode: pair ? pair.prev === pair.curr : false,
+  }
 }
 
 /** Aggregate bigram entries into (prevFinger, currFinger) totals.
@@ -82,15 +105,12 @@ export function aggregateFingerPairs(
 ): Map<string, FingerPairTotal> {
   const totals = new Map<string, FingerPairTotal>()
   for (const entry of entries) {
-    const pair = parseBigramId(entry.ngramId)
-    if (!pair) continue
-    const f1 = keycodeFinger.get(pair.prev)
-    const f2 = keycodeFinger.get(pair.curr)
+    const { prevFinger: f1, currFinger: f2 } = resolvePairFingers(entry.ngramId, keycodeFinger)
     if (!f1 || !f2) continue
     const key = `${f1}_${f2}`
     let agg = totals.get(key)
     if (!agg) {
-      agg = { count: 0, hist: new Array<number>(HIST_BUCKETS).fill(0) }
+      agg = emptyHistTotal()
       totals.set(key, agg)
     }
     agg.count += entry.count

--- a/src/renderer/components/analyze/analyze-bigram-heatmap.ts
+++ b/src/renderer/components/analyze/analyze-bigram-heatmap.ts
@@ -34,10 +34,30 @@ export function foldHist(target: number[], src: readonly number[]): void {
   for (let i = 0; i < HIST_BUCKETS; i += 1) target[i] += src[i] ?? 0
 }
 
-export interface BigramHeatmapCell {
+/** Running `{count, hist}` accumulator shared by every renderer
+ * aggregator that folds bigram entries into a bucket — finger pairs
+ * (`FingerPairTotal`), hand-usage classes (`BigramClassTotal`), and
+ * heatmap grid cells (`BigramHeatmapCell`) all use exactly this shape,
+ * just keyed differently (finger-pair string, class name, grid
+ * position). */
+export interface HistTotal {
   count: number
   hist: number[]
 }
+
+/** A fresh zero-valued `HistTotal`, `hist` sized to `HIST_BUCKETS`.
+ * Shared so every bucket-total aggregator below seeds identically
+ * instead of repeating the `new Array<number>(HIST_BUCKETS).fill(0)`
+ * literal. */
+export function emptyHistTotal(): HistTotal {
+  return { count: 0, hist: new Array<number>(HIST_BUCKETS).fill(0) }
+}
+
+/** Per-cell total in the heatmap's N × N grid. Kept as its own name
+ * (rather than exporting `HistTotal` directly) since callers address a
+ * cell by grid position, not by a class/finger-pair key — but the
+ * shape is identical, so it's an alias, not a re-declaration. */
+export type BigramHeatmapCell = HistTotal
 
 export interface BigramHeatmapResult {
   keys: number[]
@@ -84,7 +104,7 @@ export function aggregateKeyHeatmap(
     if (i === undefined || j === undefined) continue
     let cell = cells[i][j]
     if (!cell) {
-      cell = { count: 0, hist: new Array<number>(HIST_BUCKETS).fill(0) }
+      cell = emptyHistTotal()
       cells[i][j] = cell
     }
     cell.count += entry.count

--- a/src/renderer/components/analyze/analyze-csv-builders.ts
+++ b/src/renderer/components/analyze/analyze-csv-builders.ts
@@ -18,11 +18,19 @@ import type {
   TypingHeatmapCell,
   TypingKeymapSnapshot,
 } from '../../../shared/types/typing-analytics'
-import type { KeyboardLayout } from '../../../shared/kle/types'
+import type { KeyboardLayout, KleKey } from '../../../shared/kle/types'
 import type { HeatmapFilters } from '../../../shared/types/analyze-filters'
 import { distributionForcesOwnDevice, isHashScope, isOwnScope, scopeToSelectValue } from '../../../shared/types/analyze-filters'
 import { buildCsv } from '../../../shared/csv-export'
 import { LAYOUT_BY_ID } from '../../data/keyboard-layouts'
+
+/** Pulls the snapshot's KLE key list, or `[]` when there's no layout
+ * (or the layout has no keys). Shared by every builder that needs the
+ * raw key positions rather than `layoutPositions`'s matrix-label form. */
+function layoutKeysFromSnapshot(snapshot: TypingKeymapSnapshot): KleKey[] {
+  const layout = snapshot.layout as KeyboardLayout | null
+  return layout?.keys ?? []
+}
 
 /**
  * Async resolver that prefers the built-in `KEYBOARD_LAYOUTS` map and
@@ -65,6 +73,8 @@ import {
   listMatrixCellsForScope,
   listMinuteStatsForScope,
 } from './analyze-fetch'
+import { classifyBigram } from './analyze-bigram-classes'
+import { buildKeycodeFingerMap, resolvePairFingers } from './analyze-bigram-finger'
 import { bucketMinuteStats, pickBucketMs } from './analyze-bucket'
 import { buildBksRateBuckets } from './analyze-error-proxy'
 import { buildHourOfDayWpm, computeWpm } from './analyze-wpm'
@@ -375,8 +385,7 @@ export async function buildErgonomicsCsv(args: ScopeArgs & {
   t: TFunction
 }): Promise<CsvBundleEntry> {
   const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], runIdScopes = [], snapshot, fingerOverrides, t } = args
-  const layout = snapshot.layout as KeyboardLayout | null
-  const keys = layout?.keys ?? []
+  const keys = layoutKeysFromSnapshot(snapshot)
   const layerCells = await fetchMatrixHeatmapAllLayers(uid, snapshot, range.fromMs, range.toMs, deviceScope, appScopes, typingTestScopes, runIdScopes)
   const merged = mergeLayerHeatmaps(layerCells)
   const aggregation = aggregateErgonomics(merged, keys, fingerOverrides)
@@ -407,25 +416,61 @@ const BIGRAMS_EXPORT_LIMIT = 5000
 export async function buildBigramsCsv(args: ScopeArgs & {
   /** 2 = bigram (default, matches the historical export shape), 3 =
    * trigram. Only changes the id column header and output filename —
-   * the row shape (id, count, avg, sd) is the same for both, since
-   * `ngramId` already carries however many `_`-joined key codes the
-   * selected gram produces. */
+   * the row shape (id, count, avg, sd, class) is the same for both,
+   * since `ngramId` already carries however many `_`-joined key codes
+   * the selected gram produces. */
   gram?: 2 | 3
+  /** Needed to resolve each pair's finger classification (see
+   * `class` column below). `null`/absent leaves every row's `class`
+   * blank rather than guessing. */
+  snapshot?: TypingKeymapSnapshot | null
+  fingerOverrides?: Record<string, FingerType>
 }): Promise<CsvBundleEntry> {
-  const { uid, range, deviceScope, appScopes = [], typingTestScopes = [], runIdScopes = [], gram = 2 } = args
+  const {
+    uid, range, deviceScope, appScopes = [], typingTestScopes = [], runIdScopes = [],
+    gram = 2, snapshot = null, fingerOverrides = {},
+  } = args
   const result = await fetchBigramAggregateForRange(
     uid, deviceScope, range.fromMs, range.toMs, 'top', { limit: BIGRAMS_EXPORT_LIMIT, gram }, appScopes, typingTestScopes, runIdScopes,
   ).catch(() => ({ view: 'top' as const, entries: [], truncated: false }))
   const entries = result.view === 'top' ? result.entries : []
-  const rows = entries.map((e) => [
-    e.ngramId,
-    e.count,
-    e.avgIki === null ? '' : Math.round(e.avgIki),
-    e.sd === null ? '' : Math.round(e.sd),
-  ])
+
+  // The Left/Right/Alternation/Repetition classification (CHI 2018
+  // Table 3) is only defined for 2-key pairs; trigram ids have no
+  // hand-usage class, so `class` stays blank for gram === 3 rather
+  // than reporting a resolved-vs-unresolved `unknown` that would imply
+  // the concept applies.
+  let keycodeFinger: ReadonlyMap<number, FingerType> = new Map()
+  if (gram === 2 && snapshot) {
+    const keys = layoutKeysFromSnapshot(snapshot)
+    if (keys.length > 0) {
+      keycodeFinger = buildKeycodeFingerMap(snapshot, keys, fingerOverrides, snapshot.vialProtocol)
+    }
+  }
+
+  // Only attempt classification when a snapshot was actually supplied —
+  // without one there's no keymap to resolve fingers from, so `class`
+  // stays blank (no classification attempted) rather than `unknown`
+  // (classification attempted, finger unresolved). See the `snapshot`
+  // param doc above.
+  const canClassify = gram === 2 && snapshot !== null
+  const rows = entries.map((e) => {
+    let cls = ''
+    if (canClassify) {
+      const { prevFinger, currFinger, sameKeycode } = resolvePairFingers(e.ngramId, keycodeFinger)
+      cls = classifyBigram(prevFinger, currFinger, sameKeycode)
+    }
+    return [
+      e.ngramId,
+      e.count,
+      e.avgIki === null ? '' : Math.round(e.avgIki),
+      e.sd === null ? '' : Math.round(e.sd),
+      cls,
+    ]
+  })
   return {
     slug: gram === 3 ? SLUG.trigrams : SLUG.bigrams,
-    content: buildCsv([gram === 3 ? 'trigram_id' : 'bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms'], rows),
+    content: buildCsv([gram === 3 ? 'trigram_id' : 'bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms', 'class'], rows),
   }
 }
 

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.43",
+  "version": "0.1.44",
   "name": "English",
   "common": {
     "save": "Save",
@@ -1127,7 +1127,8 @@
       "quadrant": {
         "top": "Top pairs",
         "slow": "Pair interval",
-        "fingerIki": "Finger IKI"
+        "fingerIki": "Finger IKI",
+        "classes": "Alternation benefit"
       },
       "cappedNotice": "Computed from the {{limit}} most frequent pairs — rare pairs may be missing.",
       "gramToggle": {
@@ -1137,6 +1138,7 @@
       },
       "column": {
         "pair": "Pair",
+        "class": "Class",
         "count": "Count",
         "avgIki": "Avg IKI",
         "avgIkiTrigramTooltip": "Average of the two intervals between the three keystrokes — not the total time across all three.",
@@ -1150,6 +1152,19 @@
           "desc": "Slowest first",
           "asc": "Fastest first"
         }
+      },
+      "classes": {
+        "noSnapshot": "Alternation benefit needs a keymap snapshot. Start a record session or pick a range with one.",
+        "className": {
+          "left": "Left",
+          "right": "Right",
+          "alternation": "Alternation",
+          "repetition": "Repetition"
+        },
+        "coverage": "{{percent}}% of pairs classified",
+        "deltaLeft": "ΔLeft",
+        "deltaRight": "ΔRight",
+        "deltaTooltip": "Positive means alternating hands was faster than staying on one hand."
       },
       "pairIntervalThreshold": {
         "label": "Avg interval",


### PR DESCRIPTION
## Summary

Splits the bigram interval statistics by which hand(s) typed the pair, so the Bigrams chart can show how much faster alternating pairs are than single-hand ones.

Each bigram is classified into one of four mutually exclusive classes from the finger assignment snapshot:

| Class | Definition |
|---|---|
| `alternation` | The two keys are assigned to different hands |
| `left` / `right` | Both keys are on the same hand (includes same-finger pairs on different keys) |
| `repetition` | The same keycode pressed twice in a row |

The new quadrant reports the mean interval per class plus `ΔLeft` / `ΔRight` — the alternation advantage against each single-hand class.

## Notes

- `repetition` follows the letter-repetition definition used by the reference literature: the *same key* repeated. A same-finger pair on two different keys stays in `left` / `right` because it is still one hand.
- No standard deviation is reported. The stored top-entry aggregate keeps only counts and means, so a variance cannot be recombined without inventing precision that is not in the data.
- Classification needs a finger assignment snapshot for the selected range. Without one the quadrant renders an empty state, and the CSV `class` column is left blank rather than emitting `unknown`.
- The quadrant fits into the existing 2x2 grid; no layout change to the surrounding chart.

## Test plan

- `analyze-bigram-classes.test.ts` — 12 cases covering classification order, exclusivity and the aggregate
- `BigramsChart.test.tsx` — quadrant rendering, delta signs, truncation notice, empty state
- `pnpm test` — 313 files / 7212 passed / 22 skipped
- `npx eslint src/` and `pnpm typecheck` clean