### PR TITLE
fix(sync): make analytics flush safety independent of renderer timers

### DIFF
--- a/src/main/typing-analytics/__tests__/minute-buffer.test.ts
+++ b/src/main/typing-analytics/__tests__/minute-buffer.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect, beforeEach } from 'vitest'
-import { MinuteBuffer, MINUTE_MS } from '../minute-buffer'
+import { MinuteBuffer, MINUTE_MS, RETENTION_MS } from '../minute-buffer'
 import { NGRAM_MAX_IKI_MS, DRAIN_CLOSE_GRACE_MS } from '../minute-buffer'
 import { MAX_TAP_HOLD_DEFER_MS } from '../../../shared/qmk-settings-tapping-term'
 import type {
@@ -10,6 +10,22 @@ import type {
   TypingMatrixAction,
 } from '../../../shared/types/typing-analytics'
 import { canonicalScopeKey } from '../../../shared/types/typing-analytics'
+
+// Reassigned fresh in beforeEach; hoisted to module scope so addEv below
+// can close over the current instance instead of taking it as a
+// parameter at every call site.
+let buffer: MinuteBuffer
+
+/** Most of this suite predates the `nowMs` parameter `addEvent` gained for
+ *  retention/eviction (see minute-buffer.ts). Defaulting `nowMs` to the
+ *  event's own timestamp keeps every existing call site correct without
+ *  editing each one individually: `nowMs` only matters when no live entry
+ *  exists yet, and `event.ts` is always inside the grace/retention window
+ *  of its own minute, so it never triggers the ultra-late drop. Tests that
+ *  actually exercise retention/eviction pass an explicit `nowMs`. */
+function addEv(event: TypingAnalyticsEvent, fp: TypingAnalyticsFingerprint, nowMs?: number): void {
+  buffer.addEvent(event, fp, nowMs ?? event.ts)
+}
 
 function fingerprint(overrides: Partial<TypingAnalyticsFingerprint['keyboard']> = {}): TypingAnalyticsFingerprint {
   return {
@@ -50,8 +66,6 @@ function matrixEvent(
 }
 
 describe('MinuteBuffer', () => {
-  let buffer: MinuteBuffer
-
   beforeEach(() => {
     buffer = new MinuteBuffer()
   })
@@ -63,9 +77,9 @@ describe('MinuteBuffer', () => {
 
   it('groups events into minute buckets', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)
-    buffer.addEvent(charEvent('b', 30_000), fp)
-    buffer.addEvent(charEvent('a', MINUTE_MS + 5_000), fp)
+    addEv(charEvent('a', 1_000), fp)
+    addEv(charEvent('b', 30_000), fp)
+    addEv(charEvent('a', MINUTE_MS + 5_000), fp)
 
     const snapshots = buffer.drainAll().sort((a, b) => a.minuteTs - b.minuteTs)
     expect(snapshots).toHaveLength(2)
@@ -81,11 +95,11 @@ describe('MinuteBuffer', () => {
     const fp = fingerprint()
     // Two runs typing in the same minute must not collapse: each run keeps
     // its own snapshot so per-run analytics stay exact.
-    buffer.addEvent({ ...charEvent('a', 1_000), runId: 'run-1' }, fp)
-    buffer.addEvent({ ...charEvent('a', 2_000), runId: 'run-1' }, fp)
-    buffer.addEvent({ ...charEvent('b', 3_000), runId: 'run-2' }, fp)
+    addEv({ ...charEvent('a', 1_000), runId: 'run-1' }, fp)
+    addEv({ ...charEvent('a', 2_000), runId: 'run-1' }, fp)
+    addEv({ ...charEvent('b', 3_000), runId: 'run-2' }, fp)
     // Plain REC input (no runId) is its own '' bucket.
-    buffer.addEvent(charEvent('c', 4_000), fp)
+    addEv(charEvent('c', 4_000), fp)
 
     const snapshots = buffer.drainAll().sort((a, b) => a.runId.localeCompare(b.runId))
     expect(snapshots).toHaveLength(3)
@@ -100,9 +114,9 @@ describe('MinuteBuffer', () => {
 
   it('accumulates char counts within the same minute', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)
-    buffer.addEvent(charEvent('a', 2_000), fp)
-    buffer.addEvent(charEvent('b', 3_000), fp)
+    addEv(charEvent('a', 1_000), fp)
+    addEv(charEvent('a', 2_000), fp)
+    addEv(charEvent('b', 3_000), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.charCounts.get('a')).toBe(2)
@@ -111,9 +125,9 @@ describe('MinuteBuffer', () => {
 
   it('accumulates matrix counts keyed by position, keeps the latest keycode', () => {
     const fp = fingerprint()
-    buffer.addEvent(matrixEvent(0, 3, 0, 0x04, 1_000), fp)
-    buffer.addEvent(matrixEvent(0, 3, 0, 0x04, 2_000), fp)
-    buffer.addEvent(matrixEvent(2, 1, 1, 0x4015, 3_000), fp)
+    addEv(matrixEvent(0, 3, 0, 0x04, 1_000), fp)
+    addEv(matrixEvent(0, 3, 0, 0x04, 2_000), fp)
+    addEv(matrixEvent(2, 1, 1, 0x4015, 3_000), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.matrixCounts.get('0,3,0')).toEqual({ row: 0, col: 3, layer: 0, keycode: 0x04, count: 2, tapCount: 0, holdCount: 0 })
@@ -123,11 +137,11 @@ describe('MinuteBuffer', () => {
   it('computes interval stats from event timing', () => {
     const fp = fingerprint()
     // 5 events with intervals [100, 200, 300, 400]
-    buffer.addEvent(charEvent('a', 1_000), fp)
-    buffer.addEvent(charEvent('a', 1_100), fp)
-    buffer.addEvent(charEvent('a', 1_300), fp)
-    buffer.addEvent(charEvent('a', 1_600), fp)
-    buffer.addEvent(charEvent('a', 2_000), fp)
+    addEv(charEvent('a', 1_000), fp)
+    addEv(charEvent('a', 1_100), fp)
+    addEv(charEvent('a', 1_300), fp)
+    addEv(charEvent('a', 1_600), fp)
+    addEv(charEvent('a', 2_000), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.keystrokes).toBe(5)
@@ -147,8 +161,8 @@ describe('MinuteBuffer', () => {
   it('keeps separate buckets per scope within the same minute', () => {
     const fp1 = fingerprint({ uid: '0xAAAA' })
     const fp2 = fingerprint({ uid: '0xBBBB' })
-    buffer.addEvent(charEvent('a', 1_000), fp1)
-    buffer.addEvent(charEvent('a', 2_000), fp2)
+    addEv(charEvent('a', 1_000), fp1)
+    addEv(charEvent('a', 2_000), fp2)
 
     const snapshots = buffer.drainAll()
     expect(snapshots).toHaveLength(2)
@@ -159,9 +173,9 @@ describe('MinuteBuffer', () => {
 
   it('drainClosed only returns entries whose minute ended at least the grace period before the boundary', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)                // minute 0
-    buffer.addEvent(charEvent('a', MINUTE_MS + 1_000), fp)    // minute 1
-    buffer.addEvent(charEvent('a', 2 * MINUTE_MS + 1_000), fp) // minute 2
+    addEv(charEvent('a', 1_000), fp)                // minute 0
+    addEv(charEvent('a', MINUTE_MS + 1_000), fp)    // minute 1
+    addEv(charEvent('a', 2 * MINUTE_MS + 1_000), fp) // minute 2
 
     // 3 * MINUTE_MS comfortably clears minute 0 and minute 1's grace window
     // (each ended well over DRAIN_CLOSE_GRACE_MS ago) while minute 2 has
@@ -178,10 +192,10 @@ describe('MinuteBuffer', () => {
 
   it('keeps activeMs monotonic when a late event arrives with an earlier ts', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)
-    buffer.addEvent(charEvent('a', 1_200), fp)
+    addEv(charEvent('a', 1_000), fp)
+    addEv(charEvent('a', 1_200), fp)
     // Out-of-order event: still counted, but lastEventMs must not walk back.
-    buffer.addEvent(charEvent('a', 1_100), fp)
+    addEv(charEvent('a', 1_100), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.keystrokes).toBe(3)
@@ -190,11 +204,11 @@ describe('MinuteBuffer', () => {
 
   it('extends firstEventMs backwards for a late event earlier than the first seen', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_500), fp)
-    buffer.addEvent(charEvent('a', 2_000), fp)
+    addEv(charEvent('a', 1_500), fp)
+    addEv(charEvent('a', 2_000), fp)
     // Earlier than the first seen event — still within minute 0 since
     // MINUTE_MS = 60_000, so it rebuckets into the same entry.
-    buffer.addEvent(charEvent('a', 500), fp)
+    addEv(charEvent('a', 500), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.keystrokes).toBe(3)
@@ -204,7 +218,7 @@ describe('MinuteBuffer', () => {
 
   it('handles a single-event minute with null percentile stats', () => {
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)
+    addEv(charEvent('a', 1_000), fp)
 
     const [snap] = buffer.drainAll()
     expect(snap.keystrokes).toBe(1)
@@ -218,9 +232,9 @@ describe('MinuteBuffer', () => {
   describe('bigram tracking', () => {
     it('records pair IKIs across consecutive matrix events', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // KC_A
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_120), fp) // KC_H, IKI=120
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp) // KC_D, IKI=180
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // KC_A
+      addEv(matrixEvent(0, 1, 0, 11, 1_120), fp) // KC_H, IKI=120
+      addEv(matrixEvent(0, 2, 0, 7, 1_300), fp) // KC_D, IKI=180
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([
@@ -233,9 +247,9 @@ describe('MinuteBuffer', () => {
       // Bigram tracking is matrix-only; intervening char events are
       // transparent so the next matrix pairs against the prior matrix.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(charEvent('a', 1_050), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_200), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(charEvent('a', 1_050), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_200), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['4_11', [200]]])
@@ -245,8 +259,8 @@ describe('MinuteBuffer', () => {
       // NGRAM_MAX_IKI_MS = 5000ms. A 6-minute gap is far past that
       // ceiling, so the pair must be discarded.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000 + 6 * 60 * 1_000), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000 + 6 * 60 * 1_000), fp)
 
       const [snapA, snapB] = buffer.drainAll()
       // Two minutes were buffered; check the merged result has no bigrams.
@@ -258,8 +272,8 @@ describe('MinuteBuffer', () => {
       // The comparison is `iki <= NGRAM_MAX_IKI_MS`, so the boundary
       // itself is still eligible — only strictly-slower pairs are cut.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000 + NGRAM_MAX_IKI_MS), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000 + NGRAM_MAX_IKI_MS), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['4_11', [NGRAM_MAX_IKI_MS]]])
@@ -267,8 +281,8 @@ describe('MinuteBuffer', () => {
 
     it('drops a pair whose gap is one ms past NGRAM_MAX_IKI_MS', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000 + NGRAM_MAX_IKI_MS + 1), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000 + NGRAM_MAX_IKI_MS + 1), fp)
 
       const [snap] = buffer.drainAll()
       expect(snap.bigrams.size).toBe(0)
@@ -279,9 +293,9 @@ describe('MinuteBuffer', () => {
       // moves forward to B. When C then arrives in range, it must pair
       // with B — the event the gap stranded — and not reach back to A.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 0), fp) // A
-      buffer.addEvent(matrixEvent(0, 1, 0, 2, NGRAM_MAX_IKI_MS + 3_000), fp) // B, gap over cap: no pair
-      buffer.addEvent(matrixEvent(0, 2, 0, 3, NGRAM_MAX_IKI_MS + 3_100), fp) // C, gap=100: pairs with B
+      addEv(matrixEvent(0, 0, 0, 4, 0), fp) // A
+      addEv(matrixEvent(0, 1, 0, 2, NGRAM_MAX_IKI_MS + 3_000), fp) // B, gap over cap: no pair
+      addEv(matrixEvent(0, 2, 0, 3, NGRAM_MAX_IKI_MS + 3_100), fp) // C, gap=100: pairs with B
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['2_3', [100]]])
@@ -293,14 +307,14 @@ describe('MinuteBuffer', () => {
       // boundary, the prior chain head is cleared and the new event has
       // no peer to pair against.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 30_000), fp) // minute 0
+      addEv(matrixEvent(0, 0, 0, 4, 30_000), fp) // minute 0
       // Past the grace window so minute 0 actually closes on this call.
       const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
       expect(closed).toHaveLength(1)
       expect(closed[0].bigrams.size).toBe(0) // single event in minute 0, no pair to record yet
 
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 90_000), fp) // minute 1, but chain was just cleared
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 90_150), fp) // first valid pair within minute 1
+      addEv(matrixEvent(0, 1, 0, 11, 90_000), fp) // minute 1, but chain was just cleared
+      addEv(matrixEvent(0, 2, 0, 7, 90_150), fp) // first valid pair within minute 1
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['11_7', [150]]])
@@ -316,8 +330,8 @@ describe('MinuteBuffer', () => {
       // now that NGRAM_MAX_IKI_MS caps eligibility at 5 s. Left
       // unquantified rather than carried forward as a stale number.)
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 58_000), fp) // minute 0
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 61_000), fp) // minute 1, IKI=3000 → still <= NGRAM_MAX_IKI_MS
+      addEv(matrixEvent(0, 0, 0, 4, 58_000), fp) // minute 0
+      addEv(matrixEvent(0, 1, 0, 11, 61_000), fp) // minute 1, IKI=3000 → still <= NGRAM_MAX_IKI_MS
 
       const snaps = buffer.drainAll()
       const minute0 = snaps.find((s) => s.minuteTs === 0)
@@ -328,11 +342,11 @@ describe('MinuteBuffer', () => {
 
     it('does not advance the chain on tied timestamps', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
       // Tie ts — no bigram emitted (iki = 0) AND chain stays at keycode 4
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000), fp)
       // Forward ts — should pair against the original 4 (chain didn't advance to 11)
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_150), fp)
+      addEv(matrixEvent(0, 2, 0, 7, 1_150), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['4_7', [150]]])
@@ -340,12 +354,12 @@ describe('MinuteBuffer', () => {
 
     it('clears the chain after drainAll so a fresh batch does not bridge', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
       buffer.drainAll()
       // After drainAll, the previous keycode chain should be cleared, so
       // the next matrix event can't pair against a residual prior keycode.
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_500), fp)
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_650), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_500), fp)
+      addEv(matrixEvent(0, 2, 0, 7, 1_650), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['11_7', [150]]])
@@ -355,9 +369,9 @@ describe('MinuteBuffer', () => {
   describe('trigram tracking', () => {
     it('records a triple after 3 consecutive matrix events as the average of the two intervals', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // KC_A
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_120), fp) // KC_H, iki1=120
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp) // KC_D, iki2=180
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // KC_A
+      addEv(matrixEvent(0, 1, 0, 11, 1_120), fp) // KC_H, iki1=120
+      addEv(matrixEvent(0, 2, 0, 7, 1_300), fp) // KC_D, iki2=180
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [150]]]) // (120+180)/2
@@ -365,10 +379,10 @@ describe('MinuteBuffer', () => {
 
     it('forms a rolling window of triples across 4+ events', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // iki=100
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_250), fp) // iki=150 -> triple 4_11_7 = 125
-      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_450), fp) // iki=200 -> triple 11_7_5 = 175
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp) // iki=100
+      addEv(matrixEvent(0, 2, 0, 7, 1_250), fp) // iki=150 -> triple 4_11_7 = 125
+      addEv(matrixEvent(0, 3, 0, 5, 1_450), fp) // iki=200 -> triple 11_7_5 = 175
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([
@@ -379,11 +393,11 @@ describe('MinuteBuffer', () => {
 
     it('does not pair across char events but stays transparent to the chain', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(charEvent('a', 1_050), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp)
-      buffer.addEvent(charEvent('b', 1_150), fp)
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(charEvent('a', 1_050), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp)
+      addEv(charEvent('b', 1_150), fp)
+      addEv(matrixEvent(0, 2, 0, 7, 1_300), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [150]]]) // (100+200)/2
@@ -392,10 +406,10 @@ describe('MinuteBuffer', () => {
     it('drops the triple and resets the chain when the trailing interval exceeds NGRAM_MAX_IKI_MS', () => {
       // NGRAM_MAX_IKI_MS = 5000ms.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // valid iki=100, chain=[4,11]
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_100 + 6 * 60_000), fp) // gap way past the cap: no triple, chain resets to [7]
-      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_100 + 6 * 60_000 + 120), fp) // chain=[7,5], still no triple (only 2 deep)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp) // valid iki=100, chain=[4,11]
+      addEv(matrixEvent(0, 2, 0, 7, 1_100 + 6 * 60_000), fp) // gap way past the cap: no triple, chain resets to [7]
+      addEv(matrixEvent(0, 3, 0, 5, 1_100 + 6 * 60_000 + 120), fp) // chain=[7,5], still no triple (only 2 deep)
 
       const snaps = buffer.drainAll()
       const allTrigrams = new Map(snaps.flatMap((s) => [...s.trigrams]))
@@ -406,9 +420,9 @@ describe('MinuteBuffer', () => {
       // First interval exceeds NGRAM_MAX_IKI_MS; second interval (last->curr)
       // is fine on its own, but the stale k1 must not feed a triple.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_000 + 6 * 60_000), fp) // gap too large -> chain resets to [11]
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_000 + 6 * 60_000 + 100), fp) // chain=[11,7], only 2 deep, no triple yet
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000 + 6 * 60_000), fp) // gap too large -> chain resets to [11]
+      addEv(matrixEvent(0, 2, 0, 7, 1_000 + 6 * 60_000 + 100), fp) // chain=[11,7], only 2 deep, no triple yet
 
       const snaps = buffer.drainAll()
       const allTrigrams = new Map(snaps.flatMap((s) => [...s.trigrams]))
@@ -422,12 +436,12 @@ describe('MinuteBuffer', () => {
       // a triple still needs a *second* one — D-E supplies it, and only
       // then does C_D_E emit.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 1, 0), fp) // A
-      buffer.addEvent(matrixEvent(0, 1, 0, 2, 100), fp) // B, iki=100 (in range)
-      buffer.addEvent(matrixEvent(0, 2, 0, 3, 100 + NGRAM_MAX_IKI_MS + 3_000), fp) // C, gap over cap
+      addEv(matrixEvent(0, 0, 0, 1, 0), fp) // A
+      addEv(matrixEvent(0, 1, 0, 2, 100), fp) // B, iki=100 (in range)
+      addEv(matrixEvent(0, 2, 0, 3, 100 + NGRAM_MAX_IKI_MS + 3_000), fp) // C, gap over cap
       const cTs = 100 + NGRAM_MAX_IKI_MS + 3_000
-      buffer.addEvent(matrixEvent(0, 3, 0, 4, cTs + 100), fp) // D, iki=100 (in range, but only 1 interval since the gap)
-      buffer.addEvent(matrixEvent(0, 4, 0, 5, cTs + 200), fp) // E, iki=100 (2nd consecutive in-range interval)
+      addEv(matrixEvent(0, 3, 0, 4, cTs + 100), fp) // D, iki=100 (in range, but only 1 interval since the gap)
+      addEv(matrixEvent(0, 4, 0, 5, cTs + 200), fp) // E, iki=100 (2nd consecutive in-range interval)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([
@@ -440,12 +454,12 @@ describe('MinuteBuffer', () => {
 
     it('does not advance the chain on tied timestamps', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // chain=[4,11]
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp) // chain=[4,11]
       // Tie ts — discarded, chain stays at [4,11]
-      buffer.addEvent(matrixEvent(0, 2, 0, 99, 1_100), fp)
+      addEv(matrixEvent(0, 2, 0, 99, 1_100), fp)
       // Forward ts — pairs against the un-advanced chain [4,11]
-      buffer.addEvent(matrixEvent(0, 3, 0, 7, 1_250), fp)
+      addEv(matrixEvent(0, 3, 0, 7, 1_250), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([['4_11_7', [125]]]) // (100+150)/2
@@ -453,17 +467,17 @@ describe('MinuteBuffer', () => {
 
     it('drops the cross-minute triple after drainClosed resets the chain', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 20_000), fp) // minute 0
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 40_000), fp) // minute 0, chain=[4,11]
+      addEv(matrixEvent(0, 0, 0, 4, 20_000), fp) // minute 0
+      addEv(matrixEvent(0, 1, 0, 11, 40_000), fp) // minute 0, chain=[4,11]
       // Past the grace window so minute 0 actually closes on this call.
       const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
       expect(closed).toHaveLength(1)
       expect(closed[0].trigrams.size).toBe(0) // only 2 events so far, no triple yet
 
       // Chain was cleared by drainClosed, so this event starts fresh.
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 90_000), fp) // minute 1
-      buffer.addEvent(matrixEvent(0, 3, 0, 5, 90_150), fp) // minute 1, chain=[7,5]
-      buffer.addEvent(matrixEvent(0, 4, 0, 6, 90_300), fp) // minute 1, first valid triple
+      addEv(matrixEvent(0, 2, 0, 7, 90_000), fp) // minute 1
+      addEv(matrixEvent(0, 3, 0, 5, 90_150), fp) // minute 1, chain=[7,5]
+      addEv(matrixEvent(0, 4, 0, 6, 90_300), fp) // minute 1, first valid triple
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([['7_5_6', [150]]])
@@ -471,12 +485,12 @@ describe('MinuteBuffer', () => {
 
     it('clears the chain after drainAll so a fresh batch does not bridge', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp)
       buffer.drainAll()
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_500), fp)
-      buffer.addEvent(matrixEvent(0, 3, 0, 5, 1_650), fp)
-      buffer.addEvent(matrixEvent(0, 4, 0, 6, 1_800), fp)
+      addEv(matrixEvent(0, 2, 0, 7, 1_500), fp)
+      addEv(matrixEvent(0, 3, 0, 5, 1_650), fp)
+      addEv(matrixEvent(0, 4, 0, 6, 1_800), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.trigrams.entries()]).toEqual([['7_5_6', [150]]])
@@ -491,11 +505,11 @@ describe('MinuteBuffer', () => {
       // scope, so nothing is recorded at all.
       const fpA = fingerprint({ uid: '0xAAAA' })
       const fpB = fingerprint({ uid: '0xBBBB' })
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fpA)
-      buffer.addEvent(matrixEvent(0, 0, 0, 20, 1_050), fpB)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fpA)
-      buffer.addEvent(matrixEvent(0, 1, 0, 21, 1_150), fpB)
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_200), fpA)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fpA)
+      addEv(matrixEvent(0, 0, 0, 20, 1_050), fpB)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fpA)
+      addEv(matrixEvent(0, 1, 0, 21, 1_150), fpB)
+      addEv(matrixEvent(0, 2, 0, 7, 1_200), fpA)
 
       const snaps = buffer.drainAll()
       expect(snaps).toHaveLength(2)
@@ -508,11 +522,11 @@ describe('MinuteBuffer', () => {
     it('pairs consecutive same-scope events after an interleaved foreign event reset the chain', () => {
       const fpA = fingerprint({ uid: '0xAAAA' })
       const fpB = fingerprint({ uid: '0xBBBB' })
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fpA)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fpA)
       // Foreign scope restarts the chain, so 4 can no longer head a pair.
-      buffer.addEvent(matrixEvent(0, 0, 0, 20, 1_050), fpB)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fpA)
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_250), fpA)
+      addEv(matrixEvent(0, 0, 0, 20, 1_050), fpB)
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fpA)
+      addEv(matrixEvent(0, 2, 0, 7, 1_250), fpA)
 
       const snaps = buffer.drainAll()
       const snapA = snaps.find((s) => s.scopeId === canonicalScopeKey(fpA))
@@ -530,9 +544,9 @@ describe('MinuteBuffer', () => {
       // not produce a cross-run pair even though scope and timing both
       // look continuous.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp)
-      buffer.addEvent({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
-      buffer.addEvent({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
+      addEv({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
 
       const snaps = buffer.drainAll()
       const recSnap = snaps.find((s) => s.runId === '')
@@ -546,9 +560,9 @@ describe('MinuteBuffer', () => {
 
     it('keeps recording pairs and triples for an uninterrupted same-scope same-run stream', () => {
       const fp = fingerprint()
-      buffer.addEvent({ ...matrixEvent(0, 0, 0, 4, 1_000), runId: 'run-1' }, fp)
-      buffer.addEvent({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
-      buffer.addEvent({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
+      addEv({ ...matrixEvent(0, 0, 0, 4, 1_000), runId: 'run-1' }, fp)
+      addEv({ ...matrixEvent(0, 1, 0, 11, 1_100), runId: 'run-1' }, fp)
+      addEv({ ...matrixEvent(0, 2, 0, 7, 1_250), runId: 'run-1' }, fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([
@@ -562,8 +576,8 @@ describe('MinuteBuffer', () => {
   describe('hold events break the n-gram chain', () => {
     it('does not pair a hold with the event before it', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter
-      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_100, 'hold'), fp) // LT hold
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter
+      addEv(matrixEvent(1, 0, 0, 0x4015, 1_100, 'hold'), fp) // LT hold
 
       const [snap] = buffer.drainAll()
       expect(snap.bigrams.size).toBe(0)
@@ -571,8 +585,8 @@ describe('MinuteBuffer', () => {
 
     it('does not pair a hold with the event after it — the chain restarted', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp) // LT hold
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_100), fp) // letter
+      addEv(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp) // LT hold
+      addEv(matrixEvent(0, 0, 0, 4, 1_100), fp) // letter
 
       const [snap] = buffer.drainAll()
       expect(snap.bigrams.size).toBe(0)
@@ -584,9 +598,9 @@ describe('MinuteBuffer', () => {
       // treat the hold as a full reset so neither neighbour has anything
       // to pair against yet.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter A
-      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_120, 'hold'), fp) // Ctrl/LT hold
-      buffer.addEvent(matrixEvent(0, 1, 0, 7, 1_300), fp) // letter B
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // letter A
+      addEv(matrixEvent(1, 0, 0, 0x4015, 1_120, 'hold'), fp) // Ctrl/LT hold
+      addEv(matrixEvent(0, 1, 0, 7, 1_300), fp) // letter B
 
       const [snap] = buffer.drainAll()
       expect(snap.bigrams.size).toBe(0)
@@ -595,8 +609,8 @@ describe('MinuteBuffer', () => {
 
     it('lets a tap event participate in the chain exactly like an unmarked event', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000, 'tap'), fp)
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_120, 'tap'), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_000, 'tap'), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_120, 'tap'), fp)
 
       const [snap] = buffer.drainAll()
       expect([...snap.bigrams.entries()]).toEqual([['4_11', [120]]])
@@ -604,7 +618,7 @@ describe('MinuteBuffer', () => {
 
     it('still counts a hold toward keystrokes and matrix holdCount', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp)
+      addEv(matrixEvent(1, 0, 0, 0x4015, 1_000, 'hold'), fp)
 
       const [snap] = buffer.drainAll()
       expect(snap.keystrokes).toBe(1)
@@ -621,10 +635,10 @@ describe('MinuteBuffer', () => {
 
     it('does not emit a trigram spanning a hold', () => {
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 1_000), fp) // A
-      buffer.addEvent(matrixEvent(0, 1, 0, 11, 1_100), fp) // B, chain=[4,11]
-      buffer.addEvent(matrixEvent(1, 0, 0, 0x4015, 1_200, 'hold'), fp) // hold resets chain
-      buffer.addEvent(matrixEvent(0, 2, 0, 7, 1_300), fp) // C, chain=[7] only
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // A
+      addEv(matrixEvent(0, 1, 0, 11, 1_100), fp) // B, chain=[4,11]
+      addEv(matrixEvent(1, 0, 0, 0x4015, 1_200, 'hold'), fp) // hold resets chain
+      addEv(matrixEvent(0, 2, 0, 7, 1_300), fp) // C, chain=[7] only
 
       const [snap] = buffer.drainAll()
       // Only the A-B pair survives; nothing pairs or triples through the hold.
@@ -636,7 +650,7 @@ describe('MinuteBuffer', () => {
   describe('drainClosed grace period', () => {
     it('does not finalize a minute that ended less than the grace period ago', () => {
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
+      addEv(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
       // "Now" is just past the minute boundary, well inside the grace window.
       const closed = buffer.drainClosed(MINUTE_MS + 500)
       expect(closed).toHaveLength(0)
@@ -645,7 +659,7 @@ describe('MinuteBuffer', () => {
 
     it('finalizes a minute once it ended longer ago than the grace period', () => {
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
+      addEv(charEvent('a', 30_000), fp) // minute 0, ends at MINUTE_MS
       const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 1)
       expect(closed).toHaveLength(1)
       expect(closed[0].minuteTs).toBe(0)
@@ -665,7 +679,7 @@ describe('MinuteBuffer', () => {
     // Sanity check: the Map exists on every snapshot (downstream emit
     // layer relies on snapshot.bigrams.size, not optional access).
     const fp = fingerprint()
-    buffer.addEvent(charEvent('a', 1_000), fp)
+    addEv(charEvent('a', 1_000), fp)
     const [snap] = buffer.drainAll()
     expect(snap.bigrams.size).toBe(0)
     expect(snap.trigrams.size).toBe(0)
@@ -676,14 +690,14 @@ describe('MinuteBuffer', () => {
       // Default state: aggregator never observed an active app, so the
       // snapshot must say "unknown / not collected" rather than guess.
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       const [snap] = buffer.drainAll()
       expect(snap.appName).toBeNull()
     })
 
     it('returns the single app when only one was observed', () => {
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       buffer.markAppName('VSCode')
       const [snap] = buffer.drainAll()
       expect(snap.appName).toBe('VSCode')
@@ -695,7 +709,7 @@ describe('MinuteBuffer', () => {
       // never-tagged minute on the read side, so the size>1 set is
       // forced to null here rather than carrying mixed state forward.
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       buffer.markAppName('VSCode')
       buffer.markAppName('Slack')
       const [snap] = buffer.drainAll()
@@ -704,7 +718,7 @@ describe('MinuteBuffer', () => {
 
     it('treats the same app tagged twice as a single observation', () => {
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       buffer.markAppName('VSCode')
       buffer.markAppName('VSCode')
       const [snap] = buffer.drainAll()
@@ -716,7 +730,7 @@ describe('MinuteBuffer', () => {
       // when Monitor App is off / failed, and we don't want a single OS
       // hiccup to retroactively poison a single-app minute as mixed.
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       buffer.markAppName('VSCode')
       buffer.markAppName(null)
       const [snap] = buffer.drainAll()
@@ -728,8 +742,8 @@ describe('MinuteBuffer', () => {
       // every keyboard / device / minute currently in flight.
       const fpA = fingerprint({ uid: '0xAAAA' })
       const fpB = fingerprint({ uid: '0xBBBB' })
-      buffer.addEvent(charEvent('a', 1_000), fpA)
-      buffer.addEvent(charEvent('b', 1_000), fpB)
+      addEv(charEvent('a', 1_000), fpA)
+      addEv(charEvent('b', 1_000), fpB)
       buffer.markAppName('VSCode')
       const snaps = buffer.drainAll().sort((x, y) => x.scopeId.localeCompare(y.scopeId))
       expect(snaps).toHaveLength(2)
@@ -742,10 +756,10 @@ describe('MinuteBuffer', () => {
       // with an empty app set. Otherwise stale tags from the previous
       // minute would force every later minute into the mixed bucket.
       const fp = fingerprint()
-      buffer.addEvent(charEvent('a', 1_000), fp)
+      addEv(charEvent('a', 1_000), fp)
       buffer.markAppName('VSCode')
       buffer.drainAll()
-      buffer.addEvent(charEvent('b', MINUTE_MS + 500), fp)
+      addEv(charEvent('b', MINUTE_MS + 500), fp)
       buffer.markAppName('Slack')
       const [snap] = buffer.drainAll()
       expect(snap.appName).toBe('Slack')
@@ -756,8 +770,8 @@ describe('MinuteBuffer', () => {
       // ship with their final appName, while the open minute keeps its
       // app set alive for further tagging.
       const fp = fingerprint()
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, 500), fp) // minute 0
-      buffer.addEvent(matrixEvent(0, 0, 0, 4, MINUTE_MS + 500), fp) // minute 1
+      addEv(matrixEvent(0, 0, 0, 4, 500), fp) // minute 0
+      addEv(matrixEvent(0, 0, 0, 4, MINUTE_MS + 500), fp) // minute 1
       buffer.markAppName('VSCode')
       // Past the grace window so minute 0 actually closes on this call.
       const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
@@ -769,6 +783,179 @@ describe('MinuteBuffer', () => {
       const remaining = buffer.drainAll()
       expect(remaining).toHaveLength(1)
       expect(remaining[0].appName).toBeNull() // VSCode + Slack → mixed
+    })
+  })
+
+  describe('retention and full re-send', () => {
+    it('re-finalizes the whole minute (not just the late event) when a straggler arrives after drainClosed', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp) // minute 0, 1 keystroke so far
+      // Close minute 0 — the renderer's deferred-emit deadline plus jitter
+      // has passed, so drainClosed treats it as closed and finalizes it.
+      const firstClosed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(firstClosed).toHaveLength(1)
+      expect(firstClosed[0].keystrokes).toBe(1)
+
+      // A genuinely late event for minute 0 arrives well after the grace
+      // window (but within retention) — e.g. a tap-hold press deferred by
+      // IPC jitter beyond DRAIN_CLOSE_GRACE_MS.
+      const lateNow = MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 500
+      addEv(charEvent('a', 30_500), fp, lateNow)
+
+      // The next drain must emit ONE cumulative snapshot with BOTH
+      // keystrokes — not a partial snapshot containing only the straggler,
+      // which would replace the DB's real total through the LWW merge.
+      const secondClosed = buffer.drainClosed(lateNow + DRAIN_CLOSE_GRACE_MS + 1)
+      expect(secondClosed).toHaveLength(1)
+      expect(secondClosed[0].minuteTs).toBe(0)
+      expect(secondClosed[0].keystrokes).toBe(2)
+      expect(secondClosed[0].charCounts.get('a')).toBe(2)
+    })
+
+    it('does not re-emit a retained entry that has not changed since its last finalize', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp)
+      const firstClosed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(firstClosed).toHaveLength(1)
+
+      // Nothing new arrived — a later drain call must not re-emit the same,
+      // unchanged minute a second time.
+      const secondClosed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 10_000)
+      expect(secondClosed).toHaveLength(0)
+    })
+
+    it('drops an event whose minute has already aged past RETENTION_MS instead of starting a fresh partial entry', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp) // minute 0
+      // Close and evict minute 0 in one call: nowMs is past both grace and
+      // retention for minute 0.
+      const nowMs = MINUTE_MS + RETENTION_MS + 1
+      const closed = buffer.drainClosed(nowMs)
+      expect(closed).toHaveLength(1)
+      expect(buffer.isEmpty()).toBe(true)
+
+      // An ultra-late event still targeting minute 0 arrives after eviction.
+      addEv(charEvent('a', 30_100), fp, nowMs + 100)
+      // Dropped — no new entry, nothing to drain.
+      expect(buffer.isEmpty()).toBe(true)
+      expect(buffer.drainAll()).toEqual([])
+    })
+
+    it('reports isEmpty() true when only retained-clean entries remain (no infinite reschedule)', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp)
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(closed).toHaveLength(1)
+      // The entry is retained (not deleted) but clean — isEmpty must treat
+      // it as empty, or a service loop keyed on isEmpty() would reschedule
+      // a flush forever even though there is nothing left to do.
+      expect(buffer.isEmpty()).toBe(true)
+    })
+
+    it('peekMatrixCountsForUid excludes an entry once flushed, even after it is reopened dirty', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(1, 2, 0, 0x04, 30_000), fp)
+      expect(buffer.peekMatrixCountsForUid('0xAABB', 'hash-abc', 0).get('1,2')?.total).toBe(1)
+
+      // Flush the minute — its count is now in the DB, so peek must stop
+      // reporting it (double-counting against the DB row otherwise).
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(closed).toHaveLength(1)
+      expect(buffer.peekMatrixCountsForUid('0xAABB', 'hash-abc', 0).size).toBe(0)
+
+      // A straggler reopens the entry (dirty again) — still excluded from
+      // peek, since its cumulative count (now 2) would double-count the 1
+      // already reported.
+      const lateNow = MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 500
+      addEv(matrixEvent(1, 2, 0, 0x04, 30_100), fp, lateNow)
+      expect(buffer.peekMatrixCountsForUid('0xAABB', 'hash-abc', 0).size).toBe(0)
+    })
+
+    it('drainAll retains entries so a post-drainAll straggler lands in the retained entry and the next drain emits the full cumulative snapshot', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 1_000), fp)
+      const all = buffer.drainAll()
+      expect(all).toHaveLength(1)
+      expect(all[0].keystrokes).toBe(1)
+
+      // A straggler for the same minute arrives after the final flush
+      // (e.g. record-off flush raced by an in-flight matrix event).
+      addEv(charEvent('a', 1_500), fp, 2_000)
+      // Not yet re-emitted — the entry is dirty but drainClosed hasn't run.
+      expect(buffer.isEmpty()).toBe(false)
+
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 1)
+      expect(closed).toHaveLength(1)
+      expect(closed[0].minuteTs).toBe(0)
+      expect(closed[0].keystrokes).toBe(2)
+      expect(closed[0].charCounts.get('a')).toBe(2)
+    })
+
+    it('reopenAll flips retained entries back to reopened so a failed persist re-sends the full cumulative snapshot next drain', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp)
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(closed).toHaveLength(1)
+      // Nothing to re-emit right now — the entry is clean.
+      expect(buffer.isEmpty()).toBe(true)
+
+      // Simulate the flush pass's persistence step throwing after the
+      // drain already captured this snapshot: the caller reopens the
+      // buffer instead of accepting the drained data as lost.
+      buffer.reopenAll()
+      expect(buffer.isEmpty()).toBe(false)
+
+      // The next drain re-sends the FULL cumulative minute (still just
+      // the one keystroke here — nothing new arrived — proving the
+      // re-send is the complete snapshot, not an empty/partial one).
+      const resent = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 1)
+      expect(resent).toHaveLength(1)
+      expect(resent[0].minuteTs).toBe(0)
+      expect(resent[0].keystrokes).toBe(1)
+      expect(resent[0].charCounts.get('a')).toBe(1)
+    })
+
+    it('reopenAll combined with a genuine straggler still re-sends the full cumulative total, not a duplicate-inflated one', () => {
+      const fp = fingerprint()
+      addEv(charEvent('a', 30_000), fp)
+      buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+
+      // Persist failed for this pass — reopen it for retry...
+      buffer.reopenAll()
+      // ...and, independently, a real straggler for the same minute also
+      // arrives before the retry drain runs.
+      const lateNow = MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 500
+      addEv(charEvent('a', 30_100), fp, lateNow)
+
+      const resent = buffer.drainClosed(lateNow + DRAIN_CLOSE_GRACE_MS)
+      expect(resent).toHaveLength(1)
+      expect(resent[0].keystrokes).toBe(2)
+      expect(resent[0].charCounts.get('a')).toBe(2)
+    })
+
+    it('reopenAll leaves an open (never-finalized) entry untouched — nothing to re-emit for it', () => {
+      const fp = fingerprint()
+      // Still within the grace window — never finalized yet.
+      addEv(charEvent('a', 30_000), fp)
+      buffer.reopenAll()
+      // Reopening a never-finalized entry is a no-op: still just the one
+      // open, unflushed minute — not two, and not prematurely closed.
+      expect(buffer.drainClosed(30_000)).toHaveLength(0)
+      const closed = buffer.drainClosed(MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(closed).toHaveLength(1)
+      expect(closed[0].keystrokes).toBe(1)
+    })
+  })
+
+  describe('invariants', () => {
+    it('RETENTION_MS exceeds DRAIN_CLOSE_GRACE_MS, so drainClosed can never evict an entry it has not had the chance to finalize first', () => {
+      // If this ever inverted (e.g. DRAIN_CLOSE_GRACE_MS growing past
+      // RETENTION_MS because MAX_TAP_HOLD_DEFER_MS changed), drainClosed's
+      // per-entry finalize-then-evict order would stop guaranteeing a
+      // dirty entry gets its last cumulative re-send before eviction —
+      // this pins the invariant so that regression fails loudly here
+      // instead of silently dropping data in production.
+      expect(RETENTION_MS).toBeGreaterThan(DRAIN_CLOSE_GRACE_MS)
     })
   })
 })

--- a/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
+++ b/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
@@ -45,6 +45,17 @@ vi.mock('../app-monitor', () => ({
   getCurrentAppName: vi.fn(async () => null),
 }))
 
+// The real logger memoizes its log directory (derived from
+// app.getPath('userData')) at module scope on first use and never
+// recomputes it — fine in production (one userData dir for the process
+// lifetime) but incompatible with per-test mkdtemp directories: a test
+// after the first one to log anything would ENOENT against an already
+// mkdtemp mkdir/rm'd directory. Mocked out here since the flush-failure
+// tests below deliberately trigger the service's error-path log call.
+vi.mock('../../logger', () => ({
+  log: vi.fn(),
+}))
+
 const mockMachineId = vi.fn<(original?: boolean) => Promise<string>>()
 
 vi.mock('node-machine-id', () => ({
@@ -86,6 +97,7 @@ import {
 } from '../db/typing-analytics-db'
 import { IpcChannels } from '../../../shared/ipc/channels'
 import type { TypingBigramAggregateResult } from '../../../shared/types/typing-analytics'
+import { DRAIN_CLOSE_GRACE_MS, MINUTE_MS, RETENTION_MS } from '../minute-buffer'
 
 type IpcHandler<R = unknown> = (event: unknown, ...args: unknown[]) => Promise<R>
 
@@ -97,6 +109,27 @@ function getHandler<R = unknown>(channel: string): IpcHandler<R> {
 }
 
 const fakeEvent = {} as Electron.IpcMainInvokeEvent
+
+/** Dispatch a TYPING_ANALYTICS_EVENT payload through the given handler,
+ *  pinning the fake system clock to the payload's own `ts` first.
+ *
+ *  ingestEvent passes real `Date.now()` as MinuteBuffer.addEvent's `nowMs`
+ *  — the retention/eviction guard needs the actual wall-clock moment an
+ *  event is ingested, not its own `ts` (see minute-buffer.ts). In
+ *  production those are always close together (an event is ingested at
+ *  most a tapping-term-plus-jitter after it fires), but this suite's
+ *  events are timestamped by scenario (arbitrary calendar dates, small
+ *  relative offsets), independent of when the test actually runs. Pinning
+ *  the clock to each event's own `ts` keeps every pre-existing scenario's
+ *  "this is a normal, in-order event" assumption true without having to
+ *  rewrite every literal timestamp in this file. Tests that specifically
+ *  exercise retention/eviction pin the clock explicitly instead (see the
+ *  "retention and eviction" describe block below). */
+async function ingest(handler: IpcHandler, payload: Record<string, unknown>): Promise<void> {
+  const ts = payload.ts
+  if (typeof ts === 'number') vi.setSystemTime(ts)
+  await handler(fakeEvent, payload)
+}
 
 const sampleKeyboard = {
   uid: '0xAABB',
@@ -113,6 +146,12 @@ type ScopeRow = { id: string; keyboard_uid: string }
 
 describe('typing-analytics-service', () => {
   beforeEach(async () => {
+    // Only Date is faked (never setTimeout/setInterval) — the flush
+    // debounce timer and any real async I/O keep working normally; only
+    // Date.now() / new Date() become controllable, via `ingest()` above,
+    // so MinuteBuffer's retention guard sees a "now" consistent with each
+    // test's own scenario timestamps instead of the real wall clock.
+    vi.useFakeTimers({ toFake: ['Date'] })
     vi.clearAllMocks()
     mockUserDataPath = await mkdtemp(join(tmpdir(), 'pipette-typing-analytics-service-test-'))
     resetTypingAnalyticsForTests()
@@ -126,6 +165,7 @@ describe('typing-analytics-service', () => {
   afterEach(async () => {
     resetTypingAnalyticsDBForTests()
     await rm(mockUserDataPath, { recursive: true, force: true })
+    vi.useRealTimers()
   })
 
   describe('setupTypingAnalytics', () => {
@@ -186,9 +226,9 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_001, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'b', ts: 1_002, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_001, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'b', ts: 1_002, keyboard: sampleKeyboard })
 
       // Live minute buffer holds exactly one entry for minute 0.
       expect(getMinuteBufferForTests().isEmpty()).toBe(false)
@@ -199,9 +239,9 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: ts + 100, keyboard: sampleKeyboard })
-      await handler(fakeEvent, {
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: ts + 100, keyboard: sampleKeyboard })
+      await ingest(handler, {
         kind: 'matrix', row: 0, col: 3, layer: 0, keycode: 0x04, ts: ts + 200, keyboard: sampleKeyboard,
       })
 
@@ -230,9 +270,9 @@ describe('typing-analytics-service', () => {
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
       // Three matrix events in the same minute → two bigrams (a→h, h→d).
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -252,9 +292,9 @@ describe('typing-analytics-service', () => {
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
       // Same 3 events as above: iki(4->11)=120, iki(11->7)=160.
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -274,9 +314,9 @@ describe('typing-analytics-service', () => {
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
       // iki(4->11)=120, iki(11->7)=160 -> trigram value = (120+160)/2 = 140.
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -294,8 +334,8 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 120, keyboard: sampleKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -309,8 +349,8 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'b', ts: ts + 100, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'b', ts: ts + 100, keyboard: sampleKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -326,8 +366,8 @@ describe('typing-analytics-service', () => {
 
       const start = Date.UTC(2026, 3, 14, 10, 0, 0)
       const end = Date.UTC(2026, 3, 14, 10, 0, 5)
-      await eventHandler(fakeEvent, { kind: 'char', key: 'a', ts: start, keyboard: sampleKeyboard })
-      await eventHandler(fakeEvent, { kind: 'char', key: 'b', ts: end, keyboard: sampleKeyboard })
+      await ingest(eventHandler, { kind: 'char', key: 'a', ts: start, keyboard: sampleKeyboard })
+      await ingest(eventHandler, { kind: 'char', key: 'b', ts: end, keyboard: sampleKeyboard })
 
       await flushHandler(fakeEvent, sampleKeyboard.uid)
 
@@ -343,8 +383,8 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
       const otherKeyboard = { ...sampleKeyboard, uid: '0xCCDD', vendorId: 0x1234 }
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: otherKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: otherKeyboard })
 
       await flushTypingAnalyticsNowForTests()
 
@@ -357,7 +397,7 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       // After a successful flush the buffer and queued sessions are empty,
@@ -372,7 +412,7 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
       const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
       await flushTypingAnalyticsBeforeQuit()
 
@@ -387,7 +427,7 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
 
       // Kick off a flush but don't await — the chain holds the in-flight pass.
       const inflight = flushTypingAnalyticsNowForTests()
@@ -406,7 +446,7 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
 
       const a = flushTypingAnalyticsNowForTests()
       const b = flushTypingAnalyticsNowForTests()
@@ -424,8 +464,8 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
       const otherKeyboard = { ...sampleKeyboard, uid: '0xCCDD', vendorId: 0x1234 }
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: otherKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: otherKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       const machineHash = await getMachineHash()
@@ -444,7 +484,7 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
 
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
       // Force the open DB into a bad state so the transaction throws.
       getTypingAnalyticsDB().close()
       await flushTypingAnalyticsNowForTests()
@@ -457,7 +497,7 @@ describe('typing-analytics-service', () => {
       async function seedKeyboardData(keyboard: typeof sampleKeyboard, ts: number, key = 'a'): Promise<void> {
         setupTypingAnalyticsIpc()
         const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
-        await handler(fakeEvent, { kind: 'char', key, ts, keyboard })
+        await ingest(handler, { kind: 'char', key, ts, keyboard })
         await flushTypingAnalyticsNowForTests()
       }
 
@@ -546,7 +586,7 @@ describe('typing-analytics-service', () => {
         ): Promise<void> {
           setupTypingAnalyticsIpc()
           const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
-          await handler(fakeEvent, { kind: 'matrix', row, col, layer, keycode: 0x04, ts, keyboard })
+          await ingest(handler, { kind: 'matrix', row, col, layer, keycode: 0x04, ts, keyboard })
         }
 
         it('combines flushed DB rows with the live in-memory current minute', async () => {
@@ -554,9 +594,12 @@ describe('typing-analytics-service', () => {
           // One press lands in the DB via the flush.
           await ingestMatrix(sampleKeyboard, 1, 2, 0, ts)
           await flushTypingAnalyticsNowForTests()
-          // Second press stays in the buffer (not flushed), so only
-          // the peekMatrixCountsForUid path can see it.
-          await ingestMatrix(sampleKeyboard, 1, 2, 0, ts + 500)
+          // Second press lands in the NEXT minute — a genuinely fresh,
+          // never-flushed entry — so only the peekMatrixCountsForUid path
+          // can see it. (A press landing back in the SAME, already-flushed
+          // minute would instead be excluded from the peek — see the
+          // "retention and eviction" describe block below for that case.)
+          await ingestMatrix(sampleKeyboard, 1, 2, 0, ts + MINUTE_MS)
 
           const heat = await getMatrixHeatmap(sampleKeyboard.uid, 0, ts - 60_000)
           expect(heat['1,2']?.total).toBe(2)
@@ -595,9 +638,9 @@ describe('typing-analytics-service', () => {
         setupTypingAnalyticsIpc()
         const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
         // Three matrix events → two bigrams (4→11 and 11→7).
-        await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-        await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard })
-        await handler(fakeEvent, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
+        await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+        await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard })
+        await ingest(handler, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard })
         await flushTypingAnalyticsNowForTests()
       }
 
@@ -734,8 +777,8 @@ describe('typing-analytics-service', () => {
           setupTypingAnalyticsIpc()
           const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
           const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
-          await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
-          await handler(fakeEvent, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard })
+          await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+          await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard })
           await flushTypingAnalyticsNowForTests()
 
           const aggHandler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
@@ -751,13 +794,13 @@ describe('typing-analytics-service', () => {
 
       await handler(fakeEvent, null)
       await handler(fakeEvent, 'not-an-object')
-      await handler(fakeEvent, { kind: 'char', ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 1, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'unknown', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'matrix', row: -1, col: 0, layer: 0, keycode: 1, ts: 1_000, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000 })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: 1_000, keyboard: { uid: '', vendorId: 0, productId: 0, productName: '' } })
+      await ingest(handler, { kind: 'char', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 1, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'unknown', key: 'a', ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'matrix', row: -1, col: 0, layer: 0, keycode: 1, ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000 })
+      await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: { uid: '', vendorId: 0, productId: 0, productName: '' } })
 
       expect(getMinuteBufferForTests().isEmpty()).toBe(true)
     })
@@ -831,8 +874,8 @@ describe('typing-analytics-service', () => {
       setupTypingAnalyticsIpc()
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
       const ts = Date.UTC(2026, 3, 14, 10, 0, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: ts + 100, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: ts + 100, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       const hash = await getMachineHash()
@@ -856,8 +899,8 @@ describe('typing-analytics-service', () => {
       const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
       const dayOne = Date.UTC(2026, 3, 14, 10, 0, 0)
       const dayTwo = Date.UTC(2026, 3, 15, 10, 0, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: dayOne, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'b', ts: dayTwo, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: dayOne, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'b', ts: dayTwo, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       const hash = await getMachineHash()
@@ -876,8 +919,8 @@ describe('typing-analytics-service', () => {
 
       const eveningMinute = Date.UTC(2026, 3, 14, 23, 30, 0)
       const morningMinute = Date.UTC(2026, 3, 15, 0, 30, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'x', ts: eveningMinute, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'y', ts: morningMinute, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'x', ts: eveningMinute, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'y', ts: morningMinute, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       const hash = await getMachineHash()
@@ -899,8 +942,8 @@ describe('typing-analytics-service', () => {
 
       const start = Date.UTC(2026, 3, 14, 23, 59, 50)
       const end = Date.UTC(2026, 3, 15, 0, 0, 5)
-      await eventHandler(fakeEvent, { kind: 'char', key: 'a', ts: start, keyboard: sampleKeyboard })
-      await eventHandler(fakeEvent, { kind: 'char', key: 'b', ts: end, keyboard: sampleKeyboard })
+      await ingest(eventHandler, { kind: 'char', key: 'a', ts: start, keyboard: sampleKeyboard })
+      await ingest(eventHandler, { kind: 'char', key: 'b', ts: end, keyboard: sampleKeyboard })
       await flushHandler(fakeEvent, sampleKeyboard.uid)
 
       const hash = await getMachineHash()
@@ -916,13 +959,124 @@ describe('typing-analytics-service', () => {
 
       const minuteOne = Date.UTC(2026, 3, 14, 10, 0, 0)
       const minuteTwo = Date.UTC(2026, 3, 14, 10, 5, 0)
-      await handler(fakeEvent, { kind: 'char', key: 'a', ts: minuteOne, keyboard: sampleKeyboard })
-      await handler(fakeEvent, { kind: 'char', key: 'b', ts: minuteTwo, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'a', ts: minuteOne, keyboard: sampleKeyboard })
+      await ingest(handler, { kind: 'char', key: 'b', ts: minuteTwo, keyboard: sampleKeyboard })
       await flushTypingAnalyticsNowForTests()
 
       const hash = await getMachineHash()
       const rows = await readDayRows(sampleKeyboard.uid, hash, '2026-04-14')
       expect(rows.filter((r) => r.kind === 'scope')).toHaveLength(1)
+    })
+  })
+
+  describe('retention and full re-send', () => {
+    it('persists the full cumulative keystroke count when a late event arrives after a completed flush', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      let stats = conn.prepare('SELECT keystrokes FROM typing_minute_stats').all() as { keystrokes: number }[]
+      expect(stats).toEqual([{ keystrokes: 1 }])
+
+      // A straggler for the SAME minute arrives after that flush already
+      // completed — e.g. a tap-hold press whose deferred emit landed past
+      // DRAIN_CLOSE_GRACE_MS.
+      await ingest(handler, { kind: 'char', key: 'a', ts: ts + DRAIN_CLOSE_GRACE_MS + 500, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+
+      stats = conn.prepare('SELECT keystrokes FROM typing_minute_stats').all() as { keystrokes: number }[]
+      // Must be the FULL cumulative count (2), not the straggler alone —
+      // a partial re-send here would replace the DB's real total through
+      // the strict `>` LWW merge instead of adding to it.
+      expect(stats).toEqual([{ keystrokes: 2 }])
+    })
+
+    it('drops an ultra-late event targeting an already-evicted minute instead of persisting a fresh partial entry', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+
+      // drainAll (used by flushTypingAnalyticsNowForTests) retains entries —
+      // only drainClosed evicts (see minute-buffer.ts) — so eviction is
+      // driven directly here to simulate the periodic flush pass that
+      // would eventually run drainClosed once the wall clock genuinely
+      // moves this far past the minute.
+      const evictedNow = ts + MINUTE_MS + RETENTION_MS + 1
+      getMinuteBufferForTests().drainClosed(evictedNow)
+
+      // An event still targeting the now-evicted minute arrives.
+      // ingestEvent passes real Date.now() (pinned here to the same
+      // ultra-late instant) as MinuteBuffer.addEvent's nowMs, so this must
+      // be dropped rather than starting a fresh partial entry.
+      vi.setSystemTime(evictedNow)
+      await handler(fakeEvent, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const stats = conn.prepare('SELECT scope_id, minute_ts, keystrokes FROM typing_minute_stats').all() as StatsRow[]
+      // Only the original minute's original count — the ultra-late event
+      // was dropped, not persisted as a second, disconnected minute.
+      expect(stats).toHaveLength(1)
+      expect(stats[0].keystrokes).toBe(1)
+    })
+
+    it('keeps updatedAt strictly increasing across two flush passes at the exact same fake instant', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+      const conn = getTypingAnalyticsDB().getConnection()
+      const first = conn.prepare('SELECT updated_at FROM typing_minute_stats').get() as { updated_at: number }
+
+      // Same instant as the first flush (ingest() pins the clock to `ts`
+      // again) — the DB's strict `>` LWW guard would reject this second
+      // pass's row entirely if updatedAt merely tied instead of strictly
+      // increasing.
+      await ingest(handler, { kind: 'char', key: 'b', ts, keyboard: sampleKeyboard })
+      await flushTypingAnalyticsNowForTests()
+      const second = conn.prepare('SELECT updated_at FROM typing_minute_stats').get() as { updated_at: number }
+
+      expect(second.updated_at).toBeGreaterThan(first.updated_at)
+      // And the second pass's cumulative row actually landed (both chars
+      // counted) — proof the tie-break wasn't merely cosmetic.
+      const stats = conn.prepare('SELECT keystrokes FROM typing_minute_stats').get() as { keystrokes: number }
+      expect(stats.keystrokes).toBe(2)
+    })
+
+    it('recovers a failed flush by reopening the drained snapshot instead of losing it', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, { kind: 'char', key: 'a', ts, keyboard: sampleKeyboard })
+      // Force the cache-apply step to throw after the drain already
+      // captured this minute's snapshot (see persistOwnJsonlDay: JSONL
+      // append happens first, cache apply second, against this closed
+      // connection).
+      getTypingAnalyticsDB().close()
+      await flushTypingAnalyticsNowForTests()
+
+      // A second keystroke for the same minute arrives before the retry.
+      await ingest(handler, { kind: 'char', key: 'b', ts: ts + 500, keyboard: sampleKeyboard })
+
+      resetTypingAnalyticsDBForTests()
+      await flushTypingAnalyticsNowForTests()
+
+      // The retry must land BOTH keystrokes — the one from the failed
+      // pass (recovered via minuteBuffer.reopenAll()) and the one that
+      // arrived after it — not just the second one alone.
+      const conn = getTypingAnalyticsDB().getConnection()
+      const stats = conn.prepare('SELECT keystrokes FROM typing_minute_stats').get() as { keystrokes: number }
+      expect(stats.keystrokes).toBe(2)
     })
   })
 })

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -33,24 +33,32 @@ export const NGRAM_MAX_IKI_MS = 5000
 const DRAIN_CLOSE_JITTER_MARGIN_MS = 1000
 
 /** Grace period `drainClosed` waits past a minute's wall-clock end before
- * finalizing it. The renderer defers emitting an LT/MT press until it
- * resolves as tap or hold — by its release edge, or by
- * {@link MAX_TAP_HOLD_DEFER_MS} if the key is still held — so an event
- * can still be in flight after its own minute has technically ended.
- * Closing the buffer right at the boundary would land that event in a
- * *second* snapshot for a minute already flushed. That second snapshot
- * does not merge into the first: the flush path applies snapshots
- * through the same last-writer-wins merge sync uses
- * (`mergeMinuteStatsStmt`), so a late arrival *replaces* the minute's
- * recorded totals instead of adding to them. Do not remove this margin
- * to "close minutes sooner" — that reintroduces the overwrite.
+ * finalizing it for the first time. This is a PERFORMANCE window, not a
+ * correctness boundary: correctness comes from retention + full re-send
+ * (see {@link RETENTION_MS}) — an entry stays in the map, dirty-tracked,
+ * for {@link RETENTION_MS} after its minute ends, so a late arrival past
+ * this grace still lands in the same entry and produces one cumulative
+ * re-send on the next drain rather than a partial second snapshot.
  *
- * Derived from the cap (not chosen independently) so the two can never
- * drift apart: the renderer is contractually bounded to
- * MAX_TAP_HOLD_DEFER_MS regardless of the keyboard's configured
- * TAPPING_TERM, so this only needs to cover that cap plus the jitter
- * margin above — not the keyboard's raw (u16, up to 65535 ms) setting. */
+ * Sized around the renderer's deferred-emit deadline
+ * ({@link MAX_TAP_HOLD_DEFER_MS}) plus IPC/timer jitter purely to
+ * minimize how often that harmless-but-wasteful re-send happens: a
+ * tapping term or timer delay landing inside the grace closes the
+ * minute once, cleanly, on the first drain. Landing outside it — a
+ * slower straggler, renderer hiccup, whatever — just costs one extra
+ * cumulative re-send of that minute; it does not corrupt anything. */
 export const DRAIN_CLOSE_GRACE_MS = MAX_TAP_HOLD_DEFER_MS + DRAIN_CLOSE_JITTER_MARGIN_MS
+
+/** How long a finalized entry is kept in memory (dirty-tracked) after its
+ * minute ends before being evicted outright. Must comfortably exceed
+ * {@link DRAIN_CLOSE_GRACE_MS} — every ordinary late arrival should find
+ * its entry still retained, not evicted — while staying short enough
+ * that a renderer suspend/crash doesn't hold stale minutes forever. An
+ * event whose target minute has aged past this window is dropped by
+ * {@link MinuteBuffer.addEvent} instead of starting a fresh partial
+ * entry (see there for why: a partial entry for an already-flushed,
+ * evicted minute would replace its real totals through the LWW merge). */
+export const RETENTION_MS = 5 * MINUTE_MS
 
 /** Per-cell aggregated counts. `count` is the total press count. `tapCount`
  * and `holdCount` break that down for LT/MT presses, classified by
@@ -138,6 +146,23 @@ interface Entry {
    * per-event in {@link MinuteBuffer.addEvent}. Same size→value/null
    * collapse as {@link appSet} on finalize. */
   typingTestSet: Set<string>
+  /** Lifecycle relative to what has been reported in a snapshot so far:
+   *   - 'open': never finalized — a fresh, still-accumulating minute.
+   *   - 'retained': finalized at least once and unchanged since. Kept in
+   *     the map (not deleted) only so a later straggler can reopen it —
+   *     see {@link RETENTION_MS}.
+   *   - 'reopened': finalized at least once, then a later event added
+   *     data not yet captured by any snapshot. Needs one more cumulative
+   *     finalize, whose result is the complete minute (including
+   *     whatever was already reported), not just the delta.
+   *
+   * Two derived questions every consumer asks reduce to this one field:
+   * dirty (needs a finalize) ⇔ `state !== 'retained'`; flushed (has
+   * shipped at least one snapshot, so its counts already live in the DB)
+   * ⇔ `state !== 'open'`. Collapsing what used to be two independent
+   * booleans into one enum makes the fourth, meaningless combination
+   * (unflushed yet clean) unrepresentable. */
+  state: 'open' | 'retained' | 'reopened'
 }
 
 function floorMinute(ts: number): number {
@@ -152,7 +177,11 @@ function percentile(sorted: number[], q: number): number | null {
 }
 
 function finalize(entry: Entry): MinuteSnapshot {
-  // Entry is discarded right after, so in-place sort is safe and avoids a
+  // The entry is retained after this (see RETENTION_MS), so a later
+  // straggler can push more values into entry.intervals and this same
+  // array gets re-sorted on the next finalize. In-place sort stays safe
+  // either way — re-sorting an already-sorted array plus a few new
+  // values is still correct, just not free — and it avoids a
   // per-keystroke-sized allocation on every flush.
   const sorted = entry.intervals.sort((a, b) => a - b)
   const avg = sorted.length
@@ -218,7 +247,24 @@ export class MinuteBuffer {
   // the existing drain/resetBigramChain path.
   private chainKey: string | null = null
 
-  addEvent(event: TypingAnalyticsEvent, fingerprint: TypingAnalyticsFingerprint): void {
+  /** True once `minuteTs`'s `windowMs`-past-its-own-end window has fully
+   * elapsed as of `nowMs`. The single definition backing both the
+   * ultra-late drop check in {@link addEvent} (`windowMs = RETENTION_MS`)
+   * and the grace/eviction checks in {@link drainClosed}
+   * (`windowMs = DRAIN_CLOSE_GRACE_MS` / `RETENTION_MS`): those two call
+   * sites must use the identical comparison shape for the documented "a
+   * dropped event's minute would already have been evicted" invariant to
+   * hold — one shared definition makes that drift impossible. */
+  private minuteAgedPast(minuteTs: number, windowMs: number, nowMs: number): boolean {
+    return minuteTs + MINUTE_MS + windowMs <= nowMs
+  }
+
+  /** `nowMs` is a real wall-clock timestamp (the service passes
+   * `Date.now()`), used only to decide whether an event targeting a
+   * minute with no live entry is a genuine new minute or an ultra-late
+   * arrival past {@link RETENTION_MS} — never to bucket the event
+   * itself, which still buckets by `event.ts`. */
+  addEvent(event: TypingAnalyticsEvent, fingerprint: TypingAnalyticsFingerprint, nowMs: number): void {
     const scopeId = canonicalScopeKey(fingerprint)
     const minuteTs = floorMinute(event.ts)
     // run id joins the bucket key so two runs sharing a wall-clock minute
@@ -228,6 +274,15 @@ export class MinuteBuffer {
     const key = `${scopeId}|${minuteTs}|${runId}`
     let entry = this.buffers.get(key)
     if (!entry) {
+      if (this.minuteAgedPast(minuteTs, RETENTION_MS, nowMs)) {
+        // No live entry, and this minute is old enough that one would
+        // already have been evicted (or never have existed dirty this
+        // long). Starting a fresh partial entry here would eventually
+        // flush a fragment that, through the LWW merge, replaces
+        // whatever complete totals this minute already has on disk.
+        // Dropping the keystroke is the safe degradation.
+        return
+      }
       entry = {
         scopeId,
         fingerprint,
@@ -243,8 +298,14 @@ export class MinuteBuffer {
         lastEventMs: event.ts,
         appSet: new Set<string>(),
         typingTestSet: new Set<string>(),
+        state: 'open',
       }
       this.buffers.set(key, entry)
+    } else if (entry.state === 'retained') {
+      // Reopens a retained clean entry — this event's data hasn't been
+      // captured by any snapshot yet. An already-'open'/'reopened' entry
+      // is dirty already and needs no transition.
+      entry.state = 'reopened'
     }
 
     if (event.typingTest) entry.typingTestSet.add(event.typingTest)
@@ -373,19 +434,35 @@ export class MinuteBuffer {
    * adding null to the set, so the absence of any add is what signals
    * "no app observed" downstream (size === 0 in finalize → null).
    *
-   * Tags every live entry (across all scope IDs). When multiple
-   * keyboards are typing in parallel they share the OS focus, so the
-   * same app applies to all of them. */
+   * Tags only 'open' entries (across all scope IDs) — see {@link Entry.state}.
+   * When multiple keyboards are typing in parallel they share the OS
+   * focus, so the same app applies to all of them. A 'retained' or
+   * 'reopened' entry's appName was already decided and reported; tagging
+   * it from whatever app happens to be focused during a much later flush
+   * pass would contaminate that decision with unrelated activity instead
+   * of describing the minute that was actually recorded. */
   markAppName(appName: string | null): void {
     if (appName === null) return
     for (const entry of this.buffers.values()) {
+      if (entry.state !== 'open') continue
       entry.appSet.add(appName)
     }
   }
 
-  /** Finalize and return every buffer entry whose minute ended at least
-   * {@link DRAIN_CLOSE_GRACE_MS} ago. Called on each event so closed
-   * minutes don't linger in memory.
+  /** Finalize every dirty entry ('open' or 'reopened', see
+   * {@link Entry.state}) whose minute ended at least
+   * {@link DRAIN_CLOSE_GRACE_MS} ago, then evict any entry whose minute
+   * ended more than {@link RETENTION_MS} ago — both checks per entry in a
+   * single pass, so an entry due for eviction always gets its finalize
+   * check first (retention comfortably exceeds grace), giving a dirty
+   * one last cumulative re-send before it is dropped for good. Called on
+   * each flush pass.
+   *
+   * Finalized entries are marked 'retained', not deleted, so a straggler
+   * arriving after this call reopens the same entry instead of creating
+   * a second partial one — the next drain then re-finalizes the WHOLE
+   * entry (cumulative totals) rather than sending a partial that would
+   * overwrite the real totals through the LWW merge.
    *
    * `nowMs` is a real wall-clock timestamp, not a floored minute: the
    * grace is a few seconds, so flooring it first would round the margin
@@ -395,24 +472,70 @@ export class MinuteBuffer {
   drainClosed(nowMs: number): MinuteSnapshot[] {
     const closed: MinuteSnapshot[] = []
     for (const [key, entry] of this.buffers) {
-      if (entry.minuteTs + MINUTE_MS + DRAIN_CLOSE_GRACE_MS <= nowMs) {
+      if (entry.state !== 'retained' && this.minuteAgedPast(entry.minuteTs, DRAIN_CLOSE_GRACE_MS, nowMs)) {
         closed.push(finalize(entry))
+        entry.state = 'retained'
+      }
+      if (this.minuteAgedPast(entry.minuteTs, RETENTION_MS, nowMs)) {
         this.buffers.delete(key)
       }
     }
+    // A 'reopened' entry re-finalizing here triggers this same reset a
+    // second time for what is, in wall-clock terms, still one minute —
+    // the chain was already reset when this minute first closed, and a
+    // later straggler reopening it closes it again. Cost: at most one
+    // extra n-gram pair lost from whatever is the live minute at that
+    // moment. Not worth conditioning the reset on which specific minutes
+    // closed (self-healing next chain, rare in practice) just to avoid
+    // this micro-loss.
     if (closed.length > 0) this.resetBigramChain()
     return closed
   }
 
-  /** Finalize every entry — used on explicit flush (record OFF, before-quit). */
+  /** Finalize every dirty entry — used on explicit flush (record OFF,
+   * test finish, before-quit). Entries are retained the same way
+   * {@link drainClosed} retains them ('retained' entries stay in the map
+   * so a straggler after this flush lands in the retained entry rather
+   * than a fresh one); eviction still only happens in {@link drainClosed}.
+   * On process exit the retained memory is simply reclaimed by the OS, so
+   * not clearing the map here costs nothing in that case. */
   drainAll(): MinuteSnapshot[] {
     const all: MinuteSnapshot[] = []
     for (const entry of this.buffers.values()) {
+      if (entry.state === 'retained') continue
       all.push(finalize(entry))
+      entry.state = 'retained'
     }
-    this.buffers.clear()
     this.resetBigramChain()
     return all
+  }
+
+  /** Flip every 'retained' entry back to 'reopened', so the next drain
+   * re-finalizes and re-sends it. Used when a flush pass's persistence
+   * step (JSONL append / cache apply) throws AFTER a drain already
+   * captured snapshots — since those snapshots were never actually
+   * written anywhere, this un-does the "already reported" state that
+   * `drainClosed` / `drainAll` had just set, without needing to know
+   * which specific entries the failed pass touched: reopening a
+   * 'retained' entry that was NOT part of the failed pass is harmless
+   * (it just costs one extra, unnecessary cumulative re-send next drain),
+   * so this can safely be called unconditionally on any persist failure.
+   *
+   * Entries already 'open' are untouched (nothing to reopen — they were
+   * never finalized in the first place, so they're already covered by
+   * the re-queued keystrokes/session data).
+   *
+   * One loss window this cannot recover: an entry that was BOTH
+   * finalized AND evicted within the same failed pass (its minute aged
+   * past {@link RETENTION_MS} between the drain and this call) is gone
+   * from the map entirely — there's nothing left here to reopen. That
+   * requires the persist step to hang for the better part of
+   * RETENTION_MS while the wall clock keeps advancing; accepted as a
+   * rare boundary case rather than engineered around. */
+  reopenAll(): void {
+    for (const entry of this.buffers.values()) {
+      if (entry.state === 'retained') entry.state = 'reopened'
+    }
   }
 
   private resetBigramChain(): void {
@@ -423,8 +546,15 @@ export class MinuteBuffer {
     this.chainKey = null
   }
 
+  /** True only when every entry is 'retained' (see {@link Entry.state}) —
+   * i.e. nothing dirty is left to flush. If a 'retained' entry counted as
+   * non-empty, doFlushPass's dirty-reschedule check would spin forever
+   * once any minute had ever been retained. */
   isEmpty(): boolean {
-    return this.buffers.size === 0
+    for (const entry of this.buffers.values()) {
+      if (entry.state !== 'retained') return false
+    }
+    return true
   }
 
   /** Read-only view of the in-memory matrix counts matching the given
@@ -433,7 +563,28 @@ export class MinuteBuffer {
    * totals so the UI does not lag ~59 seconds behind actual input.
    * Returns `"row,col"` keyed triples summed across every live minute
    * for the scope. Matching by (uid, machineHash) lets callers query
-   * without first resolving the canonical scope key. */
+   * without first resolving the canonical scope key.
+   *
+   * Only 'open' entries are included (see {@link Entry.state}): a
+   * 'retained' or 'reopened' entry's last-reported counts are already in
+   * the DB, and this peek is meant to add only what the DB doesn't have
+   * yet. A 'reopened' entry's counts are cumulative (include what was
+   * already flushed), so including it here would double-count against
+   * the DB row until the next drain re-sends the full total and this
+   * peek naturally stops needing to cover it. The accepted cost is a
+   * transient undercount: a straggler into an already-flushed minute is
+   * invisible to the live heatmap until it is re-drained.
+   *
+   * This is not just a rare-straggler edge case — it has a routine
+   * trigger: TYPING_ANALYTICS_FLUSH always runs `final: true`, so
+   * drainAll finalizes even the still-open CURRENT minute. Toggling REC
+   * off then back on within the same wall-clock minute flushes that
+   * minute (marking it 'retained'), and every keystroke typed after
+   * re-enabling lands in a 'reopened' entry — excluded from this peek —
+   * for up to ~62s (a minute's worth of drainClosed's ~59s window, plus
+   * the grace period) until the next drainClosed re-sends it. A routine
+   * toggle cycle, not just a rare event; the trade-off stands as
+   * documented above regardless. */
   peekMatrixCountsForUid(
     uid: string,
     machineHash: string,
@@ -441,6 +592,7 @@ export class MinuteBuffer {
   ): Map<string, { total: number; tap: number; hold: number }> {
     const result = new Map<string, { total: number; tap: number; hold: number }>()
     for (const entry of this.buffers.values()) {
+      if (entry.state !== 'open') continue
       if (entry.fingerprint.keyboard.uid !== uid) continue
       if (entry.fingerprint.machineHash !== machineHash) continue
       for (const cell of entry.matrixCounts.values()) {

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -114,7 +114,7 @@ interface ResolvedScope {
   scopeKey: string
 }
 
-const minuteBuffer = new MinuteBuffer()
+let minuteBuffer = new MinuteBuffer()
 const sessionDetector = new SessionDetector()
 const scopeCache = new Map<string, ResolvedScope>()
 const pendingSessions: FinalizedSession[] = []
@@ -124,6 +124,23 @@ let flushChain: Promise<void> = Promise.resolve()
 let inFlightFlushCount = 0
 let flushTimer: ReturnType<typeof setTimeout> | null = null
 let syncState: TypingSyncState | null = null
+
+/** Last `updatedAt` a flush pass wrote. The DB's LWW merge only accepts a
+ * row when `excluded.updated_at > current.updated_at` (strict), so two
+ * passes landing in the same millisecond would make the second one — the
+ * cumulative, corrected re-send of a retained minute — silently lose to
+ * the first. Forcing each pass's `updatedAt` strictly past the previous
+ * one closes that race regardless of how fast passes run back to back.
+ *
+ * A backwards clock correction (e.g. NTP) does not roll `updatedAt` back:
+ * it stays pinned above the pre-correction value (potentially reading as
+ * up to that offset in the future) and flows into `state.last_synced_at`
+ * too. This is harmless — rows are scoped per `machineHash`, so there is
+ * no cross-machine contention over what "future" means — and required:
+ * without it, a re-send after the clock jumps backward would lose the
+ * strict `>` LWW race against its own earlier, partial write. Do not
+ * "fix" an apparently future-dated row by removing this bump. */
+let lastFlushUpdatedAt = 0
 
 async function initialize(): Promise<void> {
   // getMachineHash transitively warms getInstallationId (and caches its
@@ -1408,7 +1425,7 @@ async function resolveScope(keyboard: TypingAnalyticsKeyboard): Promise<Resolved
 
 async function ingestEvent(event: TypingAnalyticsEvent): Promise<void> {
   const { fingerprint, scopeKey } = await resolveScope(event.keyboard)
-  minuteBuffer.addEvent(event, fingerprint)
+  minuteBuffer.addEvent(event, fingerprint, Date.now())
   const finalized = sessionDetector.recordEvent(event.keyboard.uid, scopeKey, event.ts)
   if (finalized.length > 0) pendingSessions.push(...finalized)
   dirty = true
@@ -1757,6 +1774,12 @@ async function doFlushPass(options: { final: boolean }): Promise<void> {
     log('warn', `typing-analytics app-name tag failed: ${String(err)}`)
   }
 
+  // No await may be introduced between this drain and buildSnapshotRows /
+  // groupRowsByUidDay below: those functions copy each snapshot's Maps
+  // into plain row payloads synchronously, and a retained entry can be
+  // reopened (mutated) by the very next ingestEvent. Without that
+  // synchronous handoff, a snapshot already handed to a caller could be
+  // mutated out from under it before its rows are built.
   const snapshots = options.final
     ? minuteBuffer.drainAll()
     : minuteBuffer.drainClosed(Date.now())
@@ -1791,7 +1814,9 @@ async function doFlushPass(options: { final: boolean }): Promise<void> {
     scopesToUpsert.set(resolved.scopeKey, resolved.fingerprint)
   }
 
-  const updatedAt = Date.now()
+  // Strictly increasing across passes — see lastFlushUpdatedAt's docblock.
+  const updatedAt = Math.max(Date.now(), lastFlushUpdatedAt + 1)
+  lastFlushUpdatedAt = updatedAt
   const rowsByUidDay = groupRowsByUidDay(scopesToUpsert, snapshots, validSessions, updatedAt)
   if (rowsByUidDay.size === 0) {
     dirty = !minuteBuffer.isEmpty()
@@ -1833,10 +1858,18 @@ async function doFlushPass(options: { final: boolean }): Promise<void> {
     await saveSyncState(userDataDir, state)
   } catch (err) {
     log('error', `typing-analytics flush failed: ${String(err)}`)
-    // Re-queue sessions so the next pass can retry. Snapshots are already
-    // drained and cannot be cheaply reinserted, so their counts are
-    // accepted as lost (the JSONL append for the failed uid may or may
-    // not have landed; an eventual cache rebuild reconciles).
+    // Re-queue sessions so the next pass can retry. The drained snapshots
+    // themselves are NOT lost: minuteBuffer.reopenAll() flips every
+    // 'retained' entry back to 'reopened', so the next drain re-finalizes
+    // and re-sends the full cumulative minute rather than just whatever
+    // arrives after this point — a failed persist is no longer lossy for
+    // retained minutes. (Reopening entries that weren't actually part of
+    // this failed pass is harmless — see reopenAll's docblock — so this
+    // can run unconditionally.) The one gap this doesn't cover: an entry
+    // both finalized and evicted within this same failed pass is already
+    // gone from the map and cannot be recovered here — a rare boundary
+    // case, accepted.
+    minuteBuffer.reopenAll()
     pendingSessions.push(...sessionsToWrite)
     dirty = true
     return
@@ -1890,13 +1923,19 @@ function flushNow(options: { final: boolean }): Promise<void> {
 export function resetTypingAnalyticsForTests(): void {
   initialization = null
   ipcRegistered = false
-  minuteBuffer.drainAll()
+  // Not drainAll(): with retention, drainAll only finalizes dirty entries
+  // and retains the rest, so it would leak clean entries from one test
+  // case into the next case's identically-keyed scope/minute. Reassigning
+  // the singleton (mirrors flushChain's reset below) starts every case
+  // from a real empty buffer.
+  minuteBuffer = new MinuteBuffer()
   sessionDetector.closeAll()
   scopeCache.clear()
   pendingSessions.length = 0
   dirty = false
   flushChain = Promise.resolve()
   inFlightFlushCount = 0
+  lastFlushUpdatedAt = 0
   syncNotifier = null
   syncState = null
   if (flushTimer) {

--- a/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
@@ -28,6 +28,25 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
+/** emitAnalyticsEvent now chains every call behind chainRef.current (see
+ *  useInputModes.ts) — each emit reaches the mocked IPC only after the
+ *  chain's antecedent settles, and a burst of same-tick emits (e.g. a
+ *  forced drain flushing several queued presses) stacks one link's worth
+ *  of `.then().catch()` hops per emit. The exact number of microtask
+ *  ticks that takes isn't worth hand-deriving per call site, so this
+ *  loops generously — harmless overshoot for a short, already-settled
+ *  chain, and reliably enough for a several-link one. Chains gated on a
+ *  deliberately-unresolved mock (see the in-flight-drain test) still
+ *  never settle no matter how many rounds run, so this cannot mask a
+ *  premature flush. */
+async function flushMicrotasks(rounds = 10): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < rounds; i++) {
+      await Promise.resolve()
+    }
+  })
+}
+
 function buildKeymap(): Map<string, number> {
   // layer 0: (0,0) = 0x04 (KC_A basic keycode value)
   const m = new Map<string, number>()
@@ -66,12 +85,13 @@ function renderUseInputModes(overrides: Partial<Parameters<typeof useInputModes>
 }
 
 describe('useInputModes — typing analytics dispatch', () => {
-  it('dispatches a matrix event with the active keyboard attached', () => {
+  it('dispatches a matrix event with the active keyboard attached', async () => {
     const { result } = renderUseInputModes({ typingRecordEnabled: true })
 
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(
@@ -106,7 +126,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
   })
 
-  it('tags editor-test keystrokes once the test is running, with REC off', () => {
+  it('tags editor-test keystrokes once the test is running, with REC off', async () => {
     // The editor test path is independent of the REC toggle: a running test
     // feeds analytics tagged with its typing_test label. Use 'time' mode so
     // the first key starts the run without auto-finishing on an empty word
@@ -130,6 +150,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(
       expect.objectContaining({ kind: 'matrix', keyboard: sampleKeyboard, typingTest: expect.any(String) }),
@@ -149,7 +170,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
   })
 
-  it('resets press-edge tracking so the next ON toggle re-emits held keys', () => {
+  it('resets press-edge tracking so the next ON toggle re-emits held keys', async () => {
     const { result, rerender } = renderHook(
       ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
         rows: 1,
@@ -167,6 +188,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
 
     // Record OFF → further frames are dropped.
@@ -174,6 +196,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
 
     // Record ON again → the reset effect clears prevPressed, so the same held
@@ -182,6 +205,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
   })
 
@@ -251,7 +275,10 @@ describe('useInputModes — typing analytics dispatch', () => {
 
     // Recording stops mid-hold: the drain finalizes the press and calls
     // typingAnalyticsEvent, but that call's own promise is still pending.
+    // One microtask lets emitAnalyticsEvent's chainRef link actually reach
+    // the (still-pending) mocked IPC call.
     rerender({ typingRecordEnabled: false })
+    await flushMicrotasks()
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
     expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
 
@@ -273,6 +300,82 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsFlush).toHaveBeenCalledTimes(1)
   })
 
+  it('does not request the flush until an ordinary (non-queued) in-flight matrix event settles', async () => {
+    // Distinct from the drained-event regression above: an ordinary key on
+    // an empty queue never enters MatrixAnalyticsQueue at all (see its
+    // pushResolved caller in useTypingTest) — it calls emitAnalyticsEvent
+    // straight away and pendingDrainRef's drain sees nothing to wait on.
+    // The flush must still wait for it via chainRef, not just via the
+    // drain.
+    let resolveEvent: (() => void) | undefined
+    mockTypingAnalyticsEvent.mockImplementation(() => new Promise((resolve) => {
+      resolveEvent = resolve
+    }))
+
+    const { result, rerender } = renderHook(
+      ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
+        rows: 1,
+        cols: 1,
+        keymap: buildKeymap(),
+        typingTestMode: true,
+        typingTestViewOnly: true,
+        typingRecordKeyboard: sampleKeyboard,
+        typingRecordEnabled,
+      }),
+      { initialProps: { typingRecordEnabled: true } },
+    )
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+
+    // The queue was empty when recording stops, so the drain itself
+    // resolves quickly — the still-pending IPC call is what must gate
+    // the flush.
+    rerender({ typingRecordEnabled: false })
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
+
+    resolveEvent?.()
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('sends events strictly serially — a second emit does not reach the IPC before the first settles', async () => {
+    const resolvers: Array<() => void> = []
+    mockTypingAnalyticsEvent.mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(resolve)
+    }))
+    const { result } = renderUseInputModes({ typingRecordEnabled: true })
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+
+    // Release then press again — a second, independent ordinary press
+    // while the first's IPC promise is still unresolved.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), buildKeymap())
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    await flushMicrotasks()
+
+    // The second event must not have reached the mock yet — it is chained
+    // behind the first, whose promise is still pending.
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+
+    // Resolving the first lets the second proceed.
+    resolvers[0]?.()
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
+  })
+
   it('swallows IPC rejection silently (fire-and-forget)', async () => {
     mockTypingAnalyticsEvent.mockRejectedValueOnce(new Error('ipc down'))
     const handler = vi.fn()
@@ -287,6 +390,110 @@ describe('useInputModes — typing analytics dispatch', () => {
     process.off('unhandledRejection', handler)
     expect(handler).not.toHaveBeenCalled()
   })
+
+  it('recovers after a rejected event — a later emit still reaches the IPC', async () => {
+    // Regression guard: emitAnalyticsEvent's chain is
+    // `chainRef.current.then(...).catch(() => {})` — the per-link .catch
+    // is what keeps a rejection from propagating into chainRef.current
+    // itself. If a future edit dropped that .catch, the first link's
+    // rejection would permanently wedge chainRef.current in a rejected
+    // state, and every later .then() (including this test's second emit,
+    // and both flush sites) would never run again.
+    mockTypingAnalyticsEvent.mockRejectedValueOnce(new Error('ipc down'))
+    const { result } = renderUseInputModes({ typingRecordEnabled: true })
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+
+    // Release then press again — a second, independent press chained
+    // behind the first's now-rejected link.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), buildKeymap())
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    await flushMicrotasks()
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('useInputModes — test-finish flush gating', () => {
+  it('does not request the flush until the finishing keystroke\'s in-flight event settles', async () => {
+    // Mirrors the record-off regression above for the OTHER flush site:
+    // the test-finish effect also chains its flush behind
+    // resetMatrixPressTracking() and chainRef.current (see useInputModes.ts),
+    // so a still in-flight analytics IPC for the very keystroke that
+    // finished the run must gate the flush the same way.
+    // Stable across renders (computed once, outside the renderHook
+    // callback), matching the actual caller's usage: a fresh Map/config
+    // literal every render (fine for other tests here, which never await
+    // microtasks mid-run) would let the "feed matrix frames" and config-sync
+    // effects re-fire on every render once passive effects get a chance to
+    // flush, which regenerates a brand-new run mid-word.
+    const onSaveTypingTestResult = vi.fn()
+    const stableKeymap = buildKeymap()
+    const stableConfig = { mode: 'words' as const, wordCount: 1, punctuation: false, numbers: false }
+    const { result } = renderHook(() => useInputModes({
+      rows: 1,
+      cols: 1,
+      keymap: stableKeymap,
+      unlocked: true,
+      typingTestMode: true,
+      typingTestViewOnly: false,
+      typingRecordKeyboard: sampleKeyboard,
+      onSaveTypingTestResult,
+      savedTypingTestConfig: stableConfig,
+    }))
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+
+    // Type the whole word in one synchronous burst (no awaited microtasks
+    // in between — see the note above) so the run completes in a single
+    // pass instead of being disturbed mid-word. The word's last character
+    // finishes it (a single-word list finishes immediately on completing
+    // it, no trailing space needed); hold that last keystroke's IPC
+    // promise open to simulate it still being in flight when the finish
+    // effect requests the flush.
+    const [word] = result.current.typingTest.state.words
+    // Collected rather than a single overwritten variable: completing the
+    // run may emit more than one event off the finishing keystroke, and
+    // each mockImplementation call below creates its own promise.
+    const pendingResolvers: Array<() => void> = []
+    for (const char of word.slice(0, -1)) {
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    mockTypingAnalyticsEvent.mockImplementation(() => new Promise((resolve) => {
+      pendingResolvers.push(resolve)
+    }))
+    act(() => {
+      result.current.typingTest.processKeyEvent(word.slice(-1), false, false, false)
+    })
+    expect(result.current.typingTest.state.status).toBe('finished')
+
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsFlush).not.toHaveBeenCalled()
+
+    // Drain in rounds rather than once: resolving a link can itself cause
+    // the chain to reach the next still-pending mock call, adding a fresh
+    // resolver to the array after this loop would otherwise have already
+    // moved on.
+    for (let i = 0; i < 20 && mockTypingAnalyticsFlush.mock.calls.length === 0; i++) {
+      const resolvers = pendingResolvers.splice(0)
+      for (const resolve of resolvers) resolve()
+      await flushMicrotasks()
+    }
+    expect(mockTypingAnalyticsFlush).toHaveBeenCalledTimes(1)
+    expect(mockTypingAnalyticsFlush).toHaveBeenCalledWith(sampleKeyboard.uid)
+  })
 })
 
 // A matrix event can now sit in useTypingTest's ordering queue for up to
@@ -296,7 +503,7 @@ describe('useInputModes — typing analytics dispatch', () => {
 // were read to authorize the press — and is never revisited once the
 // event is actually flushed, however much the live state has since moved.
 describe('useInputModes — analytics gate/tag survive the ordering queue', () => {
-  it('still delivers an unresolved masked press (as hold) and the ordinary key queued behind it when recording stops mid-hold', () => {
+  it('still delivers an unresolved masked press (as hold) and the ordinary key queued behind it when recording stops mid-hold', async () => {
     const keymap = buildMaskedKeymap()
     const { result, rerender } = renderHook(
       ({ typingRecordEnabled }: { typingRecordEnabled: boolean }) => useInputModes({
@@ -328,6 +535,7 @@ describe('useInputModes — analytics gate/tag survive the ordering queue', () =
     // on then) and must still reach the sink, in press order — dropping
     // them here would be strictly worse than not queueing at all.
     rerender({ typingRecordEnabled: false })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
     expect(mockTypingAnalyticsEvent).toHaveBeenNthCalledWith(1, expect.objectContaining({
@@ -338,7 +546,7 @@ describe('useInputModes — analytics gate/tag survive the ordering queue', () =
     }))
   })
 
-  it("keeps a running test's label and run id when the press is flushed after the test view is exited", () => {
+  it("keeps a running test's label and run id when the press is flushed after the test view is exited", async () => {
     const keymap = buildMaskedKeymap()
     const { result, rerender } = renderHook(
       ({ typingTestViewOnly }: { typingTestViewOnly: boolean }) => useInputModes({
@@ -380,6 +588,7 @@ describe('useInputModes — analytics gate/tag survive the ordering queue', () =
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(), keymap)
     })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
@@ -389,7 +598,7 @@ describe('useInputModes — analytics gate/tag survive the ordering queue', () =
 })
 
 describe('useInputModes — tray keystroke counter', () => {
-  it('counts an authorized matrix press at press time, once — before it resolves and again not when it does', () => {
+  it('counts an authorized matrix press at press time, once — before it resolves and again not when it does', async () => {
     const keymap = buildMaskedKeymap()
     const onRecKeystroke = vi.fn()
     const { result } = renderUseInputModes({ typingRecordEnabled: true, keymap, onRecKeystroke })
@@ -408,6 +617,7 @@ describe('useInputModes — tray keystroke counter', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(), keymap)
     })
+    await flushMicrotasks()
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
     expect(onRecKeystroke).toHaveBeenCalledTimes(1)
   })
@@ -424,7 +634,7 @@ describe('useInputModes — tray keystroke counter', () => {
     expect(onRecKeystroke).not.toHaveBeenCalled()
   })
 
-  it('does not count a tagged editor-test keystroke (only untagged REC input counts)', () => {
+  it('does not count a tagged editor-test keystroke (only untagged REC input counts)', async () => {
     const onRecKeystroke = vi.fn()
     const { result } = renderUseInputModes({
       typingRecordEnabled: false,
@@ -442,6 +652,7 @@ describe('useInputModes — tray keystroke counter', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({ typingTest: expect.any(String) }))
     expect(onRecKeystroke).not.toHaveBeenCalled()

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -264,6 +264,28 @@ export function useInputModes({
     // input carries neither (so it lands as the null run / null test).
     return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null }
   }, [])
+  // Ordering contract, not an optimization: chaining every emit behind the
+  // previous one's IPC guarantees at most one typingAnalyticsEvent invoke
+  // is in flight at a time, so main's ingestEvent handlers can never
+  // interleave around their own internal `await resolveScope()` — the
+  // arrival order at main is always the call order here. Without this, a
+  // second event whose resolveScope() call resolves from a warm cache
+  // could reach the minute buffer before an earlier event still waiting
+  // on a cold-cache resolveScope(), reordering keystrokes.
+  //
+  // Four independent layers share the ordering job end to end, each
+  // covering what the one before it cannot:
+  //   - MatrixAnalyticsQueue (renderer): press-order classification —
+  //     decides tap vs. hold before anything reaches this sink.
+  //   - this chain (renderer): the arrival-order contract into main — at
+  //     most one IPC in flight, so decided order survives the IPC hop.
+  //   - MinuteBuffer retention (main): self-healing aggregation — a late
+  //     arrival re-dirties its entry instead of corrupting an already-flushed
+  //     minute, so a rare reorder or straggler heals on the next drain
+  //     rather than needing to never happen.
+  //   - `iki <= 0` guard (main, recordNgramChain): last-resort discard for
+  //     whatever tie/out-of-order pair still slips through all of the above.
+  const chainRef = useRef<Promise<void>>(Promise.resolve())
   const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
     const event = context.typingTest
       ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
@@ -272,8 +294,39 @@ export function useInputModes({
     // (MatrixAnalyticsQueue.drainAll, via resetMatrixPressTracking) — the
     // ordinary press/release/deadline paths call this and ignore it,
     // staying fire-and-forget same as before. Caught here (not left to
-    // the caller) so a drain's Promise.all never rejects on an IPC error.
-    return window.vialAPI.typingAnalyticsEvent(event).catch(() => { /* fire-and-forget */ })
+    // the caller) so a drain's Promise.all never rejects on an IPC error,
+    // and so one failed IPC doesn't stall every later link in the chain.
+    const next = chainRef.current
+      .then(() => window.vialAPI.typingAnalyticsEvent(event))
+      .catch(() => { /* fire-and-forget */ })
+    chainRef.current = next
+    return next
+  }, [])
+  /** Request a flush only after both `drained` and every event it just
+   * emitted have settled. `chainRef.current` must be read INSIDE the
+   * `.then()` — only after `drained` resolves — because draining is what
+   * pushes those emits onto the chain in the first place; reading it
+   * before `drained` resolves could capture the chain's state from
+   * before the drain ran. Shared by both flush sites (record-off, test
+   * finish): each has its own `drained` promise (from
+   * resetMatrixPressTracking) but the same requirement — main's
+   * ingestEvent does a real await (resolveScope) before an event reaches
+   * its minute buffer, so requesting the flush any earlier could have it
+   * serviced before a just-drained or still in-flight event lands,
+   * landing that event in a fresh buffer entry after the session it
+   * belonged to was already finalized.
+   *
+   * Reading `chainRef.current` here (rather than trusting emitAnalyticsEvent's
+   * return value alone) is also what survives a future refactor: useTypingTest's
+   * `onEmitAnalyticsEvent` is typed `=> void`, so nothing at the type level
+   * checks that emit keeps returning the chain tail — if a later change quietly
+   * dropped that return, this independent read of chainRef.current would still
+   * see the same in-flight state. */
+  const flushAfterPendingEmits = useCallback((drained: Promise<void>, uid: string): void => {
+    void drained
+      .then(() => chainRef.current)
+      .then(() => window.vialAPI.typingAnalyticsFlush(uid))
+      .catch(() => { /* fire-and-forget */ })
   }, [])
   const typingTest = useTypingTest(savedTypingTestConfig, savedTypingTestLanguage, {
     onPrepareAnalyticsEvent: prepareAnalyticsEvent,
@@ -391,25 +444,16 @@ export function useInputModes({
   // leaves view-only mode), finalize the open session in main and flush
   // its data for the active keyboard. Must wait for the drain the effect
   // above just kicked off (same recordingActive dependency, so it always
-  // runs first in this commit) to actually land in main before asking it
-  // to flush — main's ingestEvent does a real await before an event
-  // reaches its minute buffer, so an unawaited flush can be serviced
-  // before a just-drained event arrives, landing that event in a fresh
-  // buffer entry after the session it belonged to was already finalized.
+  // runs first in this commit) — see flushAfterPendingEmits for why.
   const prevRecordingActiveRef = useRef(recordingActive)
   useEffect(() => {
     const wasOn = prevRecordingActiveRef.current
     prevRecordingActiveRef.current = recordingActive
     if (wasOn && !recordingActive) {
       const uid = typingRecordKeyboard?.uid
-      if (uid) {
-        const drained = pendingDrainRef.current
-        void drained
-          .then(() => window.vialAPI.typingAnalyticsFlush(uid))
-          .catch(() => { /* fire-and-forget */ })
-      }
+      if (uid) flushAfterPendingEmits(pendingDrainRef.current, uid)
     }
-  }, [recordingActive, typingRecordKeyboard])
+  }, [recordingActive, typingRecordKeyboard, flushAfterPendingEmits])
 
   // Capture-phase keydown listener for typing test
   useEffect(() => {
@@ -473,18 +517,11 @@ export function useInputModes({
       // Flush the test's analytics so the just-finished minute/session
       // lands in the cache promptly (Analyze can show it without waiting
       // for the minute-close / before-quit flush). Keystrokes are recorded
-      // regardless of whether the result row is saved. Drain first (same
-      // reasoning as the record-off flush above): a masked key pressed
-      // near the end of the run may still be sitting unresolved in the
-      // ordering queue, and requesting the flush before it lands in main
-      // would land it in a fresh buffer entry after this run's session
-      // was already finalized.
+      // regardless of whether the result row is saved. See
+      // flushAfterPendingEmits for why the drain and the chain tail must
+      // both settle first.
       const uid = keyboardRef.current?.uid
-      if (uid) {
-        resetMatrixPressTracking()
-          .then(() => window.vialAPI.typingAnalyticsFlush(uid))
-          .catch(() => { /* fire-and-forget */ })
-      }
+      if (uid) flushAfterPendingEmits(resetMatrixPressTracking(), uid)
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }
@@ -501,7 +538,7 @@ export function useInputModes({
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
     typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
-    resetMatrixPressTracking])
+    resetMatrixPressTracking, flushAfterPendingEmits])
 
   // The just-finished result, exposed so the pane can build name chips: the
   // held unsaved one (save-unnamed off) until named, else the saved latest.


### PR DESCRIPTION
## Summary

Removes the last timer-dependent failure mode in the typing-analytics flush path. A late-arriving keystroke event (a deferred tap/hold emit delayed past the drain grace by renderer load or suspend) used to create a second partial snapshot for an already-flushed minute; the last-writer-wins merge then replaced that minute's real totals with the fragment.

- `MinuteBuffer` retains finalized minute entries (`state: 'open' | 'retained' | 'reopened'`) for `RETENTION_MS = 5 min` instead of deleting them. A late event reopens its entry and the next drain re-sends the **full cumulative snapshot**, making the LWW replace the correct operation. Events older than the retention window are dropped instead of overwriting flushed totals.
- A failed persist calls `reopenAll()` so the next pass re-sends retained minutes — the drained counts are no longer lost.
- Flush `updatedAt` is strictly monotonic so a corrective re-send can never lose the strict `>` LWW comparison to a same-millisecond predecessor.
- The renderer serializes analytics event IPCs through a single promise chain (at most one invoke in flight → arrival order = call order, which also removes the cold-scope-cache reordering path) and both flush triggers await the chain tail after the ordering-queue drain via a shared `flushAfterPendingEmits` helper.
- The live-heatmap peek skips retained entries to avoid double-counting against DB totals.
- Contract comments document the four ordering layers (renderer queue / serial chain / retention / `iki <= 0` guard) and the demotion of `DRAIN_CLOSE_GRACE_MS` to a performance window.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 319 files, 7307 passed / 22 skipped (new coverage: late-arrival cumulative re-send, retention eviction + ultra-late drop, reopenAll recovery incl. a forced persist failure, isEmpty/peek state awareness, chain serialization + rejection recovery, flush gating on in-flight matrix/char events, RETENTION_MS > DRAIN_CLOSE_GRACE_MS invariant, monotonic updatedAt)
