### PR TITLE
feat(sync): capture keypress durations and physical key overlap

### DIFF
--- a/src/main/typing-analytics/__tests__/bigram-aggregate.test.ts
+++ b/src/main/typing-analytics/__tests__/bigram-aggregate.test.ts
@@ -2,15 +2,31 @@
 
 import { describe, it, expect } from 'vitest'
 import {
+  aggregateMatrixDurationTotals,
   aggregatePairTotals,
+  avgDurationMsFromTotal,
   avgIkiFromHist,
+  durationSdFromTotal,
+  observedRolloverRatio,
   percentileFromHist,
   rankBigramsByCount,
   rankBigramsBySlow,
   sdFromSums,
   type BigramPairTotal,
 } from '../bigram-aggregate'
-import type { NgramMinuteCellRow } from '../db/typing-analytics-db'
+import type { MatrixDurationCellRow, NgramMinuteCellRow } from '../db/typing-analytics-db'
+
+function durationRow(
+  row: number,
+  col: number,
+  layer: number,
+  hist: number[],
+  sum: number,
+  sumSq: number,
+  minuteTs = 60_000,
+): MatrixDurationCellRow {
+  return { row, col, layer, minuteTs, hist, sum, sumSq }
+}
 
 function row(
   ngramId: string,
@@ -19,8 +35,9 @@ function row(
   minuteTs = 60_000,
   sumIki: number | null = null,
   sumSqIki: number | null = null,
+  overlap?: { overlapCount: number | null; overlapN: number | null },
 ): NgramMinuteCellRow {
-  return { ngramId, minuteTs, count, hist, sumIki, sumSqIki }
+  return { ngramId, minuteTs, count, hist, sumIki, sumSqIki, ...overlap }
 }
 
 function trigramRow(
@@ -34,7 +51,15 @@ function trigramRow(
   return { ngramId, minuteTs, count, hist, sumIki, sumSqIki }
 }
 
-function totals(entries: { ngramId: string; count: number; hist: number[]; sumIki?: number | null; sumSqIki?: number | null }[]): Map<string, BigramPairTotal> {
+function totals(entries: {
+  ngramId: string
+  count: number
+  hist: number[]
+  sumIki?: number | null
+  sumSqIki?: number | null
+  overlapCount?: number
+  overlapN?: number
+}[]): Map<string, BigramPairTotal> {
   const map = new Map<string, BigramPairTotal>()
   for (const e of entries) {
     map.set(e.ngramId, {
@@ -43,6 +68,8 @@ function totals(entries: { ngramId: string; count: number; hist: number[]; sumIk
       hist: e.hist,
       sumIki: e.sumIki ?? null,
       sumSqIki: e.sumSqIki ?? null,
+      overlapCount: e.overlapCount ?? 0,
+      overlapN: e.overlapN ?? 0,
     })
   }
   return map
@@ -70,10 +97,10 @@ describe('aggregatePairTotals', () => {
       row('A', 4, [3, 1, 0, 0, 0, 0, 0, 0]),
     ])
     expect(map.get('A')).toEqual({
-      ngramId: 'A', count: 5, hist: [4, 1, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null,
+      ngramId: 'A', count: 5, hist: [4, 1, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null, overlapCount: 0, overlapN: 0,
     })
     expect(map.get('B')).toEqual({
-      ngramId: 'B', count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null,
+      ngramId: 'B', count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null, overlapCount: 0, overlapN: 0,
     })
   })
 
@@ -118,6 +145,71 @@ describe('aggregatePairTotals', () => {
     const e = map.get('A')!
     expect(e.sumIki).toBeNull()
     expect(e.sumSqIki).toBeNull()
+  })
+
+  it('accumulates overlapCount/overlapN when every contributing row has them', () => {
+    const map = aggregatePairTotals([
+      row('A', 2, [2, 0, 0, 0, 0, 0, 0, 0], 60_000, null, null, { overlapCount: 1, overlapN: 2 }),
+      row('A', 3, [3, 0, 0, 0, 0, 0, 0, 0], 120_000, null, null, { overlapCount: 2, overlapN: 3 }),
+    ])
+    const e = map.get('A')!
+    expect(e.overlapCount).toBe(3)
+    expect(e.overlapN).toBe(5)
+  })
+
+  // Deliberate deviation from the sumIki/sumSqIki null-poisoning rule
+  // (codex P1 — overrides the original task doc's "same rule as SD"):
+  // a row with no overlap data contributes 0, it does not poison
+  // whatever the OTHER rows for the same pair DID observe. See the
+  // deviation comment at the aggregation site in bigram-aggregate.ts.
+  it('skips a row with no overlap data instead of poisoning the whole pair', () => {
+    const map = aggregatePairTotals([
+      row('A', 2, [2, 0, 0, 0, 0, 0, 0, 0], 60_000, null, null, { overlapCount: 1, overlapN: 2 }),
+      // A row whose events never had a determined overlap — contributes
+      // nothing, but does not erase the other row's contribution.
+      row('A', 1, [1, 0, 0, 0, 0, 0, 0, 0], 120_000, null, null),
+    ])
+    const e = map.get('A')!
+    expect(e.overlapCount).toBe(1)
+    expect(e.overlapN).toBe(2)
+  })
+
+  it('treats a trigram row (overlap columns structurally absent) as contributing 0, not poisoned', () => {
+    const map = aggregatePairTotals([
+      trigramRow('4_11_7', 1, [1, 0, 0, 0, 0, 0, 0, 0]),
+    ])
+    const e = map.get('4_11_7')!
+    expect(e.overlapCount).toBe(0)
+    expect(e.overlapN).toBe(0)
+  })
+})
+
+describe('observedRolloverRatio', () => {
+  it('returns null for an empty selection', () => {
+    expect(observedRolloverRatio(new Map())).toBeNull()
+  })
+
+  it('computes Σoc/Σon across every pair', () => {
+    const map = totals([
+      { ngramId: 'A', count: 5, hist: [], overlapCount: 3, overlapN: 5 },
+      { ngramId: 'B', count: 2, hist: [], overlapCount: 1, overlapN: 5 },
+    ])
+    expect(observedRolloverRatio(map)).toBe(4 / 10)
+  })
+
+  it('a pair with no overlap data contributes 0/0 rather than nulling the whole ratio', () => {
+    const map = totals([
+      { ngramId: 'A', count: 5, hist: [], overlapCount: 3, overlapN: 5 },
+      { ngramId: 'B', count: 2, hist: [] },
+    ])
+    expect(observedRolloverRatio(map)).toBe(3 / 5)
+  })
+
+  it('returns null when no pair in the selection has any overlap data (e.g. a trigram-only selection)', () => {
+    const map = totals([
+      { ngramId: 'A', count: 5, hist: [] },
+    ])
+    expect(observedRolloverRatio(map)).toBeNull()
   })
 })
 
@@ -299,5 +391,76 @@ describe('rankBigramsBySlow', () => {
     ])
     const [entry] = rankBigramsBySlow(map, 5, 5)
     expect(entry.sd).toBeNull()
+  })
+})
+
+describe('aggregateMatrixDurationTotals', () => {
+  it('returns an empty map for an empty input', () => {
+    expect(aggregateMatrixDurationTotals([]).size).toBe(0)
+  })
+
+  it('sums count/hist/sum/sumSq across rows for the same cell', () => {
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225, 60_000),
+      durationRow(0, 0, 0, [0, 0, 1, 0, 0, 0, 0, 0], 95, 9_025, 120_000),
+    ])
+    const e = map.get('0,0,0')!
+    expect(e.count).toBe(2)
+    expect(e.hist).toEqual([0, 1, 1, 0, 0, 0, 0, 0])
+    expect(e.sum).toBe(160)
+    expect(e.sumSq).toBe(13_250)
+  })
+
+  it('keeps separate entries for different cells', () => {
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [1, 0, 0, 0, 0, 0, 0, 0], 40, 1_600),
+      durationRow(0, 1, 0, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225),
+    ])
+    expect(map.size).toBe(2)
+    expect(map.get('0,0,0')!.count).toBe(1)
+    expect(map.get('0,1,0')!.count).toBe(1)
+  })
+
+  it('keeps the same physical cell on different layers distinct', () => {
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [1, 0, 0, 0, 0, 0, 0, 0], 40, 1_600),
+      durationRow(0, 0, 1, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225),
+    ])
+    expect(map.size).toBe(2)
+  })
+})
+
+describe('avgDurationMsFromTotal / durationSdFromTotal', () => {
+  it('computes the true mean from sum/count, not a histogram estimate', () => {
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [1, 1, 0, 0, 0, 0, 0, 0], 130, 8_500, 60_000),
+    ])
+    const e = map.get('0,0,0')!
+    expect(avgDurationMsFromTotal(e)).toBe(65)
+  })
+
+  it('returns null avg for a cell with no duration samples', () => {
+    const map = aggregateMatrixDurationTotals([])
+    map.set('0,0,0', { row: 0, col: 0, layer: 0, count: 0, hist: new Array(8).fill(0), sum: 0, sumSq: 0 })
+    expect(avgDurationMsFromTotal(map.get('0,0,0')!)).toBeNull()
+  })
+
+  it('returns null SD for fewer than 2 samples', () => {
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [1, 0, 0, 0, 0, 0, 0, 0], 65, 4_225),
+    ])
+    expect(durationSdFromTotal(map.get('0,0,0')!)).toBeNull()
+  })
+
+  it('computes a real SD from sum/sumSq once there are 2+ samples', () => {
+    // Durations [60, 70, 80]: mean=70, variance=((60-70)^2+(70-70)^2+(80-70)^2)/3=66.67
+    const sum = 60 + 70 + 80
+    const sumSq = 60 ** 2 + 70 ** 2 + 80 ** 2
+    const map = aggregateMatrixDurationTotals([
+      durationRow(0, 0, 0, [1, 1, 1, 0, 0, 0, 0, 0], sum, sumSq),
+    ])
+    const sd = durationSdFromTotal(map.get('0,0,0')!)
+    expect(sd).not.toBeNull()
+    expect(sd!).toBeCloseTo(Math.sqrt(200 / 3), 5)
   })
 })

--- a/src/main/typing-analytics/__tests__/bigram-bucket.test.ts
+++ b/src/main/typing-analytics/__tests__/bigram-bucket.test.ts
@@ -3,7 +3,9 @@
 import { describe, it, expect } from 'vitest'
 import {
   BIGRAM_BUCKET_UPPER_BOUNDS_MS,
+  DURATION_BUCKET_UPPER_BOUNDS_MS,
   bucketizeIki,
+  bucketizeDurations,
 } from '../bigram-bucket'
 import { BIGRAM_HIST_BUCKETS } from '../jsonl/jsonl-row'
 
@@ -47,6 +49,42 @@ describe('bucketizeIki', () => {
     // scan returns the correct bucket.
     for (let i = 1; i < BIGRAM_BUCKET_UPPER_BOUNDS_MS.length; i += 1) {
       expect(BIGRAM_BUCKET_UPPER_BOUNDS_MS[i]).toBeGreaterThan(BIGRAM_BUCKET_UPPER_BOUNDS_MS[i - 1])
+    }
+  })
+})
+
+describe('bucketizeDurations', () => {
+  it('returns an all-zero histogram for an empty array', () => {
+    const hist = bucketizeDurations([])
+    expect(hist).toHaveLength(BIGRAM_HIST_BUCKETS)
+    expect(hist.every((n) => n === 0)).toBe(true)
+  })
+
+  it('uses the tighter duration grid, not the IKI grid', () => {
+    // 120ms would land in IKI bucket 2 (100-150) but duration bucket 3
+    // (110-140) — the two grids must not be interchangeable.
+    expect(bucketizeDurations([120])).toEqual([0, 0, 0, 1, 0, 0, 0, 0])
+  })
+
+  it('places boundary values into the bucket whose lower edge they sit on', () => {
+    expect(bucketizeDurations([50])).toEqual([0, 1, 0, 0, 0, 0, 0, 0])
+    expect(bucketizeDurations([80])).toEqual([0, 0, 1, 0, 0, 0, 0, 0])
+    expect(bucketizeDurations([110])).toEqual([0, 0, 0, 1, 0, 0, 0, 0])
+    expect(bucketizeDurations([140])).toEqual([0, 0, 0, 0, 1, 0, 0, 0])
+    expect(bucketizeDurations([180])).toEqual([0, 0, 0, 0, 0, 1, 0, 0])
+    expect(bucketizeDurations([250])).toEqual([0, 0, 0, 0, 0, 0, 1, 0])
+    expect(bucketizeDurations([400])).toEqual([0, 0, 0, 0, 0, 0, 0, 1])
+  })
+
+  it('places values above the last boundary into the final bucket', () => {
+    expect(bucketizeDurations([1000, 60_000])).toEqual([0, 0, 0, 0, 0, 0, 0, 2])
+  })
+
+  it('exports a boundary array of expected length and shape', () => {
+    expect(DURATION_BUCKET_UPPER_BOUNDS_MS).toHaveLength(BIGRAM_HIST_BUCKETS)
+    expect(DURATION_BUCKET_UPPER_BOUNDS_MS[BIGRAM_HIST_BUCKETS - 1]).toBe(Number.POSITIVE_INFINITY)
+    for (let i = 1; i < DURATION_BUCKET_UPPER_BOUNDS_MS.length; i += 1) {
+      expect(DURATION_BUCKET_UPPER_BOUNDS_MS[i]).toBeGreaterThan(DURATION_BUCKET_UPPER_BOUNDS_MS[i - 1])
     }
   })
 })

--- a/src/main/typing-analytics/__tests__/minute-buffer.test.ts
+++ b/src/main/typing-analytics/__tests__/minute-buffer.test.ts
@@ -52,6 +52,7 @@ function matrixEvent(
   keycode: number,
   ts: number,
   action?: TypingMatrixAction,
+  extra?: { overlap?: boolean; pollGapMs?: number },
 ): TypingAnalyticsEvent {
   return {
     kind: 'matrix',
@@ -61,6 +62,28 @@ function matrixEvent(
     keycode,
     ts,
     ...(action ? { action } : {}),
+    ...(extra?.overlap !== undefined ? { overlap: extra.overlap } : {}),
+    ...(extra?.pollGapMs !== undefined ? { pollGapMs: extra.pollGapMs } : {}),
+    keyboard: { uid: 'x', vendorId: 0, productId: 0, productName: '' },
+  }
+}
+
+function matrixReleaseEvent(
+  row: number,
+  col: number,
+  layer: number,
+  keycode: number,
+  ts: number,
+  durationMs: number,
+): TypingAnalyticsEvent {
+  return {
+    kind: 'matrix-release',
+    row,
+    col,
+    layer,
+    keycode,
+    ts,
+    durationMs,
     keyboard: { uid: 'x', vendorId: 0, productId: 0, productName: '' },
   }
 }
@@ -130,8 +153,8 @@ describe('MinuteBuffer', () => {
     addEv(matrixEvent(2, 1, 1, 0x4015, 3_000), fp)
 
     const [snap] = buffer.drainAll()
-    expect(snap.matrixCounts.get('0,3,0')).toEqual({ row: 0, col: 3, layer: 0, keycode: 0x04, count: 2, tapCount: 0, holdCount: 0 })
-    expect(snap.matrixCounts.get('2,1,1')).toEqual({ row: 2, col: 1, layer: 1, keycode: 0x4015, count: 1, tapCount: 0, holdCount: 0 })
+    expect(snap.matrixCounts.get('0,3,0')).toEqual({ row: 0, col: 3, layer: 0, keycode: 0x04, count: 2, tapCount: 0, holdCount: 0, durations: [] })
+    expect(snap.matrixCounts.get('2,1,1')).toEqual({ row: 2, col: 1, layer: 1, keycode: 0x4015, count: 1, tapCount: 0, holdCount: 0, durations: [] })
   })
 
   it('computes interval stats from event timing', () => {
@@ -630,6 +653,7 @@ describe('MinuteBuffer', () => {
         count: 1,
         tapCount: 0,
         holdCount: 1,
+        durations: [],
       })
     })
 
@@ -644,6 +668,204 @@ describe('MinuteBuffer', () => {
       // Only the A-B pair survives; nothing pairs or triples through the hold.
       expect([...snap.bigrams.entries()]).toEqual([['4_11', [100]]])
       expect(snap.trigrams.size).toBe(0)
+    })
+  })
+
+  describe('matrix-release duration folding', () => {
+    it('folds durationMs into the cell without touching keystrokes/intervals/activeMs', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixReleaseEvent(0, 0, 0, 4, 1_120, 120), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.keystrokes).toBe(1)
+      expect(snap.activeMs).toBe(0)
+      expect(snap.intervalMinMs).toBeNull()
+      expect(snap.matrixCounts.get('0,0,0')).toEqual({
+        row: 0, col: 0, layer: 0, keycode: 4, count: 1, tapCount: 0, holdCount: 0, durations: [120],
+      })
+    })
+
+    it('accumulates multiple durations for the same cell', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixReleaseEvent(0, 0, 0, 4, 1_100, 100), fp)
+      addEv(matrixEvent(0, 0, 0, 4, 1_200), fp)
+      addEv(matrixReleaseEvent(0, 0, 0, 4, 1_290, 90), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.matrixCounts.get('0,0,0')?.durations).toEqual([100, 90])
+      expect(snap.matrixCounts.get('0,0,0')?.count).toBe(2)
+    })
+
+    it('a release landing in a later minute than its press attributes the duration to the release minute', () => {
+      const fp = fingerprint()
+      // Press at 59.9s (minute 0), release at 60.1s (minute 1).
+      addEv(matrixEvent(0, 0, 0, 4, MINUTE_MS - 100), fp)
+      addEv(matrixReleaseEvent(0, 0, 0, 4, MINUTE_MS + 100, 200), fp)
+
+      const snapshots = buffer.drainAll().sort((a, b) => a.minuteTs - b.minuteTs)
+      expect(snapshots).toHaveLength(2)
+      const [minute0, minute1] = snapshots
+      // Press count lands in minute 0, with no duration sample.
+      expect(minute0.matrixCounts.get('0,0,0')?.count).toBe(1)
+      expect(minute0.matrixCounts.get('0,0,0')?.durations).toEqual([])
+      // The duration sample lands in minute 1, as a duration-only cell
+      // (count 0 — the press itself never touched this minute).
+      expect(minute1.matrixCounts.get('0,0,0')?.count).toBe(0)
+      expect(minute1.matrixCounts.get('0,0,0')?.durations).toEqual([200])
+      expect(minute1.keystrokes).toBe(0)
+    })
+
+    it('drops a release with no matching press instead of fabricating one', () => {
+      const fp = fingerprint()
+      addEv(matrixReleaseEvent(0, 0, 0, 4, 1_000, 50), fp)
+
+      const [snap] = buffer.drainAll()
+      // The cell exists (duration-only) but nothing else is touched.
+      expect(snap.keystrokes).toBe(0)
+      expect(snap.matrixCounts.get('0,0,0')).toEqual({
+        row: 0, col: 0, layer: 0, keycode: 4, count: 0, tapCount: 0, holdCount: 0, durations: [50],
+      })
+    })
+
+    it('reopens a retained entry when a release arrives after its minute was already finalized', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      const [first] = buffer.drainClosed(1_000 + MINUTE_MS + DRAIN_CLOSE_GRACE_MS)
+      expect(first.matrixCounts.get('0,0,0')?.durations).toEqual([])
+      expect(buffer.isEmpty()).toBe(true)
+
+      // A straggler release for the same press, still inside RETENTION_MS.
+      addEv(matrixReleaseEvent(0, 0, 0, 4, 1_050, 50), fp, 1_000 + MINUTE_MS + DRAIN_CLOSE_GRACE_MS + 10)
+      expect(buffer.isEmpty()).toBe(false)
+
+      const [second] = buffer.drainAll()
+      // Re-finalize is cumulative — the press count is still there.
+      expect(second.matrixCounts.get('0,0,0')).toEqual({
+        row: 0, col: 0, layer: 0, keycode: 4, count: 1, tapCount: 0, holdCount: 0, durations: [50],
+      })
+    })
+  })
+
+  describe('bigram overlap tracking', () => {
+    it('records on/oc for a pair whose incoming event has overlap=true', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_050, undefined, { overlap: true }), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.overlaps.get('4_11')).toEqual({ oc: 1, on: 1 })
+    })
+
+    it('records on without oc for a pair whose incoming event has overlap=false', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_050, undefined, { overlap: false }), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.overlaps.get('4_11')).toEqual({ oc: 0, on: 1 })
+    })
+
+    it('excludes a pair from the on/oc denominator entirely when overlap is undefined', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      // No `overlap` field at all — the renderer couldn't determine it.
+      addEv(matrixEvent(0, 1, 0, 11, 1_050), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.overlaps.has('4_11')).toBe(false)
+      // The IKI histogram itself is unaffected by overlap being unknown.
+      expect(snap.bigrams.get('4_11')).toEqual([50])
+    })
+
+    it('accumulates overlap across a 3-key chord (both completed pairs)', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_010, undefined, { overlap: true }), fp)
+      addEv(matrixEvent(0, 2, 0, 7, 1_020, undefined, { overlap: true }), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.overlaps.get('4_11')).toEqual({ oc: 1, on: 1 })
+      expect(snap.overlaps.get('11_7')).toEqual({ oc: 1, on: 1 })
+    })
+
+    it('does not record overlap for a pair whose interval exceeds NGRAM_MAX_IKI_MS', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+      addEv(matrixEvent(0, 1, 0, 11, 1_000 + NGRAM_MAX_IKI_MS + 1, undefined, { overlap: true }), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.overlaps.size).toBe(0)
+    })
+
+    describe('same-frame ties (iki === 0)', () => {
+      it('folds overlap=true onto the tied pair without recording an IKI', () => {
+        const fp = fingerprint()
+        addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+        // Same ts as the previous press — a genuine same-frame chord.
+        addEv(matrixEvent(0, 1, 0, 11, 1_000, undefined, { overlap: true }), fp)
+
+        const [snap] = buffer.drainAll()
+        expect(snap.overlaps.get('4_11')).toEqual({ oc: 1, on: 1 })
+        // The tie is unusable as an interval — bigrams map stays untouched.
+        expect(snap.bigrams.has('4_11')).toBe(false)
+      })
+
+      it('folds overlap=false onto the tied pair too (on without oc)', () => {
+        const fp = fingerprint()
+        addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+        addEv(matrixEvent(0, 1, 0, 11, 1_000, undefined, { overlap: false }), fp)
+
+        const [snap] = buffer.drainAll()
+        expect(snap.overlaps.get('4_11')).toEqual({ oc: 0, on: 1 })
+        expect(snap.bigrams.has('4_11')).toBe(false)
+      })
+
+      it('does not fold anything for a tie when overlap is undefined', () => {
+        const fp = fingerprint()
+        addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+        addEv(matrixEvent(0, 1, 0, 11, 1_000), fp)
+
+        const [snap] = buffer.drainAll()
+        expect(snap.overlaps.has('4_11')).toBe(false)
+        expect(snap.bigrams.has('4_11')).toBe(false)
+      })
+
+      it('does not advance the chain on a tie — a later event still pairs against the pre-tie key', () => {
+        const fp = fingerprint()
+        addEv(matrixEvent(0, 0, 0, 4, 1_000), fp) // k2 becomes keycode 4
+        addEv(matrixEvent(0, 1, 0, 11, 1_000, undefined, { overlap: true }), fp) // tie: folds overlap, chain unchanged
+        addEv(matrixEvent(0, 2, 0, 7, 1_050), fp) // must still pair against keycode 4, not 11
+
+        const [snap] = buffer.drainAll()
+        expect(snap.bigrams.has('4_7')).toBe(true)
+        expect(snap.bigrams.has('11_7')).toBe(false)
+      })
+    })
+  })
+
+  describe('poll-gap p50/p95', () => {
+    it('is null when no matrix event carried a pollGapMs sample', () => {
+      const fp = fingerprint()
+      addEv(matrixEvent(0, 0, 0, 4, 1_000), fp)
+
+      const [snap] = buffer.drainAll()
+      expect(snap.pollP50Ms).toBeNull()
+      expect(snap.pollP95Ms).toBeNull()
+    })
+
+    it('computes p50/p95 from the accumulated samples', () => {
+      const fp = fingerprint()
+      // Same percentile convention as the existing IKI stats: sorted
+      // index = floor((n - 1) * q). Five ordered samples make both
+      // checkpoints land on an unambiguous element.
+      const gaps = [10, 20, 30, 40, 50]
+      gaps.forEach((gap, i) => addEv(matrixEvent(0, i, 0, 4 + i, 1_000 + i * 10, undefined, { pollGapMs: gap }), fp))
+
+      const [snap] = buffer.drainAll()
+      expect(snap.pollP50Ms).toBe(30)
+      expect(snap.pollP95Ms).toBe(40)
     })
   })
 

