### PR TITLE
refactor(sync): consolidate store path-safety helpers into the shared module

### DIFF
--- a/src/main/__tests__/analyze-filter-store-hub-post-id.test.ts
+++ b/src/main/__tests__/analyze-filter-store-hub-post-id.test.ts
@@ -144,4 +144,20 @@ describe('analyze-filter-store set-hub-post-id', () => {
     await deleteHandler(fakeEvent, UID, entry.id)
     expect(await readAnalyzeFilterEntry(UID, entry.id)).toBeNull()
   })
+
+  describe('path traversal prevention', () => {
+    it('rejects uid with path traversal characters', async () => {
+      const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_LIST)
+      const result = await handler(fakeEvent, '../..') as { success: boolean; error: string }
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid uid')
+    })
+
+    it('rejects uid with slashes', async () => {
+      const handler = getHandler(IpcChannels.ANALYZE_FILTER_STORE_SAVE)
+      const result = await handler(fakeEvent, 'foo/bar', '{}', 'test') as { success: boolean; error: string }
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid uid')
+    })
+  })
 })

--- a/src/main/__tests__/favorite-store.test.ts
+++ b/src/main/__tests__/favorite-store.test.ts
@@ -325,6 +325,22 @@ describe('favorite-store', () => {
     })
   })
 
+  describe('path traversal prevention', () => {
+    it('rejects an entry whose stored filename escapes the favorites directory', async () => {
+      const dir = join(mockUserDataPath, 'sync', 'favorites', 'tapDance')
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'index.json'), JSON.stringify({
+        type: 'tapDance',
+        entries: [{ id: 'evil-entry', label: 'Evil', filename: '../../etc/passwd', savedAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }],
+      }), 'utf-8')
+
+      const loadHandler = getHandler(IpcChannels.FAVORITE_STORE_LOAD)
+      const result = await loadHandler(fakeEvent, 'tapDance', 'evil-entry') as { success: boolean; error: string }
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('Invalid filename')
+    })
+  })
+
   describe('export', () => {
     const validTapDanceJson = '{"type":"tapDance","data":{"onTap":4,"onHold":0,"onDoubleTap":0,"onTapHold":0,"tappingTerm":200}}'
 

--- a/src/main/__tests__/key-label-store.test.ts
+++ b/src/main/__tests__/key-label-store.test.ts
@@ -145,6 +145,21 @@ describe('key-label-store', () => {
     })
   })
 
+  describe('path traversal prevention', () => {
+    it('rejects an entry whose stored filename escapes the key-labels directory', async () => {
+      const dir = join(mockUserDataPath, 'sync', 'key-labels')
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'index.json'), JSON.stringify({
+        entries: [{ id: 'evil-entry', name: 'Evil', filename: '../../etc/passwd', savedAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }],
+      }), 'utf-8')
+
+      const record = await getRecord('evil-entry')
+      expect(record.success).toBe(false)
+      expect(record.errorCode).toBe('IO_ERROR')
+      expect(record.error).toContain('Invalid filename')
+    })
+  })
+
   describe('renameRecord', () => {
     it('updates index + payload', async () => {
       const created = await saveRecord({ name: 'Old', uploaderName: 'me', map: { KC_A: '1' } })

--- a/src/main/__tests__/typing-test-text-store.test.ts
+++ b/src/main/__tests__/typing-test-text-store.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'
-import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 
 // --- Mock electron ---
@@ -213,6 +213,21 @@ describe('typing-test-text-store', () => {
       const rec = await getRecord(saved.data!.id)
       // Single spaces within a line, a newline at each line break, blank line dropped.
       expect(rec.data?.data.text).toBe('the quick brown\nfox jumps\nover')
+    })
+  })
+
+  describe('path traversal prevention', () => {
+    it('rejects an entry whose stored filename escapes the typing-test-texts directory', async () => {
+      const dir = join(mockUserDataPath, 'sync', TYPING_TEST_TEXT_SYNC_UNIT)
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'index.json'), JSON.stringify({
+        entries: [{ id: 'evil-entry', name: 'Evil', wordCount: 1, lineCount: 1, filename: '../../etc/passwd', savedAt: '2025-01-01T00:00:00.000Z', updatedAt: '2025-01-01T00:00:00.000Z' }],
+      }), 'utf-8')
+
+      const record = await getRecord('evil-entry')
+      expect(record.success).toBe(false)
+      expect(record.errorCode).toBe('IO_ERROR')
+      expect(record.error).toContain('Invalid filename')
     })
   })
 

