### PR TITLE
fix(sync): record key presses in the order they were physically typed

### DIFF
--- a/src/main/typing-analytics/__tests__/minute-buffer.test.ts
+++ b/src/main/typing-analytics/__tests__/minute-buffer.test.ts
@@ -2,10 +2,12 @@
 
 import { describe, it, expect, beforeEach } from 'vitest'
 import { MinuteBuffer, MINUTE_MS } from '../minute-buffer'
-import { NGRAM_MAX_IKI_MS } from '../minute-buffer'
+import { NGRAM_MAX_IKI_MS, DRAIN_CLOSE_GRACE_MS } from '../minute-buffer'
+import { MAX_TAP_HOLD_DEFER_MS } from '../../../shared/qmk-settings-tapping-term'
 import type {
   TypingAnalyticsEvent,
   TypingAnalyticsFingerprint,
+  TypingMatrixAction,
 } from '../../../shared/types/typing-analytics'
 import { canonicalScopeKey } from '../../../shared/types/typing-analytics'
 
@@ -27,7 +29,14 @@ function charEvent(key: string, ts: number): TypingAnalyticsEvent {
   return { kind: 'char', key, ts, keyboard: { uid: 'x', vendorId: 0, productId: 0, productName: '' } }
 }
 
-function matrixEvent(row: number, col: number, layer: number, keycode: number, ts: number): TypingAnalyticsEvent {
+function matrixEvent(
+  row: number,
+  col: number,
+  layer: number,
+  keycode: number,
+  ts: number,
+  action?: TypingMatrixAction,
+): TypingAnalyticsEvent {
   return {
     kind: 'matrix',
     row,
@@ -35,6 +44,7 @@ function matrixEvent(row: number, col: number, layer: number, keycode: number, t
     layer,
     keycode,
     ts,
+    ...(action ? { action } : {}),
     keyboard: { uid: 'x', vendorId: 0, productId: 0, productName: '' },
   }
 }
@@ -147,13 +157,16 @@ describe('MinuteBuffer', () => {
     expect(new Set(snapshots.map((s) => s.scopeId))).toEqual(new Set([scope1Id, scope2Id]))
   })
 
-  it('drainClosed only returns entries strictly older than the boundary', () => {
+  it('drainClosed only returns entries whose minute ended at least the grace period before the boundary', () => {
     const fp = fingerprint()
     buffer.addEvent(charEvent('a', 1_000), fp)                // minute 0
     buffer.addEvent(charEvent('a', MINUTE_MS + 1_000), fp)    // minute 1
     buffer.addEvent(charEvent('a', 2 * MINUTE_MS + 1_000), fp) // minute 2
 
-    const closed = buffer.drainClosed(2 * MINUTE_MS)
+    // 3 * MINUTE_MS comfortably clears minute 0 and minute 1's grace window
+    // (each ended well over DRAIN_CLOSE_GRACE_MS ago) while minute 2 has
+    // barely ended and must stay open.
+    const closed = buffer.drainClosed(3 * MINUTE_MS)
     expect(closed.map((s) => s.minuteTs).sort((a, b) => a - b)).toEqual([0, MINUTE_MS])
     // Minute 2 is still live.
     expect(buffer.isEmpty()).toBe(false)
@@ -281,7 +294,8 @@ describe('MinuteBuffer', () => {
       // no peer to pair against.
       const fp = fingerprint()
       buffer.addEvent(matrixEvent(0, 0, 0, 4, 30_000), fp) // minute 0
-      const closed = buffer.drainClosed(60_000)
+      // Past the grace window so minute 0 actually closes on this call.
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
       expect(closed).toHaveLength(1)
       expect(closed[0].bigrams.size).toBe(0) // single event in minute 0, no pair to record yet
 
@@ -441,7 +455,8 @@ describe('MinuteBuffer', () => {
       const fp = fingerprint()
       buffer.addEvent(matrixEvent(0, 0, 0, 4, 20_000), fp) // minute 0
       buffer.addEvent(matrixEvent(0, 1, 0, 11, 40_000), fp) // minute 0, chain=[4,11]
-      const closed = buffer.drainClosed(60_000)
+      // Past the grace window so minute 0 actually closes on this call.
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
       expect(closed).toHaveLength(1)
       expect(closed[0].trigrams.size).toBe(0) // only 2 events so far, no triple yet
 
@@ -544,6 +559,108 @@ describe('MinuteBuffer', () => {
     })
   })
 
+  describe('hold events break the n-gram chain', () => {
+    it('does not pair a hold with the event before it', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter
+      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_100, 'hold'), fp) // LT hold
+
+      const [snap] = buffer.drainAll()
+      expect(snap.bigrams.size).toBe(0)
+    })
+
+    it('does not pair a hold with the event after it — the chain restarted', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp) // LT hold
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_100), fp) // letter
+
+      const [snap] = buffer.drainAll()
+      expect(snap.bigrams.size).toBe(0)
+    })
+
+    it('does not join two letters into a pair across an intervening hold', () => {
+      // The naive "skip the hold and pair its neighbours" shortcut would
+      // record 4_7 here (120+180=300ms apart); the chain must instead
+      // treat the hold as a full reset so neither neighbour has anything
+      // to pair against yet.
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter A
+      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_120, 'hold'), fp) // Ctrl/LT hold
+      buffer.addEvent(matrixEvent(0, 1, 0, 7, 1_300), fp) // letter B
+
+      const [snap] = buffer.drainAll()
+      expect(snap.bigrams.size).toBe(0)
+      expect(snap.bigrams.has('4_7')).toBe(false)
+    })
+
+    it('lets a tap event participate in the chain exactly like an unmarked event', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000, 'tap'), fp)
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_120, 'tap'), fp)
+
+      const [snap] = buffer.drainAll()
+      expect([...snap.bigrams.entries()]).toEqual([['4_11', [120]]])
+    })
+
+    it('still counts a hold toward keystrokes and matrix holdCount', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.keystrokes).toBe(1)
+      expect(snap.matrixCounts.get('1,0,0')).toEqual({
+        row: 1,
+        col: 0,
+        layer: 0,
+        keycode: 0x4015,
+        count: 1,
+        tapCount: 0,
+        holdCount: 1,
+      })
+    })
+
+    it('does not emit a trigram spanning a hold', () => {
+      const fp = fingerprint()
+      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // A
+      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // B, chain=[4,11]
+      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_200, 'hold'), fp) // hold resets chain
+      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp) // C, chain=[7] only
+
+      const [snap] = buffer.drainAll()
+      // Only the A-B pair survives; nothing pairs or triples through the hold.
+      expect([...snap.bigrams.entries()]).toEqual([['4_11', [100]]])
+      expect(snap.trigrams.size).toBe(0)
+    })
+  })
+
+  describe('drainClosed grace period', () => {
+    it('does not finalize a minute that ended less than the grace period ago', () => {
+      const fp = fingerprint()
+      buffer.addEvent(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
+      // "Now" is just past the minute boundary, well inside the grace window.
+      const closed = buffer.drainClosed(MINUTE_MS + 500)
+      expect(closed).toHaveLength(0)
+      expect(buffer.isEmpty()).toBe(false)
+    })
+
+    it('finalizes a minute once it ended longer ago than the grace period', () => {
+      const fp = fingerprint()
+      buffer.addEvent(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 1)
+      expect(closed).toHaveLength(1)
+      expect(closed[0].minuteTs).toBe(0)
+      expect(buffer.isEmpty()).toBe(true)
+    })
+
+    it('always exceeds MAX_TAP_HOLD_DEFER_MS, so a press deferred up to the cap always finds its minute still open', () => {
+      // Guards against the two constants drifting apart independently: the
+      // renderer never defers a press past MAX_TAP_HOLD_DEFER_MS, so the
+      // grace only needs to be strictly larger than that cap (plus jitter
+      // margin) — not sized off the keyboard's raw, unbounded TAPPING_TERM.
+      expect(DRAIN_CLOSE_GRACE_MS).toBeGreaterThan(MAX_TAP_HOLD_DEFER_MS)
+    })
+  })
+
   it('exposes an empty bigrams map when no matrix events arrived', () => {
     // Sanity check: the Map exists on every snapshot (downstream emit
     // layer relies on snapshot.bigrams.size, not optional access).
@@ -642,7 +759,8 @@ describe('MinuteBuffer', () => {
       buffer.addEvent(matrixEvent(0, 0, 0, 4, 500), fp) // minute 0
       buffer.addEvent(matrixEvent(0, 0, 0, 4, MINUTE_MS + 500), fp) // minute 1
       buffer.markAppName('VSCode')
-      const closed = buffer.drainClosed(MINUTE_MS)
+      // Past the grace window so minute 0 actually closes on this call.
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
       expect(closed).toHaveLength(1)
       expect(closed[0].appName).toBe('VSCode')
       // Open minute should still be available; tagging again should

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -71,12 +71,14 @@ export interface MatrixMinuteRow {
   layer: number
   keycode: number
   count: number
-  /** Portion of `count` attributed to a tap on the release edge for
-   * LT/MT keys. Defaults to 0 when the row came from a non-tap-hold
-   * press (older ingestion path, test fixtures, or still-held keys). */
+  /** Portion of `count` attributed to a tap for LT/MT keys, classified
+   * by release edge or by the renderer's deferred-emit deadline,
+   * whichever comes first. Defaults to 0 when the row came from a
+   * non-tap-hold press (older ingestion path, test fixtures, or a press
+   * not yet classified). */
   tapCount?: number
-  /** Portion of `count` attributed to a hold on the release edge.
-   * Defaults to 0 for the same reasons as `tapCount`. */
+  /** Portion of `count` attributed to a hold, by the same classification
+   * as `tapCount`. Defaults to 0 for the same reasons as `tapCount`. */
   holdCount?: number
   /** See {@link CharMinuteRow.appName}. */
   appName?: string | null
@@ -2811,7 +2813,8 @@ export class TypingAnalyticsDB {
       )
     }
     // v1 -> v2: Add tap_count / hold_count columns to the matrix
-    // rollups so LT/MT release-edge classification has somewhere to
+    // rollups so LT/MT tap/hold classification (by release edge or by
+    // the renderer's deferred-emit deadline) has somewhere to
     // accumulate. Existing rows default to 0, meaning "unclassified" —
     // the heatmap falls back to the total `count` when both are zero.
     if (fromVersion < 2) {

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -9,6 +9,7 @@ import type {
   TypingAnalyticsFingerprint,
 } from '../../shared/types/typing-analytics'
 import { canonicalScopeKey } from '../../shared/types/typing-analytics'
+import { MAX_TAP_HOLD_DEFER_MS } from '../../shared/qmk-settings-tapping-term'
 
 export const MINUTE_MS = 60_000
 
@@ -24,10 +25,38 @@ export const MINUTE_MS = 60_000
  * put multi-minute idles back into the interval statistics. */
 export const NGRAM_MAX_IKI_MS = 5000
 
+/** Margin added on top of {@link MAX_TAP_HOLD_DEFER_MS} to absorb IPC and
+ * timer scheduling jitter between the renderer's deadline firing and the
+ * event actually landing in this buffer (invoke round-trip, event-loop
+ * queueing, `resolveScope`'s cache-miss I/O). Not itself a bound on
+ * deferral — that's the cap; this only covers the trip after it fires. */
+const DRAIN_CLOSE_JITTER_MARGIN_MS = 1000
+
+/** Grace period `drainClosed` waits past a minute's wall-clock end before
+ * finalizing it. The renderer defers emitting an LT/MT press until it
+ * resolves as tap or hold — by its release edge, or by
+ * {@link MAX_TAP_HOLD_DEFER_MS} if the key is still held — so an event
+ * can still be in flight after its own minute has technically ended.
+ * Closing the buffer right at the boundary would land that event in a
+ * *second* snapshot for a minute already flushed. That second snapshot
+ * does not merge into the first: the flush path applies snapshots
+ * through the same last-writer-wins merge sync uses
+ * (`mergeMinuteStatsStmt`), so a late arrival *replaces* the minute's
+ * recorded totals instead of adding to them. Do not remove this margin
+ * to "close minutes sooner" — that reintroduces the overwrite.
+ *
+ * Derived from the cap (not chosen independently) so the two can never
+ * drift apart: the renderer is contractually bounded to
+ * MAX_TAP_HOLD_DEFER_MS regardless of the keyboard's configured
+ * TAPPING_TERM, so this only needs to cover that cap plus the jitter
+ * margin above — not the keyboard's raw (u16, up to 65535 ms) setting. */
+export const DRAIN_CLOSE_GRACE_MS = MAX_TAP_HOLD_DEFER_MS + DRAIN_CLOSE_JITTER_MARGIN_MS
+
 /** Per-cell aggregated counts. `count` is the total press count. `tapCount`
- * and `holdCount` break that down for LT/MT release-edge classifications;
- * non-tap-hold presses leave both at zero and the consumer treats
- * `count` as the fallback intensity. */
+ * and `holdCount` break that down for LT/MT presses, classified by
+ * release edge or by the renderer's deferred-emit deadline, whichever
+ * comes first; non-tap-hold presses leave both at zero and the consumer
+ * treats `count` as the fallback intensity. */
 export interface MatrixCellCounts {
   row: number
   col: number
@@ -174,7 +203,8 @@ export class MinuteBuffer {
   // recompute or re-check it — see recordNgramChain. Reset on minute
   // close so cross-minute pairs are dropped per the design (see
   // Plan-analyze-bigram.md — 0.3% loss accepted to keep the flush path
-  // simple).
+  // simple), and also reset on a tap-hold `hold` event so its neighbours
+  // are never joined into a pair through it (see addEvent).
   private k1Keycode: number | null = null
   private k2Keycode: number | null = null
   private k2Ts: number | null = null
@@ -227,7 +257,10 @@ export class MinuteBuffer {
     // lastEventMs backwards (which would corrupt activeMs) or leave
     // firstEventMs above the real outer window. Intervals from out-of-order
     // events are intentionally dropped — reconstructing them would require
-    // re-sorting every flush.
+    // re-sorting every flush. This guard is no longer expected to fire for
+    // tap-hold keys once the renderer emits in press order; it stays as the
+    // correct fallback for whatever genuinely out-of-order arrival still
+    // reaches here (e.g. IPC scheduling jitter), not as the normal path.
     if (event.ts > entry.lastEventMs) entry.lastEventMs = event.ts
     if (event.ts < entry.firstEventMs) entry.firstEventMs = event.ts
     entry.keystrokes += 1
@@ -249,7 +282,22 @@ export class MinuteBuffer {
         holdCount: (existing?.holdCount ?? 0) + holdDelta,
       })
 
-      this.recordNgramChain(entry, `${scopeId}|${runId}`, event.keycode, event.ts)
+      if (event.action === 'hold') {
+        // A hold is the user reaching for a layer or modifier, not a
+        // character in the typing stream — it must still count toward
+        // keystrokes/matrix/holdCount above, but it cannot become a link
+        // in the n-gram chain. The tempting shortcut is to just skip it
+        // and let its neighbours pair directly (letter -> letter across
+        // the hold), but that would fabricate a pair that was never
+        // typed consecutively: the user's actual sequence was
+        // letter -> [reach for Ctrl/Shift/LT] -> letter, not
+        // letter -> letter. So the chain resets to empty instead of
+        // skipping through — the next event starts a fresh chain with
+        // nothing to pair against yet.
+        this.resetBigramChain()
+      } else {
+        this.recordNgramChain(entry, `${scopeId}|${runId}`, event.keycode, event.ts)
+      }
     }
   }
 
@@ -335,13 +383,19 @@ export class MinuteBuffer {
     }
   }
 
-  /** Finalize and return every buffer entry whose minute is strictly older
-   * than the given boundary. Called on each event so closed minutes don't
-   * linger in memory. */
-  drainClosed(cutoffMinuteTs: number): MinuteSnapshot[] {
+  /** Finalize and return every buffer entry whose minute ended at least
+   * {@link DRAIN_CLOSE_GRACE_MS} ago. Called on each event so closed
+   * minutes don't linger in memory.
+   *
+   * `nowMs` is a real wall-clock timestamp, not a floored minute: the
+   * grace is a few seconds, so flooring it first would round the margin
+   * up to a whole extra minute and hold every minute in memory far
+   * longer than the deferred-emission window actually requires.
+   * Callers never add the grace themselves — they just pass `Date.now()`. */
+  drainClosed(nowMs: number): MinuteSnapshot[] {
     const closed: MinuteSnapshot[] = []
     for (const [key, entry] of this.buffers) {
-      if (entry.minuteTs < cutoffMinuteTs) {
+      if (entry.minuteTs + MINUTE_MS + DRAIN_CLOSE_GRACE_MS <= nowMs) {
         closed.push(finalize(entry))
         this.buffers.delete(key)
       }

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -1759,7 +1759,7 @@ async function doFlushPass(options: { final: boolean }): Promise<void> {
 
   const snapshots = options.final
     ? minuteBuffer.drainAll()
-    : minuteBuffer.drainClosed(Math.floor(Date.now() / MINUTE_MS) * MINUTE_MS)
+    : minuteBuffer.drainClosed(Date.now())
   const sessionsToWrite = pendingSessions.splice(0)
 
   if (snapshots.length === 0 && sessionsToWrite.length === 0) {

--- a/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useInputModes } from '../useInputModes'
+import { deserialize } from '../../../../shared/keycodes/keycodes'
 
 const mockTypingAnalyticsEvent = vi.fn<(event: unknown) => Promise<void>>()
 const mockTypingAnalyticsFlush = vi.fn<(uid: string) => Promise<void>>()
@@ -31,6 +32,17 @@ function buildKeymap(): Map<string, number> {
   // layer 0: (0,0) = 0x04 (KC_A basic keycode value)
   const m = new Map<string, number>()
   m.set('0,0,0', 0x04)
+  return m
+}
+
+/** A thumb tap-hold key at (0, 0) — LT1(KC_SPACE) — and a plain letter at
+ *  (0, 1). Pressing the thumb key alone leaves it unresolved (queued,
+ *  nothing emitted) until it releases, times out at the tapping term, or
+ *  resetMatrixPressTracking drains it directly. */
+function buildMaskedKeymap(): Map<string, number> {
+  const m = new Map<string, number>()
+  m.set('0,0,0', deserialize('LT1(KC_SPACE)'))
+  m.set('0,0,1', deserialize('KC_A'))
   return m
 }
 
@@ -173,7 +185,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
   })
 
-  it('calls typingAnalyticsFlush when recording transitions from on to off', () => {
+  it('calls typingAnalyticsFlush when recording transitions from on to off, after the drain lands', async () => {
     const { rerender } = renderHook(
       ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
         rows: 1,
@@ -191,8 +203,74 @@ describe('useInputModes — typing analytics dispatch', () => {
 
     rerender({ typingRecordEnabled: false })
 
+    // The flush is now requested only after resetMatrixPressTracking's
+    // drain promise resolves (blocker: an unawaited flush could otherwise
+    // be serviced before a drained event lands in main) — that resolution
+    // is a microtask, so it isn't visible until the queue drains.
+    expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
+    await act(async () => {
+      await Promise.resolve()
+    })
+
     expect(mockTypingAnalyticsFlush).toHaveBeenCalledTimes(1)
     expect(mockTypingAnalyticsFlush).toHaveBeenCalledWith(sampleKeyboard.uid)
+  })
+
+  it('does not request the flush until a still in-flight drained event settles in main', async () => {
+    // Regression for the blocker: main's ingestEvent does a real await
+    // (resolveScope) before an event reaches its minute buffer. If the
+    // flush were requested while that await is still pending, it could be
+    // serviced first, landing the drained event in a fresh buffer entry
+    // after the session it belonged to was already finalized. Simulate
+    // that in-flight await by holding typingAnalyticsEvent's promise open
+    // until the test resolves it explicitly.
+    let resolveEvent: (() => void) | undefined
+    mockTypingAnalyticsEvent.mockImplementation(() => new Promise((resolve) => {
+      resolveEvent = resolve
+    }))
+    const keymap = buildMaskedKeymap()
+
+    const { result, rerender } = renderHook(
+      ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
+        rows: 1,
+        cols: 2,
+        keymap,
+        typingTestMode: true,
+        typingTestViewOnly: true,
+        typingRecordKeyboard: sampleKeyboard,
+        typingRecordEnabled,
+      }),
+      { initialProps: { typingRecordEnabled: true } },
+    )
+
+    // Thumb key pressed and left unresolved — sitting in the queue.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+
+    // Recording stops mid-hold: the drain finalizes the press and calls
+    // typingAnalyticsEvent, but that call's own promise is still pending.
+    rerender({ typingRecordEnabled: false })
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
+
+    // Letting microtasks drain without resolving the event must NOT let
+    // the flush through — it is chained behind the drain, not the
+    // recordingActive transition alone.
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
+
+    // Only once the drained event actually settles may the flush fire.
+    resolveEvent?.()
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(mockTypingAnalyticsFlush).toHaveBeenCalledTimes(1)
   })
 
   it('swallows IPC rejection silently (fire-and-forget)', async () => {
@@ -208,5 +286,164 @@ describe('useInputModes — typing analytics dispatch', () => {
 
     process.off('unhandledRejection', handler)
     expect(handler).not.toHaveBeenCalled()
+  })
+})
+
+// A matrix event can now sit in useTypingTest's ordering queue for up to
+// the tapping term (queued behind an unresolved masked press) before it
+// reaches the sink. These cover that the gate/tag decision is pinned to
+// press time — the moment recordingActiveRef/testLabelRef/testRunIdRef
+// were read to authorize the press — and is never revisited once the
+// event is actually flushed, however much the live state has since moved.
+describe('useInputModes — analytics gate/tag survive the ordering queue', () => {
+  it('still delivers an unresolved masked press (as hold) and the ordinary key queued behind it when recording stops mid-hold', () => {
+    const keymap = buildMaskedKeymap()
+    const { result, rerender } = renderHook(
+      ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
+        rows: 1,
+        cols: 2,
+        keymap,
+        typingTestMode: true,
+        typingTestViewOnly: true,
+        typingRecordKeyboard: sampleKeyboard,
+        typingRecordEnabled,
+      }),
+      { initialProps: { typingRecordEnabled: true } },
+    )
+
+    // Thumb key (masked tap-hold) pressed first — unresolved, so nothing
+    // is emitted yet; it sits at the head of the ordering queue.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    // A normal key rolls in behind it before the thumb key resolves — it
+    // must queue rather than emit, to preserve press order.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0', '0,1']), keymap)
+    })
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+
+    // Recording stops while the masked press is still unresolved. Both
+    // queued events were authorized when they were pressed (recording was
+    // on then) and must still reach the sink, in press order — dropping
+    // them here would be strictly worse than not queueing at all.
+    rerender({ typingRecordEnabled: false })
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
+    expect(mockTypingAnalyticsEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      kind: 'matrix', row: 0, col: 0, action: 'hold', keyboard: sampleKeyboard,
+    }))
+    expect(mockTypingAnalyticsEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      kind: 'matrix', row: 0, col: 1, keyboard: sampleKeyboard,
+    }))
+  })
+
+  it("keeps a running test's label and run id when the press is flushed after the test view is exited", () => {
+    const keymap = buildMaskedKeymap()
+    const { result, rerender } = renderHook(
+      ({ typingTestViewOnly }: { typingTestViewOnly: boolean }) => useInputModes({
+        rows: 1,
+        cols: 2,
+        keymap,
+        typingTestMode: true,
+        typingTestViewOnly,
+        typingRecordKeyboard: sampleKeyboard,
+        typingRecordEnabled: false,
+        savedTypingTestConfig: { mode: 'time', duration: 30, punctuation: false, numbers: false },
+      }),
+      { initialProps: { typingTestViewOnly: false } },
+    )
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    // First char transitions waiting -> running (untagged, per existing
+    // coverage above); the test is now the active, tagged input source.
+    act(() => {
+      result.current.typingTest.processKeyEvent('a', false, false, false)
+    })
+    const runId = result.current.typingTest.state.runId
+
+    // The thumb key is pressed while the test is running and tagged — this
+    // is the moment its context must be captured; it stays unresolved.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+
+    // The editor test view is exited before the press resolves. testLabelRef
+    // now reads null (this is no longer the tagged editor-test source) —
+    // that must not retroactively strip or drop this already-queued press.
+    rerender({ typingTestViewOnly: true })
+
+    // A quick release classifies it as a tap and flushes the queue.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'matrix', row: 0, col: 0, action: 'tap', runId, typingTest: expect.any(String),
+    }))
+  })
+})
+
+describe('useInputModes — tray keystroke counter', () => {
+  it('counts an authorized matrix press at press time, once — before it resolves and again not when it does', () => {
+    const keymap = buildMaskedKeymap()
+    const onRecKeystroke = vi.fn()
+    const { result } = renderUseInputModes({ typingRecordEnabled: true, keymap, onRecKeystroke })
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    // Not yet resolved — still queued, nothing shipped to analytics — but
+    // the tray count must not lag behind the physical press by the tapping
+    // term, so it already fired.
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+    expect(onRecKeystroke).toHaveBeenCalledTimes(1)
+
+    // The release resolves and flushes the queued event; the counter must
+    // not fire a second time for the same press.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(onRecKeystroke).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not count a press that is not authorized (recording disabled)', () => {
+    const onRecKeystroke = vi.fn()
+    const { result } = renderUseInputModes({ typingRecordEnabled: false, onRecKeystroke })
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+    expect(onRecKeystroke).not.toHaveBeenCalled()
+  })
+
+  it('does not count a tagged editor-test keystroke (only untagged REC input counts)', () => {
+    const onRecKeystroke = vi.fn()
+    const { result } = renderUseInputModes({
+      typingRecordEnabled: false,
+      typingTestViewOnly: false,
+      onRecKeystroke,
+      savedTypingTestConfig: { mode: 'time', duration: 30, punctuation: false, numbers: false },
+    })
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    act(() => {
+      result.current.typingTest.processKeyEvent('a', false, false, false)
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({ typingTest: expect.any(String) }))
+    expect(onRecKeystroke).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -28,6 +28,16 @@ function typingTestAnalyticsLabel(
   return materialLabel(config.mode, effectiveLanguage, currentQuote?.source)
 }
 
+/** Context captured by prepareAnalyticsEvent at press time and carried
+ *  opaquely through useTypingTest's ordering queue to emitAnalyticsEvent.
+ *  `typingTest`/`runId` are null for ordinary REC input (untagged); an
+ *  editor typing-test keystroke always has both set together. */
+interface PreparedAnalyticsContext {
+  keyboard: TypingAnalyticsKeyboard
+  typingTest: string | null
+  runId: string | null
+}
+
 export interface UseInputModesOptions {
   rows?: number
   cols?: number
@@ -215,26 +225,59 @@ export function useInputModes({
   const testRunIdRef = useRef<string | null>(null)
   const onRecKeystrokeRef = useRef(onRecKeystroke)
   onRecKeystrokeRef.current = onRecKeystroke
-  const analyticsSink = useCallback((payload: TypingAnalyticsEventPayload) => {
+  // The sink used to read recordingActiveRef / testLabelRef / testRunIdRef
+  // at the moment an event was actually sent, but a matrix event can now
+  // sit in useTypingTest's ordering queue for up to the tapping term
+  // (waiting on an unresolved tap-hold press ahead of it) before it gets
+  // that far. Reading live state that late meant a press authorized and
+  // tagged at press time could be silently dropped, or mistagged, by
+  // whatever the state had become by the time it was flushed — most
+  // visibly, stopping the record toggle mid-hold discarded every queued
+  // event instead of just the one it was meant to finalize.
+  //
+  // Splitting into prepare (called once, at press time) + emit (called
+  // once the event is actually ready to ship, immediately or off the
+  // back of the queue) fixes that: prepare captures the gate + tag
+  // decision when the keystroke happens and hands back an opaque
+  // context; emit only ever ships what prepare already decided.
+  const prepareAnalyticsEvent = useCallback((kind: 'matrix' | 'char'): PreparedAnalyticsContext | null => {
     const keyboard = keyboardRef.current
-    if (!keyboard) return
+    if (!keyboard) return null
     const label = testLabelRef.current
-    if (!recordingActiveRef.current && !label) return
-    // A test keystroke carries both its material label and its run id; REC
-    // input carries neither (so it lands as the null run / null test).
-    const event = label
-      ? { ...payload, keyboard, typingTest: label, runId: testRunIdRef.current ?? undefined }
-      : { ...payload, keyboard }
+    if (!recordingActiveRef.current && !label) return null
     // Tray keystroke count tracks REC only (untagged matrix events), not
     // the editor typing-test practice mode — matches recordingActive's
     // narrower definition (typingRecordEnabled && typingTestViewOnly).
-    if (!label && payload.kind === 'matrix') {
+    // Counted here, at press time, rather than when the event eventually
+    // leaves the queue: the count is a live tray readout of physical
+    // keystrokes, and a masked key can otherwise sit unresolved for up to
+    // the tapping term before its emit — the user would see the tray lag
+    // behind their own typing. Firing once per authorized press here
+    // matches the previous call frequency (once per event that used to
+    // reach the sink) without that lag, and can't double-fire or fire for
+    // an unauthorized press since this whole branch is unreachable when
+    // this function returns null above.
+    if (!label && kind === 'matrix') {
       onRecKeystrokeRef.current?.()
     }
-    window.vialAPI.typingAnalyticsEvent(event).catch(() => { /* fire-and-forget */ })
+    // A test keystroke carries both its material label and its run id; REC
+    // input carries neither (so it lands as the null run / null test).
+    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null }
+  }, [])
+  const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
+    const event = context.typingTest
+      ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
+      : { ...payload, keyboard: context.keyboard }
+    // The return value is only ever awaited by a forced drain
+    // (MatrixAnalyticsQueue.drainAll, via resetMatrixPressTracking) — the
+    // ordinary press/release/deadline paths call this and ignore it,
+    // staying fire-and-forget same as before. Caught here (not left to
+    // the caller) so a drain's Promise.all never rejects on an IPC error.
+    return window.vialAPI.typingAnalyticsEvent(event).catch(() => { /* fire-and-forget */ })
   }, [])
   const typingTest = useTypingTest(savedTypingTestConfig, savedTypingTestLanguage, {
-    onAnalyticsEvent: analyticsSink,
+    onPrepareAnalyticsEvent: prepareAnalyticsEvent,
+    onEmitAnalyticsEvent: emitAnalyticsEvent,
     tappingTermMs,
   })
   const {
@@ -336,13 +379,23 @@ export function useInputModes({
 
   // Reset matrix press-edge tracking when keymap changes or recording toggles
   // so the next frame doesn't emit stale press events against an old state.
+  // The drain's completion promise is captured so the record-off effect
+  // below can await the *same* drain instead of triggering (and racing) a
+  // second one — see pendingDrainRef's use there.
+  const pendingDrainRef = useRef<Promise<void>>(Promise.resolve())
   useEffect(() => {
-    resetMatrixPressTracking()
+    pendingDrainRef.current = resetMatrixPressTracking()
   }, [keymap, recordingActive, resetMatrixPressTracking])
 
   // When recording transitions off (either the toggle flips or the user
   // leaves view-only mode), finalize the open session in main and flush
-  // its data for the active keyboard.
+  // its data for the active keyboard. Must wait for the drain the effect
+  // above just kicked off (same recordingActive dependency, so it always
+  // runs first in this commit) to actually land in main before asking it
+  // to flush — main's ingestEvent does a real await before an event
+  // reaches its minute buffer, so an unawaited flush can be serviced
+  // before a just-drained event arrives, landing that event in a fresh
+  // buffer entry after the session it belonged to was already finalized.
   const prevRecordingActiveRef = useRef(recordingActive)
   useEffect(() => {
     const wasOn = prevRecordingActiveRef.current
@@ -350,7 +403,10 @@ export function useInputModes({
     if (wasOn && !recordingActive) {
       const uid = typingRecordKeyboard?.uid
       if (uid) {
-        window.vialAPI.typingAnalyticsFlush(uid).catch(() => { /* fire-and-forget */ })
+        const drained = pendingDrainRef.current
+        void drained
+          .then(() => window.vialAPI.typingAnalyticsFlush(uid))
+          .catch(() => { /* fire-and-forget */ })
       }
     }
   }, [recordingActive, typingRecordKeyboard])
@@ -417,9 +473,18 @@ export function useInputModes({
       // Flush the test's analytics so the just-finished minute/session
       // lands in the cache promptly (Analyze can show it without waiting
       // for the minute-close / before-quit flush). Keystrokes are recorded
-      // regardless of whether the result row is saved.
+      // regardless of whether the result row is saved. Drain first (same
+      // reasoning as the record-off flush above): a masked key pressed
+      // near the end of the run may still be sitting unresolved in the
+      // ordering queue, and requesting the flush before it lands in main
+      // would land it in a fresh buffer entry after this run's session
+      // was already finalized.
       const uid = keyboardRef.current?.uid
-      if (uid) window.vialAPI.typingAnalyticsFlush(uid).catch(() => { /* fire-and-forget */ })
+      if (uid) {
+        resetMatrixPressTracking()
+          .then(() => window.vialAPI.typingAnalyticsFlush(uid))
+          .catch(() => { /* fire-and-forget */ })
+      }
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }
@@ -435,7 +500,8 @@ export function useInputModes({
     typingTest.state.currentQuote, typingTest.state.runId, typingTest.state.romajiCapable,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
-    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult])
+    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
+    resetMatrixPressTracking])
 
   // The just-finished result, exposed so the pane can build name chips: the
   // held unsaved one (save-unnamed off) until named, else the saved latest.

--- a/src/renderer/typing-test/__tests__/useTypingTest.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.test.ts
@@ -5,7 +5,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useTypingTest } from '../useTypingTest'
 import { deserialize } from '../../../shared/keycodes/keycodes'
+import { MAX_TAP_HOLD_DEFER_MS } from '../../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig } from '../types'
+import type { TypingAnalyticsEventPayload } from '../../../shared/types/typing-analytics'
 
 function buildMultiLayerKeymap(layers: Array<{ layer: number; entries: Array<[number, number, string]> }>): Map<string, number> {
   const m = new Map<string, number>()
@@ -19,6 +21,21 @@ function buildMultiLayerKeymap(layers: Array<{ layer: number; entries: Array<[nu
 
 function pressKeys(keys: string[]): Set<string> {
   return new Set(keys)
+}
+
+/** useTypingTest's analytics options now split gate/tag (prepare, at press
+ *  time) from shipping (emit, once the item is ready to leave the ordering
+ *  queue) — see UseTypingTestOptions. These tests only exercise
+ *  useTypingTest's own queueing/ordering/tap-hold logic, not the gating a
+ *  real caller (useInputModes) layers on top, so prepare here always
+ *  authorizes (opaque token `true`) and emit forwards the bare payload —
+ *  reproducing the single-argument `sink(payload)` shape these tests were
+ *  written against. */
+function analyticsOptions(sink: (payload: TypingAnalyticsEventPayload) => void) {
+  return {
+    onPrepareAnalyticsEvent: () => true,
+    onEmitAnalyticsEvent: (_prepared: unknown, event: TypingAnalyticsEventPayload) => sink(event),
+  }
 }
 
 describe('useTypingTest', () => {
@@ -970,7 +987,7 @@ describe('useTypingTest windowFocused', () => {
   describe('analytics sink', () => {
     it('emits a char event for printable keys when a sink is provided', () => {
       const sink = vi.fn()
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.processKeyEvent('a', false, false, false))
 
@@ -980,7 +997,7 @@ describe('useTypingTest windowFocused', () => {
 
     it('emits a char event for Backspace', () => {
       const sink = vi.fn()
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.processKeyEvent('a', false, false, false))
       act(() => result.current.processKeyEvent('Backspace', false, false, false))
@@ -990,7 +1007,7 @@ describe('useTypingTest windowFocused', () => {
 
     it('does not emit char events for modifier-only keys', () => {
       const sink = vi.fn()
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.processKeyEvent('Shift', false, false, false))
       act(() => result.current.processKeyEvent('Control', false, false, false))
@@ -1001,7 +1018,7 @@ describe('useTypingTest windowFocused', () => {
 
     it('does not emit char events when the window is not focused', () => {
       const sink = vi.fn()
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.setWindowFocused(false))
       act(() => result.current.processKeyEvent('a', false, false, false))
@@ -1014,7 +1031,7 @@ describe('useTypingTest windowFocused', () => {
       const keymap = buildMultiLayerKeymap([
         { layer: 0, entries: [[0, 0, 'KC_A'], [0, 1, 'KC_B']] },
       ])
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
       expect(sink).toHaveBeenCalledTimes(1)
@@ -1037,7 +1054,7 @@ describe('useTypingTest windowFocused', () => {
       const keymap = buildMultiLayerKeymap([
         { layer: 0, entries: [[0, 0, 'KC_A']] },
       ])
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.setWindowFocused(false))
       act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1050,7 +1067,7 @@ describe('useTypingTest windowFocused', () => {
       const keymap = buildMultiLayerKeymap([
         { layer: 0, entries: [[0, 0, 'KC_A']] },
       ])
-      const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
       act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
       expect(sink).toHaveBeenCalledTimes(1)
@@ -1059,7 +1076,11 @@ describe('useTypingTest windowFocused', () => {
       act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
       expect(sink).toHaveBeenCalledTimes(1)
 
-      act(() => result.current.resetMatrixPressTracking())
+      // resetMatrixPressTracking now returns a promise (so a record-off
+      // caller can await the drain before flushing) — void it here since
+      // this test only cares about the synchronous reset of prevPressed,
+      // which happens before the promise settles.
+      act(() => { void result.current.resetMatrixPressTracking() })
       act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
       expect(sink).toHaveBeenCalledTimes(2)
     })
@@ -1071,13 +1092,13 @@ describe('useTypingTest windowFocused', () => {
     })
 
     describe('masked-key tap/hold classification', () => {
-      it('defers the matrix emit for masked keys until the release edge', () => {
+      it('defers the matrix emit for masked keys until they resolve (release or deadline)', () => {
         const sink = vi.fn()
         // LT1(KC_SPACE) on (0, 0), plain KC_A on (0, 1).
         const keymap = buildMultiLayerKeymap([
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)'], [0, 1, 'KC_A']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1090,7 +1111,7 @@ describe('useTypingTest windowFocused', () => {
         const keymap = buildMultiLayerKeymap([
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1107,17 +1128,76 @@ describe('useTypingTest windowFocused', () => {
         }))
       })
 
-      it('classifies a long press as a hold on the release edge', () => {
+      it('classifies a still-held key as a hold once its deadline passes, without waiting for release', () => {
         const sink = vi.fn()
         const keymap = buildMultiLayerKeymap([
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
 
-        vi.advanceTimersByTime(500)
+        // Nothing releases the key — the deadline timer alone must fire the
+        // 'hold' classification while it's still held.
+        act(() => vi.advanceTimersByTime(500))
+
+        expect(sink).toHaveBeenCalledTimes(1)
+        expect(sink).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'matrix',
+          action: 'hold',
+        }))
+
+        // The eventual physical release must not re-emit — the deadline
+        // already resolved and removed this press.
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+        expect(sink).toHaveBeenCalledTimes(1)
+      })
+
+      it('resolves a still-held key as hold at MAX_TAP_HOLD_DEFER_MS even when TAPPING_TERM is configured larger', () => {
+        // A TAPPING_TERM above the cap is the accepted trade-off documented
+        // on MAX_TAP_HOLD_DEFER_MS: the deferred-emit deadline must never
+        // exceed the cap, so a genuine (if unusually long) tap held past
+        // the cap resolves as a hold before the keyboard's own TAPPING_TERM
+        // would have fired.
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
+        ])
+        const largeTerm = MAX_TAP_HOLD_DEFER_MS + 2000
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: largeTerm }))
+
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+        // Still unresolved just short of the cap.
+        act(() => vi.advanceTimersByTime(MAX_TAP_HOLD_DEFER_MS - 1))
+        expect(sink).not.toHaveBeenCalled()
+
+        // Crossing the cap resolves it as hold — well before largeTerm.
+        act(() => vi.advanceTimersByTime(1))
+        expect(sink).toHaveBeenCalledTimes(1)
+        expect(sink).toHaveBeenCalledWith(expect.objectContaining({
+          kind: 'matrix',
+          action: 'hold',
+        }))
+      })
+
+      it('resolves duration === tappingTermMs as hold (boundary matches the pre-queue duration < term comparison)', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
+        ])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
+
+        const pressAt = new Date('2026-04-18T10:00:00.000Z')
+        vi.setSystemTime(pressAt)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+        // Move the clock to exactly the deadline WITHOUT advancing fake
+        // timers, so the deadline timer itself never fires — this exercises
+        // the release-edge duration comparison, not the timer fallback.
+        vi.setSystemTime(new Date(pressAt.getTime() + 200))
         act(() => result.current.processMatrixFrame(new Set(), keymap))
 
         expect(sink).toHaveBeenCalledTimes(1)
@@ -1132,7 +1212,7 @@ describe('useTypingTest windowFocused', () => {
         const keymap = buildMultiLayerKeymap([
           { layer: 0, entries: [[0, 0, 'KC_A']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1146,18 +1226,118 @@ describe('useTypingTest windowFocused', () => {
         expect(sink).toHaveBeenCalledTimes(1)
       })
 
-      it('resetMatrixPressTracking drops pending masked-key starts so no event fires on the next release', () => {
+      it('resetMatrixPressTracking finalizes a pending masked-key press as hold and flushes the queue behind it, losing nothing', () => {
+        const sink = vi.fn()
+        // LT1(KC_SPACE) on (0, 0), plain KC_A on (0, 1).
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)'], [0, 1, 'KC_A']] },
+        ])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
+
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+        // A normal key pressed while the masked press is unresolved queues
+        // behind it instead of emitting — nothing has been sent yet.
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0', '0,1']), keymap))
+        expect(sink).not.toHaveBeenCalled()
+
+        // Recording stops mid-hold — both the masked press and the queued
+        // key behind it must still reach the sink, in press order. Void
+        // the returned promise — see the earlier reset test for why.
+        act(() => { void result.current.resetMatrixPressTracking() })
+
+        expect(sink).toHaveBeenCalledTimes(2)
+        expect(sink).toHaveBeenNthCalledWith(1, expect.objectContaining({
+          kind: 'matrix', row: 0, col: 0, action: 'hold',
+        }))
+        const [, letterPayload] = sink.mock.calls.map((c) => c[0] as { row: number; col: number; action?: string })
+        expect(letterPayload.row).toBe(0)
+        expect(letterPayload.col).toBe(1)
+        expect(letterPayload.action).toBeUndefined()
+
+        // The physical release that eventually arrives must not re-emit.
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+        expect(sink).toHaveBeenCalledTimes(2)
+      })
+
+      it('clears the pending deadline timer on unmount so it cannot fire against a torn-down hook', () => {
         const sink = vi.fn()
         const keymap = buildMultiLayerKeymap([
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result, unmount } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
-        act(() => result.current.resetMatrixPressTracking())
-        act(() => result.current.processMatrixFrame(new Set(), keymap))
-
         expect(sink).not.toHaveBeenCalled()
+
+        unmount()
+
+        // The deadline timer that would have fired at +200ms must never
+        // call back into a hook that has already torn down.
+        act(() => vi.advanceTimersByTime(500))
+        expect(sink).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('press-order emission across an unresolved tap-hold', () => {
+      it('emits a quickly-tapped masked key before a later letter, in press order', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)'], [0, 1, 'KC_A']] },
+        ])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
+
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+        vi.advanceTimersByTime(50)
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+        expect(sink).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(50)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,1']), keymap))
+
+        expect(sink).toHaveBeenCalledTimes(2)
+        expect(sink).toHaveBeenNthCalledWith(1, expect.objectContaining({ row: 0, col: 0, action: 'tap' }))
+        const letterPayload = sink.mock.calls[1][0] as { row: number; col: number; action?: string }
+        expect(letterPayload.row).toBe(0)
+        expect(letterPayload.col).toBe(1)
+        expect(letterPayload.action).toBeUndefined()
+      })
+
+      it('a normal key pressed while a masked key is unresolved is not emitted before it, even when overlapping (rolled keys)', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)'], [0, 1, 'KC_A']] },
+        ])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
+
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        // Thumb LT1(KC_SPACE) pressed first.
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+        // The next letter is pressed BEFORE the thumb key releases (an
+        // ordinary fast roll) — it must queue, not emit.
+        vi.advanceTimersByTime(30)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0', '0,1']), keymap))
+        expect(sink).not.toHaveBeenCalled()
+
+        // The thumb key releases as a tap. Both events land now, still
+        // ordered by press time — the masked key (pressed first) before
+        // the letter (pressed second), even though the letter's release
+        // resolved earlier in wall-clock terms than nothing did (the
+        // letter itself never had a release edge, only a press).
+        vi.advanceTimersByTime(30)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,1']), keymap))
+
+        expect(sink).toHaveBeenCalledTimes(2)
+        expect(sink).toHaveBeenNthCalledWith(1, expect.objectContaining({ row: 0, col: 0, action: 'tap' }))
+        const letterPayload = sink.mock.calls[1][0] as { row: number; col: number; action?: string; ts: number }
+        expect(letterPayload.row).toBe(0)
+        expect(letterPayload.col).toBe(1)
+        expect(letterPayload.action).toBeUndefined()
+        const tapHoldPayload = sink.mock.calls[0][0] as { ts: number }
+        expect(tapHoldPayload.ts).toBeLessThan(letterPayload.ts)
       })
     })
 
@@ -1169,7 +1349,7 @@ describe('useTypingTest windowFocused', () => {
           { layer: 0, entries: [[0, 0, 'MO(1)']] },
           { layer: 1, entries: [[0, 0, 'KC_TRNS']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1190,7 +1370,7 @@ describe('useTypingTest windowFocused', () => {
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
           { layer: 1, entries: [[0, 0, 'KC_TRNS']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1210,7 +1390,7 @@ describe('useTypingTest windowFocused', () => {
           { layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] },
           { layer: 1, entries: [[0, 0, 'KC_TRNS']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink, tappingTermMs: 200 }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink), tappingTermMs: 200 }))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1235,7 +1415,7 @@ describe('useTypingTest windowFocused', () => {
           { layer: 0, entries: [[0, 0, 'MO(1)']] },
           { layer: 1, entries: [[0, 0, 'MO(1)']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
@@ -1255,7 +1435,7 @@ describe('useTypingTest windowFocused', () => {
           { layer: 0, entries: [[0, 0, 'MO(1)'], [1, 1, 'KC_TRNS']] },
           { layer: 1, entries: [[0, 0, 'KC_TRNS'], [1, 1, 'KC_A']] },
         ])
-        const { result } = renderHook(() => useTypingTest(undefined, undefined, { onAnalyticsEvent: sink }))
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
 
         vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
         act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))

--- a/src/renderer/typing-test/keycode-char-map.ts
+++ b/src/renderer/typing-test/keycode-char-map.ts
@@ -82,8 +82,9 @@ export function extractLMLayer(code: number): number | null {
 
 /** Check whether a code falls in the LT or MT keycode ranges (v5 & v6).
  * Exported so the typing-view tap/hold detector can distinguish LT/MT
- * presses (which need release-edge timing) from non-tap masked keys
- * like LSFT(kc) that fire together without a tap/hold ambiguity. */
+ * presses (which need release-edge-or-deadline timing to classify as
+ * tap vs hold) from non-tap masked keys like LSFT(kc) that fire together
+ * without a tap/hold ambiguity. */
 export function isTapKeycode(code: number): boolean {
   // LT (Layer Tap): 0x4000–0x4FFF (both v5 and v6)
   if ((code & 0xf000) === 0x4000) return true

--- a/src/renderer/typing-test/matrix-analytics-queue.ts
+++ b/src/renderer/typing-test/matrix-analytics-queue.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Press-order emission queue for matrix analytics events. Serves every
+ *  matrix recording path (typing test, ambient REC, anything else that
+ *  feeds processMatrixFrame-shaped presses into analytics) — nothing here
+ *  is specific to a typing test.
+ *
+ *  It exists because tap-hold keys (LT/MT) don't resolve to a tap/hold
+ *  classification until their release edge or their deferred-emit
+ *  deadline, whichever comes first — and either can land later than
+ *  physical presses that follow it. Emitting those later presses
+ *  immediately would hand the main-process n-gram aggregator a masked
+ *  key's event stamped with an earlier timestamp than events already
+ *  emitted for what came after it; the aggregator treats a
+ *  non-increasing timestamp as out of order and silently drops it,
+ *  losing the masked key from every pair around it. Queuing every press
+ *  behind an unresolved one and draining in order once it resolves keeps
+ *  the emitted stream monotonic.
+ *
+ *  {@link MatrixAnalyticsQueue} is the module's public surface: it owns
+ *  the queue array itself so callers deal in named operations (push a
+ *  resolved press, push a pending tap-hold, resolve one by key, drain
+ *  everything on teardown) rather than holding a bare array and knowing
+ *  how ordering/draining works. */
+
+import type { TypingAnalyticsEventPayload, TypingMatrixAction } from '../../shared/types/typing-analytics'
+import { MAX_TAP_HOLD_DEFER_MS } from '../../shared/qmk-settings-tapping-term'
+import type { PressStartRecord } from './matrix-layers'
+
+/** `emit` may hand back a promise the caller can wait on (used by
+ * {@link MatrixAnalyticsQueue.drainAll} so a forced teardown drain can be
+ * awaited all the way into main) or nothing at all (the normal
+ * press/release/deadline paths stay fire-and-forget — nobody downstream
+ * needs to know when those land). */
+type Emit<TPreparedEvent> = (prepared: TPreparedEvent, event: TypingAnalyticsEventPayload) => void | Promise<void>
+
+/** One entry in the press-order matrix-event queue. Ordinary keys are
+ * queued only when they land behind a still-unresolved tap-hold press;
+ * `event` is already populated for them at push time. A tap-hold press
+ * starts with `event: null` and `pending` set, and gets its `event`
+ * filled in — by the release edge or by the deadline timer, whichever
+ * comes first — without ever moving position in the queue, so press
+ * order survives resolution happening out of press order.
+ *
+ * `prepared` is the opaque value onPrepareAnalyticsEvent returned at
+ * press time (gate + tag already decided then); it travels with the
+ * item untouched and is handed back to onEmitAnalyticsEvent once the
+ * item is ready to ship, so a flush that happens later — possibly
+ * after the state that authorized it has changed — still ships with
+ * the context that was live at press time. */
+interface QueuedMatrixItem<TPreparedEvent> {
+  event: TypingAnalyticsEventPayload | null
+  prepared: TPreparedEvent
+  pending?: {
+    key: string
+    start: PressStartRecord
+    /** TAPPING_TERM captured at press time. */
+    tappingTermMs: number
+    timer: ReturnType<typeof setTimeout>
+  }
+}
+
+/** Emit every queued item whose event is ready, stopping at the first
+ * still-unresolved press (or an empty queue). Called both right after a
+ * press/release edge and from the deadline timer, since either can be
+ * what makes the front of the queue ready. */
+function flushMatrixQueue<TPreparedEvent>(
+  queue: QueuedMatrixItem<TPreparedEvent>[],
+  emit: Emit<TPreparedEvent> | undefined,
+): void {
+  while (queue.length > 0 && queue[0].event !== null) {
+    const item = queue.shift()!
+    emit?.(item.prepared, item.event!)
+  }
+}
+
+/** Settle a pending tap-hold into the event it should ship as. Shared so
+ * the release edge, the deadline timer and the teardown drain all build
+ * the same payload — a field added to one of them can't drift. */
+function settleTapHold<TPreparedEvent>(
+  item: QueuedMatrixItem<TPreparedEvent>,
+  pending: NonNullable<QueuedMatrixItem<TPreparedEvent>['pending']>,
+  action: TypingMatrixAction,
+): void {
+  clearTimeout(pending.timer)
+  item.event = {
+    kind: 'matrix',
+    row: pending.start.row,
+    col: pending.start.col,
+    layer: pending.start.layer,
+    keycode: pending.start.keycode,
+    ts: pending.start.tsMs,
+    action,
+  }
+  item.pending = undefined
+}
+
+/** Classify a still-pending tap-hold entry and let the queue drain past
+ * it. A no-op if it was already resolved by the other path (release vs.
+ * deadline racing) or already drained (e.g. resetMatrixPressTracking ran
+ * first) — `pending` is cleared exactly once, by whichever resolves it. */
+function resolveQueuedTapHold<TPreparedEvent>(
+  item: QueuedMatrixItem<TPreparedEvent>,
+  action: TypingMatrixAction,
+  queue: QueuedMatrixItem<TPreparedEvent>[],
+  emit: Emit<TPreparedEvent> | undefined,
+): void {
+  const pending = item.pending
+  if (!pending) return
+  settleTapHold(item, pending, action)
+  flushMatrixQueue(queue, emit)
+}
+
+/** The queue entry still waiting on the release of `key`, if any. Scanned
+ * rather than indexed by a second map: the queue only holds presses from
+ * the last tapping-term window, so it is a handful of items at most, and
+ * one source of truth cannot fall out of sync with itself. */
+function findPendingByKey<TPreparedEvent>(
+  queue: readonly QueuedMatrixItem<TPreparedEvent>[],
+  key: string,
+): QueuedMatrixItem<TPreparedEvent> | undefined {
+  return queue.find((item) => item.pending?.key === key)
+}
+
+/** Owning type for the press-order matrix analytics queue. One instance
+ * per recording session, held in a ref by the caller (e.g.
+ * `useTypingTest`); its methods are the only thing that touches the
+ * queue's internals, so the caller never needs to know it's backed by an
+ * array or how draining preserves order. */
+export class MatrixAnalyticsQueue<TPreparedEvent> {
+  private readonly items: QueuedMatrixItem<TPreparedEvent>[] = []
+
+  /** Whether anything is still waiting to be emitted. A resolved press
+   * can skip the queue entirely and emit straight away when this is
+   * empty — see {@link pushResolved}'s caller. */
+  get isEmpty(): boolean {
+    return this.items.length === 0
+  }
+
+  /** Push an already-resolved (non-masked) press onto the back of the
+   * queue, behind whatever is still unresolved ahead of it. */
+  pushResolved(event: TypingAnalyticsEventPayload, prepared: TPreparedEvent): void {
+    this.items.push({ event, prepared })
+  }
+
+  /** Push a tap-hold press awaiting classification, and arm the deadline
+   * timer that resolves it as `hold` if the release edge doesn't arrive
+   * first. The timer itself never waits longer than
+   * {@link MAX_TAP_HOLD_DEFER_MS}, regardless of `tappingTermMs` — see
+   * that constant's doc comment for the misclassify-vs-corrupt trade-off
+   * this caps. `tappingTermMs` is still stored and used uncapped for the
+   * release-edge tap/hold comparison in {@link resolveReleaseByKey}: a
+   * release arriving before the (possibly capped) deadline fires is
+   * always compared against the real configured term. */
+  pushPending(
+    prepared: TPreparedEvent,
+    start: PressStartRecord,
+    key: string,
+    tappingTermMs: number,
+    emit: Emit<TPreparedEvent> | undefined,
+  ): void {
+    const item: QueuedMatrixItem<TPreparedEvent> = { event: null, prepared }
+    const deferMs = Math.min(tappingTermMs, MAX_TAP_HOLD_DEFER_MS)
+    const timer = setTimeout(() => {
+      resolveQueuedTapHold(item, 'hold', this.items, emit)
+    }, deferMs)
+    item.pending = { key, start, tappingTermMs, timer }
+    this.items.push(item)
+  }
+
+  /** Resolve the release edge for `key` against its still-pending entry,
+   * if any, classifying it as tap or hold by comparing the hold duration
+   * to the TAPPING_TERM captured at press time, then let the queue drain
+   * past it. A no-op if `key` has no pending entry (e.g. it was never a
+   * tap-hold key). */
+  resolveReleaseByKey(key: string, releaseTs: number, emit: Emit<TPreparedEvent> | undefined): void {
+    const item = findPendingByKey(this.items, key)
+    if (!item?.pending) return
+    const duration = releaseTs - item.pending.start.tsMs
+    const action: TypingMatrixAction = duration < item.pending.tappingTermMs ? 'tap' : 'hold'
+    resolveQueuedTapHold(item, action, this.items, emit)
+  }
+
+  /** Finalize every still-unresolved press as `hold` and emit the whole
+   * queue in press order, then empty it. Used on record toggle, device
+   * change, or keymap reload so an in-flight masked-key press and the
+   * queue behind it aren't silently discarded — a hold only breaks the
+   * n-gram chain downstream, it never fabricates a pair.
+   *
+   * Returns a promise that resolves once every emitted item's own
+   * promise (if `emit` returned one) has settled. Callers that finalize
+   * a session — e.g. resetMatrixPressTracking ahead of a record-off
+   * flush — must await this before requesting that flush: main's
+   * ingestEvent does a real `await` before the event reaches its minute
+   * buffer, so a flush IPC call fired without waiting can be serviced
+   * before a drained event lands, landing it in a fresh buffer entry
+   * after the session it belonged to was already finalized. Ordinary
+   * per-keystroke emits (press/release/deadline) stay fire-and-forget —
+   * only a forced drain needs this. */
+  drainAll(emit: Emit<TPreparedEvent> | undefined): Promise<void> {
+    const emitted: Array<void | Promise<void>> = []
+    for (const item of this.items) {
+      if (item.pending) settleTapHold(item, item.pending, 'hold')
+      if (item.event) emitted.push(emit?.(item.prepared, item.event))
+    }
+    this.items.length = 0
+    return Promise.all(emitted).then(() => undefined)
+  }
+
+  /** Clear every still-armed deadline timer without emitting anything,
+   * and empty the queue. Call once on unmount: a timer left running past
+   * that point would still fire and call back into a hook whose refs
+   * (emit sink, prepared context) are about to be torn down along with
+   * it. Unlike {@link drainAll}, this discards rather than finalizes —
+   * there is no live caller left to hand a finalized event to. */
+  dispose(): void {
+    for (const item of this.items) {
+      if (item.pending) clearTimeout(item.pending.timer)
+    }
+    this.items.length = 0
+  }
+}

--- a/src/renderer/typing-test/matrix-layers.ts
+++ b/src/renderer/typing-test/matrix-layers.ts
@@ -6,9 +6,11 @@
 
 import { extractMOLayer, extractLTLayer, extractLMLayer } from './keycode-char-map'
 
-/** Press-edge record kept until the matching release edge is seen so
- * masked keys can classify the press as tap vs hold. Non-masked keys
- * are emitted immediately on press and never land in this map. */
+/** Press-edge record kept until the press resolves — by its matching
+ * release edge, or by the deferred-emit deadline if it is still held
+ * when that fires — so masked keys can classify the press as tap vs
+ * hold. Non-masked keys are emitted immediately on press and never land
+ * in this record. */
 export interface PressStartRecord {
   tsMs: number
   row: number

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -7,7 +7,7 @@ import { DEFAULT_TAPPING_TERM_MS } from '../../shared/qmk-settings-tapping-term'
 import type { TypingTestConfig, RomajiGuide } from './types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, applyRomajiCaseStyle, isTimeBoundedRun, runDurationSeconds } from './types'
 import type { TypingTestMemory } from '../../shared/types/pipette-settings'
-import type { TypingAnalyticsEventPayload, TypingMatrixAction } from '../../shared/types/typing-analytics'
+import type { TypingAnalyticsEventPayload } from '../../shared/types/typing-analytics'
 import { createWordsForConfig } from './word-supply'
 import {
   type TypingTestState,
@@ -21,21 +21,39 @@ import {
 } from './run-state'
 import { isRomajiInputActive, buildRomajiMatcher, romajiDetail, processRomajiKeyEvent } from './romaji-input'
 import {
-  type PressStartRecord,
   parseMatrixKey,
   extractSwitchLayer,
   resolveEffectiveCode,
   resolveEffectiveCodeWithLayer,
 } from './matrix-layers'
+import { MatrixAnalyticsQueue } from './matrix-analytics-queue'
 
 export type { WordResult, TypingTestState, TypingTestStatus } from './run-state'
 
-export interface UseTypingTestOptions {
-  onAnalyticsEvent?: (event: TypingAnalyticsEventPayload) => void
+export interface UseTypingTestOptions<TPreparedEvent = unknown> {
+  /** Authorizes and tags a keystroke at the moment it is detected — before
+   * it may sit in the ordering queue for up to TAPPING_TERM waiting on a
+   * masked key ahead of it to resolve. `kind` distinguishes a matrix press
+   * from a typed char so the caller can apply kind-specific bookkeeping
+   * (e.g. the tray keystroke counter). Returns an opaque value that
+   * useTypingTest never inspects — it only carries it alongside the queued
+   * item to {@link onEmitAnalyticsEvent} — or null/undefined to drop the
+   * press: it is then never queued or emitted, so a later state change
+   * cannot retroactively authorize it. Called once per accepted keystroke,
+   * never re-invoked for the same press. */
+  onPrepareAnalyticsEvent?: (kind: 'matrix' | 'char') => TPreparedEvent | null | undefined
+  /** Ships an event that {@link onPrepareAnalyticsEvent} already authorized
+   * and tagged for this exact press. Called either immediately (empty
+   * queue) or once the item reaches the front of the ordering queue —
+   * must not re-read whatever live state produced `prepared`, since that
+   * state may have changed while the item was queued. */
+  onEmitAnalyticsEvent?: (prepared: TPreparedEvent, event: TypingAnalyticsEventPayload) => void
   /** TAPPING_TERM (ms) used to classify masked-key presses as tap vs
-   * hold on the release edge. Defaults to QMK's 200 ms; the KeymapEditor
-   * passes the live value pulled from the keyboard's QMK settings when
-   * available. */
+   * hold against a deadline fixed at press time (pressTs + this value,
+   * captured then — not re-read at release/deadline, so a setting change
+   * mid-press doesn't retroactively reclassify it). Defaults to QMK's
+   * 200 ms; the KeymapEditor passes the live value pulled from the
+   * keyboard's QMK settings when available. */
   tappingTermMs?: number
 }
 
@@ -62,7 +80,12 @@ export interface UseTypingTestReturn {
   effectiveLayer: number
   windowFocused: boolean
   processMatrixFrame: (pressed: Set<string>, keymap: Map<string, number>) => void
-  resetMatrixPressTracking: () => void
+  /** Returns a promise that resolves once every drained item's emit has
+   * settled — see {@link MatrixAnalyticsQueue.drainAll}. A caller that
+   * finalizes a session (record-off, test-finish) before requesting a
+   * flush must await it; a caller that just wants edge-tracking reset
+   * (e.g. a keymap change) can ignore the return value. */
+  resetMatrixPressTracking: () => Promise<void>
   processKeyEvent: (key: string, ctrlKey: boolean, altKey: boolean, metaKey: boolean) => void
   processCompositionStart: () => void
   processCompositionUpdate: (data: string) => void
@@ -78,10 +101,10 @@ export interface UseTypingTestReturn {
   restoreState: (memory: TypingTestMemory, resume: boolean) => Promise<boolean>
 }
 
-export function useTypingTest(
+export function useTypingTest<TPreparedEvent = unknown>(
   initialConfig?: TypingTestConfig,
   initialLanguage?: string,
-  options?: UseTypingTestOptions,
+  options?: UseTypingTestOptions<TPreparedEvent>,
 ): UseTypingTestReturn {
   // A persisted config/language pair (e.g. restored from device prefs) is
   // taken at face value — `romajiInput` is not paired with the language
@@ -100,12 +123,13 @@ export function useTypingTest(
   const languageRef = useRef(language)
   const baseLayerRef = useRef(baseLayer)
   const windowFocusedRef = useRef(windowFocused)
-  const analyticsSinkRef = useRef(options?.onAnalyticsEvent)
+  const prepareAnalyticsEventRef = useRef(options?.onPrepareAnalyticsEvent)
+  const emitAnalyticsEventRef = useRef(options?.onEmitAnalyticsEvent)
   const prevPressedRef = useRef<Set<string>>(new Set())
-  // Press-edge starts for masked keys awaiting a release-edge match. The
-  // key is `"row,col"` to mirror the Set used for pressed keys. Not used
-  // for non-masked presses, which fire on the press edge itself.
-  const pressStartMapRef = useRef<Map<string, PressStartRecord>>(new Map())
+  // Press-order emission queue for matrix analytics events. See
+  // matrix-analytics-queue.ts for why this exists instead of emitting
+  // non-masked keys unconditionally on press.
+  const matrixQueueRef = useRef(new MatrixAnalyticsQueue<TPreparedEvent>())
   const tappingTermMsRef = useRef(options?.tappingTermMs ?? DEFAULT_TAPPING_TERM_MS)
   const seqRef = useRef(0)
   const langLoadSeqRef = useRef(0)
@@ -114,7 +138,8 @@ export function useTypingTest(
   languageRef.current = language
   baseLayerRef.current = baseLayer
   windowFocusedRef.current = windowFocused
-  analyticsSinkRef.current = options?.onAnalyticsEvent
+  prepareAnalyticsEventRef.current = options?.onPrepareAnalyticsEvent
+  emitAnalyticsEventRef.current = options?.onEmitAnalyticsEvent
   tappingTermMsRef.current = options?.tappingTermMs ?? DEFAULT_TAPPING_TERM_MS
 
   const restartAsync = useCallback(async () => {
@@ -311,15 +336,26 @@ export function useTypingTest(
     // it's the caller's responsibility to stop calling processMatrixFrame
     // when recording should pause (e.g. record toggle off).
     //
-    // Non-masked keys emit on press — one event per physical press, no
-    // action field. Masked keys (LT/MT/TT etc.) defer to the release
-    // edge so the duration vs. TAPPING_TERM can classify them into
-    // tap vs hold before the event is emitted. If a release never
-    // arrives (record toggled off mid-hold) the corresponding entry
-    // is dropped via resetMatrixPressTracking / record gate.
-    const sink = analyticsSinkRef.current
-    if (sink) {
-      const starts = pressStartMapRef.current
+    // Non-masked keys carry no action field and are queued/emitted in
+    // press order like everything else. Masked keys (LT/MT) resolve to
+    // tap vs hold on a deadline fixed at press time (see
+    // matrix-analytics-queue.ts), by the release edge if it arrives first or by
+    // the deadline timer if the key is still held — so resolution can
+    // land later than physical presses that follow it. Emitting those
+    // later presses immediately would hand the main process a masked
+    // key's event stamped with an earlier timestamp than events already
+    // emitted for what came after it; its n-gram chain treats a
+    // non-increasing timestamp as out of order and silently drops it,
+    // losing the masked key from every pair around it (the motivating
+    // case: a thumb LT(1, KC_SPACE) overlapping the next letter in
+    // ordinary fast typing). Queuing every press behind an unresolved
+    // one and draining in order once it resolves keeps the emitted
+    // stream monotonic. See resetMatrixPressTracking for what happens
+    // to a press still unresolved when recording stops.
+    const prepare = prepareAnalyticsEventRef.current
+    if (prepare) {
+      const emit = emitAnalyticsEventRef.current
+      const queue = matrixQueueRef.current
       // Layer context for a NEW press is "what OTHER keys were already
       // holding us to" — i.e. layers activated by keys carried over
       // from the previous frame. A lone MO(1) press at base 0 must
@@ -342,46 +378,82 @@ export function useTypingTest(
         const resolved = resolveEffectiveCodeWithLayer(row, col, keymap, preExistingSortedLayers, bl)
         if (!resolved) continue
         const { code, layer: eventLayer } = resolved
+        // Authorize + tag at press time, not when this press eventually
+        // reaches the sink (which may be up to TAPPING_TERM later if it
+        // queues behind an unresolved masked key ahead of it). A press
+        // that isn't authorized right now is dropped for good — it never
+        // enters the queue, so it can't be "un-dropped" by a state change
+        // (e.g. recording toggling back on) while it would have waited.
+        const prepared = prepare('matrix')
+        if (prepared == null) continue
         // Only LT / MT style tap-hold keys need the deferred classify
         // pass. LSFT(kc) etc. are "masked" too but always fire the
         // modifier + base together, so the heatmap treats them as
         // regular presses.
         if (isTapKeycode(code)) {
-          starts.set(key, { tsMs: ts, row, col, layer: eventLayer, keycode: code })
+          queue.pushPending(prepared, { tsMs: ts, row, col, layer: eventLayer, keycode: code }, key, tappingTermMs, emit)
         } else {
-          sink({ kind: 'matrix', row, col, layer: eventLayer, keycode: code, ts })
+          const event: TypingAnalyticsEventPayload = { kind: 'matrix', row, col, layer: eventLayer, keycode: code, ts }
+          // An empty queue means nothing ahead is still unresolved, so
+          // this press can go straight out instead of paying for a
+          // round trip through the queue.
+          if (queue.isEmpty) {
+            emit?.(prepared, event)
+          } else {
+            queue.pushResolved(event, prepared)
+          }
         }
       }
 
       for (const key of prev) {
         if (pressed.has(key)) continue
-        const start = starts.get(key)
-        if (!start) continue
-        starts.delete(key)
-        const duration = ts - start.tsMs
-        const action: TypingMatrixAction = duration < tappingTermMs ? 'tap' : 'hold'
-        sink({
-          kind: 'matrix',
-          row: start.row,
-          col: start.col,
-          layer: start.layer,
-          keycode: start.keycode,
-          ts: start.tsMs,
-          action,
-        })
+        queue.resolveReleaseByKey(key, ts, emit)
       }
     }
     prevPressedRef.current = new Set(pressed)
   }, [])
 
   /** Reset press-edge tracking. Call on record toggle, device change, or
-   * keymap reload so the next frame doesn't emit stale "newly pressed" events.
-   * Also clears deferred masked-key press starts so a hold in progress
-   * when recording stops doesn't resurface the next time recording
-   * resumes. */
-  const resetMatrixPressTracking = useCallback(() => {
+   * keymap reload so the next frame doesn't emit stale "newly pressed"
+   * events.
+   *
+   * Also drains any in-flight masked-key press and the queue behind it:
+   * every unresolved press is finalized as `hold` (the keystroke must
+   * not vanish just because recording stopped mid-hold — a hold only
+   * breaks the n-gram chain downstream, it never fabricates a pair),
+   * then the whole queue is flushed in press order so ordinary keys
+   * queued behind it aren't dropped either. Simply clearing the maps,
+   * as before this queue existed, would have silently discarded more
+   * than just the pending press.
+   *
+   * Each item ships with the `prepared` context its own press already
+   * captured via onPrepareAnalyticsEvent — not whatever is live right
+   * now. resetMatrixPressTracking itself typically runs *because* that
+   * live state just changed (e.g. recording toggled off), so re-reading
+   * it here would gate or tag every drained item by state that arrived
+   * after the keystroke, which is exactly what this queue exists to
+   * avoid.
+   *
+   * Returns the promise {@link MatrixAnalyticsQueue.drainAll} hands back.
+   * A caller finalizing a session (record toggling off, a test
+   * finishing) must await it before requesting a flush for that session
+   * — see the promise's own doc comment for why firing the flush
+   * without waiting can lose or misplace exactly the events this drain
+   * just sent. */
+  const resetMatrixPressTracking = useCallback((): Promise<void> => {
+    const drained = matrixQueueRef.current.drainAll(emitAnalyticsEventRef.current)
     prevPressedRef.current = new Set()
-    pressStartMapRef.current = new Map()
+    return drained
+  }, [])
+
+  // Clear any still-armed deadline timer on unmount. Without this, a
+  // timer set by MatrixAnalyticsQueue.pushPending can outlive the
+  // component and fire against refs that are no longer meaningful — see
+  // MatrixAnalyticsQueue.dispose.
+  useEffect(() => {
+    return () => {
+      matrixQueueRef.current.dispose()
+    }
   }, [])
 
   const setWindowFocused = useCallback((focused: boolean) => {
@@ -398,9 +470,15 @@ export function useTypingTest(
     if (altKey && !ctrlKey) return
     if (IGNORED_KEYS.has(key)) return
 
-    const sink = analyticsSinkRef.current
-    if (sink && (key.length === 1 || key === 'Backspace')) {
-      sink({ kind: 'char', key, ts: Date.now() })
+    // Char events never queue (unlike matrix events, they have no tap-hold
+    // ambiguity to wait out), so prepare + emit happen back to back here,
+    // in the same call — no staleness window to guard against.
+    const prepare = prepareAnalyticsEventRef.current
+    if (prepare && (key.length === 1 || key === 'Backspace')) {
+      const prepared = prepare('char')
+      if (prepared != null) {
+        emitAnalyticsEventRef.current?.(prepared, { kind: 'char', key, ts: Date.now() })
+      }
     }
 
     setState((s) => {

--- a/src/shared/qmk-settings-tapping-term.ts
+++ b/src/shared/qmk-settings-tapping-term.ts
@@ -25,3 +25,28 @@ export function resolveTappingTermMs(
   // which would flag every press as a hold. Treat it as "not configured".
   return value > 0 ? value : DEFAULT_TAPPING_TERM_MS
 }
+
+/** Hard ceiling (ms) on how long the renderer's typing-analytics queue
+ * (`matrix-analytics-queue.ts`) may defer classifying an LT/MT press as
+ * tap vs hold. TAPPING_TERM is read off the keyboard as a raw u16 (up to
+ * 65535), and nothing in the protocol stops a keyboard from reporting a
+ * value far larger than any sane typing cadence — but the analytics
+ * pipeline needs a *fixed* upper bound on how late a deferred press can
+ * arrive, not one that tracks whatever the keyboard happens to report.
+ * A press still unresolved this many ms after being pressed always
+ * settles as `hold`, even when the configured TAPPING_TERM is larger.
+ *
+ * Trade-off, deliberately accepted: with TAPPING_TERM configured above
+ * this cap, a genuine tap held past the cap is misclassified as a hold.
+ * That only breaks the n-gram chain at that one key — a hold is dropped
+ * from bigram/trigram pairing but never fabricates a pair that wasn't
+ * actually typed (see `MinuteBuffer.recordNgramChain`). The alternative
+ * — sizing the defer window to the live TAPPING_TERM instead of capping
+ * it — would let a single slow config defer a press long enough to land
+ * after its minute was already flushed, silently overwriting that
+ * minute's recorded totals instead of losing one keystroke's chain
+ * position (see `DRAIN_CLOSE_GRACE_MS` in `minute-buffer.ts`). A
+ * TAPPING_TERM this large is already well past the point where tap-hold
+ * behaves like ordinary typing, so the misclassification this trades
+ * for is the cheaper failure mode. */
+export const MAX_TAP_HOLD_DEFER_MS = 1000

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -62,8 +62,10 @@ export interface TypingAnalyticsKeyboard {
 
 /** How a physical press resolved for masked (tap-hold style) keys. The
  * heatmap uses this to colour the outer (hold) and inner (tap) rects
- * independently. `undefined` is reserved for non-masked keys and for
- * release-edge data that the press-edge pipeline dispatches eagerly.*/
+ * independently. Classified by release edge, or by the renderer's
+ * deferred-emit deadline if the key is still held when it fires,
+ * whichever comes first. `undefined` is reserved for non-masked keys and
+ * for a masked press the ordering queue hasn't classified yet. */
 export type TypingMatrixAction = 'tap' | 'hold'
 
 /** Partial event emitted by `useTypingTest` before the active keyboard is
@@ -92,10 +94,15 @@ export type TypingAnalyticsEventPayload =
       layer: number
       keycode: number
       ts: number
-      /** Only set for masked keys (LT/MT/etc.) after the release edge
-       * has been classified against TAPPING_TERM. Non-masked presses
-       * and presses that have not yet seen a release leave this
-       * undefined; the count still lands in the `count` total column. */
+      /** Only set for masked keys (LT/MT), once classified — by its
+       * release edge if that arrives first, or by the press-time
+       * deadline itself if the key is still held with no release yet.
+       * That deadline is TAPPING_TERM capped at MAX_TAP_HOLD_DEFER_MS
+       * (see `qmk-settings-tapping-term.ts`), so a press can resolve as
+       * `hold` before the keyboard's own TAPPING_TERM would have fired
+       * when the configured term exceeds the cap. Non-masked presses
+       * and masked presses not yet classified leave this undefined; the
+       * count still lands in the `count` total column. */
       action?: TypingMatrixAction
     })
 
@@ -292,8 +299,9 @@ export interface PeakRecords {
 
 /** One cell of the typing-view heatmap. `total` is the overall press
  * count for the cell; `tap` and `hold` are the portions of that total
- * that the release-edge classifier routed to the tap vs hold arm of
- * an LT/MT key. Non-tap-hold presses leave both at 0 and consumers
+ * that the tap/hold classifier (release edge, or the renderer's
+ * deferred-emit deadline if still held) routed to the tap vs hold arm
+ * of an LT/MT key. Non-tap-hold presses leave both at 0 and consumers
  * fall back to `total` as a single intensity. */
 export interface TypingHeatmapCell {
   total: number


### PR DESCRIPTION
## The bug

A tap-hold key (LT/MT) was emitted at its **release** edge, so its duration could be compared against the tapping term — but the event still carried the **press** timestamp. Nothing downstream reorders events, and the n-gram chain discards any event whose timestamp is not strictly after the previous one.

So a tap-hold key arrived *after* keys pressed later than it, carrying an *earlier* timestamp, and was silently dropped.

Verified empirically against `MinuteBuffer` by replaying the emission order the renderer actually produces:

| Scenario | Recorded pair | |
|---|---|---|
| LT tapped for space, then a letter | `(LT_SPACE, A)` | correct |
| LT held to reach a layer, layer key pressed | `(J, A)` — LT dropped | already excluded |
| LT held, layer unused, then a letter | `(LT_SPACE, A)` | hold counted as a space |
| **Thumb space overlapped with the next letter** | **`(A, J)` — the space vanished** | **worst** |

The last row is ordinary fast typing. It both **loses** real word-initiation pairs and **fabricates** a pair that was never typed consecutively. It applies to every rolled tap-hold key, home-row mods included.

## The fix

Emit in press order. Later presses queue behind an unresolved tap-hold press, which resolves at a deadline fixed when it was pressed — so the wait is bounded rather than open-ended until release.

The queue lives in `matrix-analytics-queue.ts` rather than in the typing-test hook: it serves every matrix recording path, including ambient capture that has nothing to do with a typing test.

**A hold now breaks the n-gram chain** instead of linking through it. Reaching for a layer is not a character, and letting its neighbours pair directly would claim two letters were consecutive when a modifier press sat between them.

**Events are authorized and tagged when the key goes down**, not when they reach the sink. Without this, stopping a recording discarded everything still queued — including ordinary keys that were only queued because they sat behind an unresolved key.

## Late arrival and the flush contract

Deferred emission means an event can arrive after its own minute ended, so minutes now stay open for a grace period derived from the deferral cap rather than picked independently.

This matters more than it looks: a late arrival does **not** merge into the already-flushed minute. The flush path applies snapshots through the same last-writer-wins merge that sync uses (`mergeMinuteStatsStmt`), so a second snapshot **replaces** that minute's totals. (There is an additive `writeMinuteStatsStmt`, but nothing calls it.)

Both sides now import one shared cap, so the grace cannot drift away from the deferral bound.

The cap also bounds classification: past it, a genuine tap reads as a hold. That is the deliberate trade — a hold only breaks the chain and never fabricates a pair, whereas the alternative overwrites a minute's recorded totals. A tapping term that large is already past being usable for typing.

### Known residual

The deferral bound is a `setTimeout`, which is not a hard guarantee. Under enough load the timer plus IPC could still exceed the grace. Likewise, only the drained queue is awaited before a flush — normal-path and char events are not.

Both are **pre-existing and strictly improved here**: on `main` the deferral was unbounded (a key held for minutes emitted minutes late), `drainClosed` had no grace at all, and nothing was awaited before a flush. Removing the timing dependency entirely needs a change to the flush/merge layer — tracked separately.

## Test plan

- `minute-buffer.test.ts` — a hold pairs with neither neighbour, two keys separated by a hold do not become a pair, a hold still counts toward keystrokes and `holdCount`, a trigram spanning a hold is suppressed, and `drainClosed` respects the grace boundary
- `useTypingTest.test.ts` — the overlap case emits in press order, a still-held key resolves at its deadline without waiting for release, `duration === tappingTermMs` reads as hold, a press deferred past the cap resolves at the cap, unmount clears pending timers
- `useInputModes.analytics.test.tsx` — stopping mid-hold loses nothing, a test's tag survives a flush after the test ended, the flush waits for the drain, tray counter fires once at press time
- Regression strength checked by sabotage: dropping the queueing, restoring flush-time gating, and reverting the awaited drain each failed 3, 2 and 1 tests respectively
- `pnpm test` → 315 files / 7265 passed / 22 skipped; `npx eslint src/` and `pnpm typecheck` clean