--- a/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
+++ b/src/main/typing-analytics/__tests__/typing-analytics-service.test.ts
@@ -98,6 +98,7 @@ import {
 import { IpcChannels } from '../../../shared/ipc/channels'
 import type { TypingBigramAggregateResult } from '../../../shared/types/typing-analytics'
 import { DRAIN_CLOSE_GRACE_MS, MINUTE_MS, RETENTION_MS } from '../minute-buffer'
+import { OBSERVATION_HOLE_MS } from '../../../shared/typing-analytics-timing'
 
 type IpcHandler<R = unknown> = (event: unknown, ...args: unknown[]) => Promise<R>
 
@@ -654,6 +655,29 @@ describe('typing-analytics-service', () => {
         expect(result.entries.every((e: { count: number }) => e.count === 1)).toBe(true)
       })
 
+      it('computes observedRolloverRatio from overlap-tagged matrix events', async () => {
+        setupTypingAnalyticsIpc()
+        const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+        const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+        // 4->11 completes with overlap=true, 11->7 with overlap=false.
+        await ingest(handler, { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard })
+        await ingest(handler, { kind: 'matrix', row: 0, col: 1, layer: 0, keycode: 0x0B, ts: ts + 80, keyboard: sampleKeyboard, overlap: true })
+        await ingest(handler, { kind: 'matrix', row: 0, col: 2, layer: 0, keycode: 0x07, ts: ts + 280, keyboard: sampleKeyboard, overlap: false })
+        await flushTypingAnalyticsNowForTests()
+
+        const aggHandler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+        const result = await aggHandler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
+        expect(result.observedRolloverRatio).toBe(1 / 2)
+      })
+
+      it('returns null observedRolloverRatio when no ingested event carried a determined overlap', async () => {
+        const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+        await ingestThree(ts)
+        const handler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
+        const result = await handler(fakeEvent, sampleKeyboard.uid, ts - 60_000, ts + 60_000, 'top', 'all', undefined)
+        expect(result.observedRolloverRatio).toBeNull()
+      })
+
       it('returns slow entries with p95 for view=slow', async () => {
         const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
         await ingestThree(ts)
@@ -680,21 +704,21 @@ describe('typing-analytics-service', () => {
         setupTypingAnalyticsIpc()
         const handler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
         const result = await handler(fakeEvent, sampleKeyboard.uid, 0, 60_000, 'unknown', 'all', undefined)
-        expect(result).toEqual({ view: 'top', entries: [], truncated: false })
+        expect(result).toEqual({ view: 'top', entries: [], truncated: false, observedRolloverRatio: null })
       })
 
       it('returns an empty result when sinceMs >= untilMs', async () => {
         setupTypingAnalyticsIpc()
         const handler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
         const result = await handler(fakeEvent, sampleKeyboard.uid, 60_000, 60_000, 'top', 'all', undefined)
-        expect(result).toEqual({ view: 'top', entries: [], truncated: false })
+        expect(result).toEqual({ view: 'top', entries: [], truncated: false, observedRolloverRatio: null })
       })
 
       it('returns an empty result when uid is invalid', async () => {
         setupTypingAnalyticsIpc()
         const handler = getHandler<TypingBigramAggregateResult>(IpcChannels.TYPING_ANALYTICS_GET_BIGRAM_AGGREGATE_FOR_RANGE)
         const result = await handler(fakeEvent, '', 0, 60_000, 'top', 'all', undefined)
-        expect(result).toEqual({ view: 'top', entries: [], truncated: false })
+        expect(result).toEqual({ view: 'top', entries: [], truncated: false, observedRolloverRatio: null })
       })
 
       it('honours scope=own by filtering to the local machine_hash', async () => {
@@ -801,8 +825,160 @@ describe('typing-analytics-service', () => {
       await ingest(handler, { kind: 'matrix', row: -1, col: 0, layer: 0, keycode: 1, ts: 1_000, keyboard: sampleKeyboard })
       await ingest(handler, { kind: 'char', key: 'a', ts: 1_000 })
       await ingest(handler, { kind: 'char', key: 'a', ts: 1_000, keyboard: { uid: '', vendorId: 0, productId: 0, productName: '' } })
+      // Note: an invalid action/overlap/pollGapMs on an otherwise-valid
+      // matrix event does NOT drop the payload — see the sanitization
+      // tests below (isValidEvent strips the offending optional field
+      // instead of rejecting the whole keystroke).
+      // matrix-release requires row/col/layer/keycode plus a valid durationMs.
+      await ingest(handler, { kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: 1, ts: 1_000, keyboard: sampleKeyboard })
+      await ingest(handler, {
+        kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: 1, ts: 1_000, durationMs: 0, keyboard: sampleKeyboard,
+      })
+      await ingest(handler, {
+        kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: 1, ts: 1_000, durationMs: -10, keyboard: sampleKeyboard,
+      })
+      await ingest(handler, {
+        kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: 1, ts: 1_000, durationMs: 60_000, keyboard: sampleKeyboard,
+      })
 
       expect(getMinuteBufferForTests().isEmpty()).toBe(true)
+    })
+
+    it('accepts a matrix event with valid action/overlap/pollGapMs and a matrix-release event, and persists duration to SQLite', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, {
+        kind: 'matrix', row: 0, col: 3, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard,
+        action: 'tap', overlap: true, pollGapMs: 20,
+      })
+      await ingest(handler, {
+        kind: 'matrix-release', row: 0, col: 3, layer: 0, keycode: 0x04, ts: ts + 90, durationMs: 90, keyboard: sampleKeyboard,
+      })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const row = conn.prepare('SELECT count, dur_hist, dur_sum, dur_sumsq FROM typing_matrix_minute WHERE row = 0 AND col = 3').get() as {
+        count: number
+        dur_hist: Uint8Array | null
+        dur_sum: number | null
+        dur_sumsq: number | null
+      }
+      expect(row.count).toBe(1)
+      expect(row.dur_hist).not.toBeNull()
+      expect(row.dur_sum).toBe(90)
+      expect(row.dur_sumsq).toBe(8_100)
+    })
+
+    it('sanitizes an invalid action/overlap/pollGapMs instead of dropping the keystroke', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, {
+        kind: 'matrix', row: 0, col: 5, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard,
+        action: 'bogus', overlap: 'yes', pollGapMs: -5,
+      })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      // The keystroke itself is still counted...
+      const row = conn.prepare('SELECT count, tap_count, hold_count FROM typing_matrix_minute WHERE row = 0 AND col = 5').get() as {
+        count: number
+        tap_count: number
+        hold_count: number
+      }
+      expect(row.count).toBe(1)
+      expect(row.tap_count).toBe(0)
+      expect(row.hold_count).toBe(0)
+
+      // ...but the invalid pollGapMs never reaches minute-stats.
+      const stats = conn.prepare('SELECT poll_p50_ms, poll_p95_ms FROM typing_minute_stats WHERE minute_ts = ?').get(Math.floor(ts / MINUTE_MS) * MINUTE_MS) as {
+        poll_p50_ms: number | null
+        poll_p95_ms: number | null
+      }
+      expect(stats.poll_p50_ms).toBeNull()
+      expect(stats.poll_p95_ms).toBeNull()
+    })
+
+    it('sanitizes an oversized pollGapMs (beyond OBSERVATION_HOLE_MS) without dropping the event', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const ts = Date.UTC(2026, 3, 14, 12, 0, 0)
+
+      await ingest(handler, {
+        kind: 'matrix', row: 0, col: 6, layer: 0, keycode: 0x04, ts, keyboard: sampleKeyboard,
+        pollGapMs: OBSERVATION_HOLE_MS + 1,
+      })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const row = conn.prepare('SELECT count FROM typing_matrix_minute WHERE row = 0 AND col = 6').get() as { count: number }
+      expect(row.count).toBe(1)
+
+      const stats = conn.prepare('SELECT poll_p50_ms FROM typing_minute_stats WHERE minute_ts = ?').get(Math.floor(ts / MINUTE_MS) * MINUTE_MS) as { poll_p50_ms: number | null }
+      expect(stats.poll_p50_ms).toBeNull()
+    })
+
+    it('does not create a minute-stats row for a minute whose only activity is a matrix-release (no phantom day)', async () => {
+      setupTypingAnalyticsIpc()
+      const handler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      // A press near the end of one minute, released just after the next
+      // minute starts — the release's own minute has no press activity
+      // of its own, only the duration sample.
+      const minuteStart = Date.UTC(2026, 3, 14, 10, 1, 0)
+      const pressTs = minuteStart - 50
+      const releaseTs = minuteStart + 50
+
+      await ingest(handler, { kind: 'matrix', row: 0, col: 7, layer: 0, keycode: 0x04, ts: pressTs, keyboard: sampleKeyboard })
+      await ingest(handler, {
+        kind: 'matrix-release', row: 0, col: 7, layer: 0, keycode: 0x04, ts: releaseTs, durationMs: 100, keyboard: sampleKeyboard,
+      })
+      await flushTypingAnalyticsNowForTests()
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const releaseMinuteTs = Math.floor(releaseTs / MINUTE_MS) * MINUTE_MS
+      const statsRow = conn.prepare('SELECT keystrokes FROM typing_minute_stats WHERE minute_ts = ?').get(releaseMinuteTs)
+      expect(statsRow).toBeUndefined()
+
+      // The duration data itself still ships for that same minute.
+      const matrixRow = conn.prepare('SELECT dur_sum FROM typing_matrix_minute WHERE minute_ts = ? AND row = 0 AND col = 7').get(releaseMinuteTs) as { dur_sum: number } | undefined
+      expect(matrixRow?.dur_sum).toBe(100)
+
+      // The press's own (earlier) minute still gets an ordinary
+      // minute-stats row — only the release-only minute is skipped.
+      const pressMinuteTs = Math.floor(pressTs / MINUTE_MS) * MINUTE_MS
+      const pressStatsRow = conn.prepare('SELECT keystrokes FROM typing_minute_stats WHERE minute_ts = ?').get(pressMinuteTs) as { keystrokes: number } | undefined
+      expect(pressStatsRow?.keystrokes).toBe(1)
+    })
+
+    it('excludes matrix-release from session detection (a release alone does not open or extend a session)', async () => {
+      setupTypingAnalyticsIpc()
+      const eventHandler = getHandler(IpcChannels.TYPING_ANALYTICS_EVENT)
+      const flushHandler = getHandler(IpcChannels.TYPING_ANALYTICS_FLUSH)
+
+      const pressTs = Date.UTC(2026, 3, 14, 12, 0, 0)
+      // Well past SESSION_IDLE_GAP_MS (5 min) — if the release below
+      // were treated as an ordinary keystroke for session detection, this
+      // gap would close the press's session and open a second one at
+      // the release's own ts.
+      const releaseTs = pressTs + 6 * MINUTE_MS
+
+      await ingest(eventHandler, { kind: 'matrix', row: 0, col: 8, layer: 0, keycode: 0x04, ts: pressTs, keyboard: sampleKeyboard })
+      await ingest(eventHandler, {
+        kind: 'matrix-release', row: 0, col: 8, layer: 0, keycode: 0x04, ts: releaseTs, durationMs: 6 * MINUTE_MS, keyboard: sampleKeyboard,
+      })
+
+      await flushHandler(fakeEvent, sampleKeyboard.uid)
+
+      const conn = getTypingAnalyticsDB().getConnection()
+      const sessions = conn.prepare('SELECT start_ms, end_ms FROM typing_sessions').all() as Array<{ start_ms: number; end_ms: number }>
+      // Exactly one session, ending at the press itself — the release
+      // never reached the session detector at all.
+      expect(sessions).toHaveLength(1)
+      expect(sessions[0].start_ms).toBe(pressTs)
+      expect(sessions[0].end_ms).toBe(pressTs)
     })
   })
 

--- a/src/main/typing-analytics/bigram-aggregate.ts
+++ b/src/main/typing-analytics/bigram-aggregate.ts
@@ -9,7 +9,7 @@ import {
   BIGRAM_BUCKET_CENTERS_MS,
   BIGRAM_BUCKET_UPPER_BOUNDS_MS,
 } from './bigram-bucket'
-import type { NgramMinuteCellRow } from './db/typing-analytics-db'
+import type { MatrixDurationCellRow, NgramMinuteCellRow } from './db/typing-analytics-db'
 import { BIGRAM_HIST_BUCKETS } from './jsonl/jsonl-row'
 import type {
   TypingBigramSlowEntry,
@@ -27,6 +27,15 @@ export interface BigramPairTotal {
    * pair are no longer added to it. */
   sumIki: number | null
   sumSqIki: number | null
+  /** Running physical-overlap accumulators (see OverlapCounts in
+   * minute-buffer.ts). Deliberately NOT null-poisoned the way
+   * sumIki/sumSqIki are (see {@link aggregatePairTotals}'s doc comment
+   * for why that rule doesn't transfer here) — a row with no oc/on
+   * (older data, or a v8 row whose events never had a determined
+   * overlap, or a trigram row where the columns don't exist at all)
+   * simply contributes 0 to both. Always a plain number, never null. */
+  overlapCount: number
+  overlapN: number
 }
 
 /** Sum per-(scope, minute, pair) rows into one entry per pair id
@@ -56,6 +65,8 @@ export function aggregatePairTotals(
         hist: new Array<number>(BIGRAM_HIST_BUCKETS).fill(0),
         sumIki: 0,
         sumSqIki: 0,
+        overlapCount: 0,
+        overlapN: 0,
       }
       totals.set(id, entry)
     }
@@ -70,8 +81,67 @@ export function aggregatePairTotals(
       entry.sumIki += row.sumIki
       entry.sumSqIki += row.sumSqIki
     }
+    // Deliberate deviation from the sumIki/sumSqIki null-poisoning rule
+    // above (codex P1 review — overrides the original task doc's "same
+    // rule as SD" instruction): `undefined` (trigram rows never carry
+    // these columns) and `null` (a bigram row that predates schema v8,
+    // or whose events never had a determined overlap) both just mean
+    // "this row observed nothing about overlap" and contribute 0 to
+    // both accumulators, rather than poisoning the whole pair. Unlike
+    // sumIki, there is no cross-row inconsistency possible here: each
+    // row's own oc/on is already a self-consistent fraction of the
+    // events THAT row observed, so a missing row can never hide a real
+    // partial count the way an incomplete sum could silently understate
+    // an SD. Poisoning here would mean every pair touched by even one
+    // v7-era row — i.e. every pair for the entire v7->v8 transition
+    // month — or one v8 row whose presses all had undefined overlap,
+    // permanently nulls that pair's contribution to observedRolloverRatio.
+    if (row.overlapCount != null && row.overlapN != null) {
+      entry.overlapCount += row.overlapCount
+      entry.overlapN += row.overlapN
+    }
   }
   return totals
+}
+
+/** Selection-wide overlap ratio: ΣoverlapCount / ΣoverlapN across every
+ * pair in `totals` (see {@link aggregatePairTotals} — a row with no
+ * overlap data just contributes 0 to both sums, it is never poisoned).
+ * Null when the resulting denominator is 0 (no pair in the selection
+ * ever had a determined overlap — e.g. a trigram view, or a selection
+ * entirely from before schema v8).
+ *
+ * Named with the `observed` prefix everywhere this value travels (type,
+ * IPC field, any future CSV/UI column) because it is a SAMPLED
+ * approximation of how often consecutive keys physically overlapped —
+ * bounded by the renderer's polling cadence, not a measurement of true
+ * rollover timing (see Plan-typing-metrics-chi2018.md "制約 2"). It must
+ * never be presented as "the" rollover rate.
+ *
+ * Residual bias, even after the fixes above: a same-frame tie (two
+ * presses landing in one polled frame, iki === 0 in
+ * MinuteBuffer.recordNgramChain) folds its overlap into the TIED pair
+ * rather than advancing the chain, so the tie key becomes stale for
+ * whatever pair the chain completes next. Concretely — A and B pressed
+ * in the same frame, then C pressed later: pair A_C's overlap sample
+ * actually describes "was B still down when C was pressed", not
+ * A's relationship to C. Full reference-key realignment (re-deriving
+ * which physical key the NEXT pair should compare against after a tie)
+ * was considered and rejected as machinery disproportionate to an
+ * avowedly sampled, approximate metric. What remains after the tie fix
+ * is this: the ratio no longer has a systematic downward bias (ties used
+ * to discard the overlap evidence entirely), but it does carry
+ * attribution noise — a small, non-systematic chance that a sample
+ * counted toward one pair actually describes a different, adjacent one —
+ * concentrated in fast chords where same-frame ties are common. */
+export function observedRolloverRatio(totals: ReadonlyMap<string, BigramPairTotal>): number | null {
+  let oc = 0
+  let on = 0
+  for (const entry of totals.values()) {
+    oc += entry.overlapCount
+    on += entry.overlapN
+  }
+  return on > 0 ? oc / on : null
 }
 
 /** Standard deviation of raw IKI from accumulated sum / sum-of-squares.
@@ -188,4 +258,77 @@ export function rankBigramsBySlow(
     p95: percentileFromHist(entry.hist, 0.95),
     sd: sdFromTotal(entry),
   }))
+}
+
+// --- Matrix cell keypress-duration aggregation ------------------------
+// Same per-cell-across-minutes folding pattern as aggregatePairTotals
+// above, but for matrix-release durations. There is no cross-row
+// null-poisoning case here the way there is for sumIki/overlap: every
+// MatrixDurationCellRow the DB hands back already has a complete
+// hist/sum/sumSq triple (see the JSONL dh/ds/dq all-or-nothing
+// validator) — a row with no duration sample that minute is simply
+// excluded from the SQL result (see selectMatrixDurationForUidStmt),
+// not returned with a partial/inconsistent shape.
+
+export interface MatrixCellDurationTotal {
+  row: number
+  col: number
+  layer: number
+  /** Total duration SAMPLE count for this cell across the range — not
+   * the press count (see the shared `matrix-release` event type's note
+   * on why a minute's duration samples and press count can legitimately
+   * differ). */
+  count: number
+  hist: number[]
+  sum: number
+  sumSq: number
+}
+
+/** Sum per-(scope, minute, cell) duration rows into one entry per
+ * physical cell (row, col, layer). Counts add directly (from the
+ * histogram bucket totals); histograms add element-wise; sum/sumSq
+ * accumulate unconditionally since every contributing row is already a
+ * complete triple (see this section's header comment). */
+export function aggregateMatrixDurationTotals(
+  rows: readonly MatrixDurationCellRow[],
+): Map<string, MatrixCellDurationTotal> {
+  const totals = new Map<string, MatrixCellDurationTotal>()
+  for (const row of rows) {
+    const key = `${row.row},${row.col},${row.layer}`
+    let entry = totals.get(key)
+    if (!entry) {
+      entry = {
+        row: row.row,
+        col: row.col,
+        layer: row.layer,
+        count: 0,
+        hist: new Array<number>(BIGRAM_HIST_BUCKETS).fill(0),
+        sum: 0,
+        sumSq: 0,
+      }
+      totals.set(key, entry)
+    }
+    for (let i = 0; i < BIGRAM_HIST_BUCKETS; i += 1) {
+      const bucketCount = row.hist[i] ?? 0
+      entry.hist[i] += bucketCount
+      entry.count += bucketCount
+    }
+    entry.sum += row.sum
+    entry.sumSq += row.sumSq
+  }
+  return totals
+}
+
+/** Average keypress duration (ms) for a cell total — the true mean from
+ * `sum / count`, not a histogram-bucket-center estimate (unlike
+ * avgIkiFromHist, the exact sum is always available here). Null when
+ * the cell has no duration samples in range. */
+export function avgDurationMsFromTotal(entry: MatrixCellDurationTotal): number | null {
+  return entry.count > 0 ? entry.sum / entry.count : null
+}
+
+/** Standard deviation of keypress duration (ms) for a cell total. Null
+ * when fewer than 2 samples (see {@link sdFromSums}). */
+export function durationSdFromTotal(entry: MatrixCellDurationTotal): number | null {
+  return sdFromSums(entry.sum, entry.sumSq, entry.count)
 }

--- a/src/main/typing-analytics/bigram-bucket.ts
+++ b/src/main/typing-analytics/bigram-bucket.ts
@@ -49,24 +49,78 @@ export const BIGRAM_BUCKET_CENTERS_MS: readonly number[] = [
   1500,  // bucket 7: >= 1000 (slow-tail estimate)
 ] as const
 