--- a/src/main/analyze-filter-store.ts
+++ b/src/main/analyze-filter-store.ts
@@ -3,10 +3,9 @@
 // snapshots per keyboard. File layout intentionally mirrors
 // snapshot-store.ts so the existing index-based sync (sync-bundle /
 // sync-service / merge) picks it up via the new
-// "keyboards/{uid}/analyze_filters" sync unit. Helpers are duplicated
-// rather than abstracted while there are still only two index stores;
-// see snapshot-store.ts for the original rationale on uid validation,
-// write locks, and tombstone-based deletes.
+// "keyboards/{uid}/analyze_filters" sync unit; see snapshot-store.ts for
+// the original rationale on uid validation, write locks, and
+// tombstone-based deletes.
 
 import { app } from 'electron'
 import { join } from 'node:path'
@@ -16,6 +15,7 @@ import { IpcChannels } from '../shared/ipc/channels'
 import { notifyChange } from './sync/sync-service'
 import { withWriteLock } from './per-uid-write-lock'
 import { secureHandle } from './ipc-guard'
+import { isSafePathSegment, tsForFilename } from './utils/safe-filename'
 import {
   ANALYZE_FILTER_STORE_ERROR_MAX_ENTRIES,
   ANALYZE_FILTER_STORE_MAX_ENTRIES_PER_KEYBOARD,
@@ -25,11 +25,6 @@ import {
 import type { HubPrivateLink } from '../shared/types/hub-private'
 
 const MAX_ENTRIES_PER_KEYBOARD = ANALYZE_FILTER_STORE_MAX_ENTRIES_PER_KEYBOARD
-
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
-}
 
 function validateUid(uid: string): void {
   if (!isSafePathSegment(uid)) throw new Error('Invalid uid')
@@ -130,7 +125,7 @@ export function setupAnalyzeFilterStore(): void {
           await mkdir(dir, { recursive: true })
 
           const now = new Date()
-          const timestamp = now.toISOString().replace(/:/g, '-')
+          const timestamp = tsForFilename(now)
           const filename = `${timestamp}_${randomUUID()}.json`
           const filePath = getSafeFilePath(uid, filename)
 

--- a/src/main/favorite-store.ts
+++ b/src/main/favorite-store.ts
@@ -10,13 +10,9 @@ import { isValidFavoriteType, isValidVialProtocol, isFavoriteDataFile, FAV_EXPOR
 import { serialize as serializeKeycode, deserialize as deserializeKeycode, getProtocol, setProtocol } from '../shared/keycodes/keycodes'
 import { notifyChange } from './sync/sync-service'
 import { secureHandle } from './ipc-guard'
+import { isSafePathSegment, tsForFilename, tsForExportFilename } from './utils/safe-filename'
 import type { FavoriteType, SavedFavoriteMeta, FavoriteIndex, FavoriteExportEntry, FavoriteImportResult } from '../shared/types/favorite-store'
 import type { HubPrivateLink } from '../shared/types/hub-private'
-
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
-}
 
 function validateType(type: unknown): asserts type is FavoriteType {
   if (!isValidFavoriteType(type)) throw new Error('Invalid favorite type')
@@ -108,7 +104,7 @@ export function setupFavoriteStore(): void {
         await mkdir(dir, { recursive: true })
 
         const now = new Date()
-        const timestamp = now.toISOString().replace(/:/g, '-')
+        const timestamp = tsForFilename(now)
         const filename = `${type}_${timestamp}_${randomUUID().slice(0, 8)}.json`
         const filePath = getSafeFilePath(type, filename)
 
@@ -244,7 +240,7 @@ export function setupFavoriteStore(): void {
           : {}
 
         const now = new Date()
-        const ts = now.toISOString().replace(/:/g, '').replace(/\.\d+Z$/, '').replace('T', '-')
+        const ts = tsForExportFilename(now)
         const defaultFilename = `pipette-fav-${exportKey}-${ts}.json`
 
         const result = await dialog.showSaveDialog(win, {
@@ -289,7 +285,7 @@ export function setupFavoriteStore(): void {
         const serializedData = serializeFavData(scope, parsed.data, serializeKeycode)
 
         const now = new Date()
-        const ts = now.toISOString().replace(/:/g, '').replace(/\.\d+Z$/, '').replace('T', '-')
+        const ts = tsForExportFilename(now)
         const defaultFilename = `pipette-fav-${exportKey}-current-${ts}.json`
 
         const result = await dialog.showSaveDialog(win, {
@@ -482,7 +478,7 @@ export function setupFavoriteStore(): void {
             }
 
             const now = new Date()
-            const timestamp = now.toISOString().replace(/:/g, '-')
+            const timestamp = tsForFilename(now)
             const filename = `${favType}_${timestamp}_${randomUUID().slice(0, 8)}.json`
             const filePath = getSafeFilePath(favType, filename)
 

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -446,7 +446,10 @@ function buildFiles(params: HubUploadPostParams): HubUploadFiles {
   return files
 }
 
-function isSafePathSegment(segment: string): boolean {
+// Deliberately stricter than the shared `isSafePathSegment` (ASCII
+// allowlist vs separator denylist) because these filenames cross the
+// Hub upload boundary; not consolidated by design.
+function isSafeExportFilename(segment: string): boolean {
   return /^[a-zA-Z0-9_.-]+$/.test(segment) && segment !== '.' && segment !== '..'
 }
 
@@ -462,7 +465,7 @@ async function buildFavoriteExportJson(
   const entry = index.entries.find((e) => e.id === entryId && !e.deletedAt)
   if (!entry) throw new Error('Entry not found')
 
-  if (!isSafePathSegment(entry.filename)) throw new Error('Invalid filename')
+  if (!isSafeExportFilename(entry.filename)) throw new Error('Invalid filename')
   const filePath = join(favDir, entry.filename)
   const fileRaw = await readFile(filePath, 'utf-8')
   const parsed = JSON.parse(fileRaw) as { type: string; data: unknown }

--- a/src/main/i18n-pack-store.ts
+++ b/src/main/i18n-pack-store.ts
@@ -19,7 +19,7 @@ import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
 import { gcTombstones, mergeEntries, MalformedSyncBundleError } from './sync/merge'
 import { log } from './logger'
-import { safeFilename } from './utils/safe-filename'
+import { safeFilename, isSafePackId } from './utils/safe-filename'
 import {
   BUILTIN_ENGLISH_PACK_ID,
   I18N_INDEX_SYNC_UNIT,
@@ -49,11 +49,6 @@ function getPacksDir(): string {
 
 function getIndexPath(): string {
   return join(getStoreDir(), INDEX_FILENAME)
-}
-
-function isSafePackId(id: string): boolean {
-  // UUID-like form. Reject anything that could escape the packs dir.
-  return /^[A-Za-z0-9_-]{1,64}$/.test(id)
 }
 
 /** True when `m` is at least shaped enough to read `.id` off of safely —

--- a/src/main/key-label-store.ts
+++ b/src/main/key-label-store.ts
@@ -6,7 +6,7 @@ import { basename, join } from 'node:path'
 import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
-import { safeFilename } from './utils/safe-filename'
+import { safeFilename, isSafePathSegment, tsForFilename } from './utils/safe-filename'
 import type {
   KeyLabelMeta,
   KeyLabelIndex,
@@ -32,11 +32,6 @@ function getIndexPath(): string {
   return join(getStoreDir(), 'index.json')
 }
 
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
-}
-
 function getEntryPath(filename: string): string {
   if (!isSafePathSegment(filename)) throw new Error('Invalid filename')
   return join(getStoreDir(), filename)
@@ -52,10 +47,6 @@ function ok<T>(data?: T): KeyLabelStoreResult<T> {
 
 function nowIso(): string {
   return new Date().toISOString()
-}
-
-function tsForFilename(now: Date = new Date()): string {
-  return now.toISOString().replace(/:/g, '-')
 }
 
 async function readIndex(): Promise<KeyLabelIndex> {

--- a/src/main/pipette-settings-store.ts
+++ b/src/main/pipette-settings-store.ts
@@ -8,6 +8,7 @@ import { IpcChannels } from '../shared/ipc/channels'
 import { notifyChange } from './sync/sync-service'
 import { secureHandle } from './ipc-guard'
 import { withWriteLock } from './per-uid-write-lock'
+import { isSafePathSegment } from './utils/safe-filename'
 import { isRecord } from '../shared/vil-file'
 import { getActiveKeyboardMetaMap, readKeyboardMetaIndex, resolveKeyboardDisplayName } from './sync/keyboard-meta'
 import { getTypingAnalyticsDB } from './typing-analytics/db/typing-analytics-db'
@@ -70,11 +71,6 @@ function isValidViewMatrix(value: unknown): boolean {
     if (!Number.isInteger(cell.col) || (cell.col as number) < 0) return false
   }
   return true
-}
-
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
 }
 
 function validateUid(uid: string): void {

--- a/src/main/snapshot-store.ts
+++ b/src/main/snapshot-store.ts
@@ -11,6 +11,7 @@ import { withWriteLock } from './per-uid-write-lock'
 import { upsertKeyboardMeta } from './sync/keyboard-meta'
 import { KEYBOARD_META_SYNC_UNIT } from '../shared/types/keyboard-meta'
 import { secureHandle } from './ipc-guard'
+import { isSafePathSegment, tsForFilename } from './utils/safe-filename'
 import type { SnapshotMeta, SnapshotIndex } from '../shared/types/snapshot-store'
 import type { HubPrivateLink } from '../shared/types/hub-private'
 
@@ -22,12 +23,6 @@ function sanitizeFilename(name: string): string {
     .replace(/[\x00-\x1f]/g, '')
     .replace(/\.+$/, '')
     .trim() || 'keyboard'
-}
-
-// Reject uid or filename values that could escape the snapshots directory
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
 }
 
 function validateUid(uid: string): void {
@@ -126,7 +121,7 @@ export function setupSnapshotStore(): void {
           await mkdir(dir, { recursive: true })
 
           const now = new Date()
-          const timestamp = now.toISOString().replace(/:/g, '-')
+          const timestamp = tsForFilename(now)
           const safeName = sanitizeFilename(deviceName)
           const filename = `${safeName}_${timestamp}.pipette`
           const filePath = getSafeFilePath(uid, filename)

--- a/src/main/theme-pack-store.ts
+++ b/src/main/theme-pack-store.ts
@@ -18,7 +18,7 @@ import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
 import { gcTombstones, mergeEntries, MalformedSyncBundleError } from './sync/merge'
 import { log } from './logger'
-import { safeFilename } from './utils/safe-filename'
+import { safeFilename, isSafePackId } from './utils/safe-filename'
 import { validateThemePack } from '../shared/theme/validate'
 import {
   THEME_INDEX_SYNC_UNIT,
@@ -50,11 +50,6 @@ function getPacksDir(): string {
 
 function getIndexPath(): string {
   return join(getStoreDir(), INDEX_FILENAME)
-}
-
-function isSafePackId(id: string): boolean {
-  // UUID-like form. Reject anything that could escape the packs dir.
-  return /^[A-Za-z0-9_-]{1,64}$/.test(id)
 }
 
 /** True when `m` is at least shaped enough to read `.id` off of safely —

--- a/src/main/typing-test-text-store.ts
+++ b/src/main/typing-test-text-store.ts
@@ -7,6 +7,7 @@ import { join, basename } from 'node:path'
 import { mkdir, readFile, stat, unlink, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { notifyChange } from './sync/sync-service'
+import { isSafePathSegment, tsForFilename } from './utils/safe-filename'
 import { isKanaOnlyText } from '../shared/kana-purity'
 import type {
   TypingTestTextMeta,
@@ -54,11 +55,6 @@ function getIndexPath(): string {
   return join(getStoreDir(), 'index.json')
 }
 
-function isSafePathSegment(segment: string): boolean {
-  if (!segment || segment === '.' || segment === '..') return false
-  return !/[/\\]/.test(segment)
-}
-
 function getEntryPath(filename: string): string {
   if (!isSafePathSegment(filename)) throw new Error('Invalid filename')
   return join(getStoreDir(), filename)
@@ -74,10 +70,6 @@ function ok<T>(data?: T): TypingTestTextStoreResult<T> {
 
 function nowIso(): string {
   return new Date().toISOString()
-}
-
-function tsForFilename(now: Date = new Date()): string {
-  return now.toISOString().replace(/:/g, '-')
 }
 
 async function readIndex(): Promise<TypingTestTextIndex> {

--- a/src/main/utils/safe-filename.ts
+++ b/src/main/utils/safe-filename.ts
@@ -5,4 +5,4 @@
 // `src/shared/utils/safe-filename.ts` so the renderer can use them
 // without crossing the process boundary.
 
-export { safeFilename, isSafePathSegment, tsForFilename } from '../../shared/utils/safe-filename'
+export { safeFilename, isSafePathSegment, isSafePackId, tsForFilename, tsForExportFilename } from '../../shared/utils/safe-filename'

--- a/src/renderer/components/editors/JsonEditorModal.tsx
+++ b/src/renderer/components/editors/JsonEditorModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { ModalCloseButton } from './ModalCloseButton'
 import { BTN_PRIMARY } from '../../constants/ui-tokens'
 import { useEscapeCloseCapture } from '../../hooks/useEscapeClose'
+import { tsForExportFilename } from '../../../shared/utils/safe-filename'
 
 export interface JsonEditorModalProps<T> {
   title: string
@@ -68,7 +69,7 @@ export function JsonEditorModal<T>({
   }, [text, parse, onApply, onClose, t])
 
   const handleExport = useCallback(async () => {
-    const ts = new Date().toISOString().replace(/:/g, '').replace(/\.\d+Z$/, '').replace('T', '-')
+    const ts = tsForExportFilename()
     const filename = `pipette-fav-${exportFileName}-current-all-${ts}`
     await window.vialAPI.exportJson(text, filename)
   }, [text, exportFileName])

--- a/src/shared/utils/__tests__/safe-filename.test.ts
+++ b/src/shared/utils/__tests__/safe-filename.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { safeFilename, isSafePathSegment, isSafePackId, tsForFilename, tsForExportFilename } from '../safe-filename'
+
+describe('isSafePathSegment', () => {
+  it('rejects empty string', () => {
+    expect(isSafePathSegment('')).toBe(false)
+  })
+
+  it('rejects "."', () => {
+    expect(isSafePathSegment('.')).toBe(false)
+  })
+
+  it('rejects ".."', () => {
+    expect(isSafePathSegment('..')).toBe(false)
+  })
+
+  it('rejects a forward-slash separator', () => {
+    expect(isSafePathSegment('a/b')).toBe(false)
+  })
+
+  it('rejects a backslash separator', () => {
+    expect(isSafePathSegment('a\\b')).toBe(false)
+  })
+
+  it('accepts a normal filename', () => {
+    expect(isSafePathSegment('my-file_1.json')).toBe(true)
+  })
+
+  it('accepts unicode segments', () => {
+    expect(isSafePathSegment('キーボード設定')).toBe(true)
+  })
+})
+
+describe('isSafePackId', () => {
+  it('accepts a 64-character id', () => {
+    expect(isSafePackId('a'.repeat(64))).toBe(true)
+  })
+
+  it('rejects a 65-character id', () => {
+    expect(isSafePackId('a'.repeat(65))).toBe(false)
+  })
+
+  it('rejects an empty string', () => {
+    expect(isSafePackId('')).toBe(false)
+  })
+
+  it('rejects characters outside the allowlist', () => {
+    expect(isSafePackId('../evil')).toBe(false)
+    expect(isSafePackId('pack/id')).toBe(false)
+  })
+})
+
+describe('tsForFilename', () => {
+  it('replaces every colon with a hyphen', () => {
+    const date = new Date('2026-07-31T15:30:45.123Z')
+    expect(tsForFilename(date)).toBe('2026-07-31T15-30-45.123Z')
+  })
+
+  it('defaults to the current time when no argument is given', () => {
+    expect(tsForFilename()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d+Z$/)
+  })
+})
+
+describe('tsForExportFilename', () => {
+  it('strips colons, the sub-second fraction, and the T separator', () => {
+    const date = new Date('2026-07-31T15:30:45.123Z')
+    expect(tsForExportFilename(date)).toBe('2026-07-31-153045')
+  })
+
+  it('defaults to the current time when no argument is given', () => {
+    expect(tsForExportFilename()).toMatch(/^\d{4}-\d{2}-\d{2}-\d{6}$/)
+  })
+})
+
+describe('safeFilename', () => {
+  it('collapses unsafe characters to a single underscore', () => {
+    expect(safeFilename('my file!!name', 'fallback')).toBe('my_file_name')
+  })
+
+  it('falls back when the scrubbed result is empty', () => {
+    expect(safeFilename('!!!', 'fallback')).toBe('fallback')
+  })
+})

--- a/src/shared/utils/safe-filename.ts
+++ b/src/shared/utils/safe-filename.ts
@@ -15,11 +15,12 @@ export function safeFilename(name: string, fallback: string): string {
 
 // Path-safety helpers shared across the index-based main-process stores
 // (favorites, snapshots, analyze-filter, key-label, typing-test-text, run
-// logs). Several of those stores still carry their own verbatim copy of
-// `isSafePathSegment` — see
-// .claude/tasks/backlog/Task-store-path-helper-dedup.md for consolidating
-// them here too; new call sites should import from here rather than add
-// another copy.
+// logs). `isSafePathSegment` is the separator-denylist form used for uids,
+// runIds, and stored filenames; `isSafePackId` is a stricter allowlist for
+// i18n/theme pack ids. `hub-ipc.ts`'s own `isSafeExportFilename` is
+// deliberately kept separate rather than folded into `isSafePathSegment`:
+// it's an ASCII allowlist enforced at the Hub-upload boundary, a stricter
+// contract than the general path-safety check below.
 
 /** True when `segment` is safe to use as a single path segment (a uid,
  *  runId, or filename) — rejects empty, '.', '..', and anything
@@ -30,8 +31,21 @@ export function isSafePathSegment(segment: string): boolean {
   return !/[/\\]/.test(segment)
 }
 
+/** True when `id` is a safe i18n/theme pack id — UUID-like form. Rejects
+ *  anything that could escape the packs directory. */
+export function isSafePackId(id: string): boolean {
+  return /^[A-Za-z0-9_-]{1,64}$/.test(id)
+}
+
 /** ISO timestamp with colons replaced by `-`, safe to splice into a
  *  filename (`:` is reserved on Windows). Defaults to the current time. */
 export function tsForFilename(date: Date = new Date()): string {
   return date.toISOString().replace(/:/g, '-')
+}
+
+/** Compact ISO timestamp for export filenames — strips colons, the
+ *  sub-second fraction, and the `T` separator, e.g. `2026-07-31-153045`.
+ *  Defaults to the current time. */
+export function tsForExportFilename(date: Date = new Date()): string {
+  return date.toISOString().replace(/:/g, '').replace(/\.\d+Z$/, '').replace('T', '-')
 }


### PR DESCRIPTION
## Summary

Behavior-preserving consolidation of the store path-safety helpers onto `src/shared/utils/safe-filename.ts`:

- `isSafePathSegment` — six byte-identical per-store copies (favorites, snapshots, analyze filters, key labels, typing-test texts, pipette settings) deleted in favor of the shared export. A path-traversal predicate now has exactly one definition.
- `tsForFilename` — two named copies and four inline `toISOString().replace(/:/g,'-')` expressions replaced with the shared helper.
- `isSafePackId` — the two identical i18n/theme pack-store copies hoisted.
- New `tsForExportFilename` replaces three identical compact-timestamp expressions (two in the favorites store, one renderer-side in the JSON editor).
- `hub-ipc.ts`'s predicate is deliberately NOT consolidated: it is a stricter ASCII allowlist guarding filenames at the Hub-upload boundary, now renamed `isSafeExportFilename` with a comment stating the divergence is by design (a dedup must not loosen a security predicate).
- Stale comments updated (the "duplication is fine while there are only two index stores" rationale had long expired).

Deliberately untouched: `language-store.ts`'s `isSafeName` (missing `.`/`..` rejection — tightening is a behavior change tracked separately), snapshot-store's `sanitizeFilename` (different algorithm), the trivial `nowIso()` copies.

## Test plan

- New shared-module test file pins `isSafePathSegment` / `isSafePackId` / `tsForFilename` / `tsForExportFilename` semantics (17 cases)
- Path-rejection tests added for the four stores that previously had none
- Grep proofs: no residual local definitions of the consolidated helpers anywhere in `src/`
- Full suite: 354 files, 8018 passed (+22 new, zero regressions)