### PR TITLE
fix(sync): discover all sync-unit files on Drive and merge pack bundles safely

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.53",
+  "version": "0.1.54",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -769,7 +769,8 @@
       "keyboardData": "キーボード",
       "favorites": "お気に入り",
       "appSettings": "アプリケーション",
-      "i18nPacks": "言語パック"
+      "i18nPacks": "言語パック",
+      "themePacks": "テーマパック"
     },
     "deleteSelected": "選択を削除",
     "resetTargetsConfirm": "選択したデータが完全に削除されます。この操作は取り消せません。",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.53",
+  "version": "0.1.54",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -759,7 +759,8 @@
       "keyboardData": "キーボード☆",
       "favorites": "お気に入り♡",
       "appSettings": "アプリ設定っしょ",
-      "i18nPacks": "言語パック☆"
+      "i18nPacks": "言語パック☆",
+      "themePacks": "テーマパック☆"
     },
     "deleteSelected": "選んだのポイっちょ！",
     "resetTargetsConfirm": "消したら戻んないけどいい？ガチで☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.53",
+  "version": "0.1.54",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -759,7 +759,8 @@
       "keyboardData": "キーボード",
       "favorites": "お気に入り",
       "appSettings": "アプリケーション",
-      "i18nPacks": "言語パック"
+      "i18nPacks": "言語パック",
+      "themePacks": "テーマパック"
     },
     "deleteSelected": "選んだもんを消しますえ",
     "resetTargetsConfirm": "選んだデータが完全に消えますえ。元には戻せまへんえ。",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.53",
+  "version": "0.1.54",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -759,7 +759,8 @@
       "keyboardData": "機材",
       "favorites": "お気に入り",
       "appSettings": "御用達設定",
-      "i18nPacks": "言葉の包み"
+      "i18nPacks": "言葉の包み",
+      "themePacks": "意匠の包み"
     },
     "deleteSelected": "選ばれしものを抹消",
     "resetTargetsConfirm": "選ばれた記録は永遠に失われます。よろしいのですね？",

--- a/src/main/__tests__/google-drive.test.ts
+++ b/src/main/__tests__/google-drive.test.ts
@@ -40,7 +40,13 @@ vi.mock('../sync/google-auth', () => ({
   getAccessToken: vi.fn(async () => 'mock-token'),
 }))
 
-import { driveFileName, listFiles, syncUnitFromFileName } from '../sync/google-drive'
+import { driveFileName, listFiles, syncUnitFromFileName, uploadFile } from '../sync/google-drive'
+import type { SyncEnvelope } from '../../shared/types/sync'
+
+function extractFetchUrl(call: unknown): URL {
+  const args = call as readonly [string | URL, RequestInit?]
+  return new URL(typeof args[0] === 'string' ? args[0] : args[0].toString())
+}
 
 describe('google-drive', () => {
   beforeEach(() => {
@@ -102,6 +108,36 @@ describe('google-drive', () => {
       expect(syncUnitFromFileName('layerNames_0x1234.enc')).toBeNull()
       expect(syncUnitFromFileName('')).toBeNull()
     })
+
+    // Task-sync-unit-filename-gap: these five patterns were previously
+    // unmapped, so a fresh machine could never discover a remote-only
+    // unit for these stores via scanRemoteData / polling / manual sync
+    // (the store still uploaded fine — only the reverse mapping was
+    // missing). Each case round-trips through both directions since
+    // driveFileName and syncUnitFromFileName are meant to be exact
+    // inverses of each other.
+    it.each<[syncUnit: string, fileName: string]>([
+      ['keyboards/0x1234/analyze_filters', 'keyboards_0x1234_analyze_filters.enc'],
+      ['key-labels', 'key-labels.enc'],
+      ['typing-test-texts', 'typing-test-texts.enc'],
+      ['themes/index', 'themes_index.enc'],
+      ['themes/packs/pack-abc-123', 'themes_packs_pack-abc-123.enc'],
+    ])('round-trips %s', (syncUnit, fileName) => {
+      expect(driveFileName(syncUnit)).toBe(fileName)
+      expect(syncUnitFromFileName(fileName)).toBe(syncUnit)
+    })
+
+    it('keeps password-check.enc unmapped (not a data sync unit)', () => {
+      expect(syncUnitFromFileName('password-check.enc')).toBeNull()
+    })
+
+    it('handles a uid whose own text contains "_analyze_filters"-shaped substrings via non-greedy backtracking', () => {
+      // The uid capture is non-greedy — confirm the regex still resolves
+      // to the intended (uid, store) split rather than mis-splitting on
+      // an early underscore inside the uid itself.
+      expect(syncUnitFromFileName('keyboards_foo_analyze_analyze_filters.enc'))
+        .toBe('keyboards/foo_analyze/analyze_filters')
+    })
   })
 
   describe('listFiles', () => {
@@ -116,11 +152,6 @@ describe('google-drive', () => {
       )
       vi.stubGlobal('fetch', fetchSpy)
       return { fetchSpy }
-    }
-
-    function extractFetchUrl(call: unknown): URL {
-      const args = call as readonly [string | URL, RequestInit?]
-      return new URL(typeof args[0] === 'string' ? args[0] : args[0].toString())
     }
 
     afterEach(() => {
@@ -164,6 +195,60 @@ describe('google-drive', () => {
 
       const url = extractFetchUrl(fetchSpy.mock.calls[0])
       expect(url.searchParams.has('q')).toBe(false)
+    })
+  })
+
+  // S3: the local-wins pack-body upload path (sync-service.ts's
+  // uploadSyncUnit + pack-bundle-merge.ts's pinPackBodyMtimeAfterUpload)
+  // pins the local file's mtime to whatever `modifiedTime` Drive just
+  // assigned this revision — closing a clock-skew loop where a
+  // locally-ahead wall clock would otherwise look newer than Drive's
+  // own stamped time forever. That only works if `uploadFile` actually
+  // requests and returns `modifiedTime` — Drive's default response
+  // fields for an upload omit it.
+  describe('uploadFile', () => {
+    const envelope: SyncEnvelope = {
+      version: 1,
+      syncUnit: 'i18n/packs/pack-a',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      salt: 's',
+      iv: 'i',
+      ciphertext: 'cipher',
+    }
+
+    function mockFetchUploadOk(id: string, modifiedTime: string): { fetchSpy: ReturnType<typeof vi.fn> } {
+      const fetchSpy = vi.fn(async () =>
+        new Response(JSON.stringify({ id, modifiedTime }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      vi.stubGlobal('fetch', fetchSpy)
+      return { fetchSpy }
+    }
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('requests id + modifiedTime fields and returns both when creating a new file', async () => {
+      const { fetchSpy } = mockFetchUploadOk('new-id', '2026-06-01T00:00:00.000Z')
+
+      const result = await uploadFile('i18n_packs_pack-a.enc', envelope)
+
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.get('fields')).toBe('id,modifiedTime')
+      expect(result).toEqual({ id: 'new-id', modifiedTime: '2026-06-01T00:00:00.000Z' })
+    })
+
+    it('requests id + modifiedTime fields and returns both when updating an existing file', async () => {
+      const { fetchSpy } = mockFetchUploadOk('existing-id', '2026-06-02T00:00:00.000Z')
+
+      const result = await uploadFile('i18n_packs_pack-a.enc', envelope, 'existing-id')
+
+      const url = extractFetchUrl(fetchSpy.mock.calls[0])
+      expect(url.searchParams.get('fields')).toBe('id,modifiedTime')
+      expect(result).toEqual({ id: 'existing-id', modifiedTime: '2026-06-02T00:00:00.000Z' })
     })
   })
 })

--- a/src/main/__tests__/i18n-pack-store.test.ts
+++ b/src/main/__tests__/i18n-pack-store.test.ts
@@ -9,8 +9,19 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+
+// Real fs/promises for every export except `utimes`, which is wrapped in a
+// `vi.fn` so individual tests can force it to reject (simulating a utimes
+// failure) — `vi.spyOn` cannot patch a real ESM module's export (Node's
+// `node:fs/promises` namespace is non-configurable), so the override has to
+// happen at mock-definition time instead.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, utimes: vi.fn(actual.utimes) }
+})
+
+import { mkdtemp, readFile, rm, stat, utimes } from 'node:fs/promises'
 
 let mockUserDataPath = ''
 
@@ -30,7 +41,15 @@ vi.mock('../sync/sync-service', () => ({
   notifyChange: vi.fn(),
 }))
 
+// The real logger is a module-level singleton (cached log directory) that
+// doesn't play well with a fresh mkdtemp'd userData per test — mock it out,
+// same as sync-bundle.run-log.test.ts does.
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+}))
+
 import { notifyChange } from '../sync/sync-service'
+import { log } from '../logger'
 import {
   savePack,
   listMetas,
@@ -40,6 +59,10 @@ import {
   renamePack,
   reorderActive,
   setHubPostId,
+  mergeSyncedIndex,
+  applySyncedPackBody,
+  pinPackBodyMtime,
+  statLocalPackMtime,
   __testing,
 } from '../i18n-pack-store'
 import { BUILTIN_ENGLISH_PACK_ID, I18N_INDEX_SYNC_UNIT } from '../../shared/types/i18n-store'
@@ -352,5 +375,127 @@ describe('i18n-pack-store built-in English entry (ensureBuiltinEnglishEntry)', (
     const afterGet = await getPack(BUILTIN_ENGLISH_PACK_ID)
     expect(afterGet.success).toBe(true)
     expect(afterGet.data!.pack).toEqual({ name: 'English', version: '0.0.0' })
+  })
+})
+
+// --- Task-sync-unit-discovery bugfix plan: fixes 1-3 ------------------------
+
+describe('i18n-pack-store sync robustness fixes (utimes degrade / pin CAS / malformed metas)', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    mockUserDataPath = await mkdtemp(join(tmpdir(), 'i18n-pack-store-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(mockUserDataPath, { recursive: true, force: true })
+  })
+
+  // --- Fix 1: utimes failure degrades to accept-with-warn -------------------
+
+  it('applySyncedPackBody: a utimes failure after a successful write still reports "applied" (never io-error)', async () => {
+    vi.mocked(utimes).mockRejectedValueOnce(new Error('EPERM: operation not permitted'))
+
+    const outcome = await applySyncedPackBody(
+      'utimes-fail-pack',
+      JSON.stringify({ name: 'UtimesFail', version: '1.0.0' }),
+      '2026-01-01T00:00:00.000Z',
+    )
+
+    expect(outcome).toBe('applied')
+    expect(utimes).toHaveBeenCalledTimes(1)
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('i18n/packs/utimes-fail-pack'))
+
+    // The body write itself must have landed despite the pin failure.
+    // (applySyncedPackBody only writes the body file — no index entry
+    // exists for this id, so read the file directly rather than via
+    // getPack, which requires an index meta.)
+    const body = await readFile(__testing.getPackPath('utimes-fail-pack'), 'utf-8')
+    expect(JSON.parse(body)).toEqual({ name: 'UtimesFail', version: '1.0.0' })
+  })
+
+  it('pinPackBodyMtime: a utimes failure is swallowed (warn), never thrown', async () => {
+    const saved = await savePack({ pack: makePack({ name: 'PinFail' }) })
+    const id = saved.data!.id
+    const mtime = await statLocalPackMtime(id)
+
+    vi.mocked(utimes).mockRejectedValueOnce(new Error('EPERM'))
+    await expect(pinPackBodyMtime(id, '2026-01-01T00:00:00.000Z', mtime)).resolves.toBeUndefined()
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining(`i18n/packs/${id}`))
+  })
+
+  // --- Fix 2: post-upload pin is CAS-guarded ---------------------------------
+
+  it('pinPackBodyMtime: skips the pin (no utimes call) when the local mtime no longer matches the upload snapshot', async () => {
+    const saved = await savePack({ pack: makePack({ name: 'Racer' }) })
+    const id = saved.data!.id
+    const path = __testing.getPackPath(id)
+
+    // Snapshot mtime as it was when uploadSyncUnit bundled the (old) content.
+    const snapshotDate = new Date('2020-01-01T00:00:00.000Z')
+    await utimes(path, snapshotDate, snapshotDate)
+    const snapshot = snapshotDate.getTime()
+
+    // A concurrent local save lands after the snapshot but before the pin
+    // takes the store's write lock — simulated by advancing the file's
+    // mtime well past both the snapshot and the (old) upload's Drive time.
+    const raceDate = new Date('2026-06-01T00:00:00.000Z')
+    await utimes(path, raceDate, raceDate)
+
+    vi.mocked(utimes).mockClear() // discard the setup calls above
+    await pinPackBodyMtime(id, '2020-01-01T00:00:05.000Z', snapshot)
+    expect(utimes).not.toHaveBeenCalled()
+
+    // The newer (raced) edit's mtime survives untouched, so it still wins
+    // the next LWW comparison against the stale upload's Drive time.
+    const finalMtime = (await statLocalPackMtime(id))!
+    expect(finalMtime).toBe(raceDate.getTime())
+    expect(finalMtime).toBeGreaterThan(new Date('2020-01-01T00:00:05.000Z').getTime())
+  })
+
+  it('pinPackBodyMtime: pins when the local mtime still matches the snapshot (no race)', async () => {
+    const saved = await savePack({ pack: makePack({ name: 'NoRace' }) })
+    const id = saved.data!.id
+    const snapshot = await statLocalPackMtime(id)
+
+    const remoteModifiedTime = '2026-07-01T00:00:00.000Z'
+    await pinPackBodyMtime(id, remoteModifiedTime, snapshot)
+
+    const path = __testing.getPackPath(id)
+    const finalStat = await stat(path)
+    expect(finalStat.mtime.getTime()).toBe(new Date(remoteModifiedTime).getTime())
+  })
+
+  it('pinPackBodyMtime: skips the pin when given no snapshot to compare (null)', async () => {
+    const saved = await savePack({ pack: makePack({ name: 'NoSnapshot' }) })
+    const id = saved.data!.id
+    const before = await statLocalPackMtime(id)
+
+    vi.mocked(utimes).mockClear()
+    await pinPackBodyMtime(id, '2026-07-01T00:00:00.000Z', null)
+    expect(utimes).not.toHaveBeenCalled()
+
+    const after = await statLocalPackMtime(id)
+    expect(after).toBe(before)
+  })
+
+  // --- Fix 3: meta validation must not crash on non-object entries ----------
+
+  it('mergeSyncedIndex drops non-object entries (e.g. null) instead of crashing, keeping valid siblings', async () => {
+    const goodMeta = {
+      id: 'good-1',
+      filename: 'packs/good-1.json',
+      name: 'Good',
+      version: '1.0.0',
+      enabled: true,
+      savedAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    }
+
+    const result = await mergeSyncedIndex([null, goodMeta])
+
+    expect(result.applied).toBe(true)
+    expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('dropped 1 unsafe remote meta id'))
+    const all = await listAllMetas()
+    expect(all.some((m) => m.id === 'good-1')).toBe(true)
   })
 })