-function bucketIndex(iki: number): number {
-  // Drive selection from the exported boundary array so downstream
-  // percentile / avg derivations stay consistent if boundaries change.
-  for (let i = 0; i < BIGRAM_BUCKET_UPPER_BOUNDS_MS.length; i += 1) {
-    if (iki < BIGRAM_BUCKET_UPPER_BOUNDS_MS[i]) return i
+/** Exclusive upper bounds of each keypress-duration histogram bucket, in
+ * ms. Deliberately a much tighter grid than {@link BIGRAM_BUCKET_UPPER_BOUNDS_MS}:
+ * the CHI 2018 typing-behaviour literature this project's benchmarks are
+ * modeled on (see `src/shared/typing-benchmarks.ts`) puts typical keypress
+ * durations in the 80-150 ms range — an order of magnitude narrower than
+ * inter-key intervals, which range from sub-60ms rolls to multi-second
+ * pauses. Reusing the IKI grid here would collapse almost every real
+ * duration sample into the first one or two buckets. */
+export const DURATION_BUCKET_UPPER_BOUNDS_MS: readonly number[] = [
+  50,
+  80,
+  110,
+  140,
+  180,
+  250,
+  400,
+  Number.POSITIVE_INFINITY,
+] as const
+
+/** Estimated bucket centers (ms) for the duration grid above — same
+ * midpoint-of-closed-bucket / synthetic-center-for-the-open-bucket
+ * convention as {@link BIGRAM_BUCKET_CENTERS_MS}. Not consumed yet — its
+ * reader arrives with the duration-UI task (Analyze view), same as how
+ * the histogram data itself isn't rendered anywhere until then. */
+export const DURATION_BUCKET_CENTERS_MS: readonly number[] = [
+  25,   // bucket 0: < 50
+  65,   // bucket 1: 50-80
+  95,   // bucket 2: 80-110
+  125,  // bucket 3: 110-140
+  160,  // bucket 4: 140-180
+  215,  // bucket 5: 180-250
+  325,  // bucket 6: 250-400
+  600,  // bucket 7: >= 400 (long-hold estimate)
+] as const
+
+/** Shared bucket-index lookup, generalized over any exclusive-upper-bound
+ * array so the IKI and duration grids don't need their own copy of the
+ * same linear scan. `bounds` must have exactly BIGRAM_HIST_BUCKETS - 1
+ * meaningful entries plus a POSITIVE_INFINITY tail (both exported bound
+ * arrays satisfy this) — a value that doesn't fall under any bound before
+ * the last one falls into the final (catch-all) bucket. */
+function bucketIndexFor(value: number, bounds: readonly number[]): number {
+  for (let i = 0; i < bounds.length; i += 1) {
+    if (value < bounds[i]) return i
   }
   return BIGRAM_HIST_BUCKETS - 1
+}
+
+/** Bucketize raw values into a fixed-size histogram against any grid —
+ * shared by {@link bucketizeIki} and {@link bucketizeDurations} below,
+ * which stay as distinctly-named one-liners so a call site reads which
+ * grid it means without chasing an extra argument. */
+function bucketize(values: readonly number[], bounds: readonly number[]): number[] {
+  const buckets = new Array<number>(BIGRAM_HIST_BUCKETS).fill(0)
+  for (const v of values) {
+    buckets[bucketIndexFor(v, bounds)] += 1
+  }
+  return buckets
 }
 
 /** Bucketize raw IKI values into a fixed-size histogram. Output array
  * length is always BIGRAM_HIST_BUCKETS; each entry is the count of
  * IKIs that fell into that bucket. */
 export function bucketizeIki(ikis: readonly number[]): number[] {
-  const buckets = new Array<number>(BIGRAM_HIST_BUCKETS).fill(0)
-  for (const iki of ikis) {
-    buckets[bucketIndex(iki)] += 1
-  }
-  return buckets
+  return bucketize(ikis, BIGRAM_BUCKET_UPPER_BOUNDS_MS)
+}
+
+/** Bucketize raw keypress-duration values (ms) into a fixed-size
+ * histogram using the tighter {@link DURATION_BUCKET_UPPER_BOUNDS_MS}
+ * grid. Same shape/semantics as {@link bucketizeIki} otherwise. */
+export function bucketizeDurations(durationsMs: readonly number[]): number[] {
+  return bucketize(durationsMs, DURATION_BUCKET_UPPER_BOUNDS_MS)
 }
 
 /** Sum and sum-of-squares of raw IKI values, persisted alongside the

--- a/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
+++ b/src/main/typing-analytics/db/__tests__/typing-analytics-db.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import Database from 'better-sqlite3'
+import type { Database as DatabaseType } from 'better-sqlite3'
 import { TypingAnalyticsDB, type TypingScopeRow } from '../typing-analytics-db'
 import { SCHEMA_VERSION } from '../schema'
 
@@ -24,6 +25,90 @@ function sampleScope(overrides: Partial<TypingScopeRow> = {}): TypingScopeRow {
     updatedAt: 1_000,
     ...overrides,
   }
+}
+
+/** Whether `table` has a column named `name`, per SQLite's own
+ * PRAGMA — replaces the repeated `cols.some((c) => c.name === ...)`
+ * pattern used across the migration tests below. */
+function hasColumn(conn: DatabaseType, table: string, name: string): boolean {
+  const cols = conn.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
+  return cols.some((c) => c.name === name)
+}
+
+/** Creates the pre-v8 shape of the four data tables a real v6 or v7 DB
+ * always has (typing_scopes / typing_matrix_minute / typing_minute_stats
+ * / typing_bigram_minute), shared by the v6->v7 and v7->v8 migration
+ * fixtures below — the two only differ in whether typing_bigram_minute
+ * already has the v7 sum columns and whether typing_trigram_minute (added
+ * in v7) exists yet. Does NOT insert `typing_analytics_meta` rows or any
+ * data rows — callers append those in their own `db.exec` call so each
+ * fixture's actual test data stays visible at its own call site. */
+function createLegacyTables(db: DatabaseType, options: { bigramSums: boolean; trigram: boolean }): void {
+  db.exec(`
+    CREATE TABLE typing_analytics_meta (
+      key TEXT PRIMARY KEY, value TEXT NOT NULL
+    );
+    CREATE TABLE typing_scopes (
+      id TEXT PRIMARY KEY,
+      machine_hash TEXT NOT NULL, os_platform TEXT NOT NULL,
+      os_release TEXT NOT NULL, os_arch TEXT NOT NULL,
+      keyboard_uid TEXT NOT NULL,
+      keyboard_vendor_id INTEGER NOT NULL,
+      keyboard_product_id INTEGER NOT NULL,
+      keyboard_product_name TEXT NOT NULL,
+      updated_at INTEGER NOT NULL,
+      is_deleted INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE TABLE typing_matrix_minute (
+      scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
+      row INTEGER NOT NULL, col INTEGER NOT NULL,
+      layer INTEGER NOT NULL, keycode INTEGER NOT NULL,
+      count INTEGER NOT NULL,
+      tap_count INTEGER NOT NULL DEFAULT 0,
+      hold_count INTEGER NOT NULL DEFAULT 0,
+      app_name TEXT, typing_test TEXT,
+      run_id TEXT NOT NULL DEFAULT '',
+      updated_at INTEGER NOT NULL,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (scope_id, minute_ts, run_id, row, col, layer)
+    );
+    CREATE TABLE typing_minute_stats (
+      scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
+      keystrokes INTEGER NOT NULL, active_ms INTEGER NOT NULL,
+      interval_avg_ms INTEGER, interval_min_ms INTEGER,
+      interval_p25_ms INTEGER, interval_p50_ms INTEGER,
+      interval_p75_ms INTEGER, interval_max_ms INTEGER,
+      app_name TEXT, typing_test TEXT,
+      run_id TEXT NOT NULL DEFAULT '',
+      updated_at INTEGER NOT NULL,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (scope_id, minute_ts, run_id)
+    );
+    CREATE TABLE typing_bigram_minute (
+      scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
+      bigram_id TEXT NOT NULL, count INTEGER NOT NULL,
+      hist BLOB NOT NULL,
+      ${options.bigramSums ? 'sum_iki REAL, sumsq_iki REAL,' : ''}
+      app_name TEXT, typing_test TEXT,
+      run_id TEXT NOT NULL DEFAULT '',
+      updated_at INTEGER NOT NULL,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (scope_id, minute_ts, run_id, bigram_id)
+    );
+    ${options.trigram ? `
+    CREATE TABLE typing_trigram_minute (
+      scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
+      trigram_id TEXT NOT NULL, count INTEGER NOT NULL,
+      hist BLOB NOT NULL,
+      sum_iki REAL, sumsq_iki REAL,
+      app_name TEXT, typing_test TEXT,
+      run_id TEXT NOT NULL DEFAULT '',
+      updated_at INTEGER NOT NULL,
+      is_deleted INTEGER NOT NULL DEFAULT 0,
+      PRIMARY KEY (scope_id, minute_ts, run_id, trigram_id)
+    );
+    ` : ''}
+  `)
 }
 
 describe('TypingAnalyticsDB', () => {
@@ -129,8 +214,7 @@ describe('TypingAnalyticsDB', () => {
       'typing_minute_stats',
       'typing_bigram_minute',
     ]) {
-      const cols = conn.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]
-      expect(cols.some((c) => c.name === 'app_name')).toBe(true)
+      expect(hasColumn(conn, table, 'app_name')).toBe(true)
     }
   })
 
@@ -140,32 +224,15 @@ describe('TypingAnalyticsDB', () => {
     tmpDir = mkdtempSync(join(tmpdir(), 'pipette-typing-analytics-db-upgrade67-'))
     const dbPath = join(tmpDir, 'typing-analytics.db')
 
+    // A real v6 DB has no sum_iki/sumsq_iki on typing_bigram_minute and no
+    // typing_trigram_minute yet (both arrived in v7) — but already has
+    // typing_matrix_minute/typing_minute_stats in their pre-v8 shape, so
+    // the v7 -> v8 step later in this same open (this fixture jumps
+    // straight from v6 to the current SCHEMA_VERSION) has something to
+    // ALTER on all three tables.
     const v6 = new Database(dbPath)
+    createLegacyTables(v6, { bigramSums: false, trigram: false })
     v6.exec(`
-      CREATE TABLE typing_analytics_meta (
-        key TEXT PRIMARY KEY, value TEXT NOT NULL
-      );
-      CREATE TABLE typing_scopes (
-        id TEXT PRIMARY KEY,
-        machine_hash TEXT NOT NULL, os_platform TEXT NOT NULL,
-        os_release TEXT NOT NULL, os_arch TEXT NOT NULL,
-        keyboard_uid TEXT NOT NULL,
-        keyboard_vendor_id INTEGER NOT NULL,
-        keyboard_product_id INTEGER NOT NULL,
-        keyboard_product_name TEXT NOT NULL,
-        updated_at INTEGER NOT NULL,
-        is_deleted INTEGER NOT NULL DEFAULT 0
-      );
-      CREATE TABLE typing_bigram_minute (
-        scope_id TEXT NOT NULL, minute_ts INTEGER NOT NULL,
-        bigram_id TEXT NOT NULL, count INTEGER NOT NULL,
-        hist BLOB NOT NULL,
-        app_name TEXT, typing_test TEXT,
-        run_id TEXT NOT NULL DEFAULT '',
-        updated_at INTEGER NOT NULL,
-        is_deleted INTEGER NOT NULL DEFAULT 0,
-        PRIMARY KEY (scope_id, minute_ts, run_id, bigram_id)
-      );
       INSERT INTO typing_scopes (
         id, machine_hash, os_platform, os_release, os_arch,
         keyboard_uid, keyboard_vendor_id, keyboard_product_id, keyboard_product_name,
@@ -188,9 +255,8 @@ describe('TypingAnalyticsDB', () => {
     expect(db.cacheNeedsRebuild).toBe(false)
 
     const conn = db.getConnection()
-    const bigramCols = conn.prepare('PRAGMA table_info(typing_bigram_minute)').all() as { name: string }[]
-    expect(bigramCols.some((c) => c.name === 'sum_iki')).toBe(true)
-    expect(bigramCols.some((c) => c.name === 'sumsq_iki')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'sum_iki')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'sumsq_iki')).toBe(true)
 
     // Existing count/hist row survives the migration untouched, with the
     // new sum columns reading as NULL (no source data to backfill from).
@@ -205,6 +271,115 @@ describe('TypingAnalyticsDB', () => {
 
     const trigramTable = conn.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'typing_trigram_minute'`).get()
     expect(trigramTable).toBeDefined()
+
+    // The v7 -> v8 step (schema v8: duration/overlap/poll-gap columns)
+    // also fires in the same open, since this fixture jumps straight
+    // from v6 to the current SCHEMA_VERSION.
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_hist')).toBe(true)
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_sum')).toBe(true)
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_sumsq')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'overlap_count')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'overlap_n')).toBe(true)
+    expect(hasColumn(conn, 'typing_minute_stats', 'poll_p50_ms')).toBe(true)
+    expect(hasColumn(conn, 'typing_minute_stats', 'poll_p95_ms')).toBe(true)
+  })
+
+  it('upgrades a v7 DB to v8: adds duration/overlap/poll-gap columns without a cache rebuild', () => {
+    db.close()
+    rmSync(tmpDir, { recursive: true, force: true })
+    tmpDir = mkdtempSync(join(tmpdir(), 'pipette-typing-analytics-db-upgrade78-'))
+    const dbPath = join(tmpDir, 'typing-analytics.db')
+
+    // A real v7 DB already has typing_bigram_minute's sum columns and the
+    // typing_trigram_minute table (both arrived in v7) — only the v8
+    // duration/overlap/poll-gap columns are missing.
+    const v7 = new Database(dbPath)
+    createLegacyTables(v7, { bigramSums: true, trigram: true })
+    v7.exec(`
+      INSERT INTO typing_scopes (
+        id, machine_hash, os_platform, os_release, os_arch,
+        keyboard_uid, keyboard_vendor_id, keyboard_product_id, keyboard_product_name,
+        updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 'hash-abc', 'linux', '6.8.0', 'x64',
+        '0xAABB', 65261, 0, 'Pipette', 1000, 0
+      );
+      INSERT INTO typing_matrix_minute (
+        scope_id, minute_ts, row, col, layer, keycode, count, tap_count, hold_count, run_id, updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 60000, 0, 0, 0, 4, 5, 2, 0, '', 2000, 0
+      );
+      INSERT INTO typing_bigram_minute (
+        scope_id, minute_ts, bigram_id, count, hist, sum_iki, sumsq_iki, run_id, updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 60000, '4_11', 3, X'0300000000000000000000000000000000000000000000000000000000', 250, 22000, '', 2000, 0
+      );
+      INSERT INTO typing_minute_stats (
+        scope_id, minute_ts, keystrokes, active_ms, run_id, updated_at, is_deleted
+      ) VALUES (
+        'scope-1', 60000, 5, 1000, '', 2000, 0
+      );
+      INSERT INTO typing_analytics_meta (key, value) VALUES ('schema_version', '7');
+    `)
+    v7.close()
+
+    db = new TypingAnalyticsDB(dbPath)
+    expect(db.getMeta('schema_version')).toBe(String(SCHEMA_VERSION))
+    expect(db.cacheNeedsRebuild).toBe(false)
+
+    const conn = db.getConnection()
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_hist')).toBe(true)
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_sum')).toBe(true)
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_sumsq')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'overlap_count')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'overlap_n')).toBe(true)
+    expect(hasColumn(conn, 'typing_minute_stats', 'poll_p50_ms')).toBe(true)
+    expect(hasColumn(conn, 'typing_minute_stats', 'poll_p95_ms')).toBe(true)
+
+    // Existing rows survive untouched; new columns read NULL (no source
+    // data to backfill from — the whole point of "no cache rebuild").
+    const matrixRow = conn.prepare('SELECT count, tap_count, dur_hist, dur_sum, dur_sumsq FROM typing_matrix_minute').get() as {
+      count: number
+      tap_count: number
+      dur_hist: Buffer | null
+      dur_sum: number | null
+      dur_sumsq: number | null
+    }
+    expect(matrixRow.count).toBe(5)
+    expect(matrixRow.tap_count).toBe(2)
+    expect(matrixRow.dur_hist).toBeNull()
+    expect(matrixRow.dur_sum).toBeNull()
+    expect(matrixRow.dur_sumsq).toBeNull()
+
+    const bigramRow = conn.prepare('SELECT count, sum_iki, overlap_count, overlap_n FROM typing_bigram_minute').get() as {
+      count: number
+      sum_iki: number | null
+      overlap_count: number | null
+      overlap_n: number | null
+    }
+    expect(bigramRow.count).toBe(3)
+    expect(bigramRow.sum_iki).toBe(250) // pre-existing v7 data untouched
+    expect(bigramRow.overlap_count).toBeNull()
+    expect(bigramRow.overlap_n).toBeNull()
+
+    const statsRow = conn.prepare('SELECT keystrokes, poll_p50_ms, poll_p95_ms FROM typing_minute_stats').get() as {
+      keystrokes: number
+      poll_p50_ms: number | null
+      poll_p95_ms: number | null
+    }
+    expect(statsRow.keystrokes).toBe(5)
+    expect(statsRow.poll_p50_ms).toBeNull()
+    expect(statsRow.poll_p95_ms).toBeNull()
+  })
+
+  it('fresh-creates a v8 DB directly (no migration path) with every v8 column present', () => {
+    // db was already freshly created in beforeEach — verify it landed
+    // straight at the current schema without going through migrateSchema.
+    expect(db.getMeta('schema_version')).toBe(String(SCHEMA_VERSION))
+    const conn = db.getConnection()
+    expect(hasColumn(conn, 'typing_matrix_minute', 'dur_hist')).toBe(true)
+    expect(hasColumn(conn, 'typing_bigram_minute', 'overlap_count')).toBe(true)
+    expect(hasColumn(conn, 'typing_minute_stats', 'poll_p50_ms')).toBe(true)
   })
 
   it('upserts a scope row and keeps the newest updatedAt', () => {
@@ -701,6 +876,46 @@ describe('TypingAnalyticsDB', () => {
     it('exportSessionsForUid respects the live start_ms window', () => {
       const rows = db.exportSessionsForUid('0xAABB', 100_000, 5_000)
       expect(rows.map((r) => r.id).sort()).toEqual(['session-live'])
+    })
+
+    it('exportMatrixMinutesForUid carries the v8 duration triple, decoded back to a number array', () => {
+      db.mergeMatrixMinute({
+        scopeId: 'scope-local-a', minuteTs: 200_000, row: 1, col: 2, layer: 0, keycode: 0x04,
+        count: 1, tapCount: 0, holdCount: 0,
+        dh: [0, 1, 0, 0, 0, 0, 0, 0], ds: 65, dq: 4_225,
+        updatedAt: 20_000, isDeleted: false,
+      })
+      db.mergeMatrixMinute({
+        scopeId: 'scope-local-a', minuteTs: 200_000, row: 1, col: 3, layer: 0, keycode: 0x05,
+        count: 1, tapCount: 0, holdCount: 0,
+        updatedAt: 20_000, isDeleted: false,
+      })
+      const rows = db.exportMatrixMinutesForUid('0xAABB', 100_000, 5_000)
+
+      const withDuration = rows.find((r) => r.row === 1 && r.col === 2)!
+      expect(withDuration.dh).toEqual([0, 1, 0, 0, 0, 0, 0, 0])
+      expect(withDuration.ds).toBe(65)
+      expect(withDuration.dq).toBe(4_225)
+
+      // A cell with no duration sample stays null, not a decoded
+      // zero-filled histogram.
+      const withoutDuration = rows.find((r) => r.row === 1 && r.col === 3)!
+      expect(withoutDuration.dh).toBeNull()
+      expect(withoutDuration.ds).toBeNull()
+      expect(withoutDuration.dq).toBeNull()
+    })
+
+    it('exportMinuteStatsForUid carries the v8 poll-gap columns', () => {
+      db.mergeMinuteStats({
+        scopeId: 'scope-local-a', minuteTs: 200_000, keystrokes: 1, activeMs: 1,
+        intervalAvgMs: 1, intervalMinMs: 1, intervalP25Ms: 1, intervalP50Ms: 1, intervalP75Ms: 1, intervalMaxMs: 1,
+        pollP50Ms: 20, pollP95Ms: 45,
+        updatedAt: 20_000, isDeleted: false,
+      })
+      const rows = db.exportMinuteStatsForUid('0xAABB', 100_000, 5_000)
+      const row = rows.find((r) => r.minuteTs === 200_000)!
+      expect(row.pollP50Ms).toBe(20)
+      expect(row.pollP95Ms).toBe(45)
     })
 
     it('listLocalKeyboardUids returns distinct uids for this machine only', () => {
@@ -1212,6 +1427,71 @@ describe('TypingAnalyticsDB', () => {
     })
   })
 
+  describe('listMatrixDurationCellsForUid (Analyze > keypress duration)', () => {
+    beforeEach(() => {
+      db.upsertScope(sampleScope({ id: 'scope-local', machineHash: MACHINE_HASH, keyboardUid: '0xAABB' }))
+      db.upsertScope(sampleScope({ id: 'scope-other-machine', machineHash: 'other', keyboardUid: '0xAABB' }))
+    })
+
+    function writeMatrixWithDuration(
+      scopeId: string,
+      minuteTs: number,
+      row: number,
+      col: number,
+      layer: number,
+      dh: number[] | null,
+      ds: number | null,
+      dq: number | null,
+      updatedAt = 1_000,
+    ): void {
+      db.mergeMatrixMinute({
+        scopeId, minuteTs, row, col, layer, keycode: 0x04, count: 1, tapCount: 0, holdCount: 0,
+        dh, ds, dq, updatedAt, isDeleted: false,
+      })
+    }
+
+    it('decodes the histogram back to a number array and carries sum/sumSq', () => {
+      writeMatrixWithDuration('scope-local', 60_000, 0, 0, 0, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225)
+      const rows = db.listMatrixDurationCellsForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([{ row: 0, col: 0, layer: 0, minuteTs: 60_000, hist: [0, 1, 0, 0, 0, 0, 0, 0], sum: 65, sumSq: 4_225 }])
+    })
+
+    it('excludes a row with no duration sample that minute (dur_hist NULL)', () => {
+      writeMatrixWithDuration('scope-local', 60_000, 0, 0, 0, null, null, null)
+      const rows = db.listMatrixDurationCellsForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([])
+    })
+
+    it('restricts to one machine_hash via listMatrixDurationCellsForUidAndHash', () => {
+      writeMatrixWithDuration('scope-local', 60_000, 0, 0, 0, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225)
+      writeMatrixWithDuration('scope-other-machine', 60_000, 0, 0, 0, [0, 0, 1, 0, 0, 0, 0, 0], 90, 8_100)
+      const rows = db.listMatrixDurationCellsForUidAndHash('0xAABB', MACHINE_HASH, 60_000, 120_000)
+      expect(rows).toEqual([{ row: 0, col: 0, layer: 0, minuteTs: 60_000, hist: [0, 1, 0, 0, 0, 0, 0, 0], sum: 65, sumSq: 4_225 }])
+    })
+
+    it('drops rows outside the window', () => {
+      writeMatrixWithDuration('scope-local', 30_000, 0, 0, 0, [1, 0, 0, 0, 0, 0, 0, 0], 40, 1_600)
+      const rows = db.listMatrixDurationCellsForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([])
+    })
+
+    it('excludes a row whose dur_hist is set but dur_sum is NULL (broken triple invariant)', () => {
+      // A well-formed row always writes dh/ds/dq together (see
+      // isValidDurationTriple in jsonl-row.ts) — this simulates that
+      // invariant being violated some other way (corruption, a hand-
+      // edited JSONL master) to prove the select itself refuses to hand
+      // a hist with no matching sum to the aggregator, rather than
+      // trusting the invariant blindly.
+      writeMatrixWithDuration('scope-local', 60_000, 0, 0, 0, [0, 1, 0, 0, 0, 0, 0, 0], 65, 4_225)
+      db.getConnection().prepare(
+        'UPDATE typing_matrix_minute SET dur_sum = NULL WHERE scope_id = ? AND minute_ts = ? AND row = 0 AND col = 0',
+      ).run('scope-local', 60_000)
+
+      const rows = db.listMatrixDurationCellsForUid('0xAABB', 60_000, 120_000)
+      expect(rows).toEqual([])
+    })
+  })
+
   describe('listBigramMinutesInRangeForUid (Analyze > Bigrams)', () => {
     function bigramRow(
       scopeId: string,
@@ -1240,7 +1520,7 @@ describe('TypingAnalyticsDB', () => {
       bigramRow('scope-local', 60_000, '4_11', 3, [0, 2, 1, 0, 0, 0, 0, 0])
       const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
       expect(rows).toEqual([
-        { ngramId: '4_11', minuteTs: 60_000, count: 3, hist: [0, 2, 1, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null },
+        { ngramId: '4_11', minuteTs: 60_000, count: 3, hist: [0, 2, 1, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null, overlapCount: null, overlapN: null },
       ])
     })
 
@@ -1283,8 +1563,36 @@ describe('TypingAnalyticsDB', () => {
       })
       const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 120_000)
       expect(rows).toEqual([
-        { ngramId: 'with-sum', minuteTs: 60_000, count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: 240, sumSqIki: 28_800 },
+        { ngramId: 'with-sum', minuteTs: 60_000, count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: 240, sumSqIki: 28_800, overlapCount: null, overlapN: null },
       ])
+    })
+
+    it('returns overlapCount / overlapN when the row has them, null otherwise', () => {
+      db.mergeBigramMinute({
+        scopeId: 'scope-local', minuteTs: 60_000,
+        bigrams: { 'with-overlap': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], oc: 1, on: 2 } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      bigramRow('scope-local', 120_000, 'no-overlap', 1, [1, 0, 0, 0, 0, 0, 0, 0])
+      const rows = db.listBigramMinutesInRangeForUid('0xAABB', 60_000, 180_000)
+      const byId = new Map(rows.map((r) => [r.ngramId, r]))
+      expect(byId.get('with-overlap')).toEqual({
+        ngramId: 'with-overlap', minuteTs: 60_000, count: 2, hist: [0, 2, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null, overlapCount: 1, overlapN: 2,
+      })
+      expect(byId.get('no-overlap')).toEqual({
+        ngramId: 'no-overlap', minuteTs: 120_000, count: 1, hist: [1, 0, 0, 0, 0, 0, 0, 0], sumIki: null, sumSqIki: null, overlapCount: null, overlapN: null,
+      })
+    })
+
+    it('does not select overlap columns for trigram rows (structurally absent)', () => {
+      db.mergeTrigramMinute({
+        scopeId: 'scope-local', minuteTs: 60_000,
+        trigrams: { '4_11_7': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } },
+        updatedAt: 1_000, isDeleted: false,
+      })
+      const rows = db.listNgramMinutesInRangeForUid(3, '0xAABB', 60_000, 120_000)
+      expect(rows[0].overlapCount).toBeUndefined()
+      expect(rows[0].overlapN).toBeUndefined()
     })
   })
 

--- a/src/main/typing-analytics/db/schema.ts
+++ b/src/main/typing-analytics/db/schema.ts
@@ -2,7 +2,7 @@
 // SQLite schema for the typing analytics database. See
 // .claude/plans/typing-analytics.md for the design rationale.
 
-export const SCHEMA_VERSION = 7
+export const SCHEMA_VERSION = 8
 
 /** User-data tables in the order a rebuild should truncate them. Listed
  * child-before-parent so any future FK_ON delete won't trip itself. */
@@ -89,6 +89,14 @@ CREATE TABLE IF NOT EXISTS typing_matrix_minute (
   -- both at 0 and the heatmap falls back to the total count column.
   tap_count INTEGER NOT NULL DEFAULT 0,
   hold_count INTEGER NOT NULL DEFAULT 0,
+  -- Keypress-duration histogram / sum / sum-of-squares from
+  -- matrix-release events landing in this minute (see
+  -- bigram-bucket.ts's duration grid -- deliberately tighter than the
+  -- IKI grid). All three NULL for rows written before schema v8, or for
+  -- a minute that had presses but no matching release yet.
+  dur_hist BLOB,
+  dur_sum REAL,
+  dur_sumsq REAL,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
   -- See typing_char_minute.typing_test comment.
@@ -129,6 +137,11 @@ CREATE TABLE IF NOT EXISTS typing_minute_stats (
   typing_test TEXT,
   -- See typing_char_minute.run_id comment.
   run_id TEXT NOT NULL DEFAULT '',
+  -- Median / p95 sampling gap (ms) between polled matrix frames this
+  -- minute (see matrix-press-duration.ts's pollGapMs). NULL for rows
+  -- written before schema v8, or a minute with no sample.
+  poll_p50_ms REAL,
+  poll_p95_ms REAL,
   updated_at INTEGER NOT NULL,
   is_deleted INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (scope_id, minute_ts, run_id),
@@ -161,6 +174,14 @@ CREATE TABLE IF NOT EXISTS typing_bigram_minute (
   -- approximation (see Plan-trigram-and-iki-variance.md).
   sum_iki REAL,
   sumsq_iki REAL,
+  -- Physical-overlap accumulators (see OverlapCounts in minute-buffer.ts).
+  -- overlap_n counts pairs whose incoming press had a KNOWN overlap
+  -- determination; overlap_count is the subset where it was true.
+  -- Both NULL for rows written before schema v8, or a pair whose every
+  -- contributing event had an undetermined overlap -- never treat NULL
+  -- as 0 here, the same null-poisons-aggregation rule as sum_iki above.
+  overlap_count INTEGER,
+  overlap_n INTEGER,
   -- See typing_char_minute.app_name comment.
   app_name TEXT,
   -- See typing_char_minute.typing_test comment.

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -80,6 +80,20 @@ export interface MatrixMinuteRow {
   /** Portion of `count` attributed to a hold, by the same classification
    * as `tapCount`. Defaults to 0 for the same reasons as `tapCount`. */
   holdCount?: number
+  /** Keypress-duration histogram (see bigram-bucket.ts's duration grid)
+   * / sum / sum-of-squares (ms), from `matrix-release` events landing
+   * in this minute. Field names match {@link JsonlMatrixMinutePayload}'s
+   * `dh`/`ds`/`dq` exactly (not spelled out) because apply-to-cache.ts
+   * spreads a parsed JSONL payload straight into this shape — a
+   * same-meaning-different-name pair here would silently stop
+   * persisting duration data with no type error (every field involved
+   * is optional). All three null/undefined together — a row written
+   * before schema v8, or a cell with no duration samples this minute (a
+   * routine state — see the shared event type's note on release-minute
+   * vs press-minute attribution). */
+  dh?: number[] | null
+  ds?: number | null
+  dq?: number | null
   /** See {@link CharMinuteRow.appName}. */
   appName?: string | null
   /** See {@link CharMinuteRow.typingTest}. */
@@ -99,6 +113,11 @@ export interface MinuteStatsRow {
   intervalP50Ms: number | null
   intervalP75Ms: number | null
   intervalMaxMs: number | null
+  /** Median / p95 sampling gap (ms) between polled matrix frames this
+   * minute. Null for rows written before schema v8, or a minute with
+   * no poll-gap sample. */
+  pollP50Ms?: number | null
+  pollP95Ms?: number | null
   /** See {@link CharMinuteRow.appName}. */
   appName?: string | null
   /** See {@link CharMinuteRow.typingTest}. */
@@ -143,6 +162,27 @@ export interface NgramMinuteCellRow {
   hist: number[]
   sumIki: number | null
   sumSqIki: number | null
+  /** Physical-overlap accumulators (see OverlapCounts in
+   * minute-buffer.ts) — only ever populated for BIGRAM rows;
+   * `undefined` for trigram rows (the table has no such columns) so
+   * callers can tell "not applicable" apart from "recorded as null". */
+  overlapCount?: number | null
+  overlapN?: number | null
+}
+
+/** Row shape returned by {@link TypingAnalyticsDB.listMatrixDurationCellsForUid} /
+ * {@link TypingAnalyticsDB.listMatrixDurationCellsForUidAndHash} — one row
+ * per (scope, minute, cell) that had at least one `matrix-release` sample
+ * (rows with no sample that minute are excluded by the SQL, not returned
+ * with an empty histogram). `hist` is decoded from the on-disk BLOB. */
+export interface MatrixDurationCellRow {
+  row: number
+  col: number
+  layer: number
+  minuteTs: number
+  hist: number[]
+  sum: number
+  sumSq: number
 }
 
 /** Row shapes carried across sync bundles. Live columns plus the
@@ -313,33 +353,66 @@ interface NgramStatements {
   deleteBefore: Statement
 }
 
+/** One extra column an n-gram table may carry beyond the common
+ * count/hist/sum/sumSq/tag shape — currently just overlap_count/overlap_n
+ * on typing_bigram_minute (see {@link prepareNgramStatements}). `column`
+ * is the SQL column name; `bind` is both the named-parameter key
+ * (referenced as `@bind` in generated SQL) and the SELECT alias, so it
+ * doubles as the camelCase field name the row comes back as (matching
+ * NgramMinuteCellRow). */
+interface NgramExtraColumn {
+  column: string
+  bind: string
+}
+
+/** typing_bigram_minute's only extra columns beyond the shape every
+ * n-gram table shares — see {@link NgramExtraColumn}. typing_trigram_minute
+ * passes an empty array at its {@link prepareNgramStatements} call site:
+ * overlap is a pairwise notion that doesn't extend to trigrams, and that
+ * table has no such SQL columns to reference. */
+const BIGRAM_OVERLAP_EXTRA_COLUMNS: readonly NgramExtraColumn[] = [
+  { column: 'overlap_count', bind: 'overlapCount' },
+  { column: 'overlap_n', bind: 'overlapN' },
+]
+
 /** Build the seven prepared statements one n-gram table needs. `table`
  * and `idColumn` are always hard-coded literals from the call sites
  * below (never user input), so interpolating them directly into the SQL
  * text is safe — every value-level parameter still goes through
- * better-sqlite3's `@name` binding. */
+ * better-sqlite3's `@name` binding.
+ *
+ * `extraColumns` derives all four insert/update/select SQL fragments
+ * that need to vary per table from one list, rather than four
+ * hand-maintained boolean-gated strings — a table with no extra columns
+ * (trigram) just passes an empty array and every fragment below
+ * collapses to '' automatically. */
 function prepareNgramStatements(
   db: DatabaseType,
   table: 'typing_bigram_minute' | 'typing_trigram_minute',
   idColumn: 'bigram_id' | 'trigram_id',
+  extraColumns: readonly NgramExtraColumn[],
 ): NgramStatements {
+  const insertCols = extraColumns.map((c) => `, ${c.column}`).join('')
+  const insertVals = extraColumns.map((c) => `, @${c.bind}`).join('')
+  const updateSet = extraColumns.map((c) => `${c.column} = excluded.${c.column},\n        `).join('')
+  const selectCols = extraColumns.map((c) => `,\n             t.${c.column} AS ${c.bind}`).join('')
   return {
     // Authoritative LWW upsert for sync merge — replaces the target row
     // wholesale, respects the incoming is_deleted flag, and only fires
     // when excluded.updated_at is strictly newer than the existing row.
     merge: db.prepare(`
       INSERT INTO ${table} (
-        scope_id, minute_ts, ${idColumn}, count, hist, sum_iki, sumsq_iki, app_name, typing_test, run_id, updated_at, is_deleted
+        scope_id, minute_ts, ${idColumn}, count, hist, sum_iki, sumsq_iki${insertCols}, app_name, typing_test, run_id, updated_at, is_deleted
       )
       VALUES (
-        @scopeId, @minuteTs, @ngramId, @count, @hist, @sumIki, @sumSqIki, @appName, @typingTest, @runId, @updatedAt, @isDeleted
+        @scopeId, @minuteTs, @ngramId, @count, @hist, @sumIki, @sumSqIki${insertVals}, @appName, @typingTest, @runId, @updatedAt, @isDeleted
       )
       ON CONFLICT(scope_id, minute_ts, run_id, ${idColumn}) DO UPDATE SET
         count = excluded.count,
         hist = excluded.hist,
         sum_iki = excluded.sum_iki,
         sumsq_iki = excluded.sumsq_iki,
-        app_name = excluded.app_name,
+        ${updateSet}app_name = excluded.app_name,
         typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
         is_deleted = excluded.is_deleted
@@ -359,7 +432,7 @@ function prepareNgramStatements(
              t.count AS count,
              t.hist AS hist,
              t.sum_iki AS sumIki,
-             t.sumsq_iki AS sumSqIki
+             t.sumsq_iki AS sumSqIki${selectCols}
         FROM ${table} t
         JOIN typing_scopes s ON s.id = t.scope_id
        WHERE s.keyboard_uid = @uid
@@ -379,7 +452,7 @@ function prepareNgramStatements(
              t.count AS count,
              t.hist AS hist,
              t.sum_iki AS sumIki,
-             t.sumsq_iki AS sumSqIki
+             t.sumsq_iki AS sumSqIki${selectCols}
         FROM ${table} t
         JOIN typing_scopes s ON s.id = t.scope_id
        WHERE s.keyboard_uid = @uid
@@ -462,6 +535,8 @@ export class TypingAnalyticsDB {
   private readonly selectLayerUsageForUidAndHashStmt: Statement
   private readonly selectMatrixCellsForUidStmt: Statement
   private readonly selectMatrixCellsForUidAndHashStmt: Statement
+  private readonly selectMatrixDurationForUidStmt: Statement
+  private readonly selectMatrixDurationForUidAndHashStmt: Statement
   private readonly selectMatrixCellsByDayForUidStmt: Statement
   private readonly selectMatrixCellsByDayForUidAndHashStmt: Statement
   private readonly selectMinuteStatsInRangeForUidStmt: Statement
@@ -689,8 +764,8 @@ export class TypingAnalyticsDB {
     `)
 
     this.ngramStmts = {
-      2: prepareNgramStatements(this.db, 'typing_bigram_minute', 'bigram_id'),
-      3: prepareNgramStatements(this.db, 'typing_trigram_minute', 'trigram_id'),
+      2: prepareNgramStatements(this.db, 'typing_bigram_minute', 'bigram_id', BIGRAM_OVERLAP_EXTRA_COLUMNS),
+      3: prepareNgramStatements(this.db, 'typing_trigram_minute', 'trigram_id', []),
     }
 
     this.deleteSessionsBeforeStmt = this.db.prepare(`
@@ -751,12 +826,14 @@ export class TypingAnalyticsDB {
       INSERT INTO typing_matrix_minute (
         scope_id, minute_ts, row, col, layer, keycode, count,
         tap_count, hold_count,
+        dur_hist, dur_sum, dur_sumsq,
         app_name, typing_test, run_id,
         updated_at, is_deleted
       )
       VALUES (
         @scopeId, @minuteTs, @row, @col, @layer, @keycode, @count,
         @tapCount, @holdCount,
+        @durHist, @durSum, @durSumSq,
         @appName, @typingTest, @runId,
         @updatedAt, @isDeleted
       )
@@ -765,6 +842,9 @@ export class TypingAnalyticsDB {
         count = excluded.count,
         tap_count = excluded.tap_count,
         hold_count = excluded.hold_count,
+        dur_hist = excluded.dur_hist,
+        dur_sum = excluded.dur_sum,
+        dur_sumsq = excluded.dur_sumsq,
         app_name = excluded.app_name,
         typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
@@ -777,6 +857,7 @@ export class TypingAnalyticsDB {
         scope_id, minute_ts, keystrokes, active_ms,
         interval_avg_ms, interval_min_ms,
         interval_p25_ms, interval_p50_ms, interval_p75_ms, interval_max_ms,
+        poll_p50_ms, poll_p95_ms,
         app_name, typing_test, run_id,
         updated_at, is_deleted
       )
@@ -784,6 +865,7 @@ export class TypingAnalyticsDB {
         @scopeId, @minuteTs, @keystrokes, @activeMs,
         @intervalAvgMs, @intervalMinMs,
         @intervalP25Ms, @intervalP50Ms, @intervalP75Ms, @intervalMaxMs,
+        @pollP50Ms, @pollP95Ms,
         @appName, @typingTest, @runId,
         @updatedAt, @isDeleted
       )
@@ -796,6 +878,8 @@ export class TypingAnalyticsDB {
         interval_p50_ms = excluded.interval_p50_ms,
         interval_p75_ms = excluded.interval_p75_ms,
         interval_max_ms = excluded.interval_max_ms,
+        poll_p50_ms = excluded.poll_p50_ms,
+        poll_p95_ms = excluded.poll_p95_ms,
         app_name = excluded.app_name,
         typing_test = excluded.typing_test,
         updated_at = excluded.updated_at,
@@ -854,11 +938,18 @@ export class TypingAnalyticsDB {
          )
     `)
 
+    // dur_hist/dur_sum/dur_sumsq (v8) are included even though this export
+    // path has no live caller today (see exportMatrixMinutesForUid) —
+    // omitting them here would mean a future revival of sync export
+    // silently drops every cell's duration data on the wholesale LWW
+    // replace at the receiving end, and every field involved being
+    // optional means no compile error would ever flag the gap.
     this.selectMatrixMinutesForUidStmt = this.db.prepare(`
       SELECT m.scope_id AS scopeId, m.minute_ts AS minuteTs,
              m.row AS row, m.col AS col, m.layer AS layer,
              m.keycode AS keycode, m.count AS count,
              m.tap_count AS tapCount, m.hold_count AS holdCount,
+             m.dur_hist AS dh, m.dur_sum AS ds, m.dur_sumsq AS dq,
              m.updated_at AS updatedAt, m.is_deleted AS isDeleted
         FROM typing_matrix_minute m
         JOIN typing_scopes s ON s.id = m.scope_id
@@ -870,6 +961,9 @@ export class TypingAnalyticsDB {
          )
     `)
 
+    // poll_p50_ms/poll_p95_ms (v8) — same "no live caller yet, but must
+    // not silently vanish if this export path is revived" reasoning as
+    // dur_hist/dur_sum/dur_sumsq above.
     this.selectMinuteStatsForUidStmt = this.db.prepare(`
       SELECT t.scope_id AS scopeId, t.minute_ts AS minuteTs,
              t.keystrokes AS keystrokes, t.active_ms AS activeMs,
@@ -879,6 +973,7 @@ export class TypingAnalyticsDB {
              t.interval_p50_ms AS intervalP50Ms,
              t.interval_p75_ms AS intervalP75Ms,
              t.interval_max_ms AS intervalMaxMs,
+             t.poll_p50_ms AS pollP50Ms, t.poll_p95_ms AS pollP95Ms,
              t.updated_at AS updatedAt, t.is_deleted AS isDeleted
         FROM typing_minute_stats t
         JOIN typing_scopes s ON s.id = t.scope_id
@@ -1187,6 +1282,67 @@ export class TypingAnalyticsDB {
          AND m.minute_ts < @untilMs
          ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')} ${runIdFilterClause('m.run_id')}
        GROUP BY m.layer, m.row, m.col
+    `)
+
+    // Per-(scope, minute, cell) raw duration rows for the Analyze
+    // keypress-duration aggregate. Unlike selectMatrixCellsForUidStmt
+    // above, this can't SUM the histogram BLOB in SQL — it hands back
+    // one row per contributing minute and lets bigram-aggregate.ts fold
+    // hist/sum/sumSq in JS, the same shape as the n-gram range selects.
+    // Rows with no duration sample that minute (dur_hist IS NULL) are
+    // excluded rather than returned as an empty histogram — they
+    // contribute nothing to the aggregate either way.
+    this.selectMatrixDurationForUidStmt = this.db.prepare(`
+      SELECT m.row AS row,
+             m.col AS col,
+             m.layer AS layer,
+             m.minute_ts AS minuteTs,
+             m.dur_hist AS durHist,
+             m.dur_sum AS durSum,
+             m.dur_sumsq AS durSumSq
+        FROM typing_matrix_minute m
+        JOIN typing_scopes s ON s.id = m.scope_id
+       WHERE s.keyboard_uid = @uid
+         AND s.is_deleted = 0
+         AND m.is_deleted = 0
+         -- dh/ds/dq are written as an all-or-nothing triple by the
+         -- validator (isValidDurationTriple in jsonl-row.ts), three
+         -- modules away from this query — checking both columns here
+         -- rather than trusting that invariant blindly means a future
+         -- bug in that validator (or a hand-edited JSONL master) can't
+         -- feed the mapper/aggregate a hist with no matching sum.
+         AND m.dur_hist IS NOT NULL
+         AND m.dur_sum IS NOT NULL
+         AND m.minute_ts >= @sinceMs
+         AND m.minute_ts < @untilMs
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')} ${runIdFilterClause('m.run_id')}
+    `)
+
+    this.selectMatrixDurationForUidAndHashStmt = this.db.prepare(`
+      SELECT m.row AS row,
+             m.col AS col,
+             m.layer AS layer,
+             m.minute_ts AS minuteTs,
+             m.dur_hist AS durHist,
+             m.dur_sum AS durSum,
+             m.dur_sumsq AS durSumSq
+        FROM typing_matrix_minute m
+        JOIN typing_scopes s ON s.id = m.scope_id
+       WHERE s.keyboard_uid = @uid
+         AND s.machine_hash = @machineHash
+         AND s.is_deleted = 0
+         AND m.is_deleted = 0
+         -- dh/ds/dq are written as an all-or-nothing triple by the
+         -- validator (isValidDurationTriple in jsonl-row.ts), three
+         -- modules away from this query — checking both columns here
+         -- rather than trusting that invariant blindly means a future
+         -- bug in that validator (or a hand-edited JSONL master) can't
+         -- feed the mapper/aggregate a hist with no matching sum.
+         AND m.dur_hist IS NOT NULL
+         AND m.dur_sum IS NOT NULL
+         AND m.minute_ts >= @sinceMs
+         AND m.minute_ts < @untilMs
+         ${appFilterClause('m.app_name')} ${typingTestFilterClause('m.typing_test')} ${runIdFilterClause('m.run_id')}
     `)
 
     // Per-(localDay, layer, row, col) totals for the Analyze Ergonomic
@@ -2191,6 +2347,48 @@ export class TypingAnalyticsDB {
     return this.selectMatrixCellsForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes), runIdsJson: JSON.stringify(runIdScopes) }) as TypingMatrixCellRow[]
   }
 
+  /** Per-(scope, minute, cell) raw duration rows in `[sinceMs, untilMs)`
+   * for the Analyze keypress-duration aggregate. One row per minute a
+   * cell had at least one `matrix-release` sample — the aggregation
+   * layer (bigram-aggregate.ts) folds hist/sum/sumSq per cell across
+   * rows, the same pattern as the n-gram range selects. */
+  listMatrixDurationCellsForUid(
+    uid: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): MatrixDurationCellRow[] {
+    return this.toMatrixDurationCellRows(
+      this.selectMatrixDurationForUidStmt.all({ uid, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes), runIdsJson: JSON.stringify(runIdScopes) }),
+    )
+  }
+
+  /** Same as {@link listMatrixDurationCellsForUid} but restricted to one
+   * machine_hash for the Analyze "This device" scope. */
+  listMatrixDurationCellsForUidAndHash(
+    uid: string,
+    machineHash: string,
+    sinceMs: number,
+    untilMs: number,
+    appScopes: readonly string[] = [], typingTestScopes: readonly string[] = [], runIdScopes: readonly string[] = [],
+  ): MatrixDurationCellRow[] {
+    return this.toMatrixDurationCellRows(
+      this.selectMatrixDurationForUidAndHashStmt.all({ uid, machineHash, sinceMs, untilMs, appNamesJson: JSON.stringify(appScopes), typingTestsJson: JSON.stringify(typingTestScopes), runIdsJson: JSON.stringify(runIdScopes) }),
+    )
+  }
+
+  private toMatrixDurationCellRows(raws: unknown): MatrixDurationCellRow[] {
+    return (raws as { row: number; col: number; layer: number; minuteTs: number; durHist: Uint8Array; durSum: number; durSumSq: number }[]).map((r) => ({
+      row: r.row,
+      col: r.col,
+      layer: r.layer,
+      minuteTs: r.minuteTs,
+      hist: decodeHistBuffer(r.durHist),
+      sum: r.durSum,
+      sumSq: r.durSumSq,
+    }))
+  }
+
   /** Per-(localDay, layer, row, col) press totals for the Analyze
    * Ergonomic Learning Curve. The SQL groups by a `localtime` date
    * string so day boundaries match the user's wall clock; we map that
@@ -2384,13 +2582,25 @@ export class TypingAnalyticsDB {
   }
 
   private toNgramMinuteCellRows(raws: unknown): NgramMinuteCellRow[] {
-    return (raws as { ngramId: string; minuteTs: number; count: number; hist: Uint8Array; sumIki: number | null; sumSqIki: number | null }[]).map((r) => ({
+    return (raws as {
+      ngramId: string
+      minuteTs: number
+      count: number
+      hist: Uint8Array
+      sumIki: number | null
+      sumSqIki: number | null
+      // Absent (not selected) on a trigram query — see prepareNgramStatements.
+      overlapCount?: number | null
+      overlapN?: number | null
+    }[]).map((r) => ({
       ngramId: r.ngramId,
       minuteTs: r.minuteTs,
       count: r.count,
       hist: decodeHistBuffer(r.hist),
       sumIki: r.sumIki,
       sumSqIki: r.sumSqIki,
+      overlapCount: r.overlapCount,
+      overlapN: r.overlapN,
     }))
   }
 
@@ -2639,9 +2849,11 @@ export class TypingAnalyticsDB {
     tombstoneSinceMs: number,
   ): MatrixMinuteExportRow[] {
     const rows = this.selectMatrixMinutesForUidStmt.all({ uid, liveSinceMinuteMs, tombstoneSinceMs }) as Array<
-      WithDeletedFlag<MatrixMinuteExportRow>
+      WithDeletedFlag<Omit<MatrixMinuteExportRow, 'dh'>> & { dh: Uint8Array | null }
     >
-    return rows.map((r) => ({ ...r, isDeleted: r.isDeleted === 1 }))
+    // dh comes back as a raw BLOB (or null) like every other hist column
+    // in this file — decode it the same way toMatrixDurationCellRows does.
+    return rows.map((r) => ({ ...r, isDeleted: r.isDeleted === 1, dh: r.dh ? decodeHistBuffer(r.dh) : null }))
   }
 
   exportMinuteStatsForUid(
@@ -2709,6 +2921,9 @@ export class TypingAnalyticsDB {
       count: row.count,
       tapCount: row.tapCount ?? 0,
       holdCount: row.holdCount ?? 0,
+      durHist: row.dh ? encodeHistBuffer(row.dh) : null,
+      durSum: row.ds ?? null,
+      durSumSq: row.dq ?? null,
       appName: row.appName ?? null,
       typingTest: row.typingTest ?? null,
       runId: row.runId ?? '',
@@ -2729,6 +2944,8 @@ export class TypingAnalyticsDB {
       intervalP50Ms: row.intervalP50Ms,
       intervalP75Ms: row.intervalP75Ms,
       intervalMaxMs: row.intervalMaxMs,
+      pollP50Ms: row.pollP50Ms ?? null,
+      pollP95Ms: row.pollP95Ms ?? null,
       appName: row.appName ?? null,
       typingTest: row.typingTest ?? null,
       runId: row.runId ?? '',
@@ -2769,6 +2986,8 @@ export class TypingAnalyticsDB {
         hist: encodeHistBuffer(entry.h),
         sumIki: entry.s ?? null,
         sumSqIki: entry.sq ?? null,
+        overlapCount: entry.oc ?? null,
+        overlapN: entry.on ?? null,
         appName,
         typingTest,
         runId,
@@ -2882,6 +3101,30 @@ export class TypingAnalyticsDB {
       this.db.exec(`
         ALTER TABLE typing_bigram_minute ADD COLUMN sum_iki REAL;
         ALTER TABLE typing_bigram_minute ADD COLUMN sumsq_iki REAL;
+      `)
+    }
+    // v7 -> v8: add keypress-duration columns to typing_matrix_minute,
+    // physical-overlap columns to typing_bigram_minute, and poll-gap
+    // columns to typing_minute_stats — all nullable, no cache rebuild
+    // (old JSONL masters have no source data for any of these; see
+    // schema.ts). Guarded by `fromVersion === 6 || fromVersion === 7`,
+    // not `<= 7`: every one of these three tables was in the `< 6` drop
+    // list above, so a DB migrating from before v6 already got them
+    // dropped-and-recreated by CREATE_SCHEMA_SQL (today's full v8 DDL,
+    // columns included) — re-altering here would hit "no such table" for
+    // that path, exactly like the v6->v7 precedent immediately above.
+    // Both v6 and v7 DBs, in contrast, kept these tables intact since v6
+    // (the v6->v7 step above only touched typing_bigram_minute's
+    // sum_iki/sumsq_iki, not the other two), so both need the v8 ALTER.
+    if (fromVersion === 6 || fromVersion === 7) {
+      this.db.exec(`
+        ALTER TABLE typing_matrix_minute ADD COLUMN dur_hist BLOB;
+        ALTER TABLE typing_matrix_minute ADD COLUMN dur_sum REAL;
+        ALTER TABLE typing_matrix_minute ADD COLUMN dur_sumsq REAL;
+        ALTER TABLE typing_bigram_minute ADD COLUMN overlap_count INTEGER;
+        ALTER TABLE typing_bigram_minute ADD COLUMN overlap_n INTEGER;
+        ALTER TABLE typing_minute_stats ADD COLUMN poll_p50_ms REAL;
+        ALTER TABLE typing_minute_stats ADD COLUMN poll_p95_ms REAL;
       `)
     }
   }

--- a/src/main/typing-analytics/jsonl/__tests__/apply-to-cache.test.ts
+++ b/src/main/typing-analytics/jsonl/__tests__/apply-to-cache.test.ts
@@ -159,6 +159,92 @@ describe('applyRowsToCache', () => {
     expect(conn.prepare('SELECT COUNT(*) AS n FROM typing_sessions').get()).toEqual({ n: 1 })
   })
 
+  it('applies matrix-minute dh/ds/dq, bigram-minute oc/on, and minute-stats pollP50Ms/pollP95Ms through to their SQL columns', () => {
+    const rows: JsonlRow[] = [
+      scopeRow(1_000),
+      {
+        id: matrixMinuteRowId(SCOPE_ID, 60_000, '', 1, 2, 0),
+        kind: 'matrix-minute',
+        updated_at: 1_000,
+        payload: {
+          scopeId: SCOPE_ID, minuteTs: 60_000, row: 1, col: 2, layer: 0, keycode: 0x04,
+          count: 1, tapCount: 0, holdCount: 0,
+          dh: [0, 1, 0, 0, 0, 0, 0, 0], ds: 65, dq: 4_225,
+        },
+      },
+      {
+        id: bigramMinuteRowId(SCOPE_ID, 60_000, ''),
+        kind: 'bigram-minute',
+        updated_at: 1_000,
+        payload: {
+          scopeId: SCOPE_ID, minuteTs: 60_000,
+          bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], oc: 1, on: 2 } },
+        },
+      },
+      {
+        id: minuteStatsRowId(SCOPE_ID, 60_000, ''),
+        kind: 'minute-stats',
+        updated_at: 1_000,
+        payload: {
+          scopeId: SCOPE_ID, minuteTs: 60_000, keystrokes: 2, activeMs: 100,
+          intervalAvgMs: null, intervalMinMs: null, intervalP25Ms: null, intervalP50Ms: null, intervalP75Ms: null, intervalMaxMs: null,
+          pollP50Ms: 20, pollP95Ms: 45,
+        },
+      },
+    ]
+    applyRowsToCache(db, rows)
+    const conn = db.getConnection()
+
+    const matrix = conn.prepare('SELECT dur_hist, dur_sum, dur_sumsq FROM typing_matrix_minute').get() as {
+      dur_hist: Uint8Array
+      dur_sum: number
+      dur_sumsq: number
+    }
+    expect(matrix.dur_sum).toBe(65)
+    expect(matrix.dur_sumsq).toBe(4_225)
+    // Little-endian u32 histogram: bucket 1 (offset 4) should read 1.
+    expect(Buffer.from(matrix.dur_hist).readUInt32LE(4)).toBe(1)
+
+    const bigram = conn.prepare('SELECT overlap_count, overlap_n FROM typing_bigram_minute').get() as {
+      overlap_count: number
+      overlap_n: number
+    }
+    expect(bigram.overlap_count).toBe(1)
+    expect(bigram.overlap_n).toBe(2)
+
+    const stats = conn.prepare('SELECT poll_p50_ms, poll_p95_ms FROM typing_minute_stats').get() as {
+      poll_p50_ms: number
+      poll_p95_ms: number
+    }
+    expect(stats.poll_p50_ms).toBe(20)
+    expect(stats.poll_p95_ms).toBe(45)
+  })
+
+  it('leaves dh/ds/dq, oc/on, and pollP50Ms/pollP95Ms columns NULL for pre-v8 rows that omit them', () => {
+    applyRowsToCache(db, [scopeRow(1_000), matrixRow(1_000, 5, 3, 2), statsRow(1_000, 10), bigramRow(1_000, { '4_11': { c: 1, h: [1, 0, 0, 0, 0, 0, 0, 0] } })])
+    const conn = db.getConnection()
+    const matrix = conn.prepare('SELECT dur_hist, dur_sum, dur_sumsq FROM typing_matrix_minute').get() as {
+      dur_hist: Buffer | null
+      dur_sum: number | null
+      dur_sumsq: number | null
+    }
+    expect(matrix.dur_hist).toBeNull()
+    expect(matrix.dur_sum).toBeNull()
+    expect(matrix.dur_sumsq).toBeNull()
+    const bigram = conn.prepare('SELECT overlap_count, overlap_n FROM typing_bigram_minute').get() as {
+      overlap_count: number | null
+      overlap_n: number | null
+    }
+    expect(bigram.overlap_count).toBeNull()
+    expect(bigram.overlap_n).toBeNull()
+    const stats = conn.prepare('SELECT poll_p50_ms, poll_p95_ms FROM typing_minute_stats').get() as {
+      poll_p50_ms: number | null
+      poll_p95_ms: number | null
+    }
+    expect(stats.poll_p50_ms).toBeNull()
+    expect(stats.poll_p95_ms).toBeNull()
+  })
+
   it('applies scope rows before dependent rows so FKs resolve', () => {
     const rows: JsonlRow[] = [charRow(1_000, 2), scopeRow(1_000)]
     expect(() => applyRowsToCache(db, rows)).not.toThrow()

--- a/src/main/typing-analytics/jsonl/__tests__/jsonl-row.test.ts
+++ b/src/main/typing-analytics/jsonl/__tests__/jsonl-row.test.ts
@@ -318,6 +318,55 @@ describe('parseRow rejections', () => {
     expect(parseRow(line)).toBeNull()
   })
 
+  it('accepts a bigram-minute entry with both oc and on present', () => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], oc: 1, on: 2 } },
+      },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('accepts a bigram-minute entry with oc/on entirely absent (legacy row)', () => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0] } },
+      },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it.each([
+    ['oc only', { oc: 1 }],
+    ['on only', { on: 2 }],
+    ['non-integer oc', { oc: 1.5, on: 2 }],
+    ['negative on', { oc: 1, on: -1 }],
+    ['oc greater than on', { oc: 3, on: 2 }],
+    ['non-numeric oc', { oc: '1', on: 2 }],
+  ])('returns null for a bigram-minute entry with an incomplete/invalid overlap pair (%s)', (_label, extra) => {
+    const line = JSON.stringify({
+      id: 'bigram|s|60000',
+      kind: 'bigram-minute',
+      updated_at: 1,
+      payload: {
+        scopeId: 's',
+        minuteTs: 60_000,
+        bigrams: { '4_11': { c: 2, h: [0, 2, 0, 0, 0, 0, 0, 0], ...extra } },
+      },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
   it('round-trips a trigram-minute row with an empty triple set', () => {
     const empty: JsonlRow = {
       id: trigramMinuteRowId('scope-1', 60_000, ''),
@@ -388,5 +437,105 @@ describe('parseRow rejections', () => {
       },
     })
     expect(parseRow(line)).not.toBeNull()
+  })
+
+  const baseMinuteStats = {
+    scopeId: 's',
+    minuteTs: 60_000,
+    keystrokes: 1,
+    activeMs: 1,
+    intervalAvgMs: null,
+    intervalMinMs: null,
+    intervalP25Ms: null,
+    intervalP50Ms: null,
+    intervalP75Ms: null,
+    intervalMaxMs: null,
+  }
+
+  it('accepts minute-stats with pollP50Ms/pollP95Ms both present as numbers', () => {
+    const line = JSON.stringify({
+      id: 'stats|s|60000',
+      kind: 'minute-stats',
+      updated_at: 1,
+      payload: { ...baseMinuteStats, pollP50Ms: 20, pollP95Ms: 45 },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('accepts minute-stats with pollP50Ms/pollP95Ms both null (no samples that minute)', () => {
+    const line = JSON.stringify({
+      id: 'stats|s|60000',
+      kind: 'minute-stats',
+      updated_at: 1,
+      payload: { ...baseMinuteStats, pollP50Ms: null, pollP95Ms: null },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('accepts minute-stats with pollP50Ms/pollP95Ms entirely absent (pre-v8 row)', () => {
+    const line = JSON.stringify({
+      id: 'stats|s|60000',
+      kind: 'minute-stats',
+      updated_at: 1,
+      payload: baseMinuteStats,
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('returns null for minute-stats with only one of pollP50Ms/pollP95Ms present', () => {
+    const line = JSON.stringify({
+      id: 'stats|s|60000',
+      kind: 'minute-stats',
+      updated_at: 1,
+      payload: { ...baseMinuteStats, pollP50Ms: 20 },
+    })
+    expect(parseRow(line)).toBeNull()
+  })
+
+  const baseMatrixMinute = {
+    scopeId: 's',
+    minuteTs: 60_000,
+    row: 0,
+    col: 0,
+    layer: 0,
+    keycode: 4,
+    count: 1,
+    tapCount: 0,
+    holdCount: 0,
+  }
+
+  it('accepts a matrix-minute row with dh/ds/dq all present', () => {
+    const line = JSON.stringify({
+      id: 'matrix|s|60000|0|0|0',
+      kind: 'matrix-minute',
+      updated_at: 1,
+      payload: { ...baseMatrixMinute, dh: [0, 1, 0, 0, 0, 0, 0, 0], ds: 65, dq: 4_225 },
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it('accepts a matrix-minute row with dh/ds/dq entirely absent (pre-v8 row)', () => {
+    const line = JSON.stringify({
+      id: 'matrix|s|60000|0|0|0',
+      kind: 'matrix-minute',
+      updated_at: 1,
+      payload: baseMatrixMinute,
+    })
+    expect(parseRow(line)).not.toBeNull()
+  })
+
+  it.each([
+    ['dh only', { dh: [0, 1, 0, 0, 0, 0, 0, 0] }],
+    ['ds/dq only', { ds: 65, dq: 4_225 }],
+    ['wrong-length dh', { dh: [0, 1, 0], ds: 65, dq: 4_225 }],
+    ['non-finite ds', { dh: [0, 1, 0, 0, 0, 0, 0, 0], ds: Number.NaN, dq: 4_225 }],
+  ])('returns null for a matrix-minute row with an incomplete/invalid duration triple (%s)', (_label, extra) => {
+    const line = JSON.stringify({
+      id: 'matrix|s|60000|0|0|0',
+      kind: 'matrix-minute',
+      updated_at: 1,
+      payload: { ...baseMatrixMinute, ...extra },
+    })
+    expect(parseRow(line)).toBeNull()
   })
 })

--- a/src/main/typing-analytics/jsonl/jsonl-row.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-row.ts
@@ -69,6 +69,15 @@ export interface JsonlMatrixMinutePayload {
   count: number
   tapCount: number
   holdCount: number
+  /** 8-bucket keypress-duration histogram (see bigram-bucket.ts's
+   * duration grid), `ds` its sum (ms), `dq` its sum-of-squares — same
+   * all-or-nothing-triple convention as the n-gram `s`/`sq` pair (see
+   * {@link JsonlBigramMinuteEntry}). Absent when this cell had no
+   * `matrix-release` samples this minute (including every row written
+   * before schema v8). */
+  dh?: number[]
+  ds?: number
+  dq?: number
   appName?: AppNameField
   typingTest?: TypingTestField
   runId?: RunIdField
@@ -85,6 +94,12 @@ export interface JsonlMinuteStatsPayload {
   intervalP50Ms: number | null
   intervalP75Ms: number | null
   intervalMaxMs: number | null
+  /** Median / p95 sampling gap (ms) between polled matrix frames this
+   * minute (see matrix-press-duration.ts's pollGapMs). Absent when no
+   * frame this minute contributed a sample (e.g. every frame followed an
+   * observation hole, or the minute had at most one press). */
+  pollP50Ms?: number | null
+  pollP95Ms?: number | null
   appName?: AppNameField
   typingTest?: TypingTestField
   runId?: RunIdField
@@ -105,12 +120,25 @@ export interface JsonlSessionPayload {
  * bucket-midpoint approximation. Optional and always a pair: rows
  * written before this field existed (or merged from an older peer)
  * omit both, and SD then reads as null rather than an approximation —
- * see isBigramMinuteEntry / isNgramMinuteEntry. */
+ * see isBigramMinuteEntry / isNgramMinuteEntry.
+ *
+ * `oc` / `on` are the physical-overlap accumulators for this pair (see
+ * OverlapCounts in minute-buffer.ts) — populated for BIGRAM entries only.
+ * Structurally available on {@link JsonlTrigramMinuteEntry} too (it's a
+ * straight alias of this type), but the recorder never sets them for
+ * trigrams: overlap is defined as "does the previous PRESS overlap the
+ * new one", a pairwise notion that doesn't extend to a 3-key chain
+ * without inventing a new definition. Absent for every row written
+ * before schema v8, and for a bigram row whose contributing event(s)
+ * never had a determined overlap (see {@link OverlapCounts}'s own doc
+ * comment on why "unknown" must not collapse into "no overlap"). */
 export interface JsonlBigramMinuteEntry {
   c: number
   h: number[]
   s?: number
   sq?: number
+  oc?: number
+  on?: number
 }
 
 export interface JsonlBigramMinutePayload {
@@ -293,6 +321,21 @@ function isCharMinutePayload(p: Record<string, unknown>): boolean {
   )
 }
 
+/** `dh`/`ds`/`dq` are optional but must appear as a complete triple: all
+ * absent is a pre-v8 row (valid), all present must be well-formed, and
+ * any partial combination is malformed (rejected) — same all-or-nothing
+ * discipline as {@link hasValidSumPair}. `dh` uses the same 8-bucket
+ * shape contract as a bigram/trigram `h` (see {@link isHistBuckets}) —
+ * the duration grid just has different bucket boundaries, not a
+ * different wire shape. */
+function isValidDurationTriple(p: Record<string, unknown>): boolean {
+  const gate = allOrNone(p, ['dh', 'ds', 'dq'])
+  if (gate === false) return false
+  if (gate === 'absent') return true
+  return isHistBuckets(p.dh) && typeof p.ds === 'number' && Number.isFinite(p.ds) &&
+    typeof p.dq === 'number' && Number.isFinite(p.dq)
+}
+
 function isMatrixMinutePayload(p: Record<string, unknown>): boolean {
   return (
     hasStringField(p, 'scopeId') &&
@@ -304,6 +347,7 @@ function isMatrixMinutePayload(p: Record<string, unknown>): boolean {
     hasNumberField(p, 'count') &&
     hasNumberField(p, 'tapCount') &&
     hasNumberField(p, 'holdCount') &&
+    isValidDurationTriple(p) &&
     isOptionalAppName(p) &&
     isOptionalTypingTest(p) &&
     isOptionalRunId(p)
@@ -313,6 +357,21 @@ function isMatrixMinutePayload(p: Record<string, unknown>): boolean {
 function isNumericOrNull(p: Record<string, unknown>, key: string): boolean {
   const value = p[key]
   return value === null || (typeof value === 'number' && Number.isFinite(value))
+}
+
+/** All-or-nothing presence gate shared by every optional field pair/triple
+ * validator below (`s`/`sq`, `dh`/`ds`/`dq`, `pollP50Ms`/`pollP95Ms`,
+ * `oc`/`on`): these always travel together on the wire, so a caller only
+ * needs to check each field's own value once it knows they're all
+ * present. Returns `'absent'` when none of `keys` are on `o` (a legacy
+ * row — valid as-is), `'present'` when every key is there (go on to
+ * validate values), or `false` for any partial combination (a malformed
+ * write — rejected). */
+function allOrNone(o: Record<string, unknown>, keys: readonly string[]): 'absent' | 'present' | false {
+  const presentCount = keys.filter((k) => k in o).length
+  if (presentCount === 0) return 'absent'
+  if (presentCount === keys.length) return 'present'
+  return false
 }
 
 /** appName is optional on the wire (master files written before the
@@ -341,6 +400,16 @@ function isOptionalRunId(p: Record<string, unknown>): boolean {
   return typeof p.runId === 'string'
 }
 
+/** `pollP50Ms`/`pollP95Ms` are optional but must appear as a pair — same
+ * all-or-nothing discipline as {@link hasValidSumPair}. Each present
+ * value may itself be null (no sample that minute) or a finite number. */
+function isValidPollStatsPair(p: Record<string, unknown>): boolean {
+  const gate = allOrNone(p, ['pollP50Ms', 'pollP95Ms'])
+  if (gate === false) return false
+  if (gate === 'absent') return true
+  return isNumericOrNull(p, 'pollP50Ms') && isNumericOrNull(p, 'pollP95Ms')
+}
+
 function isMinuteStatsPayload(p: Record<string, unknown>): boolean {
   return (
     hasStringField(p, 'scopeId') &&
@@ -353,6 +422,7 @@ function isMinuteStatsPayload(p: Record<string, unknown>): boolean {
     isNumericOrNull(p, 'intervalP50Ms') &&
     isNumericOrNull(p, 'intervalP75Ms') &&
     isNumericOrNull(p, 'intervalMaxMs') &&
+    isValidPollStatsPair(p) &&
     isOptionalAppName(p) &&
     isOptionalTypingTest(p) &&
     isOptionalRunId(p)
@@ -368,7 +438,12 @@ function isSessionPayload(p: Record<string, unknown>): boolean {
   )
 }
 
-function isBigramHist(value: unknown): boolean {
+/** Exactly BIGRAM_HIST_BUCKETS finite numbers. Grid-neutral name — this
+ * shape contract is shared by the bigram/trigram IKI histogram (`h`) and
+ * the matrix-release duration histogram (`dh`, see
+ * {@link isValidDurationTriple}); only the bucket boundaries differ
+ * between the two grids, not the wire shape this validates. */
+function isHistBuckets(value: unknown): boolean {
   if (!Array.isArray(value) || value.length !== BIGRAM_HIST_BUCKETS) return false
   for (const n of value) {
     if (typeof n !== 'number' || !Number.isFinite(n)) return false
@@ -382,19 +457,37 @@ function isBigramHist(value: unknown): boolean {
  * a complete sum pair yields a real SD" invariant enforceable straight
  * off the wire. */
 function hasValidSumPair(o: Record<string, unknown>): boolean {
-  const hasS = 's' in o
-  const hasSq = 'sq' in o
-  if (!hasS && !hasSq) return true
-  if (!hasS || !hasSq) return false
+  const gate = allOrNone(o, ['s', 'sq'])
+  if (gate === false) return false
+  if (gate === 'absent') return true
   return typeof o.s === 'number' && Number.isFinite(o.s) && typeof o.sq === 'number' && Number.isFinite(o.sq)
 }
 
+/** `oc` / `on` are optional but must appear as a pair (same discipline as
+ * {@link hasValidSumPair}), both non-negative finite integers, with
+ * `oc <= on` — `oc` counts a SUBSET of what `on` counts (see
+ * OverlapCounts in minute-buffer.ts), so `oc > on` can only be
+ * corruption. Structurally checked on every n-gram entry (bigram AND
+ * trigram — see {@link isNgramMinuteEntry}) even though the recorder
+ * only ever populates it for bigrams; a trigram row happening to carry
+ * it is accepted the same way an unexpected-but-well-formed field
+ * always is elsewhere in this parser. */
+function hasValidOverlapPair(o: Record<string, unknown>): boolean {
+  const gate = allOrNone(o, ['oc', 'on'])
+  if (gate === false) return false
+  if (gate === 'absent') return true
+  if (typeof o.oc !== 'number' || !Number.isInteger(o.oc) || o.oc < 0) return false
+  if (typeof o.on !== 'number' || !Number.isInteger(o.on) || o.on < 0) return false
+  return o.oc <= o.on
+}
+
 /** Shared validator for bigram and trigram minute entries — both use
- * the identical `{c, h, s?, sq?}` shape (see JsonlTrigramMinuteEntry). */
+ * the identical `{c, h, s?, sq?, oc?, on?}` shape (see JsonlTrigramMinuteEntry). */
 function isNgramMinuteEntry(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) return false
   const o = value as Record<string, unknown>
-  return typeof o.c === 'number' && Number.isFinite(o.c) && isBigramHist(o.h) && hasValidSumPair(o)
+  return typeof o.c === 'number' && Number.isFinite(o.c) && isHistBuckets(o.h) &&
+    hasValidSumPair(o) && hasValidOverlapPair(o)
 }
 
 /** Shared validator for bigram-minute / trigram-minute payloads — same

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -64,7 +64,14 @@ export const RETENTION_MS = 5 * MINUTE_MS
  * and `holdCount` break that down for LT/MT presses, classified by
  * release edge or by the renderer's deferred-emit deadline, whichever
  * comes first; non-tap-hold presses leave both at zero and the consumer
- * treats `count` as the fallback intensity. */
+ * treats `count` as the fallback intensity. `durations` are raw keypress
+ * durations (ms) from `matrix-release` events landing in this minute —
+ * bucketized into a histogram at flush time (see bigram-bucket.ts's
+ * duration grid). Its length can differ from `count` for the same
+ * minute: a release's ts drives its OWN minute attribution, independent
+ * of which minute the matching press landed in (see the `matrix-release`
+ * event type's doc comment) — a press near a minute boundary is a
+ * routine way for this to happen, not a bug. */
 export interface MatrixCellCounts {
   row: number
   col: number
@@ -73,6 +80,20 @@ export interface MatrixCellCounts {
   count: number
   tapCount: number
   holdCount: number
+  durations: number[]
+}
+
+/** Per-pair physical-overlap accumulator. `on` counts pairs whose
+ * incoming press had a KNOWN overlap determination (true or false); `oc`
+ * is the subset of those where it was true. Pairs recorded while overlap
+ * was undefined (no reference press, a hole, or a reference press that
+ * predates a hole — see matrix-press-duration.ts) contribute to neither
+ * field, so `oc / on` is a ratio over only the pairs we could actually
+ * observe — never over the full pair population, which would silently
+ * treat "unknown" as "no overlap". */
+export interface OverlapCounts {
+  oc: number
+  on: number
 }
 
 export interface MinuteSnapshot {
@@ -102,6 +123,17 @@ export interface MinuteSnapshot {
    * semantics as bigrams so the existing histogram bucketing applies
    * unchanged. */
   trigrams: Map<string, number[]>
+  /** Per-bigram physical-overlap accumulators — see {@link OverlapCounts}.
+   * Keyed identically to `bigrams` (`${prevKeycode}_${currKeycode}`). */
+  overlaps: Map<string, OverlapCounts>
+  /** Median sampling gap (ms) between polled frames this minute, from
+   * `matrix` events' `pollGapMs` — null when no sample was recorded
+   * (e.g. every frame this minute followed an observation hole, or the
+   * minute had at most one press). */
+  pollP50Ms: number | null
+  /** 95th-percentile sampling gap (ms) — same source and null semantics
+   * as {@link pollP50Ms}. */
+  pollP95Ms: number | null
   /** Active application name observed during this minute, or null when:
    *  - Monitor App is disabled
    *  - the minute observed multiple distinct apps (mixed → null)
@@ -134,6 +166,12 @@ interface Entry {
   intervals: number[]
   bigrams: Map<string, number[]>
   trigrams: Map<string, number[]>
+  /** See {@link MinuteSnapshot.overlaps}. */
+  overlaps: Map<string, OverlapCounts>
+  /** Raw sampling gaps (ms) from this minute's `matrix` events —
+   * bucketed into p50/p95 on {@link finalize}. See
+   * {@link MinuteSnapshot.pollP50Ms}. */
+  pollGaps: number[]
   keystrokes: number
   firstEventMs: number
   lastEventMs: number
@@ -200,6 +238,10 @@ function finalize(entry: Entry): MinuteSnapshot {
   if (entry.typingTestSet.size === 1) {
     typingTest = entry.typingTestSet.values().next().value ?? null
   }
+  // Same in-place-sort trade-off as `entry.intervals` above — the array
+  // is retained, so a later straggler's poll gap gets folded in and this
+  // just re-sorts a mostly-sorted array on the next finalize.
+  const sortedGaps = entry.pollGaps.sort((a, b) => a - b)
   return {
     scopeId: entry.scopeId,
     fingerprint: entry.fingerprint,
@@ -216,6 +258,9 @@ function finalize(entry: Entry): MinuteSnapshot {
     matrixCounts: entry.matrixCounts,
     bigrams: entry.bigrams,
     trigrams: entry.trigrams,
+    overlaps: entry.overlaps,
+    pollP50Ms: percentile(sortedGaps, 0.5),
+    pollP95Ms: percentile(sortedGaps, 0.95),
     appName,
     typingTest,
     runId: entry.runId,
@@ -259,6 +304,29 @@ export class MinuteBuffer {
     return minuteTs + MINUTE_MS + windowMs <= nowMs
   }
 
+  /** Fetch a cell's mutable counters, creating a zeroed one (seeded with
+   * `keycode`) if this is the first event ever recorded for it this
+   * minute. Shared by both the press path (which counts/tap/hold onto
+   * it, refreshing `keycode` itself) and the matrix-release path (which
+   * only pushes a duration sample) so neither has to hand-write the
+   * 8-field object literal — a cell created by one path is filled in by
+   * the other exactly the same way a same-path repeat would. */
+  private getOrCreateCell(
+    entry: Entry,
+    key: string,
+    row: number,
+    col: number,
+    layer: number,
+    keycode: number,
+  ): MatrixCellCounts {
+    let cell = entry.matrixCounts.get(key)
+    if (!cell) {
+      cell = { row, col, layer, keycode, count: 0, tapCount: 0, holdCount: 0, durations: [] }
+      entry.matrixCounts.set(key, cell)
+    }
+    return cell
+  }
+
   /** `nowMs` is a real wall-clock timestamp (the service passes
    * `Date.now()`), used only to decide whether an event targeting a
    * minute with no live entry is a genuine new minute or an ultra-late
@@ -293,6 +361,8 @@ export class MinuteBuffer {
         intervals: [],
         bigrams: new Map(),
         trigrams: new Map(),
+        overlaps: new Map(),
+        pollGaps: [],
         keystrokes: 0,
         firstEventMs: event.ts,
         lastEventMs: event.ts,
@@ -309,6 +379,24 @@ export class MinuteBuffer {
     }
 
     if (event.typingTest) entry.typingTestSet.add(event.typingTest)
+
+    if (event.kind === 'matrix-release') {
+      // Duration-only path: a release's ts drives ITS OWN minute
+      // attribution (see the event type's doc comment), independent of
+      // whichever minute the matching press landed in — so this must
+      // touch only the per-cell duration accumulator. Folding it into
+      // keystrokes/intervals/activeMs/lastEventMs/firstEventMs would
+      // double-count a press already tallied by its own `matrix` event
+      // (possibly in a different minute entirely), and folding it into
+      // the n-gram chain would fabricate a pair the user never typed.
+      // The entry is still marked dirty (via the 'retained' → 'reopened'
+      // transition above) and still respects the retention/ultra-late-drop
+      // guard above, exactly like every other event kind.
+      const mKey = `${event.row},${event.col},${event.layer}`
+      const cell = this.getOrCreateCell(entry, mKey, event.row, event.col, event.layer, event.keycode)
+      cell.durations.push(event.durationMs)
+      return
+    }
 
     if (entry.keystrokes > 0) {
       const gap = event.ts - entry.lastEventMs
@@ -330,18 +418,17 @@ export class MinuteBuffer {
       entry.charCounts.set(event.key, (entry.charCounts.get(event.key) ?? 0) + 1)
     } else {
       const mKey = `${event.row},${event.col},${event.layer}`
-      const existing = entry.matrixCounts.get(mKey)
-      const tapDelta = event.action === 'tap' ? 1 : 0
-      const holdDelta = event.action === 'hold' ? 1 : 0
-      entry.matrixCounts.set(mKey, {
-        row: event.row,
-        col: event.col,
-        layer: event.layer,
-        keycode: event.keycode,
-        count: (existing?.count ?? 0) + 1,
-        tapCount: (existing?.tapCount ?? 0) + tapDelta,
-        holdCount: (existing?.holdCount ?? 0) + holdDelta,
-      })
+      const cell = this.getOrCreateCell(entry, mKey, event.row, event.col, event.layer, event.keycode)
+      // Always refresh the keycode from a press — unlike a release (which
+      // only seeds it when first creating the cell), a press is the
+      // authoritative source for "what's currently mapped here" and must
+      // reflect a keymap change made mid-session.
+      cell.keycode = event.keycode
+      cell.count += 1
+      if (event.action === 'tap') cell.tapCount += 1
+      if (event.action === 'hold') cell.holdCount += 1
+
+      if (event.pollGapMs !== undefined) entry.pollGaps.push(event.pollGapMs)
 
       if (event.action === 'hold') {
         // A hold is the user reaching for a layer or modifier, not a
@@ -357,7 +444,7 @@ export class MinuteBuffer {
         // nothing to pair against yet.
         this.resetBigramChain()
       } else {
-        this.recordNgramChain(entry, `${scopeId}|${runId}`, event.keycode, event.ts)
+        this.recordNgramChain(entry, `${scopeId}|${runId}`, event.keycode, event.ts, event.overlap)
       }
     }
   }
@@ -384,8 +471,28 @@ export class MinuteBuffer {
    *
    * `chainKey` scopes the chain to one `${scopeId}|${runId}` stream: an
    * event from a different keyboard or test run restarts the chain from
-   * itself instead of pairing against the other stream's keys. */
-  private recordNgramChain(entry: Entry, chainKey: string, currKeycode: number, ts: number): void {
+   * itself instead of pairing against the other stream's keys.
+   *
+   * `overlap` is the INCOMING event's own overlap determination (from its
+   * `matrix` payload, see the shared event type) — when it is not
+   * `undefined` and this call completes an eligible bigram, it folds into
+   * that pair's {@link OverlapCounts} (`on` always, `oc` only when the
+   * overlap was true). An undefined overlap means the renderer couldn't
+   * determine it (no reference press, or a hole — see
+   * matrix-press-duration.ts) and must not silently count as "no
+   * overlap", so it contributes to neither field — see
+   * {@link OverlapCounts}'s own doc comment.
+   *
+   * A same-frame tie (`iki === 0`) still folds `overlap` into the tied
+   * pair even though the chain doesn't advance and no IKI is recorded:
+   * two presses landing in the very same polled frame is the single
+   * strongest physical-overlap evidence this tracker ever sees — overlap
+   * is guaranteed determined there (see matrix-press-duration.ts's
+   * overlapFor), so discarding it alongside the (genuinely unusable) IKI
+   * would throw away the clearest signal to avoid throwing away the
+   * noisiest one. This does introduce a small, documented attribution
+   * bias — see observedRolloverRatio in bigram-aggregate.ts. */
+  private recordNgramChain(entry: Entry, chainKey: string, currKeycode: number, ts: number, overlap: boolean | undefined): void {
     if (this.k2Ts === null || this.chainKey !== chainKey) {
       // First matrix event this chain has seen, or the event belongs to
       // a different scope/run than the current chain — nothing valid to
@@ -399,7 +506,12 @@ export class MinuteBuffer {
     }
     const iki = ts - this.k2Ts
     if (iki <= 0) {
-      // Tie / out-of-order: discard this event, chain unchanged.
+      // Tie / out-of-order: discard the IKI contribution and don't
+      // advance the chain — but still fold overlap into the tied pair
+      // (see this method's doc comment). The overlaps map is
+      // independent of the bigrams IKI array, so this doesn't touch
+      // anything the "no IKI recorded" guarantee depends on.
+      this.foldOverlap(entry, `${this.k2Keycode}_${currKeycode}`, overlap)
       return
     }
     const eligible = iki <= NGRAM_MAX_IKI_MS
@@ -411,6 +523,7 @@ export class MinuteBuffer {
         entry.bigrams.set(pairKey, ikis)
       }
       ikis.push(iki)
+      this.foldOverlap(entry, pairKey, overlap)
       if (this.k1Keycode !== null && this.prevIki !== null) {
         const tripleKey = `${this.k1Keycode}_${this.k2Keycode}_${currKeycode}`
         let ikis3 = entry.trigrams.get(tripleKey)
@@ -425,6 +538,24 @@ export class MinuteBuffer {
     this.prevIki = eligible ? iki : null
     this.k2Keycode = currKeycode
     this.k2Ts = ts
+  }
+
+  /** Fold one event's overlap determination into a pair's
+   * {@link OverlapCounts}, creating the accumulator on first use. No-op
+   * when `overlap` is undefined (renderer couldn't determine it) — see
+   * {@link recordNgramChain}'s doc comment on why that must not silently
+   * count as "no overlap". Shared by both the eligible-bigram path and
+   * the same-frame-tie path in `recordNgramChain`, since a tie folds
+   * overlap without touching the bigrams IKI array. */
+  private foldOverlap(entry: Entry, pairKey: string, overlap: boolean | undefined): void {
+    if (overlap === undefined) return
+    let ov = entry.overlaps.get(pairKey)
+    if (!ov) {
+      ov = { oc: 0, on: 0 }
+      entry.overlaps.set(pairKey, ov)
+    }
+    ov.on += 1
+    if (overlap) ov.oc += 1
   }
 
   /** Tag every currently-open buffer entry with an observed application

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -28,6 +28,7 @@ import type {
 import type { KleKey } from '../../shared/kle/types'
 import { isFingerType, isPosKey, type FingerType } from '../../shared/kle/kle-ergonomics'
 import { canonicalScopeKey, emptyTombstoneResult } from '../../shared/types/typing-analytics'
+import { OBSERVATION_HOLE_MS } from '../../shared/typing-analytics-timing'
 import { isHashScope, isOwnScope, normalizeAppScopes, parseDeviceScope } from '../../shared/types/analyze-filters'
 import { log } from '../logger'
 import { getCurrentAppName } from './app-monitor'
@@ -74,9 +75,10 @@ import {
   type JsonlRow,
 } from './jsonl/jsonl-row'
 import { appendRowsToFile } from './jsonl/jsonl-writer'
-import { bucketizeIki, sumAndSumSquares } from './bigram-bucket'
+import { bucketizeDurations, bucketizeIki, sumAndSumSquares } from './bigram-bucket'
 import {
   aggregatePairTotals,
+  observedRolloverRatio,
   rankBigramsByCount,
   rankBigramsBySlow,
 } from './bigram-aggregate'
@@ -190,8 +192,8 @@ const emptyPeakRecords = (): PeakRecords => ({
  * a defined value regardless of how far the handler got. */
 const emptyBigramResult = (view: TypingBigramAggregateView): TypingBigramAggregateResult =>
   view === 'slow'
-    ? { view: 'slow', entries: [], truncated: false }
-    : { view: 'top', entries: [], truncated: false }
+    ? { view: 'slow', entries: [], truncated: false, observedRolloverRatio: null }
+    : { view: 'top', entries: [], truncated: false, observedRolloverRatio: null }
 
 /**
  * Register typing-analytics IPC handlers. Called synchronously at startup so
@@ -810,10 +812,14 @@ export function setupTypingAnalyticsIpc(): void {
       // here (against the full pair universe) rather than left for the
       // renderer to infer from `entries.length`.
       const truncated = totals.size > limit
+      // Trigram rows never carry overlap columns (see NgramMinuteCellRow),
+      // so every entry would be null-poisoned anyway — skip the full-map
+      // pass entirely instead of walking it just to get null back.
+      const rolloverRatio = gram === 3 ? null : observedRolloverRatio(totals)
       if (parsedView === 'slow') {
-        return { view: 'slow', entries: rankBigramsBySlow(totals, minSample, limit), truncated }
+        return { view: 'slow', entries: rankBigramsBySlow(totals, minSample, limit), truncated, observedRolloverRatio: rolloverRatio }
       }
-      return { view: 'top', entries: rankBigramsByCount(totals, limit), truncated }
+      return { view: 'top', entries: rankBigramsByCount(totals, limit), truncated, observedRolloverRatio: rolloverRatio }
     },
   )
 
@@ -1395,6 +1401,49 @@ function isValidKeyboard(value: unknown): value is TypingAnalyticsKeyboard {
   )
 }
 
+/** Longest duration (ms) a single keypress is allowed to report. Well
+ * above any real tap or held layer key, but low enough to reject a
+ * clearly corrupt/fabricated sample (e.g. a renderer bug feeding a stale
+ * press record) instead of letting it skew the per-cell histogram. */
+const MAX_MATRIX_RELEASE_DURATION_MS = 60_000
+
+function isValidMatrixCommon(obj: Record<string, unknown>): boolean {
+  return (
+    typeof obj.row === 'number' && Number.isInteger(obj.row) && obj.row >= 0 &&
+    typeof obj.col === 'number' && Number.isInteger(obj.col) && obj.col >= 0 &&
+    typeof obj.layer === 'number' && Number.isInteger(obj.layer) && obj.layer >= 0 &&
+    typeof obj.keycode === 'number' && Number.isFinite(obj.keycode)
+  )
+}
+
+/** Strip an invalid optional auxiliary field from a `matrix` event
+ * payload in place, rather than rejecting the whole keystroke over it.
+ * `action`/`overlap`/`pollGapMs` are all best-effort classification data
+ * layered on top of a real physical press — an out-of-range value there
+ * (a stale/misordered pollGapMs sample, a corrupted boolean) is a timing
+ * or classification artifact, not evidence the press itself didn't
+ * happen. Rejecting the whole event over it would lose a real keystroke
+ * to something the renderer could compute wrong — precisely the class of
+ * bug #322/#323 already fixed elsewhere in this pipeline. Core fields
+ * (row/col/layer/keycode, checked by isValidMatrixCommon before this
+ * runs) are NOT sanitized: there is no safe fallback for "which cell was
+ * this", so those still reject the whole event as before.
+ *
+ * The pollGapMs bound (`0 < pollGapMs <= OBSERVATION_HOLE_MS`) reuses the
+ * same shared constant the renderer's hole detection is built on (see
+ * matrix-press-duration.ts's onFrame) — by construction, any pollGapMs
+ * the renderer ever legitimately attaches already satisfies it, so this
+ * is a self-consistency check on the wire value, not an independent
+ * policy choice that could drift from the renderer's own threshold. */
+function sanitizeMatrixAuxFields(obj: Record<string, unknown>): void {
+  if (obj.action !== undefined && obj.action !== 'tap' && obj.action !== 'hold') delete obj.action
+  if (obj.overlap !== undefined && typeof obj.overlap !== 'boolean') delete obj.overlap
+  if (obj.pollGapMs !== undefined) {
+    const gap = obj.pollGapMs
+    if (typeof gap !== 'number' || !Number.isFinite(gap) || gap <= 0 || gap > OBSERVATION_HOLE_MS) delete obj.pollGapMs
+  }
+}
+
 function isValidEvent(value: unknown): value is TypingAnalyticsEvent {
   if (typeof value !== 'object' || value === null) return false
   const obj = value as Record<string, unknown>
@@ -1404,11 +1453,15 @@ function isValidEvent(value: unknown): value is TypingAnalyticsEvent {
     return typeof obj.key === 'string' && obj.key.length > 0
   }
   if (obj.kind === 'matrix') {
+    if (!isValidMatrixCommon(obj)) return false
+    sanitizeMatrixAuxFields(obj)
+    return true
+  }
+  if (obj.kind === 'matrix-release') {
+    if (!isValidMatrixCommon(obj)) return false
     return (
-      typeof obj.row === 'number' && Number.isInteger(obj.row) && obj.row >= 0 &&
-      typeof obj.col === 'number' && Number.isInteger(obj.col) && obj.col >= 0 &&
-      typeof obj.layer === 'number' && Number.isInteger(obj.layer) && obj.layer >= 0 &&
-      typeof obj.keycode === 'number' && Number.isFinite(obj.keycode)
+      typeof obj.durationMs === 'number' && Number.isFinite(obj.durationMs) &&
+      obj.durationMs > 0 && obj.durationMs < MAX_MATRIX_RELEASE_DURATION_MS
     )
   }
   return false
@@ -1426,8 +1479,17 @@ async function resolveScope(keyboard: TypingAnalyticsKeyboard): Promise<Resolved
 async function ingestEvent(event: TypingAnalyticsEvent): Promise<void> {
   const { fingerprint, scopeKey } = await resolveScope(event.keyboard)
   minuteBuffer.addEvent(event, fingerprint, Date.now())
-  const finalized = sessionDetector.recordEvent(event.keyboard.uid, scopeKey, event.ts)
-  if (finalized.length > 0) pendingSessions.push(...finalized)
+  // matrix-release events are duration-only by contract (see the shared
+  // event type's doc comment) — they carry no new keystroke, so they
+  // must not participate in session detection. A held key's release can
+  // land minutes after its press (a long hold, or a press near a poll
+  // gap); if it counted here, that gap-spanning release could silently
+  // extend — or even re-open — a session a press-only stream would have
+  // already let idle-close.
+  if (event.kind !== 'matrix-release') {
+    const finalized = sessionDetector.recordEvent(event.keyboard.uid, scopeKey, event.ts)
+    if (finalized.length > 0) pendingSessions.push(...finalized)
+  }
   dirty = true
   scheduleFlush()
 }
@@ -1558,8 +1620,20 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
   // run_id is part of every per-minute row's identity (id + SQLite PK) so
   // two runs in one minute stay distinct. '' for non-test (REC) input.
   const runId = snapshot.runId
-  const rows: JsonlRow[] = [
-    {
+  const rows: JsonlRow[] = []
+  // A minute whose only contribution is a matrix-release event (a press
+  // near :59.9 released at :00.1 of the NEXT minute — see the
+  // matrix-release event type's doc comment on release-vs-press minute
+  // attribution) has keystrokes === 0 and no charCounts: nothing was
+  // actually typed IN this minute, only a duration sample that happens
+  // to land here. Shipping a minute-stats row for it would fabricate a
+  // phantom day in selectDailySummariesForUid — a day appears in Analyze
+  // solely because a key held across midnight happened to release a
+  // fraction of a second into the next day. The matrix-minute row for
+  // that cell (carrying the duration data) still ships in the loop
+  // below regardless; only this per-minute stats rollup is skipped.
+  if (snapshot.keystrokes > 0 || snapshot.charCounts.size > 0) {
+    rows.push({
       id: minuteStatsRowId(snapshot.scopeId, snapshot.minuteTs, runId),
       kind: 'minute-stats',
       updated_at: updatedAt,
@@ -1574,12 +1648,19 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
         intervalP50Ms: snapshot.intervalP50Ms,
         intervalP75Ms: snapshot.intervalP75Ms,
         intervalMaxMs: snapshot.intervalMaxMs,
+        // Absent (not null) when the minute recorded no poll-gap samples
+        // at all — mirrors the matrix-minute dh/ds/dq convention below:
+        // "no data" stays absent on the wire rather than an explicit
+        // null pair, keeping pre-v8 rows and "genuinely no samples" rows
+        // indistinguishable on disk — readers already treat both
+        // identically (see isValidPollStatsPair).
+        ...(snapshot.pollP50Ms !== null ? { pollP50Ms: snapshot.pollP50Ms, pollP95Ms: snapshot.pollP95Ms } : {}),
         appName,
         typingTest,
         runId,
       },
-    },
-  ]
+    })
+  }
   for (const [char, count] of snapshot.charCounts) {
     rows.push({
       id: charMinuteRowId(snapshot.scopeId, snapshot.minuteTs, runId, char),
@@ -1589,6 +1670,15 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
     })
   }
   for (const cell of snapshot.matrixCounts.values()) {
+    // Built once as a complete triple (or left undefined) rather than
+    // computed piecemeal — present only when this cell had at least one
+    // matrix-release sample this minute; see JsonlMatrixMinutePayload's
+    // doc comment for why absent (not a zeroed histogram) is correct.
+    let dur: { dh: number[]; ds: number; dq: number } | undefined
+    if (cell.durations.length > 0) {
+      const { sum, sumSq } = sumAndSumSquares(cell.durations)
+      dur = { dh: bucketizeDurations(cell.durations), ds: sum, dq: sumSq }
+    }
     rows.push({
       id: matrixMinuteRowId(snapshot.scopeId, snapshot.minuteTs, runId, cell.row, cell.col, cell.layer),
       kind: 'matrix-minute',
@@ -1603,6 +1693,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
         count: cell.count,
         tapCount: cell.tapCount,
         holdCount: cell.holdCount,
+        ...dur,
         appName,
         typingTest,
         runId,
@@ -1617,7 +1708,7 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
       payload: {
         scopeId: snapshot.scopeId,
         minuteTs: snapshot.minuteTs,
-        bigrams: toNgramEntries(snapshot.bigrams),
+        bigrams: toNgramEntries(snapshot.bigrams, snapshot.overlaps),
         appName,
         typingTest,
         runId,
@@ -1632,6 +1723,8 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
       payload: {
         scopeId: snapshot.scopeId,
         minuteTs: snapshot.minuteTs,
+        // Overlap is a bigram-only concept — see JsonlBigramMinuteEntry's
+        // doc comment on why trigram entries never carry oc/on.
         trigrams: toNgramEntries(snapshot.trigrams),
         appName,
         typingTest,
@@ -1644,12 +1737,26 @@ function buildSnapshotRows(snapshot: MinuteSnapshot, updatedAt: number): JsonlRo
 
 /** Bucketize each pair/triple's raw IKI samples into the JSONL entry
  * shape (`c`/`h`/`s`/`sq`) shared by bigram-minute and trigram-minute
- * rows — see {@link buildSnapshotRows}. */
-function toNgramEntries(ikisByKey: ReadonlyMap<string, number[]>): Record<string, JsonlBigramMinuteEntry> {
+ * rows — see {@link buildSnapshotRows}. `overlaps` is supplied for the
+ * bigram call site only; when present, a pair with a recorded overlap
+ * accumulator gains `oc`/`on` (absent — not zeroed — for a pair whose
+ * every contributing event had an undetermined overlap, since "never
+ * observed" must not collapse into "observed as never overlapping"). */
+function toNgramEntries(
+  ikisByKey: ReadonlyMap<string, number[]>,
+  overlaps?: ReadonlyMap<string, { oc: number; on: number }>,
+): Record<string, JsonlBigramMinuteEntry> {
   const entries: Record<string, JsonlBigramMinuteEntry> = {}
   for (const [key, ikis] of ikisByKey) {
     const { sum, sumSq } = sumAndSumSquares(ikis)
-    entries[key] = { c: ikis.length, h: bucketizeIki(ikis), s: sum, sq: sumSq }
+    const overlap = overlaps?.get(key)
+    entries[key] = {
+      c: ikis.length,
+      h: bucketizeIki(ikis),
+      s: sum,
+      sq: sumSq,
+      ...(overlap ? { oc: overlap.oc, on: overlap.on } : {}),
+    }
   }
   return entries
 }

--- a/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
@@ -9,22 +9,57 @@ import { deserialize } from '../../../../shared/keycodes/keycodes'
 const mockTypingAnalyticsEvent = vi.fn<(event: unknown) => Promise<void>>()
 const mockTypingAnalyticsFlush = vi.fn<(uid: string) => Promise<void>>()
 
-beforeEach(() => {
-  mockTypingAnalyticsEvent.mockReset()
-  mockTypingAnalyticsFlush.mockReset()
-  mockTypingAnalyticsEvent.mockResolvedValue(undefined)
-  mockTypingAnalyticsFlush.mockResolvedValue(undefined)
+/** Whether `matrix-release` events reach `mockTypingAnalyticsEvent` at all
+ *  — see {@link installVialApi}. Reset to the default (excluded) every
+ *  test by beforeEach; opt in per-test with `installVialApi({ includeReleases: true })`. */
+let includeMatrixReleaseEvents = false
+
+/** (Re)installs the mocked `vialAPI` used by useInputModes. Mirrors
+ *  useTypingTest.test.ts's `analyticsOptions` filtering: `matrix-release`
+ *  events are excluded from `mockTypingAnalyticsEvent` by default so every
+ *  pre-existing assertion in this file (exact call counts, nth-call
+ *  content) keeps meaning what it meant before release events existed,
+ *  regardless of whether a given test happens to advance the clock
+ *  between a press and its release. Tests that specifically cover
+ *  release/duration wiring opt in explicitly instead of relying on
+ *  incidental zero-duration suppression (a frozen clock still produces
+ *  durationMs === 0, which the tracker itself discards, but this filter
+ *  no longer depends on that coincidence). Excluded releases resolve
+ *  immediately — the IPC call still "happens", it's just not observed by
+ *  the mock callers assert against. */
+function installVialApi(options?: { includeReleases?: boolean }): void {
+  includeMatrixReleaseEvents = options?.includeReleases ?? false
   Object.defineProperty(window, 'vialAPI', {
     value: {
-      typingAnalyticsEvent: mockTypingAnalyticsEvent,
+      typingAnalyticsEvent: (event: unknown) => {
+        const kind = (event as { kind?: string } | null)?.kind
+        if (kind === 'matrix-release' && !includeMatrixReleaseEvents) return Promise.resolve()
+        return mockTypingAnalyticsEvent(event)
+      },
       typingAnalyticsFlush: mockTypingAnalyticsFlush,
     },
     writable: true,
     configurable: true,
   })
+}
+
+beforeEach(() => {
+  mockTypingAnalyticsEvent.mockReset()
+  mockTypingAnalyticsFlush.mockReset()
+  mockTypingAnalyticsEvent.mockResolvedValue(undefined)
+  mockTypingAnalyticsFlush.mockResolvedValue(undefined)
+  installVialApi()
+  // Fake ONLY Date (not setTimeout/setImmediate — several tests below rely
+  // on those firing for real via flushMicrotasks). Deterministic durations
+  // are still needed for the release-wiring tests (see "matrix-release IPC
+  // wiring" below), which advance the clock explicitly with
+  // vi.setSystemTime() between a press and its release.
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -656,5 +691,78 @@ describe('useInputModes — tray keystroke counter', () => {
 
     expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({ typingTest: expect.any(String) }))
     expect(onRecKeystroke).not.toHaveBeenCalled()
+  })
+})
+
+// The `matrix-release` event travels through the exact same
+// prepare/emit/chainRef pipeline as every other analytics event — these
+// pin that it reaches the real IPC (typingAnalyticsEvent) with the same
+// keyboard/typingTest/runId attachment as a `matrix` event, not just
+// within useTypingTest's own in-memory sink (see useTypingTest.test.ts
+// for the duration/overlap/hole semantics themselves).
+describe('useInputModes — matrix-release IPC wiring', () => {
+  it('ships a matrix-release event over IPC with the keyboard attached', async () => {
+    installVialApi({ includeReleases: true })
+    // A stable keymap reference (not a fresh buildKeymap() per render) —
+    // useInputModes resets matrix press tracking whenever its `keymap`
+    // prop identity changes, which would otherwise wipe the just-pressed
+    // key's duration record before the release frame below looks it up.
+    const keymap = buildKeymap()
+    const { result } = renderUseInputModes({ typingRecordEnabled: true, keymap })
+
+    const pressAt = new Date('2026-01-01T00:00:00.000Z')
+    vi.setSystemTime(pressAt)
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    await flushMicrotasks()
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(1)
+
+    vi.setSystemTime(new Date(pressAt.getTime() + 60))
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+    await flushMicrotasks()
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledTimes(2)
+    expect(mockTypingAnalyticsEvent).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      kind: 'matrix-release', row: 0, col: 0, durationMs: 60, keyboard: sampleKeyboard,
+    }))
+  })
+
+  it('tags a matrix-release event with the running test label and run id, like its matrix press', async () => {
+    installVialApi({ includeReleases: true })
+    const keymap = buildKeymap()
+    const { result } = renderUseInputModes({
+      typingRecordEnabled: false,
+      typingTestViewOnly: false,
+      keymap,
+      savedTypingTestConfig: { mode: 'time', duration: 30, punctuation: false, numbers: false },
+    })
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    act(() => {
+      result.current.typingTest.processKeyEvent('a', false, false, false)
+    })
+    const runId = result.current.typingTest.state.runId
+
+    const pressAt = new Date('2026-01-01T00:00:01.000Z')
+    vi.setSystemTime(pressAt)
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    await flushMicrotasks()
+
+    vi.setSystemTime(new Date(pressAt.getTime() + 45))
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+    await flushMicrotasks()
+
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'matrix-release', row: 0, col: 0, durationMs: 45, runId, typingTest: expect.any(String),
+    }))
   })
 })

--- a/src/renderer/typing-test/__tests__/matrix-press-duration.test.ts
+++ b/src/renderer/typing-test/__tests__/matrix-press-duration.test.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { PressDurationTracker, OBSERVATION_HOLE_MS, type RegisterPressInput } from '../matrix-press-duration'
+
+/** Builds the `start` half of a {@link RegisterPressInput} from a
+ * "row,col" key string plus the remaining PressStartRecord fields, so
+ * call sites below don't have to spell out the nested object literal
+ * every time. */
+function start(key: string, tsMs: number, row: number, col: number, layer: number, keycode: number) {
+  return { key, start: { tsMs, row, col, layer, keycode } }
+}
+
+function press<TPreparedEvent>(
+  t: PressDurationTracker<TPreparedEvent>,
+  key: string,
+  tsMs: number,
+  row: number,
+  col: number,
+  layer: number,
+  keycode: number,
+  prepared: TPreparedEvent,
+  pressed: ReadonlySet<string>,
+  frame: RegisterPressInput<TPreparedEvent>['frame'],
+) {
+  return t.registerPress({ ...start(key, tsMs, row, col, layer, keycode), prepared, pressed, frame })
+}
+
+describe('PressDurationTracker', () => {
+  describe('onFrame', () => {
+    it('reports no hole and a null gap on the very first frame', () => {
+      const t = new PressDurationTracker<true>()
+      expect(t.onFrame(1000)).toEqual({ isHole: false, gapMs: null })
+    })
+
+    it('reports the gap when it is within the observation window', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      expect(t.onFrame(1020)).toEqual({ isHole: false, gapMs: 20 })
+    })
+
+    it('flags a hole when the gap exceeds OBSERVATION_HOLE_MS', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const frame = t.onFrame(1000 + OBSERVATION_HOLE_MS + 1)
+      expect(frame.isHole).toBe(true)
+      expect(frame.gapMs).toBeNull()
+    })
+
+    it('does not flag a hole exactly at the threshold', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const frame = t.onFrame(1000 + OBSERVATION_HOLE_MS)
+      expect(frame.isHole).toBe(false)
+    })
+
+    it('flags a hole when the clock steps backwards (negative gap)', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const frame = t.onFrame(900)
+      expect(frame.isHole).toBe(true)
+      expect(frame.gapMs).toBeNull()
+    })
+
+    it('does not flag a hole for a zero gap (two frames at the same ts)', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const frame = t.onFrame(1000)
+      expect(frame.isHole).toBe(false)
+      expect(frame.gapMs).toBe(0)
+    })
+  })
+
+  describe('registerPress — overlap', () => {
+    it('is undefined for the first press ever registered', () => {
+      const t = new PressDurationTracker<true>()
+      const frame = t.onFrame(1000)
+      const { overlap } = press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame)
+      expect(overlap).toBeUndefined()
+    })
+
+    it('is true when the previous press-edge key is still in the pressed set', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      const frame2 = t.onFrame(1010)
+      const { overlap } = press(t, '0,1', 1010, 0, 1, 0, 5, true, new Set(['0,0', '0,1']), frame2)
+      expect(overlap).toBe(true)
+    })
+
+    it('is false when the previous press-edge key is no longer in the pressed set', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      const frame2 = t.onFrame(1010)
+      const { overlap } = press(t, '0,1', 1010, 0, 1, 0, 5, true, new Set(['0,1']), frame2)
+      expect(overlap).toBe(false)
+    })
+
+    it('handles a 3-key chord landing in one frame: first undefined, rest true', () => {
+      const t = new PressDurationTracker<true>()
+      const frame = t.onFrame(1000)
+      const pressed = new Set(['0,0', '0,1', '0,2'])
+      const a = press(t, '0,0', 1000, 0, 0, 0, 4, true, pressed, frame)
+      const b = press(t, '0,1', 1000, 0, 1, 0, 5, true, pressed, frame)
+      const c = press(t, '0,2', 1000, 0, 2, 0, 6, true, pressed, frame)
+      expect(a.overlap).toBeUndefined()
+      expect(b.overlap).toBe(true)
+      expect(c.overlap).toBe(true)
+    })
+
+    it('is undefined when the current frame itself is a hole', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      const holeTs = 1000 + OBSERVATION_HOLE_MS + 1
+      const holeFrame = t.onFrame(holeTs)
+      const { overlap } = press(t, '0,1', holeTs, 0, 1, 0, 5, true, new Set(['0,0', '0,1']), holeFrame)
+      expect(overlap).toBeUndefined()
+    })
+
+    it('is undefined when the current frame is a hole caused by a backwards clock step', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      const holeFrame = t.onFrame(900)
+      const { overlap } = press(t, '0,1', 900, 0, 1, 0, 5, true, new Set(['0,0', '0,1']), holeFrame)
+      expect(overlap).toBeUndefined()
+    })
+
+    it('is undefined when the reference press predates the last recorded hole, even in a later, non-hole frame', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      // Hole frame — records lastHoleTs and clears the reference key.
+      t.onFrame(1000 + OBSERVATION_HOLE_MS + 1)
+
+      // A later, ordinary-gap frame still can't trust '0,0' as a
+      // reference, because it was last registered before the hole.
+      const frame3 = t.onFrame(1000 + OBSERVATION_HOLE_MS + 20)
+      const { overlap } = press(t, '0,1', 1000 + OBSERVATION_HOLE_MS + 20, 0, 1, 0, 5, true, new Set(['0,0', '0,1']), frame3)
+      expect(overlap).toBeUndefined()
+    })
+  })
+
+  describe('registerPress — pollGapMs', () => {
+    it('attaches to the first press edge of a frame only', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const frame2 = t.onFrame(1020)
+      const pressed = new Set(['0,0', '0,1'])
+      const a = press(t, '0,0', 1020, 0, 0, 0, 4, true, pressed, frame2)
+      const b = press(t, '0,1', 1020, 0, 1, 0, 5, true, pressed, frame2)
+      expect(a.pollGapMs).toBe(20)
+      expect(b.pollGapMs).toBeUndefined()
+    })
+
+    it('is absent on the very first frame (no previous frame to diff against)', () => {
+      const t = new PressDurationTracker<true>()
+      const frame = t.onFrame(1000)
+      const { pollGapMs } = press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame)
+      expect(pollGapMs).toBeUndefined()
+    })
+
+    it('is absent when the frame is a hole', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const holeFrame = t.onFrame(1000 + OBSERVATION_HOLE_MS + 1)
+      const { pollGapMs } = press(t, '0,0', 1000 + OBSERVATION_HOLE_MS + 1, 0, 0, 0, 4, true, new Set(['0,0']), holeFrame)
+      expect(pollGapMs).toBeUndefined()
+    })
+
+    it('is absent when the frame is a hole caused by a backwards clock step', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      const holeFrame = t.onFrame(900)
+      const { pollGapMs } = press(t, '0,0', 900, 0, 0, 0, 4, true, new Set(['0,0']), holeFrame)
+      expect(pollGapMs).toBeUndefined()
+    })
+  })
+
+  describe('resolveRelease', () => {
+    it('returns null for a key that was never registered', () => {
+      const t = new PressDurationTracker<true>()
+      expect(t.resolveRelease('0,0', 1000)).toBeNull()
+    })
+
+    it('computes durationMs from the matching press and clears the entry', () => {
+      const t = new PressDurationTracker<string>()
+      const frame = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 2, 0x04, 'ctx', new Set(['0,0']), frame)
+
+      const resolved = t.resolveRelease('0,0', 1150)
+      expect(resolved).toEqual({
+        prepared: 'ctx',
+        event: { kind: 'matrix-release', row: 0, col: 0, layer: 2, keycode: 0x04, ts: 1150, durationMs: 150 },
+      })
+
+      // Resolved once — a second release for the same key finds nothing.
+      expect(t.resolveRelease('0,0', 1200)).toBeNull()
+    })
+
+    it('discards a press whose duration would span an observation hole', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      // A hole opens between the press and the eventual release.
+      t.onFrame(1000 + OBSERVATION_HOLE_MS + 1)
+
+      const resolved = t.resolveRelease('0,0', 1000 + OBSERVATION_HOLE_MS + 50)
+      expect(resolved).toBeNull()
+    })
+
+    it('discards a press whose duration would span a backwards-clock-step hole', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      // The clock jumps backwards between the press and the release.
+      t.onFrame(900)
+
+      const resolved = t.resolveRelease('0,0', 950)
+      expect(resolved).toBeNull()
+    })
+
+    it('does not discard a press registered AFTER the last hole', () => {
+      const t = new PressDurationTracker<true>()
+      t.onFrame(1000)
+      // Hole frame.
+      t.onFrame(1000 + OBSERVATION_HOLE_MS + 1)
+      // A fresh press registered post-hole.
+      const frame3 = t.onFrame(1000 + OBSERVATION_HOLE_MS + 20)
+      press(t, '0,0', 1000 + OBSERVATION_HOLE_MS + 20, 0, 0, 0, 4, true, new Set(['0,0']), frame3)
+
+      const resolved = t.resolveRelease('0,0', 1000 + OBSERVATION_HOLE_MS + 70)
+      expect(resolved).not.toBeNull()
+      expect(resolved?.event.durationMs).toBe(50)
+    })
+
+    it('returns null for a non-positive duration instead of emitting a zero/negative sample', () => {
+      const t = new PressDurationTracker<true>()
+      const frame = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame)
+      expect(t.resolveRelease('0,0', 1000)).toBeNull()
+    })
+  })
+
+  describe('reset', () => {
+    it('discards an unresolved press instead of letting a later release resolve it', () => {
+      const t = new PressDurationTracker<true>()
+      const frame = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame)
+
+      t.reset()
+
+      expect(t.resolveRelease('0,0', 2000)).toBeNull()
+    })
+
+    it('clears hole/overlap state so the next press is treated as the first observation', () => {
+      const t = new PressDurationTracker<true>()
+      const frame1 = t.onFrame(1000)
+      press(t, '0,0', 1000, 0, 0, 0, 4, true, new Set(['0,0']), frame1)
+
+      t.reset()
+
+      const frame2 = t.onFrame(5000)
+      expect(frame2).toEqual({ isHole: false, gapMs: null })
+      const { overlap } = press(t, '0,1', 5000, 0, 1, 0, 5, true, new Set(['0,1']), frame2)
+      expect(overlap).toBeUndefined()
+    })
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.test.ts
@@ -30,11 +30,24 @@ function pressKeys(keys: string[]): Set<string> {
  *  real caller (useInputModes) layers on top, so prepare here always
  *  authorizes (opaque token `true`) and emit forwards the bare payload —
  *  reproducing the single-argument `sink(payload)` shape these tests were
- *  written against. */
-function analyticsOptions(sink: (payload: TypingAnalyticsEventPayload) => void) {
+ *  written against.
+ *
+ *  `kind: 'matrix-release'` events are filtered out by default: every
+ *  pre-existing test in this file was written against a world where a
+ *  release edge never produced its own event, and pinning that behavior
+ *  means those assertions (call counts especially) must keep seeing
+ *  exactly what they saw before. Tests that specifically cover the new
+ *  duration/release emit opt in via `includeReleases: true`. */
+function analyticsOptions(
+  sink: (payload: TypingAnalyticsEventPayload) => void,
+  options?: { includeReleases?: boolean },
+) {
   return {
     onPrepareAnalyticsEvent: () => true,
-    onEmitAnalyticsEvent: (_prepared: unknown, event: TypingAnalyticsEventPayload) => sink(event),
+    onEmitAnalyticsEvent: (_prepared: unknown, event: TypingAnalyticsEventPayload) => {
+      if (event.kind === 'matrix-release' && !options?.includeReleases) return
+      sink(event)
+    },
   }
 }
 
@@ -1446,6 +1459,88 @@ describe('useTypingTest windowFocused', () => {
         const kcA = calls.find((c) => c.row === 1 && c.col === 1)
         expect(mo1?.layer).toBe(0)
         expect(kcA?.layer).toBe(1)
+      })
+    })
+
+    // Tracker-level semantics (overlap true/false/undefined, chords, holes,
+    // pollGapMs first-edge-only, pre-hole discard) are covered exhaustively
+    // in matrix-press-duration.test.ts. These hook-level tests stick to
+    // wiring: that the hook actually calls into the tracker and forwards
+    // its output onto the right events, not re-deriving the tracker's own
+    // branch logic.
+    describe('press duration + overlap + observation holes (hook wiring)', () => {
+      it('emits a matrix-release event on release, with the release ts and elapsed duration', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'KC_A']] }])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink, { includeReleases: true })))
+
+        const pressAt = new Date('2026-04-18T10:00:00.000Z')
+        vi.setSystemTime(pressAt)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+        vi.setSystemTime(new Date(pressAt.getTime() + 120))
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+
+        expect(sink).toHaveBeenCalledTimes(2)
+        expect(sink).toHaveBeenNthCalledWith(1, expect.objectContaining({ kind: 'matrix', row: 0, col: 0 }))
+        expect(sink).toHaveBeenNthCalledWith(2, expect.objectContaining({
+          kind: 'matrix-release', row: 0, col: 0, layer: 0, durationMs: 120,
+        }))
+      })
+
+      it('does not emit a release for a masked key (duration tracking is independent of the tap/hold queue)', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'LT1(KC_SPACE)']] }])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, { ...analyticsOptions(sink, { includeReleases: true }), tappingTermMs: 200 }))
+
+        const pressAt = new Date('2026-04-18T10:00:00.000Z')
+        vi.setSystemTime(pressAt)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+        vi.setSystemTime(new Date(pressAt.getTime() + 80))
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+
+        // The tap classification AND the release-duration event both land.
+        expect(sink).toHaveBeenCalledTimes(2)
+        expect(sink).toHaveBeenCalledWith(expect.objectContaining({ kind: 'matrix', action: 'tap' }))
+        expect(sink).toHaveBeenCalledWith(expect.objectContaining({ kind: 'matrix-release', durationMs: 80 }))
+      })
+
+      it('resetMatrixPressTracking discards an unresolved press instead of synthesizing a release', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'KC_A']] }])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink, { includeReleases: true })))
+
+        vi.setSystemTime(new Date('2026-04-18T10:00:00.000Z'))
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+        expect(sink).toHaveBeenCalledTimes(1)
+
+        act(() => { void result.current.resetMatrixPressTracking() })
+        vi.advanceTimersByTime(500)
+
+        // No release ever ships for the discarded press, even once the
+        // physical release eventually arrives — the tracker forgot it.
+        act(() => result.current.processMatrixFrame(new Set(), keymap))
+        expect(sink).toHaveBeenCalledTimes(1)
+      })
+
+      it('forwards overlap and pollGapMs from the tracker onto the emitted matrix event', () => {
+        const sink = vi.fn()
+        const keymap = buildMultiLayerKeymap([
+          { layer: 0, entries: [[0, 0, 'KC_A'], [0, 1, 'KC_B']] },
+        ])
+        const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
+
+        const start = new Date('2026-04-18T10:00:00.000Z')
+        vi.setSystemTime(start)
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+        vi.setSystemTime(new Date(start.getTime() + 20))
+        act(() => result.current.processMatrixFrame(pressKeys(['0,0', '0,1']), keymap))
+
+        expect(sink).toHaveBeenCalledTimes(2)
+        const second = sink.mock.calls[1][0] as { overlap?: boolean; pollGapMs?: number }
+        expect(second.overlap).toBe(true)
+        expect(second.pollGapMs).toBe(20)
       })
     })
   })

