### PR TITLE
feat(ui): record per-run raw keystroke logs for typing test runs

### DIFF
--- a/src/main/__tests__/google-drive.test.ts
+++ b/src/main/__tests__/google-drive.test.ts
@@ -75,6 +75,11 @@ describe('google-drive', () => {
       expect(syncUnitFromFileName('keyboards_0x1234_snapshots.enc')).toBe('keyboards/0x1234/snapshots')
     })
 
+    it('parses keyboard run-log drive filename to sync unit', () => {
+      expect(driveFileName('keyboards/0x1234/runs')).toBe('keyboards_0x1234_runs.enc')
+      expect(syncUnitFromFileName('keyboards_0x1234_runs.enc')).toBe('keyboards/0x1234/runs')
+    })
+
     it('parses per-day device JSONL drive filename to sync unit', () => {
       expect(syncUnitFromFileName('keyboards_0x1234_devices_hash-abc_days_2026-04-19.enc'))
         .toBe('keyboards/0x1234/devices/hash-abc/days/2026-04-19')

--- a/src/main/__tests__/merge.test.ts
+++ b/src/main/__tests__/merge.test.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mergeEntries, gcTombstones, effectiveTime } from '../sync/merge'
+import { mergeEntries, gcTombstones, effectiveTime, applyRunLogRetention } from '../sync/merge'
 import type { SavedFavoriteMeta } from '../../shared/types/favorite-store'
+import type { RunLogMeta } from '../../shared/types/typing-run-log'
+import { MAX_RUN_LOGS_PER_KEYBOARD } from '../../shared/types/typing-run-log'
 
 type Entry = SavedFavoriteMeta
 
@@ -344,6 +346,91 @@ describe('mergeEntries', () => {
       )
       expect(result.remoteNeedsUpdate).toBe(true)
     })
+  })
+})
+
+describe('applyRunLogRetention (pure, deterministic)', () => {
+  function makeMeta(overrides: Partial<RunLogMeta> & { id: string; startedAt: string }): RunLogMeta {
+    return { filename: `${overrides.id}.json`, savedAt: overrides.startedAt, ...overrides }
+  }
+
+  function makeMetas(count: number): RunLogMeta[] {
+    return Array.from({ length: count }, (_, i) => makeMeta({ id: `id-${i}`, startedAt: new Date(2026, 0, 1, 0, 0, i).toISOString() }))
+  }
+
+  it('is a no-op under the cap', () => {
+    const entries = makeMetas(MAX_RUN_LOGS_PER_KEYBOARD)
+    const { entries: result, evicted } = applyRunLogRetention(entries, MAX_RUN_LOGS_PER_KEYBOARD)
+    expect(result).toHaveLength(MAX_RUN_LOGS_PER_KEYBOARD)
+    expect(evicted).toHaveLength(0)
+  })
+
+  it('keeps the newest N regardless of input order (shuffled)', () => {
+    const entries = makeMetas(MAX_RUN_LOGS_PER_KEYBOARD + 10)
+    const shuffled = [...entries].sort(() => Math.random() - 0.5)
+    const { entries: result } = applyRunLogRetention(shuffled, MAX_RUN_LOGS_PER_KEYBOARD)
+    const keptIds = new Set(result.filter((e) => !e.deletedAt).map((e) => e.id))
+    expect(keptIds.size).toBe(MAX_RUN_LOGS_PER_KEYBOARD)
+    // Newest 50 (highest index, since index tracks minute-offset here) survive.
+    for (let i = 10; i < MAX_RUN_LOGS_PER_KEYBOARD + 10; i++) {
+      expect(keptIds.has(`id-${i}`)).toBe(true)
+    }
+    for (let i = 0; i < 10; i++) {
+      expect(keptIds.has(`id-${i}`)).toBe(false)
+    }
+  })
+
+  it('converges two divergent 50+ sets onto the same kept set after a union', () => {
+    // Simulate two devices that each recorded slightly different extra
+    // runs beyond the cap, then a merge that unions everything. Ranking
+    // by immutable startedAt (not by whichever device's LWW timestamp
+    // is newer) must yield the identical kept set regardless of which
+    // side's array order the union happens to preserve.
+    const shared = makeMetas(MAX_RUN_LOGS_PER_KEYBOARD)
+    const deviceAExtra = [makeMeta({ id: 'device-a-1', startedAt: new Date(2025, 0, 1).toISOString() })]
+    const deviceBExtra = [makeMeta({ id: 'device-b-1', startedAt: new Date(2025, 0, 2).toISOString() })]
+
+    const unionOrderA = [...shared, ...deviceAExtra, ...deviceBExtra]
+    const unionOrderB = [...deviceBExtra, ...deviceAExtra, ...shared].reverse()
+
+    const resultA = applyRunLogRetention(unionOrderA, MAX_RUN_LOGS_PER_KEYBOARD)
+    const resultB = applyRunLogRetention(unionOrderB, MAX_RUN_LOGS_PER_KEYBOARD)
+
+    const keptIdsA = new Set(resultA.entries.filter((e) => !e.deletedAt).map((e) => e.id))
+    const keptIdsB = new Set(resultB.entries.filter((e) => !e.deletedAt).map((e) => e.id))
+    expect(keptIdsA).toEqual(keptIdsB)
+    // Both older, single extra entries lose to the 50 newer `shared` runs.
+    expect(keptIdsA.has('device-a-1')).toBe(false)
+    expect(keptIdsA.has('device-b-1')).toBe(false)
+  })
+
+  it('mergeEntries applies retention via runLogRetentionMax and reports evicted entries', () => {
+    const local = makeMetas(MAX_RUN_LOGS_PER_KEYBOARD)
+    const remote: RunLogMeta[] = [makeMeta({ id: 'newcomer', startedAt: new Date(2027, 0, 1).toISOString() })]
+
+    const result = mergeEntries(local, remote, { runLogRetentionMax: MAX_RUN_LOGS_PER_KEYBOARD })
+
+    const keptIds = new Set(result.entries.filter((e) => !e.deletedAt).map((e) => e.id))
+    expect(keptIds.size).toBe(MAX_RUN_LOGS_PER_KEYBOARD)
+    expect(keptIds.has('newcomer')).toBe(true)
+    // The oldest local entry (id-0) was evicted to make room.
+    expect(result.evicted.map((e) => e.id)).toContain('id-0')
+    expect(keptIds.has('id-0')).toBe(false)
+  })
+
+  it('marks remoteNeedsUpdate when retention evicts entries even though the LWW pass alone found nothing to upload (P8)', () => {
+    // Remote-only-so-far merge: an empty local side merged against a
+    // remote bundle that already has MORE than the cap active — every
+    // entry lands in the "remote only" branch, which never sets
+    // remoteNeedsUpdate on its own (there's nothing local-only to report
+    // back). Retention then evicts the overflow into FRESH tombstones
+    // that remote doesn't have yet — those must upload on THIS sync.
+    const remote = makeMetas(MAX_RUN_LOGS_PER_KEYBOARD + 1)
+
+    const result = mergeEntries([], remote, { runLogRetentionMax: MAX_RUN_LOGS_PER_KEYBOARD })
+
+    expect(result.evicted.length).toBeGreaterThan(0)
+    expect(result.remoteNeedsUpdate).toBe(true)
   })
 })
 