--- a/src/main/__tests__/sync-service.test.ts
+++ b/src/main/__tests__/sync-service.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { access, mkdtemp, readFile, rm, writeFile, mkdir } from 'node:fs/promises'
+import { access, mkdtemp, readFile, rm, stat, utimes, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import type { DriveFile } from '../sync/google-drive'
 
@@ -42,31 +42,28 @@ vi.mock('electron', () => ({
 const mockListFiles = vi.fn(async (..._args: unknown[]): Promise<DriveFile[]> => [])
 const mockDownloadFile = vi.fn(async (_fileId: string): Promise<Record<string, unknown>> => ({}))
 const mockUploadFile = vi.fn(
-  async (_name: string, _envelope?: unknown, _existingFileId?: string): Promise<string> => 'file-id',
+  async (_name: string, _envelope?: unknown, _existingFileId?: string): Promise<{ id: string; modifiedTime: string }> =>
+    ({ id: 'file-id', modifiedTime: '2026-01-01T00:00:00.000Z' }),
 )
 const mockDeleteFile = vi.fn(async (_fileId: string): Promise<void> => {})
-const mockDriveFileName = vi.fn((syncUnit: string) => syncUnit.replaceAll('/', '_') + '.enc')
-const mockSyncUnitFromFileName = vi.fn((name: string) => {
-  const dayMatch = name.match(/^keyboards_(.+?)_devices_(.+?)_days_(\d{4}-\d{2}-\d{2})\.enc$/)
-  if (dayMatch) return `keyboards/${dayMatch[1]}/devices/${dayMatch[2]}/days/${dayMatch[3]}`
-  const deviceMatch = name.match(/^keyboards_(.+?)_devices_(.+)\.enc$/)
-  if (deviceMatch) return `keyboards/${deviceMatch[1]}/devices/${deviceMatch[2]}`
-  const kbMatch = name.match(/^keyboards_(.+?)_(settings|snapshots)\.enc$/)
-  if (kbMatch) return `keyboards/${kbMatch[1]}/${kbMatch[2]}`
-  const favMatch = name.match(/^favorites_(.+)\.enc$/)
-  if (favMatch) return `favorites/${favMatch[1]}`
-  return null
-})
 
-vi.mock('../sync/google-drive', () => ({
-  listFiles: (...args: unknown[]) => mockListFiles(...args),
-  downloadFile: (...args: unknown[]) => mockDownloadFile(...(args as Parameters<typeof mockDownloadFile>)),
-  uploadFile: (...args: unknown[]) => mockUploadFile(...(args as Parameters<typeof mockUploadFile>)),
-  deleteFile: (...args: unknown[]) => mockDeleteFile(...(args as Parameters<typeof mockDeleteFile>)),
-  driveFileName: (...args: unknown[]) => mockDriveFileName(...(args as Parameters<typeof mockDriveFileName>)),
-  syncUnitFromFileName: (...args: unknown[]) =>
-    mockSyncUnitFromFileName(...(args as Parameters<typeof mockSyncUnitFromFileName>)),
-}))
+vi.mock('../sync/google-drive', async () => {
+  // `driveFileName`/`syncUnitFromFileName` are imported via `importActual`
+  // (not hand-rolled) so this mock can never drift out of sync with the
+  // real filename ↔ sync-unit mapping again — a stale hand-rolled regex
+  // here previously hid a fresh-machine discovery gap for several stores
+  // (see Task-sync-unit-filename-gap.md) because the test mock silently
+  // kept "supporting" a narrower set of filenames than production code.
+  const actual = await vi.importActual<typeof import('../sync/google-drive')>('../sync/google-drive')
+  return {
+    listFiles: (...args: unknown[]) => mockListFiles(...args),
+    downloadFile: (...args: unknown[]) => mockDownloadFile(...(args as Parameters<typeof mockDownloadFile>)),
+    uploadFile: (...args: unknown[]) => mockUploadFile(...(args as Parameters<typeof mockUploadFile>)),
+    deleteFile: (...args: unknown[]) => mockDeleteFile(...(args as Parameters<typeof mockDeleteFile>)),
+    driveFileName: actual.driveFileName,
+    syncUnitFromFileName: actual.syncUnitFromFileName,
+  }
+})
 
 const mockGetAuthStatus = vi.fn(async (..._args: unknown[]) => ({ authenticated: true }))
 
@@ -189,6 +186,11 @@ vi.mock('../typing-analytics/sync-state', () => ({
 }))
 
 vi.stubGlobal('fetch', vi.fn())
+
+const mockLog = vi.fn()
+vi.mock('../logger', () => ({
+  log: (...args: unknown[]) => mockLog(...args),
+}))
 
 import { decrypt as mockDecryptFn, encrypt as mockEncryptFn, storePassword as mockStorePasswordFn, clearPassword as mockClearPasswordFn, retrievePasswordResult as mockRetrievePasswordResultFn } from '../sync/sync-crypto'
 import type { SyncProgress } from '../../shared/types/sync'
@@ -618,6 +620,56 @@ describe('sync-service', () => {
       stopPolling()
     })
 
+    // Task-sync-unit-filename-gap: themes/i18n only match scope 'all',
+    // which the 3-minute poll always uses (see matchesScope) — so once
+    // syncUnitFromFileName recognizes their filenames, polling picks up
+    // changes for them exactly like any other scope-'all' unit.
+    it('detects a changed themes/packs file on a subsequent poll and downloads it', async () => {
+      const themePackFile = (modifiedTime: string): DriveFile =>
+        ({ id: 'theme-pack-1', name: 'themes_packs_pack-a.enc', modifiedTime })
+      mockListFiles
+        .mockResolvedValueOnce([themePackFile('2026-01-01T00:00:00.000Z')])
+        .mockResolvedValueOnce([themePackFile('2026-01-02T00:00:00.000Z')])
+      mockDownloadFile.mockResolvedValue({
+        version: 1,
+        syncUnit: 'themes/packs/pack-a',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+        salt: 's',
+        iv: 'i',
+        ciphertext: JSON.stringify({
+          type: 'theme-pack',
+          key: 'pack-a',
+          index: { metas: [] },
+          files: { 'pack-a.json': JSON.stringify({ name: 'Pack A', version: '1.0.0', colorScheme: 'dark', colors: {} }) },
+        }),
+      })
+
+      startPolling()
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockListFiles.mock.calls.length >= 1)
+      await flushIO()
+
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockDownloadFile.mock.calls.some((call) => call[0] === 'theme-pack-1'))
+      // The merge's file write is real disk I/O — wait for the poll's own
+      // sync-lock release rather than a fixed tick count.
+      await flushUntil(() => !isSyncInProgress())
+
+      expect(mockDownloadFile).toHaveBeenCalledWith('theme-pack-1')
+      await expect(
+        readFile(join(mockUserDataPath, 'sync', 'themes', 'packs', 'pack-a.json'), 'utf-8'),
+      ).resolves.toContain('Pack A')
+
+      stopPolling()
+    })
+
+    // A key-labels-specific variant of this test previously lived here.
+    // Dropped as redundant: key-labels rides the same generic index-based
+    // poll-merge path already exercised above by favorites (this file's
+    // own "detects remote changes on subsequent polls and downloads"),
+    // and its filename recognition is pinned at the unit level in
+    // google-drive.test.ts's round-trip coverage.
+
     it('skips when no remote changes detected', async () => {
       mockListFiles.mockResolvedValue([makeDriveFile('2025-01-01T00:00:00.000Z')])
 
@@ -804,7 +856,7 @@ describe('sync-service', () => {
       // tapDance upload succeeds, macro upload fails (argument-based to avoid order dependency)
       mockUploadFile.mockImplementation((name: string) => {
         if (name === 'favorites_macro.enc') return Promise.reject(new Error('upload failed'))
-        return Promise.resolve('id1')
+        return Promise.resolve({ id: 'id1', modifiedTime: '2026-01-01T00:00:00.000Z' })
       })
 
       await executeSync('upload')
@@ -830,7 +882,7 @@ describe('sync-service', () => {
       // tapDance succeeds, macro fails (argument-based to avoid order dependency)
       mockUploadFile.mockImplementation((name: string) => {
         if (name === 'favorites_macro.enc') return Promise.reject(new Error('upload failed'))
-        return Promise.resolve('id1')
+        return Promise.resolve({ id: 'id1', modifiedTime: '2026-01-01T00:00:00.000Z' })
       })
 
       await executeSync('upload')
@@ -846,7 +898,7 @@ describe('sync-service', () => {
 
       mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE])
       mockDownloadFile.mockResolvedValueOnce(makePasswordCheckEnvelope())
-      mockUploadFile.mockResolvedValue('id1')
+      mockUploadFile.mockResolvedValue({ id: 'id1', modifiedTime: '2026-01-01T00:00:00.000Z' })
 
       await executeSync('upload')
 
@@ -1106,6 +1158,31 @@ describe('sync-service', () => {
       expect(result.favorites).toEqual(['tapDance'])
       expect(result.keyboards).toEqual([])
       expect(result.undecryptable).toEqual([])
+    })
+
+    // Task-sync-unit-filename-gap: scanRemoteData categorizes purely from
+    // syncUnitFromFileName — these previously fell through as unrecognized
+    // filenames (syncUnit === null) and were silently dropped from every
+    // category, including keyboards (for a uid that only has this file)
+    // and themePacks.
+    it('surfaces a uid whose only remote file is analyze_filters as a cloud keyboard', async () => {
+      mockListFiles.mockResolvedValue([
+        { id: 'f1', name: 'keyboards_uid-only-filters_analyze_filters.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+      ])
+      mockDownloadFile.mockResolvedValueOnce({ ciphertext: 'ok' })
+
+      const result = await scanRemoteData()
+      expect(result.keyboards).toEqual(['uid-only-filters'])
+    })
+
+    it('surfaces theme pack ids found on the remote', async () => {
+      mockListFiles.mockResolvedValue([
+        { id: 't1', name: 'themes_packs_pack-a.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
+      ])
+      mockDownloadFile.mockResolvedValueOnce({ ciphertext: 'ok' })
+
+      const result = await scanRemoteData()
+      expect(result.themePacks).toEqual(['pack-a'])
     })
   })
 
@@ -1388,9 +1465,88 @@ describe('sync-service', () => {
         const connectScope = { favorites: true as const, keyboard: 'uid-a' }
         expect(shouldDownloadSyncUnit(runLogUnit, connectScope, local)).toBe(false)
       })
+
+      // Task-sync-unit-filename-gap: these three stores are discovery-included
+      // ("それ以外" column in settings-persistence.md's trigger matrix — no
+      // dedicated exclusion predicate like analytics/run-logs) — the fix here
+      // is purely that syncUnitFromFileName now recognizes their filenames at
+      // all; shouldDownloadSyncUnit's own logic needs no changes for them.
+      it('keeps key-labels, typing-test-texts, and analyze_filters under the connect-time scope shape', () => {
+        const connectScope = { favorites: true as const, keyboard: 'uid-a' }
+        expect(shouldDownloadSyncUnit('key-labels', connectScope, local)).toBe(true)
+        expect(shouldDownloadSyncUnit('typing-test-texts', connectScope, local)).toBe(true)
+        expect(shouldDownloadSyncUnit('keyboards/uid-a/analyze_filters', connectScope, local)).toBe(true)
+        // Sanity: analytics/run-logs remain excluded under the same scope shape.
+        expect(shouldDownloadSyncUnit(analyticsUnit, connectScope, local)).toBe(false)
+        expect(shouldDownloadSyncUnit(runLogUnit, connectScope, local)).toBe(false)
+      })
     })
 
     describe('executeSync with scope', () => {
+      // Task-sync-unit-filename-gap: fresh-machine discovery — a remote-only
+      // unit for these stores previously could never be found because
+      // syncUnitFromFileName didn't recognize their filenames at all.
+      it.each([
+        {
+          label: 'key-labels',
+          fileId: 'kl1',
+          fileName: 'key-labels.enc',
+          syncUnit: 'key-labels',
+          bundleType: 'key-label',
+          key: 'key-labels',
+          dirSegments: ['key-labels'],
+          scope: 'favorites' as const,
+        },
+        {
+          label: 'typing-test-texts',
+          fileId: 'tt1',
+          fileName: 'typing-test-texts.enc',
+          syncUnit: 'typing-test-texts',
+          bundleType: 'typing-test-text',
+          key: 'typing-test-texts',
+          dirSegments: ['typing-test-texts'],
+          scope: 'favorites' as const,
+        },
+        {
+          label: 'analyze_filters',
+          fileId: 'af1',
+          fileName: 'keyboards_0x9999_analyze_filters.enc',
+          syncUnit: 'keyboards/0x9999/analyze_filters',
+          bundleType: 'analyze-filter',
+          key: '0x9999',
+          dirSegments: ['keyboards', '0x9999', 'analyze_filters'],
+          scope: { keyboard: '0x9999' } as const,
+        },
+      ])('fresh-machine discovery: downloads a remote-only $label unit', async ({ fileId, fileName, syncUnit, bundleType, key, dirSegments, scope }) => {
+        mockListFiles.mockResolvedValue([
+          { id: fileId, name: fileName, modifiedTime: '2025-01-01T00:00:00.000Z' },
+          PASSWORD_CHECK_DRIVE_FILE,
+        ])
+        mockDownloadFile
+          .mockResolvedValueOnce(makePasswordCheckEnvelope())
+          .mockResolvedValueOnce({
+            version: 1,
+            syncUnit,
+            updatedAt: '2025-01-01T00:00:00.000Z',
+            salt: 's',
+            iv: 'i',
+            ciphertext: JSON.stringify({
+              type: bundleType,
+              key,
+              index: { entries: [] },
+              files: {},
+            }),
+          })
+
+        await executeSync('download', scope)
+
+        const downloadedIds = mockDownloadFile.mock.calls.map((call) => call[0])
+        expect(downloadedIds).toContain(fileId)
+        await expect(
+          access(join(mockUserDataPath, 'sync', ...dirSegments, 'index.json')),
+        ).resolves.toBeUndefined()
+      })
+
       it('downloads only favorites files when scope is "favorites"', async () => {
         mockListFiles.mockResolvedValue([
           { id: 'f1', name: 'favorites_tapDance.enc', modifiedTime: '2025-01-01T00:00:00.000Z' },
@@ -1611,7 +1767,7 @@ describe('sync-service', () => {
         mockUploadFile.mockClear()
         mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE])
         mockDownloadFile.mockResolvedValueOnce(makePasswordCheckEnvelope())
-        mockUploadFile.mockResolvedValue('id1')
+        mockUploadFile.mockResolvedValue({ id: 'id1', modifiedTime: '2026-01-01T00:00:00.000Z' })
 
         await executeSync('upload', 'favorites')
 
@@ -1629,7 +1785,7 @@ describe('sync-service', () => {
 
         mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE])
         mockDownloadFile.mockResolvedValue(makePasswordCheckEnvelope())
-        mockUploadFile.mockResolvedValue('id1')
+        mockUploadFile.mockResolvedValue({ id: 'id1', modifiedTime: '2026-01-01T00:00:00.000Z' })
 
         await executeSync('upload', 'favorites')
 
@@ -1735,11 +1891,12 @@ describe('sync-service', () => {
     })
 
     it('does not treat password-check as a regular sync unit during download', async () => {
+      // syncUnitFromFileName's own null-mapping for password-check.enc is
+      // covered at the unit level by google-drive.test.ts — this test only
+      // needs the integration behavior: a download sync must succeed
+      // without trying to merge password-check as a data sync unit.
       mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE])
       mockDownloadFile.mockResolvedValue(makePasswordCheckEnvelope())
-
-      // syncUnitFromFileName should return null for password-check.enc
-      expect(mockSyncUnitFromFileName('password-check.enc')).toBeNull()
 
       await executeSync('download')
       // Should succeed without trying to merge password-check as a sync unit
@@ -2301,6 +2458,632 @@ describe('sync-service', () => {
         'drive-test-machine-hash-2026-04-18',
       ])
       expect(mockSyncState?.uploaded[pointerKey(OWN_HASH)]).toEqual([])
+    })
+  })
+
+  // Task-sync-unit-filename-gap / bundle-variant merge crash regression.
+  // i18n-index / i18n-pack / theme-index / theme-pack bundles carry
+  // `{ metas: [...] }` or a raw pack body, never `{ entries }` — so before
+  // dedicated branches existed, mergeSyncUnit's generic index-based branch
+  // called `gcTombstones((remoteBundle.index as { entries }).entries)` on
+  // `undefined`, throwing a TypeError. This first test pins the pre-fix
+  // failure mode (caught per-unit → 'partial' status); every test after it
+  // asserts the fixed LWW behavior.
+  describe('bundle-variant merge (i18n/theme index + pack)', () => {
+    /** Builds a mock decrypted SyncEnvelope for any bundle shape (index
+     *  or pack-body). Replaces the four near-identical `make*Envelope`
+     *  factories this describe block used to carry, one per
+     *  i18n/theme × index/pack combination. */
+    function makeBundleEnvelope(
+      syncUnit: string,
+      updatedAt: string,
+      bundle: { type: string; key: string; index?: unknown; files?: Record<string, string> },
+    ): Record<string, unknown> {
+      return {
+        version: 1,
+        syncUnit,
+        updatedAt,
+        salt: 's',
+        iv: 'i',
+        ciphertext: JSON.stringify({
+          type: bundle.type,
+          key: bundle.key,
+          index: bundle.index ?? { metas: [] },
+          files: bundle.files ?? {},
+        }),
+      }
+    }
+
+    it('regression baseline: merging a remote i18n-index bundle no longer crashes the sync unit', async () => {
+      // Pre-fix, this scenario threw inside gcTombstones(undefined) and
+      // surfaced as a 'partial' sync with 'i18n/index' in failedUnits.
+      // Post-fix it must merge cleanly (remote is the only side, so
+      // remote wins trivially) and report 'success'.
+      mockListFiles.mockResolvedValue([
+        { id: 'idx1', name: 'i18n_index.enc', modifiedTime: '2026-01-01T00:00:00.000Z' },
+        PASSWORD_CHECK_DRIVE_FILE,
+      ])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope('i18n/index', '2026-01-01T00:00:00.000Z', {
+          type: 'i18n-index',
+          key: 'i18n-index',
+          index: { metas: [{ id: 'p1', name: 'Test Pack', version: '1.0.0', enabled: true, savedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }] },
+        }))
+
+      const progressEvents: SyncProgress[] = []
+      setProgressCallback((p) => progressEvents.push({ ...p }))
+
+      await executeSync('download')
+
+      const final = progressEvents[progressEvents.length - 1]
+      expect(final.status).toBe('success')
+      expect(final.failedUnits).toBeUndefined()
+
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', 'i18n', 'index.json'), 'utf-8'),
+      ) as { metas: Array<{ id: string }> }
+      expect(written.metas.map((m) => m.id)).toEqual(['p1'])
+    })
+
+    it.each([
+      {
+        label: 'i18n',
+        syncUnit: 'i18n/index',
+        fileName: 'i18n_index.enc',
+        fileId: 'idx1',
+        bundleType: 'i18n-index',
+        dir: 'i18n',
+        meta: { id: 'new', name: 'New Pack', version: '2.0.0', enabled: true, savedAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z' },
+      },
+      {
+        label: 'theme',
+        syncUnit: 'themes/index',
+        fileName: 'themes_index.enc',
+        fileId: 'tidx1',
+        bundleType: 'theme-index',
+        dir: 'themes',
+        meta: { id: 't1', name: 'Ocean', version: '1.0.0', savedAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z' },
+      },
+    ])('$label-index: remote-only id merges alongside the pre-existing local id (union, not wholesale replace)', async ({ syncUnit, fileName, fileId, bundleType, dir, meta }) => {
+      // M1 fix: index merge used to be file-level LWW — "newer roster
+      // wins wholesale" — which meant a remote index arriving with a
+      // different id than local's simply erased the local-only entry
+      // forever (its body file became an orphan, unreachable because
+      // collectAllSyncUnits only walks ids present in the index). This
+      // is now entry-level LWW: both ids survive as a union, and since
+      // local has an id remote doesn't have yet, the merged index is
+      // marked for re-upload so remote converges too.
+      await mkdir(join(mockUserDataPath, 'sync', dir), { recursive: true })
+      await writeFile(
+        join(mockUserDataPath, 'sync', dir, 'index.json'),
+        JSON.stringify({ metas: [{ ...meta, id: 'old', savedAt: '2020-01-01T00:00:00.000Z', updatedAt: '2020-01-01T00:00:00.000Z' }] }),
+        'utf-8',
+      )
+
+      mockListFiles.mockResolvedValue([
+        { id: fileId, name: fileName, modifiedTime: '2026-06-01T00:00:00.000Z' },
+        PASSWORD_CHECK_DRIVE_FILE,
+      ])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope(syncUnit, '2026-06-01T00:00:00.000Z', {
+          type: bundleType,
+          key: bundleType,
+          index: { metas: [meta] },
+        }))
+
+      await executeSync('download')
+
+      // Local had an entry ('old') remote doesn't have — the unit must
+      // be re-uploaded so remote picks it up too (both sides converge).
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === fileName)).toBe(true)
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', dir, 'index.json'), 'utf-8'),
+      ) as { metas: Array<{ id: string }> }
+      expect(written.metas.map((m) => m.id).sort()).toEqual(['old', meta.id].sort())
+    })
+
+    it('two machines each install a different pack while offline: next sync converges to the union, neither pack is lost', async () => {
+      // The headline M1 scenario: machine A installs pack 'pack-a'
+      // (already on remote); machine B (this process) independently
+      // installed 'pack-b' locally before ever syncing. A naive
+      // file-level LWW would have machine B's later local timestamp win
+      // wholesale, permanently erasing 'pack-a' from both the local
+      // index AND — once B uploads — from remote too, orphaning its
+      // pack body forever. Entry-level LWW must instead keep both.
+      await mkdir(join(mockUserDataPath, 'sync', 'i18n'), { recursive: true })
+      await writeFile(
+        join(mockUserDataPath, 'sync', 'i18n', 'index.json'),
+        JSON.stringify({ metas: [{ id: 'pack-b', name: 'Pack B', version: '1.0.0', enabled: true, savedAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z' }] }),
+        'utf-8',
+      )
+
+      mockListFiles.mockResolvedValue([
+        { id: 'idx1', name: 'i18n_index.enc', modifiedTime: '2020-01-01T00:00:00.000Z' },
+      ])
+      mockDownloadFile.mockResolvedValueOnce(makeBundleEnvelope('i18n/index', '2020-01-01T00:00:00.000Z', {
+        type: 'i18n-index',
+        key: 'i18n-index',
+        index: { metas: [{ id: 'pack-a', name: 'Pack A', version: '1.0.0', enabled: true, savedAt: '2020-01-01T00:00:00.000Z', updatedAt: '2020-01-01T00:00:00.000Z' }] },
+      }))
+      mockUploadFile.mockResolvedValue({ id: 'idx-file-id', modifiedTime: '2026-01-01T00:00:00.000Z' })
+
+      await executeSync('download')
+
+      // Both packs survive the merge — this is the union, not a
+      // one-side-wins replacement.
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === 'i18n_index.enc')).toBe(true)
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', 'i18n', 'index.json'), 'utf-8'),
+      ) as { metas: Array<{ id: string }> }
+      expect(written.metas.map((m) => m.id)).toEqual(['pack-b', 'pack-a'])
+    })
+
+    it('the built-in English meta merges harmlessly across machines despite each machine stamping its own first-seen timestamp', async () => {
+      // ensureBuiltinEnglishEntry creates 'builtin-english' locally with
+      // whatever timestamp this machine first saw it at — two machines
+      // therefore carry different savedAt/updatedAt for the exact same
+      // logical entry. Confirms per-id LWW picking either side is
+      // harmless: the entry that "wins" still has the same
+      // name/version/enabled content every machine generates.
+      await mkdir(join(mockUserDataPath, 'sync', 'i18n'), { recursive: true })
+      await writeFile(
+        join(mockUserDataPath, 'sync', 'i18n', 'index.json'),
+        JSON.stringify({ metas: [{ id: 'builtin-english', filename: 'packs/builtin-english.json', name: 'English', version: '0.0.0', enabled: true, uploaderName: 'pipette', savedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' }] }),
+        'utf-8',
+      )
+
+      mockListFiles.mockResolvedValue([
+        { id: 'idx1', name: 'i18n_index.enc', modifiedTime: '2026-06-01T00:00:00.000Z' },
+        PASSWORD_CHECK_DRIVE_FILE,
+      ])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope('i18n/index', '2026-06-01T00:00:00.000Z', {
+          type: 'i18n-index',
+          key: 'i18n-index',
+          index: { metas: [{ id: 'builtin-english', filename: 'packs/builtin-english.json', name: 'English', version: '0.0.0', enabled: true, uploaderName: 'pipette', savedAt: '2026-06-01T00:00:00.000Z', updatedAt: '2026-06-01T00:00:00.000Z' }] },
+        }))
+
+      await executeSync('download')
+
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', 'i18n', 'index.json'), 'utf-8'),
+      ) as { metas: Array<{ id: string; name: string; version: string; enabled: boolean }> }
+      expect(written.metas).toHaveLength(1)
+      expect(written.metas[0]).toMatchObject({ id: 'builtin-english', name: 'English', version: '0.0.0', enabled: true })
+    })
+
+    it.each([
+      {
+        label: 'i18n',
+        syncUnit: 'i18n/packs/pack-a',
+        fileName: 'i18n_packs_pack-a.enc',
+        fileId: 'pack1',
+        bundleType: 'i18n-pack',
+        dir: 'i18n',
+        packId: 'pack-a',
+        body: { name: 'Pack A', version: '2.0.0' },
+      },
+      {
+        label: 'theme',
+        syncUnit: 'themes/packs/theme-a',
+        fileName: 'themes_packs_theme-a.enc',
+        fileId: 'tpack1',
+        bundleType: 'theme-pack',
+        dir: 'themes',
+        packId: 'theme-a',
+        body: { name: 'Theme A', version: '2.0.0', colorScheme: 'dark', colors: {} },
+      },
+    ])('$label-pack: remote newer than local mtime writes the pack body locally', async ({ syncUnit, fileName, fileId, bundleType, dir, packId, body }) => {
+      mockListFiles.mockResolvedValue([
+        { id: fileId, name: fileName, modifiedTime: '2026-06-01T00:00:00.000Z' },
+        PASSWORD_CHECK_DRIVE_FILE,
+      ])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope(syncUnit, '2026-06-01T00:00:00.000Z', {
+          type: bundleType,
+          key: packId,
+          files: { [`${packId}.json`]: JSON.stringify(body) },
+        }))
+
+      await executeSync('download')
+
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', dir, 'packs', `${packId}.json`), 'utf-8'),
+      ) as { version: string }
+      expect(written.version).toBe('2.0.0')
+      // applySyncedPackBody writes via temp-file-then-rename — the `.tmp`
+      // must never linger after a successful write.
+      await expect(
+        access(join(mockUserDataPath, 'sync', dir, 'packs', `${packId}.json.tmp`)),
+      ).rejects.toThrow()
+    })
+
+    it('local i18n-pack file newer than remote drive modifiedTime: local kept, remote re-uploaded', async () => {
+      await mkdir(join(mockUserDataPath, 'sync', 'i18n', 'packs'), { recursive: true })
+      await writeFile(
+        join(mockUserDataPath, 'sync', 'i18n', 'packs', 'pack-a.json'),
+        JSON.stringify({ name: 'Pack A', version: '3.0.0' }),
+        'utf-8',
+      )
+      // Local file mtime is "now" (just written) — the remote drive
+      // file's modifiedTime is set far in the past, so local must win.
+      // No mockDownloadFile queued for this pack: packBodyLocalWins
+      // short-circuits mergeWithRemote BEFORE downloadFile is ever
+      // called — if the production code regressed and called it
+      // anyway, the mock would throw/return undefined and this test
+      // would fail loudly instead of silently leaking a queued
+      // implementation into the next test.
+      mockListFiles.mockResolvedValue([
+        { id: 'pack1', name: 'i18n_packs_pack-a.enc', modifiedTime: '2000-01-01T00:00:00.000Z' },
+      ])
+      mockUploadFile.mockResolvedValue({ id: 'pack-file-id', modifiedTime: '2026-01-01T00:00:00.000Z' })
+
+      await executeSync('download')
+
+      expect(mockDownloadFile.mock.calls.some((c) => c[0] === 'pack1')).toBe(false)
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === 'i18n_packs_pack-a.enc')).toBe(true)
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', 'i18n', 'packs', 'pack-a.json'), 'utf-8'),
+      ) as { version: string }
+      expect(written.version).toBe('3.0.0')
+    })
+
+    it('S3: a local-wins pack-body upload pins local mtime to the Drive response modifiedTime (closes a clock-skew re-upload loop)', async () => {
+      // Without this pin, the local pack file keeps its own wall-clock
+      // write time. If the local clock runs ahead of Drive's own clock
+      // (or the two just don't line up exactly), that time permanently
+      // looks "newer than the remote copy" — every subsequent sync pass
+      // would re-upload this unchanged body, and every peer would
+      // re-download it, forever. Pinning to the upload response's own
+      // modifiedTime closes that gap the same way a remote-win already
+      // does for the download direction (see the idempotence test
+      // below).
+      await mkdir(join(mockUserDataPath, 'sync', 'i18n', 'packs'), { recursive: true })
+      const packPath = join(mockUserDataPath, 'sync', 'i18n', 'packs', 'pack-a.json')
+      await writeFile(packPath, JSON.stringify({ name: 'Pack A', version: '3.0.0' }), 'utf-8')
+
+      mockListFiles.mockResolvedValue([
+        { id: 'pack1', name: 'i18n_packs_pack-a.enc', modifiedTime: '2000-01-01T00:00:00.000Z' },
+      ])
+      const driveAssignedModifiedTime = '2026-07-15T12:00:00.000Z'
+      mockUploadFile.mockResolvedValue({ id: 'pack-file-id', modifiedTime: driveAssignedModifiedTime })
+
+      await executeSync('download')
+
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === 'i18n_packs_pack-a.enc')).toBe(true)
+      const statAfterUpload = await stat(packPath)
+      expect(statAfterUpload.mtime.toISOString()).toBe(driveAssignedModifiedTime)
+    })
+
+    it('S3-race: a concurrent local save landing between the upload snapshot and the post-upload pin is not clobbered (CAS-guarded)', async () => {
+      // uploadSyncUnit snapshots the local body's mtime BEFORE bundling —
+      // bundling/encrypting/uploading all happen without holding the
+      // store's write lock, so a fresh local save can land in that
+      // window. A blind pin would stamp the NEW content with the OLD
+      // upload's stale Drive time, making the next LWW comparison see a
+      // tie and the new edit never get uploaded. Simulate that race
+      // inside the uploadFile mock itself: by the time it "returns" from
+      // Drive, a concurrent save has already landed locally.
+      await mkdir(join(mockUserDataPath, 'sync', 'i18n', 'packs'), { recursive: true })
+      const packPath = join(mockUserDataPath, 'sync', 'i18n', 'packs', 'pack-a.json')
+      await writeFile(packPath, JSON.stringify({ name: 'Pack A', version: '3.0.0' }), 'utf-8')
+
+      mockListFiles.mockResolvedValue([
+        { id: 'pack1', name: 'i18n_packs_pack-a.enc', modifiedTime: '2000-01-01T00:00:00.000Z' },
+      ])
+      const staleDriveModifiedTime = '2026-07-15T12:00:00.000Z'
+      const raceMtime = new Date('2030-01-01T00:00:00.000Z')
+      mockUploadFile.mockImplementation(async (name: string) => {
+        if (name === 'i18n_packs_pack-a.enc') {
+          await writeFile(packPath, JSON.stringify({ name: 'Pack A', version: '4.0.0' }), 'utf-8')
+          await utimes(packPath, raceMtime, raceMtime)
+        }
+        return { id: 'pack-file-id', modifiedTime: staleDriveModifiedTime }
+      })
+
+      await executeSync('download')
+
+      // The raced edit's content and mtime must both survive untouched —
+      // the pin must have been skipped rather than overwriting either.
+      const written = JSON.parse(await readFile(packPath, 'utf-8')) as { version: string }
+      expect(written.version).toBe('4.0.0')
+      const finalStat = await stat(packPath)
+      expect(finalStat.mtime.getTime()).toBe(raceMtime.getTime())
+      expect(finalStat.mtime.toISOString()).not.toBe(staleDriveModifiedTime)
+    })
+
+    it('idempotence: a remote-won pack body is not re-uploaded on the very next sync (mtime pinned to remote modifiedTime)', async () => {
+      const remoteModifiedTime = '2026-06-01T00:00:00.000Z'
+      const remoteFile = { id: 'pack1', name: 'i18n_packs_pack-a.enc', modifiedTime: remoteModifiedTime }
+      const packEnvelope = makeBundleEnvelope('i18n/packs/pack-a', remoteModifiedTime, {
+        type: 'i18n-pack',
+        key: 'pack-a',
+        files: { 'pack-a.json': JSON.stringify({ name: 'Pack A', version: '2.0.0' }) },
+      })
+
+      mockListFiles.mockResolvedValue([remoteFile, PASSWORD_CHECK_DRIVE_FILE])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(packEnvelope)
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(packEnvelope)
+
+      await executeSync('download')
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === 'i18n_packs_pack-a.enc')).toBe(false)
+
+      // Second, independent sync pass against the exact same unchanged
+      // remote revision. Without the mtime pin in applySyncedPackBody,
+      // the file just written would carry a local mtime of "now" (>
+      // remoteModifiedTime), so this recompute would see "local newer"
+      // and immediately re-upload the identical content it just
+      // downloaded — an endless full-body ping-pong between any two
+      // devices that both hold this pack.
+      await executeSync('download')
+      expect(mockUploadFile.mock.calls.some((c) => c[0] === 'i18n_packs_pack-a.enc')).toBe(false)
+    })
+
+    it('rejects a hostile packId parsed from a crafted remote filename — nothing is written outside the packs dir', async () => {
+      // A remote Drive file is attacker-reachable data (anyone who can
+      // write to this appData folder) — a crafted filename can make
+      // syncUnitFromFileName/parsePackBodySyncUnit produce a traversal
+      // packId. applySyncedPackBody's isSafePackId guard must refuse it
+      // before it's ever joined into a filesystem path.
+      const hostileFile = { id: 'evil1', name: 'i18n_packs_../evil.enc', modifiedTime: '2026-06-01T00:00:00.000Z' }
+      mockListFiles.mockResolvedValue([hostileFile, PASSWORD_CHECK_DRIVE_FILE])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope('i18n/packs/../evil', '2026-06-01T00:00:00.000Z', {
+          type: 'i18n-pack',
+          key: '../evil',
+          files: { '../evil.json': JSON.stringify({ name: 'Evil', version: '1.0.0' }) },
+        }))
+
+      const progressEvents: SyncProgress[] = []
+      setProgressCallback((p) => progressEvents.push({ ...p }))
+
+      await executeSync('download')
+
+      const final = progressEvents[progressEvents.length - 1]
+      expect(final.status).toBe('partial')
+      expect(final.failedUnits).toContain('i18n/packs/../evil')
+
+      await expect(access(join(mockUserDataPath, 'sync', 'i18n', 'evil.json'))).rejects.toThrow()
+      await expect(access(join(mockUserDataPath, 'sync', 'evil.json'))).rejects.toThrow()
+      await expect(access(join(mockUserDataPath, 'evil.json'))).rejects.toThrow()
+    })
+
+    it('malformed generic bundle (entries not an array) is skipped with a warn, not thrown', async () => {
+      // A hypothetical corrupt favorites bundle whose index.entries isn't
+      // an array must not crash the whole sync pass — it should be
+      // contained per-unit (same shape as any other per-unit failure).
+      mockListFiles.mockResolvedValue([
+        { id: 'bad1', name: 'favorites_tapDance.enc', modifiedTime: '2026-01-01T00:00:00.000Z' },
+      ])
+      mockDownloadFile.mockResolvedValueOnce({
+        version: 1,
+        syncUnit: 'favorites/tapDance',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        salt: 's',
+        iv: 'i',
+        ciphertext: JSON.stringify({
+          type: 'favorite',
+          key: 'tapDance',
+          index: { type: 'tapDance', entries: 'not-an-array' },
+          files: {},
+        }),
+      })
+
+      const progressEvents: SyncProgress[] = []
+      setProgressCallback((p) => progressEvents.push({ ...p }))
+
+      await executeSync('download')
+
+      const final = progressEvents[progressEvents.length - 1]
+      expect(final.status).toBe('partial')
+      expect(final.failedUnits).toContain('favorites/tapDance')
+    })
+
+    it('malformed bundle: same remote revision is not retried on the next poll (contained via lastKnownRemoteState)', async () => {
+      const badFile = { id: 'bad1', name: 'favorites_tapDance.enc', modifiedTime: '2026-01-01T00:00:00.000Z' }
+      const badEnvelope = {
+        version: 1,
+        syncUnit: 'favorites/tapDance',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        salt: 's',
+        iv: 'i',
+        ciphertext: JSON.stringify({
+          type: 'favorite',
+          key: 'tapDance',
+          index: { type: 'tapDance', entries: 'not-an-array' },
+          files: {},
+        }),
+      }
+      // First poll returns only the (syncUnit-less) password-check file,
+      // so the baseline is non-empty but doesn't include badFile — the
+      // very next poll then sees badFile as newly "changed" (present but
+      // absent from the recorded state). An empty first-poll file list
+      // would instead re-trigger pollForRemoteChanges's own "first poll
+      // ever" branch (`lastKnownRemoteState.size === 0`) a second time.
+      mockListFiles.mockResolvedValueOnce([PASSWORD_CHECK_DRIVE_FILE])
+      mockDownloadFile.mockResolvedValue(badEnvelope)
+
+      startPolling()
+      // First poll: records baseline state only (no download attempts).
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockListFiles.mock.calls.length >= 1)
+      await flushIO()
+
+      // Second poll: badFile is now present and wasn't in the baseline,
+      // so it's treated as "changed" — the merge fails with
+      // MalformedSyncBundleError, but the poll's catch deliberately does
+      // NOT forget badFile's modifiedTime from lastKnownRemoteState (it
+      // was already recorded earlier in this same poll pass), so poll 3
+      // below sees an unchanged modifiedTime and skips it without ever
+      // retrying — no separate block-map data structure needed.
+      mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE, badFile])
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockDownloadFile.mock.calls.some((c) => c[0] === 'bad1'))
+      // The failing merge itself is real disk I/O (readIndexFile against a
+      // real tmp dir), which resolves via the libuv threadpool rather than
+      // the microtask queue `flushIO` drains — wait for the poll's own
+      // sync-lock release, not just a fixed tick count, so poll 3 below
+      // never races a still-in-flight poll 2.
+      await flushUntil(() => !isSyncInProgress())
+      const attemptsAfterSecondPoll = mockDownloadFile.mock.calls.filter((c) => c[0] === 'bad1').length
+      expect(attemptsAfterSecondPoll).toBeGreaterThan(0)
+      // Contained per-unit with a warn naming only the sync unit — never
+      // bundle content (attacker-reachable remote data).
+      expect(mockLog).toHaveBeenCalledWith('warn', expect.stringContaining('favorites/tapDance'))
+
+      // Third poll, same revision still on Drive — must NOT retry again.
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockListFiles.mock.calls.length >= 3)
+      await flushUntil(() => !isSyncInProgress())
+      const attemptsAfterThirdPoll = mockDownloadFile.mock.calls.filter((c) => c[0] === 'bad1').length
+      expect(attemptsAfterThirdPoll).toBe(attemptsAfterSecondPoll)
+
+      // A changed revision (new modifiedTime) clears the block and is retried.
+      const changedFile = { ...badFile, modifiedTime: '2026-01-02T00:00:00.000Z' }
+      mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE, changedFile])
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockDownloadFile.mock.calls.filter((c) => c[0] === 'bad1').length > attemptsAfterThirdPoll)
+      const attemptsAfterFourthPoll = mockDownloadFile.mock.calls.filter((c) => c[0] === 'bad1').length
+      expect(attemptsAfterFourthPoll).toBeGreaterThan(attemptsAfterThirdPoll)
+
+      stopPolling()
+    })
+
+    it('S1: a hostile packId is contained on the poll path too — not retried every 3 minutes', async () => {
+      // Task M2's hostile-packId test above only exercises the manual
+      // sync path (executeSync). S1: applySyncedPackBody now THROWS
+      // MalformedSyncBundleError for a rejected packId instead of
+      // returning false as a bare Error would — this lets the poll's
+      // `instanceof MalformedSyncBundleError` branch recognize the
+      // rejection as permanent and skip retrying it, exactly like the
+      // malformed-generic-bundle poll test above. Before this fix, a
+      // bare Error looked identical to a transient I/O failure, which
+      // the poll deliberately DOES keep retrying — so a hostile remote
+      // filename would have triggered a fresh download+decrypt attempt
+      // every 3 minutes forever.
+      const evilFile = { id: 'evil1', name: 'i18n_packs_../evil.enc', modifiedTime: '2026-06-01T00:00:00.000Z' }
+      const evilEnvelope = makeBundleEnvelope('i18n/packs/../evil', '2026-06-01T00:00:00.000Z', {
+        type: 'i18n-pack',
+        key: '../evil',
+        files: { '../evil.json': JSON.stringify({ name: 'Evil', version: '1.0.0' }) },
+      })
+      mockListFiles.mockResolvedValueOnce([PASSWORD_CHECK_DRIVE_FILE])
+      mockDownloadFile.mockResolvedValue(evilEnvelope)
+
+      startPolling()
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockListFiles.mock.calls.length >= 1)
+      await flushIO()
+
+      mockListFiles.mockResolvedValue([PASSWORD_CHECK_DRIVE_FILE, evilFile])
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockDownloadFile.mock.calls.some((c) => c[0] === 'evil1'))
+      await flushUntil(() => !isSyncInProgress())
+      const attemptsAfterSecondPoll = mockDownloadFile.mock.calls.filter((c) => c[0] === 'evil1').length
+      expect(attemptsAfterSecondPoll).toBeGreaterThan(0)
+
+      // Same revision still on Drive on the next poll — must NOT retry.
+      await vi.advanceTimersByTimeAsync(POLL_INTERVAL_MS)
+      await flushUntil(() => mockListFiles.mock.calls.length >= 3)
+      await flushUntil(() => !isSyncInProgress())
+      const attemptsAfterThirdPoll = mockDownloadFile.mock.calls.filter((c) => c[0] === 'evil1').length
+      expect(attemptsAfterThirdPoll).toBe(attemptsAfterSecondPoll)
+
+      await expect(access(join(mockUserDataPath, 'sync', 'i18n', 'evil.json'))).rejects.toThrow()
+      await expect(access(join(mockUserDataPath, 'evil.json'))).rejects.toThrow()
+
+      stopPolling()
+    })
+
+    it('M2: a hostile meta id is filtered out of the merged index — never persisted, never reaches collectAllSyncUnits', async () => {
+      // A remote index meta whose id is shaped like a path-traversal
+      // sequence would, if persisted, later flow through
+      // collectAllSyncUnits into a sync-unit string with more than the
+      // expected 3 `/`-separated segments — bundleSyncUnit's i18n pack
+      // branch fails to match that shape and falls through to the
+      // generic index-based tail, joining an attacker-chosen path into
+      // a filesystem read that gets bundled for upload. The index merge
+      // must drop the hostile id before it's ever written to disk,
+      // while keeping the legitimate sibling entry.
+      mockListFiles.mockResolvedValue([
+        { id: 'idx1', name: 'i18n_index.enc', modifiedTime: '2026-01-01T00:00:00.000Z' },
+        PASSWORD_CHECK_DRIVE_FILE,
+      ])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce(makeBundleEnvelope('i18n/index', '2026-01-01T00:00:00.000Z', {
+          type: 'i18n-index',
+          key: 'i18n-index',
+          index: {
+            metas: [
+              { id: '../evil', name: 'Evil', version: '1.0.0', enabled: true, savedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+              { id: 'ok-pack', name: 'OK Pack', version: '1.0.0', enabled: true, savedAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z' },
+            ],
+          },
+        }))
+
+      const progressEvents: SyncProgress[] = []
+      setProgressCallback((p) => progressEvents.push({ ...p }))
+
+      await executeSync('download')
+
+      const final = progressEvents[progressEvents.length - 1]
+      expect(final.status).toBe('success')
+
+      const written = JSON.parse(
+        await readFile(join(mockUserDataPath, 'sync', 'i18n', 'index.json'), 'utf-8'),
+      ) as { metas: Array<{ id: string }> }
+      expect(written.metas.map((m) => m.id)).toEqual(['ok-pack'])
+      expect(mockLog).toHaveBeenCalledWith('warn', expect.stringContaining('i18n/index'))
+    })
+
+    it('M2: a hostile favorites filename with a path-separator segment is rejected, not traversed', async () => {
+      // syncUnitFromFileName's regex captures everything after
+      // `favorites_` up to `.enc` — a crafted Drive filename (Drive
+      // names are arbitrary strings, not real filesystem paths, so
+      // they can contain '/') can make that capture contain a path
+      // separator, producing a syncUnit like 'favorites/../../evil'.
+      // Every `/`-split segment of `syncUnit` must be validated before
+      // mergeSyncUnit's settings / generic branches join it into a
+      // filesystem path — this is the pre-existing exposure M2 closes
+      // centrally, independent of the i18n/theme pack-index fix above.
+      const hostileFile = { id: 'evil1', name: 'favorites_../../evil.enc', modifiedTime: '2026-06-01T00:00:00.000Z' }
+      mockListFiles.mockResolvedValue([hostileFile, PASSWORD_CHECK_DRIVE_FILE])
+      mockDownloadFile
+        .mockResolvedValueOnce(makePasswordCheckEnvelope())
+        .mockResolvedValueOnce({
+          version: 1,
+          syncUnit: 'favorites/../../evil',
+          updatedAt: '2026-06-01T00:00:00.000Z',
+          salt: 's',
+          iv: 'i',
+          ciphertext: JSON.stringify({
+            type: 'favorite',
+            key: 'evil',
+            index: { type: 'evil', entries: [] },
+            files: {},
+          }),
+        })
+
+      const progressEvents: SyncProgress[] = []
+      setProgressCallback((p) => progressEvents.push({ ...p }))
+
+      await executeSync('download')
+
+      const final = progressEvents[progressEvents.length - 1]
+      expect(final.status).toBe('partial')
+      expect(final.failedUnits).toContain('favorites/../../evil')
+
+      await expect(access(join(mockUserDataPath, 'sync', 'evil.json'))).rejects.toThrow()
+      await expect(access(join(mockUserDataPath, 'evil.json'))).rejects.toThrow()
     })
   })
 })