--- a/src/renderer/typing-test/matrix-analytics-queue.ts
+++ b/src/renderer/typing-test/matrix-analytics-queue.ts
@@ -91,6 +91,8 @@ function settleTapHold<TPreparedEvent>(
     keycode: pending.start.keycode,
     ts: pending.start.tsMs,
     action,
+    overlap: pending.start.overlap,
+    pollGapMs: pending.start.pollGapMs,
   }
   item.pending = undefined
 }

--- a/src/renderer/typing-test/matrix-layers.ts
+++ b/src/renderer/typing-test/matrix-layers.ts
@@ -17,6 +17,13 @@ export interface PressStartRecord {
   col: number
   layer: number
   keycode: number
+  /** Overlap / pollGapMs determined at press time (see
+   * matrix-press-duration.ts) — carried through to whatever event this
+   * press eventually resolves into (tap or hold), so a masked key's
+   * deferred classification doesn't lose the fields a non-masked press
+   * gets immediately. */
+  overlap?: boolean
+  pollGapMs?: number
 }
 
 /** Parse a "row,col" matrix key string into numeric row and col. */

--- a/src/renderer/typing-test/matrix-press-duration.ts
+++ b/src/renderer/typing-test/matrix-press-duration.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Per-key press-duration + physical-overlap tracking for matrix analytics.
+ *  Split out of useTypingTest.ts (see .claude/rules/file-splitting.md) —
+ *  this owns state the queue-based tap/hold classifier
+ *  (matrix-analytics-queue.ts) doesn't need: how long every physical
+ *  press (masked or not) stays down, and whether consecutive presses
+ *  physically overlapped. Both are read straight off the `pressed` set
+ *  processMatrixFrame already computes each frame — no new HID protocol,
+ *  just carrying data through that used to be discarded on release.
+ *
+ *  ## Overlap
+ *  Binary only: whether the immediately preceding press-edge key was
+ *  still in the current frame's `pressed` set when the new key's press
+ *  edge was observed. This says nothing about *how much* the two presses
+ *  overlapped in time — sub-poll-interval timing isn't available from the
+ *  HID layer, so no attempt is made to estimate it (see
+ *  Plan-typing-metrics-chi2018.md "制約 2").
+ *
+ *  ## Observation holes
+ *  The renderer polls on a ~20ms cadence, but a HID read can block behind
+ *  other queued requests on the shared mutex (`hid-service.ts`) or simply
+ *  time out, opening a gap of unknown length with zero visibility into
+ *  what happened during it. A key could have been released and
+ *  re-pressed inside that gap without either edge ever reaching this
+ *  tracker. Treating the frame right after such a gap as an ordinary
+ *  frame would let a stale "previous press" pollute the next overlap
+ *  determination, and would let a press that started before the gap
+ *  report a duration that silently includes unobserved time. Both are
+ *  refused instead: see {@link PressDurationTracker.onFrame} and
+ *  {@link PressDurationTracker.resolveRelease}. */
+
+import type { TypingAnalyticsEventPayload } from '../../shared/types/typing-analytics'
+import { OBSERVATION_HOLE_MS } from '../../shared/typing-analytics-timing'
+import type { PressStartRecord } from './matrix-layers'
+
+// Re-exported so existing imports (this module used to define the
+// constant itself) keep working — main's validator imports the same
+// constant directly from shared/typing-analytics-timing.ts.
+export { OBSERVATION_HOLE_MS }
+
+interface PressRecord<TPreparedEvent> {
+  tsMs: number
+  row: number
+  col: number
+  layer: number
+  keycode: number
+  prepared: TPreparedEvent
+}
+
+/** Input to {@link PressDurationTracker.registerPress}, bundled into one
+ * object rather than positional params: `start`'s row/col/layer/keycode
+ * are all bare numbers, and passing them positionally alongside `key`
+ * and `ts` invites a silent transposition (e.g. col and layer swapped)
+ * that nothing would catch until the data looked wrong in Analyze.
+ * `start` mirrors {@link PressStartRecord} from matrix-layers.ts (the
+ * equivalent record the tap-hold queue keeps) rather than inventing a
+ * parallel shape. */
+export interface RegisterPressInput<TPreparedEvent> {
+  key: string
+  start: PressStartRecord
+  prepared: TPreparedEvent
+  pressed: ReadonlySet<string>
+  frame: FrameObservation
+}
+
+/** Result of {@link PressDurationTracker.onFrame} — read once at the top
+ * of processMatrixFrame and passed to every {@link PressDurationTracker.registerPress}
+ * call for that same frame. */
+export interface FrameObservation {
+  /** True when this frame's ts followed a gap larger than
+   * OBSERVATION_HOLE_MS since the previous frame, OR the gap was
+   * negative (the clock stepped backwards — e.g. an NTP correction or a
+   * suspend/resume with a skewed monotonic source). A backwards step is
+   * just as much an observation discontinuity as a forward one: it means
+   * `ts` ordering between this frame and the last one can't be trusted,
+   * so there is equally no way to vouch for what happened in between.
+   * Every press edge processed in this frame must treat overlap as
+   * unknown and must not receive a pollGapMs sample. */
+  isHole: boolean
+  /** ts - previous frame's ts. Only meaningful (and only ever consumed
+   * by {@link PressDurationTracker.registerPress}) when `!isHole`; null
+   * on a hole frame (a hole is a break in sampling, not a sample of the
+   * sampling period — see onFrame), when there is no previous frame yet,
+   * or once a press edge this same frame has already claimed it —
+   * registerPress nulls it out after reading it so a chord's later keys
+   * don't also report the same sample (see registerPress). */
+  gapMs: number | null
+}
+
+/** What to emit for a resolved release, or null when nothing should be
+ * emitted — either the key was never tracked (its press was rejected by
+ * onPrepareAnalyticsEvent, so it never entered the map) or its press
+ * predates the last observed hole and the resulting duration would
+ * include unobserved time (see the class doc comment). */
+export interface ResolvedRelease<TPreparedEvent> {
+  prepared: TPreparedEvent
+  event: TypingAnalyticsEventPayload & { kind: 'matrix-release' }
+}
+
+export class PressDurationTracker<TPreparedEvent> {
+  private readonly presses = new Map<string, PressRecord<TPreparedEvent>>()
+  private prevFrameTs: number | null = null
+  private lastHoleTs: number | null = null
+  /** The most recent press-edge key, or null when there is none to
+   * reference — either nothing has been pressed yet, or a hole was just
+   * observed (see {@link onFrame}: a hole clears this immediately, which
+   * is equivalent to invalidating it as an overlap reference without
+   * needing to separately track and compare its own timestamp against
+   * `lastHoleTs`). */
+  private lastPressKey: string | null = null
+
+  /** Call once per processMatrixFrame invocation, before handling any
+   * press edges in that frame, with the frame's own timestamp. Updates
+   * the rolling previous-frame ts and records a new hole boundary when
+   * the gap since the last frame is too large OR negative (see
+   * {@link FrameObservation.isHole}). */
+  onFrame(ts: number): FrameObservation {
+    const prev = this.prevFrameTs
+    this.prevFrameTs = ts
+    if (prev === null) return { isHole: false, gapMs: null }
+    const gapMs = ts - prev
+    if (gapMs > OBSERVATION_HOLE_MS || gapMs < 0) {
+      this.lastHoleTs = ts
+      // The previous reference press may have been released and
+      // re-pressed inside the gap we just observed — its "still held"
+      // status can no longer be trusted, so drop it as a reference
+      // rather than let a later press compare against it.
+      this.lastPressKey = null
+      // A hole is a break in sampling, not a sample of the sampling
+      // period — the raw (possibly negative or absurdly large) gap must
+      // never reach pollGapMs, so it's nulled here rather than left for
+      // registerPress's `!frame.isHole` guard to filter out.
+      return { isHole: true, gapMs: null }
+    }
+    return { isHole: false, gapMs }
+  }
+
+  /** Register a NEW press edge (must be called once per press edge, in
+   * press order within the frame — it both reads and advances the
+   * "most recent press" pointer, so a chord's second and third keys see
+   * the first, still-held key as their overlap reference). Records the
+   * press for later {@link resolveRelease} and returns the overlap /
+   * pollGapMs values to attach to the outgoing `matrix` event. */
+  registerPress(input: RegisterPressInput<TPreparedEvent>): { overlap: boolean | undefined; pollGapMs: number | undefined } {
+    const { key, start, prepared, pressed, frame } = input
+    const overlap = this.overlapFor(key, pressed, frame)
+    let pollGapMs: number | undefined
+    if (!frame.isHole && frame.gapMs !== null) {
+      pollGapMs = frame.gapMs
+      // Claim it on the frame itself so a later press this same frame
+      // (a chord) doesn't also report it.
+      frame.gapMs = null
+    }
+    this.presses.set(key, { tsMs: start.tsMs, row: start.row, col: start.col, layer: start.layer, keycode: start.keycode, prepared })
+    return { overlap, pollGapMs }
+  }
+
+  private overlapFor(key: string, pressed: ReadonlySet<string>, frame: FrameObservation): boolean | undefined {
+    const overlap = frame.isHole || this.lastPressKey === null ? undefined : pressed.has(this.lastPressKey)
+    this.lastPressKey = key
+    return overlap
+  }
+
+  /** Resolve a release edge against its press record. Returns the event
+   * to emit, or null when nothing should ship (untracked key, or a
+   * duration that would span an observation hole — see the class doc
+   * comment). Always removes the press record either way. */
+  resolveRelease(key: string, ts: number): ResolvedRelease<TPreparedEvent> | null {
+    const press = this.presses.get(key)
+    this.presses.delete(key)
+    if (!press) return null
+    if (this.lastHoleTs !== null && press.tsMs < this.lastHoleTs) {
+      // A hole opened sometime between this press and now — the key may
+      // have been released and re-pressed inside it, so the observed
+      // duration would silently include time nobody actually watched.
+      return null
+    }
+    const durationMs = ts - press.tsMs
+    // A zero (or negative) measurement is a sub-clock-resolution
+    // artifact, not a real instantaneous tap — a genuine press shorter
+    // than the poll period never produces a press AND a release edge in
+    // the first place (both would land in the same polled frame with no
+    // edge to detect at all). Discarding rather than reporting 0 is
+    // deliberate, not a rounding nicety: main's own validator agrees
+    // (`durationMs > 0` — see isValidEvent in typing-analytics-service.ts).
+    if (durationMs <= 0) return null
+    return {
+      prepared: press.prepared,
+      event: {
+        kind: 'matrix-release',
+        row: press.row,
+        col: press.col,
+        layer: press.layer,
+        keycode: press.keycode,
+        ts,
+        durationMs,
+      },
+    }
+  }
+
+  /** Clear all tracked presses and rolling frame/hole state. Call on
+   * record toggle, device change, keymap reload, and unmount — an
+   * unresolved press is discarded, never synthesized into a release. */
+  reset(): void {
+    this.presses.clear()
+    this.prevFrameTs = null
+    this.lastHoleTs = null
+    this.lastPressKey = null
+  }
+}

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -27,6 +27,7 @@ import {
   resolveEffectiveCodeWithLayer,
 } from './matrix-layers'
 import { MatrixAnalyticsQueue } from './matrix-analytics-queue'
