### PR TITLE
feat(ui): add population benchmark references to Analyze charts

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.45",
+  "version": "0.1.46",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -855,6 +855,18 @@
     "unit": {
       "keys": "回",
       "activations": "回"
+    },
+    "benchmark": {
+      "populationAverage": "全体平均 {{value}} WPM",
+      "position": {
+        "farBelow": "平均よりかなり低い",
+        "below": "平均より低い",
+        "average": "平均的",
+        "above": "平均より高い",
+        "farAbove": "平均よりかなり高い"
+      },
+      "referenceLineLabel": "全体平均",
+      "toggleAria": "全体平均の基準線を表示"
     },
     "snapshotTimeline": {
       "title": "キーマップ履歴",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.45",
+  "version": "0.1.46",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -845,6 +845,18 @@
     "unit": {
       "keys": "回っしょ",
       "activations": "回☆"
+    },
+    "benchmark": {
+      "populationAverage": "みんなの平均 {{value}} WPMだよん☆",
+      "position": {
+        "farBelow": "平均よりかなりスローっしょ",
+        "below": "平均よりゆっくりめ",
+        "average": "ふつーくらい☆",
+        "above": "平均より速いじゃん",
+        "farAbove": "平均よりめっちゃ速い★"
+      },
+      "referenceLineLabel": "みんなの平均☆",
+      "toggleAria": "みんなの平均ラインを表示するよん"
     },
     "snapshotTimeline": {
       "title": "キーマップ履歴☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.45",
+  "version": "0.1.46",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -845,6 +845,18 @@
     "unit": {
       "keys": "回",
       "activations": "回"
+    },
+    "benchmark": {
+      "populationAverage": "みなさんの平均は {{value}} WPMどすえ",
+      "position": {
+        "farBelow": "平均よりだいぶゆっくりどすなぁ",
+        "below": "平均より少しゆっくりどす",
+        "average": "平均的どす",
+        "above": "平均より少し速いどす",
+        "farAbove": "平均よりえろう速いどすなぁ"
+      },
+      "referenceLineLabel": "みなさんの平均",
+      "toggleAria": "みなさんの平均の基準線を表示しますえ"
     },
     "snapshotTimeline": {
       "title": "キーマップ履歴",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.45",
+  "version": "0.1.46",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -845,6 +845,18 @@
     "unit": {
       "keys": "回",
       "activations": "回"
+    },
+    "benchmark": {
+      "populationAverage": "全体平均は {{value}} WPM でございます",
+      "position": {
+        "farBelow": "平均よりかなり低うございます",
+        "below": "平均より低めでございます",
+        "average": "平均的でございます",
+        "above": "平均より高めでございます",
+        "farAbove": "平均よりかなり高うございます"
+      },
+      "referenceLineLabel": "全体平均",
+      "toggleAria": "全体平均の基準線を表示いたします"
     },
     "snapshotTimeline": {
       "title": "地図の変遷",

--- a/src/main/__tests__/device-prefs-store.test.ts
+++ b/src/main/__tests__/device-prefs-store.test.ts
@@ -150,6 +150,7 @@ describe('pipette-settings-store', () => {
       await patch(fakeEvent, 'uid-a', { analyze: { filters: { deviceScopes: ['all'] } } })
       await patch(fakeEvent, 'uid-a', { analyze: { compareFilters: { deviceScopes: ['own'] } } })
       await patch(fakeEvent, 'uid-a', { analyze: { goalDays: 5, goalKeystrokes: 200 } })
+      await patch(fakeEvent, 'uid-a', { analyze: { showBenchmark: false } })
       await patch(fakeEvent, 'uid-a', { analyze: { fingerAssignments: { '0,0': 'left-index' } } })
 
       const getter = getHandler(IpcChannels.PIPETTE_SETTINGS_GET)
@@ -160,6 +161,7 @@ describe('pipette-settings-store', () => {
           goalDays?: number
           goalKeystrokes?: number
           fingerAssignments?: Record<string, string>
+          showBenchmark?: boolean
         }
       }
       // every sub-field survives the others' writes
@@ -168,6 +170,7 @@ describe('pipette-settings-store', () => {
       expect(prefs.analyze?.goalDays).toBe(5)
       expect(prefs.analyze?.goalKeystrokes).toBe(200)
       expect(prefs.analyze?.fingerAssignments).toEqual({ '0,0': 'left-index' })
+      expect(prefs.analyze?.showBenchmark).toBe(false)
     })
 
     it('clears fingerAssignments with an empty map without touching siblings', async () => {

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -51,6 +51,7 @@ function isValidAnalyzeSettings(value: unknown): boolean {
   }
   if ('filters' in obj && obj.filters != null && !isValidAnalyzeFilterSettings(obj.filters)) return false
   if ('compareFilters' in obj && obj.compareFilters != null && !isValidAnalyzeFilterSettings(obj.compareFilters)) return false
+  if ('showBenchmark' in obj && obj.showBenchmark != null && typeof obj.showBenchmark !== 'boolean') return false
   return true
 }
 

--- a/src/renderer/components/analyze/AnalyzePane.tsx
+++ b/src/renderer/components/analyze/AnalyzePane.tsx
@@ -295,6 +295,9 @@ export function AnalyzePane({
   const [selectedSnapshotSavedAt, setSelectedSnapshotSavedAt] = useState<number | null>(null)
   const [fingerAssignments, setFingerAssignments] = useState<Record<string, FingerType>>({})
   const [fingersLoading, setFingersLoading] = useState(false)
+  // Population-benchmark reference line toggle (WPM / Interval time-series
+  // charts). Absent settings mean "on" — see AnalyzeSettings.showBenchmark.
+  const [showBenchmark, setShowBenchmark] = useState(true)
   const [fingerModalOpen, setFingerModalOpen] = useState(false)
   // Staged filter editor (Plan-analyze-filter-modal) — Row 1 collapsed
   // to a summary chip; every filter row now lives behind this modal.
@@ -406,7 +409,7 @@ export function AnalyzePane({
   }, [keymapSnapshot, layerFilter.baseLayer, setLayer])
 
   useEffect(() => {
-    if (!selectedUid) { setFingerAssignments({}); setFingersLoading(false); return }
+    if (!selectedUid) { setFingerAssignments({}); setShowBenchmark(true); setFingersLoading(false); return }
     let cancelled = false
     setFingersLoading(true)
     void window.vialAPI
@@ -414,8 +417,9 @@ export function AnalyzePane({
       .then((prefs) => {
         if (cancelled) return
         setFingerAssignments(prefs?.analyze?.fingerAssignments ?? {})
+        setShowBenchmark(prefs?.analyze?.showBenchmark ?? true)
       })
-      .catch(() => { if (!cancelled) setFingerAssignments({}) })
+      .catch(() => { if (!cancelled) { setFingerAssignments({}); setShowBenchmark(true) } })
       .finally(() => { if (!cancelled) setFingersLoading(false) })
     return () => { cancelled = true }
   }, [selectedUid])
@@ -558,6 +562,23 @@ export function AnalyzePane({
         // absent key falls back to the geometry estimate).
         await window.vialAPI.pipetteSettingsPatch(selectedUid, {
           analyze: { fingerAssignments: next },
+        })
+      } catch {
+        // best-effort save
+      }
+    },
+    [selectedUid],
+  )
+
+  const handleShowBenchmarkChange = useCallback(
+    async (next: boolean) => {
+      setShowBenchmark(next)
+      if (!selectedUid) return
+      try {
+        // PATCH only this sub-field; the main-side deep merge on `analyze`
+        // preserves filters/goal/fingerAssignments owned by other writers.
+        await window.vialAPI.pipetteSettingsPatch(selectedUid, {
+          analyze: { showBenchmark: next },
         })
       } catch {
         // best-effort save
@@ -927,6 +948,23 @@ export function AnalyzePane({
   }, [uploadEntryForModal, filterStore, buildHubUploadInput,
     layoutComparisonFilter, layoutLookup, keymapSnapshot])
 
+  // Shared between the WPM and Interval controls rows — both charts'
+  // reference lines are bound to the one persisted flag, so flipping
+  // this checkbox in either tab affects both.
+  const benchmarkToggle = (
+    <label className={FILTER_LABEL}>
+      <span>{t('analyze.benchmark.referenceLineLabel')}</span>
+      <input
+        type="checkbox"
+        className="cursor-pointer"
+        checked={showBenchmark}
+        onChange={(e) => void handleShowBenchmarkChange(e.target.checked)}
+        aria-label={t('analyze.benchmark.toggleAria')}
+        data-testid={tid("analyze-filter-benchmark-toggle")}
+      />
+    </label>
+  )
+
   // Activity's per-tab filters render in two places: alongside Period
   // on Row 2 in split mode, or on Row 3 in single mode. Extracted so
   // the JSX stays in one place. Order: View → Range size + cursor
@@ -1150,6 +1188,7 @@ export function AnalyzePane({
                       ))}
                     </select>
                   </label>
+                  {wpmFilter.viewMode === 'timeSeries' && benchmarkToggle}
                 </>
               )}
               {analysisTab === 'activity' && activityFilters}
@@ -1185,6 +1224,7 @@ export function AnalyzePane({
                       ))}
                     </select>
                   </label>
+                  {intervalFilter.viewMode === 'timeSeries' && benchmarkToggle}
                 </>
               )}
               {analysisTab === 'ergonomics' && (
@@ -1293,6 +1333,7 @@ export function AnalyzePane({
                   granularity={wpmFilter.granularity}
                   viewMode={wpmFilter.viewMode}
                   minActiveMs={wpmFilter.minActiveMs}
+                  showBenchmark={showBenchmark}
                 />
               ) : analysisTab === 'interval' ? (
                 <IntervalChart
@@ -1305,6 +1346,7 @@ export function AnalyzePane({
                   unit={intervalFilter.unit}
                   granularity={wpmFilter.granularity}
                   viewMode={intervalFilter.viewMode}
+                  showBenchmark={showBenchmark}
                 />
               ) : analysisTab === 'activity' ? (
                 <ActivityChart

--- a/src/renderer/components/analyze/IntervalChart.tsx
+++ b/src/renderer/components/analyze/IntervalChart.tsx
@@ -14,8 +14,10 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import type { PeakRecords, TypingMinuteStatsRow } from '../../../shared/types/typing-analytics'
+import { BENCHMARK_IKI_MS } from '../../../shared/typing-benchmarks'
+import { benchmarkReferenceLineProps } from './analyze-benchmark'
 import { distributionForcesOwnDevice, isHashScope, isOwnScope, primaryDeviceScope, scopeToSelectValue } from '../../../shared/types/analyze-filters'
 import type { DeviceScope, GranularityChoice, IntervalUnit, IntervalViewMode, RangeMs } from './analyze-types'
 import { bucketMinuteStats, pickBucketMs } from './analyze-bucket'
@@ -51,6 +53,9 @@ interface Props {
   unit: IntervalUnit
   granularity: GranularityChoice
   viewMode: IntervalViewMode
+  /** Show the population-average IKI reference line (timeSeries mode
+   * only — distribution has no counterpart in the source study). */
+  showBenchmark: boolean
 }
 
 const SERIES_KEYS = ['min', 'p25', 'p50', 'p75', 'max'] as const
@@ -89,7 +94,7 @@ function formatShare(v: number): string {
   return `${formatSharePercent(v)}%`
 }
 
-export function IntervalChart({ uid, range, deviceScopes, appScopes, typingTestScopes, runIdScopes, unit, granularity, viewMode }: Props) {
+export function IntervalChart({ uid, range, deviceScopes, appScopes, typingTestScopes, runIdScopes, unit, granularity, viewMode, showBenchmark }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingMinuteStatsRow[]>([])
   const [peakRecords, setPeakRecords] = useState<PeakRecords | null>(null)
@@ -295,6 +300,16 @@ export function IntervalChart({ uid, range, deviceScopes, appScopes, typingTestS
               style: { fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' },
             }}
           />
+          {showBenchmark && (
+            // `unit` only swaps the axis tick-label formatter (ms vs. sec
+            // text) — `chartData` itself (and thus the chart's y domain)
+            // always stays in ms, so the reference value is the paper's
+            // raw ms mean regardless of `unit`. Converting it here would
+            // put the line 1000x off whenever `unit === 'sec'`.
+            <ReferenceLine
+              {...benchmarkReferenceLineProps(BENCHMARK_IKI_MS.mean, t('analyze.benchmark.referenceLineLabel'))}
+            />
+          )}
           <Tooltip
             {...ANALYZE_TOOLTIP_DEFAULTS}
             labelFormatter={(v) => formatBucketAxisLabel(v as number, bucketMs)}

--- a/src/renderer/components/analyze/TypingProfileCard.tsx
+++ b/src/renderer/components/analyze/TypingProfileCard.tsx
@@ -15,11 +15,13 @@ import type {
   TypingMinuteStatsRow,
 } from '../../../shared/types/typing-analytics'
 import type { FingerType } from '../../../shared/kle/kle-ergonomics'
+import { BENCHMARK_WPM } from '../../../shared/typing-benchmarks'
 import type { AnalyzeSummaryItem } from './analyze-summary-table'
 import { AnalyzeStatGrid } from './stat-card'
 import { EMPTY_STAT_VALUE } from './analyze-constants'
 import { fetchBigramAggregateForRange, listMinuteStatsForScope } from './analyze-fetch'
 import { aggregateFingerPairs } from './analyze-bigram-finger'
+import { benchmarkPosition } from './analyze-benchmark'
 import { filterDailyWindow, shiftLocalDate } from './analyze-streak-goal'
 import {
   classifyFatigue,
@@ -118,6 +120,14 @@ export function TypingProfileCard({
   )
 
   const speed = useMemo(() => classifySpeed(dailyWindow), [dailyWindow])
+  // Population reference for the speed cell only — the paper (see
+  // shared/typing-benchmarks.ts) has no counterpart stat for hand
+  // balance or SFB, so those cells stay as-is. `null` when the speed
+  // bucket itself is 'unknown' (not enough data to trust a WPM figure).
+  const speedBenchmark = useMemo(
+    () => (speed.label === 'unknown' ? null : benchmarkPosition(speed.wpm, BENCHMARK_WPM)),
+    [speed],
+  )
   const handBalance = useMemo(
     () => (keycodeFinger.size === 0
       ? { label: 'unknown' as HandBalanceLabel, leftRatio: null, leftCount: 0, rightCount: 0 }
@@ -140,7 +150,19 @@ export function TypingProfileCard({
         : t(`analyze.summary.profile.speed.${speed.label as Exclude<SpeedLabel, 'unknown'>}`),
       context: speed.label === 'unknown'
         ? t('analyze.summary.profile.insufficient')
-        : t('analyze.summary.profile.speedContext', { wpm: formatWpm(speed.wpm) }),
+        : (
+          <>
+            {t('analyze.summary.profile.speedContext', { wpm: formatWpm(speed.wpm) })}
+            {speedBenchmark && (
+              <>
+                <br />
+                {t('analyze.benchmark.populationAverage', { value: formatWpm(BENCHMARK_WPM.mean) })}
+                {' · '}
+                {t(`analyze.benchmark.position.${speedBenchmark.label}`)}
+              </>
+            )}
+          </>
+        ),
       descriptionKey: 'analyze.summary.profile.speedDesc',
     },
     {
@@ -176,7 +198,7 @@ export function TypingProfileCard({
         : t('analyze.summary.profile.fatigueContext', { pct: fatigue.dropPct.toFixed(1) }),
       descriptionKey: 'analyze.summary.profile.fatigueDesc',
     },
-  ], [speed, handBalance, sfb, fatigue, t])
+  ], [speed, speedBenchmark, handBalance, sfb, fatigue, t])
 
   return (
     <section className="flex flex-col gap-2" data-testid="analyze-typing-profile-section">

--- a/src/renderer/components/analyze/WpmChart.tsx
+++ b/src/renderer/components/analyze/WpmChart.tsx
@@ -17,12 +17,14 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { Bar, BarChart, CartesianGrid, Cell, Legend, Line, LineChart, ReferenceLine, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import type {
   PeakRecords,
   TypingBksMinuteRow,
   TypingMinuteStatsRow,
 } from '../../../shared/types/typing-analytics'
+import { BENCHMARK_WPM } from '../../../shared/typing-benchmarks'
+import { benchmarkReferenceLineProps } from './analyze-benchmark'
 import { formatDateTime } from '../editors/store-modal-shared'
 import { isHashScope, isOwnScope, primaryDeviceScope, scopeToSelectValue } from '../../../shared/types/analyze-filters'
 import type { DeviceScope, GranularityChoice, RangeMs, WpmViewMode } from './analyze-types'
@@ -61,6 +63,9 @@ interface Props {
    * toward peak / lowest / weighted-median WPM. Does not gate the
    * chart itself — every bucket is still plotted. */
   minActiveMs: number
+  /** Show the population-average reference line (timeSeries mode
+   * only — timeOfDay has no counterpart in the source study). */
+  showBenchmark: boolean
 }
 
 const ERROR_PROXY_COLOR = 'var(--color-danger)'
@@ -73,7 +78,7 @@ function formatHourWithWpm(hour: number, wpm: number): string {
 
 type WpmLineKey = 'wpm' | 'bksPercent'
 
-export function WpmChart({ uid, range, deviceScopes, appScopes, typingTestScopes, runIdScopes, granularity, viewMode, minActiveMs }: Props) {
+export function WpmChart({ uid, range, deviceScopes, appScopes, typingTestScopes, runIdScopes, granularity, viewMode, minActiveMs, showBenchmark }: Props) {
   const { t } = useTranslation()
   const [rows, setRows] = useState<TypingMinuteStatsRow[]>([])
   const [bksRows, setBksRows] = useState<TypingBksMinuteRow[]>([])
@@ -313,6 +318,12 @@ export function WpmChart({ uid, range, deviceScopes, appScopes, typingTestScopes
                 stroke="var(--color-edge)"
                 tickFormatter={(v: number) => `${v}%`}
                 width={40}
+              />
+            )}
+            {showBenchmark && (
+              <ReferenceLine
+                yAxisId="wpm"
+                {...benchmarkReferenceLineProps(BENCHMARK_WPM.mean, t('analyze.benchmark.referenceLineLabel'))}
               />
             )}
             <Tooltip

--- a/src/renderer/components/analyze/__tests__/IntervalChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/IntervalChart.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Coverage for the population-benchmark reference line only. Same
+// recharts stub rationale as WpmChart.test.tsx.
+
+import type { ReactNode } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { IntervalChart } from '../IntervalChart'
+import type { PeakRecords, TypingMinuteStatsRow } from '../../../../shared/types/typing-analytics'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  LineChart: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Line: () => null,
+  Bar: () => null,
+  Cell: () => null,
+  ReferenceLine: (props: { y?: number }) => (
+    <div data-testid="analyze-reference-line" data-y={props.y} />
+  ),
+}))
+
+const emptyPeakRecords: PeakRecords = {
+  peakWpm: null,
+  lowestWpm: null,
+  peakKeystrokesPerMin: null,
+  peakKeystrokesPerDay: null,
+  longestSession: null,
+}
+
+function minuteRow(minuteMs: number): TypingMinuteStatsRow {
+  return {
+    minuteMs,
+    keystrokes: 40,
+    activeMs: 60_000,
+    intervalMinMs: 80,
+    intervalP25Ms: 120,
+    intervalP50Ms: 180,
+    intervalP75Ms: 260,
+    intervalMaxMs: 900,
+  }
+}
+
+const rows: TypingMinuteStatsRow[] = [minuteRow(0), minuteRow(60_000)]
+const range = { fromMs: 0, toMs: 2 * 60_000 }
+
+function setVialAPI(): void {
+  Object.defineProperty(window, 'vialAPI', {
+    value: {
+      typingAnalyticsListMinuteStatsLocal: () => Promise.resolve(rows),
+      typingAnalyticsGetPeakRecordsLocal: () => Promise.resolve(emptyPeakRecords),
+    },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function renderChart(overrides: Partial<Parameters<typeof IntervalChart>[0]> = {}): void {
+  render(
+    <IntervalChart
+      uid="0xAABB"
+      range={range}
+      deviceScopes={['own']}
+      appScopes={[]}
+      typingTestScopes={[]}
+      runIdScopes={[]}
+      unit="ms"
+      granularity={60_000}
+      viewMode="timeSeries"
+      showBenchmark
+      {...overrides}
+    />,
+  )
+}
+
+describe('IntervalChart benchmark reference line', () => {
+  beforeEach(() => {
+    setVialAPI()
+  })
+
+  it('renders the reference line at the population IKI mean (in ms) when the toggle is on', async () => {
+    renderChart()
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-reference-line')).toBeTruthy()
+    })
+    expect(screen.getByTestId('analyze-reference-line').getAttribute('data-y')).toBe('238.66')
+  })
+
+  // Regression guard: the chart's y-axis switches its *tick label* text
+  // between ms and seconds via `unit`, but the plotted data (and thus the
+  // reference line) always stays in ms. A conversion applied here by
+  // mistake would put the line 1000x off whenever `unit === 'sec'`.
+  it('keeps the reference line value in ms even when the display unit is seconds', async () => {
+    renderChart({ unit: 'sec' })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-reference-line')).toBeTruthy()
+    })
+    expect(screen.getByTestId('analyze-reference-line').getAttribute('data-y')).toBe('238.66')
+  })
+
+  it('does not render the reference line when the toggle is off', async () => {
+    renderChart({ showBenchmark: false })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-interval-chart')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('analyze-reference-line')).toBeNull()
+  })
+
+  it('does not render the reference line in distribution mode even when the toggle is on', async () => {
+    renderChart({ viewMode: 'distribution' })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-interval-distribution')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('analyze-reference-line')).toBeNull()
+  })
+})

--- a/src/renderer/components/analyze/__tests__/TypingProfileCard.test.tsx
+++ b/src/renderer/components/analyze/__tests__/TypingProfileCard.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Covers the speed cell's population-benchmark subline only — the
+// classifier boundary logic itself is covered by
+// analyze-typing-profile.test.ts and analyze-benchmark.test.ts.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { TypingProfileCard } from '../TypingProfileCard'
+import { SPEED_MIN_KEYSTROKES } from '../analyze-typing-profile'
+import type { TypingDailySummary } from '../../../../shared/types/typing-analytics'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+Object.defineProperty(window, 'vialAPI', {
+  value: {
+    typingAnalyticsGetBigramAggregateForRange: () => Promise.resolve({ view: 'top', entries: [], truncated: false }),
+    typingAnalyticsListMinuteStatsLocal: () => Promise.resolve([]),
+  },
+  writable: true,
+  configurable: true,
+})
+
+const today = '2026-01-30'
+
+function renderCard(daily: ReadonlyArray<TypingDailySummary>): void {
+  render(
+    <TypingProfileCard
+      uid="0xAABB"
+      deviceScope="own"
+      appScopes={[]}
+      typingTestScopes={[]}
+      runIdScopes={[]}
+      daily={daily}
+      today={today}
+      snapshot={null}
+      fingerOverrides={{}}
+    />,
+  )
+}
+
+describe('TypingProfileCard benchmark subline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows the population line when the speed bucket is known', async () => {
+    // Well over SPEED_MIN_KEYSTROKES with activeMs tuned for a plausible
+    // WPM (keystrokes / 5 * 60000 / activeMs) — the exact position label
+    // isn't asserted here, only that the benchmark subline appears.
+    const daily: TypingDailySummary[] = [
+      { date: today, keystrokes: SPEED_MIN_KEYSTROKES * 3, activeMs: 600_000 },
+    ]
+    renderCard(daily)
+    let grid: HTMLElement
+    await waitFor(() => {
+      grid = screen.getByTestId('analyze-typing-profile')
+    })
+    // The benchmark subline is plain text split across sibling text nodes
+    // (label · position), not its own element, so assert on the card's
+    // combined text content rather than a single getByText match.
+    expect(grid!.textContent).toContain('analyze.benchmark.populationAverage')
+  })
+
+  it('shows nothing new when the speed bucket is unknown (insufficient data)', async () => {
+    renderCard([])
+    let grid: HTMLElement
+    await waitFor(() => {
+      grid = screen.getByTestId('analyze-typing-profile')
+    })
+    expect(grid!.textContent).not.toContain('analyze.benchmark.populationAverage')
+  })
+})

--- a/src/renderer/components/analyze/__tests__/WpmChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/WpmChart.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Coverage for the population-benchmark reference line only. recharts
+// renders zero-size SVGs under jsdom (ResponsiveContainer has no real
+// layout to measure), so — same "avoid dragging recharts into jsdom"
+// approach the TypingAnalyticsView suite already uses for the chart
+// components themselves — the module is stubbed down to plain divs.
+// ReferenceLine is the one primitive under test, so it renders its `y`
+// prop into the DOM instead of an SVG line.
+
+import type { ReactNode } from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { WpmChart } from '../WpmChart'
+import type { PeakRecords, TypingMinuteStatsRow } from '../../../../shared/types/typing-analytics'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}))
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  LineChart: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  BarChart: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  Line: () => null,
+  Bar: () => null,
+  Cell: () => null,
+  ReferenceLine: (props: { y?: number; yAxisId?: string }) => (
+    <div data-testid="analyze-reference-line" data-y={props.y} data-y-axis-id={props.yAxisId} />
+  ),
+}))
+
+const emptyPeakRecords: PeakRecords = {
+  peakWpm: null,
+  lowestWpm: null,
+  peakKeystrokesPerMin: null,
+  peakKeystrokesPerDay: null,
+  longestSession: null,
+}
+
+function minuteRow(minuteMs: number, keystrokes: number, activeMs: number): TypingMinuteStatsRow {
+  return {
+    minuteMs,
+    keystrokes,
+    activeMs,
+    intervalMinMs: null,
+    intervalP25Ms: null,
+    intervalP50Ms: null,
+    intervalP75Ms: null,
+    intervalMaxMs: null,
+  }
+}
+
+const rows: TypingMinuteStatsRow[] = [minuteRow(0, 50, 60_000), minuteRow(60_000, 60, 60_000)]
+const range = { fromMs: 0, toMs: 2 * 60_000 }
+
+function setVialAPI(): void {
+  Object.defineProperty(window, 'vialAPI', {
+    value: {
+      typingAnalyticsListMinuteStatsLocal: () => Promise.resolve(rows),
+      typingAnalyticsListBksMinuteLocal: () => Promise.resolve([]),
+      typingAnalyticsGetPeakRecordsLocal: () => Promise.resolve(emptyPeakRecords),
+    },
+    writable: true,
+    configurable: true,
+  })
+}
+
+function renderChart(overrides: Partial<Parameters<typeof WpmChart>[0]> = {}): void {
+  render(
+    <WpmChart
+      uid="0xAABB"
+      range={range}
+      deviceScopes={['own']}
+      appScopes={[]}
+      typingTestScopes={[]}
+      runIdScopes={[]}
+      granularity={60_000}
+      viewMode="timeSeries"
+      minActiveMs={0}
+      showBenchmark
+      {...overrides}
+    />,
+  )
+}
+
+describe('WpmChart benchmark reference line', () => {
+  beforeEach(() => {
+    setVialAPI()
+  })
+
+  it('renders the reference line at the population WPM mean when the toggle is on', async () => {
+    renderChart()
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-reference-line')).toBeTruthy()
+    })
+    expect(screen.getByTestId('analyze-reference-line').getAttribute('data-y')).toBe('51.56')
+  })
+
+  it('does not render the reference line when the toggle is off', async () => {
+    renderChart({ showBenchmark: false })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-wpm-chart')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('analyze-reference-line')).toBeNull()
+  })
+
+  it('does not render the reference line in timeOfDay mode even when the toggle is on', async () => {
+    renderChart({ viewMode: 'timeOfDay' })
+    await waitFor(() => {
+      expect(screen.getByTestId('analyze-wpm-time-of-day')).toBeTruthy()
+    })
+    expect(screen.queryByTestId('analyze-reference-line')).toBeNull()
+  })
+})

--- a/src/renderer/components/analyze/__tests__/analyze-benchmark.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-benchmark.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Pure-logic coverage for the benchmark z-position classifier. Boundary
+// values are pinned exactly since the ≤ rule decides which side of the
+// 0.5 / 1.5 cutoffs a value lands on.
+
+import { describe, it, expect } from 'vitest'
+import { benchmarkPosition } from '../analyze-benchmark'
+import type { BenchmarkStat } from '../../../../shared/typing-benchmarks'
+
+const STAT: BenchmarkStat = { mean: 100, sd: 20 }
+
+describe('benchmarkPosition', () => {
+  it('computes z as (value - mean) / sd', () => {
+    const result = benchmarkPosition(140, STAT)
+    expect(result?.z).toBeCloseTo(2, 10)
+  })
+
+  it('labels z = 0 as average', () => {
+    expect(benchmarkPosition(100, STAT)?.label).toBe('average')
+  })
+
+  it('labels z = +0.5 as average (inner boundary, inclusive)', () => {
+    expect(benchmarkPosition(110, STAT)?.label).toBe('average')
+  })
+
+  it('labels z = -0.5 as average (inner boundary, inclusive)', () => {
+    expect(benchmarkPosition(90, STAT)?.label).toBe('average')
+  })
+
+  it('labels z just above +0.5 as above', () => {
+    expect(benchmarkPosition(110.01, STAT)?.label).toBe('above')
+  })
+
+  it('labels z just below -0.5 as below', () => {
+    expect(benchmarkPosition(89.99, STAT)?.label).toBe('below')
+  })
+
+  it('labels z = +1.5 as above (outer boundary, inclusive)', () => {
+    expect(benchmarkPosition(130, STAT)?.label).toBe('above')
+  })
+
+  it('labels z = -1.5 as below (outer boundary, inclusive)', () => {
+    expect(benchmarkPosition(70, STAT)?.label).toBe('below')
+  })
+
+  it('labels z just above +1.5 as farAbove', () => {
+    expect(benchmarkPosition(130.01, STAT)?.label).toBe('farAbove')
+  })
+
+  it('labels z just below -1.5 as farBelow', () => {
+    expect(benchmarkPosition(69.99, STAT)?.label).toBe('farBelow')
+  })
+
+  it('returns null when sd is zero', () => {
+    expect(benchmarkPosition(100, { mean: 100, sd: 0 })).toBeNull()
+  })
+
+  it('returns null when sd is negative', () => {
+    expect(benchmarkPosition(100, { mean: 100, sd: -1 })).toBeNull()
+  })
+
+  it('returns null when value is NaN', () => {
+    expect(benchmarkPosition(Number.NaN, STAT)).toBeNull()
+  })
+
+  it('returns null when value is Infinity', () => {
+    expect(benchmarkPosition(Number.POSITIVE_INFINITY, STAT)).toBeNull()
+  })
+
+  it('returns null when value is -Infinity', () => {
+    expect(benchmarkPosition(Number.NEGATIVE_INFINITY, STAT)).toBeNull()
+  })
+})

--- a/src/renderer/components/analyze/analyze-benchmark.ts
+++ b/src/renderer/components/analyze/analyze-benchmark.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Places a measured value against a population {@link BenchmarkStat}
+// (see shared/typing-benchmarks.ts) as a signed distance in standard
+// deviations. This deliberately reports "how many SDs from the
+// population mean" and NEVER a percentile — the study's underlying
+// distributions are skewed (skewness 0.51 for WPM, 1.98 for IKI), so a
+// percentile derived from z under a normality assumption would be
+// false precision the data doesn't support.
+//
+// Labels are direction-neutral on purpose: for IKI a lower value is
+// faster, so 'below' must not read as worse (and 'above' must not read
+// as better). Callers that want a value judgement have to add their own
+// framing — this function only reports position.
+
+import type { BenchmarkStat } from '../../../shared/typing-benchmarks'
+import { CHART_TICK_FONT_SIZE } from '../../utils/chart-palette'
+
+/** Shared props for the population-average ReferenceLine that WpmChart
+ * and IntervalChart both render — one place to change the look, same
+ * role as ANALYZE_TOOLTIP_DEFAULTS for the shared Tooltip styling.
+ * `label` is the already-translated text (callers own the t() call so
+ * this module stays hook-free). `ifOverflow: 'extendDomain'` overrides
+ * recharts' default of discarding a ReferenceLine that falls outside the
+ * axis domain — the line must stay visible even when the user's own data
+ * sits entirely below (or above) the population mean; the axis rescaling
+ * this causes is the accepted cost. */
+export function benchmarkReferenceLineProps(y: number, label: string): {
+  y: number
+  stroke: string
+  strokeDasharray: string
+  ifOverflow: 'extendDomain'
+  label: { value: string; position: 'insideTopRight'; fontSize: number; fill: string }
+} {
+  return {
+    y,
+    stroke: 'var(--color-content-muted)',
+    strokeDasharray: '4 4',
+    ifOverflow: 'extendDomain',
+    label: {
+      value: label,
+      position: 'insideTopRight',
+      fontSize: CHART_TICK_FONT_SIZE,
+      fill: 'var(--color-content-muted)',
+    },
+  }
+}
+
+export type BenchmarkPositionLabel = 'farBelow' | 'below' | 'average' | 'above' | 'farAbove'
+
+export interface BenchmarkPosition {
+  z: number
+  label: BenchmarkPositionLabel
+}
+
+export function benchmarkPosition(value: number, stat: BenchmarkStat): BenchmarkPosition | null {
+  if (!Number.isFinite(value) || !Number.isFinite(stat.mean) || !Number.isFinite(stat.sd)) return null
+  if (stat.sd <= 0) return null
+  const z = (value - stat.mean) / stat.sd
+  const abs = Math.abs(z)
+  const label: BenchmarkPositionLabel = abs <= 0.5
+    ? 'average'
+    : abs <= 1.5
+      ? (z < 0 ? 'below' : 'above')
+      : (z < 0 ? 'farBelow' : 'farAbove')
+  return { z, label }
+}

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.45",
+  "version": "0.1.46",
   "name": "English",
   "common": {
     "save": "Save",
@@ -855,6 +855,18 @@
     "unit": {
       "keys": "keys",
       "activations": "activations"
+    },
+    "benchmark": {
+      "populationAverage": "Population avg {{value}} WPM",
+      "position": {
+        "farBelow": "Far below average",
+        "below": "Below average",
+        "average": "Average",
+        "above": "Above average",
+        "farAbove": "Far above average"
+      },
+      "referenceLineLabel": "Population avg",
+      "toggleAria": "Show population average reference line"
     },
     "snapshotTimeline": {
       "title": "Keymap snapshots",

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -153,6 +153,11 @@ export interface AnalyzeSettings {
    * panes have the same uid loaded. Optional so panes A and B start
    * from defaults on first use. */
   compareFilters?: AnalyzeFilterSettings
+  /** Show the population-benchmark reference line on the WPM / Interval
+   * time-series charts (see `src/shared/typing-benchmarks.ts`). Absent
+   * means shown — older settings files predate this field, and the
+   * overlay is meant to be on by default. */
+  showBenchmark?: boolean
 }
 
 /** Fallback used when no per-keyboard goal has been saved yet. */

--- a/src/shared/typing-benchmarks.ts
+++ b/src/shared/typing-benchmarks.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Population reference statistics for the Analyze benchmark overlay.
+//
+// Source: Dhakal, Feit, Kristensson, Oulasvirta, "Observations on Typing
+// from 136 Million Keystrokes", CHI 2018, DOI 10.1145/3173574.3174220 —
+// 168,960 participants. Every mean/SD pair below was transcribed from
+// Table 3 (p.5) and the Typist Groups definition (p.4) of that paper and
+// verified against the PDF.
+//
+// Two caveats future consumers must not miss:
+//
+//  1. The four hand-class IKI values (left-hand / right-hand /
+//     alternation / letter-repetition) were computed by the paper
+//     *after excluding word-initiation bigrams* (a letter following a
+//     space). This app's hand-class quadrant does not exclude those, so
+//     the two are not directly comparable. Any future overlay onto that
+//     quadrant must resolve this definition gap first — do not wire
+//     these four constants into a chart without addressing it.
+//
+//  2. The study measured transcription typing in English. These are
+//     population references for context, not thresholds of "good" or
+//     "bad" typing.
+
+/** One reported statistic: population mean and standard deviation. */
+export interface BenchmarkStat {
+  mean: number
+  sd: number
+}
+
+/** Population reference from transcription typing (see caveat 2 above),
+ * not a threshold of "good" or "bad" typing. */
+export const BENCHMARK_WPM: BenchmarkStat = { mean: 51.56, sd: 20.20 }
+/** Population reference from transcription typing (see caveat 2 above),
+ * not a threshold of "good" or "bad" typing. */
+export const BENCHMARK_IKI_MS: BenchmarkStat = { mean: 238.66, sd: 111.60 }
+export const BENCHMARK_KEYPRESS_DURATION_MS: BenchmarkStat = { mean: 116.25, sd: 23.88 }
+export const BENCHMARK_UNCORRECTED_ERROR_RATE_PCT: BenchmarkStat = { mean: 1.17, sd: 1.43 }
+export const BENCHMARK_ERROR_CORRECTION_RATE_PCT: BenchmarkStat = { mean: 6.31, sd: 4.48 }
+export const BENCHMARK_KSPC: BenchmarkStat = { mean: 1.17, sd: 0.09 }
+
+// Hand-class IKI values — see caveat 1 above before using these.
+
+/** Excludes word-initiation bigrams (see caveat 1 above) — do not wire
+ * into a chart that doesn't exclude them without resolving that gap. */
+export const BENCHMARK_LEFT_HAND_IKI_MS: BenchmarkStat = { mean: 215.23, sd: 96.80 }
+/** Excludes word-initiation bigrams (see caveat 1 above) — do not wire
+ * into a chart that doesn't exclude them without resolving that gap. */
+export const BENCHMARK_RIGHT_HAND_IKI_MS: BenchmarkStat = { mean: 203.60, sd: 99.13 }
+/** Excludes word-initiation bigrams (see caveat 1 above) — do not wire
+ * into a chart that doesn't exclude them without resolving that gap. */
+export const BENCHMARK_ALTERNATION_IKI_MS: BenchmarkStat = { mean: 198.26, sd: 103.95 }
+/** Excludes word-initiation bigrams (see caveat 1 above) — do not wire
+ * into a chart that doesn't exclude them without resolving that gap. */
+export const BENCHMARK_LETTER_REPETITION_IKI_MS: BenchmarkStat = { mean: 176.36, sd: 70.26 }
+
+export const BENCHMARK_ROLLOVER_RATIO_PCT: BenchmarkStat = { mean: 25.00, sd: 17.00 }
+
+/** Typist-group thresholds from the paper's Typist Groups definition
+ * (p.4): "fast" is faster than ~90% of participants, "slow" is slower
+ * than ~90% (i.e. among the slowest ~10%). Plain WPM numbers, not a
+ * {@link BenchmarkStat} — the paper defines these as percentile cuts,
+ * not a mean/SD pair. */
+export const BENCHMARK_FAST_TYPIST_WPM = 78
+export const BENCHMARK_SLOW_TYPIST_WPM = 26


### PR DESCRIPTION
## Summary

Adds an optional population-average overlay to the Analyze view so users can see where their typing sits relative to a large typing-study population.

- New `src/shared/typing-benchmarks.ts` pure-data module with population reference stats (mean/SD for WPM and inter-key interval)
- WPM and Interval time-series charts gain a dashed population-average reference line, toggled by a per-keyboard checkbox persisted in `PipetteSettings.analyze.showBenchmark` (synced, keyboard-scoped)
- Typing Profile speed cell shows the population average plus a direction-neutral position label (average / below / above / far below / far above) computed from standard-deviation distance — deliberately no percentiles, since the underlying distributions are skewed
- Shared `benchmarkReferenceLineProps` keeps both charts' line styling identical and sets `ifOverflow: 'extendDomain'` so the line stays visible even when all of the user's data falls on one side of the population mean

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 319 files, 7289 passed / 22 skipped (new: analyze-benchmark 15, WpmChart 3, IntervalChart 4, TypingProfileCard 2; device-prefs sibling-writer no-clobber extended)
- [x] i18n parity: english.json + all 4 sample packs updated, version bumped to 0.1.46 in lockstep