--- a/src/main/__tests__/theme-pack-store.test.ts
+++ b/src/main/__tests__/theme-pack-store.test.ts
@@ -2,8 +2,19 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { mkdtemp, rm, readFile, writeFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+
+// Real fs/promises for every export except `utimes`, which is wrapped in a
+// `vi.fn` so individual tests can force it to reject (simulating a utimes
+// failure) — `vi.spyOn` cannot patch a real ESM module's export (Node's
+// `node:fs/promises` namespace is non-configurable), so the override has to
+// happen at mock-definition time instead.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, utimes: vi.fn(actual.utimes) }
+})
+
+import { mkdtemp, rm, readFile, writeFile, mkdir, stat, utimes } from 'node:fs/promises'
 
 let mockUserDataPath = ''
 
@@ -23,7 +34,15 @@ vi.mock('../sync/sync-service', () => ({
   notifyChange: vi.fn(),
 }))
 
+// The real logger is a module-level singleton (cached log directory) that
+// doesn't play well with a fresh mkdtemp'd userData per test — mock it out,
+// same as sync-bundle.run-log.test.ts does.
+vi.mock('../logger', () => ({
+  log: vi.fn(),
+}))
+
 import { notifyChange } from '../sync/sync-service'
+import { log } from '../logger'
 import {
   savePack,
   getPack,
@@ -35,6 +54,10 @@ import {
   hasActiveName,
   purgeExpiredTombstones,
   reorderActive,
+  mergeSyncedIndex,
+  applySyncedPackBody,
+  pinPackBodyMtime,
+  statLocalPackMtime,
   __testing,
 } from '../theme-pack-store'
 import {
@@ -702,6 +725,118 @@ describe('theme-pack-store', () => {
     it('accepts valid pack ids', () => {
       expect(() => __testing.getPackPath('valid-id-123')).not.toThrow()
       expect(() => __testing.getPackPath('abc_def')).not.toThrow()
+    })
+  })
+
+  // --- Task-sync-unit-discovery bugfix plan: fixes 1-3 ----------------------
+
+  describe('sync robustness fixes (utimes degrade / pin CAS / malformed metas)', () => {
+    // --- Fix 1: utimes failure degrades to accept-with-warn -----------------
+
+    it('applySyncedPackBody: a utimes failure after a successful write still reports "applied" (never io-error)', async () => {
+      vi.mocked(utimes).mockRejectedValueOnce(new Error('EPERM: operation not permitted'))
+
+      const outcome = await applySyncedPackBody(
+        'utimes-fail-pack',
+        JSON.stringify(makeValidPack({ name: 'UtimesFail' })),
+        '2026-01-01T00:00:00.000Z',
+      )
+
+      expect(outcome).toBe('applied')
+      expect(utimes).toHaveBeenCalledTimes(1)
+      expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('themes/packs/utimes-fail-pack'))
+
+      // The body write itself must have landed despite the pin failure.
+      // (applySyncedPackBody only writes the body file — no index entry
+      // exists for this id, so read the file directly rather than via
+      // getPack, which requires an index meta.)
+      const body = await readFile(__testing.getPackPath('utimes-fail-pack'), 'utf-8')
+      expect(JSON.parse(body)).toEqual(makeValidPack({ name: 'UtimesFail' }))
+    })
+
+    it('pinPackBodyMtime: a utimes failure is swallowed (warn), never thrown', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'PinFail' }) })
+      const id = saved.data!.id
+      const mtime = await statLocalPackMtime(id)
+
+      vi.mocked(utimes).mockRejectedValueOnce(new Error('EPERM'))
+      await expect(pinPackBodyMtime(id, '2026-01-01T00:00:00.000Z', mtime)).resolves.toBeUndefined()
+      expect(log).toHaveBeenCalledWith('warn', expect.stringContaining(`themes/packs/${id}`))
+    })
+
+    // --- Fix 2: post-upload pin is CAS-guarded -------------------------------
+
+    it('pinPackBodyMtime: skips the pin (no utimes call) when the local mtime no longer matches the upload snapshot', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'Racer' }) })
+      const id = saved.data!.id
+      const path = __testing.getPackPath(id)
+
+      // Snapshot mtime as it was when uploadSyncUnit bundled the (old) content.
+      const snapshotDate = new Date('2020-01-01T00:00:00.000Z')
+      await utimes(path, snapshotDate, snapshotDate)
+      const snapshot = snapshotDate.getTime()
+
+      // A concurrent local save lands after the snapshot but before the pin
+      // takes the store's write lock — simulated by advancing the file's
+      // mtime well past both the snapshot and the (old) upload's Drive time.
+      const raceDate = new Date('2026-06-01T00:00:00.000Z')
+      await utimes(path, raceDate, raceDate)
+
+      vi.mocked(utimes).mockClear() // discard the setup calls above
+      await pinPackBodyMtime(id, '2020-01-01T00:00:05.000Z', snapshot)
+      expect(utimes).not.toHaveBeenCalled()
+
+      // The newer (raced) edit's mtime survives untouched, so it still wins
+      // the next LWW comparison against the stale upload's Drive time.
+      const finalMtime = (await statLocalPackMtime(id))!
+      expect(finalMtime).toBe(raceDate.getTime())
+      expect(finalMtime).toBeGreaterThan(new Date('2020-01-01T00:00:05.000Z').getTime())
+    })
+
+    it('pinPackBodyMtime: pins when the local mtime still matches the snapshot (no race)', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'NoRace' }) })
+      const id = saved.data!.id
+      const snapshot = await statLocalPackMtime(id)
+
+      const remoteModifiedTime = '2026-07-01T00:00:00.000Z'
+      await pinPackBodyMtime(id, remoteModifiedTime, snapshot)
+
+      const path = __testing.getPackPath(id)
+      const finalStat = await stat(path)
+      expect(finalStat.mtime.getTime()).toBe(new Date(remoteModifiedTime).getTime())
+    })
+
+    it('pinPackBodyMtime: skips the pin when given no snapshot to compare (null)', async () => {
+      const saved = await savePack({ raw: makeValidPack({ name: 'NoSnapshot' }) })
+      const id = saved.data!.id
+      const before = await statLocalPackMtime(id)
+
+      vi.mocked(utimes).mockClear()
+      await pinPackBodyMtime(id, '2026-07-01T00:00:00.000Z', null)
+      expect(utimes).not.toHaveBeenCalled()
+
+      const after = await statLocalPackMtime(id)
+      expect(after).toBe(before)
+    })
+
+    // --- Fix 3: meta validation must not crash on non-object entries --------
+
+    it('mergeSyncedIndex drops non-object entries (e.g. null) instead of crashing, keeping valid siblings', async () => {
+      const goodMeta = {
+        id: 'good-1',
+        filename: 'packs/good-1.json',
+        name: 'Good',
+        version: '1.0.0',
+        savedAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      }
+
+      const result = await mergeSyncedIndex([null, goodMeta])
+
+      expect(result.applied).toBe(true)
+      expect(log).toHaveBeenCalledWith('warn', expect.stringContaining('dropped 1 unsafe remote meta id'))
+      const all = await listAllMetas()
+      expect(all.some((m) => m.id === 'good-1')).toBe(true)
     })
   })
 })