+import { PressDurationTracker } from './matrix-press-duration'
 
 export type { WordResult, TypingTestState, TypingTestStatus } from './run-state'
 
@@ -130,6 +131,16 @@ export function useTypingTest<TPreparedEvent = unknown>(
   // matrix-analytics-queue.ts for why this exists instead of emitting
   // non-masked keys unconditionally on press.
   const matrixQueueRef = useRef(new MatrixAnalyticsQueue<TPreparedEvent>())
+  // Per-key press-duration + overlap tracking, independent of the queue
+  // above — it covers every press (masked or not) and ships its own
+  // 'matrix-release' event straight through `emit`, bypassing the queue
+  // entirely. Safe to bypass: a release event only touches the per-cell
+  // duration accumulator in main (no keystrokes/intervals/activeMs/n-gram),
+  // so it can never corrupt the ordering the queue exists to protect, and
+  // a release arriving late relative to a still-queued masked press is
+  // absorbed by the main-process MinuteBuffer's retention window instead
+  // of needing to arrive in order. See matrix-press-duration.ts.
+  const matrixDurationRef = useRef(new PressDurationTracker<TPreparedEvent>())
   const tappingTermMsRef = useRef(options?.tappingTermMs ?? DEFAULT_TAPPING_TERM_MS)
   const seqRef = useRef(0)
   const langLoadSeqRef = useRef(0)
@@ -371,6 +382,8 @@ export function useTypingTest<TPreparedEvent = unknown>(
       const preExistingSortedLayers = [...preExistingLayerSet].sort((a, b) => b - a)
       const ts = Date.now()
       const tappingTermMs = tappingTermMsRef.current
+      const duration = matrixDurationRef.current
+      const frame = duration.onFrame(ts)
 
       for (const key of pressed) {
         if (prev.has(key)) continue
@@ -386,14 +399,26 @@ export function useTypingTest<TPreparedEvent = unknown>(
         // (e.g. recording toggling back on) while it would have waited.
         const prepared = prepare('matrix')
         if (prepared == null) continue
+        // Overlap / pollGapMs are derived from the raw pressed set, not
+        // from anything queue-related — see matrix-press-duration.ts.
+        // registerPress also records this press so the matching release
+        // edge (below, in a later frame) can compute its duration and
+        // ship the same `prepared` context this press already captured.
+        const { overlap, pollGapMs } = duration.registerPress({
+          key,
+          start: { tsMs: ts, row, col, layer: eventLayer, keycode: code },
+          prepared,
+          pressed,
+          frame,
+        })
         // Only LT / MT style tap-hold keys need the deferred classify
         // pass. LSFT(kc) etc. are "masked" too but always fire the
         // modifier + base together, so the heatmap treats them as
         // regular presses.
         if (isTapKeycode(code)) {
-          queue.pushPending(prepared, { tsMs: ts, row, col, layer: eventLayer, keycode: code }, key, tappingTermMs, emit)
+          queue.pushPending(prepared, { tsMs: ts, row, col, layer: eventLayer, keycode: code, overlap, pollGapMs }, key, tappingTermMs, emit)
         } else {
-          const event: TypingAnalyticsEventPayload = { kind: 'matrix', row, col, layer: eventLayer, keycode: code, ts }
+          const event: TypingAnalyticsEventPayload = { kind: 'matrix', row, col, layer: eventLayer, keycode: code, ts, overlap, pollGapMs }
           // An empty queue means nothing ahead is still unresolved, so
           // this press can go straight out instead of paying for a
           // round trip through the queue.
@@ -408,6 +433,8 @@ export function useTypingTest<TPreparedEvent = unknown>(
       for (const key of prev) {
         if (pressed.has(key)) continue
         queue.resolveReleaseByKey(key, ts, emit)
+        const resolved = duration.resolveRelease(key, ts)
+        if (resolved) emit?.(resolved.prepared, resolved.event)
       }
     }
     prevPressedRef.current = new Set(pressed)
@@ -443,6 +470,12 @@ export function useTypingTest<TPreparedEvent = unknown>(
   const resetMatrixPressTracking = useCallback((): Promise<void> => {
     const drained = matrixQueueRef.current.drainAll(emitAnalyticsEventRef.current)
     prevPressedRef.current = new Set()
+    // Discard rather than finalize — an in-flight press with no release
+    // yet must not be synthesized into a fabricated release event (see
+    // matrix-press-duration.ts). Unlike the queue's forced hold
+    // classification, there is nothing to salvage here: a duration
+    // sample without an observed release is just noise.
+    matrixDurationRef.current.reset()
     return drained
   }, [])
 
@@ -453,6 +486,7 @@ export function useTypingTest<TPreparedEvent = unknown>(
   useEffect(() => {
     return () => {
       matrixQueueRef.current.dispose()
+      matrixDurationRef.current.reset()
     }
   }, [])
 

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -104,6 +104,43 @@ export type TypingAnalyticsEventPayload =
        * and masked presses not yet classified leave this undefined; the
        * count still lands in the `count` total column. */
       action?: TypingMatrixAction
+      /** Whether the immediately preceding press-edge key (across any
+       * frame) was still physically held down when THIS press was
+       * observed — a same-frame set-membership check, not a measurement
+       * of how much the two presses overlapped in time (sub-poll-interval
+       * timing isn't available from the HID layer). `undefined` when
+       * there is no prior press to compare against, when that prior
+       * press predates an observation hole, or when this frame itself
+       * follows a hole — see `PressDurationTracker` in
+       * matrix-press-duration.ts for the full derivation. */
+      overlap?: boolean
+      /** Effective gap (ms) since the previous polled frame, attached
+       * only to the first press edge of a frame (attaching it to every
+       * simultaneous key in a chord would over-weight that one sample in
+       * any per-minute percentile). Absent when there is no previous
+       * frame yet, or when the gap exceeds the observation-hole
+       * threshold (a hole is a break in sampling, not a sample of the
+       * sampling period itself). */
+      pollGapMs?: number
+    })
+  | (TypingAnalyticsEventCommon & {
+      kind: 'matrix-release'
+      row: number
+      col: number
+      layer: number
+      keycode: number
+      /** Release timestamp. Minute attribution follows this ts, NOT the
+       * matching press's ts — a press in second 59 and its release in
+       * second 00 of the next minute land the press count and the
+       * duration sample in different per-minute buckets. Consumers must
+       * not assume the duration sample count equals the press count for
+       * any given minute. */
+      ts: number
+      /** ts - (the matching press's ts), in ms. Always > 0; a press
+       * whose duration would span an observation hole is never emitted
+       * (see matrix-press-duration.ts) rather than reported with a
+       * fabricated value. */
+      durationMs: number
     })
 
 /** Normalized analytics event carried over the IPC to the main process. */
@@ -379,10 +416,35 @@ export interface TypingBigramSlowEntry extends TypingBigramTopEntry {
  * count-ranked before any avgIki re-ranking) may be missing low-
  * frequency-but-slow pairs. Computed server-side from the full pair
  * universe rather than guessed from `entries.length` on the renderer,
- * so a period with exactly `limit` distinct pairs isn't misreported. */
+ * so a period with exactly `limit` distinct pairs isn't misreported.
+ *
+ * `observedRolloverRatio` is Σoverlap / Σcount across every pair in the
+ * selection — see aggregatePairTotals / observedRolloverRatio in
+ * bigram-aggregate.ts. A row with no overlap data (older than schema
+ * v8, or a trigram row where the columns don't exist) simply
+ * contributes 0 to both sums rather than poisoning the whole pair —
+ * unlike the sum/sumSq columns used for standard deviation, a row's
+ * own overlap counts are always self-consistent on their own, so a
+ * missing row can't hide a real partial count. Null when the resulting
+ * denominator is 0 (no pair in the selection ever had a determined
+ * overlap — e.g. the `slow`/`top` view was requested with `gram: 3`, or
+ * every contributing row predates schema v8). The `observed` prefix is
+ * deliberate and must be kept on every surface this value reaches (type
+ * name, IPC field, any future CSV/UI column): it is a SAMPLED
+ * approximation bounded by the renderer's polling cadence, not a
+ * measurement of true rollover timing — see the Typing Metrics plan's
+ * constraint on why the exact overlap duration can never be recovered
+ * from HID polling alone. It also carries a small amount of pair
+ * misattribution noise from same-frame ties (two presses landing in one
+ * polled frame): the tied key's overlap can end up counted against the
+ * NEXT pair the chain completes rather than the pair it was actually
+ * measured against, concentrated in fast chords — see
+ * MinuteBuffer.recordNgramChain and observedRolloverRatio's own doc
+ * comment for why a full fix was rejected as disproportionate to an
+ * avowedly approximate metric. */
 export type TypingBigramAggregateResult =
-  | { view: 'top'; entries: TypingBigramTopEntry[]; truncated: boolean }
-  | { view: 'slow'; entries: TypingBigramSlowEntry[]; truncated: boolean }
+  | { view: 'top'; entries: TypingBigramTopEntry[]; truncated: boolean; observedRolloverRatio?: number | null }
+  | { view: 'slow'; entries: TypingBigramSlowEntry[]; truncated: boolean; observedRolloverRatio?: number | null }
 
 /** Phase 1 metrics for the Layout Comparison. Bigram-derived ones
  * (travel distance / SFB) are added in Phase 2. */

--- a/src/shared/typing-analytics-timing.ts
+++ b/src/shared/typing-analytics-timing.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Timing constant shared between the renderer's per-frame observation-hole
+// detection (src/renderer/typing-test/matrix-press-duration.ts) and main's
+// ingest-time validation of the pollGapMs field that detection produces
+// (src/main/typing-analytics/typing-analytics-service.ts). Kept in one
+// place so the validator's upper bound and the renderer's hole threshold
+// can never drift apart: by construction, any pollGapMs the renderer ever
+// legitimately emits is already <= this value.
+
+/** Longest gap between two polled matrix frames that still counts as
+ * continuous observation. 10x the renderer's ~20ms poll cadence (see
+ * POLL_INTERVAL in src/renderer/components/editors/matrix-utils.ts) — an
+ * ordinary sampling-period gap should never come close to this; anything
+ * larger (or negative — a clock step backwards is just as much a break in
+ * observation) means the HID read timed out, blocked behind another
+ * queued request on the shared mutex (hid-service.ts), or the clock
+ * jumped, and any overlap/duration inference spanning it would be
+ * fabricating data the poller never actually saw. */
+export const OBSERVATION_HOLE_MS = 200


### PR DESCRIPTION
## Summary

Adds the capture layer for keypress duration and physical key overlap to typing analytics (schema v7→v8). The release edge was previously discarded after tap/hold classification; this records it. Analyze UI consumption lands in follow-up tasks.

- **Durations**: a new `matrix-release` event carries press→release duration, attributed to the release minute, folding only into per-cell duration accumulators (8-bucket histogram + sum/sumSq on a grid sized for typical ~80–150 ms durations) — never into keystroke/interval/n-gram statistics, so arrival order and lateness are harmless
- **Overlap**: matrix press events carry a same-frame physical-overlap flag; bigrams accumulate an `oc/on` pair and the aggregate exposes `observedRolloverRatio` (Σoc/Σon, undefined judgments excluded from the denominator; rows without overlap data are skipped, not poisoned, so pre-v8 history can't null the ratio)
- **Effective sampling period**: the first press of each polled frame records the frame gap; minute stats persist per-minute p50/p95 (`poll_p50_ms`/`poll_p95_ms`)
- **Observation holes** (HID read timeouts, backwards clock steps) discard any inference spanning the gap: overlap judgments, gap samples, and durations whose press predates the hole
- **Schema v8**: nullable columns, no DEFAULT (null = not recorded); v6/v7 migrate via ALTER (older versions already rebuild from full DDL); no cache rebuild
- The event validator sanitizes invalid auxiliary fields instead of rejecting the keystroke, sharing the observation-hole bound with the renderer via `src/shared/typing-analytics-timing.ts`

## Real-device verification

60-second typing test on real hardware: v7→v8 migration succeeded on a live DB; measured poll p50 = 23–24 ms, p95 = 25–40 ms; durations averaged ~119.5 ms (94/96 cells recorded); overlap recorded on all 275 pairs with observedRolloverRatio = 0.255.

## Test plan

- [x] `pnpm run lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 320 files, 7412 passed / 22 skipped (new coverage: duration folding incl. minute-boundary straddle, overlap incl. same-frame ties and 3-key chords, observation-hole discards incl. backwards clock, v7→v8 and v6→v8 migrations, old-JSONL backward compat, new-field round-trips, validator sanitization, session-detector exclusion, phantom-minute suppression)