--- a/src/main/__tests__/sync-service.test.ts
+++ b/src/main/__tests__/sync-service.test.ts
@@ -98,6 +98,7 @@ let mockAutoSync = false
 vi.mock('../app-config', () => ({
   loadAppConfig: vi.fn(async () => ({ autoSync: mockAutoSync })),
   saveAppConfig: vi.fn(async () => {}),
+  getAppConfigStore: vi.fn(() => ({ get: () => false })),
 }))
 
 vi.mock('../typing-analytics/sync', () => ({
@@ -717,6 +718,22 @@ describe('sync-service', () => {
         (call) => call[0] !== 'password-check.enc',
       )
       expect(syncUnitUploads).toHaveLength(0)
+    })
+
+    it('never writes a remote entry whose filename attempts path traversal (P9)', async () => {
+      await setupLocalFavorite('2025-01-01T00:00:00.000Z', { name: 'data.json', content: '{"local":true}' })
+
+      mockListFiles.mockResolvedValue([makeDriveFile('2025-06-01T00:00:00.000Z')])
+      mockDownloadFile.mockResolvedValue(makeRemoteEnvelope('2025-06-01T00:00:00.000Z', [
+        { id: 'evil', label: 'evil', filename: '../../../evil.json', savedAt: '2025-06-01T00:00:00.000Z' },
+      ]))
+
+      await executeSync('download')
+
+      // The merge itself must not have thrown, and the traversal target
+      // must never be created outside the sync store's own directory.
+      await expect(access(join(mockUserDataPath, 'evil.json'))).rejects.toThrow()
+      await expect(access(join(mockUserDataPath, 'sync', 'evil.json'))).rejects.toThrow()
     })
 
     it('uses updatedAt for local timestamp comparison', async () => {
@@ -1339,9 +1356,14 @@ describe('sync-service', () => {
       })
     })
 
+    // isRunLogSyncUnit itself is just re-exported here (see sync-bundle's
+    // own isRunLogSyncUnit tests in sync-bundle.run-log.test.ts) — only
+    // its use in shouldDownloadSyncUnit's scope logic is worth covering
+    // in this file.
     describe('shouldDownloadSyncUnit', () => {
       const local = new Set(['uid-a'])
       const analyticsUnit = 'keyboards/uid-a/devices/hash/days/2026-04-19'
+      const runLogUnit = 'keyboards/uid-a/runs'
       const settingsUnit = 'keyboards/uid-a/settings'
       const favoritesUnit = 'favorites/macro'
 
@@ -1358,6 +1380,13 @@ describe('sync-service', () => {
         expect(shouldDownloadSyncUnit(analyticsUnit, scope, local)).toBe(false)
         expect(shouldDownloadSyncUnit(settingsUnit, scope, local)).toBe(true)
         expect(shouldDownloadSyncUnit(favoritesUnit, scope, local)).toBe(true)
+      })
+
+      it("keeps run logs when scope is 'all' or an explicit keyboard scope, but drops them at connect time", () => {
+        expect(shouldDownloadSyncUnit(runLogUnit, 'all', local)).toBe(true)
+        expect(shouldDownloadSyncUnit(runLogUnit, { keyboard: 'uid-a' }, local)).toBe(true)
+        const connectScope = { favorites: true as const, keyboard: 'uid-a' }
+        expect(shouldDownloadSyncUnit(runLogUnit, connectScope, local)).toBe(false)
       })
     })
 

--- a/src/main/__tests__/typing-run-log-store.test.ts
+++ b/src/main/__tests__/typing-run-log-store.test.ts
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdtemp, rm, readFile, access, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+let mockUserDataPath = ''
+let consentAccepted = true
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+}))
+
+vi.mock('../sync/sync-service', () => ({
+  notifyChange: vi.fn(),
+}))
+
+vi.mock('../app-config', () => ({
+  getAppConfigStore: () => ({
+    get: (key: string) => (key === 'typingRecordingConsentAccepted' ? consentAccepted : undefined),
+  }),
+}))
+
+import { notifyChange } from '../sync/sync-service'
+import {
+  saveRunLog,
+  listRunLogs,
+  getRunLog,
+} from '../typing-run-log-store'
+import type { RunKeystrokeLog, RunLogMeta } from '../../shared/types/typing-run-log'
+import { MAX_RUN_LOG_EVENTS, MAX_RUN_LOGS_PER_KEYBOARD } from '../../shared/types/typing-run-log'
+
+function makeLog(overrides?: Partial<RunKeystrokeLog>): RunKeystrokeLog {
+  return {
+    runId: 'run-1',
+    uid: 'kb-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    durationMs: 5000,
+    mode: 'words',
+    language: 'english',
+    words: [
+      {
+        index: 0,
+        display: 'hello',
+        typed: 'hello',
+        correct: true,
+        keystrokes: [
+          { pressMs: 0, releaseMs: 80, keycode: 1, row: 0, col: 0, expectedChar: 'h', correct: true },
+          { pressMs: 100, releaseMs: 180, keycode: 2, row: 0, col: 1, expectedChar: 'e', correct: true },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('typing-run-log-store', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    consentAccepted = true
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'typing-run-log-store-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  describe('saveRunLog', () => {
+    it('persists index + payload and notifies sync', async () => {
+      const result = await saveRunLog('kb-1', makeLog())
+      expect(result.success).toBe(true)
+      expect(result.entry?.id).toBe('run-1')
+      expect(notifyChange).toHaveBeenCalledWith('keyboards/kb-1/runs')
+
+      const indexPath = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', 'index.json')
+      const index = JSON.parse(await readFile(indexPath, 'utf-8')) as { uid: string; entries: RunLogMeta[] }
+      expect(index.uid).toBe('kb-1')
+      expect(index.entries).toHaveLength(1)
+
+      const dataPath = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', index.entries[0].filename)
+      const saved = JSON.parse(await readFile(dataPath, 'utf-8')) as RunKeystrokeLog
+      expect(saved.runId).toBe('run-1')
+      expect(saved.words[0].keystrokes).toHaveLength(2)
+    })
+
+    it('rejects when recording consent has not been accepted', async () => {
+      consentAccepted = false
+      const result = await saveRunLog('kb-1', makeLog())
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/consent/i)
+    })
+
+    it('rejects an unsafe uid', async () => {
+      const result = await saveRunLog('../evil', makeLog({ uid: '../evil' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an unsafe runId (path traversal)', async () => {
+      const result = await saveRunLog('kb-1', makeLog({ runId: '../../evil' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a uid mismatch between the IPC arg and the payload', async () => {
+      const result = await saveRunLog('kb-1', makeLog({ uid: 'kb-2' }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects malformed payloads (missing required fields)', async () => {
+      const result = await saveRunLog('kb-1', { runId: 'run-1' })
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a payload with more keystrokes than MAX_RUN_LOG_EVENTS', async () => {
+      const keystrokes = Array.from({ length: MAX_RUN_LOG_EVENTS + 1 }, (_, i) => ({
+        pressMs: i, keycode: 1, row: 0, col: 0,
+      }))
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{ index: 0, display: 'x', typed: 'x', correct: true, keystrokes }],
+      }))
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/many keystrokes/i)
+    })
+
+    it('rejects an absolute-looking (out-of-bounds) keystroke timestamp', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        durationMs: 1000,
+        words: [{
+          index: 0, display: 'x', typed: 'x', correct: true,
+          keystrokes: [{ pressMs: Date.now(), keycode: 1, row: 0, col: 0 }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a releaseMs earlier than its own pressMs', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'x', typed: 'x', correct: true,
+          keystrokes: [{ pressMs: 500, releaseMs: 100, keycode: 1, row: 0, col: 0 }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a NaN durationMs', async () => {
+      const result = await saveRunLog('kb-1', makeLog({ durationMs: Number.NaN }))
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/durationMs/i)
+    })
+
+    it('rejects an Infinity durationMs', async () => {
+      const result = await saveRunLog('kb-1', makeLog({ durationMs: Number.POSITIVE_INFINITY }))
+      expect(result.success).toBe(false)
+      expect(result.error).toMatch(/durationMs/i)
+    })
+
+    it('rejects a NaN word index', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{ index: Number.NaN, display: 'x', typed: 'x', correct: true, keystrokes: [] }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a non-integer word index', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{ index: 1.5, display: 'x', typed: 'x', correct: true, keystrokes: [] }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts a trailing partial word (P5) and persists its partial flag', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [
+          { index: 0, display: 'hello', typed: 'hello', correct: true, keystrokes: [] },
+          {
+            index: 1, display: 'world', typed: 'wo', correct: false, partial: true,
+            keystrokes: [{ pressMs: 0, keycode: 1, row: 0, col: 0 }],
+          },
+        ],
+      }))
+      expect(result.success).toBe(true)
+
+      const dataPath = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', result.entry!.filename)
+      const saved = JSON.parse(await readFile(dataPath, 'utf-8')) as RunKeystrokeLog
+      expect(saved.words[1].partial).toBe(true)
+    })
+
+    it('rejects a non-boolean partial flag', async () => {
+      const log = makeLog()
+      const malformed = {
+        ...log,
+        words: [{ index: 0, display: 'x', typed: 'x', correct: true, partial: 'yes', keystrokes: [] }],
+      }
+      const result = await saveRunLog('kb-1', malformed)
+      expect(result.success).toBe(false)
+    })
+
+    it('saving the same runId twice leaves exactly one payload file on disk (P7)', async () => {
+      // Fake timers guarantee the two saves land at different millisecond
+      // timestamps — the filename prefix — so the second save's filename
+      // genuinely differs from the first's (the scenario the leak needs).
+      vi.useFakeTimers()
+      try {
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+        const first = await saveRunLog('kb-1', makeLog({ runId: 'run-dup' }))
+        expect(first.success).toBe(true)
+        const firstFilename = first.entry!.filename
+
+        vi.setSystemTime(new Date('2026-01-01T00:00:05.000Z'))
+        const second = await saveRunLog('kb-1', makeLog({ runId: 'run-dup', durationMs: 6000 }))
+        expect(second.success).toBe(true)
+        const secondFilename = second.entry!.filename
+        expect(secondFilename).not.toBe(firstFilename)
+
+        const listed = await listRunLogs('kb-1')
+        expect(listed.entries).toHaveLength(1)
+        expect(listed.entries?.[0].filename).toBe(secondFilename)
+
+        // The FIRST save's payload file must have been unlinked, not leaked.
+        await expect(access(join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', firstFilename)))
+          .rejects.toThrow()
+        // The second (current) payload file must still be present.
+        await expect(access(join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', secondFilename)))
+          .resolves.toBeUndefined()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('removes an orphan payload file the index has no memory of (D3)', async () => {
+      const runsDir = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs')
+      await mkdir(runsDir, { recursive: true })
+      // Simulate a previous save whose index write failed/was corrupted
+      // after its payload was already written — nothing in index.json
+      // references this file.
+      await writeFile(join(runsDir, '2020-01-01T00-00-00.000Z_orphan-run.json'), '{"runId":"orphan-run"}', 'utf-8')
+
+      const result = await saveRunLog('kb-1', makeLog({ runId: 'run-1' }))
+      expect(result.success).toBe(true)
+
+      await expect(access(join(runsDir, '2020-01-01T00-00-00.000Z_orphan-run.json'))).rejects.toThrow()
+      // The current save's own payload must be untouched.
+      await expect(access(join(runsDir, result.entry!.filename))).resolves.toBeUndefined()
+    })
+  })
+
+  describe('list / get roundtrip', () => {
+    it('lists newest-first and gets the full payload', async () => {
+      await saveRunLog('kb-1', makeLog({ runId: 'run-1', startedAt: '2026-01-01T00:00:00.000Z' }))
+      await saveRunLog('kb-1', makeLog({ runId: 'run-2', startedAt: '2026-01-02T00:00:00.000Z' }))
+
+      const listed = await listRunLogs('kb-1')
+      expect(listed.success).toBe(true)
+      expect(listed.entries?.map((e) => e.id)).toEqual(['run-2', 'run-1'])
+
+      const fetched = await getRunLog('kb-1', 'run-1')
+      expect(fetched.success).toBe(true)
+      expect(fetched.data?.runId).toBe('run-1')
+
+      const missing = await getRunLog('kb-1', 'no-such-run')
+      expect(missing.success).toBe(false)
+    })
+  })
+
+  describe('retention (51st run evicts the oldest)', () => {
+    it('keeps only MAX_RUN_LOGS_PER_KEYBOARD runs, tombstoning + unlinking the oldest', async () => {
+      for (let i = 0; i < MAX_RUN_LOGS_PER_KEYBOARD + 1; i++) {
+        const startedAt = new Date(2026, 0, 1, 0, 0, i).toISOString()
+        await saveRunLog('kb-1', makeLog({ runId: `run-${i}`, startedAt }))
+      }
+
+      const listed = await listRunLogs('kb-1')
+      expect(listed.entries).toHaveLength(MAX_RUN_LOGS_PER_KEYBOARD)
+      // The very first (oldest startedAt) run must be gone.
+      expect(listed.entries?.some((e) => e.id === 'run-0')).toBe(false)
+      expect(listed.entries?.some((e) => e.id === `run-${MAX_RUN_LOGS_PER_KEYBOARD}`)).toBe(true)
+
+      const indexPath = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', 'index.json')
+      const index = JSON.parse(await readFile(indexPath, 'utf-8')) as { entries: RunLogMeta[] }
+      const evictedMeta = index.entries.find((e) => e.id === 'run-0')
+      expect(evictedMeta?.deletedAt).toBeDefined()
+
+      // The evicted entry's file must have been unlinked from disk.
+      await expect(access(join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', evictedMeta!.filename)))
+        .rejects.toThrow()
+    })
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import { setupAnalyzeFilterStore } from './analyze-filter-store'
 import { setupFavoriteStore } from './favorite-store'
 import { setupKeyLabelStore } from './key-label-ipc'
 import { setupTypingTestTextStore } from './typing-test-text-ipc'
+import { setupTypingRunLogStore } from './typing-run-log-ipc'
 import { setupI18nPackStore } from './i18n-pack-ipc'
 import { setupThemePackStore } from './theme-pack-ipc'
 import { setupHidIpc } from './hid-ipc'
@@ -413,6 +414,7 @@ app.whenReady().then(() => {
   setupFavoriteStore()
   setupKeyLabelStore()
   setupTypingTestTextStore()
+  setupTypingRunLogStore()
   setupI18nPackStore()
   setupThemePackStore()
   setupPipetteSettingsStore()

--- a/src/main/sync/__tests__/sync-bundle.run-log.test.ts
+++ b/src/main/sync/__tests__/sync-bundle.run-log.test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Focused coverage for the run-log sync unit (keyboards/{uid}/runs) —
+// see .claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md. Mirrors
+// sync-bundle.test.ts's scoping/mocking approach.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { join } from 'node:path'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
+let mockUserDataPath = ''
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return mockUserDataPath
+      return `/mock/${name}`
+    },
+  },
+}))
+
+vi.mock('../../app-config', () => ({
+  loadAppConfig: vi.fn(async () => ({})),
+  saveAppConfig: vi.fn(async () => {}),
+}))
+vi.mock('../../typing-analytics/db/typing-analytics-db', () => ({
+  getTypingAnalyticsDB: vi.fn(),
+}))
+vi.mock('../../typing-analytics/machine-hash', () => ({
+  getMachineHash: vi.fn(async () => 'mock-hash'),
+}))
+vi.mock('../../logger', () => ({
+  log: vi.fn(),
+}))
+
+import { bundleSyncUnit, collectAllSyncUnits, isRunLogSyncUnit } from '../sync-bundle'
+
+describe('run-log sync unit', () => {
+  beforeEach(async () => {
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'sync-bundle-run-log-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  describe('isRunLogSyncUnit', () => {
+    it('matches a per-keyboard runs unit', () => {
+      expect(isRunLogSyncUnit('keyboards/0x1234/runs')).toBe(true)
+    })
+
+    it('rejects everything else', () => {
+      expect(isRunLogSyncUnit('keyboards/0x1234/snapshots')).toBe(false)
+      expect(isRunLogSyncUnit('keyboards/0x1234/analyze_filters')).toBe(false)
+      expect(isRunLogSyncUnit('keyboards/0x1234/devices/hash/days/2026-01-01')).toBe(false)
+      expect(isRunLogSyncUnit('favorites/macro')).toBe(false)
+    })
+  })
+
+  it('collectAllSyncUnits picks up keyboards/{uid}/runs when its index exists', async () => {
+    const runsDir = join(mockUserDataPath, 'sync', 'keyboards', 'uid-a', 'runs')
+    await mkdir(runsDir, { recursive: true })
+    await writeFile(join(runsDir, 'index.json'), JSON.stringify({ uid: 'uid-a', entries: [] }), 'utf-8')
+
+    const units = await collectAllSyncUnits()
+    expect(units).toContain('keyboards/uid-a/runs')
+  })
+
+  it('collectAllSyncUnits does not invent a runs unit when none exists', async () => {
+    const units = await collectAllSyncUnits()
+    expect(units.some((u) => u.endsWith('/runs'))).toBe(false)
+  })
+
+  it('bundleSyncUnit tags a runs unit as type "run-log"', async () => {
+    const runsDir = join(mockUserDataPath, 'sync', 'keyboards', 'uid-a', 'runs')
+    await mkdir(runsDir, { recursive: true })
+    const meta = { id: 'run-1', startedAt: '2026-01-01T00:00:00.000Z', filename: 'run-1.json', savedAt: '2026-01-01T00:00:00.000Z' }
+    await writeFile(join(runsDir, 'index.json'), JSON.stringify({ uid: 'uid-a', entries: [meta] }), 'utf-8')
+    await writeFile(join(runsDir, 'run-1.json'), JSON.stringify({ runId: 'run-1' }), 'utf-8')
+
+    const bundle = await bundleSyncUnit('keyboards/uid-a/runs')
+    expect(bundle).not.toBeNull()
+    expect(bundle!.type).toBe('run-log')
+    expect(bundle!.key).toBe('uid-a')
+    expect(bundle!.files['run-1.json']).toBeDefined()
+  })
+})

--- a/src/main/sync/google-drive.ts
+++ b/src/main/sync/google-drive.ts
@@ -177,7 +177,12 @@ export function syncUnitFromFileName(fileName: string): string | null {
 
   // "keyboards_0x1234_settings.enc" → "keyboards/0x1234/settings"
   // "keyboards_0x1234_snapshots.enc" → "keyboards/0x1234/snapshots"
-  const kbMatch = fileName.match(/^keyboards_(.+?)_(settings|snapshots)\.enc$/)
+  // "keyboards_0x1234_runs.enc" → "keyboards/0x1234/runs" (per-run raw
+  // keystroke log — added so a fresh machine can discover a remote-only
+  // run-log unit via manual sync; the same gap exists today for
+  // analyze_filters/key-labels/typing-test-texts/themes, tracked
+  // separately and deliberately not fixed here)
+  const kbMatch = fileName.match(/^keyboards_(.+?)_(settings|snapshots|runs)\.enc$/)
   if (kbMatch) return `keyboards/${kbMatch[1]}/${kbMatch[2]}`
 
   // "favorites_tapDance.enc" → "favorites/tapDance"

--- a/src/main/sync/merge.ts
+++ b/src/main/sync/merge.ts
@@ -6,19 +6,61 @@ import type { SnapshotMeta } from '../../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from '../../shared/types/analyze-filter-store'
 import type { KeyLabelMeta } from '../../shared/types/key-label-store'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
+import type { RunLogMeta } from '../../shared/types/typing-run-log'
 
-export type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta | KeyLabelMeta | TypingTestTextMeta
+export type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta | KeyLabelMeta | TypingTestTextMeta | RunLogMeta
 
 const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 
 export interface MergeOptions {
   preserveLocalOrder?: boolean
+  /** Run-log sync unit only: after the entry-level LWW merge below,
+   *  additionally retain only the newest N entries (see
+   *  `applyRunLogRetention`), tombstoning the overflow. Narrow — every
+   *  other sync unit type omits this and gets ordinary LWW merge with no
+   *  retention cap. */
+  runLogRetentionMax?: number
 }
 
 export interface MergeResult<T extends EntryMeta> {
   entries: T[]
   remoteFilesToCopy: string[]
   remoteNeedsUpdate: boolean
+  /** Entries evicted by `runLogRetentionMax` retention, if that option was
+   *  set — the caller unlinks their backing files. Always empty otherwise. */
+  evicted: T[]
+}
+
+/** Deterministic retention trim: keep the newest {@link max} active
+ *  (non-tombstoned) entries, ranked by immutable `startedAt` (id as a
+ *  stable tiebreaker for an exact-same-ms collision), converting the
+ *  overflow into fresh tombstones. Pure — the caller unlinks `evicted`'s
+ *  files and persists `entries`. Ranking by an immutable field (never
+ *  local `savedAt`/LWW-mutable `updatedAt`) is what lets two devices that
+ *  independently exceeded the cap converge on the identical kept set once
+ *  they sync — LWW alone would let a later `updatedAt` resurrect an entry
+ *  the other device already evicted. Operates on a full entries array
+ *  (active + already-tombstoned, same shape `mergeEntries` returns), so it
+ *  can run standalone (typing-run-log-store's local save path) or as
+ *  `mergeEntries`'s own post-merge step (`runLogRetentionMax`). */
+export function applyRunLogRetention(entries: readonly RunLogMeta[], max: number): { entries: RunLogMeta[]; evicted: RunLogMeta[] } {
+  const active = entries.filter((e) => !e.deletedAt)
+  const tombstones = entries.filter((e) => e.deletedAt)
+  if (active.length <= max) return { entries: entries.slice(), evicted: [] }
+
+  const ranked = active.slice().sort((a, b) => {
+    const byTime = new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime()
+    if (byTime !== 0) return byTime
+    // Deterministic tiebreaker for an exact startedAt collision so every
+    // device ranks the tie identically.
+    if (a.id === b.id) return 0
+    return a.id < b.id ? 1 : -1
+  })
+  const kept = ranked.slice(0, max)
+  const evicted = ranked.slice(max)
+  const now = new Date().toISOString()
+  const evictedTombstones = evicted.map((e) => ({ ...e, deletedAt: now, updatedAt: now }))
+  return { entries: [...kept, ...evictedTombstones, ...tombstones], evicted }
 }
 
 export function effectiveTime(entry: EntryMeta): number {
@@ -93,7 +135,23 @@ export function mergeEntries<T extends EntryMeta>(local: T[], remote: T[], optio
   }
 
   active.push(...tombstones)
-  return { entries: active, remoteFilesToCopy, remoteNeedsUpdate }
+
+  if (options?.runLogRetentionMax !== undefined) {
+    const retained = applyRunLogRetention(active as unknown as readonly RunLogMeta[], options.runLogRetentionMax)
+    return {
+      entries: retained.entries as unknown as T[],
+      remoteFilesToCopy,
+      // Retention evicting entries produces fresh tombstones that remote
+      // doesn't have yet (e.g. a remote-only-so-far merge where the LWW
+      // pass above never had a reason to set remoteNeedsUpdate on its
+      // own) — those tombstones must upload on THIS sync, not wait for a
+      // later one to happen to also flip this flag for an unrelated reason.
+      remoteNeedsUpdate: remoteNeedsUpdate || retained.evicted.length > 0,
+      evicted: retained.evicted as unknown as T[],
+    }
+  }
+
+  return { entries: active, remoteFilesToCopy, remoteNeedsUpdate, evicted: [] }
 }
 
 export function gcTombstones<T extends EntryMeta>(entries: T[]): T[] {

--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -12,6 +12,7 @@ import type { SnapshotIndex } from '../../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotIndex } from '../../shared/types/analyze-filter-store'
 import type { KeyLabelIndex } from '../../shared/types/key-label-store'
 import type { TypingTestTextIndex } from '../../shared/types/typing-test-text-store'
+import type { RunLogIndex } from '../../shared/types/typing-run-log'
 import type { SyncBundle } from '../../shared/types/sync'
 import { KEYBOARD_META_SYNC_UNIT } from '../../shared/types/keyboard-meta'
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
@@ -30,10 +31,10 @@ import {
 } from '../typing-analytics/sync'
 import { log } from '../logger'
 
-export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex | TypingTestTextIndex | null> {
+export async function readIndexFile(dir: string): Promise<FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | RunLogIndex | KeyLabelIndex | TypingTestTextIndex | null> {
   try {
     const raw = await readFile(join(dir, 'index.json'), 'utf-8')
-    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyLabelIndex | TypingTestTextIndex
+    return JSON.parse(raw) as FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | RunLogIndex | KeyLabelIndex | TypingTestTextIndex
   } catch {
     return null
   }
@@ -195,6 +196,9 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
   } else if (parts[2] === 'analyze_filters') {
     type = 'analyze-filter'
     key = parts[1]
+  } else if (parts[2] === 'runs') {
+    type = 'run-log'
+    key = parts[1]
   } else {
     type = 'layout'
     key = parts[1]
@@ -211,6 +215,17 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
  * `.claude/rules/settings-persistence.md`. */
 export function isAnalyticsSyncUnit(syncUnit: string): boolean {
   return parseTypingAnalyticsDeviceDaySyncUnit(syncUnit) !== null
+}
+
+/** Per-run raw keystroke log units (`keyboards/{uid}/runs`). Excluded
+ * from connect-time initial sync and 3-minute polling for the same
+ * reason as `isAnalyticsSyncUnit` — see
+ * `.claude/rules/settings-persistence.md`'s trigger matrix. Unlike
+ * typing-analytics units, this data has no dedicated on-demand sync
+ * entry point yet (Row F: "no dedicated sync") — it only syncs via the
+ * generic before-quit flush and manual "sync now". */
+export function isRunLogSyncUnit(syncUnit: string): boolean {
+  return /^keyboards\/[^/]+\/runs$/.test(syncUnit)
 }
 
 /** Own-hash typing-analytics units for one keyboard. Narrower than
@@ -304,6 +319,14 @@ export async function collectAllSyncUnits(): Promise<string[]> {
         await access(join(keyboardsDir, uid, 'analyze_filters', 'index.json'))
         units.push(`keyboards/${uid}/analyze_filters`)
       } catch { /* no analyze filter snapshots */ }
+      // per-run raw keystroke logs (index-based, mirrors analyze_filters
+      // layout) — connect-time initial sync/polling exclude this unit
+      // via isRunLogSyncUnit, but it still needs to be collected here so
+      // before-quit flush and manual sync can upload it.
+      try {
+        await access(join(keyboardsDir, uid, 'runs', 'index.json'))
+        units.push(`keyboards/${uid}/runs`)
+      } catch { /* no run logs */ }
     }
   } catch { /* dir doesn't exist */ }
 

--- a/src/main/sync/sync-ipc.ts
+++ b/src/main/sync/sync-ipc.ts
@@ -422,7 +422,9 @@ export function setupSyncIpc(): void {
         const bundle = await bundleSyncUnit(syncUnit)
         if (!bundle) continue
         const category = bundleTypeToCategory[bundle.type]
-        if (!category) continue // typing-analytics / keyboard-meta not in export contract yet
+        // typing-analytics / keyboard-meta / run-log not in export contract yet —
+        // run-log is deliberately absent (highest input-recovery-risk data; never leaves this device via Export Local Data)
+        if (!category) continue
         // bundleTypeToCategory only maps 'favorite' / 'layout' / 'settings',
         // so bundle.index is always a FavoriteIndex or SnapshotIndex here —
         // SyncBundle['index'] just isn't discriminated by ['type'] in the type system.

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -27,7 +27,10 @@ import {
   collectAllSyncUnits,
   collectAnalyticsSyncUnitsForUid,
   isAnalyticsSyncUnit,
+  isRunLogSyncUnit,
 } from './sync-bundle'
+import { isSafePathSegment } from '../utils/safe-filename'
+import { MAX_RUN_LOGS_PER_KEYBOARD } from '../../shared/types/typing-run-log'
 import {
   applyRemoteKeyboardMetaIndex,
   backfillKeyboardMeta,
@@ -153,9 +156,9 @@ export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean
   return syncUnit.startsWith(`keyboards/${scope.keyboard}/`)
 }
 
-// Re-export the analytics-sync-unit detector so existing callers
-// (sync-ipc, tests) keep importing it from sync-service.
-export { isAnalyticsSyncUnit }
+// Re-export the analytics/run-log sync-unit detectors so existing
+// callers (sync-ipc, tests) keep importing them from sync-service.
+export { isAnalyticsSyncUnit, isRunLogSyncUnit }
 
 async function listLocalKeyboardUids(): Promise<Set<string>> {
   const userData = app.getPath('userData')
@@ -180,8 +183,10 @@ export function shouldDownloadSyncUnit(
   // Keyboard-connect initial sync (useDeviceAutoSync) passes a
   // `{ favorites: true, keyboard }` scope. typing-analytics is pulled
   // separately when the Analyze panel opens — skip it here so the
-  // connect progress bar stays short.
-  if (typeof scope === 'object' && 'favorites' in scope && isAnalyticsSyncUnit(syncUnit)) {
+  // connect progress bar stays short. Run logs are excluded the same
+  // way (no per-uid keystroke count to show on the connect progress
+  // bar either) — see .claude/rules/settings-persistence.md Row E.
+  if (typeof scope === 'object' && 'favorites' in scope && (isAnalyticsSyncUnit(syncUnit) || isRunLogSyncUnit(syncUnit))) {
     return false
   }
   // Lazy: when scope is 'all' only download keyboards/<uid>/* that already exist locally.
@@ -571,26 +576,68 @@ async function mergeSyncUnit(
   const localEntries = gcTombstones((localIndex?.entries ?? []) as EntryMeta[])
   const remoteEntries = gcTombstones((remoteBundle.index as { entries: EntryMeta[] }).entries)
 
-  // Merge entries (both sides GC'd to prevent expired-tombstone upload loops)
+  // Merge entries (both sides GC'd to prevent expired-tombstone upload loops).
+  // Run-log retention is a deterministic trim (not reject-at-cap like
+  // analyze-filter/snapshot), applied as part of this same merge via
+  // `runLogRetentionMax` — see applyRunLogRetention's doc comment for why
+  // ranking by immutable `startedAt` lets two devices that independently
+  // exceeded the cap converge on the same kept set.
   const preserveLocalOrder = syncUnit === KEY_LABEL_SYNC_UNIT
-  const result = mergeEntries(localEntries, remoteEntries, { preserveLocalOrder })
+  const runLogRetentionMax = isRunLogSyncUnit(syncUnit) ? MAX_RUN_LOGS_PER_KEYBOARD : undefined
+  const result = mergeEntries(localEntries, remoteEntries, { preserveLocalOrder, runLogRetentionMax })
 
-  // Copy files from remote bundle for entries that remote won
+  // Copy files from remote bundle for entries that remote won. Every
+  // remote entry's filename must pass isSafePathSegment before it's
+  // joined into a local path — a remote bundle is attacker-reachable
+  // data (anyone who can write to this sync unit's Drive file), and this
+  // is the generic write site every index-based sync unit (favorites,
+  // snapshots, analyze-filter, key-label, typing-test-text, run logs)
+  // funnels through, so the guard has to live here rather than per-unit.
+  let unsafeRemoteFilenames = 0
   for (const filename of result.remoteFilesToCopy) {
+    if (!isSafePathSegment(filename)) {
+      unsafeRemoteFilenames++
+      continue
+    }
     if (filename in remoteBundle.files) {
       await writeFile(join(basePath, filename), remoteBundle.files[filename], 'utf-8')
     }
   }
+  if (unsafeRemoteFilenames > 0) {
+    log('warn', `sync: skipped ${unsafeRemoteFilenames} unsafe remote filename(s) for ${syncUnit}`)
+  }
 
   // Write merged index
-  const mergedIndex = localIndex
+  let mergedIndex = localIndex
     ? { ...localIndex, entries: result.entries }
     : remoteBundle.index
+
+  // For the remote-only-so-far branch (no local index yet) the retention
+  // trim above must still land in what gets written — narrow override
+  // kept to exactly this sync unit.
+  if (isRunLogSyncUnit(syncUnit)) {
+    mergedIndex = { ...mergedIndex, entries: result.entries }
+  }
+
   await writeFile(
     join(basePath, 'index.json'),
     JSON.stringify(mergedIndex, null, 2),
     'utf-8',
   )
+
+  // Unlink files for entries retention evicted during the merge above —
+  // best-effort, a file already gone is not an error. Always empty for
+  // every sync unit except run logs (runLogRetentionMax above). Inlined
+  // here (rather than shared with typing-run-log-store.ts's own local-save
+  // eviction) since this module already owns basePath/fs for this branch.
+  for (const meta of result.evicted) {
+    if (!isSafePathSegment(meta.filename)) continue
+    try {
+      await unlink(join(basePath, meta.filename))
+    } catch {
+      // best-effort
+    }
+  }
 
   return result.remoteNeedsUpdate
 }
@@ -1130,6 +1177,10 @@ async function pollForRemoteChanges(): Promise<void> {
       const syncUnit = syncUnitFromFileName(file.name)
       // analytics: handled by executeAnalyticsSync (Analyze panel mount).
       if (syncUnit && isAnalyticsSyncUnit(syncUnit)) return false
+      // run logs: no dedicated on-demand sync entry point yet (see
+      // isRunLogSyncUnit's doc comment) — before-quit flush and manual
+      // sync still cover it, 3-minute polling does not.
+      if (syncUnit && isRunLogSyncUnit(syncUnit)) return false
       return shouldDownloadSyncUnit(syncUnit, 'all', localKeyboardUids)
     })
 

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -1507,12 +1507,24 @@ function isValidKeyboard(value: unknown): value is TypingAnalyticsKeyboard {
  * press record) instead of letting it skew the per-cell histogram. */
 const MAX_MATRIX_RELEASE_DURATION_MS = 60_000
 
-function isValidMatrixCommon(obj: Record<string, unknown>): boolean {
+/** row/col/keycode validity (non-negative integers for row/col, any
+ * finite number for keycode) — shared with `typing-run-log-store.ts`'s
+ * per-keystroke validation, which carries the same three fields but no
+ * `layer` (a run-log keystroke isn't tagged by layer), hence this being
+ * split out from `isValidMatrixCommon` rather than that function being
+ * reused directly. */
+export function isValidRowColKeycode(obj: Record<string, unknown>): boolean {
   return (
     typeof obj.row === 'number' && Number.isInteger(obj.row) && obj.row >= 0 &&
     typeof obj.col === 'number' && Number.isInteger(obj.col) && obj.col >= 0 &&
-    typeof obj.layer === 'number' && Number.isInteger(obj.layer) && obj.layer >= 0 &&
     typeof obj.keycode === 'number' && Number.isFinite(obj.keycode)
+  )
+}
+
+function isValidMatrixCommon(obj: Record<string, unknown>): boolean {
+  return (
+    isValidRowColKeycode(obj) &&
+    typeof obj.layer === 'number' && Number.isInteger(obj.layer) && obj.layer >= 0
   )
 }
 

--- a/src/main/typing-run-log-ipc.ts
+++ b/src/main/typing-run-log-ipc.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// IPC wiring for the per-run raw keystroke log store — see
+// typing-run-log-store.ts for the actual read/write logic.
+
+import { IpcChannels } from '../shared/ipc/channels'
+import { secureHandle } from './ipc-guard'
+import { getRunLog, listRunLogs, saveRunLog } from './typing-run-log-store'
+
+export function setupTypingRunLogStore(): void {
+  secureHandle(
+    IpcChannels.TYPING_RUN_LOG_SAVE,
+    async (_event, uid: string, log: unknown) => saveRunLog(uid, log),
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_RUN_LOG_LIST,
+    async (_event, uid: string) => listRunLogs(uid),
+  )
+
+  secureHandle(
+    IpcChannels.TYPING_RUN_LOG_GET,
+    async (_event, uid: string, runId: string) => getRunLog(uid, runId),
+  )
+}

--- a/src/main/typing-run-log-store.ts
+++ b/src/main/typing-run-log-store.ts
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Per-run raw keystroke log store — save/list/get per keyboard. File
+// layout mirrors analyze-filter-store.ts (index.json + one JSON file per
+// entry under sync/keyboards/{uid}/runs/), but retention and trust model
+// differ deliberately:
+//
+//  - Retention is a deterministic TRIM (newest MAX_RUN_LOGS_PER_KEYBOARD
+//    kept, overflow tombstoned), not a reject-at-cap like
+//    analyze-filter-store / snapshot-store. The trim itself lives in
+//    `sync/merge.ts` (`applyRunLogRetention`), shared with
+//    `sync-service.ts`'s post-merge step for this sync unit — see that
+//    function's doc comment for why ranking by immutable `startedAt`
+//    (not local `savedAt`/LWW `updatedAt`) is what lets every device
+//    converge on the same kept set after a sync merge.
+//  - This is the highest input-content-recovery-risk data in the app
+//    (see `../shared/types/typing-run-log.ts`), so `saveRunLog` re-checks
+//    the recording-consent flag itself (main-side defense in depth,
+//    independent of the renderer's own gate) and validates the payload's
+//    shape/size/timestamps before writing anything to disk.
+//  - No delete endpoint: retention is the only eviction path. A
+//    renderer-reachable delete for this data is speculative until a
+//    timeline UI actually needs it.
+
+import { app } from 'electron'
+import { join } from 'node:path'
+import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
+import { getAppConfigStore } from './app-config'
+import { notifyChange } from './sync/sync-service'
+import { withWriteLock } from './per-uid-write-lock'
+import { applyRunLogRetention } from './sync/merge'
+import { isSafePathSegment, tsForFilename } from './utils/safe-filename'
+import { isValidRowColKeycode } from './typing-analytics/typing-analytics-service'
+import {
+  MAX_RUN_LOG_BYTES,
+  MAX_RUN_LOG_EVENTS,
+  MAX_RUN_LOGS_PER_KEYBOARD,
+  type RunKeystroke,
+  type RunKeystrokeLog,
+  type RunLogIndex,
+  type RunLogMeta,
+  type RunWord,
+} from '../shared/types/typing-run-log'
+
+/** How far past the run's own duration a keystroke timestamp may land
+ *  before it's rejected as implausible (clock jitter / rounding, not an
+ *  absolute-time leak) — see `validateRunLog`. */
+const TIMESTAMP_SLACK_MS = 5000
+
+function getStoreDir(uid: string): string {
+  return join(app.getPath('userData'), 'sync', 'keyboards', uid, 'runs')
+}
+
+function getIndexPath(uid: string): string {
+  return join(getStoreDir(uid), 'index.json')
+}
+
+function getSafeFilePath(uid: string, filename: string): string {
+  if (!isSafePathSegment(filename)) throw new Error('Invalid filename')
+  return join(getStoreDir(uid), filename)
+}
+
+async function readIndex(uid: string): Promise<RunLogIndex> {
+  try {
+    const raw = await readFile(getIndexPath(uid), 'utf-8')
+    const parsed = JSON.parse(raw) as RunLogIndex
+    if (parsed.uid === uid && Array.isArray(parsed.entries)) return parsed
+  } catch {
+    // Missing or corrupt — start fresh
+  }
+  return { uid, entries: [] }
+}
+
+async function writeIndex(uid: string, index: RunLogIndex): Promise<void> {
+  await writeFile(getIndexPath(uid), JSON.stringify(index, null, 2), 'utf-8')
+}
+
+/** Best-effort unlink of the entries `applyRunLogRetention` just evicted
+ *  during a local save — never throws (a file already gone, e.g. from a
+ *  previous partial trim, is not an error). Kept private and separate
+ *  from `sync-service.ts`'s own inline unlink for the same eviction
+ *  during a merge: the two run under different write-lock/ownership
+ *  assumptions, so duplicating this handful of lines is simpler than
+ *  sharing it across a module boundary that isn't otherwise coupled. */
+async function unlinkEvictedRunLogs(dir: string, entries: readonly RunLogMeta[]): Promise<void> {
+  for (const meta of entries) {
+    if (!isSafePathSegment(meta.filename)) continue
+    try {
+      await unlink(join(dir, meta.filename))
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+/** Best-effort reconciliation: unlink any `*.json` payload file in the
+ *  runs dir that appears in NEITHER `index.entries` nor its tombstones —
+ *  a tombstoned entry still carries its own `filename` (`applyRunLogRetention`
+ *  spreads the original entry when converting it), so this only ever
+ *  catches a file the index has no memory of at all, e.g. one left behind
+ *  by an index write that failed or was corrupted after its payload was
+ *  already written. Cheap: `MAX_RUN_LOGS_PER_KEYBOARD` retention already
+ *  bounds this directory to a small number of files, so a full `readdir`
+ *  on every save is not a scaling concern. Never throws — a listing or
+ *  unlink failure here is not fatal to the save that just succeeded. */
+async function reconcileOrphanRunLogFiles(dir: string, index: RunLogIndex): Promise<void> {
+  const known = new Set(index.entries.map((e) => e.filename))
+  let files: string[]
+  try {
+    files = await readdir(dir)
+  } catch {
+    return
+  }
+  for (const file of files) {
+    if (file === 'index.json') continue
+    if (!file.endsWith('.json')) continue
+    if (known.has(file)) continue
+    if (!isSafePathSegment(file)) continue
+    try {
+      await unlink(join(dir, file))
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+function isRecordingConsentAccepted(): boolean {
+  return getAppConfigStore().get('typingRecordingConsentAccepted') === true
+}
+
+function isValidKeystroke(value: unknown, durationMs: number): value is RunKeystroke {
+  if (!value || typeof value !== 'object') return false
+  const k = value as Record<string, unknown>
+  if (typeof k.pressMs !== 'number' || !Number.isFinite(k.pressMs)) return false
+  const bound = durationMs + TIMESTAMP_SLACK_MS
+  if (k.pressMs < 0 || k.pressMs > bound) return false
+  if (k.releaseMs !== undefined) {
+    if (typeof k.releaseMs !== 'number' || !Number.isFinite(k.releaseMs)) return false
+    if (k.releaseMs < k.pressMs || k.releaseMs > bound) return false
+  }
+  if (!isValidRowColKeycode(k)) return false
+  if (k.expectedChar !== undefined && typeof k.expectedChar !== 'string') return false
+  if (k.correct !== undefined && typeof k.correct !== 'boolean') return false
+  if (k.overlapped !== undefined && typeof k.overlapped !== 'boolean') return false
+  return true
+}
+
+function isValidWord(value: unknown, durationMs: number): value is RunWord {
+  if (!value || typeof value !== 'object') return false
+  const w = value as Record<string, unknown>
+  if (typeof w.index !== 'number' || !Number.isInteger(w.index)) return false
+  if (w.index < 0) return false
+  if (w.partial !== undefined && typeof w.partial !== 'boolean') return false
+  if (typeof w.display !== 'string') return false
+  if (typeof w.typed !== 'string') return false
+  if (typeof w.correct !== 'boolean') return false
+  if (!Array.isArray(w.keystrokes)) return false
+  return w.keystrokes.every((k) => isValidKeystroke(k, durationMs))
+}
+
+/** Structural + size + timestamp validation for a run log about to be
+ *  saved — main-side defense in depth, independent of whatever the
+ *  renderer already enforced (`run-log-recorder.ts`'s own caps).
+ *  `expectedUid` must match the payload's own `uid` field. Returns the
+ *  already-serialized JSON alongside the validated data so `saveRunLog`
+ *  doesn't stringify the (potentially ~1MB) payload a second time. */
+function validateRunLog(
+  raw: unknown,
+  expectedUid: string,
+): { ok: true; data: RunKeystrokeLog; serialized: string } | { ok: false; error: string } {
+  if (!raw || typeof raw !== 'object') return { ok: false, error: 'Malformed run log' }
+  const log = raw as Record<string, unknown>
+  if (typeof log.runId !== 'string' || !isSafePathSegment(log.runId)) return { ok: false, error: 'Invalid runId' }
+  if (typeof log.uid !== 'string' || log.uid !== expectedUid) return { ok: false, error: 'uid mismatch' }
+  if (typeof log.startedAt !== 'string' || Number.isNaN(new Date(log.startedAt).getTime())) return { ok: false, error: 'Invalid startedAt' }
+  if (typeof log.durationMs !== 'number' || !Number.isFinite(log.durationMs) || log.durationMs < 0) return { ok: false, error: 'Invalid durationMs' }
+  if (typeof log.mode !== 'string') return { ok: false, error: 'Invalid mode' }
+  if (typeof log.language !== 'string') return { ok: false, error: 'Invalid language' }
+  if (log.charCorrelationUnavailable !== undefined && typeof log.charCorrelationUnavailable !== 'boolean') {
+    return { ok: false, error: 'Invalid charCorrelationUnavailable' }
+  }
+  if (!Array.isArray(log.words)) return { ok: false, error: 'Invalid words' }
+
+  const words: RunWord[] = []
+  let eventCount = 0
+  for (const word of log.words) {
+    if (!isValidWord(word, log.durationMs)) return { ok: false, error: 'Invalid word entry' }
+    words.push(word)
+    eventCount += word.keystrokes.length
+  }
+  if (eventCount > MAX_RUN_LOG_EVENTS) return { ok: false, error: 'Too many keystrokes' }
+
+  let serialized: string
+  try {
+    serialized = JSON.stringify(log)
+  } catch {
+    return { ok: false, error: 'Unserializable run log' }
+  }
+  if (Buffer.byteLength(serialized, 'utf-8') > MAX_RUN_LOG_BYTES) return { ok: false, error: 'Run log too large' }
+
+  return {
+    ok: true,
+    data: {
+      runId: log.runId,
+      uid: log.uid,
+      startedAt: log.startedAt,
+      durationMs: log.durationMs,
+      mode: log.mode,
+      language: log.language,
+      charCorrelationUnavailable: log.charCorrelationUnavailable,
+      words,
+    },
+    serialized,
+  }
+}
+
+export async function saveRunLog(uid: string, raw: unknown): Promise<{ success: boolean; entry?: RunLogMeta; error?: string }> {
+  if (!isSafePathSegment(uid)) return { success: false, error: 'Invalid uid' }
+  if (!isRecordingConsentAccepted()) {
+    return { success: false, error: 'Recording consent not accepted' }
+  }
+  const validated = validateRunLog(raw, uid)
+  if (!validated.ok) return { success: false, error: validated.error }
+  const log = validated.data
+
+  return withWriteLock(uid, async () => {
+    try {
+      const dir = getStoreDir(uid)
+      await mkdir(dir, { recursive: true })
+
+      const now = new Date()
+      const filename = `${tsForFilename(now)}_${log.runId}.json`
+      await writeFile(getSafeFilePath(uid, filename), validated.serialized, 'utf-8')
+
+      const index = await readIndex(uid)
+      const nowIso = now.toISOString()
+      const meta: RunLogMeta = { id: log.runId, startedAt: log.startedAt, filename, savedAt: nowIso, updatedAt: nowIso }
+      // Replace-by-id defensively (a run only finishes once per the
+      // renderer's own save latch, but never trust that from here). The
+      // replaced entry's own payload file (a different filename — the
+      // timestamp prefix differs) must be unlinked too, or it leaks on
+      // disk forever: it's gone from the index either way, so retention
+      // will never see or evict it.
+      const existingDup = index.entries.find((e) => e.id === meta.id)
+      const withoutDup = index.entries.filter((e) => e.id !== meta.id)
+      const { entries, evicted } = applyRunLogRetention([meta, ...withoutDup], MAX_RUN_LOGS_PER_KEYBOARD)
+      index.entries = entries
+      await writeIndex(uid, index)
+      await unlinkEvictedRunLogs(dir, evicted)
+      if (existingDup && existingDup.filename !== meta.filename) {
+        await unlinkEvictedRunLogs(dir, [existingDup])
+      }
+      // Corrupt-index reconciliation (defense in depth, not this save's
+      // own concern): a payload file the index has no memory of at all —
+      // e.g. left behind by a previous save whose index write failed
+      // after its payload was already on disk — would otherwise never be
+      // evicted by retention (which only ever sees indexed entries),
+      // silently defeating the disk bound this data class relies on.
+      await reconcileOrphanRunLogFiles(dir, index)
+
+      notifyChange(`keyboards/${uid}/runs`)
+      return { success: true, entry: meta }
+    } catch (err) {
+      return { success: false, error: String(err) }
+    }
+  })
+}
+
+export async function listRunLogs(uid: string): Promise<{ success: boolean; entries?: RunLogMeta[]; error?: string }> {
+  if (!isSafePathSegment(uid)) return { success: false, error: 'Invalid uid' }
+  try {
+    const index = await readIndex(uid)
+    return { success: true, entries: index.entries.filter((e) => !e.deletedAt) }
+  } catch (err) {
+    return { success: false, error: String(err) }
+  }
+}
+
+export async function getRunLog(uid: string, runId: string): Promise<{ success: boolean; data?: RunKeystrokeLog; error?: string }> {
+  if (!isSafePathSegment(uid)) return { success: false, error: 'Invalid uid' }
+  try {
+    const index = await readIndex(uid)
+    const meta = index.entries.find((e) => e.id === runId)
+    if (!meta || meta.deletedAt) return { success: false, error: 'Not found' }
+    const raw = await readFile(getSafeFilePath(uid, meta.filename), 'utf-8')
+    return { success: true, data: JSON.parse(raw) as RunKeystrokeLog }
+  } catch (err) {
+    return { success: false, error: String(err) }
+  }
+}

--- a/src/main/utils/safe-filename.ts
+++ b/src/main/utils/safe-filename.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// Re-export the shared `safeFilename` helper for backwards-compat
-// with main-process call sites. The implementation lives in
-// `src/shared/utils/safe-filename.ts` so the renderer can use it
+// Re-export the shared path-safety helpers for backwards-compat
+// with main-process call sites. The implementations live in
+// `src/shared/utils/safe-filename.ts` so the renderer can use them
 // without crossing the process boundary.
 
-export { safeFilename } from '../../shared/utils/safe-filename'
+export { safeFilename, isSafePathSegment, tsForFilename } from '../../shared/utils/safe-filename'

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -12,6 +12,7 @@ import type { DeviceInfo, KeyboardDefinition, ProbeResult } from '../shared/type
 import type { TrayStatus } from '../shared/types/vial-api'
 import type { SnapshotMeta } from '../shared/types/snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from '../shared/types/analyze-filter-store'
+import type { RunKeystrokeLog, RunLogMeta } from '../shared/types/typing-run-log'
 import type { SavedFavoriteMeta, FavoriteImportResult } from '../shared/types/favorite-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult, KeyLabelImportBatchResult } from '../shared/types/key-label-store'
 import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from '../shared/types/typing-test-text-store'
@@ -248,6 +249,14 @@ const vialAPI = {
     ipcRenderer.invoke(IpcChannels.ANALYZE_FILTER_STORE_RENAME, uid, entryId, newLabel),
   analyzeFilterStoreDelete: (uid: string, entryId: string): Promise<{ success: boolean; error?: string }> =>
     ipcRenderer.invoke(IpcChannels.ANALYZE_FILTER_STORE_DELETE, uid, entryId),
+
+  // --- Typing Run Log Store (per-run raw keystroke log) ---
+  typingRunLogSave: (uid: string, log: RunKeystrokeLog): Promise<{ success: boolean; entry?: RunLogMeta; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_RUN_LOG_SAVE, uid, log),
+  typingRunLogList: (uid: string): Promise<{ success: boolean; entries?: RunLogMeta[]; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_RUN_LOG_LIST, uid),
+  typingRunLogGet: (uid: string, runId: string): Promise<{ success: boolean; data?: RunKeystrokeLog; error?: string }> =>
+    ipcRenderer.invoke(IpcChannels.TYPING_RUN_LOG_GET, uid, runId),
 
   // --- Favorite Store (internal save/load via IPC) ---
   favoriteStoreList: (type: string): Promise<{ success: boolean; entries?: SavedFavoriteMeta[]; error?: string }> =>

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -101,6 +101,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     onTypingTestConfigChange, onTypingTestLanguageChange, onSaveTypingTestResult, onRenameTypingTestResult, saveUnnamed: typingTestSaveUnnamed, typingTestHistory,
     savedTypingTestMemory, onTypingTestMemoryChange,
     typingTestViewOnly, typingRecordEnabled, onRecKeystroke,
+    recordingConsentAccepted: typingRecordingConsentAccepted,
     typingRecordKeyboard: keyboardUid && connectedDevice
       ? {
           uid: keyboardUid,

--- a/src/renderer/components/editors/__tests__/useInputModes.run-log.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.run-log.test.tsx
@@ -1,0 +1,407 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useInputModes } from '../useInputModes'
+import { getFileImportTextData, clearFileImportTextCache } from '../../../typing-test/word-generator'
+import type { TypingTestMemory } from '../../../../shared/types/pipette-settings'
+
+const mockTypingAnalyticsEvent = vi.fn<(event: unknown) => Promise<void>>()
+const mockTypingAnalyticsFlush = vi.fn<(uid: string) => Promise<void>>()
+const mockTypingRunLogSave = vi.fn<(uid: string, log: unknown) => Promise<{ success: boolean }>>()
+
+function installVialApi(): void {
+  Object.defineProperty(window, 'vialAPI', {
+    value: {
+      typingAnalyticsEvent: mockTypingAnalyticsEvent,
+      typingAnalyticsFlush: mockTypingAnalyticsFlush,
+      typingRunLogSave: mockTypingRunLogSave,
+    },
+    writable: true,
+    configurable: true,
+  })
+}
+
+beforeEach(() => {
+  mockTypingAnalyticsEvent.mockReset().mockResolvedValue(undefined)
+  mockTypingAnalyticsFlush.mockReset().mockResolvedValue(undefined)
+  mockTypingRunLogSave.mockReset().mockResolvedValue({ success: true })
+  installVialApi()
+  vi.useFakeTimers({ toFake: ['Date'] })
+  vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  clearFileImportTextCache()
+})
+
+async function flushMicrotasks(rounds = 10): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < rounds; i++) {
+      await Promise.resolve()
+    }
+  })
+}
+
+function buildKeymap(): Map<string, number> {
+  const m = new Map<string, number>()
+  m.set('0,0,0', 0x04) // KC_A
+  return m
+}
+
+const sampleKeyboard = {
+  uid: '0xAABB',
+  vendorId: 0xFEED,
+  productId: 0x0000,
+  productName: 'Pipette Keyboard',
+}
+
+/** Shared setup for the three tests exercising a real (non-viewOnly)
+ *  practice run through to completion — a `wordCount`-word run, unlocked,
+ *  with the given initial consent. `rerender({ recordingConsentAccepted })`
+ *  flips consent mid-run for the revocation test. */
+function renderRunLogHook({ consent, wordCount }: { consent: boolean; wordCount: number }) {
+  const onSaveTypingTestResult = vi.fn()
+  const stableKeymap = buildKeymap()
+  const stableConfig = { mode: 'words' as const, wordCount, punctuation: false, numbers: false }
+  return renderHook(
+    ({ recordingConsentAccepted }: { recordingConsentAccepted: boolean }) => useInputModes({
+      rows: 1,
+      cols: 1,
+      keymap: stableKeymap,
+      unlocked: true,
+      typingTestMode: true,
+      typingTestViewOnly: false,
+      typingRecordKeyboard: sampleKeyboard,
+      onSaveTypingTestResult,
+      savedTypingTestConfig: stableConfig,
+      recordingConsentAccepted,
+    }),
+    { initialProps: { recordingConsentAccepted: consent } },
+  )
+}
+
+describe('useInputModes — run-log recording', () => {
+  it('never saves a run log for pure REC input (typingTestViewOnly), even with consent granted', async () => {
+    const keymap = buildKeymap()
+    const { result } = renderHook(() => useInputModes({
+      rows: 1,
+      cols: 1,
+      keymap,
+      typingTestMode: true,
+      typingTestViewOnly: true,
+      typingRecordEnabled: true,
+      typingRecordKeyboard: sampleKeyboard,
+      recordingConsentAccepted: true,
+    }))
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+    await flushMicrotasks()
+
+    // The per-minute analytics pipeline still runs (untagged REC input) —
+    // it's the run-log save specifically that must never fire.
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalled()
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+
+  it('saves a run log once a tagged practice run finishes, with consent granted', async () => {
+    const { result } = renderRunLogHook({ consent: true, wordCount: 1 })
+    const keymap = buildKeymap()
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    const [word] = result.current.typingTest.state.words
+    const runId = result.current.typingTest.state.runId
+    for (const char of word) {
+      // A real keystroke is both a matrix press/release (registers the
+      // word attribution noteRegistration needs — see run-log-recorder.ts's
+      // `record()` doc comment on why it never mints a buffer on its own)
+      // and the DOM char event; drive both so there's something to save.
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
+    const [savedUid, savedLog] = mockTypingRunLogSave.mock.calls[0] as [string, { runId: string; uid: string }]
+    expect(savedUid).toBe(sampleKeyboard.uid)
+    expect(savedLog.runId).toBe(runId)
+    expect(savedLog.uid).toBe(sampleKeyboard.uid)
+  })
+
+  it('never saves a run log without recording consent, even for a completed practice run', async () => {
+    const { result } = renderRunLogHook({ consent: false, wordCount: 1 })
+    const keymap = buildKeymap()
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    const [word] = result.current.typingTest.state.words
+    for (const char of word) {
+      // Drive both the matrix press/release (what noteRegistration/record
+      // actually gate on) and the DOM char event, same as the passing
+      // "saves a run log" test above — without the matrix side, this test
+      // could never fail regardless of the consent gate (nothing would
+      // ever have entered the buffer in the first place).
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+
+  it('discards the buffer when consent is revoked mid-run, so the finished run is not saved', async () => {
+    const { result, rerender } = renderRunLogHook({ consent: true, wordCount: 2 })
+    const keymap = buildKeymap()
+
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    const [firstWord] = result.current.typingTest.state.words
+    for (const char of firstWord) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    act(() => {
+      result.current.typingTest.processKeyEvent(' ', false, false, false)
+    })
+    expect(result.current.typingTest.state.status).not.toBe('finished')
+
+    // Consent revoked mid-run — the recorder's buffer must be discarded
+    // immediately, before the run goes on to finish.
+    rerender({ recordingConsentAccepted: false })
+
+    const [secondWord] = result.current.typingTest.state.words.slice(1)
+    for (const char of secondWord) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+
+  it('does not attribute matrix keystrokes registered while unfocused, but resumes once refocused (P1)', async () => {
+    // Two words: the first is typed and submitted entirely while
+    // focused, which puts the run solidly mid-'running' (regardless of
+    // either word's length) before the unfocused phase — avoids the
+    // waiting->running transition edge (see testLabelRef's own gating
+    // comment in useInputModes.ts), where the very first keystroke of a
+    // run goes untagged for an unrelated, pre-existing reason.
+    const { result } = renderRunLogHook({ consent: true, wordCount: 2 })
+    const keymap = buildKeymap()
+
+    // Let useInputModes's mount-time "sync saved config" effect settle
+    // BEFORE reading any state below — that effect fires exactly once
+    // per (re)mount (it's a no-op afterward, since savedTypingTestConfig's
+    // reference is stable across this hook's renders) and calls
+    // typingTest.setConfig(), which regenerates words/runId asynchronously.
+    // Every other test in this suite dodges it by never `await`-ing
+    // mid-run (so it never gets a chance to fire until after the run has
+    // already finished synchronously); THIS test needs an early `await`
+    // to observe the per-minute analytics call while still unfocused, so
+    // it must flush the one-time reset up front instead, or it would fire
+    // mid-run and reset currentWordIndex/words/runId out from under it.
+    await flushMicrotasks()
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    const [word1, word2] = result.current.typingTest.state.words
+    for (const char of word1) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    act(() => {
+      result.current.typingTest.processKeyEvent(' ', false, false, false)
+    })
+    expect(result.current.typingTest.state.currentWordIndex).toBe(1)
+    expect(result.current.typingTest.state.status).toBe('running')
+
+    // Alt-tab away mid-run: a press on the SAME physical keyboard, typed
+    // into an entirely different, unfocused application — must never be
+    // attributed to the run log. No processKeyEvent accompanies it (a
+    // foreign app's keydown never reaches this app's char handler), so
+    // word2's own input is untouched by this.
+    act(() => {
+      result.current.typingTest.setWindowFocused(false)
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+    await flushMicrotasks()
+    // The per-minute analytics pipeline is unaffected by focus.
+    expect(mockTypingAnalyticsEvent).toHaveBeenCalled()
+    mockTypingAnalyticsEvent.mockClear()
+
+    // Refocus and finish typing word2 (the whole word — nothing of it was
+    // consumed above) normally.
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    for (const char of word2) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
+    const [, savedLog] = mockTypingRunLogSave.mock.calls[0] as [string, { words: { keystrokes: unknown[] }[] }]
+    const totalKeystrokes = savedLog.words.reduce((sum, w) => sum + w.keystrokes.length, 0)
+    // The very first char of word1 lands while status is still 'waiting'
+    // (untagged — an existing, unrelated trade-off, see testLabelRef's
+    // own comment), so exactly `word1.length - 1 + word2.length` presses
+    // are attributable in this exact drive pattern. The point of this
+    // assertion is that the unfocused press did not add a spurious +1.
+    expect(totalKeystrokes).toBe(word1.length - 1 + word2.length)
+  })
+
+  it('discards the buffer on pause, so a resumed-then-finished run saves no raw log (P3)', async () => {
+    // Pause/resume (memory mode) only exists for imported fileImport
+    // text — captureMemory() returns null for every other mode, so
+    // pauseTypingTest() is a no-op there. Set up a one-word fileImport
+    // text ("hello") the same way useTypingTest.fileImportText.test.ts does.
+    const mockGet = vi.fn().mockResolvedValue({
+      success: true,
+      data: { meta: { id: 't' }, data: { name: 'T', text: 'hello' } },
+    })
+    window.vialAPI = {
+      ...window.vialAPI,
+      typingTestTextStoreGet: mockGet,
+    } as unknown as typeof window.vialAPI
+    await getFileImportTextData('t')
+
+    const onSaveTypingTestResult = vi.fn()
+    const onTypingTestMemoryChange = vi.fn()
+    const keymap = buildKeymap()
+    const { result, rerender } = renderHook(
+      ({ savedTypingTestMemory }: { savedTypingTestMemory?: TypingTestMemory }) => useInputModes({
+        rows: 1,
+        cols: 1,
+        keymap,
+        unlocked: true,
+        typingTestMode: true,
+        typingTestViewOnly: false,
+        typingRecordKeyboard: sampleKeyboard,
+        onSaveTypingTestResult,
+        savedTypingTestConfig: { mode: 'fileImport', textId: 't' },
+        savedTypingTestMemory,
+        onTypingTestMemoryChange,
+        recordingConsentAccepted: true,
+      }),
+      { initialProps: {} },
+    )
+
+    await flushMicrotasks()
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    expect(result.current.typingTest.state.words).toEqual(['hello'])
+
+    // Type "he" (2 of 5 chars), then pause.
+    for (const char of ['h', 'e']) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+
+    // Pause mid-run — the run-log buffer must be discarded immediately.
+    act(() => {
+      result.current.pauseTypingTest()
+    })
+    expect(onTypingTestMemoryChange).toHaveBeenCalled()
+    const savedMemory = onTypingTestMemoryChange.mock.calls[0][0] as TypingTestMemory
+    expect(savedMemory.currentInput).toBe('he')
+
+    // Feed the captured memory back in (mirrors the real caller
+    // persisting it to device prefs and passing it back down) and resume.
+    rerender({ savedTypingTestMemory: savedMemory })
+    act(() => {
+      result.current.resumeTypingTest()
+    })
+    await flushMicrotasks()
+
+    // Finish the run — the summary result still saves normally (memory
+    // mode is unaffected), but no raw keystroke log should ever be sent.
+    for (const char of ['l', 'l', 'o']) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(onSaveTypingTestResult).toHaveBeenCalled()
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/editors/use-run-log-recorder.ts
+++ b/src/renderer/components/editors/use-run-log-recorder.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Owns the per-session RunLogRecorder instance (see run-log-recorder.ts)
+ *  and the refs it needs to gate on, so `useInputModes` doesn't have to.
+ *  Exposes exactly the five call shapes it needs:
+ *   - `record` at the per-minute analytics emit seam.
+ *   - `noteRegistration` — a direct drop-in for useTypingTest's
+ *     `onNoteKeystrokeRegistration` option (same signature, no wrapping
+ *     needed at the call site).
+ *   - `noteCharContext` — the same drop-in shape for
+ *     `onNoteCharContext`, resolving its thunk itself before forwarding
+ *     to the recorder's own (non-thunk) `noteCharContext` — see its own
+ *     doc comment for why this keeps the "derivation is free while
+ *     gated off" property matching `noteRegistration`'s.
+ *   - `finishAndSave` for the finished-run effect: discards outright when
+ *     there's no active keyboard uid to save under, otherwise finalizes
+ *     and saves.
+ *   - `discardRun` for the pause handler (see useInputModes's
+ *     `pauseTypingTest`) — a paused run's raw timeline would otherwise
+ *     be corrupted by the pause gap once resumed (see
+ *     run-log-recorder.ts's `discardRun()`), so the summary result still
+ *     pauses/resumes normally but the raw log does not, even once typing
+ *     resumes under the same runId.
+ *  Also owns the two discard-on-teardown effects (consent revoked
+ *  mid-run, active keyboard changed). */
+
+import { useCallback, useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import { RunLogRecorder, type RunLogRecordContext, type RunLogFinishMeta } from '../../typing-test/run-log-recorder'
+import type { TypingAnalyticsEventPayload } from '../../../shared/types/typing-analytics'
+import type { WordResult } from '../../typing-test/run-state'
+
+export interface UseRunLogRecorderOptions {
+  /** `AppConfig.typingRecordingConsentAccepted`. */
+  recordingConsentAccepted?: boolean
+  /** Active keyboard's uid, if any — the buffer is discarded (never
+   *  saved) whenever this changes. */
+  keyboardUid?: string
+  /** `useInputModes`'s own testLabelRef, forwarded BY REFERENCE (not by
+   *  value): `noteRegistration` is called directly as useTypingTest's
+   *  option, with no notion of tagging, so it must read the label live at
+   *  invocation time rather than whatever it was when this hook last
+   *  rendered — passing the stable ref object sidesteps that entirely. */
+  typingTestLabelRef: RefObject<string | null>
+}
+
+export interface UseRunLogRecorderReturn {
+  record: (tag: Pick<RunLogRecordContext, 'typingTestLabel' | 'runId' | 'windowFocused'>, payload: TypingAnalyticsEventPayload) => void
+  noteRegistration: (
+    runId: string, row: number, col: number, ts: number, wordIndex: number,
+    getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => void
+  noteCharContext: (
+    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => void
+  finishAndSave: (uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>) => void
+  /** Discard `runId`'s buffer and block it from being re-buffered later
+   *  under the same id — see the module doc comment's `discardRun`
+   *  bullet and run-log-recorder.ts's `discardRun()`. */
+  discardRun: (runId: string) => void
+}
+
+export function useRunLogRecorder({
+  recordingConsentAccepted = false,
+  keyboardUid,
+  typingTestLabelRef,
+}: UseRunLogRecorderOptions): UseRunLogRecorderReturn {
+  const recorderRef = useRef(new RunLogRecorder())
+  const consentRef = useRef(recordingConsentAccepted)
+  consentRef.current = recordingConsentAccepted
+
+  // Discard the run-log buffer on consent revocation, a keyboard switch,
+  // or unmount — never finalize/save a buffer whose gating condition no
+  // longer holds.
+  useEffect(() => {
+    if (!recordingConsentAccepted) recorderRef.current.discard()
+  }, [recordingConsentAccepted])
+  useEffect(() => {
+    const recorder = recorderRef.current
+    return () => recorder.discard()
+  }, [keyboardUid])
+
+  const record = useCallback((tag: Pick<RunLogRecordContext, 'typingTestLabel' | 'runId' | 'windowFocused'>, payload: TypingAnalyticsEventPayload) => {
+    recorderRef.current.record({ ...tag, consentAccepted: consentRef.current }, payload)
+  }, [])
+
+  const noteRegistration = useCallback((
+    runId: string, row: number, col: number, ts: number, wordIndex: number,
+    getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => {
+    const typingTestLabel = typingTestLabelRef.current
+    recorderRef.current.noteRegistration(
+      { typingTestLabel, runId: typingTestLabel ? runId : null, consentAccepted: consentRef.current, windowFocused },
+      row, col, ts, wordIndex, getExpectedChar,
+    )
+  }, [typingTestLabelRef])
+
+  const noteCharContext = useCallback((
+    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => {
+    const typingTestLabel = typingTestLabelRef.current
+    // Skip the (possibly expensive, for romaji) derivation whenever no
+    // test label is active, same as noteRegistration's `runId` gate
+    // below — the recorder's own `noteCharContext` takes an
+    // already-resolved value rather than a thunk (see its doc comment),
+    // so this wrapper is what has to defer calling `getExpectedChar`.
+    recorderRef.current.noteCharContext(
+      { typingTestLabel, runId: typingTestLabel ? runId : null, consentAccepted: consentRef.current, windowFocused },
+      wordIndex, typingTestLabel ? getExpectedChar() : undefined,
+    )
+  }, [typingTestLabelRef])
+
+  const finishAndSave = useCallback((
+    uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>,
+  ) => {
+    if (!uid) {
+      recorderRef.current.discard()
+      return
+    }
+    const log = recorderRef.current.finish(wordResults, { ...meta, uid })
+    if (log) void window.vialAPI.typingRunLogSave(uid, log)
+  }, [])
+
+  const discardRun = useCallback((runId: string) => {
+    recorderRef.current.discardRun(runId)
+  }, [])
+
+  return { record, noteRegistration, noteCharContext, finishAndSave, discardRun }
+}

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -6,6 +6,7 @@ import { buildTypingTestResult, isPbForConfig, materialLabel } from '../../typin
 import { isRomajiInputActive } from '../../typing-test/romaji-input'
 import type { TypingTestConfig } from '../../typing-test/types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../typing-test/types'
+import { useRunLogRecorder } from './use-run-log-recorder'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingAnalyticsEventPayload, TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
 import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
@@ -36,6 +37,13 @@ interface PreparedAnalyticsContext {
   keyboard: TypingAnalyticsKeyboard
   typingTest: string | null
   runId: string | null
+  /** Window-focus state snapshotted at press time (see useTypingTest's
+   *  `onPrepareAnalyticsEvent` doc comment) — carried through to
+   *  `emitAnalyticsEvent` so the run-log recorder's defense-in-depth gate
+   *  (see run-log-recorder.ts's PRIVACY note) checks the value as of
+   *  when this keystroke actually happened, not whatever focus is by the
+   *  time a queued masked-key event finally ships. */
+  windowFocused: boolean
 }
 
 export interface UseInputModesOptions {
@@ -78,6 +86,10 @@ export interface UseInputModesOptions {
    * tap/hold classification. Defaults to QMK's 200 ms when the
    * keyboard hasn't reported one. */
   tappingTermMs?: number
+  /** `AppConfig.typingRecordingConsentAccepted` — gates the per-run raw
+   * keystroke log (see run-log-recorder.ts), independently of and
+   * stricter than `typingRecordEnabled`'s per-minute analytics gate. */
+  recordingConsentAccepted?: boolean
 }
 
 export interface UseInputModesReturn {
@@ -128,6 +140,7 @@ export function useInputModes({
   typingRecordKeyboard,
   onRecKeystroke,
   tappingTermMs,
+  recordingConsentAccepted = false,
 }: UseInputModesOptions): UseInputModesReturn {
   // --- Matrix tester state ---
   const [matrixMode, setMatrixMode] = useState(false)
@@ -225,6 +238,14 @@ export function useInputModes({
   const testRunIdRef = useRef<string | null>(null)
   const onRecKeystrokeRef = useRef(onRecKeystroke)
   onRecKeystrokeRef.current = onRecKeystroke
+  // Per-run raw keystroke log recorder (see run-log-recorder.ts and
+  // use-run-log-recorder.ts) — one instance per editor session, mirroring
+  // matrixQueueRef's construction style in useTypingTest.ts.
+  const runLog = useRunLogRecorder({
+    recordingConsentAccepted,
+    keyboardUid: typingRecordKeyboard?.uid,
+    typingTestLabelRef: testLabelRef,
+  })
   // The sink used to read recordingActiveRef / testLabelRef / testRunIdRef
   // at the moment an event was actually sent, but a matrix event can now
   // sit in useTypingTest's ordering queue for up to the tapping term
@@ -240,7 +261,7 @@ export function useInputModes({
   // back of the queue) fixes that: prepare captures the gate + tag
   // decision when the keystroke happens and hands back an opaque
   // context; emit only ever ships what prepare already decided.
-  const prepareAnalyticsEvent = useCallback((kind: 'matrix' | 'char'): PreparedAnalyticsContext | null => {
+  const prepareAnalyticsEvent = useCallback((kind: 'matrix' | 'char', windowFocused: boolean): PreparedAnalyticsContext | null => {
     const keyboard = keyboardRef.current
     if (!keyboard) return null
     const label = testLabelRef.current
@@ -262,7 +283,7 @@ export function useInputModes({
     }
     // A test keystroke carries both its material label and its run id; REC
     // input carries neither (so it lands as the null run / null test).
-    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null }
+    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null, windowFocused }
   }, [])
   // Ordering contract, not an optimization: chaining every emit behind the
   // previous one's IPC guarantees at most one typingAnalyticsEvent invoke
@@ -287,6 +308,11 @@ export function useInputModes({
   //     whatever tie/out-of-order pair still slips through all of the above.
   const chainRef = useRef<Promise<void>>(Promise.resolve())
   const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
+    // Run-keystroke-log capture — gates itself independently (see
+    // RunLogRecordContext); a no-op for ordinary REC input (context.typingTest
+    // null), without recording consent, or without window focus (see
+    // context.windowFocused's doc comment).
+    runLog.record({ typingTestLabel: context.typingTest, runId: context.runId, windowFocused: context.windowFocused }, payload)
     const event = context.typingTest
       ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
       : { ...payload, keyboard: context.keyboard }
@@ -331,6 +357,12 @@ export function useInputModes({
   const typingTest = useTypingTest(savedTypingTestConfig, savedTypingTestLanguage, {
     onPrepareAnalyticsEvent: prepareAnalyticsEvent,
     onEmitAnalyticsEvent: emitAnalyticsEvent,
+    // A direct passthrough — runLog.noteRegistration re-checks the label/
+    // consent gate itself (same privacy-critical gate `record` uses
+    // above), so ambient REC frames (testLabelRef null) never touch the
+    // recorder buffer at all, not even to register.
+    onNoteKeystrokeRegistration: runLog.noteRegistration,
+    onNoteCharContext: runLog.noteCharContext,
     tappingTermMs,
   })
   const {
@@ -526,6 +558,31 @@ export function useInputModes({
       // both settle first.
       const uid = keyboardRef.current?.uid
       if (uid) flushAfterPendingEmits(resetMatrixPressTracking(), uid)
+      // The word the run ended on without submitting (e.g. a timed run
+      // expiring mid-word) — undefined when the run ended cleanly on a
+      // word boundary (currentWordIndex === words.length, every
+      // words/quote-mode finish) or with nothing typed into it yet.
+      // `currentInput` covers verbatim mode; `romajiKeystrokes` covers
+      // romaji mode (currentInput stays '' there — see handleRomajiChar
+      // in romaji-input.ts). See run-log-recorder.ts's `finish()`.
+      const typedSoFar = typingTest.state.currentInput || typingTest.state.romajiKeystrokes
+      const inFlightWord = typingTest.state.currentWordIndex < typingTest.state.words.length && typedSoFar.length > 0
+        ? { display: typingTest.state.words[typingTest.state.currentWordIndex], typed: typedSoFar }
+        : undefined
+      // Finalize the per-run raw keystroke log — discards outright when
+      // there's no active keyboard uid to save under; otherwise builds and
+      // saves it (itself a no-op unless this run was actually
+      // recorder-gated — see `record`'s own gate). Never
+      // truncated-and-saved: finish() refuses instead.
+      runLog.finishAndSave(uid, typingTest.state.wordResults, {
+        runId: typingTest.state.runId,
+        startedAtMs: typingTest.state.startTime ?? Date.now(),
+        durationMs: elapsed,
+        mode: typingTest.config.mode,
+        language: typingTest.language,
+        charCorrelationUnavailable: typingTest.state.kspcUncomputable,
+        inFlightWord,
+      })
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }
@@ -540,10 +597,11 @@ export function useInputModes({
     typingTest.state.currentWordIndex, typingTest.state.wpmHistory,
     typingTest.state.currentQuote, typingTest.state.runId, typingTest.state.romajiCapable,
     typingTest.state.totalKeystrokes, typingTest.state.confirmedChars, typingTest.state.kspcUncomputable,
+    typingTest.state.currentInput, typingTest.state.romajiKeystrokes, typingTest.state.words,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
     typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
-    resetMatrixPressTracking, flushAfterPendingEmits])
+    resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave])
 
   // The just-finished result, exposed so the pane can build name chips: the
   // held unsaved one (save-unnamed off) until named, else the saved latest.
@@ -607,7 +665,14 @@ export function useInputModes({
     if (!mem) return
     onMemoryChangeRef.current?.(mem)
     typingTest.pause()
-  }, [typingTest])
+    // Discard (never save) the run-log buffer for THIS run on pause, and
+    // block it from being re-buffered once typing resumes under the same
+    // runId (see run-log-recorder.ts's `discardRun()`): resume rebases
+    // `startTime` to `Date.now() - elapsedMs`, so this run's raw timeline
+    // is already broken by the pause gap — the summary result above still
+    // saves/resumes normally, just not this run's raw log.
+    runLog.discardRun(typingTest.state.runId)
+  }, [typingTest, runLog.discardRun])
 
   const resumeTypingTest = useCallback(() => {
     const mem = savedMemoryRef.current

--- a/src/renderer/typing-test/__tests__/expected-char.test.ts
+++ b/src/renderer/typing-test/__tests__/expected-char.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { deriveExpectedChar } from '../expected-char'
+import type { TypingTestState } from '../run-state'
+import { createInitialState } from '../run-state'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../types'
+
+describe('deriveExpectedChar', () => {
+  it('returns the next unconfirmed character of the current word in verbatim mode', () => {
+    const state: TypingTestState = { ...createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE), words: ['hello'], currentInput: 'he' }
+    expect(deriveExpectedChar(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBe('l')
+  })
+
+  it('returns undefined once past the last word', () => {
+    const state: TypingTestState = { ...createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE), words: ['hi'], currentWordIndex: 1 }
+    expect(deriveExpectedChar(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBeUndefined()
+  })
+})

--- a/src/renderer/typing-test/__tests__/romaji-engine.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-engine.test.ts
@@ -550,3 +550,44 @@ describe('canonicalRomaji', () => {
     expect(canonicalRomaji('あい')).toBe('ai')
   })
 })
+
+// nextGuideChar is a cheap one-character read meant to be exactly
+// equivalent to remainingGuide()[0] without paying for the recursive
+// build of the whole remaining-word guide — see its own doc comment in
+// romaji-engine.ts. This sweep pins that equivalence across ordinary
+// kana, a pending-n case (single "n" that could still extend to "nn"),
+// sokuon (gemination), and the empty-prefix (nothing typed yet) case.
+describe('nextGuideChar equivalence with remainingGuide()[0]', () => {
+  const cases: Array<{ word: string; typed: string }> = [
+    { word: 'こんにちは', typed: '' },
+    { word: 'こんにちは', typed: 'ko' },
+    { word: 'ありがとう', typed: 'a' },
+    // Pending "n" — could still commit as ん (single tap) or extend to
+    // "nn"/"n'" — remainingGuide falls through to the NEXT segment here
+    // since the current segment's winner is already fully typed.
+    { word: 'かんい', typed: 'ka' + 'n' },
+    { word: 'あんない', typed: 'a' + 'n' },
+    // Sokuon (っ) — explicit small-tsu and geminated-consonant spellings.
+    { word: 'がっこう', typed: 'ga' },
+    { word: 'がっこう', typed: 'ga' + 'k' },
+    { word: 'きって', typed: '' },
+    // でぃなーにいく — ambiguous digraph vs decomposed segmentation.
+    { word: 'でぃなーにいく', typed: '' },
+    { word: 'でぃなーにいく', typed: 'de' },
+    // Word-final ん, single-tap pending.
+    { word: 'ほん', typed: 'ho' + 'n' },
+  ]
+
+  it.each(cases)('word=$word typed=$typed', ({ word, typed }) => {
+    const matcher = createRomajiMatcher(word)
+    for (const key of typed) matcher.acceptChar(key)
+    const guide = matcher.remainingGuide()
+    expect(matcher.nextGuideChar()).toBe(guide.length > 0 ? guide[0] : undefined)
+  })
+
+  it('returns undefined once the word is fully typed, matching an empty remainingGuide', () => {
+    const { matcher } = type('あい', 'ai')
+    expect(matcher.remainingGuide()).toBe('')
+    expect(matcher.nextGuideChar()).toBeUndefined()
+  })
+})

--- a/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
+++ b/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
@@ -1,0 +1,672 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { RunLogRecorder, type RunLogRecordContext, type RunLogFinishMeta } from '../run-log-recorder'
+import type { TypingAnalyticsEventPayload } from '../../../shared/types/typing-analytics'
+import { MAX_RUN_LOG_EVENTS } from '../../../shared/types/typing-run-log'
+import type { WordResult } from '../run-state'
+import { deserialize } from '../../../shared/keycodes/keycodes'
+
+const KC_A = deserialize('KC_A')
+const KC_B = deserialize('KC_B')
+const KC_C = deserialize('KC_C')
+const KC_LSFT = deserialize('KC_LSFT')
+
+const DEFAULT_LABEL = 'words (english)'
+
+/** Registers a press the same way the (gated) useInputModes wrapper
+ *  does — `typingTestLabel`/`consentAccepted`/`windowFocused` default to
+ *  "a real, gated test run" so most call sites below don't have to spell
+ *  them out; tests of the gate itself override them explicitly. */
+function register(
+  recorder: RunLogRecorder, runId: string, row: number, col: number, ts: number, wordIndex: number,
+  expectedChar: string | undefined,
+  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean },
+): void {
+  recorder.noteRegistration(
+    {
+      typingTestLabel: gate?.typingTestLabel !== undefined ? gate.typingTestLabel : DEFAULT_LABEL,
+      runId,
+      consentAccepted: gate?.consentAccepted ?? true,
+      windowFocused: gate?.windowFocused ?? true,
+    },
+    row, col, ts, wordIndex, () => expectedChar,
+  )
+}
+
+/** Captures a char's pre-advance annotation the same way
+ *  useTypingTest.processKeyEvent's real call site does, immediately
+ *  before the matching `record(ctx(), charEvent(...))` call — see
+ *  `noteCharContext`'s own doc comment. Same gate defaults as
+ *  `register`. */
+function noteChar(
+  recorder: RunLogRecorder, runId: string, wordIndex: number, expectedChar: string | undefined,
+  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean },
+): void {
+  recorder.noteCharContext(
+    {
+      typingTestLabel: gate?.typingTestLabel !== undefined ? gate.typingTestLabel : DEFAULT_LABEL,
+      runId,
+      consentAccepted: gate?.consentAccepted ?? true,
+      windowFocused: gate?.windowFocused ?? true,
+    },
+    wordIndex, expectedChar,
+  )
+}
+
+function ctx(overrides?: Partial<RunLogRecordContext>): RunLogRecordContext {
+  return { typingTestLabel: DEFAULT_LABEL, runId: 'run-1', consentAccepted: true, windowFocused: true, ...overrides }
+}
+
+function matrixPress(overrides?: Partial<Extract<TypingAnalyticsEventPayload, { kind: 'matrix' }>>): Extract<TypingAnalyticsEventPayload, { kind: 'matrix' }> {
+  return { kind: 'matrix', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1000, ...overrides }
+}
+
+function matrixRelease(overrides?: Partial<Extract<TypingAnalyticsEventPayload, { kind: 'matrix-release' }>>): Extract<TypingAnalyticsEventPayload, { kind: 'matrix-release' }> {
+  return { kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1050, durationMs: 50, ...overrides }
+}
+
+function charEvent(key: string, ts = 1010): Extract<TypingAnalyticsEventPayload, { kind: 'char' }> {
+  return { kind: 'char', key, ts }
+}
+
+function finishMeta(overrides?: Partial<RunLogFinishMeta>): RunLogFinishMeta {
+  return {
+    uid: 'kb-1', runId: 'run-1', startedAtMs: 1000, durationMs: 5000, mode: 'words', language: 'english',
+    charCorrelationUnavailable: false, ...overrides,
+  }
+}
+
+function oneWordResult(typed = 'a', correct = true): WordResult[] {
+  return [{ word: 'a', typed, correct }]
+}
+
+describe('RunLogRecorder', () => {
+  describe('the mandatory privacy invariant', () => {
+    it('never buffers or finishes anything for pure REC input (typingTestLabel null)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { typingTestLabel: null })
+      recorder.record(ctx({ typingTestLabel: null }), matrixPress())
+      recorder.record(ctx({ typingTestLabel: null }), charEvent('a'))
+      recorder.record(ctx({ typingTestLabel: null }), matrixRelease())
+
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+
+    it('records nothing without recording consent, even during a tagged test run', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { consentAccepted: false })
+      recorder.record(ctx({ consentAccepted: false }), matrixPress())
+      recorder.record(ctx({ consentAccepted: false }), charEvent('a'))
+
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+
+    it('records nothing while the window is unfocused, even during a tagged, consented test run', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { windowFocused: false })
+      recorder.record(ctx({ windowFocused: false }), matrixPress())
+      recorder.record(ctx({ windowFocused: false }), charEvent('a'))
+
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+
+    it('resumes buffering once the window regains focus, without the earlier unfocused press leaking in', () => {
+      const recorder = new RunLogRecorder()
+      // Unfocused: alt-tabbed away, still typing on the same keyboard —
+      // must not be attributed to the run log at all.
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { windowFocused: false })
+      recorder.record(ctx({ windowFocused: false }), matrixPress({ ts: 1000 }))
+
+      // Refocused: this press must be recorded normally.
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'b', { windowFocused: true })
+      recorder.record(ctx({ windowFocused: true }), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B }))
+
+      const log = recorder.finish(
+        [{ word: 'ab', typed: 'ab', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].col).toBe(1)
+    })
+  })
+
+  describe('restart / stale runId handling', () => {
+    it('discards the previous run and starts fresh when noteRegistration sees a new runId', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-A', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx({ runId: 'run-A' }), matrixPress({ ts: 1000 }))
+
+      // Restart: a new run id begins.
+      register(recorder, 'run-B', 0, 0, 2000, 0, 'x')
+      recorder.record(ctx({ runId: 'run-B' }), matrixPress({ row: 0, col: 0, ts: 2000 }))
+
+      const log = recorder.finish([{ word: 'x', typed: 'x', correct: true }], finishMeta({ runId: 'run-B', startedAtMs: 2000 }))
+      expect(log?.runId).toBe('run-B')
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].expectedChar).toBe('x')
+    })
+
+    it('drops a stale queued press carrying the old runId after a restart instead of resurrecting it', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-A', 0, 0, 1000, 0, 'a')
+      // The old run's masked press is still queued (not yet emitted).
+
+      // Restart advances the buffer to run-B via noteRegistration (always
+      // real-time, never delayed).
+      register(recorder, 'run-B', 0, 1, 2000, 0, 'x')
+      recorder.record(ctx({ runId: 'run-B' }), matrixPress({ row: 0, col: 1, ts: 2000 }))
+
+      // The OLD run's press finally resolves and emits — must be dropped,
+      // not resurrect run-A's buffer.
+      recorder.record(ctx({ runId: 'run-A' }), matrixPress({ row: 0, col: 0, ts: 1000 }))
+
+      const log = recorder.finish([{ word: 'x', typed: 'x', correct: true }], finishMeta({ runId: 'run-B', startedAtMs: 2000 }))
+      expect(log?.runId).toBe('run-B')
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].col).toBe(1)
+    })
+  })
+
+  describe('finish() runId check (P2)', () => {
+    it('refuses to finish (and clears the buffer) when meta.runId does not match the buffered run', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-A', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx({ runId: 'run-A' }), matrixPress({ ts: 1000 }))
+
+      // Caller (e.g. a stale effect closure) asks to finish under a
+      // DIFFERENT run's id than what's actually buffered.
+      expect(recorder.finish(oneWordResult(), finishMeta({ runId: 'run-B', startedAtMs: 1000 }))).toBeNull()
+      // The buffer is cleared either way (matching every other refusal
+      // path) — a second finish() call under the CORRECT runId must not
+      // resurrect it.
+      expect(recorder.finish(oneWordResult(), finishMeta({ runId: 'run-A', startedAtMs: 1000 }))).toBeNull()
+    })
+  })
+
+  describe('word attribution survives a delayed emission', () => {
+    it('keeps the word index registered at press time even if the word advances before the event emits', () => {
+      const recorder = new RunLogRecorder()
+      // Registered while word 0 was current...
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      // ...but the analytics event for it only reaches record() after the
+      // queue has already drained later presses belonging to word 1 (a
+      // masked key deferred up to TAPPING_TERM, for example).
+      register(recorder, 'run-1', 0, 1, 1005, 1, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1005, keycode: KC_B }))
+      recorder.record(ctx(), matrixPress({ row: 0, col: 0, ts: 1000, keycode: KC_A }))
+
+      const log = recorder.finish(
+        [{ word: 'a', typed: 'a', correct: true }, { word: 'b', typed: 'b', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].row).toBe(0)
+      expect(log?.words[0].keystrokes[0].col).toBe(0)
+      expect(log?.words[1].keystrokes).toHaveLength(1)
+    })
+  })
+
+  describe('finish() output shape', () => {
+    it('converts every timestamp to run-relative ms', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1500, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1500 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1580, durationMs: 80 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000, durationMs: 5000 }))
+      const [k] = log!.words[0].keystrokes
+      expect(k.pressMs).toBe(500)
+      expect(k.releaseMs).toBe(580)
+      // Never looks like an epoch ms value, and never exceeds durationMs.
+      expect(k.pressMs).toBeLessThanOrEqual(log!.durationMs)
+      expect(k.releaseMs!).toBeLessThanOrEqual(log!.durationMs)
+    })
+
+    it('keeps a mid-hold keystroke with pressMs but no releaseMs', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      // No matching matrix-release — the run finished mid-hold.
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000 }))
+      const [k] = log!.words[0].keystrokes
+      expect(k.pressMs).toBe(0)
+      expect(k.releaseMs).toBeUndefined()
+    })
+
+    it('preserves the overlapped tri-state (true / false / undefined)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000, overlap: undefined }))
+
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B, overlap: true }))
+
+      const log = recorder.finish(
+        [{ word: 'ab', typed: 'ab', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      const [first, second] = log!.words[0].keystrokes
+      expect(first.overlapped).toBeUndefined()
+      expect(second.overlapped).toBe(true)
+    })
+
+    it('sets charCorrelationUnavailable when the caller flags an IME-composition run', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ charCorrelationUnavailable: true }))
+      expect(log?.charCorrelationUnavailable).toBe(true)
+    })
+
+    it('omits charCorrelationUnavailable (rather than storing false) for an ordinary run', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ charCorrelationUnavailable: false }))
+      expect(log?.charCorrelationUnavailable).toBeUndefined()
+    })
+
+    it('drops (rather than clamps to 0) a keystroke whose relative pressMs would be negative (P3 belt-and-braces)', () => {
+      const recorder = new RunLogRecorder()
+      // A keystroke buffered before meta.startedAtMs — the shape a
+      // pause/resume startTime rebase would produce if the recorder's
+      // buffer were ever resurrected across a pause (it no longer is,
+      // see pauseTypingTest's discard() call, but this guard stays as
+      // defense in depth).
+      register(recorder, 'run-1', 0, 0, 900, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 900 }))
+      register(recorder, 'run-1', 0, 1, 1100, 0, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1100, keycode: KC_B }))
+
+      const log = recorder.finish(
+        [{ word: 'ab', typed: 'ab', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      // Only the keystroke at or after startedAtMs survives.
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].col).toBe(1)
+      expect(log?.words[0].keystrokes[0].pressMs).toBe(100)
+    })
+  })
+
+  describe('char correlation (best-effort)', () => {
+    it('confirms correct=true when the char event arrives BEFORE its own matrix press (the real, usual ordering)', () => {
+      // DOM keydown fires synchronously; the matching 'matrix' analytics
+      // event arrives via ~20ms HID polling — so a char USUALLY precedes
+      // its own matrix press, not the other way around. This is the
+      // primary case (see the module doc comment's char-correlation
+      // note) — it used to be mishandled as a permanent off-by-one
+      // (every char confirmed the NEXT press instead of its own).
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), charEvent('a', 995))
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      expect(log?.words[0].keystrokes[0].correct).toBe(true)
+    })
+
+    it('confirms correct=false when the char event (arriving first) does not match expectedChar', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), charEvent('z', 995))
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      expect(log?.words[0].keystrokes[0].correct).toBe(false)
+    })
+
+    it('keeps multi-keystroke verdicts aligned when every char arrives before its own matrix press', () => {
+      // 3 correct chars typed in sequence, each arriving ahead of its own
+      // press (the normal timing) — every keystroke must end up aligned
+      // to its OWN char, not shifted by one.
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'b')
+      register(recorder, 'run-1', 0, 2, 1020, 0, 'c')
+
+      recorder.record(ctx(), charEvent('a', 995))
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_A }))
+      recorder.record(ctx(), charEvent('b', 1005))
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B }))
+      recorder.record(ctx(), charEvent('c', 1015))
+      recorder.record(ctx(), matrixPress({ row: 0, col: 2, ts: 1020, keycode: KC_C }))
+
+      const log = recorder.finish(
+        [{ word: 'abc', typed: 'abc', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      const keystrokes = log!.words[0].keystrokes
+      expect(keystrokes).toHaveLength(3)
+      expect(keystrokes.every((k) => k.correct === true)).toBe(true)
+    })
+
+    it('confirms correct=true when the char event arrives AFTER its own matrix press (secondary/legacy ordering, e.g. a tap-hold key deferred past its own char)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), charEvent('a'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      expect(log?.words[0].keystrokes[0].correct).toBe(true)
+    })
+
+    it('never enqueues a bare modifier press for char confirmation, so it stays unconfirmed', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, undefined)
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_LSFT }))
+      // The following real letter's char event must confirm ITS OWN
+      // keystroke, not the shift's.
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'a')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_A }))
+      recorder.record(ctx(), charEvent('a'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [shiftKeystroke, letterKeystroke] = log!.words[0].keystrokes
+      expect(shiftKeystroke.correct).toBeUndefined()
+      expect(letterKeystroke.correct).toBe(true)
+    })
+
+    it('never enqueues a masked key resolved as hold for char confirmation', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      // action: 'hold' — a layer switch, never commits a character.
+      recorder.record(ctx(), matrixPress({ ts: 1000, action: 'hold' }))
+      recorder.record(ctx(), charEvent('a'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      // The stray char event found nothing queued (the hold was never
+      // enqueued) and was simply dropped.
+      expect(log?.words[0].keystrokes[0].correct).toBeUndefined()
+    })
+
+    it('pops Backspace off the queue without setting a misleading correctness verdict (matrix-then-char)', () => {
+      const recorder = new RunLogRecorder()
+      const KC_BSPC = deserialize('KC_BSPC')
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_BSPC }))
+      recorder.record(ctx(), charEvent('Backspace'))
+
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'a')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_A }))
+      recorder.record(ctx(), charEvent('a'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [backspaceKeystroke, letterKeystroke] = log!.words[0].keystrokes
+      expect(backspaceKeystroke.correct).toBeUndefined()
+      expect(letterKeystroke.correct).toBe(true)
+    })
+
+    it('pops Backspace off the queue without a verdict when its char arrives BEFORE its own matrix press too (symmetric)', () => {
+      const recorder = new RunLogRecorder()
+      const KC_BSPC = deserialize('KC_BSPC')
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), charEvent('Backspace', 995))
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_BSPC }))
+
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'a')
+      recorder.record(ctx(), charEvent('a', 1005))
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_A }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [backspaceKeystroke, letterKeystroke] = log!.words[0].keystrokes
+      expect(backspaceKeystroke.correct).toBeUndefined()
+      expect(letterKeystroke.correct).toBe(true)
+    })
+  })
+
+  describe('char-first pre-advance annotation (noteCharContext)', () => {
+    it('fresh run: 3 keystrokes arriving char-first (the real ordering) are all correct, none shifted', () => {
+      const recorder = new RunLogRecorder()
+      // For each key, the char's own record() call reaches the recorder
+      // BEFORE that key's matrix press has even registered (noteRegistration
+      // fires later — mirroring the real ~20ms HID poll delay behind a
+      // synchronous DOM keydown) — the first key's char must mint the
+      // buffer with no registration and no buffer at all yet to lean on.
+      noteChar(recorder, 'run-1', 0, 'a')
+      recorder.record(ctx(), charEvent('a', 995))
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_A }))
+
+      noteChar(recorder, 'run-1', 0, 'b')
+      recorder.record(ctx(), charEvent('b', 1005))
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B }))
+
+      noteChar(recorder, 'run-1', 0, 'c')
+      recorder.record(ctx(), charEvent('c', 1015))
+      register(recorder, 'run-1', 0, 2, 1020, 0, 'c')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 2, ts: 1020, keycode: KC_C }))
+
+      const log = recorder.finish(
+        [{ word: 'abc', typed: 'abc', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      const keystrokes = log!.words[0].keystrokes
+      expect(keystrokes).toHaveLength(3)
+      expect(keystrokes.every((k) => k.correct === true)).toBe(true)
+      expect(keystrokes.map((k) => k.col)).toEqual([0, 1, 2])
+    })
+
+    it('the first char of a run arriving before ANY matrix event is not lost (buffer minted by the char)', () => {
+      const recorder = new RunLogRecorder()
+      // No noteRegistration precedes this char at all — a totally fresh
+      // recorder, with no buffer, told about run-1 only by the char.
+      noteChar(recorder, 'run-1', 0, 'a')
+      recorder.record(ctx(), charEvent('a', 995))
+      // The press only registers (and then reaches record()) afterward.
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].correct).toBe(true)
+    })
+
+    it('restart: a new run\'s char-first keystroke advances the buffer; a subsequent stale MATRIX press for the old run is still dropped (asymmetry pinned)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-A', 0, 0, 1000, 0, 'a')
+      // run-A's masked press is still queued (not yet emitted) when the
+      // restart below happens.
+
+      // Restart: run-B's first char arrives before any matrix
+      // registration for it at all — only a 'char' payload may advance
+      // the buffer to a new run (see run-log-recorder.ts's ASYMMETRIC
+      // STALENESS note); a 'matrix' payload still may not.
+      noteChar(recorder, 'run-B', 0, 'x')
+      recorder.record(ctx({ runId: 'run-B' }), charEvent('x', 1995))
+      register(recorder, 'run-B', 0, 0, 2000, 0, 'x')
+      recorder.record(ctx({ runId: 'run-B' }), matrixPress({ ts: 2000 }))
+
+      // run-A's stale press finally resolves and emits — must be
+      // dropped, not resurrect run-A's buffer.
+      recorder.record(ctx({ runId: 'run-A' }), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish([{ word: 'x', typed: 'x', correct: true }], finishMeta({ runId: 'run-B', startedAtMs: 2000 }))
+      expect(log?.runId).toBe('run-B')
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[0].keystrokes[0].correct).toBe(true)
+    })
+
+    it('a separator typed char-first at a word boundary is attributed to the word it terminated, not the next one', () => {
+      const recorder = new RunLogRecorder()
+      const KC_SPC = deserialize('KC_SPC')
+      // The space's own annotation is captured while word 0 ("ab") is
+      // still current — BEFORE the space handler advances
+      // currentWordIndex to 1 — exactly mirroring processKeyEvent's real
+      // call order (noteCharContext runs before the reducer).
+      noteChar(recorder, 'run-1', 0, undefined)
+      recorder.record(ctx(), charEvent(' ', 995))
+      // The matching matrix press only registers AFTER state has already
+      // advanced to word 1 (the real ordering this fix addresses) — if
+      // attribution came from this registration snapshot instead of the
+      // annotation, the space would land on word 1 instead of word 0.
+      register(recorder, 'run-1', 0, 0, 1000, 1, undefined)
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_SPC }))
+
+      const log = recorder.finish(
+        [{ word: 'ab', typed: 'ab', correct: true }, { word: 'cd', typed: 'cd', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[1].keystrokes).toHaveLength(0)
+    })
+
+    it('keeps verdicts and word attribution aligned when both orderings interleave across several keys', () => {
+      const recorder = new RunLogRecorder()
+      // key 1: char-first (the real ordering)
+      noteChar(recorder, 'run-1', 0, 'a')
+      recorder.record(ctx(), charEvent('a', 995))
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_A }))
+
+      // key 2: matrix-first (the secondary ordering)
+      register(recorder, 'run-1', 0, 1, 1010, 0, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B }))
+      noteChar(recorder, 'run-1', 0, 'b')
+      recorder.record(ctx(), charEvent('b', 1015))
+
+      // key 3: char-first again
+      noteChar(recorder, 'run-1', 0, 'c')
+      recorder.record(ctx(), charEvent('c', 1018))
+      register(recorder, 'run-1', 0, 2, 1020, 0, 'c')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 2, ts: 1020, keycode: KC_C }))
+
+      const log = recorder.finish(
+        [{ word: 'abc', typed: 'abc', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      const keystrokes = log!.words[0].keystrokes
+      expect(keystrokes).toHaveLength(3)
+      expect(keystrokes.every((k) => k.correct === true)).toBe(true)
+      expect(keystrokes.map((k) => k.col)).toEqual([0, 1, 2])
+    })
+
+    it('a poisoned runId also blocks a char event from minting a buffer', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.discardRun('run-1')
+
+      noteChar(recorder, 'run-1', 0, 'x')
+      recorder.record(ctx({ runId: 'run-1' }), charEvent('x'))
+
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+  })
+
+  describe('release parking (D2 — a release arriving before its own queued press)', () => {
+    it('recovers a release that arrives before its own deferred press event', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      // 'matrix-release' bypasses the tap-hold ordering queue and ships
+      // immediately, landing before this press's own deferred 'matrix'
+      // event (e.g. a masked key awaiting tap/hold classification).
+      recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000 }))
+      const [k] = log!.words[0].keystrokes
+      expect(k.pressMs).toBe(0)
+      expect(k.releaseMs).toBe(50)
+    })
+
+    it('does not mis-assign a same-key re-press\'s release to an earlier still-unclaimed press for that key', () => {
+      const recorder = new RunLogRecorder()
+      // Press A (masked, deferred) — its release ships immediately.
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixRelease({ ts: 1030, durationMs: 30 }))
+      // Press B (same physical key, re-pressed) is ALSO deferred — its
+      // own release ships before either press event ever emits.
+      register(recorder, 'run-1', 0, 0, 1200, 0, 'a')
+      recorder.record(ctx(), matrixRelease({ ts: 1230, durationMs: 30 }))
+      // A's deferred press event finally emits — must claim ITS OWN
+      // parked release (the OLDEST one for this key), not B's.
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      // B's deferred press event finally emits — must claim its own.
+      recorder.record(ctx(), matrixPress({ ts: 1200 }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000 }))
+      const [a, b] = log!.words[0].keystrokes
+      expect(a.pressMs).toBe(0)
+      expect(a.releaseMs).toBe(30)
+      expect(b.pressMs).toBe(200)
+      expect(b.releaseMs).toBe(230)
+    })
+  })
+
+  describe('trailing in-flight word (P5)', () => {
+    it('appends a partial:true RunWord carrying an interrupted word\'s keystrokes instead of dropping them', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'h')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      // Time-bounded run expires with word 0 (index 0) still in flight —
+      // no submitted words at all.
+      const log = recorder.finish([], finishMeta({
+        startedAtMs: 1000,
+        inFlightWord: { display: 'hello', typed: 'h' },
+      }))
+      expect(log).not.toBeNull()
+      expect(log!.words).toHaveLength(1)
+      const [word] = log!.words
+      expect(word.index).toBe(0)
+      expect(word.partial).toBe(true)
+      expect(word.display).toBe('hello')
+      expect(word.typed).toBe('h')
+      expect(word.correct).toBe(false)
+      expect(word.keystrokes).toHaveLength(1)
+    })
+
+    it('appends the in-flight word AFTER already-submitted words, at the correct index', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      register(recorder, 'run-1', 0, 1, 1010, 1, 'w')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1010, keycode: KC_B }))
+
+      const log = recorder.finish(
+        [{ word: 'a', typed: 'a', correct: true }],
+        finishMeta({ startedAtMs: 1000, inFlightWord: { display: 'word', typed: 'w' } }),
+      )
+      expect(log!.words).toHaveLength(2)
+      expect(log!.words[0].partial).toBeUndefined()
+      expect(log!.words[1].index).toBe(1)
+      expect(log!.words[1].partial).toBe(true)
+      expect(log!.words[1].keystrokes).toHaveLength(1)
+    })
+
+    it('still refuses to save (returns null) when there are no submitted words AND no in-flight word', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      expect(recorder.finish([], finishMeta({ startedAtMs: 1000 }))).toBeNull()
+    })
+  })
+
+  describe('caps', () => {
+    it('refuses to finish (returns null) once the keystroke cap is exceeded', () => {
+      const recorder = new RunLogRecorder()
+      for (let i = 0; i <= MAX_RUN_LOG_EVENTS; i++) {
+        register(recorder, 'run-1', 0, 0, 1000 + i, 0, 'a')
+        recorder.record(ctx(), matrixPress({ ts: 1000 + i }))
+      }
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+  })
+
+  describe('discard()', () => {
+    it('clears the buffer (unmount / keyboard-switch cleanup)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+      recorder.discard()
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
+    })
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.test.ts
@@ -1862,3 +1862,62 @@ describe('useTypingTest windowFocused', () => {
     })
   })
 })