--- a/src/main/i18n-pack-store.ts
+++ b/src/main/i18n-pack-store.ts
@@ -14,9 +14,11 @@
 
 import { app, dialog, BrowserWindow } from 'electron'
 import { join } from 'node:path'
-import { access, mkdir, readFile, readdir, rm, unlink, writeFile } from 'node:fs/promises'
+import { access, mkdir, readFile, readdir, rename, rm, stat, unlink, utimes, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
+import { gcTombstones, mergeEntries, MalformedSyncBundleError } from './sync/merge'
+import { log } from './logger'
 import { safeFilename } from './utils/safe-filename'
 import {
   BUILTIN_ENGLISH_PACK_ID,
@@ -54,6 +56,14 @@ function isSafePackId(id: string): boolean {
   return /^[A-Za-z0-9_-]{1,64}$/.test(id)
 }
 
+/** True when `m` is at least shaped enough to read `.id` off of safely —
+ *  a non-null object with a string `id` field. Guards `mergeSyncedIndex`'s
+ *  per-entry filter against a remote `metas` array containing `null` or
+ *  other non-object garbage (attacker-reachable data). */
+function isPackMetaCandidate(m: unknown): m is I18nPackMeta {
+  return typeof m === 'object' && m !== null && typeof (m as { id?: unknown }).id === 'string'
+}
+
 function getPackPath(packId: string): string {
   if (!isSafePackId(packId)) throw new Error(`Invalid packId: ${packId}`)
   return join(getPacksDir(), `${packId}.json`)
@@ -87,14 +97,284 @@ function nowIso(): string {
 // chain so a concurrent pair can't each read a stale snapshot and
 // clobber the other's write — mirrors `sync/keyboard-meta.ts`'s
 // `withMetaWriteLock` precedent. Scoped to this store only; Key Labels
-// and Theme Packs have the same pre-existing gap (see the module
-// report, not fixed here).
+// has the same pre-existing gap (see the module report, not fixed
+// here). Theme Packs used to share this gap too but now has its own
+// equivalent lock across all mutation methods (`theme-pack-store.ts`'s
+// `withIndexWriteLock`) — that store gained a real second writer
+// (remote sync) once its index-merge landed, so its own lock could no
+// longer stay scoped to only the two sync entry points.
 let indexWriteChain: Promise<unknown> = Promise.resolve()
 
 async function withIndexWriteLock<T>(fn: () => Promise<T>): Promise<T> {
   const next = indexWriteChain.then(() => fn(), () => fn())
   indexWriteChain = next.catch(() => undefined)
   return next
+}
+
+/** Write `content` to `path` via a temp-file-then-rename so a reader can
+ *  never observe a torn (partially-written) file — a plain `writeFile`
+ *  racing a concurrent read is how `readIndex`'s parse-failure fallback
+ *  (`{ metas: [] }`) could otherwise get persisted right over a real
+ *  roster by a subsequent read-modify-write. */
+async function writeFileAtomic(path: string, content: string): Promise<void> {
+  const tmpPath = `${path}.tmp`
+  await writeFile(tmpPath, content, 'utf-8')
+  await rename(tmpPath, path)
+}
+
+// --- Sync entry points (pack-bundle-merge.ts) --------------------------------
+//
+// mergePackIndexBundle/mergePackBodyBundle own the LWW comparison
+// (Drive modifiedTime vs local mtime for the body; nothing to own for
+// the index anymore — see mergeSyncedIndex below) — these entry points
+// only know how to apply an already-decided winning write. Routing the
+// write through here (instead of pack-bundle-merge.ts joining
+// userData/sync/i18n/... and calling writeFile itself, as it used to)
+// gets two things pack-bundle-merge.ts cannot provide on its own:
+// `isSafePackId` validation of a packId sourced from a remote Drive
+// filename (least-trusted input), and `withIndexWriteLock` so a merge
+// write can't land in the middle of this store's own read-modify-write
+// cycle (save/rename/delete/reorder/purge) — which, combined with the
+// old non-atomic write, is how a torn read could get persisted as an
+// empty index over a real roster.
+
+/** Entry-level LWW merge + persist for a synced remote index. Replaces
+ *  the old whole-file "remote newer wholesale-replaces local" strategy,
+ *  which silently destroyed the other side's roster whenever two
+ *  machines each installed a different pack while offline — see
+ *  pack-bundle-merge.ts's `mergePackIndexBundle` doc for the full
+ *  writeup. Reuses the exact same `mergeEntries`/`gcTombstones`
+ *  machinery every other entry-based sync unit (favorites, key-labels,
+ *  etc.) already relies on — `I18nPackMeta` carries the same
+ *  id/filename/savedAt/updatedAt/deletedAt? shape `EntryMeta` requires.
+ *  `preserveLocalOrder` is set because index order is user-meaningful
+ *  (drag order), same as key-labels.
+ *
+ *  Reads, merges, and writes under the write lock as a single atomic
+ *  step — not a separate outside-lock read followed by a decided
+ *  "apply" call, which is what the old `applySyncedIndex(rawJson)`
+ *  shape did. That gap let a concurrent local mutation
+ *  (save/rename/delete/reorder) land between the caller's read and its
+ *  write (TOCTOU); folding read→merge→write into one lock-held function
+ *  closes it.
+ *
+ *  A remote meta whose `id` doesn't pass `isSafePackId` is dropped
+ *  before merging (never persisted, never counted toward
+ *  `remoteNeedsUpdate`) — a hostile id here would otherwise later flow
+ *  through `collectAllSyncUnits` into a sync-unit string with more than
+ *  the expected 3 `/`-separated segments, which `bundleSyncUnit`'s i18n
+ *  pack branch would fail to match, falling through to the generic
+ *  index-based tail and joining an attacker-chosen path into a
+ *  filesystem read that gets bundled for upload. Kept metas also get
+ *  their `filename` recomputed from the (now-validated) `id` rather than
+ *  trusting whatever string the remote sent — `filename` is never
+ *  actually used to build a filesystem path in this store (every path
+ *  is derived from `id` via `getPackPath`), but there's no reason to
+ *  persist an attacker-controlled string when the correct value is a
+ *  one-line derivation.
+ *
+ *  The built-in English meta rides along in this same merge like any
+ *  other entry: every machine creates it locally with its own
+ *  first-seen timestamp (`ensureBuiltinEnglishEntry`), so two machines'
+ *  copies differ only in `savedAt`/`updatedAt` — whichever side's
+ *  per-id LWW wins is harmless, since the content (`name`/`version`/
+ *  `enabled`) every machine generates is identical.
+ *
+ *  `remoteMetas` is typed `unknown[]` rather than `I18nPackMeta[]`
+ *  because it is attacker-reachable data (a remote Drive file) whose
+ *  shape is never actually guaranteed — a bare `metas: [null]` used to
+ *  crash this function reading `m.id` off `null` before `isSafePackId`
+ *  ever ran. `isPackMetaCandidate` treats any non-object entry the same
+ *  way as a rejected id: dropped via the same unit-name-only warn path
+ *  below, never thrown. The `metas` field not being an array at all is
+ *  a stronger malformation than a bad element and is rejected one layer
+ *  up, by `mergePackIndexBundle` (pack-bundle-merge.ts), which throws
+ *  `MalformedSyncBundleError` before this function is even called — see
+ *  its own doc for why that one is poll-skip-permanent rather than
+ *  silently-filtered.
+ *
+ *  Returns `applied: false` (never throws) only on an I/O failure
+ *  writing the merged index — never for a rejected meta, since those
+ *  are silently filtered rather than failing the whole unit. */
+export async function mergeSyncedIndex(
+  remoteMetas: readonly unknown[],
+): Promise<{ applied: boolean; remoteNeedsUpdate: boolean }> {
+  return withIndexWriteLock(async () => {
+    try {
+      const localIndex = await readIndex()
+      const rejectedCount = remoteMetas.filter((m) => !isPackMetaCandidate(m) || !isSafePackId(m.id)).length
+      if (rejectedCount > 0) {
+        log('warn', `sync: dropped ${rejectedCount} unsafe remote meta id(s) for ${I18N_INDEX_SYNC_UNIT}`)
+      }
+      const safeRemoteMetas = remoteMetas
+        .filter((m): m is I18nPackMeta => isPackMetaCandidate(m) && isSafePackId(m.id))
+        .map((m) => ({ ...m, filename: `${PACKS_DIRNAME}/${m.id}.json` }))
+      const localMetas = gcTombstones(localIndex.metas)
+      const remoteMetasGced = gcTombstones(safeRemoteMetas)
+      const result = mergeEntries(localMetas, remoteMetasGced, { preserveLocalOrder: true })
+      await mkdir(getStoreDir(), { recursive: true })
+      await writeFileAtomic(getIndexPath(), JSON.stringify({ metas: result.entries }, null, 2))
+      return { applied: true, remoteNeedsUpdate: result.remoteNeedsUpdate }
+    } catch {
+      return { applied: false, remoteNeedsUpdate: false }
+    }
+  })
+}
+
+/** Local mtime (ms) of a pack body file, or `null` when `packId` is
+ *  unsafe or the file doesn't exist yet — either way there is no local
+ *  clock to compare against, so the remote side trivially wins the LWW
+ *  comparison. */
+export async function statLocalPackMtime(packId: string): Promise<number | null> {
+  if (!isSafePackId(packId)) return null
+  try {
+    const stats = await stat(getPackPath(packId))
+    return stats.mtime.getTime()
+  } catch {
+    return null
+  }
+}
+
+/** Outcome of `applySyncedPackBody`: `'applied'` (write landed),
+ *  `'local-wins'` (the in-lock CAS re-check below found local is
+ *  already newer-or-tied, so nothing was written), or `'io-error'` (a
+ *  genuine, presumably-transient failure). Callers treat `'io-error'`
+ *  as an ordinary retried sync failure and `'local-wins'` as "mark for
+ *  re-upload, don't fail the unit" — see `mergePackBodyBundle`. */
+export type ApplyPackBodyOutcome = 'applied' | 'local-wins' | 'io-error'
+
+/** Apply an already-LWW-won remote pack body. Rejects an unsafe `packId`
+ *  by THROWING `MalformedSyncBundleError` (defense in depth — the merge
+ *  layer's own filename parsing should never produce one, but this is
+ *  the boundary where a remote Drive filename, the least-trusted input
+ *  in the sync pipeline, actually gets joined into a filesystem path).
+ *  Throwing here (rather than returning `false`, as this used to) lets
+ *  the sync poll's `instanceof MalformedSyncBundleError` check recognize
+ *  this as a permanently-rejected revision and stop retrying it every 3
+ *  minutes — a bare `Error` previously looked identical to a transient
+ *  I/O failure, which the poll deliberately DOES keep retrying.
+ *
+ *  Re-checks the local pack file's mtime against `remoteModifiedTime`
+ *  again HERE, under the lock, immediately before writing (a
+ *  compare-and-swap): the caller's own LWW decision
+ *  (`mergePackBodyBundle` in pack-bundle-merge.ts) reads local mtime
+ *  OUTSIDE this lock, so a local save (`savePack`/`renamePack` — both
+ *  lock-serialized) can land in the window between that read and this
+ *  write acquiring the lock. If local is now `>=` the remote revision
+ *  this call was about to apply, refuse the write and report
+ *  `'local-wins'` instead of clobbering the fresher local save — the
+ *  caller then marks the unit for re-upload rather than treating it as
+ *  a failure.
+ *
+ *  On success, pins the written file's mtime to the remote's own
+ *  `modifiedTime` rather than leaving it at "now" — without that, the
+ *  very next LWW comparison would see the freshly written local copy as
+ *  newer than the remote it was just copied from, re-upload it, and
+ *  round-trip forever between any two devices that both hold this
+ *  pack. The mtime pin is a SEPARATE try/catch from the body write
+ *  above: the write already landed by the time we attempt this, so a
+ *  utimes failure (e.g. a filesystem without utimes support) must not
+ *  report `'io-error'` — that would fail the whole unit and re-enter
+ *  this same clock-skew race on the very next poll, unbounded. Instead
+ *  it's logged as a unit-name-only warn and treated as `'applied'`: the
+ *  worst case is one redundant future re-upload of unchanged content,
+ *  which is strictly better than an unbounded retry loop. Returns
+ *  `'io-error'` (never throws for this case) on any OTHER I/O failure
+ *  (i.e. the write itself) so the caller can surface it as an ordinary,
+ *  retried, per-unit sync failure. */
+export async function applySyncedPackBody(
+  packId: string,
+  rawJson: string,
+  remoteModifiedTime: string,
+): Promise<ApplyPackBodyOutcome> {
+  if (!isSafePackId(packId)) {
+    throw new MalformedSyncBundleError(packSyncUnit(packId))
+  }
+  return withIndexWriteLock(async () => {
+    try {
+      const path = getPackPath(packId)
+      const modMs = new Date(remoteModifiedTime).getTime()
+      if (!Number.isNaN(modMs)) {
+        try {
+          const currentStat = await stat(path)
+          if (currentStat.mtime.getTime() >= modMs) return 'local-wins'
+        } catch {
+          // no local file yet — nothing to race against, proceed
+        }
+      }
+      await mkdir(getPacksDir(), { recursive: true })
+      await writeFileAtomic(path, rawJson)
+      if (!Number.isNaN(modMs)) {
+        try {
+          const pinned = new Date(modMs)
+          await utimes(path, pinned, pinned)
+        } catch {
+          log('warn', `sync: failed to pin mtime for ${packSyncUnit(packId)} after apply`)
+        }
+      }
+      return 'applied'
+    } catch {
+      return 'io-error'
+    }
+  })
+}
+
+/** Pin a pack body file's mtime to the Drive `modifiedTime` a
+ *  just-completed local-wins UPLOAD was assigned, closing a
+ *  clock-skew gap: without this, the local file keeps its own
+ *  wall-clock write time, which (if the local clock runs even slightly
+ *  ahead of Drive's own clock) permanently looks "newer than the
+ *  remote copy" — every subsequent sync pass would then re-upload this
+ *  unchanged body, and every peer would re-download it, forever.
+ *  Lock-scoped so it can't race a concurrent local save's own write of
+ *  this same file.
+ *
+ *  `expectedLocalMtimeMs` is a compare-and-swap guard: the caller
+ *  (`uploadSyncUnit`, sync-service.ts) snapshots the local file's mtime
+ *  BEFORE bundling the content for upload — outside this store's write
+ *  lock, since bundling/encrypting/uploading to Drive all happen
+ *  without holding it. A user save (`savePack`/`renamePack`, both
+ *  lock-serialized) can land in the window between that snapshot and
+ *  this function actually acquiring the lock. Blindly pinning in that
+ *  case would stamp the NEW content with the OLD upload's Drive time —
+ *  the next LWW comparison then sees local and remote as tied, and the
+ *  new edit never gets uploaded. So this re-checks the file's current
+ *  mtime against the snapshot, under the lock, immediately before
+ *  writing: only pin if nothing changed; otherwise skip (the newer
+ *  edit's own upload will supersede this pin attempt). `null` means the
+ *  caller had no local snapshot to compare (the pack body did not exist
+ *  yet at snapshot time) — since there's nothing to safely CAS against,
+ *  skip rather than guess.
+ *
+ *  Best-effort beyond the CAS check: swallows any I/O error (stat or
+ *  utimes) with a unit-name-only warn, since a missed pin only costs a
+ *  redundant re-upload on the next pass, not data loss. */
+export async function pinPackBodyMtime(
+  packId: string,
+  modifiedTime: string,
+  expectedLocalMtimeMs: number | null,
+): Promise<void> {
+  if (!isSafePackId(packId)) return
+  await withIndexWriteLock(async () => {
+    const modMs = new Date(modifiedTime).getTime()
+    if (Number.isNaN(modMs)) return
+    if (expectedLocalMtimeMs === null) {
+      log('debug', `sync: skipped mtime pin for ${packSyncUnit(packId)} — no local snapshot to compare`)
+      return
+    }
+    try {
+      const path = getPackPath(packId)
+      const currentStat = await stat(path)
+      if (currentStat.mtime.getTime() !== expectedLocalMtimeMs) {
+        log('debug', `sync: skipped mtime pin for ${packSyncUnit(packId)} — local file changed since upload snapshot`)
+        return
+      }
+      const pinned = new Date(modMs)
+      await utimes(path, pinned, pinned)
+    } catch {
+      log('warn', `sync: failed to pin mtime for ${packSyncUnit(packId)} after upload`)
+    }
+  })
 }
 
 // --- Result type -------------------------------------------------------------
@@ -112,7 +392,12 @@ function fail<T>(errorCode: I18nPackStoreErrorCode, error: string): I18nPackStor
 
 // --- Index I/O ---------------------------------------------------------------
 
-async function readIndex(): Promise<I18nPackIndex> {
+// Exported (in addition to internal use throughout this module) so
+// `mergePackIndexBundle` (pack-bundle-merge.ts) can read the current
+// local index for its LWW comparison without pack-bundle-merge.ts
+// knowing this store's on-disk path — same parse-failure-tolerant
+// fallback (`{ metas: [] }`) callers relied on before.
+export async function readIndex(): Promise<I18nPackIndex> {
   try {
     const raw = await readFile(getIndexPath(), 'utf-8')
     const parsed = JSON.parse(raw) as I18nPackIndex
@@ -563,14 +848,11 @@ export async function hasActiveName(name: string, excludeId?: string): Promise<b
  * entry. Only the index changes — pack bodies are untouched — so only
  * `I18N_INDEX_SYNC_UNIT` is bumped, matching `setEnabled`/`setHubPostId`.
  *
- * Known limitation (pre-existing store property, not a Phase 2
- * regression): unlike `key-labels` — a single sync unit with
- * entry-level LWW merge — `i18n/index` has no merge logic wired into
- * `sync-service.ts` yet. `notifyChange` marks the unit dirty for
- * upload, but a remote index downloaded during sync is not merged
- * against this reordered one, so the manual order (drag or Name sort)
- * is effectively machine-local until index-merge lands. Tracked as
- * future work in the unification plan, not addressed here.
+ * Like `key-labels`, `i18n/index` now has entry-level LWW merge wired
+ * into `sync-service.ts` (`mergeSyncedIndex`, with `preserveLocalOrder`
+ * so drag/Name-sort order survives the merge) — a remote index
+ * downloaded during sync merges against this reordered one instead of
+ * one side replacing the other wholesale.
  */
 export async function reorderActive(orderedIds: string[]): Promise<I18nPackStoreResult<void>> {
   return withIndexWriteLock(async () => {
@@ -642,8 +924,12 @@ export async function resetAllI18nPacks(): Promise<void> {
 }
 
 /** Best-effort orphan sweep: pack files on disk without an index entry
- * are deleted. Triggered after sync downloads to keep the packs dir
- * tidy when remote tombstones are reconciled. */
+ * are deleted. NOT currently wired to run automatically anywhere (no
+ * call site triggers it after a sync download applies a tombstone) —
+ * it exists as a standalone utility a future cleanup pass can call.
+ * Wiring it in after the index-merge landed (so a GC'd tombstone's
+ * orphaned body file gets swept) is tracked as follow-up in
+ * `Task-sync-remote-reset-and-discovery-gaps.md`. */
 export async function sweepOrphans(): Promise<number> {
   let removed = 0
   try {

--- a/src/main/sync/__tests__/pack-bundle-merge.test.ts
+++ b/src/main/sync/__tests__/pack-bundle-merge.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Focused coverage for pack-bundle-merge.ts's mergePackIndexBundle: a
+// malformed remote `metas` field (not an array, or missing entirely) must
+// throw MalformedSyncBundleError so the sync poll's unchanged-revision skip
+// applies — mirroring the generic index-based tail in sync-service.ts,
+// which already does this for a non-array `.entries`. Previously this
+// silently defaulted to an empty array, which made a corrupt remote index
+// indistinguishable from a legitimately-empty one.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../i18n-pack-store', () => ({
+  mergeSyncedIndex: vi.fn(),
+  statLocalPackMtime: vi.fn(),
+  applySyncedPackBody: vi.fn(),
+  pinPackBodyMtime: vi.fn(),
+}))
+
+vi.mock('../../theme-pack-store', () => ({
+  mergeSyncedIndex: vi.fn(),
+  statLocalPackMtime: vi.fn(),
+  applySyncedPackBody: vi.fn(),
+  pinPackBodyMtime: vi.fn(),
+}))
+
+vi.mock('../../utils/broadcast', () => ({
+  broadcastToAllWindows: vi.fn(),
+}))
+
+import { mergePackIndexBundle } from '../pack-bundle-merge'
+import { MalformedSyncBundleError } from '../merge'
+import { mergeSyncedIndex as mergeSyncedI18nIndex } from '../../i18n-pack-store'
+import { mergeSyncedIndex as mergeSyncedThemeIndex } from '../../theme-pack-store'
+import { I18N_INDEX_SYNC_UNIT } from '../../../shared/types/i18n-store'
+import { THEME_INDEX_SYNC_UNIT } from '../../../shared/types/theme-store'
+import type { SyncBundle } from '../../../shared/types/sync'
+
+function makeBundle(index: unknown): SyncBundle {
+  return { type: 'i18n-index', key: 'i18n-index', index, files: {} } as unknown as SyncBundle
+}
+
+describe('mergePackIndexBundle — malformed metas field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws MalformedSyncBundleError when remote index.metas is not an array (i18n)', async () => {
+    const bundle = makeBundle({ metas: 'not-an-array' })
+    await expect(mergePackIndexBundle(I18N_INDEX_SYNC_UNIT, bundle)).rejects.toThrow(MalformedSyncBundleError)
+    expect(mergeSyncedI18nIndex).not.toHaveBeenCalled()
+  })
+
+  it('throws MalformedSyncBundleError when remote index.metas is missing entirely (i18n)', async () => {
+    const bundle = makeBundle({})
+    await expect(mergePackIndexBundle(I18N_INDEX_SYNC_UNIT, bundle)).rejects.toThrow(MalformedSyncBundleError)
+    expect(mergeSyncedI18nIndex).not.toHaveBeenCalled()
+  })
+
+  it('throws MalformedSyncBundleError when remote index.metas is not an array (theme)', async () => {
+    const bundle = makeBundle({ metas: { not: 'an array' } })
+    await expect(mergePackIndexBundle(THEME_INDEX_SYNC_UNIT, bundle)).rejects.toThrow(MalformedSyncBundleError)
+    expect(mergeSyncedThemeIndex).not.toHaveBeenCalled()
+  })
+
+  it('still merges normally when metas is a valid (possibly empty) array', async () => {
+    vi.mocked(mergeSyncedI18nIndex).mockResolvedValue({ applied: true, remoteNeedsUpdate: false })
+    const bundle = makeBundle({ metas: [] })
+
+    const result = await mergePackIndexBundle(I18N_INDEX_SYNC_UNIT, bundle)
+
+    expect(result).toBe(false)
+    expect(mergeSyncedI18nIndex).toHaveBeenCalledWith([])
+  })
+
+  it('propagates the merge result even with non-empty, well-formed metas', async () => {
+    vi.mocked(mergeSyncedThemeIndex).mockResolvedValue({ applied: true, remoteNeedsUpdate: true })
+    const bundle = makeBundle({ metas: [{ id: 'a' }] })
+
+    const result = await mergePackIndexBundle(THEME_INDEX_SYNC_UNIT, bundle)
+
+    expect(result).toBe(true)
+    expect(mergeSyncedThemeIndex).toHaveBeenCalledWith([{ id: 'a' }])
+  })
+})

--- a/src/main/sync/google-drive.ts
+++ b/src/main/sync/google-drive.ts
@@ -69,18 +69,32 @@ export async function downloadFile(fileId: string): Promise<SyncEnvelope> {
   return (await response.json()) as SyncEnvelope
 }
 
+export interface UploadedFile {
+  id: string
+  /** Drive's own `modifiedTime` for the revision this call just wrote.
+   *  Callers that decide a local-wins upload (i18n/theme pack bodies —
+   *  see `pinPackBodyMtimeAfterUpload` in pack-bundle-merge.ts) pin the
+   *  local file's mtime to this value instead of leaving it at "now",
+   *  closing a clock-skew gap: a locally-ahead wall clock would
+   *  otherwise permanently look newer than Drive's own stamped time,
+   *  forcing a redundant re-upload (and re-download on every peer) on
+   *  every subsequent sync pass. */
+  modifiedTime: string
+}
+
 export async function uploadFile(
   name: string,
   envelope: SyncEnvelope,
   existingFileId?: string,
-): Promise<string> {
+): Promise<UploadedFile> {
   const headers = await authHeaders()
   const content = JSON.stringify(envelope)
 
   if (existingFileId) {
-    // Update existing file
+    // Update existing file. `fields` is requested explicitly — the
+    // default response for a media-upload PATCH omits `modifiedTime`.
     const response = await fetch(
-      `${UPLOAD_API}/files/${existingFileId}?uploadType=media`,
+      `${UPLOAD_API}/files/${existingFileId}?uploadType=media&fields=id,modifiedTime`,
       {
         method: 'PATCH',
         headers: { ...headers, 'Content-Type': 'application/json' },
@@ -91,8 +105,7 @@ export async function uploadFile(
       const body = await response.text()
       throw new Error(`Drive update failed: ${response.status} ${body}`)
     }
-    const data = (await response.json()) as { id: string }
-    return data.id
+    return (await response.json()) as UploadedFile
   }
 
   // Create new file with multipart upload
@@ -114,7 +127,8 @@ export async function uploadFile(
     `--${boundary}--`,
   ].join('\r\n')
 
-  const response = await fetch(`${UPLOAD_API}/files?uploadType=multipart`, {
+  // `fields` requested explicitly — same reasoning as the update path above.
+  const response = await fetch(`${UPLOAD_API}/files?uploadType=multipart&fields=id,modifiedTime`, {
     method: 'POST',
     headers: {
       ...headers,
@@ -128,8 +142,7 @@ export async function uploadFile(
     throw new Error(`Drive upload failed: ${response.status} ${body}`)
   }
 
-  const data = (await response.json()) as { id: string }
-  return data.id
+  return (await response.json()) as UploadedFile
 }
 
 export async function deleteFile(fileId: string): Promise<void> {
@@ -167,7 +180,23 @@ export function driveFilenamePrefix(syncUnitPrefix: string): string {
   return syncUnitPrefix.replaceAll('/', '_')
 }
 
+/** Filenames with no uid/packId segment — a plain Map lookup resolves
+ * these before any regex is attempted, rather than falling through a
+ * chain of `===` checks interleaved with the regex-based patterns below.
+ * `KEYBOARD_META_SYNC_UNIT`'s filename is derived via `driveFileName` so
+ * it can't drift from the constant if that ever changes. */
+const EXACT_SYNC_UNIT_FILENAMES = new Map<string, string>([
+  ['key-labels.enc', 'key-labels'], // global, all-keyboard store — no uid segment
+  ['typing-test-texts.enc', 'typing-test-texts'], // global, all-keyboard store
+  ['i18n_index.enc', 'i18n/index'],
+  ['themes_index.enc', 'themes/index'],
+  [driveFileName(KEYBOARD_META_SYNC_UNIT), KEYBOARD_META_SYNC_UNIT],
+])
+
 export function syncUnitFromFileName(fileName: string): string | null {
+  const exact = EXACT_SYNC_UNIT_FILENAMES.get(fileName)
+  if (exact) return exact
+
   // "keyboards_0x1234_devices_{hash}_days_{YYYY-MM-DD}.enc"
   //   → "keyboards/0x1234/devices/{hash}/days/{YYYY-MM-DD}"
   // The day regex pins to exactly `YYYY-MM-DD` so machineHash strings
@@ -178,19 +207,20 @@ export function syncUnitFromFileName(fileName: string): string | null {
   // "keyboards_0x1234_settings.enc" → "keyboards/0x1234/settings"
   // "keyboards_0x1234_snapshots.enc" → "keyboards/0x1234/snapshots"
   // "keyboards_0x1234_runs.enc" → "keyboards/0x1234/runs" (per-run raw
-  // keystroke log — added so a fresh machine can discover a remote-only
-  // run-log unit via manual sync; the same gap exists today for
-  // analyze_filters/key-labels/typing-test-texts/themes, tracked
-  // separately and deliberately not fixed here)
-  const kbMatch = fileName.match(/^keyboards_(.+?)_(settings|snapshots|runs)\.enc$/)
+  // keystroke log)
+  // "keyboards_0x1234_analyze_filters.enc" → "keyboards/0x1234/analyze_filters"
+  // (Task-sync-unit-filename-gap: closed the fresh-machine discovery gap
+  // for this store — see the task doc for the original report. The uid
+  // capture is non-greedy, so this alternation is only unambiguous as
+  // long as no future store name here is itself a suffix-composition of
+  // another store name in this list (e.g. adding a bare 'filters' store
+  // would collide with 'analyze_filters') — pick distinct names.)
+  const kbMatch = fileName.match(/^keyboards_(.+?)_(settings|snapshots|runs|analyze_filters)\.enc$/)
   if (kbMatch) return `keyboards/${kbMatch[1]}/${kbMatch[2]}`
 
   // "favorites_tapDance.enc" → "favorites/tapDance"
   const favMatch = fileName.match(/^favorites_(.+)\.enc$/)
   if (favMatch) return `favorites/${favMatch[1]}`
-
-  // "i18n_index.enc" → "i18n/index"
-  if (fileName === 'i18n_index.enc') return 'i18n/index'
 
   // "i18n_packs_{packId}.enc" → "i18n/packs/{packId}"
   // Pack ids are restricted to safe filename characters (UUID-like) so
@@ -198,7 +228,15 @@ export function syncUnitFromFileName(fileName: string): string | null {
   const i18nPackMatch = fileName.match(/^i18n_packs_(.+)\.enc$/)
   if (i18nPackMatch) return `i18n/packs/${i18nPackMatch[1]}`
 
-  if (fileName === driveFileName(KEYBOARD_META_SYNC_UNIT)) return KEYBOARD_META_SYNC_UNIT
+  // "themes_packs_{packId}.enc" → "themes/packs/{packId}" — same
+  // greedy-capture reasoning as the i18n pack pattern above.
+  const themePackMatch = fileName.match(/^themes_packs_(.+)\.enc$/)
+  if (themePackMatch) return `themes/packs/${themePackMatch[1]}`
+
+  // "password-check.enc" is intentionally never mapped to a sync unit —
+  // it's a standalone credential-validation file (see sync-service.ts's
+  // PASSWORD_CHECK_UNIT), not a data sync unit, and must stay invisible
+  // to scanRemoteData / polling / fresh-machine discovery.
 
   return null
 }

--- a/src/main/sync/merge.ts
+++ b/src/main/sync/merge.ts
@@ -7,10 +7,34 @@ import type { AnalyzeFilterSnapshotMeta } from '../../shared/types/analyze-filte
 import type { KeyLabelMeta } from '../../shared/types/key-label-store'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 import type { RunLogMeta } from '../../shared/types/typing-run-log'
+import type { I18nPackMeta } from '../../shared/types/i18n-store'
+import type { ThemePackMeta } from '../../shared/types/theme-store'
 
-export type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta | KeyLabelMeta | TypingTestTextMeta | RunLogMeta
+// I18nPackMeta / ThemePackMeta are structurally identical to every other
+// member here (id / filename / savedAt / updatedAt / deletedAt?) — see
+// pack-bundle-merge.ts's mergePackIndexBundle, which reuses this same
+// mergeEntries/gcTombstones machinery for the i18n/theme pack roster
+// instead of the file-level whole-index LWW this module used to require
+// bundle-merge.ts to implement on its own.
+export type EntryMeta = SavedFavoriteMeta | SnapshotMeta | AnalyzeFilterSnapshotMeta | KeyLabelMeta | TypingTestTextMeta | RunLogMeta | I18nPackMeta | ThemePackMeta
 
 const TOMBSTONE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
+
+/** Thrown when a downloaded bundle's index doesn't have the `entries`
+ * array shape `mergeEntries`/`gcTombstones` require (favorites /
+ * snapshots / analyze-filter / key-label / typing-test-text / run-log —
+ * every generic index-based sync unit). A remote bundle is
+ * attacker-reachable data (anyone who can write to this sync unit's
+ * Drive file), so this guards `mergeEntries`' input contract rather than
+ * letting a malformed shape throw an opaque TypeError deep inside it.
+ * The message intentionally carries only the sync unit name — never
+ * bundle content — so logs never leak ciphertext-derived payloads. */
+export class MalformedSyncBundleError extends Error {
+  constructor(syncUnit: string) {
+    super(`malformed sync bundle index for ${syncUnit}`)
+    this.name = 'MalformedSyncBundleError'
+  }
+}
 
 export interface MergeOptions {
   preserveLocalOrder?: boolean
@@ -63,9 +87,29 @@ export function applyRunLogRetention(entries: readonly RunLogMeta[], max: number
   return { entries: [...kept, ...evictedTombstones, ...tombstones], evicted }
 }
 
-export function effectiveTime(entry: EntryMeta): number {
-  const t = new Date(entry.updatedAt ?? entry.savedAt).getTime()
+/** Parses an ISO timestamp to epoch ms, treating a missing/invalid value
+ *  as 0 (oldest possible) so a corrupt or absent timestamp always loses
+ *  an LWW comparison rather than throwing. Shared by every file-level and
+ *  entry-level LWW comparison in the sync subsystem (settings, i18n/theme
+ *  pack bundles, favorites/snapshots/etc. via `effectiveTime` below). */
+export function safeTimestamp(value: string | undefined): number {
+  if (!value) return 0
+  const t = new Date(value).getTime()
   return Number.isNaN(t) ? 0 : t
+}
+
+/** Timestamp shape shared by every meta this module and the i18n/theme
+ *  pack-bundle merge (`pack-bundle-merge.ts`) compare for LWW — the
+ *  newest of `updatedAt`/`savedAt` wins. Kept structural (rather than
+ *  `EntryMeta`) so non-entry meta shapes (`I18nPackMeta`, `ThemePackMeta`)
+ *  can share this single comparison instead of re-implementing it. */
+export interface TimestampedMeta {
+  updatedAt?: string
+  savedAt?: string
+}
+
+export function effectiveTime(entry: TimestampedMeta): number {
+  return safeTimestamp(entry.updatedAt ?? entry.savedAt)
 }
 
 export function mergeEntries<T extends EntryMeta>(local: T[], remote: T[], options?: MergeOptions): MergeResult<T> {

--- a/src/main/sync/pack-bundle-merge.ts
+++ b/src/main/sync/pack-bundle-merge.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Merge strategies for the i18n/theme index + pack-body bundle shapes.
+// Split out of sync-service.ts (Task-sync-unit-filename-gap) so these
+// bundle-variant merge branches don't push an already-oversized file
+// further past its budget — see .claude/rules/file-splitting.md.
+//
+// This module owns only the merge/LWW decision and the post-write
+// broadcast — every path/mkdir/writeFile concern lives in
+// i18n-pack-store.ts / theme-pack-store.ts's own sync-facing entry
+// points (`mergeSyncedIndex`/`applySyncedPackBody`/`statLocalPackMtime`/
+// `pinPackBodyMtime`), so a packId sourced from a remote Drive filename
+// (the least-trusted input in the sync pipeline) is always validated at
+// the same boundary the store already guards its own writes with.
+//
+// Import-cycle note: this module imports from i18n-pack-store.ts /
+// theme-pack-store.ts, which each import `notifyChange` from
+// `./sync-service`, which imports from this module — a cycle. This is
+// the same shape sync-bundle.ts already has via key-label-store.ts
+// (sync-service → sync-bundle → key-label-store → sync-service) and is
+// inert here for the same reason: every import is only used inside a
+// function body, never at module-evaluation time.
+
+import { IpcChannels } from '../../shared/ipc/channels'
+import { broadcastToAllWindows } from '../utils/broadcast'
+import { safeTimestamp, MalformedSyncBundleError } from './merge'
+import { I18N_SYNC_UNIT_PREFIX } from '../../shared/types/i18n-store'
+import { THEME_SYNC_UNIT_PREFIX, THEME_INDEX_SYNC_UNIT } from '../../shared/types/theme-store'
+import {
+  mergeSyncedIndex as mergeSyncedI18nIndex,
+  statLocalPackMtime as statLocalI18nPackMtime,
+  applySyncedPackBody as applySyncedI18nPackBody,
+  pinPackBodyMtime as pinI18nPackBodyMtime,
+} from '../i18n-pack-store'
+import {
+  mergeSyncedIndex as mergeSyncedThemeIndex,
+  statLocalPackMtime as statLocalThemePackMtime,
+  applySyncedPackBody as applySyncedThemePackBody,
+  pinPackBodyMtime as pinThemePackBodyMtime,
+} from '../theme-pack-store'
+import type { SyncBundle } from '../../shared/types/sync'
+
+/** `i18n/packs/{packId}` / `themes/packs/{packId}` parsed once — the
+ *  shape every caller in this module and sync-service.ts needs, instead
+ *  of each re-splitting `syncUnit` and re-deriving `isTheme` on its own. */
+export interface PackBodySyncUnit {
+  isTheme: boolean
+  packId: string
+}
+
+/** Parses `"i18n/packs/{packId}"` / `"themes/packs/{packId}"` into a
+ *  descriptor, or `null` for any other shape (including the bare index
+ *  units, handled separately by `mergePackIndexBundle`). */
+export function parsePackBodySyncUnit(syncUnit: string): PackBodySyncUnit | null {
+  const i18nPrefix = `${I18N_SYNC_UNIT_PREFIX}packs/`
+  const themePrefix = `${THEME_SYNC_UNIT_PREFIX}packs/`
+  const isTheme = syncUnit.startsWith(themePrefix)
+  const isI18n = !isTheme && syncUnit.startsWith(i18nPrefix)
+  if (!isI18n && !isTheme) return null
+  const packId = syncUnit.slice((isTheme ? themePrefix : i18nPrefix).length)
+  if (!packId) return null
+  return { isTheme, packId }
+}
+
+/** Broadcast the same "pack list changed" event `theme-pack-ipc.ts`'s
+ * own mutating handlers fire after a local save/rename/delete, and
+ * `i18n-startup-sync.ts` fires after its Hub reconcile. Unlike themes,
+ * `i18n-pack-ipc.ts` itself never broadcasts `I18N_PACK_CHANGED` on a
+ * local mutation — the window that issued the IPC call already has the
+ * fresh data from that call's own return value, so only the
+ * cross-process paths (this merge, and the Hub startup reconcile) need
+ * to tell OTHER windows. mergePackIndexBundle/mergePackBodyBundle apply
+ * an already-merged/already-decided write via the stores' own
+ * `mergeSyncedIndex`/`applySyncedPackBody` (not their local
+ * read-modify-write helpers, which assume the mutation originated from
+ * an IPC call in this same process) — so any open language/theme picker
+ * still needs this broadcast to know new content is on disk. No
+ * `notifyChange` call here: this merge already decided the correct
+ * persisted state (a union that may still need uploading, signalled via
+ * this function's own return value / `remoteNeedsUpdate` — not via
+ * re-queueing through `notifyChange`). */
+function broadcastPackChanged(isTheme: boolean): void {
+  broadcastToAllWindows(isTheme ? IpcChannels.THEME_PACK_CHANGED : IpcChannels.I18N_PACK_CHANGED)
+}
+
+/**
+ * Entry-level LWW merge for "i18n/index" / "themes/index". Delegates
+ * the actual read→merge→write to the store's own `mergeSyncedIndex`
+ * (i18n-pack-store.ts / theme-pack-store.ts), which runs it as a single
+ * step under that store's write lock — this function only picks which
+ * store to call and translates the result into the return convention
+ * every `mergeSyncUnit` branch shares (`true` = local has data remote
+ * still needs, i.e. re-upload the unit).
+ *
+ * This used to be file-level LWW (whichever side had the newer
+ * `metas[].updatedAt`/`savedAt` won wholesale, and the other side's
+ * entire roster was discarded). That was a data-loss bug: two machines
+ * that each installed a different pack while offline would
+ * deterministically erase one of the two packs everywhere once both
+ * had synced — whichever machine uploaded second overwrote the cloud
+ * roster, and the first machine's next poll then overwrote its own
+ * local roster with that incomplete cloud copy, permanently losing its
+ * own pack (its body file became an orphan, unreachable because
+ * `collectAllSyncUnits` only enumerates pack ids that appear in the
+ * index). Entry-level LWW does not have this failure mode: each pack's
+ * meta is merged independently by id, so an install on one machine and
+ * a concurrent install on another both survive the merge as a union,
+ * and only an actual same-id conflict (e.g. two ids that happen to
+ * collide, or a delete racing an edit) is resolved by comparing that
+ * one id's own timestamps — never by discarding an unrelated id's
+ * entry just because it arrived on the "losing" side of the whole
+ * file.
+ *
+ * The built-in English meta (i18n only) rides along in this merge like
+ * any other entry and needs no special-casing: every machine creates it
+ * locally with its own first-seen timestamp, so two copies differ only
+ * in `savedAt`/`updatedAt` — whichever wins that id's own LWW comparison
+ * is harmless, since the content every machine generates is identical.
+ *
+ * `remoteBundle.index.metas` not being an array at all (a stronger
+ * malformation than a bad individual element, which the stores' own
+ * `mergeSyncedIndex` filters per-entry instead) throws
+ * `MalformedSyncBundleError` here rather than silently defaulting to an
+ * empty array — the latter used to make a corrupt remote index look
+ * like a legitimately-empty one, which the sync poll's `instanceof`
+ * check couldn't distinguish from "nothing to merge" to apply its
+ * permanently-rejected-revision skip. This mirrors the generic
+ * index-based tail in sync-service.ts, which throws the same way for a
+ * non-array `.entries`.
+ */
+export async function mergePackIndexBundle(
+  syncUnit: string,
+  remoteBundle: SyncBundle,
+): Promise<boolean> {
+  const isTheme = syncUnit === THEME_INDEX_SYNC_UNIT
+  const remoteMetasRaw = (remoteBundle.index as { metas?: unknown } | undefined)?.metas
+  if (!Array.isArray(remoteMetasRaw)) {
+    throw new MalformedSyncBundleError(syncUnit)
+  }
+
+  const result = isTheme
+    ? await mergeSyncedThemeIndex(remoteMetasRaw)
+    : await mergeSyncedI18nIndex(remoteMetasRaw)
+
+  if (!result.applied) {
+    throw new Error(`sync: failed to persist merged ${syncUnit} index`)
+  }
+  broadcastPackChanged(isTheme)
+  return result.remoteNeedsUpdate
+}
+
+/** True when the local pack-body file is already strictly newer than
+ *  the remote Drive file's `modifiedTime` — i.e. `mergePackBodyBundle`'s
+ *  own comparison would end in "local wins" without needing to look at
+ *  the bundle at all. `mergeWithRemote` (sync-service.ts) consults this
+ *  BEFORE downloading + decrypting the full remote bundle, so a manual
+ *  'all'-scope sync doesn't pay that cost for every pack whose local
+ *  copy is already known to be newer. A tie or a remote win both return
+ *  `false` here — the caller falls through to the normal download path,
+ *  which is the only place that actually applies a remote write. */
+export async function packBodyLocalWins(
+  ref: PackBodySyncUnit,
+  remoteModifiedTime: string,
+): Promise<boolean> {
+  const localTime = await statPackBodyLocalMtime(ref)
+  if (localTime === null) return false
+  return localTime > safeTimestamp(remoteModifiedTime)
+}
+
+/** Local mtime (ms) of the pack body `ref` refers to, or `null` if it's
+ *  unsafe or doesn't exist yet. Exposed so `uploadSyncUnit`
+ *  (sync-service.ts) can snapshot the mtime BEFORE bundling the body for
+ *  upload — that snapshot is later passed to `pinPackBodyMtimeAfterUpload`
+ *  as its compare-and-swap baseline, see that function's doc. */
+export async function statPackBodyLocalMtime(ref: PackBodySyncUnit): Promise<number | null> {
+  return ref.isTheme
+    ? statLocalThemePackMtime(ref.packId)
+    : statLocalI18nPackMtime(ref.packId)
+}
+
+/**
+ * File-level LWW merge for "i18n/packs/{id}" / "themes/packs/{id}".
+ * The pack body itself carries no timestamp (it's the raw pack JSON,
+ * meant to round-trip byte-for-byte with export/import), and the
+ * bundle's `index` is a trivial `{ metas: [] }` placeholder for this
+ * unit (see sync-bundle.ts's bundleSyncUnit) — so unlike the index
+ * bundle above, there is no per-entry timestamp to compare here.
+ * Instead: remote side uses the Drive file's own `modifiedTime`, local
+ * side uses the pack file's filesystem mtime (pinned to the remote's
+ * `modifiedTime` on a prior remote-win by `applySyncedPackBody`, or to
+ * the upload response's own `modifiedTime` on a prior local-win — see
+ * `pinPackBodyMtimeAfterUpload`). Rejected alternative — reconciling
+ * against the sibling index's per-id `updatedAt` — was not used because
+ * a remote-only-so-far merge of this unit can race the index unit's own
+ * merge (they're separate sync units, downloaded in parallel), so the
+ * index's meta for this id is not guaranteed to be present locally yet
+ * when this function runs.
+ *
+ * The snapshot of `localTime` taken here (via `statLocalPackMtime`) is
+ * read OUTSIDE the store's write lock — a concurrent local save
+ * (savePack/renamePack, both lock-serialized in the store) can land
+ * between that read and `applySyncedPackBody` actually acquiring the
+ * lock to write. `applySyncedPackBody` re-checks the same comparison
+ * again itself, under its lock, immediately before writing (a
+ * compare-and-swap) and reports `'local-wins'` instead of clobbering a
+ * fresher local save if the race occurred — handled below by marking
+ * the unit for re-upload rather than treating it as a failure.
+ */
+export async function mergePackBodyBundle(
+  ref: PackBodySyncUnit,
+  remoteBundle: SyncBundle,
+  remoteModifiedTime: string,
+): Promise<boolean> {
+  const { isTheme, packId } = ref
+  const remoteContent = remoteBundle.files[`${packId}.json`]
+  if (!remoteContent) return false
+
+  const remoteTime = safeTimestamp(remoteModifiedTime)
+  const localMtime = isTheme
+    ? await statLocalThemePackMtime(packId)
+    : await statLocalI18nPackMtime(packId)
+  const localTime = localMtime ?? 0
+
+  if (remoteTime <= localTime) {
+    // Local already newer-or-tied at this snapshot — no write. A tie
+    // keeps local as-is (no reupload); local strictly newer reports
+    // `true` so the caller re-uploads.
+    return localTime > remoteTime
+  }
+
+  // applySyncedPackBody throws MalformedSyncBundleError (not a plain
+  // Error) when packId fails the store's own safety check — that
+  // propagates straight through this function uncaught, so the sync
+  // poll's `instanceof` check can recognize a permanently-rejected
+  // revision and stop retrying it (see the store's own doc for why this
+  // matters).
+  const outcome = isTheme
+    ? await applySyncedThemePackBody(packId, remoteContent, remoteModifiedTime)
+    : await applySyncedI18nPackBody(packId, remoteContent, remoteModifiedTime)
+
+  if (outcome === 'applied') {
+    broadcastPackChanged(isTheme)
+    return false
+  }
+  if (outcome === 'local-wins') {
+    // The store's own in-lock CAS re-check found a fresher local write
+    // landed after this function's own localTime snapshot above (a
+    // save-vs-download race) — local is now the winner; mark for
+    // re-upload instead of throwing.
+    return true
+  }
+  throw new Error(`sync: failed to write ${isTheme ? 'theme' : 'i18n'} pack body for ${packId}`)
+}
+
+/**
+ * After a local-wins UPLOAD of a pack-body sync unit, pin the local
+ * body file's mtime to the Drive `modifiedTime` the upload response was
+ * just assigned. Without this, the local file keeps its own wall-clock
+ * write time — if the local clock runs even slightly ahead of Drive's
+ * own clock, that time permanently looks "newer than the remote copy",
+ * so every subsequent sync pass would re-upload this unchanged body
+ * (and every peer would re-download it), forever.
+ *
+ * `expectedLocalMtimeMs` is the local body's mtime snapshot taken by the
+ * caller (`uploadSyncUnit`, sync-service.ts) at upload-bundling time,
+ * BEFORE this store-serialized pin call even runs — bundling, encrypting
+ * and uploading to Drive all happen outside the store's write lock, so a
+ * user save can land in that window. `pinPackBodyMtime` (i18n/theme
+ * stores) re-checks the file's current mtime against this snapshot under
+ * its lock and only pins on a match; otherwise it skips, so a fresher
+ * local edit doesn't get its content stamped with this stale upload's
+ * Drive time (which would make the next LWW compare as a tie and the new
+ * edit never get uploaded). See `pinPackBodyMtime`'s own doc for the
+ * full CAS contract. A no-op for any syncUnit that isn't a pack-body
+ * unit.
+ */
+export async function pinPackBodyMtimeAfterUpload(
+  ref: PackBodySyncUnit,
+  modifiedTime: string,
+  expectedLocalMtimeMs: number | null,
+): Promise<void> {
+  if (ref.isTheme) {
+    await pinThemePackBodyMtime(ref.packId, modifiedTime, expectedLocalMtimeMs)
+  } else {
+    await pinI18nPackBodyMtime(ref.packId, modifiedTime, expectedLocalMtimeMs)
+  }
+}

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sync orchestration: bundling, conflict resolution, debounce upload, before-quit flush
 
-import { app, BrowserWindow } from 'electron'
+import { app } from 'electron'
 import { join } from 'node:path'
 import { readFile, writeFile, mkdir, readdir } from 'node:fs/promises'
 import { encrypt, decrypt, retrievePasswordResult, storePassword, clearPassword } from './sync-crypto'
@@ -20,7 +20,15 @@ import {
 import { unlink } from 'node:fs/promises'
 import { pLimit } from '../../shared/concurrency'
 import { IpcChannels } from '../../shared/ipc/channels'
-import { mergeEntries, gcTombstones, type EntryMeta } from './merge'
+import { mergeEntries, gcTombstones, safeTimestamp, MalformedSyncBundleError, type EntryMeta } from './merge'
+import {
+  mergePackIndexBundle,
+  mergePackBodyBundle,
+  parsePackBodySyncUnit,
+  packBodyLocalWins,
+  pinPackBodyMtimeAfterUpload,
+  statPackBodyLocalMtime,
+} from './pack-bundle-merge'
 import {
   readIndexFile,
   bundleSyncUnit,
@@ -40,8 +48,9 @@ import {
 import { KEYBOARD_META_SYNC_UNIT, type KeyboardMetaIndex } from '../../shared/types/keyboard-meta'
 import { KEY_LABEL_SYNC_UNIT } from '../key-label-store'
 import { TYPING_TEST_TEXT_SYNC_UNIT } from '../typing-test-text-store'
-import { I18N_SYNC_UNIT_PREFIX } from '../../shared/types/i18n-store'
-import { THEME_SYNC_UNIT_PREFIX } from '../../shared/types/theme-store'
+import { I18N_SYNC_UNIT_PREFIX, I18N_INDEX_SYNC_UNIT } from '../../shared/types/i18n-store'
+import { THEME_SYNC_UNIT_PREFIX, THEME_INDEX_SYNC_UNIT } from '../../shared/types/theme-store'
+import { broadcastToAllWindows } from '../utils/broadcast'
 import {
   parseTypingAnalyticsDeviceDaySyncUnit,
   typingAnalyticsDeviceDaySyncUnit,
@@ -82,12 +91,6 @@ const POLL_INTERVAL_MS = 3 * 60 * 1000 // 3 minutes
 const PASSWORD_CHECK_UNIT = 'password-check'
 const PASSWORD_CHECK_PAYLOAD = JSON.stringify({ type: 'password-check', version: 1 })
 
-function safeTimestamp(value: string | undefined): number {
-  if (!value) return 0
-  const t = new Date(value).getTime()
-  return Number.isNaN(t) ? 0 : t
-}
-
 type ProgressCallback = (progress: SyncProgress) => void
 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
@@ -123,10 +126,7 @@ export function isSyncInProgress(): boolean {
 }
 
 function broadcastPendingStatus(): void {
-  const pending = hasPendingChanges()
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(IpcChannels.SYNC_PENDING_STATUS, pending)
-  }
+  broadcastToAllWindows(IpcChannels.SYNC_PENDING_STATUS, hasPendingChanges())
 }
 
 export function setProgressCallback(cb: ProgressCallback): void {
@@ -147,8 +147,22 @@ export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean
   if (syncUnit === KEYBOARD_META_SYNC_UNIT) return true // meta follows every scope
   if (syncUnit === KEY_LABEL_SYNC_UNIT) return true // key-labels follow every scope (global, all-keyboard)
   if (syncUnit === TYPING_TEST_TEXT_SYNC_UNIT) return true // imported typing-test texts follow every scope (global, all-keyboard)
-  if (syncUnit.startsWith(I18N_SYNC_UNIT_PREFIX)) return false // i18n checked once at startup via i18n-startup-sync
-  if (syncUnit.startsWith(THEME_SYNC_UNIT_PREFIX)) return false // themes follow i18n pattern — not in periodic polls
+  // i18n/themes only match scope 'all' (short-circuited above) — excluded
+  // from favorites/keyboard-scoped syncs (connect-time initial sync,
+  // manual per-keyboard sync), but both DO participate in the 3-minute
+  // poll and any other scope-'all' sync, symmetrically. i18n additionally
+  // gets its own startup reconcile via i18n-startup-sync (Hub-linked
+  // packs only); themes have no Hub auto-update path.
+  //
+  // Production UI has no button that calls executeSync with scope
+  // 'all' — connect-time initial sync and manual per-keyboard sync both
+  // pass a scope this function rejects for i18n/themes. So the 3-minute
+  // poll (which always uses 'all' — see pollForRemoteChanges) is
+  // currently the ONLY download route that discovers a remote-only
+  // i18n/theme pack on a fresh machine; the Pack Manager's own explicit
+  // Hub pull is the only immediate alternative. Tracked as
+  // Task-sync-remote-reset-and-discovery-gaps.md's "問題 2".
+  if (syncUnit.startsWith(I18N_SYNC_UNIT_PREFIX) || syncUnit.startsWith(THEME_SYNC_UNIT_PREFIX)) return false
   if (scope === 'favorites') return syncUnit.startsWith('favorites/')
   if (typeof scope === 'object' && 'favorites' in scope) {
     return syncUnit.startsWith('favorites/') || syncUnit.startsWith(`keyboards/${scope.keyboard}/`)
@@ -436,6 +450,16 @@ async function uploadSyncUnit(
   password: string,
   remoteFiles?: DriveFile[],
 ): Promise<void> {
+  // i18n/theme pack bodies: snapshot the local file's mtime BEFORE
+  // bundling — bundling/encrypting/uploading all happen without holding
+  // the store's write lock, so a user save (savePack/renamePack) can
+  // land in that window. This snapshot is the CAS baseline
+  // pinPackBodyMtimeAfterUpload needs below to detect that race — see
+  // its doc for why a blind post-upload pin would otherwise stamp a
+  // fresher local edit with this upload's stale Drive time.
+  const packBodyRef = parsePackBodySyncUnit(syncUnit)
+  const packBodyMtimeSnapshot = packBodyRef ? await statPackBodyLocalMtime(packBodyRef) : null
+
   const bundle = await bundleSyncUnit(syncUnit)
   if (!bundle) return
 
@@ -446,13 +470,21 @@ async function uploadSyncUnit(
   const targetName = driveFileName(syncUnit)
   const existing = files.find((f) => f.name === targetName)
 
-  await uploadFile(targetName, envelope, existing?.id)
+  const uploaded = await uploadFile(targetName, envelope, existing?.id)
 
   // Post-upload bookkeeping: record a successful cloud upload for
   // per-day units so the reconcile logic can later distinguish
   // "never uploaded" from "uploaded then remotely deleted".
   const dayRef = parseTypingAnalyticsDeviceDaySyncUnit(syncUnit)
   if (dayRef) await recordDayUploaded(dayRef)
+
+  // i18n/theme pack bodies: a local-wins upload just gave Drive a fresh
+  // `modifiedTime` — pin the local file's mtime to it (rather than
+  // leaving it at "now") so a locally-ahead wall clock can't make this
+  // file look newer than Drive's own stamped time forever. See
+  // pinPackBodyMtimeAfterUpload's doc for the full clock-skew rationale
+  // and why the snapshot above is passed through as a CAS guard.
+  if (packBodyRef) await pinPackBodyMtimeAfterUpload(packBodyRef, uploaded.modifiedTime, packBodyMtimeSnapshot)
 }
 
 /** Add `{uid}|{hash}` → utcDay to sync-state.uploaded after a
@@ -512,6 +544,7 @@ async function mergeSyncUnit(
   syncUnit: string,
   envelope: SyncEnvelope,
   password: string,
+  remoteModifiedTime: string,
 ): Promise<boolean> {
   const plaintext = await decrypt(envelope, password)
   const remoteBundle = JSON.parse(plaintext) as SyncBundle
@@ -525,6 +558,21 @@ async function mergeSyncUnit(
 
   const parts = syncUnit.split('/')
   const userData = app.getPath('userData')
+
+  // `syncUnit` here is derived from `syncUnitFromFileName(file.name)` —
+  // a Drive filename is attacker-reachable data (anyone who can write
+  // to this appData folder), and a crafted name (e.g.
+  // `favorites_../../evil.enc` or `keyboards_../../evil_settings.enc`)
+  // can make a capture group in that regex contain a path separator.
+  // Every `/`-split segment must pass `isSafePathSegment` before ANY
+  // branch below joins it into a filesystem path (the settings branch
+  // and the generic index-based tail both do) — a single unsafe segment
+  // throws the same `MalformedSyncBundleError` a corrupt bundle shape
+  // does, so the sync poll's unchanged-revision skip applies here too
+  // instead of retrying a permanently-hostile filename every 3 minutes.
+  if (parts.some((part) => !isSafePathSegment(part))) {
+    throw new MalformedSyncBundleError(syncUnit)
+  }
 
   // Typing-analytics JSONL: each file is owned by one device. Skip our
   // own hash so a stale remote never clobbers freshly-flushed local
@@ -562,19 +610,57 @@ async function mergeSyncUnit(
     return localTime > remoteTime
   }
 
-  // Handle index-based sync units (favorites, snapshots)
+  // Handle "i18n/index" / "themes/index" — the language/theme pack
+  // roster, entry-level LWW (same mergeEntries/gcTombstones machinery
+  // as favorites/key-labels/etc. below, applied to the pack meta shape
+  // instead of a whole-file "newer roster wins wholesale" comparison —
+  // see mergePackIndexBundle's doc for why the old file-level strategy
+  // was a data-loss bug).
+  if (syncUnit === I18N_INDEX_SYNC_UNIT || syncUnit === THEME_INDEX_SYNC_UNIT) {
+    return mergePackIndexBundle(syncUnit, remoteBundle)
+  }
+
+  // Handle "i18n/packs/{packId}" / "themes/packs/{packId}" — a single
+  // pack body, file-level LWW using the Drive file's own modifiedTime
+  // (the bundle carries no timestamp of its own — see
+  // mergePackBodyBundle's doc).
+  const packBodyRef = parsePackBodySyncUnit(syncUnit)
+  if (packBodyRef) {
+    return mergePackBodyBundle(packBodyRef, remoteBundle, remoteModifiedTime)
+  }
+
+  // Handle index-based sync units (favorites, snapshots, analyze-filter,
+  // key-label, typing-test-text, run-log)
   const basePath = join(userData, 'sync', ...parts)
   await mkdir(basePath, { recursive: true })
 
   const localIndex = await readIndexFile(basePath)
   // Both sides' index shape is a union of each possible sync unit's own
   // index type, which a generic function call can't unify against — every
-  // constituent reached on this "index-based sync units" branch (favorites,
-  // snapshots, analyze-filter, key-label, typing-test-text) is an
-  // EntryMeta[] at runtime. i18n/theme/keyboard-meta bundles don't have
-  // `.entries` and never reach this branch.
-  const localEntries = gcTombstones((localIndex?.entries ?? []) as EntryMeta[])
-  const remoteEntries = gcTombstones((remoteBundle.index as { entries: EntryMeta[] }).entries)
+  // constituent reached on this branch is an EntryMeta[] at runtime.
+  // i18n/theme/keyboard-meta bundles are intercepted by the dedicated
+  // branches above and never reach here.
+  //
+  // Deliberate coerce-vs-throw asymmetry below: a non-array `.entries` on
+  // the LOCAL side is coerced to `[]` (trusted data — a missing/corrupt
+  // local index is just an empty starting point, not a reason to fail
+  // the merge), while the same shape on the REMOTE side throws
+  // MalformedSyncBundleError (untrusted, attacker-reachable data — see
+  // its doc for why silently coercing there would be the wrong call).
+  const localEntries = gcTombstones(
+    Array.isArray(localIndex?.entries) ? (localIndex.entries as EntryMeta[]) : [],
+  )
+  // A remote bundle is attacker-reachable data (anyone who can write to
+  // this sync unit's Drive file) — validate `.entries` is actually an
+  // array before handing it to gcTombstones/mergeEntries instead of
+  // letting a malformed shape throw an opaque TypeError deep inside
+  // them. See MalformedSyncBundleError's doc for how callers contain
+  // this per-unit.
+  const remoteIndexEntries = (remoteBundle.index as { entries?: unknown } | undefined)?.entries
+  if (!Array.isArray(remoteIndexEntries)) {
+    throw new MalformedSyncBundleError(syncUnit)
+  }
+  const remoteEntries = gcTombstones(remoteIndexEntries as EntryMeta[])
 
   // Merge entries (both sides GC'd to prevent expired-tombstone upload loops).
   // Run-log retention is a deterministic trim (not reject-at-cap like
@@ -642,16 +728,26 @@ async function mergeSyncUnit(
   return result.remoteNeedsUpdate
 }
 
-// Merges with remote, uploads if local has changes remote doesn't have
+// Merges with remote, uploads if local has changes remote doesn't have.
+// Takes the full DriveFile (not just its id) because it's the single
+// choke point every merge path funnels through (download sync, polling,
+// analytics sync, upload-time merge-before-upload) — an i18n/theme
+// pack-body unit can skip the download+decrypt entirely here when local
+// is already known to be newer (see `packBodyLocalWins`'s doc).
 async function mergeWithRemote(
-  remoteFileId: string,
+  remoteFile: DriveFile,
   syncUnit: string,
   password: string,
   remoteFiles?: DriveFile[],
 ): Promise<void> {
-  const envelope = await downloadFile(remoteFileId)
-  const needsUpload = await mergeSyncUnit(syncUnit, envelope, password)
+  const packBodyRef = parsePackBodySyncUnit(syncUnit)
+  if (packBodyRef && await packBodyLocalWins(packBodyRef, remoteFile.modifiedTime)) {
+    await uploadSyncUnit(syncUnit, password, remoteFiles)
+    return
+  }
 
+  const envelope = await downloadFile(remoteFile.id)
+  const needsUpload = await mergeSyncUnit(syncUnit, envelope, password, remoteFile.modifiedTime)
   if (needsUpload) {
     await uploadSyncUnit(syncUnit, password, remoteFiles)
   }
@@ -666,7 +762,7 @@ async function syncOrUpload(
   const remoteFile = remoteFiles.find((f) => f.name === targetName)
 
   if (remoteFile) {
-    await mergeWithRemote(remoteFile.id, syncUnit, password, remoteFiles)
+    await mergeWithRemote(remoteFile, syncUnit, password, remoteFiles)
   } else {
     await uploadSyncUnit(syncUnit, password, remoteFiles)
   }
@@ -756,9 +852,12 @@ async function executeDownloadSync(
   updateRemoteState(remoteFiles) // Always record full remote state for polling
 
   const localKeyboardUids = await listLocalKeyboardUids()
-  const filesToDownload = remoteFiles.filter((f) => {
-    const syncUnit = syncUnitFromFileName(f.name)
-    return shouldDownloadSyncUnit(syncUnit, scope, localKeyboardUids)
+  // {file, syncUnit} pairs resolved once here rather than re-parsing the
+  // filename again inside the download loop below.
+  const filesToDownload = remoteFiles.flatMap((file) => {
+    const syncUnit = syncUnitFromFileName(file.name)
+    if (!syncUnit || !shouldDownloadSyncUnit(syncUnit, scope, localKeyboardUids)) return []
+    return [{ file, syncUnit }]
   })
 
   const total = filesToDownload.length
@@ -767,11 +866,9 @@ async function executeDownloadSync(
   const limit = pLimit(SYNC_CONCURRENCY)
 
   await Promise.allSettled(
-    filesToDownload.map((remoteFile) =>
+    filesToDownload.map(({ file: remoteFile, syncUnit }) =>
       limit(async () => {
         completed++
-        const syncUnit = syncUnitFromFileName(remoteFile.name)
-        if (!syncUnit) return
 
         emitProgress({
           direction: 'download',
@@ -782,7 +879,7 @@ async function executeDownloadSync(
         })
 
         try {
-          await mergeWithRemote(remoteFile.id, syncUnit, password, remoteFiles)
+          await mergeWithRemote(remoteFile, syncUnit, password, remoteFiles)
         } catch (err) {
           failedUnits.push(syncUnit)
           emitProgress({
@@ -1172,36 +1269,54 @@ async function pollForRemoteChanges(): Promise<void> {
     }
 
     const localKeyboardUids = await listLocalKeyboardUids()
-    const changedFiles = remoteFiles.filter((file) => {
-      if (lastKnownRemoteState.get(file.name) === file.modifiedTime) return false
+    // {file, syncUnit} pairs resolved once here rather than re-parsing
+    // the filename again inside the merge loop below.
+    const changedFiles = remoteFiles.flatMap((file) => {
+      if (lastKnownRemoteState.get(file.name) === file.modifiedTime) return []
       const syncUnit = syncUnitFromFileName(file.name)
+      if (!syncUnit) return []
       // analytics: handled by executeAnalyticsSync (Analyze panel mount).
-      if (syncUnit && isAnalyticsSyncUnit(syncUnit)) return false
+      if (isAnalyticsSyncUnit(syncUnit)) return []
       // run logs: no dedicated on-demand sync entry point yet (see
       // isRunLogSyncUnit's doc comment) — before-quit flush and manual
       // sync still cover it, 3-minute polling does not.
-      if (syncUnit && isRunLogSyncUnit(syncUnit)) return false
-      return shouldDownloadSyncUnit(syncUnit, 'all', localKeyboardUids)
+      if (isRunLogSyncUnit(syncUnit)) return []
+      if (!shouldDownloadSyncUnit(syncUnit, 'all', localKeyboardUids)) return []
+      return [{ file, syncUnit }]
     })
 
     updateRemoteState(remoteFiles)
 
     const limit = pLimit(SYNC_CONCURRENCY)
     await Promise.allSettled(
-      changedFiles.map((remoteFile) =>
+      changedFiles.map(({ file: remoteFile, syncUnit }) =>
         limit(async () => {
-          const syncUnit = syncUnitFromFileName(remoteFile.name)
-          if (!syncUnit) return
-
           try {
-            await mergeWithRemote(remoteFile.id, syncUnit, password, remoteFiles)
+            await mergeWithRemote(remoteFile, syncUnit, password, remoteFiles)
             emitProgress({
               direction: 'download',
               status: 'success',
               syncUnit,
               message: 'Sync complete',
             })
-          } catch {
+          } catch (err) {
+            if (err instanceof MalformedSyncBundleError) {
+              // Contained per-unit, same as any other poll failure — but
+              // deliberately do NOT forget the modifiedTime below: this
+              // poll already recorded it into lastKnownRemoteState above
+              // (before this loop ran), so leaving it in place makes the
+              // NEXT poll see this exact revision as unchanged and skip
+              // retrying it forever. A later fix (a new modifiedTime) is
+              // a different key and is retried normally. Manual syncs
+              // (executeDownloadSync/executeUploadSync) have no such
+              // memory and may retry a malformed unit on every attempt —
+              // deliberate, since those are visible, user-initiated
+              // actions, not a silent background loop. Unit name only —
+              // never bundle content — per the project's
+              // no-payload-in-logs rule for attacker-reachable remote data.
+              log('warn', `sync: ${err.message}`)
+              return
+            }
             // Forget the modifiedTime so the next poll re-detects this file as changed
             // and gets another chance to merge it.
             lastKnownRemoteState.delete(remoteFile.name)
@@ -1276,7 +1391,7 @@ export async function executeAnalyticsSync(uid: string): Promise<boolean> {
           if (!unit || !isAnalyticsSyncUnit(unit)) return
           if (!unit.startsWith(prefix)) return
           try {
-            await mergeWithRemote(file.id, unit, password, remoteFiles)
+            await mergeWithRemote(file, unit, password, remoteFiles)
             mergedUnits.add(unit)
           } catch {
             anyFailure = true

--- a/src/main/theme-pack-store.ts
+++ b/src/main/theme-pack-store.ts
@@ -13,9 +13,11 @@
 
 import { app, dialog, BrowserWindow } from 'electron'
 import { join } from 'node:path'
-import { mkdir, readFile, rm, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rename, rm, stat, unlink, utimes, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
+import { gcTombstones, mergeEntries, MalformedSyncBundleError } from './sync/merge'
+import { log } from './logger'
 import { safeFilename } from './utils/safe-filename'
 import { validateThemePack } from '../shared/theme/validate'
 import {
@@ -55,6 +57,14 @@ function isSafePackId(id: string): boolean {
   return /^[A-Za-z0-9_-]{1,64}$/.test(id)
 }
 
+/** True when `m` is at least shaped enough to read `.id` off of safely —
+ *  a non-null object with a string `id` field. Guards `mergeSyncedIndex`'s
+ *  per-entry filter against a remote `metas` array containing `null` or
+ *  other non-object garbage (attacker-reachable data). */
+function isPackMetaCandidate(m: unknown): m is ThemePackMeta {
+  return typeof m === 'object' && m !== null && typeof (m as { id?: unknown }).id === 'string'
+}
+
 function getPackPath(packId: string): string {
   if (!isSafePackId(packId)) throw new Error(`Invalid packId: ${packId}`)
   return join(getPacksDir(), `${packId}.json`)
@@ -66,6 +76,196 @@ function packSyncUnit(packId: string): `themes/packs/${string}` {
 
 function nowIso(): string {
   return new Date().toISOString()
+}
+
+// --- Write serialization ------------------------------------------------------
+//
+// Every whole-index read-modify-write path (save/rename/delete/
+// setHubPostId/reorder/purge) shares one promise chain so a concurrent
+// pair can't each read a stale snapshot and clobber the other's write —
+// mirrors `i18n-pack-store.ts`'s `withIndexWriteLock` (itself mirroring
+// `sync/keyboard-meta.ts`'s `withMetaWriteLock`). This store used to
+// scope the lock to only the two sync entry points below
+// (applySyncedIndex/applySyncedPackBody) on the theory that its other
+// mutation methods had no real second writer to race — but the
+// index-merge landed (mergeSyncedIndex below), which makes remote sync
+// a genuine concurrent writer of `themes/index.json`, so every method
+// that reads-then-writes the index needs the same lock the sync entry
+// points already had.
+let indexWriteChain: Promise<unknown> = Promise.resolve()
+
+async function withIndexWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = indexWriteChain.then(() => fn(), () => fn())
+  indexWriteChain = next.catch(() => undefined)
+  return next
+}
+
+/** Write `content` to `path` via a temp-file-then-rename so a reader can
+ *  never observe a torn (partially-written) file. See the i18n-pack-store
+ *  equivalent for the full rationale. */
+async function writeFileAtomic(path: string, content: string): Promise<void> {
+  const tmpPath = `${path}.tmp`
+  await writeFile(tmpPath, content, 'utf-8')
+  await rename(tmpPath, path)
+}
+
+// --- Sync entry points (pack-bundle-merge.ts) --------------------------------
+//
+// See i18n-pack-store.ts's equivalent section doc for the full
+// rationale (isSafePackId at the least-trusted boundary, atomic write,
+// lock-scoped serialization) — mirrored here for themes.
+
+/** Entry-level LWW merge + persist for a synced remote index. See
+ *  i18n-pack-store.ts's `mergeSyncedIndex` for the full rationale
+ *  (replaces whole-file "remote newer wholesale-replaces local", closes
+ *  the outside-lock TOCTOU, filters/rederives unsafe metas before they
+ *  can reach `collectAllSyncUnits`/`bundleSyncUnit`'s generic tail) —
+ *  identical here for themes, just without a built-in-entry special
+ *  case (themes has none).
+ *
+ *  `remoteMetas` is typed `unknown[]` (not `ThemePackMeta[]`) since it's
+ *  attacker-reachable remote data — `isPackMetaCandidate` drops any
+ *  non-object entry (e.g. `null`) the same way as a rejected id, via the
+ *  same unit-name-only warn path, rather than crashing on `m.id`. A
+ *  non-array `metas` field is a stronger malformation, rejected one
+ *  layer up by `mergePackIndexBundle` (pack-bundle-merge.ts) before this
+ *  function is ever called.
+ *
+ *  Returns `applied: false` (never throws) only on an I/O failure
+ *  persisting the merged index. */
+export async function mergeSyncedIndex(
+  remoteMetas: readonly unknown[],
+): Promise<{ applied: boolean; remoteNeedsUpdate: boolean }> {
+  return withIndexWriteLock(async () => {
+    try {
+      const localIndex = await readIndex()
+      const rejectedCount = remoteMetas.filter((m) => !isPackMetaCandidate(m) || !isSafePackId(m.id)).length
+      if (rejectedCount > 0) {
+        log('warn', `sync: dropped ${rejectedCount} unsafe remote meta id(s) for ${THEME_INDEX_SYNC_UNIT}`)
+      }
+      const safeRemoteMetas = remoteMetas
+        .filter((m): m is ThemePackMeta => isPackMetaCandidate(m) && isSafePackId(m.id))
+        .map((m) => ({ ...m, filename: `${PACKS_DIRNAME}/${m.id}.json` }))
+      const localMetas = gcTombstones(localIndex.metas)
+      const remoteMetasGced = gcTombstones(safeRemoteMetas)
+      const result = mergeEntries(localMetas, remoteMetasGced, { preserveLocalOrder: true })
+      await mkdir(getStoreDir(), { recursive: true })
+      await writeFileAtomic(getIndexPath(), JSON.stringify({ metas: result.entries }, null, 2))
+      return { applied: true, remoteNeedsUpdate: result.remoteNeedsUpdate }
+    } catch {
+      return { applied: false, remoteNeedsUpdate: false }
+    }
+  })
+}
+
+/** Local mtime (ms) of a pack body file, or `null` when `packId` is
+ *  unsafe or the file doesn't exist yet. */
+export async function statLocalPackMtime(packId: string): Promise<number | null> {
+  if (!isSafePackId(packId)) return null
+  try {
+    const stats = await stat(getPackPath(packId))
+    return stats.mtime.getTime()
+  } catch {
+    return null
+  }
+}
+
+/** Outcome of `applySyncedPackBody` — see i18n-pack-store.ts's
+ *  `ApplyPackBodyOutcome` for the full contract each state carries. */
+export type ApplyPackBodyOutcome = 'applied' | 'local-wins' | 'io-error'
+
+/** Apply an already-LWW-won remote pack body, pinning its mtime to the
+ *  remote's own `modifiedTime` so the next LWW comparison sees the two
+ *  sides as equal instead of re-uploading the just-downloaded copy
+ *  forever. Throws `MalformedSyncBundleError` for an unsafe `packId`
+ *  (so the sync poll stops retrying a permanently-rejected revision
+ *  instead of treating it like a transient failure) and re-checks local
+ *  mtime under the lock immediately before writing (CAS) so a
+ *  concurrent local save can't be clobbered by a stale remote-wins
+ *  decision made outside the lock. See i18n-pack-store.ts's equivalent
+ *  for the full rationale — identical here for themes, including the
+ *  mtime pin being a SEPARATE try/catch from the body write: a utimes
+ *  failure after a successful write is logged as a unit-name-only warn
+ *  and still reported `'applied'` (a redundant future re-upload beats
+ *  failing the unit and re-entering the clock-skew loop). Returns
+ *  `'io-error'` (never throws for this case) on any other I/O
+ *  failure. */
+export async function applySyncedPackBody(
+  packId: string,
+  rawJson: string,
+  remoteModifiedTime: string,
+): Promise<ApplyPackBodyOutcome> {
+  if (!isSafePackId(packId)) {
+    throw new MalformedSyncBundleError(packSyncUnit(packId))
+  }
+  return withIndexWriteLock(async () => {
+    try {
+      const path = getPackPath(packId)
+      const modMs = new Date(remoteModifiedTime).getTime()
+      if (!Number.isNaN(modMs)) {
+        try {
+          const currentStat = await stat(path)
+          if (currentStat.mtime.getTime() >= modMs) return 'local-wins'
+        } catch {
+          // no local file yet — nothing to race against, proceed
+        }
+      }
+      await mkdir(getPacksDir(), { recursive: true })
+      await writeFileAtomic(path, rawJson)
+      if (!Number.isNaN(modMs)) {
+        try {
+          const pinned = new Date(modMs)
+          await utimes(path, pinned, pinned)
+        } catch {
+          log('warn', `sync: failed to pin mtime for ${packSyncUnit(packId)} after apply`)
+        }
+      }
+      return 'applied'
+    } catch {
+      return 'io-error'
+    }
+  })
+}
+
+/** Pin a pack body file's mtime to the Drive `modifiedTime` a
+ *  just-completed local-wins upload was assigned. See
+ *  i18n-pack-store.ts's equivalent for the full clock-skew rationale,
+ *  including the `expectedLocalMtimeMs` compare-and-swap guard: the
+ *  caller snapshots the local mtime before bundling/uploading (outside
+ *  this store's lock), and this function only pins if the file's
+ *  current mtime still matches that snapshot when the lock is finally
+ *  acquired — otherwise a concurrent local save's fresh content would
+ *  get stamped with this stale upload's Drive time, and the new edit
+ *  would never get re-uploaded (the next LWW compares as a tie). `null`
+ *  means the caller had no snapshot to compare, so this skips rather
+ *  than guessing. Best-effort beyond the CAS check: swallows any I/O
+ *  error (stat or utimes) with a unit-name-only warn. */
+export async function pinPackBodyMtime(
+  packId: string,
+  modifiedTime: string,
+  expectedLocalMtimeMs: number | null,
+): Promise<void> {
+  if (!isSafePackId(packId)) return
+  await withIndexWriteLock(async () => {
+    const modMs = new Date(modifiedTime).getTime()
+    if (Number.isNaN(modMs)) return
+    if (expectedLocalMtimeMs === null) {
+      log('debug', `sync: skipped mtime pin for ${packSyncUnit(packId)} — no local snapshot to compare`)
+      return
+    }
+    try {
+      const path = getPackPath(packId)
+      const currentStat = await stat(path)
+      if (currentStat.mtime.getTime() !== expectedLocalMtimeMs) {
+        log('debug', `sync: skipped mtime pin for ${packSyncUnit(packId)} — local file changed since upload snapshot`)
+        return
+      }
+      const pinned = new Date(modMs)
+      await utimes(path, pinned, pinned)
+    } catch {
+      log('warn', `sync: failed to pin mtime for ${packSyncUnit(packId)} after upload`)
+    }
+  })
 }
 
 // --- Result type -------------------------------------------------------------
@@ -83,7 +283,10 @@ function fail<T>(errorCode: ThemePackStoreErrorCode, error: string): ThemePackSt
 
 // --- Index I/O ---------------------------------------------------------------
 
-async function readIndex(): Promise<ThemePackIndex> {
+// Exported so `mergePackIndexBundle` (pack-bundle-merge.ts) can read the
+// current local index for its LWW comparison — see the i18n-pack-store
+// equivalent's doc.
+export async function readIndex(): Promise<ThemePackIndex> {
   try {
     const raw = await readFile(getIndexPath(), 'utf-8')
     const parsed = JSON.parse(raw) as ThemePackIndex
@@ -137,12 +340,14 @@ async function purgeExpiredTombstonesInPlace(index: ThemePackIndex): Promise<{ r
 }
 
 export async function purgeExpiredTombstones(): Promise<void> {
-  const index = await readIndex()
-  const result = await purgeExpiredTombstonesInPlace(index)
-  if (result.touched) {
-    await writeIndex(index)
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-  }
+  return withIndexWriteLock(async () => {
+    const index = await readIndex()
+    const result = await purgeExpiredTombstonesInPlace(index)
+    if (result.touched) {
+      await writeIndex(index)
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+    }
+  })
 }
 
 // --- Public API --------------------------------------------------------------
@@ -185,66 +390,68 @@ export async function savePack(input: {
   }
   const { name, version } = validation.header
 
-  try {
-    const index = await readIndex()
-    // Auto-overwrite path: if the caller did not specify an id but
-    // an active entry already shares this name (case-insensitive),
-    // adopt that entry's id so the import replaces the existing pack
-    // instead of failing with DUPLICATE_NAME. Mirrors KeyLabels.
-    let resolvedId = input.id
-    if (!resolvedId) {
-      const existingByName = findActiveByName(index.metas, name)
-      if (existingByName) resolvedId = existingByName.id
+  return withIndexWriteLock(async () => {
+    try {
+      const index = await readIndex()
+      // Auto-overwrite path: if the caller did not specify an id but
+      // an active entry already shares this name (case-insensitive),
+      // adopt that entry's id so the import replaces the existing pack
+      // instead of failing with DUPLICATE_NAME. Mirrors KeyLabels.
+      let resolvedId = input.id
+      if (!resolvedId) {
+        const existingByName = findActiveByName(index.metas, name)
+        if (existingByName) resolvedId = existingByName.id
+      }
+      if (findActiveByName(index.metas, name, resolvedId)) {
+        return fail('DUPLICATE_NAME', 'A theme pack with the same name already exists')
+      }
+
+      const id = resolvedId ?? randomUUID()
+      if (!isSafePackId(id)) return fail('INVALID_FILE', 'Generated pack id is unsafe')
+
+      await mkdir(getPacksDir(), { recursive: true })
+      await writeFile(getPackPath(id), JSON.stringify(input.raw, null, 2), 'utf-8')
+
+      const now = nowIso()
+      const existing = index.metas.find((m) => m.id === id)
+      // hubUpdatedAt: empty/whitespace string is treated the same as null
+      // (explicit clear) so a stray '' from a Hub response never persists.
+      const hubUpdatedAtInput = typeof input.hubUpdatedAt === 'string'
+        ? (input.hubUpdatedAt.trim() || null)
+        : input.hubUpdatedAt
+      const uploaderNameInput = typeof input.uploaderName === 'string'
+        ? (input.uploaderName.trim() || null)
+        : input.uploaderName
+      const nextHubPostId = resolveOptionalField(input.hubPostId, existing?.hubPostId)
+      const nextHubUpdatedAt = resolveOptionalField(hubUpdatedAtInput, existing?.hubUpdatedAt)
+      const nextUploaderName = resolveOptionalField(uploaderNameInput, existing?.uploaderName)
+      const meta: ThemePackMeta = {
+        id,
+        filename: `${PACKS_DIRNAME}/${id}.json`,
+        name,
+        version,
+        ...(nextHubPostId ? { hubPostId: nextHubPostId } : {}),
+        ...(nextHubUpdatedAt ? { hubUpdatedAt: nextHubUpdatedAt } : {}),
+        ...(nextUploaderName ? { uploaderName: nextUploaderName } : {}),
+        savedAt: existing?.savedAt ?? now,
+        updatedAt: now,
+      }
+
+      const existingIndex = index.metas.findIndex((m) => m.id === id)
+      if (existingIndex >= 0) {
+        index.metas[existingIndex] = meta
+      } else {
+        index.metas.push(meta)
+      }
+      await writeIndex(index)
+
+      notifyChange(packSyncUnit(id))
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+      return ok(meta)
+    } catch (err) {
+      return fail('IO_ERROR', String(err))
     }
-    if (findActiveByName(index.metas, name, resolvedId)) {
-      return fail('DUPLICATE_NAME', 'A theme pack with the same name already exists')
-    }
-
-    const id = resolvedId ?? randomUUID()
-    if (!isSafePackId(id)) return fail('INVALID_FILE', 'Generated pack id is unsafe')
-
-    await mkdir(getPacksDir(), { recursive: true })
-    await writeFile(getPackPath(id), JSON.stringify(input.raw, null, 2), 'utf-8')
-
-    const now = nowIso()
-    const existing = index.metas.find((m) => m.id === id)
-    // hubUpdatedAt: empty/whitespace string is treated the same as null
-    // (explicit clear) so a stray '' from a Hub response never persists.
-    const hubUpdatedAtInput = typeof input.hubUpdatedAt === 'string'
-      ? (input.hubUpdatedAt.trim() || null)
-      : input.hubUpdatedAt
-    const uploaderNameInput = typeof input.uploaderName === 'string'
-      ? (input.uploaderName.trim() || null)
-      : input.uploaderName
-    const nextHubPostId = resolveOptionalField(input.hubPostId, existing?.hubPostId)
-    const nextHubUpdatedAt = resolveOptionalField(hubUpdatedAtInput, existing?.hubUpdatedAt)
-    const nextUploaderName = resolveOptionalField(uploaderNameInput, existing?.uploaderName)
-    const meta: ThemePackMeta = {
-      id,
-      filename: `${PACKS_DIRNAME}/${id}.json`,
-      name,
-      version,
-      ...(nextHubPostId ? { hubPostId: nextHubPostId } : {}),
-      ...(nextHubUpdatedAt ? { hubUpdatedAt: nextHubUpdatedAt } : {}),
-      ...(nextUploaderName ? { uploaderName: nextUploaderName } : {}),
-      savedAt: existing?.savedAt ?? now,
-      updatedAt: now,
-    }
-
-    const existingIndex = index.metas.findIndex((m) => m.id === id)
-    if (existingIndex >= 0) {
-      index.metas[existingIndex] = meta
-    } else {
-      index.metas.push(meta)
-    }
-    await writeIndex(index)
-
-    notifyChange(packSyncUnit(id))
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-    return ok(meta)
-  } catch (err) {
-    return fail('IO_ERROR', String(err))
-  }
+  })
 }
 
 export async function renamePack(id: string, newName: string): Promise<ThemePackStoreResult<ThemePackMeta>> {
@@ -252,50 +459,54 @@ export async function renamePack(id: string, newName: string): Promise<ThemePack
   if (!trimmed) return fail('INVALID_NAME', 'Name must not be empty')
   if (trimmed.length > THEME_PACK_LIMITS.MAX_NAME_LENGTH) return fail('INVALID_NAME', `Name must be at most ${THEME_PACK_LIMITS.MAX_NAME_LENGTH} characters`)
 
-  try {
-    const index = await readIndex()
-    const meta = index.metas.find((m) => m.id === id && !m.deletedAt)
-    if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
-    if (findActiveByName(index.metas, trimmed, id)) {
-      return fail('DUPLICATE_NAME', 'A theme pack with the same name already exists')
+  return withIndexWriteLock(async () => {
+    try {
+      const index = await readIndex()
+      const meta = index.metas.find((m) => m.id === id && !m.deletedAt)
+      if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
+      if (findActiveByName(index.metas, trimmed, id)) {
+        return fail('DUPLICATE_NAME', 'A theme pack with the same name already exists')
+      }
+
+      // Rewrite the pack body so the on-disk JSON's `name` mirrors meta.
+      const path = getPackPath(id)
+      const raw = await readFile(path, 'utf-8')
+      const pack = JSON.parse(raw) as Record<string, unknown>
+      pack.name = trimmed
+      await writeFile(path, JSON.stringify(pack, null, 2), 'utf-8')
+
+      meta.name = trimmed
+      meta.updatedAt = nowIso()
+      await writeIndex(index)
+
+      notifyChange(packSyncUnit(id))
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+      return ok(meta)
+    } catch (err) {
+      return fail('IO_ERROR', String(err))
     }
-
-    // Rewrite the pack body so the on-disk JSON's `name` mirrors meta.
-    const path = getPackPath(id)
-    const raw = await readFile(path, 'utf-8')
-    const pack = JSON.parse(raw) as Record<string, unknown>
-    pack.name = trimmed
-    await writeFile(path, JSON.stringify(pack, null, 2), 'utf-8')
-
-    meta.name = trimmed
-    meta.updatedAt = nowIso()
-    await writeIndex(index)
-
-    notifyChange(packSyncUnit(id))
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-    return ok(meta)
-  } catch (err) {
-    return fail('IO_ERROR', String(err))
-  }
+  })
 }
 
 export async function deletePack(id: string): Promise<ThemePackStoreResult<void>> {
-  try {
-    const index = await readIndex()
-    const meta = index.metas.find((m) => m.id === id)
-    if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
+  return withIndexWriteLock(async () => {
+    try {
+      const index = await readIndex()
+      const meta = index.metas.find((m) => m.id === id)
+      if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
 
-    const now = nowIso()
-    meta.deletedAt = now
-    meta.updatedAt = now
-    await writeIndex(index)
+      const now = nowIso()
+      meta.deletedAt = now
+      meta.updatedAt = now
+      await writeIndex(index)
 
-    notifyChange(packSyncUnit(id))
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-    return ok()
-  } catch (err) {
-    return fail('IO_ERROR', String(err))
-  }
+      notifyChange(packSyncUnit(id))
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+      return ok()
+    } catch (err) {
+      return fail('IO_ERROR', String(err))
+    }
+  })
 }
 
 /** `uploaderName` / `hubUpdatedAt` mirror `key-label-store.ts`'s
@@ -307,43 +518,45 @@ export async function setHubPostId(
   uploaderName?: string | null,
   hubUpdatedAt?: string | null,
 ): Promise<ThemePackStoreResult<ThemePackMeta>> {
-  try {
-    const index = await readIndex()
-    const meta = index.metas.find((m) => m.id === id)
-    if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
-    const normalized = hubPostId?.trim() || null
-    if (normalized === null) {
-      delete meta.hubPostId
-      // hubUpdatedAt is meaningless once detached from Hub; drop it so a
-      // future re-link gets a fresh round-trip rather than comparing
-      // against a stale cached timestamp.
-      delete meta.hubUpdatedAt
-    } else {
-      meta.hubPostId = normalized
-    }
-    if (uploaderName !== undefined) {
-      const trimmed = uploaderName?.trim() ?? ''
-      if (trimmed) {
-        meta.uploaderName = trimmed
-      } else {
-        delete meta.uploaderName
-      }
-    }
-    if (hubUpdatedAt !== undefined) {
-      const trimmed = hubUpdatedAt?.trim() ?? ''
-      if (trimmed) {
-        meta.hubUpdatedAt = trimmed
-      } else {
+  return withIndexWriteLock(async () => {
+    try {
+      const index = await readIndex()
+      const meta = index.metas.find((m) => m.id === id)
+      if (!meta) return fail('NOT_FOUND', 'Theme pack not found')
+      const normalized = hubPostId?.trim() || null
+      if (normalized === null) {
+        delete meta.hubPostId
+        // hubUpdatedAt is meaningless once detached from Hub; drop it so a
+        // future re-link gets a fresh round-trip rather than comparing
+        // against a stale cached timestamp.
         delete meta.hubUpdatedAt
+      } else {
+        meta.hubPostId = normalized
       }
+      if (uploaderName !== undefined) {
+        const trimmed = uploaderName?.trim() ?? ''
+        if (trimmed) {
+          meta.uploaderName = trimmed
+        } else {
+          delete meta.uploaderName
+        }
+      }
+      if (hubUpdatedAt !== undefined) {
+        const trimmed = hubUpdatedAt?.trim() ?? ''
+        if (trimmed) {
+          meta.hubUpdatedAt = trimmed
+        } else {
+          delete meta.hubUpdatedAt
+        }
+      }
+      meta.updatedAt = nowIso()
+      await writeIndex(index)
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+      return ok(meta)
+    } catch (err) {
+      return fail('IO_ERROR', String(err))
     }
-    meta.updatedAt = nowIso()
-    await writeIndex(index)
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-    return ok(meta)
-  } catch (err) {
-    return fail('IO_ERROR', String(err))
-  }
+  })
 }
 
 export async function hasActiveName(name: string, excludeId?: string): Promise<ThemePackStoreResult<boolean>> {
@@ -363,43 +576,42 @@ export async function hasActiveName(name: string, excludeId?: string): Promise<T
  * entry. Only the index changes — pack bodies are untouched — so only
  * `THEME_INDEX_SYNC_UNIT` is bumped, matching `setHubPostId`.
  *
- * Known limitation (pre-existing store property, not a Phase 2
- * regression): unlike `key-labels` — a single sync unit with
- * entry-level LWW merge — `themes/index` has no merge logic wired into
- * `sync-service.ts` yet. `notifyChange` marks the unit dirty for
- * upload, but a remote index downloaded during sync is not merged
- * against this reordered one, so the manual order (drag or Name sort)
- * is effectively machine-local until index-merge lands. Tracked as
- * future work in the unification plan, not addressed here.
+ * Like `key-labels`, `themes/index` now has entry-level LWW merge wired
+ * into `sync-service.ts` (`mergeSyncedIndex`, with `preserveLocalOrder`
+ * so drag/Name-sort order survives the merge) — a remote index
+ * downloaded during sync merges against this reordered one instead of
+ * one side replacing the other wholesale.
  */
 export async function reorderActive(orderedIds: string[]): Promise<ThemePackStoreResult<void>> {
-  try {
-    const index = await readIndex()
-    const byId = new Map<string, ThemePackMeta>()
-    for (const meta of index.metas) byId.set(meta.id, meta)
+  return withIndexWriteLock(async () => {
+    try {
+      const index = await readIndex()
+      const byId = new Map<string, ThemePackMeta>()
+      for (const meta of index.metas) byId.set(meta.id, meta)
 
-    const seen = new Set<string>()
-    const reordered: ThemePackMeta[] = []
-    const now = nowIso()
-    for (const id of orderedIds) {
-      const meta = byId.get(id)
-      if (!meta || meta.deletedAt || seen.has(id)) continue
-      meta.updatedAt = now
-      reordered.push(meta)
-      seen.add(id)
+      const seen = new Set<string>()
+      const reordered: ThemePackMeta[] = []
+      const now = nowIso()
+      for (const id of orderedIds) {
+        const meta = byId.get(id)
+        if (!meta || meta.deletedAt || seen.has(id)) continue
+        meta.updatedAt = now
+        reordered.push(meta)
+        seen.add(id)
+      }
+
+      for (const meta of index.metas) {
+        if (seen.has(meta.id)) continue
+        reordered.push(meta)
+      }
+
+      await writeIndex({ metas: reordered })
+      notifyChange(THEME_INDEX_SYNC_UNIT)
+      return ok()
+    } catch (err) {
+      return fail('IO_ERROR', String(err))
     }
-
-    for (const meta of index.metas) {
-      if (seen.has(meta.id)) continue
-      reordered.push(meta)
-    }
-
-    await writeIndex({ metas: reordered })
-    notifyChange(THEME_INDEX_SYNC_UNIT)
-    return ok()
-  } catch (err) {
-    return fail('IO_ERROR', String(err))
-  }
+  })
 }
 
 export async function exportPackToDialog(

--- a/src/main/utils/broadcast.ts
+++ b/src/main/utils/broadcast.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Shared "send to every open window" helper.
+
+import { BrowserWindow } from 'electron'
+
+/**
+ * Send `channel` (with optional `args`) to every open `BrowserWindow`.
+ * Pulled out of `pack-bundle-merge.ts` and `sync-service.ts`, which each
+ * had their own identical `for (const win of BrowserWindow.getAllWindows())`
+ * loop. Three other call sites (`i18n-startup-sync.ts`, `theme-pack-ipc.ts`,
+ * `sync-ipc.ts`) have the same shape but are left as pre-existing debt —
+ * see `Task-sync-remote-reset-and-discovery-gaps.md`.
+ *
+ * Guards against a window closing between `getAllWindows()` enumerating
+ * it and this loop reaching it (a real window-close race, not
+ * hypothetical — several call sites here run after an `await`, e.g. a
+ * sync merge's disk write, during which the user can close a window)
+ * — `win.webContents.send` on an already-destroyed window/webContents
+ * throws synchronously, which would otherwise abort the loop partway
+ * through and skip broadcasting to any windows still open after it.
+ */
+export function broadcastToAllWindows(channel: string, ...args: unknown[]): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) continue
+    win.webContents.send(channel, ...args)
+  }
+}

--- a/src/renderer/components/settings-modal/SyncDataResetSection.tsx
+++ b/src/renderer/components/settings-modal/SyncDataResetSection.tsx
@@ -29,6 +29,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
       keyboardNames: rawScanResult.keyboardNames,
       favorites: [], // All favorites exist locally, so cloud-only = none
       i18nPacks: rawScanResult.i18nPacks,
+      themePacks: rawScanResult.themePacks,
       undecryptable: rawScanResult.undecryptable,
     }
   }, [rawScanResult, excludeLocalData, localKeyboardUids])
@@ -36,6 +37,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
   const [selectedKeyboardUids, setSelectedKeyboardUids] = useState<Set<string>>(new Set())
   const [favoritesSelected, setFavoritesSelected] = useState(false)
   const [i18nPacksSelected, setI18nPacksSelected] = useState(false)
+  const [themePacksSelected, setThemePacksSelected] = useState(false)
   const [selectedUndecryptable, setSelectedUndecryptable] = useState<Set<string>>(new Set())
   const [confirming, setConfirming] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -48,6 +50,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
     setSelectedKeyboardUids(new Set())
     setFavoritesSelected(false)
     setI18nPacksSelected(false)
+    setThemePacksSelected(false)
     setSelectedUndecryptable(new Set())
   }, [])
 
@@ -89,7 +92,7 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
     setConfirming(false)
   }, [scanResult, selectedUndecryptable.size])
 
-  const anySelected = selectedKeyboardUids.size > 0 || favoritesSelected || i18nPacksSelected || selectedUndecryptable.size > 0
+  const anySelected = selectedKeyboardUids.size > 0 || favoritesSelected || i18nPacksSelected || themePacksSelected || selectedUndecryptable.size > 0
   const allUndecryptableSelected = scanResult !== null && scanResult.undecryptable.length > 0 && selectedUndecryptable.size === scanResult.undecryptable.length
 
   const handleDelete = useCallback(async () => {
@@ -98,11 +101,12 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
     setError(null)
     onResetStart?.()
     try {
-      if (selectedKeyboardUids.size > 0 || favoritesSelected || i18nPacksSelected) {
+      if (selectedKeyboardUids.size > 0 || favoritesSelected || i18nPacksSelected || themePacksSelected) {
         const targets = {
           keyboards: selectedKeyboardUids.size > 0 ? [...selectedKeyboardUids] : false as const,
           favorites: favoritesSelected,
           i18nPacks: i18nPacksSelected,
+          themePacks: themePacksSelected,
         }
         const result = await sync.resetSyncTargets(targets)
         if (!result.success) {
@@ -131,12 +135,13 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
       setDeleting(false)
       onResetEnd?.()
     }
-  }, [sync, selectedKeyboardUids, favoritesSelected, i18nPacksSelected, selectedUndecryptable, resetSelections, onResetStart, onResetEnd, t])
+  }, [sync, selectedKeyboardUids, favoritesSelected, i18nPacksSelected, themePacksSelected, selectedUndecryptable, resetSelections, onResetStart, onResetEnd, t])
 
   const hasNoData = scanResult !== null
     && scanResult.keyboards.length === 0
     && scanResult.favorites.length === 0
     && (scanResult.i18nPacks?.length ?? 0) === 0
+    && scanResult.themePacks.length === 0
     && scanResult.undecryptable.length === 0
 
   return (
@@ -214,6 +219,21 @@ export function SyncDataResetSection({ sync, storedKeyboards, disabled, onResetS
                 className="accent-danger"
               />
               {t('sync.resetTarget.i18nPacks')}
+            </label>
+          )}
+          {scanResult.themePacks.length > 0 && (
+            <label className="flex items-center gap-2 text-sm text-content" data-testid="sync-target-themePacks">
+              <input
+                type="checkbox"
+                checked={themePacksSelected}
+                onChange={(e) => {
+                  setThemePacksSelected(e.target.checked)
+                  setConfirming(false)
+                }}
+                disabled={disabled || deleting}
+                className="accent-danger"
+              />
+              {t('sync.resetTarget.themePacks')}
             </label>
           )}
           {scanResult.undecryptable.length > 0 && (

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.53",
+  "version": "0.1.54",
   "name": "English",
   "common": {
     "save": "Save",
@@ -769,7 +769,8 @@
       "keyboardData": "Keyboard",
       "favorites": "Favorite",
       "appSettings": "Application",
-      "i18nPacks": "Language Packs"
+      "i18nPacks": "Language Packs",
+      "themePacks": "Theme Packs"
     },
     "deleteSelected": "Delete Selected",
     "resetTargetsConfirm": "The selected data will be permanently deleted. This action cannot be undone.",

--- a/src/shared/types/sync.ts
+++ b/src/shared/types/sync.ts
@@ -8,7 +8,7 @@ import type { KeyboardMetaIndex, KeyboardMetaSyncUnit } from './keyboard-meta'
 import type { KeyLabelIndex } from './key-label-store'
 import type { TypingTestTextIndex } from './typing-test-text-store'
 import type { I18nPackIndex, I18nIndexSyncUnit, I18nPackSyncUnit } from './i18n-store'
-import type { ThemePackIndex } from './theme-store'
+import type { ThemePackIndex, ThemeIndexSyncUnit, ThemePackSyncUnit } from './theme-store'
 import type { RunLogIndex } from './typing-run-log'
 
 export type { AppConfig }
@@ -80,6 +80,8 @@ export type SyncUnit =
   | TypingTestTextSyncUnit
   | I18nIndexSyncUnit
   | I18nPackSyncUnit
+  | ThemeIndexSyncUnit
+  | ThemePackSyncUnit
 
 export interface PasswordStrength {
   score: number // 0-4


### PR DESCRIPTION
## Summary

Closes two related holes in the Google Drive sync layer.

**1. Discovery gap.** `syncUnitFromFileName` (the remote-filename → sync-unit reverse mapper behind remote scan, polling, and fresh-machine discovery) could not invert five producible unit shapes — `keyboards/{uid}/analyze_filters`, `key-labels`, `typing-test-texts`, `themes/index`, `themes/packs/{id}`. Those stores uploaded fine but their remote files were dropped before download on any machine without a local copy, so a fresh machine never materialized them. All five now round-trip (exact-name map consulted first, extended keyboard alternation with a collision-guard note, greedy pack-id capture mirroring i18n; `password-check.enc` stays deliberately unmapped).

**2. Bundle-variant merge crash (live bug).** i18n/theme bundles carry `{ metas }`, not `{ entries }`; when one reached the generic merge branch it crashed on `gcTombstones(undefined)` — firing today on the upload path whenever `i18n_index.enc` already exists remotely, and putting polling into a 3-minute retry loop. Making themes discoverable would have routed them into the same crash, so the merge support ships with the mapper as one concern:
- Pack **indexes** merge entry-level (the metas are structurally `EntryMeta` with tombstones already) via the existing `mergeEntries`/`gcTombstones` machinery, read-merge-write under the store lock — two machines installing different packs converge to the union, deletions propagate via tombstones.
- Pack **bodies** merge file-level LWW on Drive `modifiedTime` vs local mtime, with the local mtime pinned to Drive's stamp after both remote-wins writes and local-wins uploads (prevents re-upload ping-pong under clock skew), a pre-download local-wins short-circuit, and CAS guards against concurrent local edits.
- Writes go through new sync-facing store entry points: `isSafePackId` on remote-derived pack ids, filename recomputation, atomic tmp+rename, shared write locks (theme store's mutations now all take the lock). `mergeSyncUnit` additionally validates every sync-unit path segment centrally.
- Malformed bundles throw a typed error contained per unit; polling keeps the remembered revision so an unchanged bad file is skipped instead of re-downloaded forever.

Also: the Sync Data reset UI now surfaces remote theme packs (backend support existed, the scan could never populate it), and the sync-service test suite's hand-rolled `syncUnitFromFileName`/`driveFileName` mocks were replaced with the real implementations so they can't silently go stale again.

## Test plan

- Round-trips for all five new filename patterns + negative cases.
- Merge: crash regression (i18n index reaching the merge), two-machine install-install convergence, deletion propagation, builtin-English harmless merge, hostile pack-id rejection (manual + poll paths), malformed metas (`[null]`, non-array), mtime-pin idempotence, upload-race CAS (verified failing without the fix), utimes-failure degradation.
- Discovery: fresh-machine downloads for key-labels / typing-test-texts / analyze_filters under their production scopes; scan surfacing analyze_filters-only keyboards and theme packs; poll pickup of changed theme/key-label files.
- Full suite: 353 files, 7994 passed.