### PR TITLE
fix(ui): latch layer-switch keys at press time in the typing view

### DIFF
--- a/src/renderer/typing-test/__tests__/useTypingTest.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.test.ts
@@ -564,6 +564,196 @@ describe('useTypingTest layer tracking with MO/LT', () => {
   })
 })
 
+// Issue #333: a layer-switch key's action must be latched against the
+// layer state active at its OWN press time, then never re-resolved while
+// it stays held — even if the layer it activates redefines its own cell.
+// The old fixed-point activateLayers() violated this by re-resolving
+// already-held keys against layers they themselves had just activated.
+describe('useTypingTest layer tracking — press-time latch (issue #333)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+  })
+
+  it('resolves a lone MO(2) press from the layer active at press time, not the layer it activates', () => {
+    const { result } = renderHook(() => useTypingTest())
+
+    // (3,0) is MO(2) on layer 0, but the SAME cell is MO(5) on layer 2 —
+    // the exact keymap shape reported in issue #333.
+    const keymap = buildMultiLayerKeymap([
+      { layer: 0, entries: [[3, 0, 'MO(2)']] },
+      { layer: 2, entries: [[3, 0, 'MO(5)']] },
+    ])
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0']), keymap))
+
+    expect(result.current.effectiveLayer).toBe(2)
+  })
+
+  it('activates the nested layer once a different key latched on layer 2 is pressed while MO(2) is held', () => {
+    const { result } = renderHook(() => useTypingTest())
+
+    const keymap = buildMultiLayerKeymap([
+      { layer: 0, entries: [[3, 0, 'MO(2)']] },
+      { layer: 2, entries: [[0, 1, 'MO(5)']] },
+    ])
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0']), keymap))
+    expect(result.current.effectiveLayer).toBe(2)
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0', '0,1']), keymap))
+    expect(result.current.effectiveLayer).toBe(5)
+  })
+
+  it('attributes a press made while MO(2) is held to layer 2, not layer 5, even though MO(2)\'s own cell targets layer 5', () => {
+    const sink = vi.fn()
+    const keymap = buildMultiLayerKeymap([
+      { layer: 0, entries: [[3, 0, 'MO(2)']] },
+      { layer: 2, entries: [[3, 0, 'MO(5)'], [0, 1, 'KC_C']] },
+      { layer: 5, entries: [[0, 1, 'KC_F']] },
+    ])
+    const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0']), keymap))
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0', '0,1']), keymap))
+
+    const calls = sink.mock.calls.map((c) => c[0]) as Array<{ row: number; col: number; layer: number }>
+    const second = calls.find((c) => c.row === 0 && c.col === 1)
+    expect(second?.layer).toBe(2)
+  })
+
+  it('resolves a same-frame chord where the lower-row press activates the layer the higher-row press needs', () => {
+    const { result } = renderHook(() => useTypingTest())
+
+    const keymap = buildMultiLayerKeymap([
+      { layer: 0, entries: [[0, 0, 'MO(2)'], [1, 0, 'KC_B']] },
+      { layer: 2, entries: [[1, 0, 'MO(5)']] },
+    ])
+
+    // Both keys are new presses in a single frame — row-major order means
+    // (0,0) is processed before (1,0), so (1,0) resolves against layer 2.
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0', '1,0']), keymap))
+
+    expect(result.current.effectiveLayer).toBe(5)
+  })
+
+  describe('same-frame release + press rollover (row-major order)', () => {
+    it('a lower-row release is processed before a higher-row press, clearing the latch first', () => {
+      const sink = vi.fn()
+      const keymap = buildMultiLayerKeymap([
+        { layer: 0, entries: [[0, 0, 'MO(2)'], [5, 0, 'KC_BASE']] },
+        { layer: 2, entries: [[5, 0, 'KC_OVERRIDE']] },
+      ])
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
+
+      act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+      expect(result.current.effectiveLayer).toBe(2)
+      sink.mockClear()
+
+      // Same frame: MO(2) at row 0 releases while a new key at row 5
+      // presses. Row-major order processes the row-0 release first, so
+      // the press resolves with the latch already gone.
+      act(() => result.current.processMatrixFrame(pressKeys(['5,0']), keymap))
+
+      expect(result.current.effectiveLayer).toBe(0)
+      expect(sink).toHaveBeenCalledWith(expect.objectContaining({ row: 5, col: 0, layer: 0 }))
+    })
+
+    it('a higher-row release is processed after a lower-row press, still resolving against the latch', () => {
+      const sink = vi.fn()
+      const keymap = buildMultiLayerKeymap([
+        { layer: 0, entries: [[5, 0, 'MO(2)'], [0, 0, 'KC_BASE']] },
+        { layer: 2, entries: [[0, 0, 'KC_OVERRIDE']] },
+      ])
+      const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
+
+      act(() => result.current.processMatrixFrame(pressKeys(['5,0']), keymap))
+      expect(result.current.effectiveLayer).toBe(2)
+      sink.mockClear()
+
+      // Same frame: a new key at row 0 presses while MO(2) at row 5
+      // releases. Row-major order processes the row-0 press first, so it
+      // still resolves against layer 2 before the release clears it.
+      act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+      expect(sink).toHaveBeenCalledWith(expect.objectContaining({ row: 0, col: 0, layer: 2 }))
+      expect(result.current.effectiveLayer).toBe(0)
+    })
+  })
+
+  it('keeps the nested layer active after releasing the outer MO key that activated it', () => {
+    const { result } = renderHook(() => useTypingTest())
+
+    const keymap = buildMultiLayerKeymap([
+      { layer: 0, entries: [[3, 0, 'MO(2)']] },
+      { layer: 2, entries: [[0, 1, 'MO(5)']] },
+    ])
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0']), keymap))
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0', '0,1']), keymap))
+    expect(result.current.effectiveLayer).toBe(5)
+
+    // Release MO(2) (the outer key) while the nested MO(5) stays held —
+    // MO(5) was latched directly at its own press time and doesn't
+    // depend on MO(2) staying active, matching QMK's layer_on semantics.
+    act(() => result.current.processMatrixFrame(pressKeys(['0,1']), keymap))
+
+    expect(result.current.effectiveLayer).toBe(5)
+  })
+
+  it('shows the latched target above a new base layer, using the raw target captured at press time (not maxed against the old base)', async () => {
+    const { result } = renderHook(() => useTypingTest())
+
+    await act(async () => result.current.setBaseLayer(3))
+    expect(result.current.effectiveLayer).toBe(3)
+
+    // MO(1) is defined on layer 3 (the current base) and targets layer 1
+    // — below the current base, so the indicator correctly stays at 3.
+    // If the latch stored Math.max(oldBase=3, target=1) = 3 instead of
+    // the raw target 1, the next assertion (after dropping the base to
+    // 0) would incorrectly still show 3 instead of 1.
+    const keymap = buildMultiLayerKeymap([{ layer: 3, entries: [[0, 0, 'MO(1)']] }])
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+    expect(result.current.effectiveLayer).toBe(3)
+
+    // Base drops below the latched target while MO(1) is still held —
+    // the indicator must now show the raw target (1), derived fresh from
+    // { newBase(0) } ∪ { latched target(1) }.
+    await act(async () => result.current.setBaseLayer(0))
+    expect(result.current.effectiveLayer).toBe(1)
+  })
+
+  it('attributes a press to a layer below the current base, when the key is only defined there', async () => {
+    const sink = vi.fn()
+    // (3,0) is MO(1) on the base layer (3). (0,1) has no cell at all on
+    // layer 3 — only on layer 1, the layer MO(1) latches — so
+    // resolveEffectiveCodeWithLayer's walk over sortedLayers ([3, 1])
+    // must fall through past the (undefined) base-layer cell to find it
+    // on the latched target below the base, not just above it.
+    const keymap = buildMultiLayerKeymap([
+      { layer: 3, entries: [[3, 0, 'MO(1)']] },
+      { layer: 1, entries: [[0, 1, 'KC_A']] },
+    ])
+    const { result } = renderHook(() => useTypingTest(undefined, undefined, analyticsOptions(sink)))
+
+    await act(async () => result.current.setBaseLayer(3))
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0']), keymap))
+    // The latched target (1) is below the base (3), so the indicator
+    // correctly stays at the base rather than dropping to it.
+    expect(result.current.effectiveLayer).toBe(3)
+
+    act(() => result.current.processMatrixFrame(pressKeys(['3,0', '0,1']), keymap))
+
+    expect(sink).toHaveBeenCalledWith(expect.objectContaining({
+      row: 0,
+      col: 1,
+      layer: 1,
+      keycode: deserialize('KC_A'),
+    }))
+  })
+})
+
 describe('useTypingTest effectiveLayer', () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/src/renderer/typing-test/matrix-layer-latch.ts
+++ b/src/renderer/typing-test/matrix-layer-latch.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Press-time layer-switch latch: which matrix keys are currently
+ *  holding the typing test's layer indicator above the base layer, and
+ *  what target layer each one latched onto at the moment it was
+ *  resolved.
+ *
+ *  Mirrors the ownership pattern of the other per-frame trackers in this
+ *  directory (PressDurationTracker in matrix-press-duration.ts,
+ *  MatrixAnalyticsQueue in matrix-analytics-queue.ts): one instance per
+ *  recording session, held in a ref by useTypingTest, with the same
+ *  reset-on-toggle / reset-on-unmount lifecycle.
+ *
+ *  A key's target is captured once, by the press edge that resolves it
+ *  (see processMatrixFrame in useTypingTest.ts), and is never
+ *  re-resolved while the key stays held — matching QMK's own behavior
+ *  of caching a key's action at press time instead of re-evaluating a
+ *  held key against layers it (or another key) activates later. */
+export class MatrixLayerLatch {
+  private readonly targets = new Map<string, number | null>()
+
+  /** Record the raw target layer a press resolved to (null for a
+   * non-layer-switch key). Deliberately NOT Math.max'd against the base
+   * layer that was active at press time — see {@link displayLayer} for
+   * why the raw value is what keeps a base-layer change mid-hold
+   * correct. */
+  latch(key: string, target: number | null): void {
+    this.targets.set(key, target)
+  }
+
+  /** Drop a key's latch on its release edge. */
+  release(key: string): void {
+    this.targets.delete(key)
+  }
+
+  /** Clear every latch. Call on record toggle, device change, keymap
+   * reload, or unmount so a key still physically held afterward starts
+   * fresh — re-latched from its next press edge — rather than keeping a
+   * target left over from before the reset. */
+  clear(): void {
+    this.targets.clear()
+  }
+
+  /** The layer set to resolve a new press against, right now: the base
+   * layer plus every currently latched (non-null) target, highest
+   * first. Includes the base layer itself (not just as a trailing
+   * fallback) so a latched target below the base layer correctly loses
+   * to a base-layer override at the same position, matching QMK's
+   * highest-active-layer walk. */
+  activeLayers(baseLayer: number): number[] {
+    const layers = new Set<number>([baseLayer])
+    for (const target of this.targets.values()) {
+      if (target != null) layers.add(target)
+    }
+    return [...layers].sort((a, b) => b - a)
+  }
+
+  /** The layer the UI indicator should show: the highest of the base
+   * layer and every currently latched target. Each target is the raw
+   * value latched at its own press time, so this stays correct even
+   * after the base layer changes mid-hold (see setBaseLayer in
+   * useTypingTest.ts, which calls this for the same reason). Walks the
+   * map directly rather than going through {@link activeLayers} — this
+   * runs once per frame (and once per setBaseLayer call) and only needs
+   * the max, not the full sorted set a press resolution requires. */
+  displayLayer(baseLayer: number): number {
+    let highest = baseLayer
+    for (const target of this.targets.values()) {
+      if (target != null && target > highest) highest = target
+    }
+    return highest
+  }
+}

--- a/src/renderer/typing-test/matrix-layers.ts
+++ b/src/renderer/typing-test/matrix-layers.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /** Matrix key (row/col) resolution against active layers: parsing matrix
- *  key strings, extracting layer-switch targets, and resolving the
- *  effective keycode for a pressed matrix position. */
+ *  key strings, extracting layer-switch targets, resolving the effective
+ *  keycode for a pressed matrix position, and diffing two frames' pressed
+ *  sets into an ordered list of press/release edges. */
 
 import { extractMOLayer, extractLTLayer, extractLMLayer } from './keycode-char-map'
 
@@ -37,23 +38,6 @@ export function extractSwitchLayer(code: number): number | null {
   return extractMOLayer(code) ?? extractLTLayer(code) ?? extractLMLayer(code)
 }
 
-/** Resolve the effective keycode for a matrix position by checking active
- * layers in descending order, skipping KC_TRNS (0x01), then falling back
- * to the base layer. */
-export function resolveEffectiveCode(
-  row: number,
-  col: number,
-  keymap: Map<string, number>,
-  sortedLayers: number[],
-  baseLayer: number,
-): number | undefined {
-  for (const layer of sortedLayers) {
-    const code = keymap.get(`${layer},${row},${col}`)
-    if (code != null && code !== 0x01) return code
-  }
-  return keymap.get(`${baseLayer},${row},${col}`)
-}
-
 /** Resolve the effective keycode AND the layer the keycode was picked
  * from. Used by the analytics path so each event is attributed to the
  * layer where the key is actually defined, not the (possibly different)
@@ -74,4 +58,39 @@ export function resolveEffectiveCodeWithLayer(
   }
   const baseCode = keymap.get(`${baseLayer},${row},${col}`)
   return baseCode != null ? { code: baseCode, layer: baseLayer } : undefined
+}
+
+/** One press or release edge between two frames' pressed sets, in
+ * row-major walk order (see {@link matrixFrameEdges}). */
+export interface MatrixEdge {
+  key: string
+  row: number
+  col: number
+  isPress: boolean
+}
+
+/** Diff `prev` and `pressed` into the keys whose held-status changed —
+ * a key present in both is not an edge and is skipped. Edges are
+ * returned in row-major order (ascending row, then col) rather than Set
+ * iteration order, which has no ordering guarantee: a caller resolving
+ * each edge against state mutated by the edges before it (as
+ * processMatrixFrame does for its layer latch) needs that order to be
+ * deterministic, not incidental to Set internals. Built from two direct
+ * scans of `prev` and `pressed` rather than a unioned copy, so an idle
+ * frame (nothing changed) does no allocation beyond the empty result. */
+export function matrixFrameEdges(prev: ReadonlySet<string>, pressed: ReadonlySet<string>): MatrixEdge[] {
+  const edges: MatrixEdge[] = []
+  for (const key of prev) {
+    if (!pressed.has(key)) {
+      const [row, col] = parseMatrixKey(key)
+      edges.push({ key, row, col, isPress: false })
+    }
+  }
+  for (const key of pressed) {
+    if (!prev.has(key)) {
+      const [row, col] = parseMatrixKey(key)
+      edges.push({ key, row, col, isPress: true })
+    }
+  }
+  return edges.sort((a, b) => a.row - b.row || a.col - b.col)
 }

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -22,13 +22,13 @@ import {
 import { isRomajiInputActive, buildRomajiMatcher, romajiDetail, processRomajiKeyEvent } from './romaji-input'
 import { computeKspc } from '../../shared/kspc'
 import {
-  parseMatrixKey,
   extractSwitchLayer,
-  resolveEffectiveCode,
   resolveEffectiveCodeWithLayer,
+  matrixFrameEdges,
 } from './matrix-layers'
 import { MatrixAnalyticsQueue } from './matrix-analytics-queue'
 import { PressDurationTracker } from './matrix-press-duration'
+import { MatrixLayerLatch } from './matrix-layer-latch'
 
 export type { WordResult, TypingTestState, TypingTestStatus } from './run-state'
 
@@ -87,7 +87,7 @@ export interface UseTypingTestReturn {
   baseLayer: number
   effectiveLayer: number
   windowFocused: boolean
-  processMatrixFrame: (pressed: Set<string>, keymap: Map<string, number>) => void
+  processMatrixFrame: (pressed: ReadonlySet<string>, keymap: Map<string, number>) => void
   /** Returns a promise that resolves once every drained item's emit has
    * settled — see {@link MatrixAnalyticsQueue.drainAll}. A caller that
    * finalizes a session (record-off, test-finish) before requesting a
@@ -133,7 +133,8 @@ export function useTypingTest<TPreparedEvent = unknown>(
   const windowFocusedRef = useRef(windowFocused)
   const prepareAnalyticsEventRef = useRef(options?.onPrepareAnalyticsEvent)
   const emitAnalyticsEventRef = useRef(options?.onEmitAnalyticsEvent)
-  const prevPressedRef = useRef<Set<string>>(new Set())
+  const prevPressedRef = useRef<ReadonlySet<string>>(new Set())
+  const latchedLayersRef = useRef(new MatrixLayerLatch())
   // Press-order emission queue for matrix analytics events. See
   // matrix-analytics-queue.ts for why this exists instead of emitting
   // non-masked keys unconditionally on press.
@@ -227,7 +228,10 @@ export function useTypingTest<TPreparedEvent = unknown>(
   const setBaseLayer = useCallback(async (layer: number) => {
     setBaseLayerState(layer)
     baseLayerRef.current = layer
-    setEffectiveLayer(layer)
+    // A layer key held across the base-layer change (e.g. the keyboard
+    // popover's own layer selector) must keep the indicator on its
+    // latched target rather than snapping to the newly selected base.
+    setEffectiveLayer(latchedLayersRef.current.displayLayer(layer))
     const seq = ++seqRef.current
     const result = await createWordsForConfig(configRef.current, languageRef.current)
     if (seqRef.current !== seq) return
@@ -328,140 +332,124 @@ export function useTypingTest<TPreparedEvent = unknown>(
     return true
   }, [])
 
-  const processMatrixFrame = useCallback((pressed: Set<string>, keymap: Map<string, number>) => {
+  const processMatrixFrame = useCallback((pressed: ReadonlySet<string>, keymap: Map<string, number>) => {
     const bl = baseLayerRef.current
     const prev = prevPressedRef.current
+    const latched = latchedLayersRef.current
 
-    // Fixed-point layer activation: a key that activates a layer may
-    // itself resolve differently on that newly-active layer, so keep
-    // iterating until no new layer is added. Used for both the full
-    // live set (drives the UI layer indicator) and the pre-existing
-    // set used to classify new presses against the layer context that
-    // existed before this frame.
-    function activateLayers(keys: Iterable<string>): Set<number> {
-      const set = new Set<number>()
-      let changed = true
-      while (changed) {
-        changed = false
-        for (const key of keys) {
-          const sortedLayers = [...set].sort((a, b) => b - a)
-          const [row, col] = parseMatrixKey(key)
-          const code = resolveEffectiveCode(row, col, keymap, sortedLayers, bl)
-          if (code == null) continue
-          const targetLayer = extractSwitchLayer(code)
-          if (targetLayer === null) continue
-          const effective = Math.max(bl, targetLayer)
-          if (!set.has(effective)) {
-            set.add(effective)
-            changed = true
-          }
-        }
-      }
-      return set
-    }
-
-    const activeLayerSet = activateLayers(pressed)
-    const highestActiveLayer = activeLayerSet.size > 0
-      ? Math.max(...activeLayerSet)
-      : bl
-    setEffectiveLayer(highestActiveLayer)
-
-    // Detect press / release edges for analytics recording. Matrix events
-    // come from HID polling and should fire regardless of window focus;
-    // it's the caller's responsibility to stop calling processMatrixFrame
-    // when recording should pause (e.g. record toggle off).
-    //
-    // Non-masked keys carry no action field and are queued/emitted in
-    // press order like everything else. Masked keys (LT/MT) resolve to
-    // tap vs hold on a deadline fixed at press time (see
-    // matrix-analytics-queue.ts), by the release edge if it arrives first or by
-    // the deadline timer if the key is still held — so resolution can
-    // land later than physical presses that follow it. Emitting those
-    // later presses immediately would hand the main process a masked
-    // key's event stamped with an earlier timestamp than events already
-    // emitted for what came after it; its n-gram chain treats a
-    // non-increasing timestamp as out of order and silently drops it,
-    // losing the masked key from every pair around it (the motivating
-    // case: a thumb LT(1, KC_SPACE) overlapping the next letter in
-    // ordinary fast typing). Queuing every press behind an unresolved
-    // one and draining in order once it resolves keeps the emitted
-    // stream monotonic. See resetMatrixPressTracking for what happens
-    // to a press still unresolved when recording stops.
+    // Matrix events come from HID polling and should fire regardless of
+    // window focus; it's the caller's responsibility to stop calling
+    // processMatrixFrame when recording should pause (e.g. record
+    // toggle off).
     const prepare = prepareAnalyticsEventRef.current
-    if (prepare) {
-      const emit = emitAnalyticsEventRef.current
-      const queue = matrixQueueRef.current
-      // Layer context for a NEW press is "what OTHER keys were already
-      // holding us to" — i.e. layers activated by keys carried over
-      // from the previous frame. A lone MO(1) press at base 0 must
-      // resolve as layer 0 even if MO(1) is also the layer 1 keycode
-      // at the same cell; otherwise the press is attributed to the
-      // very layer the key is activating and disappears from the
-      // base-layer heatmap.
-      const carriedKeys: string[] = []
-      for (const k of prev) {
-        if (pressed.has(k)) carriedKeys.push(k)
-      }
-      const preExistingLayerSet = activateLayers(carriedKeys)
-      const preExistingSortedLayers = [...preExistingLayerSet].sort((a, b) => b - a)
-      const ts = Date.now()
-      const tappingTermMs = tappingTermMsRef.current
-      const duration = matrixDurationRef.current
-      const frame = duration.onFrame(ts)
+    const emit = emitAnalyticsEventRef.current
+    const queue = matrixQueueRef.current
+    const duration = matrixDurationRef.current
+    const ts = Date.now()
+    const tappingTermMs = tappingTermMsRef.current
+    // Read once per frame, before any press edge, regardless of whether
+    // any press lands this frame — onFrame's rolling gap/hole tracking
+    // needs a sample every frame to detect a hole between frames with no
+    // edges at all. Always defined together with `prepare`; both are
+    // checked together below purely so `frame`'s type narrows to
+    // non-null at the registerPress call site.
+    const frame = prepare ? duration.onFrame(ts) : null
 
-      for (const key of pressed) {
-        if (prev.has(key)) continue
-        const [row, col] = parseMatrixKey(key)
-        const resolved = resolveEffectiveCodeWithLayer(row, col, keymap, preExistingSortedLayers, bl)
-        if (!resolved) continue
-        const { code, layer: eventLayer } = resolved
-        // Authorize + tag at press time, not when this press eventually
-        // reaches the sink (which may be up to TAPPING_TERM later if it
-        // queues behind an unresolved masked key ahead of it). A press
-        // that isn't authorized right now is dropped for good — it never
-        // enters the queue, so it can't be "un-dropped" by a state change
-        // (e.g. recording toggling back on) while it would have waited.
-        const prepared = prepare('matrix')
-        if (prepared == null) continue
-        // Overlap / pollGapMs are derived from the raw pressed set, not
-        // from anything queue-related — see matrix-press-duration.ts.
-        // registerPress also records this press so the matching release
-        // edge (below, in a later frame) can compute its duration and
-        // ship the same `prepared` context this press already captured.
-        const { overlap, pollGapMs } = duration.registerPress({
-          key,
-          start: { tsMs: ts, row, col, layer: eventLayer, keycode: code },
+    // Walk this frame's press/release edges in row-major order — a held
+    // key (no edge) is skipped entirely, since its action was already
+    // latched on the frame it was pressed and QMK never re-resolves a
+    // held key against layers it or another key activates later. A
+    // release drops its own latch; a press resolves against whatever is
+    // latched right now (base layer + targets latched by keys already
+    // held, or by an earlier edge in this same walk), THEN latches its
+    // own target — so a same-frame rollover between a release and a
+    // press "sees" each other in the deterministic row-scan order rather
+    // than in whatever order a Set happened to iterate.
+    for (const edge of matrixFrameEdges(prev, pressed)) {
+      if (!edge.isPress) {
+        latched.release(edge.key)
+        if (prepare) {
+          queue.resolveReleaseByKey(edge.key, ts, emit)
+          const resolved = duration.resolveRelease(edge.key, ts)
+          if (resolved) emit?.(resolved.prepared, resolved.event)
+        }
+        continue
+      }
+
+      const sortedLayers = latched.activeLayers(bl)
+      const resolved = resolveEffectiveCodeWithLayer(edge.row, edge.col, keymap, sortedLayers, bl)
+      if (!resolved) continue
+      const { code, layer: eventLayer } = resolved
+      latched.latch(edge.key, extractSwitchLayer(code))
+
+      if (!prepare || !frame) continue
+      // Authorize + tag at press time, not when this press eventually
+      // reaches the sink (which may be up to TAPPING_TERM later if it
+      // queues behind an unresolved masked key ahead of it). A press
+      // that isn't authorized right now is dropped for good — it never
+      // enters the queue, so it can't be "un-dropped" by a state change
+      // (e.g. recording toggling back on) while it would have waited.
+      const prepared = prepare('matrix')
+      if (prepared == null) continue
+      // Overlap / pollGapMs are derived from the raw pressed set, not
+      // from anything queue-related — see matrix-press-duration.ts.
+      // registerPress also records this press so the matching release
+      // edge (in a later frame) can compute its duration and ship the
+      // same `prepared` context this press already captured.
+      const { overlap, pollGapMs } = duration.registerPress({
+        key: edge.key,
+        start: { tsMs: ts, row: edge.row, col: edge.col, layer: eventLayer, keycode: code },
+        prepared,
+        pressed,
+        frame,
+      })
+      // Non-masked keys carry no action field and are queued/emitted in
+      // press order like everything else. Masked keys (LT/MT) resolve to
+      // tap vs hold on a deadline fixed at press time (see
+      // matrix-analytics-queue.ts), by the release edge if it arrives
+      // first or by the deadline timer if the key is still held — so
+      // resolution can land later than physical presses that follow it.
+      // Emitting those later presses immediately would hand the main
+      // process a masked key's event stamped with an earlier timestamp
+      // than events already emitted for what came after it; its n-gram
+      // chain treats a non-increasing timestamp as out of order and
+      // silently drops it, losing the masked key from every pair around
+      // it (the motivating case: a thumb LT(1, KC_SPACE) overlapping the
+      // next letter in ordinary fast typing). Queuing every press behind
+      // an unresolved one and draining in order once it resolves keeps
+      // the emitted stream monotonic. See resetMatrixPressTracking for
+      // what happens to a press still unresolved when recording stops.
+      // Only LT / MT style tap-hold keys need the deferred classify
+      // pass. LSFT(kc) etc. are "masked" too but always fire the
+      // modifier + base together, so the heatmap treats them as regular
+      // presses.
+      if (isTapKeycode(code)) {
+        queue.pushPending(
           prepared,
-          pressed,
-          frame,
-        })
-        // Only LT / MT style tap-hold keys need the deferred classify
-        // pass. LSFT(kc) etc. are "masked" too but always fire the
-        // modifier + base together, so the heatmap treats them as
-        // regular presses.
-        if (isTapKeycode(code)) {
-          queue.pushPending(prepared, { tsMs: ts, row, col, layer: eventLayer, keycode: code, overlap, pollGapMs }, key, tappingTermMs, emit)
+          { tsMs: ts, row: edge.row, col: edge.col, layer: eventLayer, keycode: code, overlap, pollGapMs },
+          edge.key,
+          tappingTermMs,
+          emit,
+        )
+      } else {
+        const event: TypingAnalyticsEventPayload = { kind: 'matrix', row: edge.row, col: edge.col, layer: eventLayer, keycode: code, ts, overlap, pollGapMs }
+        // An empty queue means nothing ahead is still unresolved, so
+        // this press can go straight out instead of paying for a round
+        // trip through the queue.
+        if (queue.isEmpty) {
+          emit?.(prepared, event)
         } else {
-          const event: TypingAnalyticsEventPayload = { kind: 'matrix', row, col, layer: eventLayer, keycode: code, ts, overlap, pollGapMs }
-          // An empty queue means nothing ahead is still unresolved, so
-          // this press can go straight out instead of paying for a
-          // round trip through the queue.
-          if (queue.isEmpty) {
-            emit?.(prepared, event)
-          } else {
-            queue.pushResolved(event, prepared)
-          }
+          queue.pushResolved(event, prepared)
         }
       }
-
-      for (const key of prev) {
-        if (pressed.has(key)) continue
-        queue.resolveReleaseByKey(key, ts, emit)
-        const resolved = duration.resolveRelease(key, ts)
-        if (resolved) emit?.(resolved.prepared, resolved.event)
-      }
     }
-    prevPressedRef.current = new Set(pressed)
+
+    setEffectiveLayer(latched.displayLayer(bl))
+    // `pressed` is a fresh Set the caller builds every poll and never
+    // mutates afterward (see parseMatrixState in matrix-utils.ts), so
+    // adopting the reference is safe and skips a same-size Set clone on
+    // every frame, busy or idle.
+    prevPressedRef.current = pressed
   }, [])
 
   /** Reset press-edge tracking. Call on record toggle, device change, or
@@ -494,6 +482,16 @@ export function useTypingTest<TPreparedEvent = unknown>(
   const resetMatrixPressTracking = useCallback((): Promise<void> => {
     const drained = matrixQueueRef.current.drainAll(emitAnalyticsEventRef.current)
     prevPressedRef.current = new Set()
+    // A latch with no corresponding entry in prevPressedRef (now empty)
+    // can never be reached by a future release edge — its key would
+    // have to reappear in `pressed` AND `prev` at once to register as
+    // "held, no edge", which can't happen once prev is cleared. Left
+    // uncleared, a key still physically held through this reset would
+    // keep its stale target forever, permanently inflating the layer
+    // indicator. Clearing here is safe either way: a key still actually
+    // held gets treated as a fresh press (and re-latched) on the very
+    // next frame, per its own row/col resolution at that point.
+    latchedLayersRef.current.clear()
     // Discard rather than finalize — an in-flight press with no release
     // yet must not be synthesized into a fabricated release event (see
     // matrix-press-duration.ts). Unlike the queue's forced hold
@@ -511,6 +509,7 @@ export function useTypingTest<TPreparedEvent = unknown>(
     return () => {
       matrixQueueRef.current.dispose()
       matrixDurationRef.current.reset()
+      latchedLayersRef.current.clear()
     }
   }, [])
 


### PR DESCRIPTION
## Summary

The typing view's layer indicator resolved **held** keys against the layers they had just activated. With MO(2) on the base layer and MO(5) on layer 2 at the same physical position, a lone MO(2) press re-resolved itself on layer 2 and jumped the display to layer 5.

Real firmware latches a key's action at press time and never re-resolves a held key, so the indicator now does the same.

Closes #333

## Changes

- **`matrix-layer-latch.ts` (new):** `MatrixLayerLatch` — press-time latch map (raw target layers; active set derived from base ∪ latched targets), following the `PressDurationTracker` / `MatrixAnalyticsQueue` pattern.
- **`matrix-layers.ts`:** `matrixFrameEdges()` returns the press/release diff of two frames sorted in matrix scan order (row-major); removed the now-unused `resolveEffectiveCode`.
- **`useTypingTest.ts`:** replaced the fixed-point `activateLayers()` with a single interleaved edge walk — a release drops its latch, a press resolves against the layers active at that instant and then latches its own target; the captured resolution also feeds analytics attribution directly. `setBaseLayer` keeps latched targets in the indicator; the latch clears on `resetMatrixPressTracking` and unmount. `pressed` is now `ReadonlySet`.
- **Tests:** 9 new cases pinning the latch behavior — issue repro, nested activation via a second key, analytics attribution (including a target below the base layer), same-frame chords and release+press rollover in both row orders, nested latch surviving an outer release, and base-layer changes mid-hold.

## Verification

- New tests fail on the previous implementation (5 of 9 red before the fix), all pass after.
- `pnpm test`: 341 files, 7775 passed / 22 skipped (device-dependent).
- `pnpm lint` / `pnpm typecheck`: clean.
- Reproduced and confirmed fixed on a real keyboard (4-layer setup: MO(1) at base, MO(3) on the same cell of layer 1).