### PR TITLE
feat(ui): split bigram intervals by position relative to a word break

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.44",
+  "version": "0.1.45",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -1128,7 +1128,7 @@
         "top": "頻出ペア",
         "slow": "ペア間隔",
         "fingerIki": "指間隔",
-        "classes": "交互打鍵ベネフィット"
+        "classes": "バイグラムパターン"
       },
       "cappedNotice": "頻度上位 {{limit}} 件のペアから算出しています — 低頻度のペアは含まれない場合があります",
       "gramToggle": {
@@ -1154,17 +1154,25 @@
         }
       },
       "classes": {
-        "noSnapshot": "交互打鍵ベネフィットには keymap snapshot が必要です。Record セッションを開始するか snapshot のある期間を選択してください",
+        "noSnapshot": "手の使用には keymap snapshot が必要です。Record セッションを開始するか snapshot のある期間を選択してください",
+        "section": {
+          "handUsage": "手の使用",
+          "wordPosition": "単語内位置"
+        },
         "className": {
           "left": "左手",
           "right": "右手",
           "alternation": "交互打鍵",
-          "repetition": "同指連打"
+          "repetition": "同指連打",
+          "initiation": "語頭",
+          "inWord": "語中"
         },
         "coverage": "{{percent}}% のペアを分類できました",
         "deltaLeft": "ΔLeft",
         "deltaRight": "ΔRight",
-        "deltaTooltip": "プラスなら、同じ手を使い続けるより手を交互に使う方が速かったことを示します"
+        "deltaInitiation": "ΔInitiation",
+        "deltaTooltip": "プラスなら、先に挙げた分類の方が遅かったことを示します",
+        "excludedNote": "{{count}} 件のペアは区切り文字で終わるため除外しました"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.44",
+  "version": "0.1.45",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -1118,7 +1118,7 @@
         "top": "頻出ペア☆",
         "slow": "ペア間隔っしょ",
         "fingerIki": "指間隔☆",
-        "classes": "交互打鍵ベネフィット☆"
+        "classes": "打鍵パターン☆"
       },
       "cappedNotice": "頻度上位 {{limit}} 件から出してるよん — レアなペアは入ってないかもっしょ",
       "gramToggle": {
@@ -1144,17 +1144,25 @@
         }
       },
       "classes": {
-        "noSnapshot": "交互打鍵ベネフィットもスナップショットないと無理っしょ☆REC開始して！",
+        "noSnapshot": "手の使用もスナップショットないと無理っしょ☆REC開始して！",
+        "section": {
+          "handUsage": "手の使用☆",
+          "wordPosition": "単語内位置☆"
+        },
         "className": {
           "left": "左手☆",
           "right": "右手☆",
           "alternation": "交互っしょ☆",
-          "repetition": "連打ｗ"
+          "repetition": "連打ｗ",
+          "initiation": "語頭ｗ",
+          "inWord": "語中っしょ"
         },
         "coverage": "{{percent}}%のペア分類できたっしょ☆",
         "deltaLeft": "ΔLeft",
         "deltaRight": "ΔRight",
-        "deltaTooltip": "プラスなら交互に手動かした方が速かったってことっしょ☆"
+        "deltaInitiation": "ΔInitiation",
+        "deltaTooltip": "プラスなら最初に書いてる方が遅かったってことっしょ☆",
+        "excludedNote": "{{count}}件は区切り文字で終わってるから除外したっしょ☆"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.44",
+  "version": "0.1.45",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -1118,7 +1118,7 @@
         "top": "よう出るペア",
         "slow": "ペア間隔",
         "fingerIki": "指間隔",
-        "classes": "交互打鍵ベネフィット"
+        "classes": "打鍵パターン"
       },
       "cappedNotice": "頻度上位 {{limit}} 件のペアから出してますえ — 珍しいペアは入っとらんこともありますえ",
       "gramToggle": {
@@ -1144,17 +1144,25 @@
         }
       },
       "classes": {
-        "noSnapshot": "交互打鍵ベネフィットにはスナップショットが要りますえ。Record を始めるかスナップショットのある期間を選んでおくれやす",
+        "noSnapshot": "手の使用にもスナップショットが要りますえ。Record を始めるかスナップショットのある期間を選んでおくれやす",
+        "section": {
+          "handUsage": "手の使用どすえ",
+          "wordPosition": "単語内位置どすえ"
+        },
         "className": {
           "left": "左手どすえ",
           "right": "右手どすえ",
           "alternation": "交互打鍵どすえ",
-          "repetition": "同指連打どすえ"
+          "repetition": "同指連打どすえ",
+          "initiation": "語頭どすえ",
+          "inWord": "語中どすえ"
         },
         "coverage": "{{percent}}% のペアを分類できましたえ",
         "deltaLeft": "ΔLeft",
         "deltaRight": "ΔRight",
-        "deltaTooltip": "プラスやったら、片手だけよりも両手交互の方が速かったいうことどすえ"
+        "deltaInitiation": "ΔInitiation",
+        "deltaTooltip": "プラスやったら、先に書いてる方の分類が遅かったいうことどすえ",
+        "excludedNote": "{{count}} 件のペアは区切り文字で終わるさかい除外しましたえ"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.44",
+  "version": "0.1.45",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -1118,7 +1118,7 @@
         "top": "頻出ペア",
         "slow": "ペア間隔",
         "fingerIki": "指間隔",
-        "classes": "交互打鍵の恩恵"
+        "classes": "打鍵の傾向"
       },
       "cappedNotice": "頻度上位 {{limit}} 件の組より算出しております — 稀な組は含まれぬこともございます",
       "gramToggle": {
@@ -1144,17 +1144,25 @@
         }
       },
       "classes": {
-        "noSnapshot": "交互打鍵の恩恵にも地図の写しが必要でございます",
+        "noSnapshot": "手の使用にも地図の写しが必要でございます",
+        "section": {
+          "handUsage": "手の使用",
+          "wordPosition": "単語内の位置"
+        },
         "className": {
           "left": "左手",
           "right": "右手",
           "alternation": "交互打鍵",
-          "repetition": "同指連打"
+          "repetition": "同指連打",
+          "initiation": "語頭",
+          "inWord": "語中"
         },
         "coverage": "{{percent}}% の組を分類できましてございます",
         "deltaLeft": "ΔLeft",
         "deltaRight": "ΔRight",
-        "deltaTooltip": "正の値であれば、片手のみより両手を交互に用いた方が速かったことを意味いたします"
+        "deltaInitiation": "ΔInitiation",
+        "deltaTooltip": "正の値であれば、先に挙げた分類の方が遅かったことを意味いたします",
+        "excludedNote": "{{count}} 件のペアは区切り文字で終わるため除外いたしました"
       },
       "pairIntervalThreshold": {
         "label": "平均間隔",

--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -16,6 +16,7 @@ import type {
 import { fetchBigramAggregateForRange } from './analyze-fetch'
 import { useKeycodeFingerMap } from './use-keycode-finger-map'
 import { aggregateBigramClasses } from './analyze-bigram-classes'
+import { aggregateWordPosition } from './analyze-bigram-word-position'
 import { ALL_PAIRS_LIMIT } from './analyze-constants'
 import { FILTER_SELECT } from './analyze-filter-styles'
 import type { RangeMs } from './analyze-types'
@@ -167,6 +168,19 @@ export function BigramsChart({
     [classesEntries, classesFingerMap],
   )
 
+  // Word-position (initiation / in-word) aggregate — same "1
+  // calculation, N consumers" treatment as `classesAggregate` above,
+  // but with no finger map dependency: it only compares keycodes
+  // against a fixed separator set, so it doesn't need a snapshot.
+  // The snapshot is passed for its `vialProtocol` alone, not for a
+  // keymap: it decides whether dual-role (LT/MT/SH_T) space keys can be
+  // unwrapped safely. Without a snapshot the rows still render, just
+  // counting bare KC_SPACE / KC_ENTER — see `aggregateWordPosition`.
+  const wordPositionAggregate = useMemo(
+    () => aggregateWordPosition(classesEntries, snapshot?.vialProtocol),
+    [classesEntries, snapshot],
+  )
+
   const body = loading ? (
     <div className="py-4 text-center text-sm text-content-muted" data-testid="analyze-bigrams-loading">
       {t('analyze.bigrams.loading')}
@@ -267,7 +281,11 @@ export function BigramsChart({
             </>
           }
         >
-          <BigramClassesTable aggregate={classesAggregate} hasSnapshot={snapshot !== null} />
+          <BigramClassesTable
+            aggregate={classesAggregate}
+            wordPositionAggregate={wordPositionAggregate}
+            hasSnapshot={snapshot !== null}
+          />
         </Quadrant>
       )}
     </div>

--- a/src/renderer/components/analyze/BigramsClassesQuadrant.tsx
+++ b/src/renderer/components/analyze/BigramsClassesQuadrant.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Hand-usage classes (Left / Right / Alternation / Repetition) quadrant
-// for the Analyze Bigrams tab. Split out of BigramsChart.tsx — see that
-// file for the surrounding grid and the shared `classesAggregate` memo
-// computed once and passed down to both `BigramClassesCoverage` and
-// `BigramClassesTable`.
+// Bigram pattern quadrant for the Analyze Bigrams tab: hand usage
+// (Left / Right / Alternation / Repetition) and word position
+// (Initiation / In-word), rendered as two row groups of one table.
+// Split out of BigramsChart.tsx — see that file for the surrounding
+// grid and for the two aggregate memos, each computed once there and
+// passed down rather than recomputed per consumer.
 
 import { useTranslation } from 'react-i18next'
 import {
@@ -12,11 +13,11 @@ import {
   type BigramClassTotal,
   type ClassifiedBigramClass,
 } from './analyze-bigram-classes'
+import type { WordPositionAggregate } from './analyze-bigram-word-position'
 import { BIGRAM_MIN_COUNT } from './analyze-typing-profile'
 import { avgIkiFromHist } from './analyze-bigram-heatmap'
 import { EMPTY_STAT_VALUE } from './analyze-constants'
 import { fmtMs } from './analyze-format'
-import { EmptyQuadrant } from './bigrams-quadrant-ui'
 
 interface BigramClassesQuadrantProps {
   /** Classes aggregate computed once by the parent `BigramsChart` and
@@ -51,30 +52,38 @@ function classAvgOrNull(total: BigramClassTotal): number | null {
 }
 
 /** Signed `+N ms` / `-N ms` delta, `'—'` when either side is `null`.
- * Positive means alternating hands was faster than staying on the
- * class's hand — the CHI 2018 headline result. */
+ * Positive means the first-named class was slower — e.g. ΔLeft
+ * (Left − Alternation) positive means alternating hands was faster
+ * than staying on the left hand, the CHI 2018 headline result; ΔInitiation
+ * (Initiation − In-word) positive means starting a word was slower
+ * than continuing one. */
 function fmtDelta(value: number | null): string {
   if (value === null) return EMPTY_STAT_VALUE
   const rounded = Math.round(value)
   return `${rounded > 0 ? '+' : ''}${rounded} ms`
 }
 
-/** Left / Right / Alternation / Repetition IKI quadrant — the
- * CHI 2018 Table 3 hand-usage classes. Each row's average comes from
- * `avgIkiFromHist` on that class's own folded histogram (never a mean
- * of two other classes' averages), and ΔLeft / ΔRight compare each
- * same-hand class directly against Alternation. */
-function BigramClassesTable({ aggregate, hasSnapshot }: BigramClassesQuadrantProps): JSX.Element {
-  const { t } = useTranslation()
+interface BigramClassesTableProps extends BigramClassesQuadrantProps {
+  /** Word-position aggregate computed once by the parent `BigramsChart`
+   * — see the "1 calculation, N consumers" note at the call site. Has
+   * no `hasSnapshot` gate of its own: unlike hand usage, this section
+   * renders unconditionally since it needs no snapshot. */
+  wordPositionAggregate: WordPositionAggregate
+}
 
-  if (!hasSnapshot) {
-    return (
-      <EmptyQuadrant
-        text={t('analyze.bigrams.classes.noSnapshot')}
-        testId="analyze-bigrams-classes-no-snapshot"
-      />
-    )
-  }
+/** One table, two `<tbody>` sections: hand usage (Left / Right /
+ * Alternation / Repetition, the CHI 2018 Table 3 classes — needs a
+ * snapshot to resolve fingers) and word position (Initiation / In-word
+ * — needs only keycode equality against a separator set, so it renders
+ * even without one). Each row's average comes from `avgIkiFromHist` on
+ * that bucket's own folded histogram (never a mean of two other
+ * buckets' averages). */
+function BigramClassesTable({
+  aggregate,
+  wordPositionAggregate,
+  hasSnapshot,
+}: BigramClassesTableProps): JSX.Element {
+  const { t } = useTranslation()
 
   const avgByClass: Record<ClassifiedBigramClass, number | null> = {
     left: classAvgOrNull(aggregate.totals.left),
@@ -89,6 +98,21 @@ function BigramClassesTable({ aggregate, hasSnapshot }: BigramClassesQuadrantPro
     ? avgByClass.right - avgByClass.alternation
     : null
 
+  // `WordPositionTotal` is the same `{count, hist}` shape as
+  // `BigramClassTotal`, so the hand-usage floor applies unchanged.
+  const avgInitiation = classAvgOrNull(wordPositionAggregate.initiation)
+  const avgInWord = classAvgOrNull(wordPositionAggregate.inWord)
+  const deltaInitiation = avgInitiation !== null && avgInWord !== null
+    ? avgInitiation - avgInWord
+    : null
+  // Mapped the same way as CLASSIFIED_CLASSES above rather than written
+  // out as two hand-copied rows, so the cell markup lives in one place
+  // for both sections.
+  const wordPositionRows = [
+    { key: 'initiation', avg: avgInitiation, total: wordPositionAggregate.initiation },
+    { key: 'inWord', avg: avgInWord, total: wordPositionAggregate.inWord },
+  ] as const
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-2" data-testid="analyze-bigrams-classes-table">
       <table className="w-full text-xs">
@@ -99,12 +123,58 @@ function BigramClassesTable({ aggregate, hasSnapshot }: BigramClassesQuadrantPro
             <th className="px-2 py-1 text-right font-medium">{t('analyze.bigrams.column.count')}</th>
           </tr>
         </thead>
+        {/* Two `<tbody>` groups, not one: the two sections partition the
+            same pairs along different axes, so merging them into a single
+            run of rows would read as one six-way split whose counts ought
+            to sum. Separate row groups also make `scope="rowgroup"` on the
+            section headings true rather than decorative. */}
         <tbody>
-          {CLASSIFIED_CLASSES.map((cls) => (
-            <tr key={cls} className="border-t border-surface-dim">
-              <td className="px-2 py-1">{t(`analyze.bigrams.classes.className.${cls}`)}</td>
-              <td className="px-2 py-1 text-right tabular-nums">{fmtMs(avgByClass[cls])}</td>
-              <td className="px-2 py-1 text-right tabular-nums">{aggregate.totals[cls].count.toLocaleString()}</td>
+          <tr>
+            <th
+              colSpan={3}
+              scope="rowgroup"
+              className="px-2 py-1 text-left text-xs font-medium text-content-muted"
+              data-testid="analyze-bigrams-classes-section-hand-usage"
+            >
+              {t('analyze.bigrams.classes.section.handUsage')}
+            </th>
+          </tr>
+          {hasSnapshot ? (
+            CLASSIFIED_CLASSES.map((cls) => (
+              <tr key={cls} className="border-t border-surface-dim">
+                <td className="px-2 py-1">{t(`analyze.bigrams.classes.className.${cls}`)}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{fmtMs(avgByClass[cls])}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{aggregate.totals[cls].count.toLocaleString()}</td>
+              </tr>
+            ))
+          ) : (
+            <tr className="border-t border-surface-dim">
+              <td
+                colSpan={3}
+                className="px-2 py-2 text-center text-content-muted"
+                data-testid="analyze-bigrams-classes-no-snapshot"
+              >
+                {t('analyze.bigrams.classes.noSnapshot')}
+              </td>
+            </tr>
+          )}
+        </tbody>
+        <tbody>
+          <tr>
+            <th
+              colSpan={3}
+              scope="rowgroup"
+              className="px-2 py-1 text-left text-xs font-medium text-content-muted"
+              data-testid="analyze-bigrams-classes-section-word-position"
+            >
+              {t('analyze.bigrams.classes.section.wordPosition')}
+            </th>
+          </tr>
+          {wordPositionRows.map((row) => (
+            <tr key={row.key} className="border-t border-surface-dim">
+              <td className="px-2 py-1">{t(`analyze.bigrams.classes.className.${row.key}`)}</td>
+              <td className="px-2 py-1 text-right tabular-nums">{fmtMs(row.avg)}</td>
+              <td className="px-2 py-1 text-right tabular-nums">{row.total.count.toLocaleString()}</td>
             </tr>
           ))}
         </tbody>
@@ -116,7 +186,13 @@ function BigramClassesTable({ aggregate, hasSnapshot }: BigramClassesQuadrantPro
       >
         <span>{t('analyze.bigrams.classes.deltaLeft')}: {fmtDelta(deltaLeft)}</span>
         <span>{t('analyze.bigrams.classes.deltaRight')}: {fmtDelta(deltaRight)}</span>
+        <span>{t('analyze.bigrams.classes.deltaInitiation')}: {fmtDelta(deltaInitiation)}</span>
       </div>
+      {wordPositionAggregate.excludedCount > 0 && (
+        <div className="text-xs text-content-muted" data-testid="analyze-bigrams-classes-excluded-note">
+          {t('analyze.bigrams.classes.excludedNote', { count: wordPositionAggregate.excludedCount })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/BigramsChart.test.tsx
@@ -532,10 +532,13 @@ describe('BigramsChart', () => {
       const table = screen.getByTestId('analyze-bigrams-classes-table')
       // Bucket center for index 2 is 125ms (see HIST_BUCKETS centers),
       // so the alternation row shows the folded-hist average, not the
-      // raw entry.avgIki from the wire payload.
-      expect(within(table).getByText('analyze.bigrams.classes.className.alternation')).toBeTruthy()
-      expect(within(table).getByText('125 ms')).toBeTruthy()
-      expect(within(table).getByText('2,000')).toBeTruthy()
+      // raw entry.avgIki from the wire payload. Scoped to the row (not
+      // the whole table) because the same pair also lands in the
+      // word-position in-word bucket with matching numbers.
+      const rows = table.querySelectorAll('tbody tr')
+      const alternationRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.alternation'))
+      expect(alternationRow?.textContent).toContain('125 ms')
+      expect(alternationRow?.textContent).toContain('2,000')
     })
 
     it('is exclusive: two keys sharing one finger classify as left, not repetition', async () => {
@@ -604,6 +607,71 @@ describe('BigramsChart', () => {
       await waitFor(() => {
         expect(screen.getByTestId('analyze-bigrams-classes-coverage')).toBeTruthy()
       })
+    })
+
+    it('renders the word-position section even without a snapshot', async () => {
+      const keSpace = deserialize('KC_SPACE')
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keSpace}_${keyA}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: null })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      const table = screen.getByTestId('analyze-bigrams-classes-table')
+      // No snapshot -> hand usage shows the no-snapshot row, but word
+      // position needs no snapshot and still resolves the pair.
+      expect(within(table).getByTestId('analyze-bigrams-classes-no-snapshot')).toBeTruthy()
+      const rows = table.querySelectorAll('tbody tr')
+      const initiationRow = Array.from(rows).find((r) => r.textContent?.includes('classes.className.initiation'))
+      expect(initiationRow?.textContent).toContain('125 ms')
+      expect(initiationRow?.textContent).toContain('2,000')
+    })
+
+    it('computes ΔInitiation from the initiation and in-word buckets', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [
+          // space -> A: initiation, avgIki bucket center 400ms
+          { ngramId: `${deserialize('KC_SPACE')}_${keyA}`, count: 2000, hist: [0, 0, 0, 0, 0, 2000, 0, 0], avgIki: 400, sd: 10 },
+          // A -> B: in-word, avgIki bucket center 125ms
+          { ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 },
+        ],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-delta')).toBeTruthy()
+      })
+      const delta = screen.getByTestId('analyze-bigrams-classes-delta')
+      expect(delta.textContent).toContain('+275 ms')
+    })
+
+    it('shows the excluded-pairs note only when a pair ends at a separator', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${deserialize('KC_SPACE')}`, count: 7, hist: [0, 0, 7, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-excluded-note')).toBeTruthy()
+      })
+    })
+
+    it('hides the excluded-pairs note when no pair ends at a separator', async () => {
+      fetchSpy.mockResolvedValue({
+        view: 'top',
+        entries: [{ ngramId: `${keyA}_${keyB}`, count: 2000, hist: [0, 0, 2000, 0, 0, 0, 0, 0], avgIki: 125, sd: 10 }],
+        truncated: false,
+      })
+      renderChart({ gram: 2, snapshot: buildSnapshot(), fingerOverrides: alternationOverrides })
+      await waitFor(() => {
+        expect(screen.getByTestId('analyze-bigrams-classes-table')).toBeTruthy()
+      })
+      expect(screen.queryByTestId('analyze-bigrams-classes-excluded-note')).toBeNull()
     })
   })
 })

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-word-position.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-word-position.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import {
+  aggregateWordPosition,
+  classifyWordPosition,
+  tapKeycodeOf,
+} from '../analyze-bigram-word-position'
+import {
+  buildLTKeycode,
+  buildModMaskKeycode,
+  buildModTapKeycode,
+  deserialize,
+} from '../../../../shared/keycodes/keycodes'
+import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
+import { withSnapshotProtocol } from '../analyze-protocol'
+
+/** Build a keycode under a specific protocol so the test can name which
+ * version's range a wrapped keycode came from. */
+function withProtocol<T>(protocol: number, body: () => T): T {
+  return withSnapshotProtocol(protocol, body)
+}
+
+const KC_SPACE = deserialize('KC_SPACE')
+const KC_ENTER = deserialize('KC_ENTER')
+const KC_TAB = deserialize('KC_TAB')
+const KC_A = deserialize('KC_A')
+const KC_B = deserialize('KC_B')
+
+function entry(
+  ngramId: string,
+  count: number,
+  hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0],
+): TypingBigramTopEntry {
+  return { ngramId, count, hist, avgIki: null, sd: null }
+}
+
+describe('tapKeycodeOf', () => {
+  it('unwraps Layer-Tap to its basic key', () => {
+    expect(tapKeycodeOf(buildLTKeycode(1, KC_SPACE))).toBe(KC_SPACE)
+  })
+
+  it('unwraps Mod-Tap to its basic key', () => {
+    expect(tapKeycodeOf(buildModTapKeycode(0x01, KC_ENTER))).toBe(KC_ENTER)
+  })
+
+  it('does NOT unwrap a modifier-mask keycode — it never types the bare key', () => {
+    const lctlSpace = buildModMaskKeycode(0x01, KC_SPACE)
+    expect(tapKeycodeOf(lctlSpace)).toBe(lctlSpace)
+    expect(tapKeycodeOf(lctlSpace)).not.toBe(KC_SPACE)
+  })
+
+  it('returns everything else unchanged, including a high keycode whose low byte matches KC_SPACE', () => {
+    // Simulates a macro / tap-dance style keycode living well above the
+    // basic-key range but sharing KC_SPACE's low byte — masking
+    // unconditionally would incorrectly fold this down to KC_SPACE.
+    const highCodeSharingLowByte = 0x7000 | (KC_SPACE & 0xff)
+    expect(tapKeycodeOf(highCodeSharingLowByte)).toBe(highCodeSharingLowByte)
+    expect(tapKeycodeOf(KC_TAB)).toBe(KC_TAB)
+  })
+})
+
+describe('classifyWordPosition', () => {
+  it('classifies space->letter as initiation', () => {
+    expect(classifyWordPosition(KC_SPACE, KC_A, true)).toBe('initiation')
+  })
+
+  it('classifies letter->letter as in-word', () => {
+    expect(classifyWordPosition(KC_A, KC_B, true)).toBe('inWord')
+  })
+
+  it('excludes letter->space, space->space, and enter->space', () => {
+    expect(classifyWordPosition(KC_A, KC_SPACE, true)).toBe('excluded')
+    expect(classifyWordPosition(KC_SPACE, KC_SPACE, true)).toBe('excluded')
+    expect(classifyWordPosition(KC_ENTER, KC_SPACE, true)).toBe('excluded')
+  })
+
+  it('classifies enter->letter as initiation — pins the approved decision to include Enter', () => {
+    expect(classifyWordPosition(KC_ENTER, KC_A, true)).toBe('initiation')
+  })
+
+  it('classifies tab->letter as in-word, not initiation — Tab is not a separator', () => {
+    expect(classifyWordPosition(KC_TAB, KC_A, true)).toBe('inWord')
+  })
+
+  it('classifies LT(1, KC_SPACE)->letter as initiation', () => {
+    expect(classifyWordPosition(buildLTKeycode(1, KC_SPACE), KC_A, true)).toBe('initiation')
+  })
+
+  it('classifies MT(mod, KC_ENTER)->letter as initiation', () => {
+    expect(classifyWordPosition(buildModTapKeycode(0x01, KC_ENTER), KC_A, true)).toBe('initiation')
+  })
+
+  it('does NOT classify LCTL(KC_SPACE)->letter as initiation — mod-mask never types a space', () => {
+    expect(classifyWordPosition(buildModMaskKeycode(0x01, KC_SPACE), KC_A, true)).toBe('inWord')
+  })
+})
+
+describe('aggregateWordPosition', () => {
+  it('returns zeroed totals for empty entries', () => {
+    const result = aggregateWordPosition([])
+    expect(result.initiation).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.inWord).toEqual({ count: 0, hist: [0, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.excludedCount).toBe(0)
+  })
+
+  it('folds a space->letter pair into initiation', () => {
+    const result = aggregateWordPosition([
+      entry(`${KC_SPACE}_${KC_A}`, 4, [4, 0, 0, 0, 0, 0, 0, 0]),
+    ])
+    expect(result.initiation).toEqual({ count: 4, hist: [4, 0, 0, 0, 0, 0, 0, 0] })
+    expect(result.inWord.count).toBe(0)
+  })
+
+  it('folds a letter->letter pair into in-word', () => {
+    const result = aggregateWordPosition([
+      entry(`${KC_A}_${KC_B}`, 3, [0, 3, 0, 0, 0, 0, 0, 0]),
+    ])
+    expect(result.inWord).toEqual({ count: 3, hist: [0, 3, 0, 0, 0, 0, 0, 0] })
+    expect(result.initiation.count).toBe(0)
+  })
+
+  it('drops a pair ending at a separator from both buckets and reports it as excluded', () => {
+    const result = aggregateWordPosition([
+      entry(`${KC_A}_${KC_SPACE}`, 5),
+    ])
+    expect(result.excludedCount).toBe(5)
+    expect(result.initiation.count).toBe(0)
+    expect(result.inWord.count).toBe(0)
+  })
+
+  it('skips a malformed ngram id entirely — it reaches neither bucket nor the excluded count', () => {
+    const result = aggregateWordPosition([
+      entry('bad', 2),
+      entry(`${KC_A}_${KC_B}`, 1, [1, 0, 0, 0, 0, 0, 0, 0]),
+    ])
+    expect(result.excludedCount).toBe(0)
+    expect(result.initiation.count).toBe(0)
+    expect(result.inWord.count).toBe(1)
+  })
+
+  it('folds two entries in the same bucket into a weighted-average histogram', () => {
+    const result = aggregateWordPosition([
+      entry(`${KC_SPACE}_${KC_A}`, 2, [2, 0, 0, 0, 0, 0, 0, 0]),
+      entry(`${KC_ENTER}_${KC_B}`, 1, [0, 1, 0, 0, 0, 0, 0, 0]),
+    ])
+    expect(result.initiation).toEqual({ count: 3, hist: [2, 1, 0, 0, 0, 0, 0, 0] })
+  })
+
+  it('leaves a dual-role space key alone when no protocol is supplied', () => {
+    // Without the recording protocol, the Mod-Tap range can't be
+    // identified (v5 bases it at 0x6000, v6 at 0x2000), so the pair
+    // must fall through to in-word rather than be unwrapped against
+    // whichever protocol the session happens to be in.
+    const mtSpace = withProtocol(6, () => buildModTapKeycode(0x01, KC_SPACE))
+    const result = aggregateWordPosition([entry(`${mtSpace}_${KC_A}`, 4)])
+    expect(result.initiation.count).toBe(0)
+    expect(result.inWord.count).toBe(4)
+  })
+
+  it('unwraps a dual-role space key against the protocol it was recorded under', () => {
+    const mtSpaceV6 = withProtocol(6, () => buildModTapKeycode(0x01, KC_SPACE))
+    expect(aggregateWordPosition([entry(`${mtSpaceV6}_${KC_A}`, 4)], 6).initiation.count).toBe(4)
+
+    const mtSpaceV5 = withProtocol(5, () => buildModTapKeycode(0x01, KC_SPACE))
+    expect(aggregateWordPosition([entry(`${mtSpaceV5}_${KC_A}`, 4)], 5).initiation.count).toBe(4)
+  })
+
+  it('does not unwrap a v5-recorded Mod-Tap against v6 ranges', () => {
+    // The regression this guards: the two protocols put Mod-Tap in
+    // different ranges, so classifying with the wrong one silently
+    // drops the pair out of initiation instead of erroring.
+    const mtSpaceV5 = withProtocol(5, () => buildModTapKeycode(0x01, KC_SPACE))
+    const result = aggregateWordPosition([entry(`${mtSpaceV5}_${KC_A}`, 4)], 6)
+    expect(result.initiation.count).toBe(0)
+  })
+})

--- a/src/renderer/components/analyze/__tests__/analyze-csv-builders.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-csv-builders.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildBigramsCsv } from '../analyze-csv-builders'
+import { deserialize } from '../../../../shared/keycodes/keycodes'
+import { parseKle } from '../../../../shared/kle/kle-parser'
+import type { FingerType } from '../../../../shared/kle/kle-ergonomics'
+import type {
+  TypingBigramAggregateResult,
+  TypingKeymapSnapshot,
+} from '../../../../shared/types/typing-analytics'
+
+const fetchSpy = vi.fn<(...args: unknown[]) => Promise<TypingBigramAggregateResult>>()
+
+Object.defineProperty(window, 'vialAPI', {
+  value: {
+    typingAnalyticsGetBigramAggregateForRange: (...args: unknown[]) => fetchSpy(...args),
+  },
+  writable: true,
+})
+
+const range = { fromMs: 0, toMs: 60_000 }
+const scopeArgs = { uid: '0xAABB', range, deviceScope: 'own' as const }
+
+const layout = parseKle([['0,0', '0,1']])
+const keyA = deserialize('KC_A')
+const keyB = deserialize('KC_B')
+const keSpace = deserialize('KC_SPACE')
+
+function buildSnapshot(): TypingKeymapSnapshot {
+  return {
+    uid: '0x00',
+    machineHash: 'h',
+    productName: 'Test',
+    savedAt: 0,
+    layers: 1,
+    matrix: { rows: 1, cols: 2 },
+    keymap: [[['KC_A', 'KC_B']]],
+    layout,
+  }
+}
+
+const fingerOverrides: Record<string, FingerType> = {
+  '0,0': 'left-index',
+  '0,1': 'right-index',
+}
+
+function parseCsv(content: string): { headers: string[]; rows: string[][] } {
+  const [headerLine, ...dataLines] = content.split('\n')
+  return {
+    headers: headerLine?.split(',') ?? [],
+    rows: dataLines.filter((l) => l.length > 0).map((l) => l.split(',')),
+  }
+}
+
+describe('buildBigramsCsv', () => {
+  beforeEach(() => {
+    fetchSpy.mockReset()
+  })
+
+  it('adds a word_position column populated for gram === 2 even without a snapshot', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: `${keSpace}_${keyA}`, count: 5, hist: [0, 0, 0, 0, 0, 5, 0, 0], avgIki: 400, sd: 10 },
+        { ngramId: `${keyA}_${keyB}`, count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 5 },
+      ],
+      truncated: false,
+    })
+    const result = await buildBigramsCsv({ ...scopeArgs, gram: 2, snapshot: null })
+    const { headers, rows } = parseCsv(result.content)
+    expect(headers).toEqual(['bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms', 'class', 'word_position'])
+    // No snapshot -> class stays blank, word_position still resolves.
+    expect(rows[0]).toEqual([`${keSpace}_${keyA}`, '5', '400', '10', '', 'initiation'])
+    expect(rows[1]).toEqual([`${keyA}_${keyB}`, '3', '30', '5', '', 'inWord'])
+  })
+
+  it('populates both class and word_position when a snapshot is supplied', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: `${keyA}_${keyB}`, count: 3, hist: [3, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 5 },
+      ],
+      truncated: false,
+    })
+    const result = await buildBigramsCsv({
+      ...scopeArgs, gram: 2, snapshot: buildSnapshot(), fingerOverrides,
+    })
+    const { rows } = parseCsv(result.content)
+    expect(rows[0]).toEqual([`${keyA}_${keyB}`, '3', '30', '5', 'alternation', 'inWord'])
+  })
+
+  it('excludes a pair ending at a separator from word_position via the "excluded" value', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: `${keyA}_${keSpace}`, count: 2, hist: [2, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 0 },
+      ],
+      truncated: false,
+    })
+    const result = await buildBigramsCsv({ ...scopeArgs, gram: 2, snapshot: null })
+    const { rows } = parseCsv(result.content)
+    expect(rows[0]).toEqual([`${keyA}_${keSpace}`, '2', '30', '0', '', 'excluded'])
+  })
+
+  it('leaves word_position blank for trigrams, matching the class column', async () => {
+    fetchSpy.mockResolvedValue({
+      view: 'top',
+      entries: [
+        { ngramId: `${keyA}_${keyB}_${keyA}`, count: 4, hist: [4, 0, 0, 0, 0, 0, 0, 0], avgIki: 30, sd: 0 },
+      ],
+      truncated: false,
+    })
+    const result = await buildBigramsCsv({ ...scopeArgs, gram: 3, snapshot: buildSnapshot(), fingerOverrides })
+    const { headers, rows } = parseCsv(result.content)
+    expect(headers).toEqual(['trigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms', 'class', 'word_position'])
+    expect(rows[0]).toEqual([`${keyA}_${keyB}_${keyA}`, '4', '30', '0', '', ''])
+  })
+})

--- a/src/renderer/components/analyze/analyze-bigram-word-position.ts
+++ b/src/renderer/components/analyze/analyze-bigram-word-position.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Bigram -> Initiation / In-word word-position classification, the
+// sibling of `analyze-bigram-classes.ts`'s hand-usage classes. Kept as
+// its own module rather than folded into that file because the two
+// classifications depend on fundamentally different inputs: hand usage
+// needs the snapshot-derived finger map (it can't resolve without a
+// keymap), while word position only needs to compare two recorded
+// keycodes against a small separator set — no snapshot, no finger map,
+// no per-keyboard state at all. A classification this cheap doesn't
+// belong behind the same "needs a snapshot" gate as its sibling.
+
+import {
+  deserialize,
+  extractBasicKey,
+  isLTKeycode,
+  isModTapKeycode,
+  isSHTKeycode,
+} from '../../../shared/keycodes/keycodes'
+import type { TypingBigramTopEntry } from '../../../shared/types/typing-analytics'
+import { emptyHistTotal, foldHist, parseBigramId, type HistTotal } from './analyze-bigram-heatmap'
+import { withSnapshotProtocol } from './analyze-protocol'
+
+export type WordPosition = 'initiation' | 'inWord' | 'excluded'
+
+/**
+ * Unwraps a recorded keycode to the basic key its TAP action produces.
+ *
+ * PROTOCOL-SENSITIVE. The three range predicates below resolve their
+ * base constants through the *current global* protocol, and two of the
+ * three move between versions — `QK_MOD_TAP` is 0x6000 under v5 but
+ * 0x2000 under v6, and `SH_T(kc)` is 0x999d0 under v5 but 0x5600 under
+ * v6. A code recorded under one protocol and tested under the other
+ * silently fails to unwrap. Callers must therefore run this inside
+ * `withSnapshotProtocol(snapshot.vialProtocol, ...)`; when the
+ * recording protocol is unknown, don't call it at all — see
+ * `aggregateWordPosition`'s `vialProtocol` parameter. (`QK_LAYER_TAP`
+ * happens to be 0x4000 in both, but relying on that would make the
+ * behaviour depend on which of the three wrappers a user picked.)
+ *
+ * KNOWN APPROXIMATION — a hold is counted as a tap. The recorded event
+ * carries an `action: 'tap' | 'hold'` for masked keys, but the ngram
+ * chain stores only `event.keycode` and drops it (see
+ * `minute-buffer.ts`'s `recordNgramChain` call), so by the time a pair
+ * reaches this function there is no way to tell the two apart. Holding
+ * `LT(1, KC_SPACE)` to reach a layer therefore lands in `initiation`
+ * exactly like tapping it for a space would, biasing the initiation
+ * bucket by roughly the user's layer-switch rate. Accepted rather than
+ * fixed here because the alternative — refusing to classify any
+ * dual-role key — leaves anyone who put space on a thumb LT with no
+ * word-position data at all. A real fix has to keep `action` on the
+ * ngram at record time; existing aggregates can't be repaired.
+ *
+ * Only Layer-Tap, Mod-Tap and Swap-Hands-Tap are unwrapped: holding any
+ * of the three sends a layer switch / modifier / hand swap, but tapping
+ * them genuinely emits the bare basic key underneath, so a `LT(1,
+ * KC_SPACE)` tap is indistinguishable from a plain `KC_SPACE` tap for
+ * word-position purposes.
+ *
+ * A modifier-mask keycode (`isModMaskKeycode`, e.g. `LCTL(KC_SPACE)`)
+ * is deliberately NOT unwrapped: unlike the three tap-actions above, a
+ * mod-mask keycode always sends the modifier together with the key —
+ * there is no tap/hold distinction that ever emits the bare key alone.
+ * `Ctrl+Space` is not a word separator just because its low byte
+ * happens to equal `KC_SPACE`.
+ *
+ * Everything else — including macro and tap-dance keycodes, which live
+ * well above the basic-key range — is returned unchanged. Masking
+ * unconditionally (`code & 0xff`) would fold any such high keycode down
+ * into the basic range and risk a false separator match whenever its
+ * low byte happened to coincide with `KC_SPACE` / `KC_ENTER`.
+ */
+export function tapKeycodeOf(code: number): number {
+  if (isLTKeycode(code) || isModTapKeycode(code) || isSHTKeycode(code)) {
+    return extractBasicKey(code)
+  }
+  return code
+}
+
+// Lazily resolved so module init doesn't depend on the keycode table
+// being ready yet, and cached because `classifyWordPosition` runs once
+// per entry. Unlike the tap-range predicates above, these two ARE
+// protocol-independent — `KC_SPACE` / `KC_ENTER` are basic keycodes
+// with the same numeric value under v5 and v6 — which is what makes the
+// no-protocol fallback path below safe rather than merely convenient.
+let separatorCodes: Set<number> | null = null
+
+function separatorKeycodes(): Set<number> {
+  if (!separatorCodes) {
+    separatorCodes = new Set([deserialize('KC_SPACE'), deserialize('KC_ENTER')])
+  }
+  return separatorCodes
+}
+
+/**
+ * Classifies a bigram by where it falls relative to a word boundary.
+ * Exclusive — checked in this order:
+ *
+ *   1. `curr`'s tap keycode is a separator -> `excluded`. A pair ending
+ *      at a separator is the *end* of a word, a different act from both
+ *      starting one and continuing one, so it's dropped rather than
+ *      counted as either. Checking this first also correctly drops a
+ *      `space->space` (double separator) pair instead of miscounting it
+ *      as an initiation.
+ *   2. `prev`'s tap keycode is a separator -> `initiation` (the first
+ *      pair typed after a separator).
+ *   3. otherwise -> `inWord`.
+ *
+ * Including `KC_ENTER` in the separator set makes this "after a
+ * separator" rather than the CHI 2018 paper's strict space-only word
+ * initiation — a deliberate, user-approved widening: a line break ends
+ * a word exactly like a space does for this purpose.
+ *
+ * `unwrapTaps` controls whether `LT`/`MT`/`SH_T` keys are resolved to
+ * the key they emit when tapped. Pass `true` only from inside a
+ * `withSnapshotProtocol` scope — see `tapKeycodeOf`. With `false` only
+ * bare `KC_SPACE` / `KC_ENTER` count, which under-counts a user who
+ * put space on a dual-role key but never mis-classifies.
+ */
+export function classifyWordPosition(
+  prevCode: number,
+  currCode: number,
+  unwrapTaps: boolean,
+): WordPosition {
+  const separators = separatorKeycodes()
+  const resolve = (code: number): number => (unwrapTaps ? tapKeycodeOf(code) : code)
+  if (separators.has(resolve(currCode))) return 'excluded'
+  if (separators.has(resolve(prevCode))) return 'initiation'
+  return 'inWord'
+}
+
+/** Per-bucket running total — see `HistTotal` (shared with
+ * `BigramClassTotal`, the hand-usage sibling) for the shape. */
+export type WordPositionTotal = HistTotal
+
+export interface WordPositionAggregate {
+  initiation: WordPositionTotal
+  inWord: WordPositionTotal
+  /** Pair count dropped because the pair ends at a separator. Surfaced
+   * as a raw count in the quadrant's footnote so the two buckets aren't
+   * read as covering every pair. Deliberately not paired with a grand
+   * total: nothing renders a percentage, and carrying a denominator no
+   * caller divides by would just be one more field to keep true. */
+  excludedCount: number
+}
+
+/**
+ * Aggregates bigram entries into the `initiation` / `inWord` word-
+ * position buckets. Mirrors `aggregateBigramClasses`'s fold-then-
+ * average approach: per bucket, `{count, hist}` accumulate and the
+ * caller derives the average with `avgIkiFromHist` — never average two
+ * buckets' pre-computed averages together.
+ *
+ * A malformed ngram id (`parseBigramId` returns `null`) is skipped
+ * entirely: it's neither folded into `inWord` nor counted as excluded,
+ * since it can't be resolved to a (prev, curr) pair at all. Lumping it
+ * into `inWord` would be the tempting shortcut and the wrong one — an
+ * unparseable pair is not evidence of anything about word position.
+ *
+ * No SD is produced here (nor should one be approximated from the
+ * hist) for the same reason as `analyze-bigram-classes.ts`: the wire
+ * entries only carry a per-pair `sd`, and re-combining per-pair SDs
+ * into a per-bucket variance needs sum/sumsq, which
+ * `TypingBigramTopEntry` doesn't have.
+ */
+export function aggregateWordPosition(
+  entries: readonly TypingBigramTopEntry[],
+  vialProtocol?: number,
+): WordPositionAggregate {
+  // Tap unwrapping only happens when the caller can name the protocol
+  // the pairs were recorded under — the tap-range constants move
+  // between v5 and v6 (see `tapKeycodeOf`). Without it, fall back to
+  // bare separator codes: those are identical across protocols, so the
+  // fallback under-counts dual-role space keys rather than guessing.
+  const unwrapTaps = vialProtocol !== undefined
+  return withSnapshotProtocol(vialProtocol, () => {
+    const initiation = emptyHistTotal()
+    const inWord = emptyHistTotal()
+    let excludedCount = 0
+    for (const entry of entries) {
+      const pair = parseBigramId(entry.ngramId)
+      if (!pair) continue
+      const position = classifyWordPosition(pair.prev, pair.curr, unwrapTaps)
+      if (position === 'excluded') {
+        excludedCount += entry.count
+        continue
+      }
+      const bucket = position === 'initiation' ? initiation : inWord
+      bucket.count += entry.count
+      foldHist(bucket.hist, entry.hist)
+    }
+    return { initiation, inWord, excludedCount }
+  })
+}

--- a/src/renderer/components/analyze/analyze-csv-builders.ts
+++ b/src/renderer/components/analyze/analyze-csv-builders.ts
@@ -74,7 +74,10 @@ import {
   listMinuteStatsForScope,
 } from './analyze-fetch'
 import { classifyBigram } from './analyze-bigram-classes'
+import { classifyWordPosition } from './analyze-bigram-word-position'
 import { buildKeycodeFingerMap, resolvePairFingers } from './analyze-bigram-finger'
+import { parseBigramId } from './analyze-bigram-heatmap'
+import { withSnapshotProtocol } from './analyze-protocol'
 import { bucketMinuteStats, pickBucketMs } from './analyze-bucket'
 import { buildBksRateBuckets } from './analyze-error-proxy'
 import { buildHourOfDayWpm, computeWpm } from './analyze-wpm'
@@ -454,11 +457,27 @@ export async function buildBigramsCsv(args: ScopeArgs & {
   // (classification attempted, finger unresolved). See the `snapshot`
   // param doc above.
   const canClassify = gram === 2 && snapshot !== null
-  const rows = entries.map((e) => {
+  // Word position, unlike `class`, needs no snapshot to be computable —
+  // it's keycode equality against a fixed separator set — so it's gated
+  // on `gram` alone, never on `canClassify`. Trigram ids fail
+  // `parseBigramId` (which only accepts a `_`-joined pair) and so fall
+  // through to the blank default just like `class` does.
+  //
+  // The snapshot's protocol is still used when present: it's what makes
+  // unwrapping a dual-role (LT/MT/SH_T) space key safe, since those
+  // ranges move between v5 and v6. Without it the column falls back to
+  // bare separator codes rather than guessing — see `tapKeycodeOf`.
+  const unwrapTaps = snapshot?.vialProtocol !== undefined
+  const rows = withSnapshotProtocol(snapshot?.vialProtocol, () => entries.map((e) => {
     let cls = ''
     if (canClassify) {
       const { prevFinger, currFinger, sameKeycode } = resolvePairFingers(e.ngramId, keycodeFinger)
       cls = classifyBigram(prevFinger, currFinger, sameKeycode)
+    }
+    let wordPosition = ''
+    if (gram === 2) {
+      const pair = parseBigramId(e.ngramId)
+      if (pair) wordPosition = classifyWordPosition(pair.prev, pair.curr, unwrapTaps)
     }
     return [
       e.ngramId,
@@ -466,11 +485,15 @@ export async function buildBigramsCsv(args: ScopeArgs & {
       e.avgIki === null ? '' : Math.round(e.avgIki),
       e.sd === null ? '' : Math.round(e.sd),
       cls,
+      wordPosition,
     ]
-  })
+  }))
   return {
     slug: gram === 3 ? SLUG.trigrams : SLUG.bigrams,
-    content: buildCsv([gram === 3 ? 'trigram_id' : 'bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms', 'class'], rows),
+    content: buildCsv(
+      [gram === 3 ? 'trigram_id' : 'bigram_id', 'count', 'avg_iki_ms', 'sd_iki_ms', 'class', 'word_position'],
+      rows,
+    ),
   }
 }
 

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.44",
+  "version": "0.1.45",
   "name": "English",
   "common": {
     "save": "Save",
@@ -1128,7 +1128,7 @@
         "top": "Top pairs",
         "slow": "Pair interval",
         "fingerIki": "Finger IKI",
-        "classes": "Alternation benefit"
+        "classes": "Bigram patterns"
       },
       "cappedNotice": "Computed from the {{limit}} most frequent pairs — rare pairs may be missing.",
       "gramToggle": {
@@ -1154,17 +1154,25 @@
         }
       },
       "classes": {
-        "noSnapshot": "Alternation benefit needs a keymap snapshot. Start a record session or pick a range with one.",
+        "noSnapshot": "Hand usage needs a keymap snapshot. Start a record session or pick a range with one.",
+        "section": {
+          "handUsage": "Hand usage",
+          "wordPosition": "Word position"
+        },
         "className": {
           "left": "Left",
           "right": "Right",
           "alternation": "Alternation",
-          "repetition": "Repetition"
+          "repetition": "Repetition",
+          "initiation": "Initiation",
+          "inWord": "In-word"
         },
         "coverage": "{{percent}}% of pairs classified",
         "deltaLeft": "ΔLeft",
         "deltaRight": "ΔRight",
-        "deltaTooltip": "Positive means alternating hands was faster than staying on one hand."
+        "deltaInitiation": "ΔInitiation",
+        "deltaTooltip": "Positive means the first-named class was slower.",
+        "excludedNote": "{{count}} pairs ending at a separator excluded"
       },
       "pairIntervalThreshold": {
         "label": "Avg interval",


### PR DESCRIPTION
## Summary

Adds a word-position split to the Bigrams chart: pairs typed right after a separator vs. pairs typed inside a word. Reference work on typing behaviour excludes post-space keystrokes from its interval analysis precisely because starting a word is structurally slower, so this surfaces the size of that effect for the user's own data.

The rows join the hand-usage classes in the same card, as a second row group rather than four more rows — the two are different partitions of the same pairs, so merging them into one run would read as a six-way split whose counts ought to sum.

| Class | Definition |
|---|---|
| Initiation | The previous key was a separator |
| In-word | Neither key was a separator |
| *(excluded)* | The pair **ends** at a separator |

A pair ending at a separator is the end of a word, which is neither starting one nor continuing one, so it is dropped from both buckets and reported as a footnote instead of being silently absorbed. Checking that case first also drops a double separator rather than counting it as an initiation.

`ΔInitiation` is `Initiation − In-word`, so a positive value means starting a word was slower.

## Dual-role space keys

A separator is Space or Enter. Bigrams store the raw keycode that fired, so matching only bare `KC_SPACE` would report nothing at all for anyone who put space on a thumb `LT` or `MT` — including this repo's own virtual device keymap. Matching therefore resolves `LT` / `MT` / `SH_T` to the key they emit when tapped.

Two limits on that, both deliberate:

- **Modifier-mask keycodes are not unwrapped.** `LCTL(KC_SPACE)` always sends the modifier with the key and never types a space, so its low byte matching `KC_SPACE` is a coincidence, not a separator. Nothing else is unwrapped either — masking unconditionally would fold macro and tap-dance codes into the basic range and invent separator matches.
- **Unwrapping only runs when the recording protocol is known.** The Mod-Tap and Swap-Hands-Tap ranges move between protocol versions (`QK_MOD_TAP` is `0x6000` under v5 and `0x2000` under v6), and `resolve()` reads the current global protocol. Without the snapshot's `vialProtocol` the classification falls back to bare keycodes, which undercounts rather than misclassifies. Regression tests pin both directions.

## Known approximation

A hold is counted as a tap. The recorded event carries `action: 'tap' | 'hold'` for masked keys, but the ngram chain keeps only the keycode and drops it, so holding `LT(1, KC_SPACE)` to reach a layer lands in Initiation exactly like tapping it for a space. This biases Initiation by roughly the user's layer-switch rate.

Accepted here rather than fixed, because the alternative — refusing to classify any dual-role key — leaves thumb-`LT` users with no word-position data at all, which is the problem this change exists to solve. A real fix has to keep `action` on the ngram at record time and cannot repair existing aggregates; that is tracked separately.

## Notes

- No snapshot required. Unlike the hand-usage rows, word position needs no keymap, so the rows render whenever bigram data exists; only the hand-usage group shows the no-snapshot state.
- No standard deviation, for the same reason as the hand-usage rows: the stored aggregate keeps counts and means only, so a variance cannot be recombined.
- Hidden for trigrams, unchanged — a trigram value is the mean of two intervals, not the single separator-to-letter transition.
- CSV gains a `word_position` column, gated on gram alone rather than on snapshot availability.

## Test plan

- `analyze-bigram-word-position.test.ts` — 21 cases: classification order and exclusivity, Enter and Tab handling, each unwrap case including the mod-mask and high-keycode guards, malformed ids, histogram folding, and the three protocol cases
- `analyze-csv-builders.test.ts` — new file; column coexistence, snapshot independence, trigram blanking
- `BigramsChart.test.tsx` — the new row group, ΔInitiation, the excluded footnote, and rendering without a snapshot
- `pnpm test` → 315 files / 7241 passed / 22 skipped
- `npx eslint src/` and `pnpm typecheck` clean