+
+describe('useTypingTest onNoteKeystrokeRegistration / window focus gate (P1)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'))
+  })
+
+  it('does not call onNoteKeystrokeRegistration while the window is unfocused, but the per-minute matrix event still ships', () => {
+    const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'KC_A']] }])
+    const sink = vi.fn()
+    const noteRegistration = vi.fn()
+    const { result } = renderHook(() => useTypingTest(undefined, undefined, {
+      ...analyticsOptions(sink),
+      onNoteKeystrokeRegistration: noteRegistration,
+    }))
+
+    act(() => result.current.setWindowFocused(false))
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+    expect(noteRegistration).not.toHaveBeenCalled()
+    // HID matrix polling is unaffected by focus — the per-minute analytics
+    // pipeline deliberately keeps recording regardless (see the module's
+    // own comment on processMatrixFrame).
+    expect(sink).toHaveBeenCalled()
+  })
+
+  it('calls onNoteKeystrokeRegistration with windowFocused=true once the window is focused', () => {
+    const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'KC_A']] }])
+    const noteRegistration = vi.fn()
+    const { result } = renderHook(() => useTypingTest(undefined, undefined, {
+      ...analyticsOptions(() => {}),
+      onNoteKeystrokeRegistration: noteRegistration,
+    }))
+
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+
+    expect(noteRegistration).toHaveBeenCalledTimes(1)
+    const windowFocusedArg = noteRegistration.mock.calls[0][6] as boolean
+    expect(windowFocusedArg).toBe(true)
+  })
+
+  it('resumes calling onNoteKeystrokeRegistration once focus is restored', () => {
+    const keymap = buildMultiLayerKeymap([{ layer: 0, entries: [[0, 0, 'KC_A']] }])
+    const noteRegistration = vi.fn()
+    const { result } = renderHook(() => useTypingTest(undefined, undefined, {
+      ...analyticsOptions(() => {}),
+      onNoteKeystrokeRegistration: noteRegistration,
+    }))
+
+    act(() => result.current.setWindowFocused(false))
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+    expect(noteRegistration).not.toHaveBeenCalled()
+
+    act(() => result.current.processMatrixFrame(new Set(), keymap))
+    act(() => result.current.setWindowFocused(true))
+    act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
+    expect(noteRegistration).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/typing-test/expected-char.ts
+++ b/src/renderer/typing-test/expected-char.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** Derives the character a matrix press registered right now should
+ *  confirm, for both verbatim and romaji-keystroke judging. Lives in the
+ *  typing-test engine layer (not run-log-recorder.ts, which is a
+ *  feature built on top of this engine): useTypingTest itself calls this
+ *  at registration time, so the engine must not depend on the
+ *  run-keystroke-log feature module — see run-log-recorder.ts's own doc
+ *  comment for the consumer this exists to serve. */
+
+import { isRomajiInputActive, romajiNextExpectedChar, romajiDetail } from './romaji-input'
+import type { TypingTestConfig } from './types'
+import type { TypingTestState } from './run-state'
+
+/** Returns undefined once the run has no current word (defensive; the
+ *  caller never registers past the last word) or, in romaji mode, once
+ *  the current word's kana are already fully matched. */
+export function deriveExpectedChar(state: TypingTestState, config: TypingTestConfig, language: string): string | undefined {
+  const word = state.words[state.currentWordIndex]
+  if (word === undefined) return undefined
+  if (isRomajiInputActive(config, language, state.romajiCapable)) {
+    return romajiNextExpectedChar(word, state.romajiKeystrokes, romajiDetail(config))
+  }
+  return word[state.currentInput.length]
+}

--- a/src/renderer/typing-test/keycode-char-map.ts
+++ b/src/renderer/typing-test/keycode-char-map.ts
@@ -95,6 +95,47 @@ export function isTapKeycode(code: number): boolean {
   return false
 }
 
+const ENTER_QMKIDS = new Set(['KC_ENTER', 'KC_ENT'])
+
+/** Shared resolution cascade for both `resolveCharFromMatrix` (a live
+ * row/col + keymap lookup) and `producesChar` (an already-resolved
+ * keycode, e.g. off a queued/emitted analytics event): try the code
+ * directly first (handles basic keycodes), then — for LT/MT tap-hold
+ * ranges only, to avoid false positives for TD/TT/LM/etc — fall back to
+ * the inner keycode extracted from the low byte. */
+function resolveCodeWithTapFallback(code: number, shifted: boolean): CharResult {
+  const direct = resolveCode(code, shifted)
+  if (direct) return direct
+  if (isTapKeycode(code)) {
+    const inner = code & 0xff
+    if (inner !== 0) return resolveCode(inner, shifted)
+  }
+  return null
+}
+
+/** Whether a resolved keycode can ever produce a character — the same
+ * resolution `resolveCharFromMatrix` performs internally, exposed for a
+ * caller that already has the effective keycode rather than a live
+ * row/col + keymap to look it up from. Used by run-log-recorder.ts to
+ * decide whether a matrix keystroke can ever be joined against a later
+ * DOM `char` event, so a key that will never produce one (a bare
+ * modifier, a layer key) isn't left permanently queued for a
+ * confirmation that will never arrive.
+ *
+ * Enter is deliberately excluded even though `SPECIAL_ACTIONS` maps it
+ * to the same 'space' action as literal Space: Space's DOM `key` is
+ * `' '` (length 1, passes the char-event gate in
+ * useTypingTest.processKeyEvent), but Enter's DOM `key` is `'Enter'`
+ * (length 5, never passes it) — so Enter never actually produces a
+ * `char` event despite resolving to an action here. Unshifted only —
+ * its only caller (the run-log recorder) has no notion of shift state
+ * for a matrix press and only ever needs the yes/no answer. */
+export function producesChar(code: number): boolean {
+  const qmkId = serialize(code)
+  if (qmkId && ENTER_QMKIDS.has(qmkId)) return false
+  return resolveCodeWithTapFallback(code, false) !== null
+}
+
 export function resolveCharFromMatrix(
   row: number,
   col: number,
@@ -104,20 +145,5 @@ export function resolveCharFromMatrix(
 ): CharResult {
   const code = keymap.get(`${layer},${row},${col}`)
   if (code == null) return null
-
-  // Try resolving the full keycode first (handles basic keycodes)
-  const result = resolveCode(code, shifted)
-  if (result) return result
-
-  // For LT/MT keycodes, extract the inner keycode from the low byte
-  // and try again. Only apply to known tap-key ranges to avoid
-  // false positives for TD, TT, LM, etc.
-  if (isTapKeycode(code)) {
-    const inner = code & 0xff
-    if (inner !== 0) {
-      return resolveCode(inner, shifted)
-    }
-  }
-
-  return null
+  return resolveCodeWithTapFallback(code, shifted)
 }

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -843,6 +843,21 @@ function pickGuideWinner(candidates: readonly FlatPattern[], guideStyles: Readon
   return pickWinner(candidates)
 }
 
+/** The first character `canonicalGuideFrom(kana, index, ...)` would
+ *  produce, without recursively building the guide for the rest of the
+ *  word — just one segment's `representativeAt` call. Used by
+ *  `nextGuideChar`'s fallthrough case (see its own doc comment). */
+function firstGuideCharAt(
+  kana: readonly string[],
+  index: number,
+  disabledStyles: ReadonlySet<RomajiStyle> | undefined,
+  guideStyles: ReadonlySet<RomajiStyle> | undefined,
+): string | undefined {
+  if (index >= kana.length) return undefined
+  const winner = representativeAt(kana, index, '', disabledStyles, guideStyles)
+  return winner ? winner.pattern[0] : undefined
+}
+
 function representativeAt(
   kana: readonly string[],
   index: number,
@@ -946,6 +961,11 @@ export interface RomajiMatcher {
    *  keystroke, so it tracks whichever spelling the user is actually
    *  typing once earlier alternatives fall out of contention. */
   remainingGuide(): string
+  /** Equivalent to `remainingGuide()[0]` (the next character the guide
+   *  would display), computed without building the guide for the rest of
+   *  the word — a cheap read for a caller that only needs one character
+   *  (e.g. the run-keystroke-log recorder's per-press `expectedChar`). */
+  nextGuideChar(): string | undefined
   isComplete(): boolean
   /** Number of kana characters fully confirmed so far — i.e. committed
    *  segments only, excluding whatever's in the in-progress keystroke
@@ -1069,6 +1089,19 @@ export function createRomajiMatcher(word: string, opts?: RomajiMatcherOptions): 
         winner.pattern.slice(buffer.length) +
         canonicalGuideFrom(kana, position + winner.length, disabledStyles, guideStyles)
       )
+    },
+
+    nextGuideChar(): string | undefined {
+      if (position >= kana.length) return undefined
+      const winner = representativeAt(kana, position, buffer, disabledStyles, guideStyles)
+      if (!winner) return undefined
+      const rest = winner.pattern.slice(buffer.length)
+      // Mirrors remainingGuide's own fallthrough: when the current
+      // segment's winner is already fully typed (buffer === winner.pattern
+      // exactly — e.g. a pending bare "n" that could still extend to
+      // "nn"), the next displayed character comes from the following
+      // segment instead.
+      return rest.length > 0 ? rest[0] : firstGuideCharAt(kana, position + winner.length, disabledStyles, guideStyles)
     },
 
     isComplete(): boolean {

--- a/src/renderer/typing-test/romaji-input.ts
+++ b/src/renderer/typing-test/romaji-input.ts
@@ -100,6 +100,15 @@ export function buildRomajiMatcher(word: string, keystrokes: string, opts?: Roma
   return matcher
 }
 
+/** The single next character romaji judging expects for `word`, given
+ *  what's been typed so far — `buildRomajiMatcher(...).nextGuideChar()`,
+ *  which (unlike reading `remainingGuide()[0]`) never builds the guide
+ *  for the rest of the word just to read one character off it. Used by
+ *  expected-char.ts's `deriveExpectedChar` for the romaji branch. */
+export function romajiNextExpectedChar(word: string, keystrokes: string, opts?: RomajiMatcherOptions): string | undefined {
+  return buildRomajiMatcher(word, keystrokes, opts).nextGuideChar()
+}
+
 /** Romaji Settings modal detail fields (disabledStyles / guideStyles /
  *  caseStyle), read only while `romajiInput` is honored (see
  *  `isRomajiInputActive`) — the config shape guarantees `romaji` only

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -1,0 +1,688 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+/** In-memory buffer + join logic for the per-run raw keystroke log (see
+ *  `.claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md`). Owned by
+ *  `useInputModes` (one instance per editor session) and fed from three
+ *  seams already wired for the existing per-minute analytics pipeline:
+ *
+ *  - `noteRegistration` — called from `useTypingTest.processMatrixFrame`
+ *    at matrix-press REGISTRATION time (before the press may sit in the
+ *    tap-hold ordering queue for up to TAPPING_TERM). Snapshots the word
+ *    this press should confirm, keyed by the exact (row, col, ts) triple
+ *    the eventual 'matrix' analytics event will carry — so a press that
+ *    resolves late still joins back to the word it was actually typed
+ *    against, not whatever word is current by the time it resolves.
+ *  - `noteCharContext` — called from `useTypingTest.processKeyEvent`
+ *    immediately BEFORE this same key's own char analytics emit, which is
+ *    itself the FIRST place this run's state gets touched for this key
+ *    (unlike a matrix press, whose registration always runs before its
+ *    own possibly-deferred emit but AFTER this handler already advanced
+ *    state for the same physical press — see the CHAR CORRELATION note
+ *    below). Stashes the pre-advance word/expectedChar in a single slot
+ *    (`pendingCharAnnotation`) for `record`'s 'char' branch, called
+ *    synchronously right after, to consume.
+ *  - `record` — called from `useInputModes`'s `emitAnalyticsEvent` sink,
+ *    the same place every per-minute analytics event ships from. Builds
+ *    keystrokes from 'matrix'/'matrix-release' events and best-effort
+ *    confirms them against 'char' events (see the char-correlation note
+ *    below).
+ *
+ *  PRIVACY: `record` only ever touches the buffer while
+ *  `context.typingTestLabel` is set (an editor Typing Test run, not
+ *  ambient REC input) AND `context.consentAccepted` is true AND
+ *  `context.windowFocused` is true AND the event's runId matches the
+ *  buffer's own — see the module doc comment on
+ *  `../../shared/types/typing-run-log.ts` for the full privacy
+ *  rationale. The window-focus check is checked independently here (not
+ *  only trusted from the caller) as defense in depth on top of
+ *  useTypingTest's own primary gate (it never even calls
+ *  `noteRegistration`/`noteCharContext` while unfocused): HID matrix
+ *  polling keeps running regardless of window focus — that's deliberate
+ *  for the per-minute analytics pipeline — so without this gate a
+ *  keystroke typed into an entirely different, unfocused application on
+ *  the same keyboard would otherwise be captured verbatim. A run's buffer
+ *  is memory-only until `finish()`; nothing is written to disk while a
+ *  run is in progress.
+ *
+ *  CHAR CORRELATION (best-effort, not exact): a 'char' DOM keydown event
+ *  carries no row/col, so it can't be joined to its matrix keystroke by
+ *  position — only by relative arrival order. The REAL, usual ordering
+ *  is char-before-matrix: a DOM keydown fires synchronously, while the
+ *  matching 'matrix' analytics event arrives via ~20ms HID polling (and
+ *  can be deferred further still, up to TAPPING_TERM, for a masked
+ *  tap-hold key awaiting its tap/hold classification) — so a char
+ *  USUALLY arrives before its own matrix press, not after. Pairing is
+ *  therefore symmetric: two small bounded FIFOs, not one.
+ *   - `awaitingChar` — char-producing presses that registered before
+ *     their own char event arrived (the less common ordering, e.g. a
+ *     tap-hold key deferred past its own char).
+ *   - `pendingChars` — char events that arrived before their own press
+ *     had registered (the usual ordering). `recordMatrixPress` checks
+ *     this queue first and applies the verdict immediately; only when
+ *     empty does the press fall back to waiting in `awaitingChar`.
+ *  Two mitigations keep both queues bounded rather than exhaustive:
+ *   1. Only keystrokes classified as char-producing (`producesChar`,
+ *      and never a masked key resolved as `hold`) ever touch either
+ *      queue — a bare modifier or a hold action would otherwise jam
+ *      `awaitingChar` forever waiting for a 'char' event that will
+ *      never come.
+ *   2. Each queue is capped at a handful of pending entries (oldest
+ *      evicted first), so one stretch of uncorrelatable input (e.g. IME
+ *      composition — see `charCorrelationUnavailable`) can only desync a
+ *      few keystrokes immediately following it before both queues
+ *      self-heal, not the rest of the run.
+ *  Backspace produces a 'char' event but confirms nothing — its
+ *  keystroke is still consumed from whichever queue it lands in (so the
+ *  alignment stays correct for what follows) without ever setting a
+ *  correctness verdict; symmetric in both directions, see
+ *  `recordChar`/`recordMatrixPress`.
+ *
+ *  ASYMMETRIC STALENESS (why `record` may let a 'char' payload mint/
+ *  advance the buffer but never a 'matrix' one): a matrix analytics event
+ *  can physically arrive up to TAPPING_TERM after the press that produced
+ *  it (queued behind an unresolved tap-hold classification — see
+ *  useTypingTest.ts's own comment on the ordering queue), so letting it
+ *  advance the buffer here risked resurrecting an already-abandoned run
+ *  with a stale, unrelated press. A 'char' DOM event has no such
+ *  ordering queue — it is dispatched synchronously at keydown and reaches
+ *  `record` immediately, so it can never be stale in that sense. Without
+ *  this asymmetry a fresh run's very first keystroke was lost outright
+ *  whenever its char arrived (the usual ordering) before ANY buffer
+ *  existed: `record` refused to touch an absent buffer, `noteRegistration`
+ *  (matrix-only) hadn't run yet either, so the char had nowhere to go —
+ *  the following press then had to wait in `awaitingChar` for a char that
+ *  would never come, permanently shifting every later confirmation by
+ *  one. Only `noteRegistration` and a live 'char' payload may mint/
+ *  advance the buffer now; `record`'s 'matrix'/'matrix-release' branches
+ *  keep the original drop-on-absent/mismatch behavior. */
+
+import type { TypingAnalyticsEventPayload } from '../../shared/types/typing-analytics'
+import type { RunKeystroke, RunKeystrokeLog, RunWord } from '../../shared/types/typing-run-log'
+import { MAX_RUN_LOG_BYTES, MAX_RUN_LOG_EVENTS } from '../../shared/types/typing-run-log'
+import { producesChar } from './keycode-char-map'
+import type { WordResult } from './run-state'
+
+/** Context carried into every `record` call — mirrors the gate/tag
+ *  decision `useInputModes.emitAnalyticsEvent` already makes for the
+ *  per-minute pipeline (see `PreparedAnalyticsContext`), but re-checked
+ *  independently here rather than trusted from the caller: this is the
+ *  privacy-critical gate for the highest-recovery-risk data in the app. */
+export interface RunLogRecordContext {
+  /** The editor Typing Test's material label, or null for ordinary
+   *  Typing View REC input. Recording requires this to be non-null —
+   *  the mandatory invariant this whole module exists to enforce. */
+  typingTestLabel: string | null
+  runId: string | null
+  /** `AppConfig.typingRecordingConsentAccepted` — stricter than the
+   *  per-minute analytics gate, which records test runs without REC
+   *  consent (see the task spec's explicit mandate). */
+  consentAccepted: boolean
+  /** Whether the app window was focused at the moment this keystroke was
+   *  captured (press time for `noteRegistration`/`noteCharContext`,
+   *  snapshotted at the same press time for `record` — see
+   *  `PreparedAnalyticsContext` in useInputModes.ts). Defense in depth on
+   *  top of useTypingTest's own primary gate — see the module doc
+   *  comment's PRIVACY paragraph for why HID matrix polling continuing
+   *  while unfocused makes this mandatory, not optional. */
+  windowFocused: boolean
+}
+
+/** Caller-supplied envelope fields `finish()` can't derive from the
+ *  buffered keystrokes alone. */
+export interface RunLogFinishMeta {
+  uid: string
+  /** The finishing run's own id (`TypingTestState.runId`) — `finish()`
+   *  refuses (returns null) when this doesn't match the buffer's own
+   *  runId, so a buffer left over from an earlier, already-abandoned run
+   *  (e.g. one that never got a chance to advance via `noteRegistration`
+   *  before this call) can never be saved joined to the wrong run's
+   *  words. */
+  runId: string
+  /** Epoch ms the run actually started at — every buffered keystroke's
+   *  absolute `Date.now()` timestamp is converted relative to this at
+   *  finish time (never persisted as an absolute time itself). */
+  startedAtMs: number
+  durationMs: number
+  mode: string
+  language: string
+  /** Forwarded verbatim from `TypingTestState.kspcUncomputable` — the
+   *  same IME-composition condition that makes KSPC uncomputable also
+   *  makes per-keystroke char correlation unreliable for this run (see
+   *  the module doc comment's char-correlation note). */
+  charCorrelationUnavailable: boolean
+  /** The word the run ended on without submitting (e.g. a timed run
+   *  expiring mid-word), if any — `display` is the target word text,
+   *  `typed` whatever input was accumulated for it. Omitted when the run
+   *  ended cleanly on a word boundary (every words/quote-mode finish) or
+   *  with nothing at all typed into the current word. `finish()` appends
+   *  this as a trailing `partial: true` RunWord instead of silently
+   *  dropping its keystrokes. */
+  inFlightWord?: { display: string; typed: string }
+}
+
+/** Buffered keystroke, kept in absolute-ms form (`Date.now()` values)
+ *  until `finish()` converts every run to run-relative ms — see
+ *  `RunKeystroke` in `typing-run-log.ts` for why the persisted shape
+ *  must never carry an absolute timestamp. Adds `wordIndex`, which is
+ *  NOT part of the persisted shape (`RunWord.keystrokes` already groups
+ *  implicitly by word) — carrying it on the keystroke itself instead of
+ *  bucketing by word up front lets a char event's later, more accurate
+ *  attribution (see `noteCharContext`) correct it with a single field
+ *  write rather than moving the object between per-word lists. `finish()`
+ *  groups the flat buffer back into each `RunWord` by this field, then
+ *  strips it before persisting. */
+interface BufferedKeystroke extends RunKeystroke {
+  wordIndex: number
+}
+
+interface RegistrationAnnotation {
+  wordIndex: number
+  expectedChar: string | undefined
+}
+
+/** Bound on how many char-producing keystrokes may sit unconfirmed in
+ *  EITHER direction at once — see the module doc comment's
+ *  char-correlation note, mitigation 2. Shared by `awaitingChar` (presses
+ *  awaiting their char) and `pendingChars` (chars awaiting their press). */
+const MAX_PENDING_CHAR_CONFIRMATIONS = 3
+
+/** Bound on how many `matrix-release` events may sit parked awaiting
+ *  their own press to register — see `recordMatrixRelease`'s doc
+ *  comment. Deliberately small: this only ever holds entries for a
+ *  release that arrived before its own (still-queued, tap-hold-deferred)
+ *  press, an already-rare ordering, doubly so to still be unresolved
+ *  after a handful more keys. */
+const MAX_PARKED_RELEASES = 4
+
+/** A `matrix-release` that arrived before its own press had registered —
+ *  see `recordMatrixRelease`. Keyed the same way as `openPresses`
+ *  (row/col/keycode, not a timestamp) since that's all a release event
+ *  itself carries to identify which physical key it belongs to. */
+interface ParkedRelease {
+  row: number
+  col: number
+  keycode: number
+  durationMs: number
+}
+
+/** A 'char' event that arrived before its own press had registered — see
+ *  the module doc comment's char-correlation note. `wordIndex`/
+ *  `expectedChar` come from `noteCharContext`'s pre-advance annotation
+ *  when one was captured for this exact char (the normal case for a
+ *  properly-wired caller); `wordIndex: null` means no annotation was
+ *  available, so `recordMatrixPress` falls back to the eventually-
+ *  registering press's OWN registration-time snapshot instead of
+ *  overriding it — the same behavior this module had before
+ *  `noteCharContext` existed. */
+interface PendingChar {
+  key: string
+  wordIndex: number | null
+  expectedChar: string | undefined
+}
+
+interface RunLogBuffer {
+  runId: string
+  registrations: Map<string, RegistrationAnnotation>
+  openPresses: Map<string, BufferedKeystroke>
+  /** FIFO, oldest first — see `MAX_PARKED_RELEASES`. A plain array
+   *  (not keyed by row/col/keycode) so a same-key re-press's own release
+   *  is matched in arrival order rather than risking a later parked
+   *  release for the SAME key overwriting an earlier still-unclaimed one
+   *  in a keyed map. */
+  parkedReleases: ParkedRelease[]
+  awaitingChar: BufferedKeystroke[]
+  /** FIFO, oldest first — see the module doc comment's char-correlation
+   *  note. */
+  pendingChars: PendingChar[]
+  /** Every buffered keystroke this run, in registration/arrival order,
+   *  each carrying its own current word attribution — see
+   *  `BufferedKeystroke.wordIndex`. `finish()` groups this back into
+   *  each `RunWord` by that field. */
+  keystrokes: BufferedKeystroke[]
+  eventCount: number
+  byteEstimate: number
+  /** Set once a cap is crossed. `finish()` refuses (returns null) rather
+   *  than save a silently-truncated log — checked once here instead of
+   *  re-deriving it from `eventCount`/`byteEstimate` at finish time. */
+  exceeded: boolean
+}
+
+function registrationKey(row: number, col: number, ts: number): string {
+  return `${row},${col},${ts}`
+}
+
+function pressKey(row: number, col: number, keycode: number): string {
+  return `${row},${col},${keycode}`
+}
+
+/** Rough per-keystroke byte estimate for the {@link MAX_RUN_LOG_BYTES}
+ *  running total — doesn't need to be exact, only a cheap, monotonic
+ *  proxy for the final serialized size. A flat constant (the fields
+ *  other than `expectedChar` vary little in width) plus the one field
+ *  whose length actually varies, rather than paying for a real
+ *  `JSON.stringify` on every keystroke just to measure it. */
+function approxByteSize(k: BufferedKeystroke): number {
+  return 110 + (k.expectedChar?.length ?? 0)
+}
+
+export class RunLogRecorder {
+  private buffer: RunLogBuffer | null = null
+  /** Set by `discardRun()` (the pause path) to the paused run's own id —
+   *  blocks `noteRegistration`/`noteCharContext`/`record` from
+   *  re-buffering THAT SPECIFIC run again, even though it keeps the same
+   *  runId across resume (see `discardRun`'s own doc comment). A plain
+   *  `discard()` (consent revoked, keyboard switch, unmount) does not set
+   *  this: those cases have no notion of "the same run continuing under a
+   *  still-valid runId" the way pause/resume does. */
+  private poisonedRunId: string | null = null
+  /** Single-slot pre-advance annotation captured by `noteCharContext` for
+   *  the NEXT 'char' payload `record` sees — see `noteCharContext`'s own
+   *  doc comment for why one slot (not a queue) suffices. Cleared
+   *  whenever the buffer is replaced by `noteRegistration` or discarded,
+   *  so a leftover annotation from a superseded run can never leak onto
+   *  an unrelated keystroke; NOT cleared by `record`'s own char-mint
+   *  path (see its doc comment), since that path's very next statement
+   *  is what consumes it for this same keystroke. */
+  private pendingCharAnnotation: RegistrationAnnotation | null = null
+
+  private newBuffer(runId: string): RunLogBuffer {
+    return {
+      runId,
+      registrations: new Map(),
+      openPresses: new Map(),
+      parkedReleases: [],
+      awaitingChar: [],
+      pendingChars: [],
+      keystrokes: [],
+      eventCount: 0,
+      byteEstimate: 0,
+      exceeded: false,
+    }
+  }
+
+  /** Snapshot a matrix press's word attribution at REGISTRATION time
+   *  (see the module doc comment). `context` mirrors {@link
+   *  RunLogRecordContext}'s own gate — checked here too (not only
+   *  trusted from the caller, i.e. `useInputModes`'s wrapper) so this
+   *  privacy-critical module can never buffer anything on its own,
+   *  regardless of call-site discipline. `getExpectedChar` is a thunk
+   *  rather than an already-computed value so a caller gated off (no
+   *  label, no consent, or a stale `runId`) never pays for deriving
+   *  it — the gate below runs BEFORE the thunk is ever invoked.
+   *
+   *  Unconditionally switches to a fresh buffer when `context.runId`
+   *  differs from whatever is currently buffered — this is what actually
+   *  advances the recorder to a new run (restart / setConfig /
+   *  setLanguage). Safe to do unconditionally here specifically because
+   *  a matrix press is registered synchronously at press time, never
+   *  delayed — unlike `record`'s 'matrix'/'matrix-release' branches,
+   *  which can see a masked key's event land up to TAPPING_TERM after the
+   *  press that produced it and must not let a stale one un-discard an
+   *  abandoned run this way (see the module doc comment's ASYMMETRIC
+   *  STALENESS note; a 'char' payload is the one other exception). */
+  noteRegistration(
+    context: RunLogRecordContext, row: number, col: number, ts: number, wordIndex: number,
+    getExpectedChar: () => string | undefined,
+  ): void {
+    if (!context.typingTestLabel) return
+    if (!context.consentAccepted) return
+    if (!context.windowFocused) return
+    if (!context.runId) return
+    if (context.runId === this.poisonedRunId) return
+    const runId = context.runId
+    if (!this.buffer || this.buffer.runId !== runId) {
+      this.buffer = this.newBuffer(runId)
+      // A leftover annotation from whatever run was buffered before this
+      // must never leak onto an unrelated keystroke in the new one — see
+      // this field's own doc comment.
+      this.pendingCharAnnotation = null
+    }
+    this.buffer.registrations.set(registrationKey(row, col, ts), { wordIndex, expectedChar: getExpectedChar() })
+  }
+
+  /** Snapshot a char-producing keystroke's word attribution immediately
+   *  BEFORE this same key's own run-state update (see
+   *  `useTypingTest.processKeyEvent`'s call site) — the DOM 'char' event
+   *  is synchronous and never deferred (see the module doc comment's
+   *  ASYMMETRIC STALENESS note), so unlike `noteRegistration` (which runs
+   *  at HID-poll time, always AFTER this handler already advanced state
+   *  for the same physical press) this is the FIRST place this run's
+   *  state is read for this key at all — the resulting annotation is
+   *  therefore the more accurate of the two when both exist for the same
+   *  keystroke. `context` mirrors {@link RunLogRecordContext}'s own gate,
+   *  checked here too for the same reason as `noteRegistration`.
+   *
+   *  Stores the result in {@link pendingCharAnnotation} for `record`'s
+   *  'char' branch — called synchronously right after, in the same call
+   *  stack (see `processKeyEvent`) — to consume; nothing else can run in
+   *  between to observe or clobber it. Never mints/advances the buffer
+   *  itself (that happens in `record`, see its own doc comment) — this
+   *  method only ever writes the slot. */
+  noteCharContext(context: RunLogRecordContext, wordIndex: number, expectedChar: string | undefined): void {
+    if (!context.typingTestLabel) return
+    if (!context.consentAccepted) return
+    if (!context.windowFocused) return
+    if (!context.runId) return
+    if (context.runId === this.poisonedRunId) return
+    this.pendingCharAnnotation = { wordIndex, expectedChar }
+  }
+
+  /** Record one analytics event already destined for the per-minute
+   *  pipeline — this module's own gate (see {@link RunLogRecordContext})
+   *  decides independently whether it also belongs in a run log. */
+  record(context: RunLogRecordContext, payload: TypingAnalyticsEventPayload): void {
+    if (!context.typingTestLabel) return
+    if (!context.consentAccepted) return
+    if (!context.windowFocused) return
+    if (!context.runId) return
+    if (context.runId === this.poisonedRunId) return
+    if (!this.buffer || this.buffer.runId !== context.runId) {
+      // A 'char' payload may mint/advance the buffer here — see the
+      // module doc comment's ASYMMETRIC STALENESS note for why this is
+      // safe for 'char' specifically (never stale, unlike 'matrix'/
+      // 'matrix-release', which keep the original drop-on-absent/
+      // mismatch behavior below): only `noteRegistration` or a live
+      // 'char' payload may advance the buffer to a new run.
+      if (payload.kind !== 'char') return
+      this.buffer = this.newBuffer(context.runId)
+    }
+    const buf = this.buffer
+    if (buf.exceeded) return
+    switch (payload.kind) {
+      case 'matrix':
+        this.recordMatrixPress(buf, payload)
+        break
+      case 'matrix-release':
+        this.recordMatrixRelease(buf, payload)
+        break
+      case 'char':
+        this.recordChar(buf, payload)
+        break
+    }
+  }
+
+  private pushKeystroke(buf: RunLogBuffer, keystroke: BufferedKeystroke): void {
+    buf.eventCount++
+    buf.byteEstimate += approxByteSize(keystroke)
+    if (buf.eventCount > MAX_RUN_LOG_EVENTS || buf.byteEstimate > MAX_RUN_LOG_BYTES) {
+      buf.exceeded = true
+      return
+    }
+    buf.keystrokes.push(keystroke)
+  }
+
+  private recordMatrixPress(buf: RunLogBuffer, payload: Extract<TypingAnalyticsEventPayload, { kind: 'matrix' }>): void {
+    const key = registrationKey(payload.row, payload.col, payload.ts)
+    const reg = buf.registrations.get(key)
+    buf.registrations.delete(key)
+    // No annotation captured for this press (e.g. it registered before
+    // gating turned on) — nothing to attribute it to, so drop it rather
+    // than guess a word index.
+    if (!reg) return
+
+    const keystroke: BufferedKeystroke = {
+      pressMs: payload.ts,
+      keycode: payload.keycode,
+      row: payload.row,
+      col: payload.col,
+      wordIndex: reg.wordIndex,
+      expectedChar: reg.expectedChar,
+      overlapped: payload.overlap,
+    }
+    this.pushKeystroke(buf, keystroke)
+    if (buf.exceeded) return
+
+    // A release for THIS key may have already arrived and parked (see
+    // `recordMatrixRelease`) — 'matrix-release' bypasses the tap-hold
+    // ordering queue and ships immediately, while this 'matrix' press
+    // event can be the one still deferred. Claim the OLDEST parked
+    // release for this exact key (FIFO — see `parkedReleases`'s own doc
+    // comment for why a same-key re-press must not steal a different
+    // press's parked duration) and resolve immediately instead of
+    // waiting in `openPresses` for a release that already happened.
+    const pk = pressKey(payload.row, payload.col, payload.keycode)
+    const parkedIndex = buf.parkedReleases.findIndex(
+      (p) => p.row === payload.row && p.col === payload.col && p.keycode === payload.keycode,
+    )
+    if (parkedIndex !== -1) {
+      const [parked] = buf.parkedReleases.splice(parkedIndex, 1)
+      keystroke.releaseMs = keystroke.pressMs + parked.durationMs
+    } else {
+      buf.openPresses.set(pk, keystroke)
+    }
+
+    // A masked key resolved as `hold` never commits a character (it's a
+    // layer switch), so it must never enter char confirmation at all —
+    // see the module doc comment's char-correlation note, mitigation 1.
+    const mayProduceChar = payload.action !== 'hold' && producesChar(payload.keycode)
+    if (mayProduceChar) {
+      // Check `pendingChars` FIRST — the real, usual ordering (see the
+      // module doc comment) is char-before-matrix, so the char this
+      // press should confirm has very likely already arrived and is
+      // waiting here, not the other way around.
+      const pendingChar = buf.pendingChars.shift()
+      if (pendingChar) {
+        // Override the registration-time snapshot with the char's own
+        // pre-advance annotation, when one was captured for it (see
+        // `noteCharContext`) — it reflects this press's word more
+        // accurately than the registration snapshot does (registration
+        // runs AFTER this same press's char handler already advanced
+        // state for it). `wordIndex: null` means no annotation was ever
+        // captured (a caller that emits 'char' without `noteCharContext`
+        // first) — keep the registration snapshot already on `keystroke`
+        // rather than overriding with nothing, the same behavior this
+        // module had before `noteCharContext` existed.
+        if (pendingChar.wordIndex !== null) {
+          keystroke.wordIndex = pendingChar.wordIndex
+          keystroke.expectedChar = pendingChar.expectedChar
+        }
+        this.applyCharVerdict(keystroke, pendingChar.key)
+      } else {
+        buf.awaitingChar.push(keystroke)
+        // The single push above can grow the queue past the cap by at
+        // most one, so a single shift (not a loop) suffices to restore it.
+        if (buf.awaitingChar.length > MAX_PENDING_CHAR_CONFIRMATIONS) buf.awaitingChar.shift()
+      }
+    }
+  }
+
+  /** `recordMatrixRelease` bypasses the tap-hold ordering queue (see
+   *  useTypingTest.ts's own comment on why release events ship straight
+   *  through `emit`), while the matching 'matrix' PRESS event for a
+   *  masked key can still be sitting in that queue awaiting its tap/hold
+   *  classification — so a release can physically arrive here before
+   *  `recordMatrixPress` has ever run for its own press. Parking it
+   *  (rather than dropping it, which is what happened before this fix)
+   *  lets `recordMatrixPress` claim it once the press finally registers,
+   *  instead of the keystroke permanently reading as "still open" (no
+   *  `releaseMs`) despite having actually been released. */
+  private recordMatrixRelease(buf: RunLogBuffer, payload: Extract<TypingAnalyticsEventPayload, { kind: 'matrix-release' }>): void {
+    const key = pressKey(payload.row, payload.col, payload.keycode)
+    const press = buf.openPresses.get(key)
+    if (press) {
+      buf.openPresses.delete(key)
+      press.releaseMs = press.pressMs + payload.durationMs
+      return
+    }
+    buf.parkedReleases.push({ row: payload.row, col: payload.col, keycode: payload.keycode, durationMs: payload.durationMs })
+    if (buf.parkedReleases.length > MAX_PARKED_RELEASES) buf.parkedReleases.shift()
+  }
+
+  /** Shared correctness-verdict logic between the two pairing directions
+   *  (a char confirming an already-registered press in `recordChar`, or a
+   *  press claiming an already-arrived char in `recordMatrixPress`) — see
+   *  the module doc comment's char-correlation note. Backspace produces a
+   *  'char' event (see the DOM gate in useTypingTest.processKeyEvent) but
+   *  confirms nothing, in either direction — the keystroke it lands on is
+   *  still consumed (to keep the surrounding queue aligned) just without
+   *  a misleading correctness verdict. */
+  private applyCharVerdict(keystroke: BufferedKeystroke, key: string): void {
+    if (key === 'Backspace') return
+    if (keystroke.expectedChar !== undefined) {
+      // expectedChar (deriveExpectedChar / romajiNextExpectedChar) is
+      // always the canonical, unstyled character — romaji's own
+      // remainingGuide()/nextGuideChar() are never case-styled
+      // (applyRomajiCaseStyle only transforms the display-only guide
+      // built in useTypingTest's romajiGuide memo, not the matcher
+      // itself). `key` is the raw DOM key as physically typed, so a case
+      // difference from Shift can make a physically-correct press
+      // compare false here — a known, accepted limitation, not fixed by
+      // this comparison.
+      keystroke.correct = key === keystroke.expectedChar
+    }
+  }
+
+  private recordChar(buf: RunLogBuffer, payload: Extract<TypingAnalyticsEventPayload, { kind: 'char' }>): void {
+    // Consume the pre-advance annotation `noteCharContext` stashed for
+    // THIS exact char, called synchronously right before this same
+    // `record` call (see its own doc comment) — null when no such call
+    // preceded this one.
+    const annotation = this.pendingCharAnnotation
+    this.pendingCharAnnotation = null
+
+    const keystroke = buf.awaitingChar.shift()
+    if (!keystroke) {
+      // No press waiting to confirm — this is the REAL, usual ordering
+      // (see the module doc comment): the char arrived first. Queue it
+      // for the matching press to claim once IT registers, rather than
+      // dropping it (which is what caused the permanent off-by-one this
+      // queue exists to fix — pairing this char to whatever unrelated
+      // press happens to come next).
+      buf.pendingChars.push({ key: payload.key, wordIndex: annotation?.wordIndex ?? null, expectedChar: annotation?.expectedChar })
+      if (buf.pendingChars.length > MAX_PENDING_CHAR_CONFIRMATIONS) buf.pendingChars.shift()
+      return
+    }
+    // Override the registration-time snapshot with the pre-advance
+    // annotation, when one was captured — see `noteCharContext`'s doc
+    // comment for why it is the more accurate of the two.
+    if (annotation) {
+      keystroke.wordIndex = annotation.wordIndex
+      keystroke.expectedChar = annotation.expectedChar
+    }
+    this.applyCharVerdict(keystroke, payload.key)
+  }
+
+  /** Discard the current run's buffer without saving anything. Call on
+   *  consent revocation mid-run, unmount, or a keyboard switch/disconnect
+   *  — cases where either recording is stopping for good or the
+   *  identity of "what's being typed" is changing, so there's no
+   *  expectation that more keystrokes for the SAME runId should still be
+   *  recordable afterward. For the pause case specifically, see
+   *  `discardRun()` instead. */
+  discard(): void {
+    this.buffer = null
+    this.pendingCharAnnotation = null
+  }
+
+  /** Discard `runId`'s buffer AND block it from ever being re-buffered —
+   *  unlike `discard()`, this survives across further `noteRegistration`/
+   *  `noteCharContext`/`record` calls carrying the SAME runId, because
+   *  that's exactly what a pause/resume does (the run keeps its id across
+   *  the pause). Call on pause: resuming rebases
+   *  `TypingTestState.startTime` to `Date.now() - elapsedMs`, so this
+   *  run's raw timeline is already broken by the pause gap even once
+   *  typing resumes — the summary result still saves normally, just not
+   *  this run's raw log, for either its pre- or post-pause portion. A
+   *  later, genuinely NEW runId (restart) is unaffected — it will never
+   *  equal the poisoned id, so recording resumes normally for it without
+   *  any further action here. */
+  discardRun(runId: string): void {
+    this.buffer = null
+    this.poisonedRunId = runId
+    this.pendingCharAnnotation = null
+  }
+
+  /** Converts one word's buffered keystrokes to the persisted,
+   *  run-relative shape, dropping the buffer-only `wordIndex` field. A
+   *  keystroke whose absolute `pressMs` precedes `startedAtMs` is
+   *  DROPPED rather than clamped to 0 — belt-and-braces alongside the
+   *  pause-time discard() this module's callers now do (see `finish()`'s
+   *  own doc comment): clamping would misrepresent a keystroke as having
+   *  happened at the exact instant the run started, silently corrupting
+   *  the timeline instead of just omitting the one data point that can't
+   *  be placed on it. `releaseMs` still gets a defensive `Math.max(0,
+   *  ...)` even though it's normally >= the (now-guaranteed-non-negative)
+   *  `pressMs` by construction. */
+  private convertKeystrokes(keystrokes: readonly BufferedKeystroke[], startedAtMs: number): RunKeystroke[] {
+    return keystrokes
+      .filter((k) => k.pressMs - startedAtMs >= 0)
+      .map((k) => ({
+        pressMs: k.pressMs - startedAtMs,
+        releaseMs: k.releaseMs !== undefined ? Math.max(0, k.releaseMs - startedAtMs) : undefined,
+        keycode: k.keycode,
+        row: k.row,
+        col: k.col,
+        expectedChar: k.expectedChar,
+        correct: k.correct,
+        overlapped: k.overlapped,
+      }))
+  }
+
+  /** Finalize the current run's buffer into a saveable log, joining each
+   *  buffered word's keystrokes against `wordResults` (display/typed/
+   *  correct) and converting every timestamp to run-relative ms. Returns
+   *  null (clearing the buffer either way) when there is nothing at all
+   *  to save (no submitted words AND no in-flight word — see
+   *  `meta.inFlightWord`), `meta.runId` doesn't match the buffer's own
+   *  runId (a stale buffer left over from an abandoned run, never
+   *  advanced past by `noteRegistration`/a 'char' payload before this
+   *  call — see `RunLogFinishMeta.runId`'s own doc comment), or a cap was
+   *  exceeded during recording — a silently-truncated log is never
+   *  saved. */
+  finish(wordResults: readonly WordResult[], meta: RunLogFinishMeta): RunKeystrokeLog | null {
+    const buf = this.buffer
+    this.buffer = null
+    if (!buf) return null
+    if (buf.runId !== meta.runId) return null
+    if (buf.exceeded) return null
+    if (wordResults.length === 0 && !meta.inFlightWord) return null
+
+    // Group the flat, arrival-ordered buffer back into per-word lists
+    // once here (rather than keeping a live per-word map throughout the
+    // run) — see `BufferedKeystroke.wordIndex`'s own doc comment for why
+    // attribution is a field write during recording, not a list move.
+    // Grouping preserves each word's own arrival order since `keystrokes`
+    // itself is append-only in registration/arrival order.
+    const byWord = new Map<number, BufferedKeystroke[]>()
+    for (const k of buf.keystrokes) {
+      const list = byWord.get(k.wordIndex)
+      if (list) list.push(k)
+      else byWord.set(k.wordIndex, [k])
+    }
+
+    const words: RunWord[] = wordResults.map((wr, index) => ({
+      index,
+      display: wr.word,
+      typed: wr.typed,
+      correct: wr.correct,
+      keystrokes: this.convertKeystrokes(byWord.get(index) ?? [], meta.startedAtMs),
+    }))
+
+    // The word the run ended on without submitting (e.g. a timed run
+    // expiring mid-word) — its keystrokes were buffered under this same
+    // index (see `noteRegistration`/`noteCharContext`) but would
+    // otherwise never be attached to any RunWord, since `wordResults`
+    // only ever contains SUBMITTED words. See `RunWord.partial`.
+    if (meta.inFlightWord) {
+      words.push({
+        index: wordResults.length,
+        display: meta.inFlightWord.display,
+        typed: meta.inFlightWord.typed,
+        correct: false,
+        partial: true,
+        keystrokes: this.convertKeystrokes(byWord.get(wordResults.length) ?? [], meta.startedAtMs),
+      })
+    }
+
+    return {
+      runId: buf.runId,
+      uid: meta.uid,
+      startedAt: new Date(meta.startedAtMs).toISOString(),
+      durationMs: meta.durationMs,
+      mode: meta.mode,
+      language: meta.language,
+      charCorrelationUnavailable: meta.charCorrelationUnavailable || undefined,
+      words,
+    }
+  }
+}

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -29,6 +29,7 @@ import {
 import { MatrixAnalyticsQueue } from './matrix-analytics-queue'
 import { PressDurationTracker } from './matrix-press-duration'
 import { MatrixLayerLatch } from './matrix-layer-latch'
+import { deriveExpectedChar } from './expected-char'
 
 export type { WordResult, TypingTestState, TypingTestStatus } from './run-state'
 
@@ -42,14 +43,51 @@ export interface UseTypingTestOptions<TPreparedEvent = unknown> {
    * item to {@link onEmitAnalyticsEvent} — or null/undefined to drop the
    * press: it is then never queued or emitted, so a later state change
    * cannot retroactively authorize it. Called once per accepted keystroke,
-   * never re-invoked for the same press. */
-  onPrepareAnalyticsEvent?: (kind: 'matrix' | 'char') => TPreparedEvent | null | undefined
+   * never re-invoked for the same press. `windowFocused` is this hook's own
+   * live focus state at the moment of the call (always true for 'char' —
+   * processKeyEvent already refuses to run at all while unfocused) — the
+   * caller carries it into its own opaque `TPreparedEvent` so a
+   * consumer gated on focus (see run-log-recorder.ts's PRIVACY note) can
+   * apply the press-time value rather than whatever focus is by the time
+   * the event actually ships. */
+  onPrepareAnalyticsEvent?: (kind: 'matrix' | 'char', windowFocused: boolean) => TPreparedEvent | null | undefined
   /** Ships an event that {@link onPrepareAnalyticsEvent} already authorized
    * and tagged for this exact press. Called either immediately (empty
    * queue) or once the item reaches the front of the ordering queue —
    * must not re-read whatever live state produced `prepared`, since that
    * state may have changed while the item was queued. */
   onEmitAnalyticsEvent?: (prepared: TPreparedEvent, event: TypingAnalyticsEventPayload) => void
+  /** Notifies the run-keystroke-log recorder (owned by the caller, e.g.
+   * useInputModes) of a matrix press at REGISTRATION time, so a later
+   * (possibly TAPPING_TERM-delayed) analytics event can still be joined
+   * back to the word it was actually typed against. See
+   * run-log-recorder.ts's `noteRegistration`. `getExpectedChar` is a
+   * thunk (not an already-computed value) so its — possibly expensive,
+   * for romaji — derivation is free whenever the recorder is gated off;
+   * the recorder invokes it only once it has confirmed recording is
+   * actually active. Only ever called while `windowFocused` (this
+   * hook's own live focus state) is true — see the call site in
+   * `processMatrixFrame` — so `windowFocused` is always `true` here too;
+   * threaded through anyway so the recorder's own gate (defense in
+   * depth, see run-log-recorder.ts's PRIVACY note) doesn't have to
+   * assume the caller's discipline. */
+  onNoteKeystrokeRegistration?: (
+    runId: string, row: number, col: number, ts: number, wordIndex: number,
+    getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => void
+  /** Notifies the run-keystroke-log recorder of a char-producing
+   * keystroke's word attribution, snapshotted immediately BEFORE this
+   * same key's own run-state update — unlike a matrix press (registered
+   * at HID-poll time, always AFTER its own handler already advanced
+   * state for the same physical press), a DOM char event's own emit
+   * below IS that state's first touch for this key, so this call must
+   * run first, not merely before the emit. See run-log-recorder.ts's
+   * `noteCharContext`. `getExpectedChar` is a thunk for the same reason
+   * as `onNoteKeystrokeRegistration`'s. Only ever called while
+   * `windowFocused` is true, same as `onNoteKeystrokeRegistration`. */
+  onNoteCharContext?: (
+    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+  ) => void
   /** TAPPING_TERM (ms) used to classify masked-key presses as tap vs
    * hold against a deadline fixed at press time (pressTs + this value,
    * captured then — not re-read at release/deadline, so a setting change
@@ -133,6 +171,8 @@ export function useTypingTest<TPreparedEvent = unknown>(
   const windowFocusedRef = useRef(windowFocused)
   const prepareAnalyticsEventRef = useRef(options?.onPrepareAnalyticsEvent)
   const emitAnalyticsEventRef = useRef(options?.onEmitAnalyticsEvent)
+  const noteKeystrokeRegistrationRef = useRef(options?.onNoteKeystrokeRegistration)
+  const noteCharContextRef = useRef(options?.onNoteCharContext)
   const prevPressedRef = useRef<ReadonlySet<string>>(new Set())
   const latchedLayersRef = useRef(new MatrixLayerLatch())
   // Press-order emission queue for matrix analytics events. See
@@ -159,6 +199,8 @@ export function useTypingTest<TPreparedEvent = unknown>(
   windowFocusedRef.current = windowFocused
   prepareAnalyticsEventRef.current = options?.onPrepareAnalyticsEvent
   emitAnalyticsEventRef.current = options?.onEmitAnalyticsEvent
+  noteKeystrokeRegistrationRef.current = options?.onNoteKeystrokeRegistration
+  noteCharContextRef.current = options?.onNoteCharContext
   tappingTermMsRef.current = options?.tappingTermMs ?? DEFAULT_TAPPING_TERM_MS
 
   const restartAsync = useCallback(async () => {
@@ -389,8 +431,23 @@ export function useTypingTest<TPreparedEvent = unknown>(
       // that isn't authorized right now is dropped for good — it never
       // enters the queue, so it can't be "un-dropped" by a state change
       // (e.g. recording toggling back on) while it would have waited.
-      const prepared = prepare('matrix')
+      const prepared = prepare('matrix', windowFocusedRef.current)
       if (prepared == null) continue
+      // Run-keystroke-log word attribution, snapshotted now (registration
+      // time) rather than whenever this press eventually emits — see
+      // onNoteKeystrokeRegistration's doc comment. Gated on window focus
+      // here (the primary gate — HID matrix polling itself is NOT gated
+      // on focus, see the comment atop this function, so without this
+      // check a keystroke typed into a different, unfocused application
+      // on the same keyboard would be attributed to the run log): only
+      // ever called while the app window is actually focused.
+      if (windowFocusedRef.current) {
+        noteKeystrokeRegistrationRef.current?.(
+          stateRef.current.runId, edge.row, edge.col, ts, stateRef.current.currentWordIndex,
+          () => deriveExpectedChar(stateRef.current, configRef.current, languageRef.current),
+          windowFocusedRef.current,
+        )
+      }
       // Overlap / pollGapMs are derived from the raw pressed set, not
       // from anything queue-related — see matrix-press-duration.ts.
       // registerPress also records this press so the matching release
@@ -532,8 +589,22 @@ export function useTypingTest<TPreparedEvent = unknown>(
     // in the same call — no staleness window to guard against.
     const prepare = prepareAnalyticsEventRef.current
     if (prepare && (key.length === 1 || key === 'Backspace')) {
-      const prepared = prepare('char')
+      // Always true here — the early return above already refused to run
+      // at all while unfocused — passed through anyway for a uniform
+      // prepare() signature between the matrix and char call sites.
+      const prepared = prepare('char', windowFocusedRef.current)
       if (prepared != null) {
+        // Run-keystroke-log word attribution for this char, captured NOW
+        // — before the reducer below advances state for this same key —
+        // see onNoteCharContext's doc comment. Gated on focus the same
+        // way as onNoteKeystrokeRegistration's own call site.
+        if (windowFocusedRef.current) {
+          noteCharContextRef.current?.(
+            stateRef.current.runId, stateRef.current.currentWordIndex,
+            () => deriveExpectedChar(stateRef.current, configRef.current, languageRef.current),
+            windowFocusedRef.current,
+          )
+        }
         emitAnalyticsEventRef.current?.(prepared, { kind: 'char', key, ts: Date.now() })
       }
     }

--- a/src/shared/ipc/channels.ts
+++ b/src/shared/ipc/channels.ts
@@ -174,6 +174,11 @@ export const IpcChannels = {
    * narrowing). */
   TYPING_ANALYTICS_LIST_DURATION_CELLS: 'typing-analytics:list-duration-cells',
 
+  // Typing Run Log Store — per-run raw keystroke log (renderer → main → renderer)
+  TYPING_RUN_LOG_SAVE: 'typing-run-log:save',
+  TYPING_RUN_LOG_LIST: 'typing-run-log:list',
+  TYPING_RUN_LOG_GET: 'typing-run-log:get',
+
   // Typing Test Text Store (renderer → main → renderer)
   TYPING_TEST_TEXT_LIST: 'typing-test-text:list',
   TYPING_TEST_TEXT_GET: 'typing-test-text:get',

--- a/src/shared/types/sync.ts
+++ b/src/shared/types/sync.ts
@@ -9,6 +9,7 @@ import type { KeyLabelIndex } from './key-label-store'
 import type { TypingTestTextIndex } from './typing-test-text-store'
 import type { I18nPackIndex, I18nIndexSyncUnit, I18nPackSyncUnit } from './i18n-store'
 import type { ThemePackIndex } from './theme-store'
+import type { RunLogIndex } from './typing-run-log'
 
 export type { AppConfig }
 export { DEFAULT_APP_CONFIG } from './app-config'
@@ -23,9 +24,9 @@ export interface SyncEnvelope {
 }
 
 export interface SyncBundle {
-  type: 'favorite' | 'layout' | 'analyze-filter' | 'settings' | 'keyboard-meta' | 'typing-analytics-device' | 'key-label' | 'typing-test-text' | 'i18n-index' | 'i18n-pack' | 'theme-index' | 'theme-pack'
+  type: 'favorite' | 'layout' | 'analyze-filter' | 'run-log' | 'settings' | 'keyboard-meta' | 'typing-analytics-device' | 'key-label' | 'typing-test-text' | 'i18n-index' | 'i18n-pack' | 'theme-index' | 'theme-pack'
   key: string // FavoriteType, UID, 'keyboard-names' for meta, `${uid}|${machineHash}` for device, 'key-labels', 'typing-test-texts', 'i18n-index', or packId for i18n-pack
-  index: FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | KeyboardMetaIndex | KeyLabelIndex | TypingTestTextIndex | I18nPackIndex | ThemePackIndex
+  index: FavoriteIndex | SnapshotIndex | AnalyzeFilterSnapshotIndex | RunLogIndex | KeyboardMetaIndex | KeyLabelIndex | TypingTestTextIndex | I18nPackIndex | ThemePackIndex
   files: Record<string, string> // filename -> content (empty for meta / i18n-index)
 }
 
@@ -63,6 +64,7 @@ export type FavoriteSyncUnit = `favorites/${FavoriteType}`
 export type KeyboardSettingsSyncUnit = `keyboards/${string}/settings`
 export type KeyboardSnapshotsSyncUnit = `keyboards/${string}/snapshots`
 export type KeyboardAnalyzeFiltersSyncUnit = `keyboards/${string}/analyze_filters`
+export type KeyboardRunLogSyncUnit = `keyboards/${string}/runs`
 export type KeyboardTypingAnalyticsDeviceSyncUnit = `keyboards/${string}/devices/${string}`
 export type KeyLabelSyncUnit = 'key-labels'
 export type TypingTestTextSyncUnit = 'typing-test-texts'
@@ -71,6 +73,7 @@ export type SyncUnit =
   | KeyboardSettingsSyncUnit
   | KeyboardSnapshotsSyncUnit
   | KeyboardAnalyzeFiltersSyncUnit
+  | KeyboardRunLogSyncUnit
   | KeyboardMetaSyncUnit
   | KeyboardTypingAnalyticsDeviceSyncUnit
   | KeyLabelSyncUnit

--- a/src/shared/types/typing-run-log.ts
+++ b/src/shared/types/typing-run-log.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Per-run raw keystroke log for a Typing Test run — the timeline data a
+// per-minute aggregate cannot reconstruct (order and inter-keystroke
+// gaps are lost once folded into a minute bucket). See
+// .claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md and
+// .claude/plans/Plan-typing-metrics-chi2018.md Phase 5.
+//
+// PRIVACY (read before touching this file): this is the highest
+// input-content-recovery-risk data in the app — higher than trigrams.
+// It is captured ONLY for a Typing Test run (known, non-secret
+// material, unlike ambient REC), only under the existing REC recording-
+// consent gate, is never sent to Hub, and carries no absolute
+// timestamps in the per-keystroke payload (see RunKeystroke). See
+// run-log-recorder.ts (renderer) for the capture-side guarantees this
+// file only describes the shape of.
+
+/** One physical keystroke within a run, timed relative to the run's own
+ *  start (never an absolute clock timestamp — see the module doc
+ *  comment). Deliberate deviations from the task sketch, spelled out so
+ *  a future reader doesn't "fix" them back:
+ *  - `overlapped` is optional to preserve the same tri-state
+ *    observability contract as the existing per-minute analytics
+ *    (`overlap` on `TypingAnalyticsEventPayload`) — undefined means
+ *    "unobservable" (e.g. following an observation hole), not "false".
+ *    See matrix-press-duration.ts.
+ *  - `releaseMs` is optional: a run can finish (or the recorder's
+ *    buffer can be handed to `finish()`) while a key is still held —
+ *    `resetMatrixPressTracking` discards a still-open press rather
+ *    than fabricating a release for it, so the keystroke is kept with
+ *    no release instead of being dropped.
+ *  - `correct`/`expectedChar` are optional: a modifier-only press (no
+ *    char produced) and any keystroke typed during IME composition
+ *    have no char to correlate against (see
+ *    `RunKeystrokeLog.charCorrelationUnavailable`).
+ *  - There is no `reading` field — no data source in this codebase
+ *    produces one for a run's keystrokes. */
+export interface RunKeystroke {
+  /** ms since the owning `RunKeystrokeLog.startedAt`. */
+  pressMs: number
+  /** ms since `RunKeystrokeLog.startedAt`, when observed — see the
+   *  field doc above for why this can be absent. A release that
+   *  physically arrives before its own press has registered (the press
+   *  is still queued behind an unresolved tap-hold classification, while
+   *  `matrix-release` bypasses that queue and ships immediately) is
+   *  recovered via a small parking map in run-log-recorder.ts rather
+   *  than being lost, so `releaseMs` being absent genuinely means the
+   *  run ended mid-hold, not just an unlucky arrival order. */
+  releaseMs?: number
+  keycode: number
+  row: number
+  col: number
+  /** The character this press was expected to confirm, when known. */
+  expectedChar?: string
+  /** Whether the press matched `expectedChar` (verbatim mode) or
+   *  confirmed the current romaji segment (romaji mode). Absent when
+   *  there is nothing to correlate against (modifier press, IME
+   *  composition input). */
+  correct?: boolean
+  /** Whether the immediately preceding press was still physically held
+   *  when this one landed — mirrors
+   *  `TypingAnalyticsEventPayload['overlap']`'s tri-state semantics. */
+  overlapped?: boolean
+}
+
+/** One finalized word's keystrokes, joined against its `WordResult`. */
+export interface RunWord {
+  index: number
+  display: string
+  typed: string
+  correct: boolean
+  /** True only for the trailing in-flight word a run ended on without
+   *  submitting (e.g. a timed run expiring mid-word) — its keystrokes are
+   *  real, but `typed`/`correct` describe an interrupted attempt rather
+   *  than a judged submission. Absent (not `false`) for every ordinarily
+   *  finalized word, mirroring this module's other optional-field
+   *  convention. See run-log-recorder.ts's `finish()`. */
+  partial?: boolean
+  keystrokes: RunKeystroke[]
+}
+
+export interface RunKeystrokeLog {
+  runId: string
+  uid: string
+  /** ISO 8601 — the run's absolute start time. This is the ONLY
+   *  absolute timestamp anywhere in this payload; every `RunKeystroke`
+   *  time is relative to it (see the module doc comment). Same
+   *  exposure class as the already-synced `TypingTestResult.date` — not
+   *  a new category of absolute-time exposure, just a finer-grained
+   *  one attached to per-keystroke detail instead of a per-run summary. */
+  startedAt: string
+  durationMs: number
+  mode: string
+  language: string
+  /** True once at least one keystroke in this run went through IME
+   *  composition, making char-level correctness/expectedChar
+   *  unavailable for (at least) that keystroke — mirrors
+   *  `TypingTestState.kspcUncomputable`'s naming/spirit for this log. */
+  charCorrelationUnavailable?: boolean
+  words: RunWord[]
+}
+
+/** Index entry — deliberately `id` (not `runId`) to mirror every other
+ *  index-based store's `EntryMeta` shape (`AnalyzeFilterSnapshotMeta`,
+ *  `KeyLabelMeta`, ...) so this store's index can reuse the generic
+ *  `mergeEntries`/`gcTombstones` helpers in `sync/merge.ts` unchanged —
+ *  those key strictly on `.id`. `id` holds the same value as the
+ *  matching `RunKeystrokeLog.runId`. */
+export interface RunLogMeta {
+  id: string
+  /** ISO 8601, immutable for the entry's lifetime — the ranking key
+   *  `applyRunLogRetention` retains-newest-N by, so every device converges
+   *  on the same kept set after a merge (see `MAX_RUN_LOGS_PER_KEYBOARD`). */
+  startedAt: string
+  filename: string
+  savedAt: string
+  updatedAt?: string
+  deletedAt?: string
+}
+
+export interface RunLogIndex {
+  uid: string
+  entries: RunLogMeta[]
+}
+
+/** Per-run keystroke event cap — a run producing more than this many
+ *  keystrokes has its log refused at `finish()` rather than saved
+ *  truncated (see run-log-recorder.ts: a silently-truncated log must
+ *  never be saved). */
+export const MAX_RUN_LOG_EVENTS = 10_000
+
+/** Per-run serialized-payload byte cap, same refuse-rather-than-
+ *  truncate policy as {@link MAX_RUN_LOG_EVENTS}. Checked again on the
+ *  main-process side (defense in depth) before a save is accepted. */
+export const MAX_RUN_LOG_BYTES = 1_000_000
+
+/** Retention: newest N runs kept per keyboard (see `applyRunLogRetention`
+ *  in sync/merge.ts). Ranked by immutable `startedAt` (runId as
+ *  tiebreaker) so every device converges on the same 50 after a merge,
+ *  rather than LWW resurrecting an evicted entry. */
+export const MAX_RUN_LOGS_PER_KEYBOARD = 50

--- a/src/shared/types/vial-api.ts
+++ b/src/shared/types/vial-api.ts
@@ -15,6 +15,7 @@ import type {
 } from './protocol'
 import type { SnapshotMeta } from './snapshot-store'
 import type { AnalyzeFilterSnapshotMeta } from './analyze-filter-store'
+import type { RunKeystrokeLog, RunLogMeta } from './typing-run-log'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteImportResult } from './favorite-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult, KeyLabelImportBatchResult } from './key-label-store'
 import type { TypingTestTextMeta, TypingTestTextRecord, TypingTestTextStoreResult } from './typing-test-text-store'
@@ -168,6 +169,11 @@ export interface VialAPI {
   analyzeFilterStoreUpdate(uid: string, entryId: string, json: string): Promise<{ success: boolean; error?: string }>
   analyzeFilterStoreRename(uid: string, entryId: string, newLabel: string): Promise<{ success: boolean; error?: string }>
   analyzeFilterStoreDelete(uid: string, entryId: string): Promise<{ success: boolean; error?: string }>
+
+  // --- Typing Run Log Store (per-run raw keystroke log) ---
+  typingRunLogSave(uid: string, log: RunKeystrokeLog): Promise<{ success: boolean; entry?: RunLogMeta; error?: string }>
+  typingRunLogList(uid: string): Promise<{ success: boolean; entries?: RunLogMeta[]; error?: string }>
+  typingRunLogGet(uid: string, runId: string): Promise<{ success: boolean; data?: RunKeystrokeLog; error?: string }>
 
   // Favorite Store (internal save/load)
   favoriteStoreList(type: string): Promise<{ success: boolean; entries?: SavedFavoriteMeta[]; error?: string }>

--- a/src/shared/utils/safe-filename.ts
+++ b/src/shared/utils/safe-filename.ts
@@ -12,3 +12,26 @@ const SAFE_FILENAME_REGEX = /[^\p{L}\p{N}_-]+/gu
 export function safeFilename(name: string, fallback: string): string {
   return name.replace(SAFE_FILENAME_REGEX, '_').replace(/^_+|_+$/g, '') || fallback
 }
+
+// Path-safety helpers shared across the index-based main-process stores
+// (favorites, snapshots, analyze-filter, key-label, typing-test-text, run
+// logs). Several of those stores still carry their own verbatim copy of
+// `isSafePathSegment` — see
+// .claude/tasks/backlog/Task-store-path-helper-dedup.md for consolidating
+// them here too; new call sites should import from here rather than add
+// another copy.
+
+/** True when `segment` is safe to use as a single path segment (a uid,
+ *  runId, or filename) — rejects empty, '.', '..', and anything
+ *  containing a path separator, so a caller can never escape its own
+ *  store directory via a crafted value. */
+export function isSafePathSegment(segment: string): boolean {
+  if (!segment || segment === '.' || segment === '..') return false
+  return !/[/\\]/.test(segment)
+}
+
+/** ISO timestamp with colons replaced by `-`, safe to splice into a
+ *  filename (`:` is reserved on Windows). Defaults to the current time. */
+export function tsForFilename(date: Date = new Date()): string {
+  return date.toISOString().replace(/:/g, '-')
+}


### PR DESCRIPTION
## Summary

Adds per-run raw keystroke logging for Typing Test runs — the data foundation for the upcoming per-word keystroke timeline view. Each completed run stores an ordered press/release log with word attribution at `sync/keyboards/{uid}/runs/` (no UI in this PR).

## Privacy design (the core constraint)

- Captured **only** during editor Typing Test runs — the recorder double-gates every event on the typing-test label, the recording-consent flag, **window focus**, and the current runId, independently of the call-site gating. Ambient Typing View REC input and keystrokes typed into other applications while unfocused never reach the buffer.
- Keystroke timestamps are run-relative ms only; the envelope carries a single ISO `startedAt` (same exposure class as existing history dates).
- Aborted/restarted runs are never saved (runId mismatch discards; `finish()` re-checks the runId). Paused runs are discarded and the runId poisoned so a resume cannot re-buffer.
- Memory-only during a run; one save at completion. Event/byte caps on both sides; an over-cap run is discarded, never truncated-and-saved.
- Main process independently re-validates consent, path segments, finite numbers, and size caps; excluded from Export Local Data; never sent to Hub.

## Mechanics

- Word attribution: registration-time snapshots on the matrix side plus pre-advance annotations on the DOM char side; char events may mint/advance the buffer while matrix events cannot (matrix events can arrive up to TAPPING_TERM late via the ordering queue; DOM chars are synchronous and never stale) — this asymmetry keeps correlation exact under real event timing in both orders.
- Best-effort char correlation via symmetric bounded FIFOs; parked releases recover durations for presses queued behind an unresolved tap-hold; in-flight final word saved as a `partial` word.
- Store follows the keyboard-scoped index-store shape (per-uid write lock, index + per-run file, tombstones). Retention (50 runs/keyboard) is a deterministic newest-first trim in the merge layer, applied at save and on every sync merge, so all devices converge to the same set; retention-only merges mark the remote for upload.
- Sync: rides the existing encrypted sync as a new `run-log` bundle type; excluded from connect-time initial sync and 3-min polling (same policy as analytics); discoverable by manual sync on a fresh machine; remote entry filenames validated before any path join.
- New helpers: `aggregateInWordBigramClasses`-adjacent seams untouched; `expected-char.ts`, `RomajiMatcher.nextGuideChar()` (single-char accessor, equivalence-tested against `remainingGuide()`), shared `isSafePathSegment`/`tsForFilename`, stricter shared row/col/keycode validation.

## Test plan

- Privacy invariants pinned: pure-REC never buffers; no consent / revoked mid-run; unfocused presses; restart/config-change/unmount/keyboard-switch discards; stale matrix events cannot resurrect an abandoned run; no absolute timestamps in keystroke payloads.
- Correlation under real timing (char-before-matrix primary, matrix-first secondary, interleaved), separator word-boundary attribution, parked releases, partial trailing word.
- Store: validation rejections, duplicate-runId file cleanup, orphan reconciliation, retention convergence, path-traversal guard.
- Full suite: 346 files, 7865 passed.