### PR TITLE
refactor(ui): split KeymapEditor into rewrite and pack-tab modules

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1,91 +1,77 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useCallback, useEffect, useMemo, useRef, useState, useImperativeHandle, forwardRef } from 'react'
+import { useCallback, useEffect, useRef, useImperativeHandle, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
 import { useTileContentOverride } from '../../hooks/useTileContentOverride'
-import { KeycodesOverlayPanel } from './KeycodesOverlayPanel'
 import { ViewMatrixPanel } from './ViewMatrixPanel'
-import { ZoomIn, ZoomOut, SlidersHorizontal } from 'lucide-react'
-import { ICON_SM, ICON_MD, BTN_PRIMARY_FOOTER } from '../../constants/ui-tokens'
 
 // Extracted modules
 import type { KeymapEditorProps as Props } from './keymap-editor-types'
-import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH, EMPTY_REMAPPED } from './keymap-editor-types'
+import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 export type { KeymapEditorHandle } from './keymap-editor-types'
-import { KeyboardPane } from './KeyboardPane'
-import { LayerListPanel } from './LayerListPanel'
-import { ScaleInput, ghostZoomButtonClass, KeymapToolbar } from './keymap-editor-toolbar'
+import { KeymapToolbar, ViewMatrixZoomRow, useKeymapTabFooter } from './keymap-editor-toolbar'
 import { PopoverForState, popoverInstanceKey } from './keymap-editor-popover'
-import { Tooltip } from '../ui/Tooltip'
 import { useInputModes } from './useInputModes'
 import { useKeymapMultiSelect } from './useKeymapMultiSelect'
 import { useLayoutOptionsPanel } from './useLayoutOptionsPanel'
 import { useKeymapSelectionHandlers } from './useKeymapSelectionHandlers'
 import { useKeymapHistory } from './useKeymapHistory'
-import type { SingleHistoryEntry } from './useKeymapHistory'
 import { useKeyFlash } from './useKeyFlash'
-import { rewriteNumericKeycode } from '../../../shared/keymap/keymap-apply'
-import type { KeymapRewriteTable } from '../../../shared/keymap/keymap-apply'
-import type { KeymapApplyResult } from './keymap-editor-types'
 import { useAppConfig } from '../../hooks/useAppConfig'
-import { TypingTestPane } from './TypingTestPane'
+import { KeymapTypingTestPane } from './KeymapTypingTestPane'
 import { useLayoutPicker } from './useLayoutPicker'
 import { useKeymapJsonEditors } from './useKeymapJsonEditors'
 import { useViewMatrixEditing } from './useViewMatrixEditing'
 import { KeymapEditorModals } from './KeymapEditorModals'
 import { useLayerKeycodes } from './use-layer-keycodes'
-import { KeymapPackTabs, type KeymapPackTab } from './KeymapPackTabs'
-import { KeymapApplyConfirmModal } from '../key-labels/KeymapApplyConfirmModal'
+import { useKeymapRewrite } from './use-keymap-rewrite'
+import { useKeymapPackTabs } from './use-keymap-pack-tabs'
+import { KeymapPickerRegion } from './KeymapPickerRegion'
+import { KeymapPrimaryPane } from './KeymapPrimaryPane'
 
-export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEditorHandle, Props>(function KeymapEditor({
-  keyboardUid, layout, layers, currentLayer, onLayerChange, keymap, encoderLayout, encoderCount,
-  layoutOptions, layoutLabels, packedLayoutOptions, onSetLayoutOptions,
-  remapLabel, isRemapped, remapKind, pickerRemapLabel, onSetKey, onSetKeysBulk, onSetEncoder,
-  rows, cols, getMatrixState, unlocked, onUnlock,
-  tapDanceEntries, onSetTapDanceEntry,
-  macroCount, macroBufferSize, macroBuffer, vialProtocol, parsedMacros, onSaveMacros,
-  tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported,
-  autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
-  supportedQsids, qmkSettingsGet, qmkSettingsSet, qmkSettingsReset, onSettingsUpdate,
-  autoAdvance = true, onAutoAdvanceChange, viewMatrix, onViewMatrixChange,
-  basicViewType, onBasicViewTypeChange, splitKeyMode, onSplitKeyModeChange,
-  quickSelect, onQuickSelectChange, keyboardLayout = 'qwerty', onKeyboardLayoutChange: _onKeyboardLayoutChange,
-  keymapPackName, onRequestKeymapApply,
-  keymapApplyOpen, keymapApplyLabelName, keymapApplyBusy, onKeymapApplyConfirm, onKeymapApplyCancel, keymapApplyError,
-  onLock, onMatrixModeChange, onOpenLighting,
-  comboEntries, onOpenCombo, onSetComboEntry,
-  keyOverrideEntries, onOpenKeyOverride, onSetKeyOverrideEntry,
-  altRepeatKeyEntries, onOpenAltRepeatKey, onSetAltRepeatKeyEntry,
-  toolsExtra, dataPanel, onOverlayOpen,
-  layerNames, onSetLayerName,
-  layerPanelOpen: layerPanelOpenProp, onLayerPanelOpenChange,
-  scale: scaleProp = 1, onScaleChange,
-  keyEditorZoom, onKeyEditorZoomChange,
-  typingTestMode, onTypingTestModeChange, onSaveTypingTestResult, onRenameTypingTestResult, onDeleteTypingTestResult, typingTestHistory,
-  typingTestConfig: savedTypingTestConfig, typingTestMonkeytypeConfig, typingTestLanguage: savedTypingTestLanguage,
-  onTypingTestConfigChange, onTypingTestLanguageChange,
-  typingTestViewOnly, onTypingTestViewOnlyChange,
-  typingTestViewOnlyWindowSize, onTypingTestViewOnlyWindowSizeChange,
-  typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
-  typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
-  typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
-  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestSaveUnnamed = true, typingTestComparisonBaselines, onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestSaveUnnamedChange, onTypingTestComparisonBaselineChange,
-  typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
-  typingRecordEnabled, onTypingRecordEnabledChange, onRecKeystroke,
-  typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
-  typingHeatmapWindowMin, onTypingHeatmapWindowMinChange,
-  typingMonitorAppEnabled, onTypingMonitorAppEnabledChange,
-  typingTrayResident, onTypingTrayResidentChange, typingStartInTray, onTypingStartInTrayChange,
-  typingViewMenuTab, onTypingViewMenuTabChange,
-  onViewAnalytics, onTypingTestRunningChange,
-  timelineHandoff,
-  tappingTermMs,
-  deviceName, isDummy, onExportLayoutPdfAll, onExportLayoutPdfCurrent,
-  favHubOrigin, favHubNeedsDisplayName, favHubUploading, favHubUploadResult,
-  onFavUploadToHub, onFavUpdateOnHub, onFavRemoveFromHub, onFavRenameOnHub,
-  devices, connectedDevice, onDeviceListActiveChange,
-}, ref) {
+export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEditorHandle, Props>(function KeymapEditor(props, ref) {
+  // Kept as a whole object (not just destructured) so the typing-test
+  // surface below can forward it wholesale to `KeymapTypingTestPane` via
+  // `{...props}` — most of that pane's props are plain pass-through from
+  // here, and only a handful of runtime-computed values need to be listed
+  // explicitly at that call site (see the comment there).
+  const {
+    keyboardUid, layout, layers, currentLayer, onLayerChange, keymap, encoderLayout, encoderCount,
+    layoutOptions, layoutLabels, packedLayoutOptions, onSetLayoutOptions,
+    remapLabel, isRemapped, remapKind, pickerRemapLabel, onSetKey, onSetKeysBulk, onSetEncoder,
+    rows, cols, getMatrixState, unlocked, onUnlock,
+    tapDanceEntries, onSetTapDanceEntry,
+    macroCount, macroBufferSize, macroBuffer, vialProtocol, parsedMacros, onSaveMacros,
+    tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported,
+    autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
+    supportedQsids, qmkSettingsGet, qmkSettingsSet, qmkSettingsReset, onSettingsUpdate,
+    autoAdvance = true, viewMatrix, onViewMatrixChange,
+    basicViewType, splitKeyMode,
+    quickSelect, keyboardLayout = 'qwerty',
+    keymapPackName, onRequestKeymapApply,
+    keymapApplyOpen, keymapApplyLabelName, keymapApplyBusy, onKeymapApplyConfirm, onKeymapApplyCancel, keymapApplyError,
+    onMatrixModeChange, onOpenLighting,
+    comboEntries, onOpenCombo, onSetComboEntry,
+    keyOverrideEntries, onOpenKeyOverride, onSetKeyOverrideEntry,
+    altRepeatKeyEntries, onOpenAltRepeatKey, onSetAltRepeatKeyEntry,
+    layerNames,
+    layerPanelOpen: layerPanelOpenProp, onLayerPanelOpenChange,
+    scale: scaleProp = 1, onScaleChange,
+    typingTestMode, onTypingTestModeChange, onSaveTypingTestResult, onRenameTypingTestResult, typingTestHistory,
+    typingTestConfig: savedTypingTestConfig, typingTestLanguage: savedTypingTestLanguage,
+    onTypingTestConfigChange, onTypingTestLanguageChange,
+    typingTestViewOnly,
+    typingTestMemory: savedTypingTestMemory, onTypingTestMemoryChange,
+    typingTestSaveUnnamed = true,
+    typingRecordEnabled, onRecKeystroke,
+    typingRecordingConsentAccepted,
+    onTypingTestRunningChange,
+    tappingTermMs,
+    deviceName, isDummy,
+    favHubOrigin, favHubNeedsDisplayName, favHubUploading, favHubUploadResult,
+    onFavUploadToHub, onFavUpdateOnHub, onFavRemoveFromHub, onFavRenameOnHub,
+    devices, connectedDevice, onDeviceListActiveChange,
+  } = props
   const { t } = useTranslation()
   const keyboardContentRef = useRef<HTMLDivElement>(null)
 
@@ -169,61 +155,6 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     matrixMode, handleMatrixToggle, handleDeselect, handleKeycodeSelect,
   })
 
-  // --- Simulation/Base tab (Plan-qwerty-select-no-rewrite v7 — シミュレー
-  // ションタブ方式). Local to this component: which of the two vertical
-  // tabs (pack-name simulation vs. the real "Base" keymap) is showing when
-  // `remapKind === 'simulated'` shows them at all — see `showPackTabs`
-  // below. Defaults to the simulation tab; a user switch to Base persists
-  // only until the next uid change (see the reset in the effect below), not
-  // across a select change or a re-render. ---
-  const [packTab, setPackTab] = useState<KeymapPackTab>('pack')
-  // Switching TO the simulation tab also drops any live selection/multi-
-  // select/picker-selection state — belt-and-braces on top of that pane's
-  // own `readOnly` (which already blocks every click/dblclick path into
-  // it): without this, a key selected on Base right before switching tabs
-  // would stay selected in the (invisible) shared selection state, and a
-  // picker click while viewing the simulation tab would still paste into
-  // it. handleDeselect is defined further below (useKeymapSelectionHandlers)
-  // but is stable across renders, so referencing it from this callback
-  // (declared after) is safe — see its own useCallback deps.
-  const handlePackTabChange = useCallback((tab: KeymapPackTab) => {
-    setPackTab(tab)
-    if (tab === 'pack') handleDeselect()
-  }, [handleDeselect])
-
-  // Clear history and exit View Matrix mode on keyboard/context switch or disconnect
-  const prevUidRef = useRef(keyboardUid)
-  const keymapSize = keymap.size
-  useEffect(() => {
-    if (keyboardUid !== prevUidRef.current || keymapSize === 0) {
-      prevUidRef.current = keyboardUid
-      history.clear()
-      viewMatrixMode.exit()
-      setPackTab('pack')
-    }
-  }, [keyboardUid, keymapSize, history.clear, viewMatrixMode.exit])
-
-  // Reset to the simulation tab whenever the selected Key Label / layout
-  // changes (the footer's Keyboard Layout select — `keyboardLayout` here is
-  // the exact same value `useDevicePrefs.layout` feeds into `remapKind`'s
-  // own derivation). Without this, a user parked on the Base tab who then
-  // picks a different pack sees no visible change: the newly selected
-  // pack's simulated keymap only ever renders on the pack tab, and
-  // `remapKind` alone can't signal the switch since it stays `'simulated'`
-  // across two different permutation packs. Same prev-value-ref idiom as
-  // the uid reset above (own ref, not folded into it — that effect also
-  // clears history/View Matrix, which a same-uid layout change must not
-  // trigger) — only acts on an actual change, not on mount or every
-  // render, so a manual tab click right after a layout change isn't
-  // immediately undone by a stray re-render.
-  const prevKeyboardLayoutRef = useRef(keyboardLayout)
-  useEffect(() => {
-    if (keyboardLayout !== prevKeyboardLayoutRef.current) {
-      prevKeyboardLayoutRef.current = keyboardLayout
-      setPackTab('pack')
-    }
-  }, [keyboardLayout])
-
   // Surface the editor test's run state so the host can disable the
   // StatusBar "View Analytics" button mid-run (it lives in the footer, not
   // this component). False whenever the test isn't running or mode is off.
@@ -262,128 +193,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   // --- Key Label "apply to keymap" bulk rewrite (Plan-key-label-keymap-apply
   // Phase 3). Reachable from the footer's layout select via the imperative
   // handle below, so the write lands on this same `history` instance
-  // instead of a second undo stack. Writes go through `onSetKey` /
-  // `onSetEncoder` sequentially (not `onSetKeysBulk`) so a mid-way failure
-  // leaves both the local keymap state and the pushed history entry
-  // containing only the positions that actually succeeded.
-  //
-  // Same "ref mirrors the latest prop for use inside a stable callback"
-  // idiom as `hasActiveSingleSelectionRef` above: `keymap`/`encoderLayout`
-  // are re-read fresh from these refs before every single write below, so a
-  // concurrent edit that lands on a position between two `await`s (or
-  // during a re-render triggered by one of this function's own writes) is
-  // detected instead of silently clobbered.
-  const keymapRef = useRef(keymap)
-  keymapRef.current = keymap
-  const encoderLayoutRef = useRef(encoderLayout)
-  encoderLayoutRef.current = encoderLayout
-  const isApplyingRewriteRef = useRef(false)
-  // Belt-and-braces unmount guard: the editor-footer Analyze button can open
-  // AnalyzePage (unmounting this component) while a rewrite's sequential
-  // `await`ed device writes are still in flight — the caller-side guard in
-  // App.tsx disables that button while a rewrite is running, but this ref
-  // is the last line of defense so a rewrite already past that guard still
-  // stops cleanly instead of pushing history / firing callbacks / setting
-  // state on an unmounted component.
-  const isMountedRef = useRef(true)
-  useEffect(() => {
-    isMountedRef.current = true
-    return () => { isMountedRef.current = false }
-  }, [])
-
-  const applyKeymapRewrite = useCallback(async (
-    table: KeymapRewriteTable,
-  ): Promise<KeymapApplyResult> => {
-    // Re-entrancy guard: a double Apply click (or any other concurrent
-    // caller) must never interleave two rewrite passes against the same
-    // undo stack. No-op rather than throwing — the in-flight call already
-    // owns the operation.
-    if (isApplyingRewriteRef.current) return { appliedCount: 0 }
-    isApplyingRewriteRef.current = true
-
-    try {
-      const keyChanges: { layer: number; row: number; col: number; oldKeycode: number; newKeycode: number }[] = []
-      for (const [posKey, code] of keymap) {
-        const newKeycode = rewriteNumericKeycode(code, table)
-        if (newKeycode === code) continue
-        const [layer, row, col] = posKey.split(',').map(Number)
-        keyChanges.push({ layer, row, col, oldKeycode: code, newKeycode })
-      }
-      const encoderChanges: { layer: number; idx: number; dir: number; oldKeycode: number; newKeycode: number }[] = []
-      for (const [posKey, code] of encoderLayout) {
-        const newKeycode = rewriteNumericKeycode(code, table)
-        if (newKeycode === code) continue
-        const [layer, idx, dir] = posKey.split(',').map(Number)
-        encoderChanges.push({ layer, idx, dir, oldKeycode: code, newKeycode })
-      }
-
-      const applied: SingleHistoryEntry[] = []
-      let error: string | undefined
-      try {
-        for (const c of keyChanges) {
-          // Stop immediately once the component has unmounted (e.g. the
-          // Analyze button navigated away mid-rewrite) — no further writes.
-          if (!isMountedRef.current) break
-          // Freshness check: skip this position if a concurrent edit
-          // already moved it away from the value this rewrite was
-          // computed against, instead of overwriting whatever that edit
-          // just wrote.
-          const current = keymapRef.current.get(`${c.layer},${c.row},${c.col}`) ?? 0
-          if (current !== c.oldKeycode) continue
-          await onSetKey(c.layer, c.row, c.col, c.newKeycode)
-          applied.push({ kind: 'key', layer: c.layer, row: c.row, col: c.col, oldKeycode: c.oldKeycode, newKeycode: c.newKeycode })
-        }
-        for (const c of encoderChanges) {
-          if (!isMountedRef.current) break
-          const current = encoderLayoutRef.current.get(`${c.layer},${c.idx},${c.dir}`) ?? 0
-          if (current !== c.oldKeycode) continue
-          await onSetEncoder(c.layer, c.idx, c.dir, c.newKeycode)
-          applied.push({ kind: 'encoder', layer: c.layer, idx: c.idx, dir: c.dir as 0 | 1, oldKeycode: c.oldKeycode, newKeycode: c.newKeycode })
-        }
-      } catch (err) {
-        error = err instanceof Error ? err.message : String(err)
-      }
-
-      // Unmounted mid-rewrite: skip ALL bookkeeping below (history clear,
-      // post-apply flash state/timer) — the component is gone, so there is
-      // nothing left to flash and no history stack of this instance to
-      // touch. The device is left mid-rewrite exactly like a
-      // partial-failure apply; the counts are still returned to the caller
-      // for its own error surfacing.
-      //
-      // Rewrite is a destructive one-shot (Plan-qwerty-select-no-rewrite v5
-      // 最終仕様), same class of operation as a snapshot/.vil restore: the
-      // moment ANY write actually landed, both undo/redo stacks are wiped
-      // rather than gaining a revertible batch entry — no history entry is
-      // ever pushed for a rewrite, success or partial failure alike.
-      // Recovery from a bad or partial rewrite is the user's own
-      // .vil/snapshot backup (the confirm modal recommends saving before
-      // applying), not Undo. A rewrite that touched nothing (table matched
-      // no live keycode, or the very first write itself failed) leaves
-      // history untouched — nothing was destroyed, so there's nothing to
-      // protect the user from.
-      //
-      // This clear fires on ANY landed write, including a partial failure —
-      // it is unconditional on `error`. The OTHER half of the destructive
-      // one-shot contract — resetting the footer's select back to QWERTY —
-      // lives one layer up, in `useKeymapApplyPrompt.handleApplyConfirm`,
-      // and fires ONLY on a clean (error-free) success; a partial failure
-      // leaves the select untouched there. Shared invariant: a rewrite
-      // leaves no undo trail; only a clean success returns the select to
-      // QWERTY.
-      if (applied.length > 0 && isMountedRef.current) {
-        history.clear()
-        // Flash the rewritten positions (see `useKeyFlash`) — only for a
-        // clean, error-free pass. A partial failure leaves the keymap
-        // mixed, which isn't the "here's what changed" story this visual
-        // is telling.
-        if (error === undefined) triggerFlash(applied)
-      }
-      return { appliedCount: applied.length, error }
-    } finally {
-      isApplyingRewriteRef.current = false
-    }
-  }, [keymap, encoderLayout, onSetKey, onSetEncoder, history, triggerFlash])
+  // instead of a second undo stack. See `useKeymapRewrite` for the full
+  // destructive-one-shot / freshness-check / unmount-guard contract.
+  const { applyKeymapRewrite } = useKeymapRewrite({
+    keymap, encoderLayout, onSetKey, onSetEncoder, history, triggerFlash,
+  })
 
   useImperativeHandle(ref, () => ({
     toggleMatrix: handleMatrixToggle, toggleTypingTest: handleTypingTestToggle,
@@ -404,49 +218,34 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     typingTestMode, typingTestEffectiveLayer: typingTest.effectiveLayer,
   })
 
-  // FIX C (external review): a keymap must actually be loaded for a
-  // Rewrite to mean anything — `useKeymapApplyPrompt.requestApply` already
-  // no-ops when `keymapEditable` is false (App.tsx passes `keyboard.keymap
-  // .size > 0` into that hook), but nothing here previously folded that
-  // into tab/button VISIBILITY, so a permutation pack could show a
-  // tabs+Apply UI that silently did nothing when clicked. Derived straight
-  // from this component's own `keymap` prop — the exact same `Map` App.tsx
-  // reads `.size` off of for the hook — rather than a second prop that
-  // could drift out of sync with it.
-  const keymapEditable = keymap.size > 0
-
-  // SINGLE PREDICATE (Plan-qwerty-select-no-rewrite v7): `remapKind` is
-  // ALREADY the unified "does the active pack want a keymap rewrite"
-  // signal (see `useDevicePrefs.ts` — it's gated on `keymapApplicable &&
-  // buildKeymapRewriteTable(map).ok`, not `.ok` alone); combined with
-  // `keymapEditable` above, this is the SAME condition `requestApply`
-  // itself requires, so tab AND Apply-button visibility (the button only
-  // ever renders nested inside the tabs branch below, never standalone)
-  // both collapse onto this one boolean rather than needing separate
-  // checks that could disagree. Suppressed during typing test / View
-  // Matrix mode too, neither of which has a concept of a second (Base)
-  // keymap surface to switch to.
-  const showPackTabs = remapKind === 'simulated' && keymapEditable && !typingTestMode && !viewMatrixMode.active
-  // True exactly while the visible pane is the read-only simulation tab —
-  // gates both `KeyboardPane`'s own `readOnly` and every picker edit path
-  // (TabbedKeycodes/tabContentOverride below), belt-and-braces on top of
-  // `handlePackTabChange` already clearing any live selection when this
-  // becomes true.
-  const packTabReadOnly = showPackTabs && packTab === 'pack'
-
-  // Raw (never remapped) keycodes for the Base tab — same underlying
-  // keymap/macro data as `layerKeycodes` above, built with `remapLabel`/
-  // `isRemapped` omitted so `useLayerKeycodes` falls back to identity (see
-  // its own `remap`/`checkRemapped` defaults). `enabled` skips the whole
-  // O(keymap size) build (and the duplicate macro parse) whenever this
-  // instance's output isn't actually being shown — tabs hidden, or the
-  // simulation tab active — rather than paying for it every render.
-  const { layerKeycodes: baseLayerKeycodes, layerEncoderKeycodes: baseLayerEncoderKeycodes } = useLayerKeycodes({
+  // --- Simulation/Base tab (Plan-qwerty-select-no-rewrite v7). See
+  // `useKeymapPackTabs` for the full tab-visibility / read-only / Base-tab
+  // raw-data contract. ---
+  const {
+    packTab, showPackTabs, packTabReadOnly,
+    primaryKeycodes, primaryEncoderKeycodes, primaryRemappedKeys, primaryRemappedEncoders, primaryRemapLabel,
+    handlePackTabChange, resetPackTab,
+  } = useKeymapPackTabs({
+    keyboardLayout, remapKind, keymap, encoderLayout, encoderCount, currentLayer,
+    typingTestMode, viewMatrixActive: viewMatrixMode.active, handleDeselect,
     parsedMacros, macroBuffer, macroCount, vialProtocol, tapDanceEntries,
-    keymap, encoderLayout, encoderCount, currentLayer,
-    typingTestMode: false, typingTestEffectiveLayer: 0,
-    enabled: showPackTabs && packTab === 'base',
+    remapLabel, layerKeycodes, layerEncoderKeycodes, remappedKeys, layerEncoderRemapped,
   })
+
+  // Clear history and exit View Matrix mode on keyboard/context switch or
+  // disconnect — kept in this component (rather than folded into
+  // `useKeymapPackTabs`) because it also owns `history`/`viewMatrixMode`,
+  // not just the pack tab.
+  const prevUidRef = useRef(keyboardUid)
+  const keymapSize = keymap.size
+  useEffect(() => {
+    if (keyboardUid !== prevUidRef.current || keymapSize === 0) {
+      prevUidRef.current = keyboardUid
+      history.clear()
+      viewMatrixMode.exit()
+      resetPackTab()
+    }
+  }, [keyboardUid, keymapSize, history.clear, viewMatrixMode.exit, resetPackTab])
 
   // --- Layout picker (device browse / file browse / probe / keyboard view) ---
   // The Keyboard tab's keyboard-as-picker (`LayoutPickerContent`'s
@@ -469,36 +268,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   })
 
   // --- Tab footer ---
-  const tabFooterContent = useMemo(() => {
-    const btnClass = 'rounded border border-edge px-3 py-1 text-xs text-content-secondary hover:text-content hover:bg-surface-dim'
-    const buttonDefs = [
-      { tab: 'tapDance', key: 'tdJsonEditor', label: t('editor.tapDance.editJson'), onClick: tdJson.open, testId: 'tap-dance-json-editor-btn', enabled: !!tapDanceEntries && tapDanceEntries.length > 0 },
-      { tab: 'tapDance', key: 'tapHold', label: t('editor.keymap.tapHoldLabel'), onClick: () => openSettings('tapHold'), testId: 'tap-hold-settings-btn', enabled: tapHoldSupported },
-      { tab: 'system', key: 'mouseKeys', label: t('editor.keymap.mouseKeysLabel'), onClick: () => openSettings('mouseKeys'), testId: 'mouse-keys-settings-btn', enabled: mouseKeysSupported },
-      { tab: 'modifiers', key: 'graveEscape', label: t('editor.keymap.graveEscapeLabel'), onClick: () => openSettings('graveEscape'), testId: 'grave-escape-settings-btn', enabled: graveEscapeSupported },
-      { tab: 'modifiers', key: 'oneShotKeys', label: t('editor.keymap.oneShotKeysLabel'), onClick: () => openSettings('oneShotKeys'), testId: 'one-shot-keys-settings-btn', enabled: oneShotKeysSupported },
-      { tab: 'behavior', key: 'magic', label: t('editor.keymap.magicLabel'), onClick: () => openSettings('magic'), testId: 'magic-settings-btn', enabled: magicSupported },
-      { tab: 'behavior', key: 'autoshift', label: t('editor.keymap.autoShiftLabel'), onClick: () => openSettings('autoShift'), testId: 'auto-shift-settings-btn', enabled: autoShiftSupported },
-      { tab: 'macro', key: 'macroJsonEditor', label: t('editor.tapDance.editJson'), onClick: macroJson.openGated, testId: 'macro-json-editor-btn', enabled: !!deserializedMacros && deserializedMacros.length > 0 },
-      { tab: 'combo', key: 'comboJsonEditor', label: t('editor.tapDance.editJson'), onClick: comboJson.open, testId: 'combo-json-editor-btn', enabled: !!comboEntries && comboEntries.length > 0 },
-      { tab: 'combo', key: 'combo', label: t('common.configuration'), onClick: () => openSettings('combo'), testId: 'combo-settings-btn', enabled: comboSettingsSupported },
-      { tab: 'keyOverride', key: 'koJsonEditor', label: t('editor.tapDance.editJson'), onClick: koJson.open, testId: 'ko-json-editor-btn', enabled: !!keyOverrideEntries && keyOverrideEntries.length > 0 },
-      { tab: 'altRepeatKey', key: 'arkJsonEditor', label: t('editor.tapDance.editJson'), onClick: arkJson.open, testId: 'ark-json-editor-btn', enabled: !!altRepeatKeyEntries && altRepeatKeyEntries.length > 0 },
-      { tab: 'lighting', key: 'lighting', label: t('common.configuration'), onClick: onOpenLighting, testId: 'lighting-settings-btn', enabled: !!onOpenLighting },
-    ]
-    const content: Record<string, React.ReactNode> = {}
-    const grouped = new Map<string, typeof buttonDefs>()
-    for (const def of buttonDefs) { if (!def.enabled) continue; const existing = grouped.get(def.tab); if (existing) existing.push(def); else grouped.set(def.tab, [def]) }
-    for (const [tab, defs] of grouped) {
-      content[tab] = (
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-content-secondary/70">{t('common.settingsLabel')}</span>
-          {defs.map((d) => (<button key={d.key} type="button" className={btnClass} onClick={d.onClick} data-testid={d.testId}>{d.label}</button>))}
-        </div>
-      )
-    }
-    return content
-  }, [tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros, tapHoldSupported, mouseKeysSupported, magicSupported, autoShiftSupported, graveEscapeSupported, oneShotKeysSupported, comboSettingsSupported, onOpenLighting, t, openSettings, tdJson.open, comboJson.open, koJson.open, arkJson.open, macroJson.openGated])
+  const tabFooterContent = useKeymapTabFooter({
+    tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros,
+    tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported, autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
+    onOpenLighting, openSettings, tdJson, comboJson, koJson, arkJson, macroJson,
+  })
 
   const tabContentOverride = useTileContentOverride({
     tapDanceEntries,
@@ -514,42 +288,9 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
 
   if (!layout) return <div className="p-4 text-content-muted">{t('common.loading')}</div>
 
-  const applyButtonNode = onRequestKeymapApply ? (
-    <span className="flex items-center gap-2">
-      <button
-        type="button"
-        className={BTN_PRIMARY_FOOTER}
-        onClick={onRequestKeymapApply}
-        disabled={!!keymapApplyBusy}
-        data-testid="keymap-pack-apply-button"
-      >
-        {t('common.apply')}
-      </button>
-      {keymapApplyError && (
-        <span className="text-xs text-danger" data-testid="keymap-apply-error">
-          {t('keyLabels.keymapApply.errorPartial')}
-        </span>
-      )}
-    </span>
-  ) : undefined
-
   function layerLabel(layer: number): string {
     return layerNames?.[layer] || t('editor.keymap.layerN', { n: layer })
   }
-
-  // Base tab's data source (Plan-qwerty-select-no-rewrite v7): the SAME
-  // "no tabs" `<KeyboardPane>` JSX below renders both the plain (no-tabs)
-  // state and `showPackTabs && packTab === 'base'` — only these source
-  // variables differ between the two. Raw/identity (`baseLayer*`,
-  // `EMPTY_REMAPPED`, `undefined` remapLabel) while on the Base tab;
-  // otherwise the normal `remapLabel`/`isRemapped`-driven values every
-  // other state (JIS, QWERTY, View Matrix, ...) already used.
-  const onBaseTab = showPackTabs && packTab === 'base'
-  const primaryKeycodes = onBaseTab ? baseLayerKeycodes : layerKeycodes
-  const primaryEncoderKeycodes = onBaseTab ? baseLayerEncoderKeycodes : layerEncoderKeycodes
-  const primaryRemappedKeys = onBaseTab ? EMPTY_REMAPPED : remappedKeys
-  const primaryRemappedEncoders = onBaseTab ? EMPTY_REMAPPED : layerEncoderRemapped
-  const primaryRemapLabel = onBaseTab ? undefined : remapLabel
 
   return (
     <div className={`flex min-h-0 flex-1 flex-col ${typingTestMode && typingTestViewOnly ? '' : 'gap-3'}`}>
@@ -617,73 +358,34 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           }${remapKind === 'simulated' && (!showPackTabs || packTab === 'pack') ? ' remap-simulated' : ''}`}
         >
           {typingTestMode ? (
-            <TypingTestPane
+            // Forwards the full `props` object; only the values genuinely
+            // computed HERE at render time are listed explicitly (see
+            // `KeymapTypingTestPane` for which fields are plain
+            // `KeymapEditorProps` pass-throughs). `layoutOptions`, `scale`,
+            // and `typingTestSaveUnnamed` all override the raw spread value
+            // with the already-effective/defaulted local instead.
+            <KeymapTypingTestPane
+              {...props}
               typingTest={typingTest}
               onConfigChange={handleTypingTestConfigChange}
-              monkeytypeConfig={typingTestMonkeytypeConfig}
               onLanguageChange={handleTypingTestLanguageChange}
-              layers={layers}
-              layerNames={layerNames}
-              typingTestHistory={typingTestHistory}
-              onRenameTypingTestResult={onRenameTypingTestResult}
-              onDeleteTypingTestResult={onDeleteTypingTestResult}
-              deviceName={deviceName}
               pressedKeys={pressedKeys}
               keycodes={typingTestKeycodes}
               encoderKeycodes={typingTestEncoderKeycodes}
               remappedKeys={typingTestRemapped}
               remappedEncoders={typingTestEncoderRemapped}
-              remapLabel={remapLabel}
               layoutOptions={effectiveLayoutOptions}
               scale={scaleProp}
+              typingTestSaveUnnamed={typingTestSaveUnnamed}
               keys={layout.keys}
               layerLabel={layerLabel(typingTest.effectiveLayer)}
               contentRef={keyboardContentRef}
               hasSavedMemory={!!savedTypingTestMemory}
-              displayLines={typingTestDisplayLines}
-              fontSize={typingTestFontSize}
-              onDisplayLinesChange={onTypingTestDisplayLinesChange}
-              onFontSizeChange={onTypingTestFontSizeChange}
-              hideKeymap={typingTestHideKeymap}
-              hideStatsRow={typingTestHideStatsRow}
-              hideControls={typingTestHideControls}
-              saveUnnamed={typingTestSaveUnnamed}
               finishedResult={finishedResult}
               onNameFinishedResult={nameFinishedResult}
-              comparisonBaselines={typingTestComparisonBaselines}
-              onToggleHideKeymap={onTypingTestHideKeymapChange}
-              onToggleHideStatsRow={onTypingTestHideStatsRowChange}
-              onToggleHideControls={onTypingTestHideControlsChange}
-              onToggleSaveUnnamed={onTypingTestSaveUnnamedChange}
-              onComparisonBaselineChange={onTypingTestComparisonBaselineChange}
-              settingsPanelOpen={typingTestSettingsPanelOpen}
-              onToggleSettingsPanel={onTypingTestSettingsPanelOpenChange}
               onPauseTest={pauseTypingTest}
               onResumeTest={resumeTypingTest}
               onRestartTestFromStart={restartTypingTestFromStart}
-              viewOnly={typingTestViewOnly}
-              onViewOnlyChange={onTypingTestViewOnlyChange}
-              viewOnlyWindowSize={typingTestViewOnlyWindowSize}
-              onViewOnlyWindowSizeChange={onTypingTestViewOnlyWindowSizeChange}
-              viewOnlyAlwaysOnTop={typingTestViewOnlyAlwaysOnTop}
-              onViewOnlyAlwaysOnTopChange={onTypingTestViewOnlyAlwaysOnTopChange}
-              recordEnabled={typingRecordEnabled}
-              onRecordEnabledChange={onTypingRecordEnabledChange}
-              recordingConsentAccepted={typingRecordingConsentAccepted}
-              onRecordingConsentAccepted={onTypingRecordingConsentAccepted}
-              heatmapWindowMin={typingHeatmapWindowMin}
-              onHeatmapWindowMinChange={onTypingHeatmapWindowMinChange}
-              monitorAppEnabled={typingMonitorAppEnabled}
-              onMonitorAppEnabledChange={onTypingMonitorAppEnabledChange}
-              trayResident={typingTrayResident}
-              onTrayResidentChange={onTypingTrayResidentChange}
-              startInTray={typingStartInTray}
-              onStartInTrayChange={onTypingStartInTrayChange}
-              menuTab={typingViewMenuTab}
-              onMenuTabChange={onTypingViewMenuTabChange}
-              onViewAnalytics={onViewAnalytics}
-              keyboardUid={keyboardUid}
-              timelineHandoff={timelineHandoff}
             />
           ) : (
             <>
@@ -691,92 +393,35 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
                   the vertical tab strip sits to the RIGHT of the keymap
                   pane, attached flush to its edge (index/sticky-note style
                   — see `KeymapPackTabs`). The wrapping `flex items-stretch`
-                  div with no gap is what keeps the strip touching the pane
-                  regardless of this row's own `gap-4` (which only spaces
-                  this pane+tabs unit from its own siblings, e.g. the
-                  overlay-panel spacer). View Matrix mode is excluded from
-                  `showPackTabs` above, so it can never overlap with either
-                  tab. */}
-              <div className="flex items-stretch">
-                {showPackTabs && packTab === 'pack' ? (
-                  // Simulation pane: display data only — no selection props,
-                  // no click/double-click/deselect handlers at all. `readOnly`
-                  // (always `true` here, not a ternary) already makes
-                  // `KeyboardWidget` null out every handler it's given
-                  // regardless, and `KeyboardPane`'s own deselect-on-
-                  // background-click checks `!readOnly` too — omitting the
-                  // handlers here as well means read-only holds by
-                  // construction, not by three separate `packTab === 'pack'`
-                  // checks that could drift out of sync.
-                  <KeyboardPane
-                    paneId="primary" isActive={true}
-                    keys={layout.keys} keycodes={layerKeycodes} encoderKeycodes={layerEncoderKeycodes}
-                    selectedKey={null} selectedEncoder={null} selectedMaskPart={false} selectedKeycode={null}
-                    pressedKeys={matrixMode ? pressedKeys : undefined} everPressedKeys={matrixMode ? everPressedKeys : undefined}
-                    remappedKeys={remappedKeys} remappedEncoders={layerEncoderRemapped}
-                    layoutOptions={effectiveLayoutOptions} scale={scaleProp}
-                    remapLabel={remapLabel}
-                    layerLabel={layerLabel(currentLayer)} layerLabelTestId="layer-label"
-                    preview
-                    footerExtra={applyButtonNode}
-                    readOnly
-                    contentRef={keyboardContentRef}
-                  />
-                ) : (
-                  // Also the "no tabs" pane (JIS/QWERTY/typing-test-adjacent
-                  // states) — the `showPackTabs && packTab === 'base'`
-                  // case reuses this exact block rather than a second copy,
-                  // swapping only the keycode/remap source variables below
-                  // (`primaryKeycodes` etc.) for the Base tab's raw data.
-                  <KeyboardPane
-                    paneId="primary" isActive={true}              keys={layout.keys} keycodes={primaryKeycodes} encoderKeycodes={primaryEncoderKeycodes}
-                    selectedKey={selectedKey} selectedEncoder={selectedEncoder} selectedMaskPart={selectedMaskPart} selectedKeycode={selectedKeycode}
-                    pressedKeys={matrixMode ? pressedKeys : undefined} everPressedKeys={matrixMode ? everPressedKeys : undefined}
-                    remappedKeys={primaryRemappedKeys} remappedEncoders={primaryRemappedEncoders} flash={flash} multiSelectedKeys={viewMatrixMode.active ? viewMatrixMode.selectedKeys : multiSelectedKeys}
-                    layoutOptions={effectiveLayoutOptions} scale={scaleProp}
-                    labelOverrides={viewMatrixLabelOverrides} keyColors={viewMatrixDuplicateKeyColors} remapLabel={primaryRemapLabel}
-                    layerLabel={viewMatrixMode.active ? undefined : layerLabel(currentLayer)} layerLabelTestId="layer-label"
-                    onKeyClick={viewMatrixMode.active ? handleViewMatrixKeyClick : handleKeyClick}
-                    onKeyDoubleClick={viewMatrixMode.active ? undefined : handleKeyDoubleClick}
-                    onEncoderClick={viewMatrixMode.active ? undefined : handleEncoderClick}
-                    onEncoderDoubleClick={viewMatrixMode.active ? undefined : handleEncoderDoubleClick}
-                    onDeselect={viewMatrixMode.active ? viewMatrixMode.clearSelection : handleDeselect} contentRef={keyboardContentRef}
-                  />
-                )}
-                {showPackTabs && (
-                  <KeymapPackTabs activeTab={packTab} onTabChange={handlePackTabChange} packName={keymapPackName ?? ''} />
-                )}
-              </div>
-              {/* View Matrix mode's relocated zoom row — same controls as
-                  the normal-mode toolbar, moved below the keymap pane —
-                  plus the same Ctrl/Shift multi-select hint the keycode
-                  picker shows in normal mode (reused key: the picker is
-                  hidden entirely for the mode's duration, but the
-                  Ctrl+click / Shift+click gestures it describes still
-                  drive this mode's own multi-selection). */}
+                  div (in `KeymapPrimaryPane`) with no gap is what keeps the
+                  strip touching the pane regardless of this row's own
+                  `gap-4` (which only spaces this pane+tabs unit from its
+                  own siblings, e.g. the overlay-panel spacer). View Matrix
+                  mode is excluded from `showPackTabs` above, so it can
+                  never overlap with either tab. */}
+              <KeymapPrimaryPane
+                showPackTabs={showPackTabs} packTab={packTab}
+                keys={layout.keys} layerKeycodes={layerKeycodes} layerEncoderKeycodes={layerEncoderKeycodes}
+                remappedKeys={remappedKeys} layerEncoderRemapped={layerEncoderRemapped}
+                matrixMode={matrixMode} pressedKeys={pressedKeys} everPressedKeys={everPressedKeys}
+                layoutOptions={effectiveLayoutOptions} scale={scaleProp} remapLabel={remapLabel}
+                currentLayerLabel={layerLabel(currentLayer)}
+                onRequestKeymapApply={onRequestKeymapApply} keymapApplyBusy={keymapApplyBusy} keymapApplyError={keymapApplyError}
+                contentRef={keyboardContentRef}
+                primaryKeycodes={primaryKeycodes} primaryEncoderKeycodes={primaryEncoderKeycodes}
+                selectedKey={selectedKey} selectedEncoder={selectedEncoder} selectedMaskPart={selectedMaskPart} selectedKeycode={selectedKeycode}
+                primaryRemappedKeys={primaryRemappedKeys} primaryRemappedEncoders={primaryRemappedEncoders}
+                flash={flash} viewMatrixMode={viewMatrixMode} multiSelectedKeys={multiSelectedKeys}
+                viewMatrixLabelOverrides={viewMatrixLabelOverrides} viewMatrixDuplicateKeyColors={viewMatrixDuplicateKeyColors}
+                primaryRemapLabel={primaryRemapLabel}
+                handleViewMatrixKeyClick={handleViewMatrixKeyClick} handleKeyClick={handleKeyClick}
+                handleKeyDoubleClick={handleKeyDoubleClick} handleEncoderClick={handleEncoderClick} handleEncoderDoubleClick={handleEncoderDoubleClick}
+                handleDeselect={handleDeselect} handlePackTabChange={handlePackTabChange} keymapPackName={keymapPackName}
+              />
+              {/* The relocated zoom row the toolbar comment above points to
+                  — see `ViewMatrixZoomRow` for what it contains and why. */}
               {viewMatrixMode.active && (
-                <div className="flex flex-col items-center gap-1">
-                  <p className="text-xs text-content-muted">{t('editor.keymap.pickerHint')}</p>
-                  {/* Same arrangement as the picker Keyboard tab's zoom
-                      row: ZoomOut, scale, ZoomIn in ghost styling. */}
-                  {onScaleChange && (
-                    <div className="flex items-center gap-1">
-                      <Tooltip content={t('editor.keymap.zoomOut')}>
-                        <button type="button" data-testid="zoom-out-button" aria-label={t('editor.keymap.zoomOut')}
-                          className={ghostZoomButtonClass} disabled={scaleProp <= MIN_SCALE} onClick={() => onScaleChange(-0.1)}>
-                          <ZoomOut size={ICON_SM} aria-hidden="true" />
-                        </button>
-                      </Tooltip>
-                      <ScaleInput scale={scaleProp} onScaleChange={onScaleChange} />
-                      <Tooltip content={t('editor.keymap.zoomIn')}>
-                        <button type="button" data-testid="zoom-in-button" aria-label={t('editor.keymap.zoomIn')}
-                          className={ghostZoomButtonClass} disabled={scaleProp >= MAX_SCALE} onClick={() => onScaleChange(0.1)}>
-                          <ZoomIn size={ICON_SM} aria-hidden="true" />
-                        </button>
-                      </Tooltip>
-                    </div>
-                  )}
-                </div>
+                <ViewMatrixZoomRow scale={scaleProp} onScaleChange={onScaleChange} />
               )}
             </>
           )}
@@ -803,61 +448,25 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
           (incl. its own View Matrix Edit/Done button) — is hidden while
           View Matrix mode is active; ViewMatrixPanel above is the mode's
           only surface, and its own toggle is the sole way back to normal
-          editing. */}
+          editing. Rendered as a SIBLING of `keymap-surface` above, never
+          inside it — see `KeymapPickerRegion`. */}
       {!typingTestMode && !viewMatrixMode.active && (
-        <div className="flex min-h-0 flex-1 gap-2">
-          {onLayerChange && layers > 1 && (
-            <LayerListPanel layers={layers} currentLayer={currentLayer} onLayerChange={onLayerChange}
-              layerNames={layerNames} onSetLayerName={onSetLayerName} collapsed={layerPanelCollapsed} onToggleCollapse={toggleLayerPanel} />
-          )}
-          <TabbedKeycodes
-            keyboardPickerContent={layoutPickerContent}
-            // Simulation tab is completely read-only (Plan-qwerty-select-
-            // no-rewrite v7): no picker click can paste into the shared
-            // selection state, and no picker multi-select can accumulate a
-            // selection that would still be sitting there — pasteable —
-            // once the user switches back to Base.
-            onKeycodeSelect={packTabReadOnly ? undefined : gatedHandleKeycodeSelect}
-            onKeycodeMultiSelect={packTabReadOnly ? undefined : handlePickerMultiSelect}
-            pickerSelectedIndices={pickerSelectedIndices}
-            pickerMultiSelectEnabled={!packTabReadOnly && !selectedKey && !selectedEncoder}
-            onBackgroundClick={handleDeselect}
-            onTabChange={() => { multiSelect.clearPickerSelection() }}
-            highlightedKeycodes={configuredKeycodes} maskOnly={isMaskKey} lmMode={isLMMask} showHint={!isMaskKey}
-            tabFooterContent={tabFooterContent} tabContentOverride={tabContentOverride}
-            basicViewType={basicViewType} onBasicViewTypeChange={onBasicViewTypeChange} splitKeyMode={splitKeyMode} remapLabel={pickerRemapLabel}
-            tabBarRight={
-              <Tooltip content={t('editorSettings.title')}>
-                <button ref={layoutButtonRef} type="button" aria-label={t('editorSettings.title')}
-                  aria-expanded={layoutPanelOpen} aria-controls="keycodes-overlay-panel"
-                  className={`rounded p-1 transition-colors ${layoutPanelOpen ? 'bg-surface-dim text-accent' : 'text-content-secondary hover:bg-surface-dim hover:text-content'}`}
-                  onClick={() => { setLayoutPanelOpen((prev) => { if (!prev) onOverlayOpen?.(); return !prev }) }}
-                >
-                  <SlidersHorizontal size={ICON_MD} aria-hidden="true" />
-                </button>
-              </Tooltip>
-            }
-            panelOverlay={
-              <div id="keycodes-overlay-panel" ref={layoutPanelRef}
-                className={`absolute inset-y-0 right-0 z-10 w-fit min-w-keycode-panel max-w-keycode-panel rounded-l-lg rounded-r-panel-connector border-l border-edge-subtle bg-surface-alt shadow-lg transition-transform duration-200 ease-out ${layoutPanelOpen ? 'translate-x-0' : 'translate-x-full'}`}
-                inert={!layoutPanelOpen || undefined}
-              >
-                <KeycodesOverlayPanel
-                  hasLayoutOptions={hasLayoutOptions} layoutOptions={parsedOptions} layoutValues={layoutValues}
-                  onLayoutOptionChange={handleLayoutOptionChange} autoAdvance={autoAdvance} onAutoAdvanceChange={onAutoAdvanceChange}
-                  viewMatrixActive={viewMatrixMode.active} onToggleViewMatrixMode={handleToggleViewMatrixMode}
-                  splitKeyMode={splitKeyMode} onSplitKeyModeChange={onSplitKeyModeChange}
-                  quickSelect={quickSelect} onQuickSelectChange={onQuickSelectChange}
-                  matrixMode={matrixMode} hasMatrixTester={hasMatrixTester} onToggleMatrix={viewMatrixMode.active ? undefined : handleMatrixToggle}
-                  unlocked={unlocked ?? false} onLock={onLock} isDummy={isDummy}
-                  toolsExtra={toolsExtra} dataPanel={dataPanel}
-                  keyEditorZoom={keyEditorZoom} onKeyEditorZoomChange={onKeyEditorZoomChange}
-                  onExportLayoutPdfAll={onExportLayoutPdfAll} onExportLayoutPdfCurrent={onExportLayoutPdfCurrent}
-                />
-              </div>
-            }
-          />
-        </div>
+        <KeymapPickerRegion
+          {...props}
+          layerPanelCollapsed={layerPanelCollapsed} toggleLayerPanel={toggleLayerPanel}
+          layoutPickerContent={layoutPickerContent} packTabReadOnly={packTabReadOnly}
+          gatedHandleKeycodeSelect={gatedHandleKeycodeSelect} handlePickerMultiSelect={handlePickerMultiSelect}
+          pickerSelectedIndices={pickerSelectedIndices} selectedKey={selectedKey} selectedEncoder={selectedEncoder}
+          handleDeselect={handleDeselect} clearPickerSelection={multiSelect.clearPickerSelection}
+          configuredKeycodes={configuredKeycodes} isMaskKey={isMaskKey} isLMMask={isLMMask}
+          tabFooterContent={tabFooterContent} tabContentOverride={tabContentOverride}
+          layoutButtonRef={layoutButtonRef} layoutPanelOpen={layoutPanelOpen} setLayoutPanelOpen={setLayoutPanelOpen}
+          layoutPanelRef={layoutPanelRef}
+          hasLayoutOptions={hasLayoutOptions} parsedLayoutOptions={parsedOptions} layoutValues={layoutValues}
+          handleLayoutOptionChange={handleLayoutOptionChange} autoAdvance={autoAdvance}
+          viewMatrixActive={viewMatrixMode.active} onToggleViewMatrixMode={handleToggleViewMatrixMode}
+          matrixMode={matrixMode} hasMatrixTester={hasMatrixTester} handleMatrixToggle={handleMatrixToggle}
+        />
       )}
 
       <KeymapEditorModals
@@ -878,14 +487,8 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         supportedQsids={supportedQsids} qmkSettingsGet={qmkSettingsGet} qmkSettingsSet={qmkSettingsSet}
         qmkSettingsReset={qmkSettingsReset} onSettingsUpdate={onSettingsUpdate}
         visibleModals={visibleModals} closeSettings={closeSettings}
-      />
-
-      <KeymapApplyConfirmModal
-        open={!!keymapApplyOpen}
-        labelName={keymapApplyLabelName ?? ''}
-        onApply={() => onKeymapApplyConfirm?.()}
-        onCancel={() => onKeymapApplyCancel?.()}
-        busy={!!keymapApplyBusy}
+        keymapApplyOpen={keymapApplyOpen} keymapApplyLabelName={keymapApplyLabelName} keymapApplyBusy={keymapApplyBusy}
+        onKeymapApplyConfirm={onKeymapApplyConfirm} onKeymapApplyCancel={onKeymapApplyCancel}
       />
     </div>
   )

--- a/src/renderer/components/editors/KeymapEditorModals.tsx
+++ b/src/renderer/components/editors/KeymapEditorModals.tsx
@@ -16,6 +16,7 @@ import { TapDanceJsonEditor } from './TapDanceJsonEditor'
 import { JsonEditorModal } from './JsonEditorModal'
 import { comboToJson, parseCombo, keyOverrideToJson, parseKeyOverride, altRepeatKeyToJson, parseAltRepeatKey, macroToJson, parseMacro } from './json-entry-serializers'
 import { QmkSettingsModals } from './QmkSettingsModal'
+import { KeymapApplyConfirmModal } from '../key-labels/KeymapApplyConfirmModal'
 import type { FavHubEntryResult } from './FavoriteHubActions'
 import type { EntryJsonEditor, MacroJsonEditor, VisibleQmkModals } from './useKeymapJsonEditors'
 
@@ -74,6 +75,13 @@ export interface KeymapEditorModalsProps {
   onSettingsUpdate?: (qsid: number, data: number[]) => void
   visibleModals: VisibleQmkModals
   closeSettings: (key: string) => void
+
+  // --- Key Label "apply to keymap" confirm modal ---
+  keymapApplyOpen?: boolean
+  keymapApplyLabelName?: string
+  keymapApplyBusy?: boolean
+  onKeymapApplyConfirm?: () => void
+  onKeymapApplyCancel?: () => void
 }
 
 export function KeymapEditorModals({
@@ -86,6 +94,7 @@ export function KeymapEditorModals({
   comboEntries, keyOverrideEntries, altRepeatKeyEntries,
   tdJson, comboJson, koJson, arkJson, macroJson,
   supportedQsids, qmkSettingsGet, qmkSettingsSet, qmkSettingsReset, onSettingsUpdate, visibleModals, closeSettings,
+  keymapApplyOpen, keymapApplyLabelName, keymapApplyBusy, onKeymapApplyConfirm, onKeymapApplyCancel,
 }: KeymapEditorModalsProps) {
   const { t } = useTranslation()
 
@@ -182,6 +191,14 @@ export function KeymapEditorModals({
           qmkSettingsSet={qmkSettingsSet} qmkSettingsReset={qmkSettingsReset}
           onSettingsUpdate={onSettingsUpdate} visibleModals={visibleModals} onCloseModal={closeSettings} />
       )}
+
+      <KeymapApplyConfirmModal
+        open={!!keymapApplyOpen}
+        labelName={keymapApplyLabelName ?? ''}
+        onApply={() => onKeymapApplyConfirm?.()}
+        onCancel={() => onKeymapApplyCancel?.()}
+        busy={!!keymapApplyBusy}
+      />
     </>
   )
 }

--- a/src/renderer/components/editors/KeymapPackTabs.tsx
+++ b/src/renderer/components/editors/KeymapPackTabs.tsx
@@ -38,6 +38,7 @@
 // `modal-tabs.tsx`).
 
 import { useTranslation } from 'react-i18next'
+import { BTN_PRIMARY_FOOTER } from '../../constants/ui-tokens'
 
 export type KeymapPackTab = 'pack' | 'base'
 
@@ -98,5 +99,40 @@ export function KeymapPackTabs({ activeTab, onTabChange, packName }: KeymapPackT
         {t('keyLabels.qwertyDefaultShort')}
       </button>
     </div>
+  )
+}
+
+export interface KeymapPackApplyButtonProps {
+  onRequestKeymapApply?: () => void
+  keymapApplyBusy?: boolean
+  keymapApplyError?: string | null
+}
+
+/** The simulation tab's own Apply button (layer-indicator row's
+ *  `footerExtra`) — reachable only while the pack tab is showing (see
+ *  `KeymapEditor`'s `footerExtra={...}`, passed exclusively to the
+ *  pack-tab `<KeyboardPane>`). Renders nothing when the host has no
+ *  `onRequestKeymapApply` handler wired up (e.g. `keymapEditable` is
+ *  false) — same as the previous inline `undefined` fallback. */
+export function KeymapPackApplyButton({ onRequestKeymapApply, keymapApplyBusy, keymapApplyError }: KeymapPackApplyButtonProps): JSX.Element | null {
+  const { t } = useTranslation()
+  if (!onRequestKeymapApply) return null
+  return (
+    <span className="flex items-center gap-2">
+      <button
+        type="button"
+        className={BTN_PRIMARY_FOOTER}
+        onClick={onRequestKeymapApply}
+        disabled={!!keymapApplyBusy}
+        data-testid="keymap-pack-apply-button"
+      >
+        {t('common.apply')}
+      </button>
+      {keymapApplyError && (
+        <span className="text-xs text-danger" data-testid="keymap-apply-error">
+          {t('keyLabels.keymapApply.errorPartial')}
+        </span>
+      )}
+    </span>
   )
 }

--- a/src/renderer/components/editors/KeymapPickerRegion.tsx
+++ b/src/renderer/components/editors/KeymapPickerRegion.tsx
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import { SlidersHorizontal } from 'lucide-react'
+import { TabbedKeycodes } from '../keycodes/TabbedKeycodes'
+import { KeycodesOverlayPanel } from './KeycodesOverlayPanel'
+import { LayerListPanel } from './LayerListPanel'
+import { Tooltip } from '../ui/Tooltip'
+import { ICON_MD } from '../../constants/ui-tokens'
+import type { KeymapEditorProps } from './keymap-editor-types'
+import type { Keycode } from '../../../shared/keycodes/keycodes'
+import type { parseLayoutLabels } from '../../../shared/layout-options'
+
+/** `KeymapEditorProps` covers every plain pass-through field below
+ *  (layers/currentLayer/onLayerChange/layerNames/onSetLayerName for
+ *  `LayerListPanel`; basicViewType/splitKeyMode/quickSelect/autoAdvance/
+ *  unlocked/isDummy/toolsExtra/dataPanel/keyEditorZoom/onExportLayoutPdf*
+ *  for `KeycodesOverlayPanel`; pickerRemapLabel for both); these additions
+ *  are values `KeymapEditor` only has at render time from its own hooks
+ *  (selection state, the layout-options panel, View Matrix mode, the
+ *  layer/tab footer builders, ...). */
+export interface KeymapPickerRegionProps extends KeymapEditorProps {
+  layerPanelCollapsed: boolean
+  toggleLayerPanel: () => void
+  layoutPickerContent: React.ReactNode
+  packTabReadOnly: boolean
+  gatedHandleKeycodeSelect: (kc: Keycode) => void
+  handlePickerMultiSelect: (
+    index: number,
+    keycode: number,
+    event: { ctrlKey: boolean; shiftKey: boolean },
+    tabKeycodeNumbers: number[],
+  ) => void
+  pickerSelectedIndices: Set<number>
+  selectedKey: { row: number; col: number } | null
+  selectedEncoder: { idx: number; dir: 0 | 1 } | null
+  handleDeselect: () => void
+  clearPickerSelection: () => void
+  configuredKeycodes?: Set<string>
+  isMaskKey: boolean
+  isLMMask: boolean
+  tabFooterContent: Record<string, React.ReactNode>
+  tabContentOverride: Record<string, React.ReactNode> | undefined
+  layoutButtonRef: RefObject<HTMLButtonElement | null>
+  layoutPanelOpen: boolean
+  setLayoutPanelOpen: (updater: (prev: boolean) => boolean) => void
+  layoutPanelRef: RefObject<HTMLDivElement | null>
+  viewMatrixActive: boolean
+  onToggleViewMatrixMode: () => void
+  matrixMode: boolean
+  hasMatrixTester: boolean
+  handleMatrixToggle: () => void
+  hasLayoutOptions: boolean
+  parsedLayoutOptions: ReturnType<typeof parseLayoutLabels>
+  layoutValues: Map<number, number>
+  handleLayoutOptionChange: (index: number, value: number) => Promise<void>
+  /** Overrides `KeymapEditorProps.autoAdvance` (optional there) —
+   *  `KeymapEditor` always passes its own already-defaulted local, same
+   *  reasoning as `KeymapTypingTestPane`'s `scale` override. */
+  autoAdvance: boolean
+}
+
+/** The entire keycode picker area — layer list, tabs/tiles, and the overlay
+ *  settings panel (incl. its own View Matrix Edit/Done button) — rendered as
+ *  a SIBLING of `keymap-surface`, never inside it (the picker's "actual"
+ *  tint must never inherit the simulation tab's `remap-simulated` CSS
+ *  override). Hidden entirely by the caller while View Matrix mode is
+ *  active or typing-test mode is on — this component doesn't gate on
+ *  either itself. */
+export function KeymapPickerRegion(props: KeymapPickerRegionProps): JSX.Element {
+  const {
+    layers, currentLayer, onLayerChange, layerNames, onSetLayerName, layerPanelCollapsed, toggleLayerPanel,
+    layoutPickerContent, packTabReadOnly, gatedHandleKeycodeSelect, handlePickerMultiSelect,
+    pickerSelectedIndices, selectedKey, selectedEncoder, handleDeselect, clearPickerSelection,
+    configuredKeycodes, isMaskKey, isLMMask, tabFooterContent, tabContentOverride,
+    basicViewType, onBasicViewTypeChange, splitKeyMode, onSplitKeyModeChange, pickerRemapLabel,
+    layoutButtonRef, layoutPanelOpen, setLayoutPanelOpen, layoutPanelRef, onOverlayOpen,
+    hasLayoutOptions, parsedLayoutOptions, layoutValues, handleLayoutOptionChange,
+    autoAdvance, onAutoAdvanceChange, viewMatrixActive, onToggleViewMatrixMode,
+    quickSelect, onQuickSelectChange, matrixMode, hasMatrixTester, handleMatrixToggle,
+    unlocked, onLock, isDummy, toolsExtra, dataPanel, keyEditorZoom, onKeyEditorZoomChange,
+    onExportLayoutPdfAll, onExportLayoutPdfCurrent,
+  } = props
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-h-0 flex-1 gap-2">
+      {onLayerChange && layers > 1 && (
+        <LayerListPanel layers={layers} currentLayer={currentLayer} onLayerChange={onLayerChange}
+          layerNames={layerNames} onSetLayerName={onSetLayerName} collapsed={layerPanelCollapsed} onToggleCollapse={toggleLayerPanel} />
+      )}
+      <TabbedKeycodes
+        keyboardPickerContent={layoutPickerContent}
+        // Simulation tab is completely read-only (Plan-qwerty-select-
+        // no-rewrite v7): no picker click can paste into the shared
+        // selection state, and no picker multi-select can accumulate a
+        // selection that would still be sitting there — pasteable —
+        // once the user switches back to Base.
+        onKeycodeSelect={packTabReadOnly ? undefined : gatedHandleKeycodeSelect}
+        onKeycodeMultiSelect={packTabReadOnly ? undefined : handlePickerMultiSelect}
+        pickerSelectedIndices={pickerSelectedIndices}
+        pickerMultiSelectEnabled={!packTabReadOnly && !selectedKey && !selectedEncoder}
+        onBackgroundClick={handleDeselect}
+        onTabChange={() => { clearPickerSelection() }}
+        highlightedKeycodes={configuredKeycodes} maskOnly={isMaskKey} lmMode={isLMMask} showHint={!isMaskKey}
+        tabFooterContent={tabFooterContent} tabContentOverride={tabContentOverride}
+        basicViewType={basicViewType} onBasicViewTypeChange={onBasicViewTypeChange} splitKeyMode={splitKeyMode} remapLabel={pickerRemapLabel}
+        tabBarRight={
+          <Tooltip content={t('editorSettings.title')}>
+            <button ref={layoutButtonRef} type="button" aria-label={t('editorSettings.title')}
+              aria-expanded={layoutPanelOpen} aria-controls="keycodes-overlay-panel"
+              className={`rounded p-1 transition-colors ${layoutPanelOpen ? 'bg-surface-dim text-accent' : 'text-content-secondary hover:bg-surface-dim hover:text-content'}`}
+              onClick={() => { setLayoutPanelOpen((prev) => { if (!prev) onOverlayOpen?.(); return !prev }) }}
+            >
+              <SlidersHorizontal size={ICON_MD} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        }
+        panelOverlay={
+          <div id="keycodes-overlay-panel" ref={layoutPanelRef}
+            className={`absolute inset-y-0 right-0 z-10 w-fit min-w-keycode-panel max-w-keycode-panel rounded-l-lg rounded-r-panel-connector border-l border-edge-subtle bg-surface-alt shadow-lg transition-transform duration-200 ease-out ${layoutPanelOpen ? 'translate-x-0' : 'translate-x-full'}`}
+            inert={!layoutPanelOpen || undefined}
+          >
+            <KeycodesOverlayPanel
+              hasLayoutOptions={hasLayoutOptions} layoutOptions={parsedLayoutOptions} layoutValues={layoutValues}
+              onLayoutOptionChange={handleLayoutOptionChange} autoAdvance={autoAdvance} onAutoAdvanceChange={onAutoAdvanceChange}
+              viewMatrixActive={viewMatrixActive} onToggleViewMatrixMode={onToggleViewMatrixMode}
+              splitKeyMode={splitKeyMode} onSplitKeyModeChange={onSplitKeyModeChange}
+              quickSelect={quickSelect} onQuickSelectChange={onQuickSelectChange}
+              matrixMode={matrixMode} hasMatrixTester={hasMatrixTester} onToggleMatrix={viewMatrixActive ? undefined : handleMatrixToggle}
+              unlocked={unlocked ?? false} onLock={onLock} isDummy={isDummy}
+              toolsExtra={toolsExtra} dataPanel={dataPanel}
+              keyEditorZoom={keyEditorZoom} onKeyEditorZoomChange={onKeyEditorZoomChange}
+              onExportLayoutPdfAll={onExportLayoutPdfAll} onExportLayoutPdfCurrent={onExportLayoutPdfCurrent}
+            />
+          </div>
+        }
+      />
+    </div>
+  )
+}

--- a/src/renderer/components/editors/KeymapPrimaryPane.tsx
+++ b/src/renderer/components/editors/KeymapPrimaryPane.tsx
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { RefObject } from 'react'
+import { KeyboardPane } from './KeyboardPane'
+import { KeymapPackTabs, KeymapPackApplyButton, type KeymapPackTab } from './KeymapPackTabs'
+import type { KleKey } from '../../../shared/kle/types'
+import type { KeyFlashState } from '../keyboard/key-flash'
+import type { UseViewMatrixModeReturn } from './useViewMatrixMode'
+
+export interface KeymapPrimaryPaneProps {
+  showPackTabs: boolean
+  packTab: KeymapPackTab
+  keys: KleKey[]
+  layerKeycodes: Map<string, string>
+  layerEncoderKeycodes: Map<string, [string, string]>
+  remappedKeys: Set<string>
+  layerEncoderRemapped: Set<string>
+  matrixMode: boolean
+  pressedKeys: Set<string>
+  everPressedKeys: Set<string>
+  layoutOptions: Map<number, number>
+  scale: number
+  remapLabel?: (qmkId: string) => string
+  /** `layerLabel(currentLayer)` computed once by the caller — the same
+   *  value both branches below need (the pack-tab branch always shows it;
+   *  the no-tabs/Base branch only while View Matrix mode is off). */
+  currentLayerLabel: string
+  /** Raw inputs for the simulation tab's own Apply button (`footerExtra`
+   *  below) — built here, where its only consumer lives, rather than
+   *  constructed unconditionally by the caller and discarded whenever
+   *  this pane isn't even on the pack tab. */
+  onRequestKeymapApply?: () => void
+  keymapApplyBusy?: boolean
+  keymapApplyError?: string | null
+  contentRef?: RefObject<HTMLDivElement | null>
+  primaryKeycodes: Map<string, string>
+  primaryEncoderKeycodes: Map<string, [string, string]>
+  selectedKey: { row: number; col: number } | null
+  selectedEncoder: { idx: number; dir: 0 | 1 } | null
+  selectedMaskPart: boolean
+  selectedKeycode: string | null
+  primaryRemappedKeys: Set<string>
+  primaryRemappedEncoders: Set<string>
+  flash?: KeyFlashState
+  viewMatrixMode: UseViewMatrixModeReturn
+  multiSelectedKeys: Set<string>
+  viewMatrixLabelOverrides?: Map<string, { outer: string; inner: string; masked: boolean }>
+  viewMatrixDuplicateKeyColors?: Map<string, string>
+  primaryRemapLabel?: (qmkId: string) => string
+  handleViewMatrixKeyClick: (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
+  handleKeyClick: (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
+  handleKeyDoubleClick: (key: KleKey, rect: DOMRect, maskClicked: boolean) => void
+  handleEncoderClick: (key: KleKey, dir: number, maskClicked: boolean) => void
+  handleEncoderDoubleClick: (key: KleKey, dir: number, rect: DOMRect, maskClicked: boolean) => void
+  handleDeselect: () => void
+  handlePackTabChange: (tab: KeymapPackTab) => void
+  keymapPackName?: string
+}
+
+/** The dual `KeyboardPane` branches (simulation-tab preview vs. the real,
+ *  fully editable pane — JIS/QWERTY/typing-test-adjacent states, and the
+ *  Base tab reusing the exact same branch with swapped-in raw data) plus
+ *  the vertical `KeymapPackTabs` strip attached flush to the pane's edge.
+ *  Lives inside `KeymapEditor`'s `keymap-surface` container — only one of
+ *  the two `<KeyboardPane>`s below ever renders at a time. */
+export function KeymapPrimaryPane({
+  showPackTabs, packTab, keys, layerKeycodes, layerEncoderKeycodes, remappedKeys, layerEncoderRemapped,
+  matrixMode, pressedKeys, everPressedKeys, layoutOptions, scale, remapLabel, currentLayerLabel,
+  onRequestKeymapApply, keymapApplyBusy, keymapApplyError, contentRef, primaryKeycodes, primaryEncoderKeycodes,
+  selectedKey, selectedEncoder, selectedMaskPart, selectedKeycode,
+  primaryRemappedKeys, primaryRemappedEncoders, flash, viewMatrixMode, multiSelectedKeys,
+  viewMatrixLabelOverrides, viewMatrixDuplicateKeyColors, primaryRemapLabel,
+  handleViewMatrixKeyClick, handleKeyClick, handleKeyDoubleClick, handleEncoderClick, handleEncoderDoubleClick,
+  handleDeselect, handlePackTabChange, keymapPackName,
+}: KeymapPrimaryPaneProps): JSX.Element {
+  return (
+    <div className="flex items-stretch">
+      {showPackTabs && packTab === 'pack' ? (
+        // Simulation pane: display data only — no selection props,
+        // no click/double-click/deselect handlers at all. `readOnly`
+        // (always `true` here, not a ternary) already makes
+        // `KeyboardWidget` null out every handler it's given
+        // regardless, and `KeyboardPane`'s own deselect-on-
+        // background-click checks `!readOnly` too — omitting the
+        // handlers here as well means read-only holds by
+        // construction, not by three separate `packTab === 'pack'`
+        // checks that could drift out of sync.
+        <KeyboardPane
+          paneId="primary" isActive={true}
+          keys={keys} keycodes={layerKeycodes} encoderKeycodes={layerEncoderKeycodes}
+          selectedKey={null} selectedEncoder={null} selectedMaskPart={false} selectedKeycode={null}
+          pressedKeys={matrixMode ? pressedKeys : undefined} everPressedKeys={matrixMode ? everPressedKeys : undefined}
+          remappedKeys={remappedKeys} remappedEncoders={layerEncoderRemapped}
+          layoutOptions={layoutOptions} scale={scale}
+          remapLabel={remapLabel}
+          layerLabel={currentLayerLabel} layerLabelTestId="layer-label"
+          preview
+          footerExtra={
+            <KeymapPackApplyButton
+              onRequestKeymapApply={onRequestKeymapApply}
+              keymapApplyBusy={keymapApplyBusy}
+              keymapApplyError={keymapApplyError}
+            />
+          }
+          readOnly
+          contentRef={contentRef}
+        />
+      ) : (
+        // Also the "no tabs" pane (JIS/QWERTY/typing-test-adjacent
+        // states) — the `showPackTabs && packTab === 'base'`
+        // case reuses this exact block rather than a second copy,
+        // swapping only the keycode/remap source variables below
+        // (`primaryKeycodes` etc.) for the Base tab's raw data.
+        <KeyboardPane
+          paneId="primary" isActive={true} keys={keys} keycodes={primaryKeycodes} encoderKeycodes={primaryEncoderKeycodes}
+          selectedKey={selectedKey} selectedEncoder={selectedEncoder} selectedMaskPart={selectedMaskPart} selectedKeycode={selectedKeycode}
+          pressedKeys={matrixMode ? pressedKeys : undefined} everPressedKeys={matrixMode ? everPressedKeys : undefined}
+          remappedKeys={primaryRemappedKeys} remappedEncoders={primaryRemappedEncoders} flash={flash} multiSelectedKeys={viewMatrixMode.active ? viewMatrixMode.selectedKeys : multiSelectedKeys}
+          layoutOptions={layoutOptions} scale={scale}
+          labelOverrides={viewMatrixLabelOverrides} keyColors={viewMatrixDuplicateKeyColors} remapLabel={primaryRemapLabel}
+          layerLabel={viewMatrixMode.active ? undefined : currentLayerLabel} layerLabelTestId="layer-label"
+          onKeyClick={viewMatrixMode.active ? handleViewMatrixKeyClick : handleKeyClick}
+          onKeyDoubleClick={viewMatrixMode.active ? undefined : handleKeyDoubleClick}
+          onEncoderClick={viewMatrixMode.active ? undefined : handleEncoderClick}
+          onEncoderDoubleClick={viewMatrixMode.active ? undefined : handleEncoderDoubleClick}
+          onDeselect={viewMatrixMode.active ? viewMatrixMode.clearSelection : handleDeselect} contentRef={contentRef}
+        />
+      )}
+      {showPackTabs && (
+        <KeymapPackTabs activeTab={packTab} onTabChange={handlePackTabChange} packName={keymapPackName ?? ''} />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/editors/KeymapTypingTestPane.tsx
+++ b/src/renderer/components/editors/KeymapTypingTestPane.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { RefObject } from 'react'
+import { TypingTestPane } from './TypingTestPane'
+import type { KeymapEditorProps } from './keymap-editor-types'
+import type { KleKey } from '../../../shared/kle/types'
+import type { TypingTestConfig } from '../../typing-test/types'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { useTypingTest } from '../../typing-test/useTypingTest'
+
+/** `KeymapEditorProps` covers every plain pass-through field below (layers,
+ *  layerNames, typingTestHistory, every "typingTest"/"onTypingTest"-prefixed
+ *  setting, ...); these additions are the values `KeymapEditor` only has at
+ *  render time — the running test's own state, this layer's keycodes/keys,
+ *  and the shared refs/callbacks the surrounding editor owns. */
+export interface KeymapTypingTestPaneProps extends KeymapEditorProps {
+  typingTest: ReturnType<typeof useTypingTest>
+  onConfigChange: (config: TypingTestConfig) => void
+  onLanguageChange: (lang: string) => Promise<void>
+  pressedKeys: Set<string>
+  keycodes: Map<string, string>
+  encoderKeycodes: Map<string, [string, string]>
+  remappedKeys: Set<string>
+  remappedEncoders?: Set<string>
+  /** Overrides `KeymapEditorProps.scale` (optional there) — `KeymapEditor`
+   *  always passes its own already-defaulted `scaleProp` local here, so
+   *  this pane can rely on a definite number, same as `TypingTestPane`'s
+   *  own required `scale`. */
+  scale: number
+  keys: KleKey[]
+  layerLabel: string
+  contentRef?: RefObject<HTMLDivElement | null>
+  hasSavedMemory?: boolean
+  finishedResult?: TypingTestResult | null
+  onNameFinishedResult?: (name: string) => void
+  onPauseTest?: () => void
+  onResumeTest?: () => void
+  onRestartTestFromStart?: () => void
+}
+
+/** Renders the typing-test surface inside `KeymapEditor`'s keymap-surface
+ *  container. Pure translation layer: every field here is either forwarded
+ *  unchanged or renamed onto `TypingTestPane`'s own (differently-named)
+ *  props — `viewOnly` vs. `typingTestViewOnly`, `hideKeymap` vs.
+ *  `typingTestHideKeymap`, and so on for nearly every "typingTest"/
+ *  "onTypingTest"-prefixed field. Imports the REAL `./TypingTestPane` module (not a
+ *  re-export) so `KeymapEditor.typingTestNote.test.tsx` (which doesn't mock
+ *  it) still renders the genuine component, and `vi.mock('../TypingTestPane',
+ *  ...)` in the other KeymapEditor test suites still intercepts the same
+ *  resolved module regardless of which file imports it. */
+export function KeymapTypingTestPane({
+  typingTest, onConfigChange, typingTestMonkeytypeConfig, onLanguageChange,
+  layers, layerNames, typingTestHistory, onRenameTypingTestResult, onDeleteTypingTestResult, deviceName,
+  pressedKeys, keycodes, encoderKeycodes, remappedKeys, remappedEncoders,
+  remapLabel, layoutOptions, scale, keys, layerLabel, contentRef,
+  hasSavedMemory, typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
+  typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestSaveUnnamed,
+  finishedResult, onNameFinishedResult, typingTestComparisonBaselines,
+  onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestSaveUnnamedChange, onTypingTestComparisonBaselineChange,
+  typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
+  onPauseTest, onResumeTest, onRestartTestFromStart,
+  typingTestViewOnly, onTypingTestViewOnlyChange,
+  typingTestViewOnlyWindowSize, onTypingTestViewOnlyWindowSizeChange,
+  typingTestViewOnlyAlwaysOnTop, onTypingTestViewOnlyAlwaysOnTopChange,
+  typingRecordEnabled, onTypingRecordEnabledChange,
+  typingRecordingConsentAccepted, onTypingRecordingConsentAccepted,
+  typingHeatmapWindowMin, onTypingHeatmapWindowMinChange,
+  typingMonitorAppEnabled, onTypingMonitorAppEnabledChange,
+  typingTrayResident, onTypingTrayResidentChange, typingStartInTray, onTypingStartInTrayChange,
+  typingViewMenuTab, onTypingViewMenuTabChange,
+  onViewAnalytics, keyboardUid, timelineHandoff,
+}: KeymapTypingTestPaneProps): JSX.Element {
+  return (
+    <TypingTestPane
+      typingTest={typingTest}
+      onConfigChange={onConfigChange}
+      monkeytypeConfig={typingTestMonkeytypeConfig}
+      onLanguageChange={onLanguageChange}
+      layers={layers}
+      layerNames={layerNames}
+      typingTestHistory={typingTestHistory}
+      onRenameTypingTestResult={onRenameTypingTestResult}
+      onDeleteTypingTestResult={onDeleteTypingTestResult}
+      deviceName={deviceName}
+      pressedKeys={pressedKeys}
+      keycodes={keycodes}
+      encoderKeycodes={encoderKeycodes}
+      remappedKeys={remappedKeys}
+      remappedEncoders={remappedEncoders}
+      remapLabel={remapLabel}
+      layoutOptions={layoutOptions}
+      scale={scale}
+      keys={keys}
+      layerLabel={layerLabel}
+      contentRef={contentRef}
+      hasSavedMemory={hasSavedMemory}
+      displayLines={typingTestDisplayLines}
+      fontSize={typingTestFontSize}
+      onDisplayLinesChange={onTypingTestDisplayLinesChange}
+      onFontSizeChange={onTypingTestFontSizeChange}
+      hideKeymap={typingTestHideKeymap}
+      hideStatsRow={typingTestHideStatsRow}
+      hideControls={typingTestHideControls}
+      saveUnnamed={typingTestSaveUnnamed}
+      finishedResult={finishedResult}
+      onNameFinishedResult={onNameFinishedResult}
+      comparisonBaselines={typingTestComparisonBaselines}
+      onToggleHideKeymap={onTypingTestHideKeymapChange}
+      onToggleHideStatsRow={onTypingTestHideStatsRowChange}
+      onToggleHideControls={onTypingTestHideControlsChange}
+      onToggleSaveUnnamed={onTypingTestSaveUnnamedChange}
+      onComparisonBaselineChange={onTypingTestComparisonBaselineChange}
+      settingsPanelOpen={typingTestSettingsPanelOpen}
+      onToggleSettingsPanel={onTypingTestSettingsPanelOpenChange}
+      onPauseTest={onPauseTest}
+      onResumeTest={onResumeTest}
+      onRestartTestFromStart={onRestartTestFromStart}
+      viewOnly={typingTestViewOnly}
+      onViewOnlyChange={onTypingTestViewOnlyChange}
+      viewOnlyWindowSize={typingTestViewOnlyWindowSize}
+      onViewOnlyWindowSizeChange={onTypingTestViewOnlyWindowSizeChange}
+      viewOnlyAlwaysOnTop={typingTestViewOnlyAlwaysOnTop}
+      onViewOnlyAlwaysOnTopChange={onTypingTestViewOnlyAlwaysOnTopChange}
+      recordEnabled={typingRecordEnabled}
+      onRecordEnabledChange={onTypingRecordEnabledChange}
+      recordingConsentAccepted={typingRecordingConsentAccepted}
+      onRecordingConsentAccepted={onTypingRecordingConsentAccepted}
+      heatmapWindowMin={typingHeatmapWindowMin}
+      onHeatmapWindowMinChange={onTypingHeatmapWindowMinChange}
+      monitorAppEnabled={typingMonitorAppEnabled}
+      onMonitorAppEnabledChange={onTypingMonitorAppEnabledChange}
+      trayResident={typingTrayResident}
+      onTrayResidentChange={onTypingTrayResidentChange}
+      startInTray={typingStartInTray}
+      onStartInTrayChange={onTypingStartInTrayChange}
+      menuTab={typingViewMenuTab}
+      onMenuTabChange={onTypingViewMenuTabChange}
+      onViewAnalytics={onViewAnalytics}
+      keyboardUid={keyboardUid}
+      timelineHandoff={timelineHandoff}
+    />
+  )
+}

--- a/src/renderer/components/editors/keymap-editor-toolbar.tsx
+++ b/src/renderer/components/editors/keymap-editor-toolbar.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useRef } from 'react'
+import { useState, useCallback, useRef, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ZoomIn, ZoomOut, Undo2, Redo2 } from 'lucide-react'
 import { MIN_SCALE, MAX_SCALE, PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
-import { TOOLBAR_BTN_ACTIVE, TOOLBAR_BTN_INACTIVE, ICON_MD } from '../../constants/ui-tokens'
+import { TOOLBAR_BTN_ACTIVE, TOOLBAR_BTN_INACTIVE, ICON_MD, ICON_SM } from '../../constants/ui-tokens'
 import { Tooltip } from '../ui/Tooltip'
+import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
+import type { MacroAction } from '../../../preload/macro'
+import type { EntryJsonEditor, MacroJsonEditor } from './useKeymapJsonEditors'
 
 export function ScaleInput({ scale, onScaleChange }: { scale: number; onScaleChange: (delta: number) => void }) {
   const display = `${Math.round(scale * 100)}`
@@ -120,4 +123,106 @@ export function KeymapToolbar({
       <div className="flex-1" />
     </div>
   )
+}
+
+export interface ViewMatrixZoomRowProps {
+  scale: number
+  onScaleChange?: (delta: number) => void
+}
+
+/** View Matrix mode's relocated zoom row — same controls as the normal-mode
+ *  toolbar (`KeymapToolbar`'s own `zoomControls`), moved below the keymap
+ *  pane — plus the same Ctrl/Shift multi-select hint the keycode picker
+ *  shows in normal mode (reused key: the picker is hidden entirely for the
+ *  mode's duration, but the Ctrl+click / Shift+click gestures it describes
+ *  still drive this mode's own multi-selection). */
+export function ViewMatrixZoomRow({ scale, onScaleChange }: ViewMatrixZoomRowProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col items-center gap-1">
+      <p className="text-xs text-content-muted">{t('editor.keymap.pickerHint')}</p>
+      {/* Same arrangement as the picker Keyboard tab's zoom row: ZoomOut,
+          scale, ZoomIn in ghost styling. */}
+      {onScaleChange && (
+        <div className="flex items-center gap-1">
+          <Tooltip content={t('editor.keymap.zoomOut')}>
+            <button type="button" data-testid="zoom-out-button" aria-label={t('editor.keymap.zoomOut')}
+              className={ghostZoomButtonClass} disabled={scale <= MIN_SCALE} onClick={() => onScaleChange(-0.1)}>
+              <ZoomOut size={ICON_SM} aria-hidden="true" />
+            </button>
+          </Tooltip>
+          <ScaleInput scale={scale} onScaleChange={onScaleChange} />
+          <Tooltip content={t('editor.keymap.zoomIn')}>
+            <button type="button" data-testid="zoom-in-button" aria-label={t('editor.keymap.zoomIn')}
+              className={ghostZoomButtonClass} disabled={scale >= MAX_SCALE} onClick={() => onScaleChange(0.1)}>
+              <ZoomIn size={ICON_SM} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export interface UseKeymapTabFooterOptions {
+  tapDanceEntries?: TapDanceEntry[]
+  comboEntries?: ComboEntry[]
+  keyOverrideEntries?: KeyOverrideEntry[]
+  altRepeatKeyEntries?: AltRepeatKeyEntry[]
+  deserializedMacros?: MacroAction[][] | null
+  tapHoldSupported?: boolean
+  mouseKeysSupported?: boolean
+  magicSupported?: boolean
+  graveEscapeSupported?: boolean
+  autoShiftSupported?: boolean
+  oneShotKeysSupported?: boolean
+  comboSettingsSupported?: boolean
+  onOpenLighting?: () => void
+  openSettings: (key: string) => void
+  tdJson: EntryJsonEditor<TapDanceEntry>
+  comboJson: EntryJsonEditor<ComboEntry>
+  koJson: EntryJsonEditor<KeyOverrideEntry>
+  arkJson: EntryJsonEditor<AltRepeatKeyEntry>
+  macroJson: MacroJsonEditor
+}
+
+/** Per-tab footer buttons (Edit JSON / settings shortcuts) shown under the
+ *  keycode picker's tab strip — grouped by which tab each button belongs to
+ *  so `TabbedKeycodes` can render only the group matching its active tab. */
+export function useKeymapTabFooter({
+  tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros,
+  tapHoldSupported, mouseKeysSupported, magicSupported, graveEscapeSupported, autoShiftSupported, oneShotKeysSupported, comboSettingsSupported,
+  onOpenLighting, openSettings, tdJson, comboJson, koJson, arkJson, macroJson,
+}: UseKeymapTabFooterOptions): Record<string, React.ReactNode> {
+  const { t } = useTranslation()
+  return useMemo(() => {
+    const btnClass = 'rounded border border-edge px-3 py-1 text-xs text-content-secondary hover:text-content hover:bg-surface-dim'
+    const buttonDefs = [
+      { tab: 'tapDance', key: 'tdJsonEditor', label: t('editor.tapDance.editJson'), onClick: tdJson.open, testId: 'tap-dance-json-editor-btn', enabled: !!tapDanceEntries && tapDanceEntries.length > 0 },
+      { tab: 'tapDance', key: 'tapHold', label: t('editor.keymap.tapHoldLabel'), onClick: () => openSettings('tapHold'), testId: 'tap-hold-settings-btn', enabled: tapHoldSupported },
+      { tab: 'system', key: 'mouseKeys', label: t('editor.keymap.mouseKeysLabel'), onClick: () => openSettings('mouseKeys'), testId: 'mouse-keys-settings-btn', enabled: mouseKeysSupported },
+      { tab: 'modifiers', key: 'graveEscape', label: t('editor.keymap.graveEscapeLabel'), onClick: () => openSettings('graveEscape'), testId: 'grave-escape-settings-btn', enabled: graveEscapeSupported },
+      { tab: 'modifiers', key: 'oneShotKeys', label: t('editor.keymap.oneShotKeysLabel'), onClick: () => openSettings('oneShotKeys'), testId: 'one-shot-keys-settings-btn', enabled: oneShotKeysSupported },
+      { tab: 'behavior', key: 'magic', label: t('editor.keymap.magicLabel'), onClick: () => openSettings('magic'), testId: 'magic-settings-btn', enabled: magicSupported },
+      { tab: 'behavior', key: 'autoshift', label: t('editor.keymap.autoShiftLabel'), onClick: () => openSettings('autoShift'), testId: 'auto-shift-settings-btn', enabled: autoShiftSupported },
+      { tab: 'macro', key: 'macroJsonEditor', label: t('editor.tapDance.editJson'), onClick: macroJson.openGated, testId: 'macro-json-editor-btn', enabled: !!deserializedMacros && deserializedMacros.length > 0 },
+      { tab: 'combo', key: 'comboJsonEditor', label: t('editor.tapDance.editJson'), onClick: comboJson.open, testId: 'combo-json-editor-btn', enabled: !!comboEntries && comboEntries.length > 0 },
+      { tab: 'combo', key: 'combo', label: t('common.configuration'), onClick: () => openSettings('combo'), testId: 'combo-settings-btn', enabled: comboSettingsSupported },
+      { tab: 'keyOverride', key: 'koJsonEditor', label: t('editor.tapDance.editJson'), onClick: koJson.open, testId: 'ko-json-editor-btn', enabled: !!keyOverrideEntries && keyOverrideEntries.length > 0 },
+      { tab: 'altRepeatKey', key: 'arkJsonEditor', label: t('editor.tapDance.editJson'), onClick: arkJson.open, testId: 'ark-json-editor-btn', enabled: !!altRepeatKeyEntries && altRepeatKeyEntries.length > 0 },
+      { tab: 'lighting', key: 'lighting', label: t('common.configuration'), onClick: onOpenLighting, testId: 'lighting-settings-btn', enabled: !!onOpenLighting },
+    ]
+    const content: Record<string, React.ReactNode> = {}
+    const grouped = new Map<string, typeof buttonDefs>()
+    for (const def of buttonDefs) { if (!def.enabled) continue; const existing = grouped.get(def.tab); if (existing) existing.push(def); else grouped.set(def.tab, [def]) }
+    for (const [tab, defs] of grouped) {
+      content[tab] = (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-content-secondary/70">{t('common.settingsLabel')}</span>
+          {defs.map((d) => (<button key={d.key} type="button" className={btnClass} onClick={d.onClick} data-testid={d.testId}>{d.label}</button>))}
+        </div>
+      )
+    }
+    return content
+  }, [tapDanceEntries, comboEntries, keyOverrideEntries, altRepeatKeyEntries, deserializedMacros, tapHoldSupported, mouseKeysSupported, magicSupported, autoShiftSupported, graveEscapeSupported, oneShotKeysSupported, comboSettingsSupported, onOpenLighting, t, openSettings, tdJson.open, comboJson.open, koJson.open, arkJson.open, macroJson.openGated])
 }

--- a/src/renderer/components/editors/use-keymap-pack-tabs.ts
+++ b/src/renderer/components/editors/use-keymap-pack-tabs.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TapDanceEntry } from '../../../shared/types/protocol'
+import type { MacroAction } from '../../../preload/macro'
+import type { KeyboardLayoutId } from '../../hooks/useKeyboardLayout'
+import type { RemapKind } from '../keyboard/constants'
+import { EMPTY_REMAPPED } from './keymap-editor-types'
+import type { KeymapPackTab } from './KeymapPackTabs'
+import { useLayerKeycodes } from './use-layer-keycodes'
+
+export interface UseKeymapPackTabsOptions {
+  keyboardLayout?: KeyboardLayoutId
+  remapKind?: RemapKind
+  keymap: Map<string, number>
+  encoderLayout: Map<string, number>
+  encoderCount: number
+  currentLayer: number
+  typingTestMode?: boolean
+  viewMatrixActive: boolean
+  handleDeselect: () => void
+  parsedMacros?: MacroAction[][] | null
+  macroBuffer?: number[]
+  macroCount?: number
+  vialProtocol?: number
+  tapDanceEntries?: TapDanceEntry[]
+  remapLabel?: (qmkId: string) => string
+  layerKeycodes: Map<string, string>
+  layerEncoderKeycodes: Map<string, [string, string]>
+  remappedKeys: Set<string>
+  layerEncoderRemapped: Set<string>
+}
+
+export interface UseKeymapPackTabsReturn {
+  packTab: KeymapPackTab
+  /** SINGLE PREDICATE (Plan-qwerty-select-no-rewrite v7): `remapKind` is
+   *  ALREADY the unified "does the active pack want a keymap rewrite"
+   *  signal (see `useDevicePrefs.ts` — it's gated on `keymapApplicable &&
+   *  buildKeymapRewriteTable(map).ok`, not `.ok` alone); combined with
+   *  `keymap.size > 0`, this is the SAME condition `requestApply` itself
+   *  requires, so tab AND Apply-button visibility both collapse onto this
+   *  one boolean rather than needing separate checks that could disagree.
+   *  Suppressed during typing test / View Matrix mode too, neither of
+   *  which has a concept of a second (Base) keymap surface to switch to. */
+  showPackTabs: boolean
+  /** True exactly while the visible pane is the read-only simulation tab —
+   *  gates both `KeyboardPane`'s own `readOnly` and every picker edit path,
+   *  belt-and-braces on top of `handlePackTabChange` already clearing any
+   *  live selection when this becomes true. */
+  packTabReadOnly: boolean
+  primaryKeycodes: Map<string, string>
+  primaryEncoderKeycodes: Map<string, [string, string]>
+  primaryRemappedKeys: Set<string>
+  primaryRemappedEncoders: Set<string>
+  primaryRemapLabel?: (qmkId: string) => string
+  handlePackTabChange: (tab: KeymapPackTab) => void
+  /** Resets back to the simulation/pack tab — called by the host's own
+   *  uid/keymap-size clear effect (which also clears history / exits View
+   *  Matrix mode, so it stays in `KeymapEditor` rather than moving here). */
+  resetPackTab: () => void
+}
+
+/** Simulation/Base tab (Plan-qwerty-select-no-rewrite v7 — シミュレーション
+ * タブ方式). Which of the two vertical tabs (pack-name simulation vs. the
+ * real "Base" keymap) is showing when `remapKind === 'simulated'` shows them
+ * at all. Defaults to the simulation tab; a user switch to Base persists
+ * only until the next uid change (via `resetPackTab`) or a layout change
+ * (tracked internally below), not across a select change or a re-render. */
+export function useKeymapPackTabs({
+  keyboardLayout, remapKind, keymap, encoderLayout, encoderCount, currentLayer,
+  typingTestMode, viewMatrixActive, handleDeselect,
+  parsedMacros, macroBuffer, macroCount, vialProtocol, tapDanceEntries,
+  remapLabel, layerKeycodes, layerEncoderKeycodes, remappedKeys, layerEncoderRemapped,
+}: UseKeymapPackTabsOptions): UseKeymapPackTabsReturn {
+  const [packTab, setPackTab] = useState<KeymapPackTab>('pack')
+
+  const resetPackTab = useCallback(() => { setPackTab('pack') }, [])
+
+  // Switching TO the simulation tab also drops any live selection/multi-
+  // select/picker-selection state — belt-and-braces on top of that pane's
+  // own `readOnly` (which already blocks every click/dblclick path into
+  // it): without this, a key selected on Base right before switching tabs
+  // would stay selected in the (invisible) shared selection state, and a
+  // picker click while viewing the simulation tab would still paste into
+  // it.
+  const handlePackTabChange = useCallback((tab: KeymapPackTab) => {
+    setPackTab(tab)
+    if (tab === 'pack') handleDeselect()
+  }, [handleDeselect])
+
+  // Reset to the simulation tab whenever the selected Key Label / layout
+  // changes (the footer's Keyboard Layout select — `keyboardLayout` here is
+  // the exact same value `useDevicePrefs.layout` feeds into `remapKind`'s
+  // own derivation). Without this, a user parked on the Base tab who then
+  // picks a different pack sees no visible change: the newly selected
+  // pack's simulated keymap only ever renders on the pack tab, and
+  // `remapKind` alone can't signal the switch since it stays `'simulated'`
+  // across two different permutation packs. Same prev-value-ref idiom as
+  // the host's own uid reset effect (kept separate there — that effect also
+  // clears history/View Matrix, which a same-uid layout change must not
+  // trigger) — only acts on an actual change, not on mount or every
+  // render, so a manual tab click right after a layout change isn't
+  // immediately undone by a stray re-render.
+  const prevKeyboardLayoutRef = useRef(keyboardLayout)
+  useEffect(() => {
+    if (keyboardLayout !== prevKeyboardLayoutRef.current) {
+      prevKeyboardLayoutRef.current = keyboardLayout
+      setPackTab('pack')
+    }
+  }, [keyboardLayout])
+
+  // FIX C (external review): a keymap must actually be loaded for a
+  // Rewrite to mean anything — `useKeymapApplyPrompt.requestApply` already
+  // no-ops when `keymapEditable` is false (App.tsx passes `keyboard.keymap
+  // .size > 0` into that hook), but nothing here previously folded that
+  // into tab/button VISIBILITY, so a permutation pack could show a
+  // tabs+Apply UI that silently did nothing when clicked. Derived straight
+  // from this component's own `keymap` prop — the exact same `Map` App.tsx
+  // reads `.size` off of for the hook — rather than a second prop that
+  // could drift out of sync with it.
+  const keymapEditable = keymap.size > 0
+  const showPackTabs = remapKind === 'simulated' && keymapEditable && !typingTestMode && !viewMatrixActive
+  const packTabReadOnly = showPackTabs && packTab === 'pack'
+
+  // Raw (never remapped) keycodes for the Base tab — same underlying
+  // keymap/macro data as `layerKeycodes` above, built with `remapLabel`/
+  // `isRemapped` omitted so `useLayerKeycodes` falls back to identity (see
+  // its own `remap`/`checkRemapped` defaults). `enabled` skips the whole
+  // O(keymap size) build (and the duplicate macro parse) whenever this
+  // instance's output isn't actually being shown — tabs hidden, or the
+  // simulation tab active — rather than paying for it every render.
+  const { layerKeycodes: baseLayerKeycodes, layerEncoderKeycodes: baseLayerEncoderKeycodes } = useLayerKeycodes({
+    parsedMacros, macroBuffer, macroCount, vialProtocol, tapDanceEntries,
+    keymap, encoderLayout, encoderCount, currentLayer,
+    typingTestMode: false, typingTestEffectiveLayer: 0,
+    enabled: showPackTabs && packTab === 'base',
+  })
+
+  // Base tab's data source (Plan-qwerty-select-no-rewrite v7): the SAME
+  // "no tabs" `<KeyboardPane>` JSX renders both the plain (no-tabs) state
+  // and `showPackTabs && packTab === 'base'` — only these source variables
+  // differ between the two. Raw/identity (`baseLayer*`, `EMPTY_REMAPPED`,
+  // `undefined` remapLabel) while on the Base tab; otherwise the normal
+  // `remapLabel`/`isRemapped`-driven values every other state (JIS, QWERTY,
+  // View Matrix, ...) already used.
+  const onBaseTab = showPackTabs && packTab === 'base'
+  const primaryKeycodes = onBaseTab ? baseLayerKeycodes : layerKeycodes
+  const primaryEncoderKeycodes = onBaseTab ? baseLayerEncoderKeycodes : layerEncoderKeycodes
+  const primaryRemappedKeys = onBaseTab ? EMPTY_REMAPPED : remappedKeys
+  const primaryRemappedEncoders = onBaseTab ? EMPTY_REMAPPED : layerEncoderRemapped
+  const primaryRemapLabel = onBaseTab ? undefined : remapLabel
+
+  return {
+    packTab, showPackTabs, packTabReadOnly,
+    primaryKeycodes, primaryEncoderKeycodes, primaryRemappedKeys, primaryRemappedEncoders, primaryRemapLabel,
+    handlePackTabChange, resetPackTab,
+  }
+}

--- a/src/renderer/components/editors/use-keymap-rewrite.ts
+++ b/src/renderer/components/editors/use-keymap-rewrite.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback, useEffect, useRef } from 'react'
+import { rewriteNumericKeycode } from '../../../shared/keymap/keymap-apply'
+import type { KeymapRewriteTable } from '../../../shared/keymap/keymap-apply'
+import type { KeymapApplyResult } from './keymap-editor-types'
+import type { SingleHistoryEntry, UseKeymapHistoryReturn } from './useKeymapHistory'
+
+export interface UseKeymapRewriteOptions {
+  keymap: Map<string, number>
+  encoderLayout: Map<string, number>
+  onSetKey: (layer: number, row: number, col: number, keycode: number) => Promise<void>
+  onSetEncoder: (layer: number, idx: number, dir: number, keycode: number) => Promise<void>
+  history: UseKeymapHistoryReturn
+  triggerFlash: (entries: SingleHistoryEntry[]) => void
+}
+
+export interface UseKeymapRewriteReturn {
+  applyKeymapRewrite: (table: KeymapRewriteTable) => Promise<KeymapApplyResult>
+}
+
+// --- Key Label "apply to keymap" bulk rewrite (Plan-key-label-keymap-apply
+// Phase 3). Reachable from the footer's layout select via the imperative
+// handle in KeymapEditor, so the write lands on this same `history` instance
+// instead of a second undo stack. Writes go through `onSetKey` /
+// `onSetEncoder` sequentially (not `onSetKeysBulk`) so a mid-way failure
+// leaves both the local keymap state and the pushed history entry
+// containing only the positions that actually succeeded.
+export function useKeymapRewrite({
+  keymap, encoderLayout, onSetKey, onSetEncoder, history, triggerFlash,
+}: UseKeymapRewriteOptions): UseKeymapRewriteReturn {
+  // Same "ref mirrors the latest prop for use inside a stable callback"
+  // idiom as `hasActiveSingleSelectionRef` in KeymapEditor: `keymap`/
+  // `encoderLayout` are re-read fresh from these refs before every single
+  // write below, so a concurrent edit that lands on a position between two
+  // `await`s (or during a re-render triggered by one of this function's own
+  // writes) is detected instead of silently clobbered.
+  const keymapRef = useRef(keymap)
+  keymapRef.current = keymap
+  const encoderLayoutRef = useRef(encoderLayout)
+  encoderLayoutRef.current = encoderLayout
+  const isApplyingRewriteRef = useRef(false)
+  // Belt-and-braces unmount guard: the editor-footer Analyze button can open
+  // AnalyzePage (unmounting this component) while a rewrite's sequential
+  // `await`ed device writes are still in flight — the caller-side guard in
+  // App.tsx disables that button while a rewrite is running, but this ref
+  // is the last line of defense so a rewrite already past that guard still
+  // stops cleanly instead of pushing history / firing callbacks / setting
+  // state on an unmounted component.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => { isMountedRef.current = false }
+  }, [])
+
+  const applyKeymapRewrite = useCallback(async (
+    table: KeymapRewriteTable,
+  ): Promise<KeymapApplyResult> => {
+    // Re-entrancy guard: a double Apply click (or any other concurrent
+    // caller) must never interleave two rewrite passes against the same
+    // undo stack. No-op rather than throwing — the in-flight call already
+    // owns the operation.
+    if (isApplyingRewriteRef.current) return { appliedCount: 0 }
+    isApplyingRewriteRef.current = true
+
+    try {
+      const keyChanges: { layer: number; row: number; col: number; oldKeycode: number; newKeycode: number }[] = []
+      for (const [posKey, code] of keymap) {
+        const newKeycode = rewriteNumericKeycode(code, table)
+        if (newKeycode === code) continue
+        const [layer, row, col] = posKey.split(',').map(Number)
+        keyChanges.push({ layer, row, col, oldKeycode: code, newKeycode })
+      }
+      const encoderChanges: { layer: number; idx: number; dir: number; oldKeycode: number; newKeycode: number }[] = []
+      for (const [posKey, code] of encoderLayout) {
+        const newKeycode = rewriteNumericKeycode(code, table)
+        if (newKeycode === code) continue
+        const [layer, idx, dir] = posKey.split(',').map(Number)
+        encoderChanges.push({ layer, idx, dir, oldKeycode: code, newKeycode })
+      }
+
+      const applied: SingleHistoryEntry[] = []
+      let error: string | undefined
+      try {
+        for (const c of keyChanges) {
+          // Stop immediately once the component has unmounted (e.g. the
+          // Analyze button navigated away mid-rewrite) — no further writes.
+          if (!isMountedRef.current) break
+          // Freshness check: skip this position if a concurrent edit
+          // already moved it away from the value this rewrite was
+          // computed against, instead of overwriting whatever that edit
+          // just wrote.
+          const current = keymapRef.current.get(`${c.layer},${c.row},${c.col}`) ?? 0
+          if (current !== c.oldKeycode) continue
+          await onSetKey(c.layer, c.row, c.col, c.newKeycode)
+          applied.push({ kind: 'key', layer: c.layer, row: c.row, col: c.col, oldKeycode: c.oldKeycode, newKeycode: c.newKeycode })
+        }
+        for (const c of encoderChanges) {
+          if (!isMountedRef.current) break
+          const current = encoderLayoutRef.current.get(`${c.layer},${c.idx},${c.dir}`) ?? 0
+          if (current !== c.oldKeycode) continue
+          await onSetEncoder(c.layer, c.idx, c.dir, c.newKeycode)
+          applied.push({ kind: 'encoder', layer: c.layer, idx: c.idx, dir: c.dir as 0 | 1, oldKeycode: c.oldKeycode, newKeycode: c.newKeycode })
+        }
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err)
+      }
+
+      // Unmounted mid-rewrite: skip ALL bookkeeping below (history clear,
+      // post-apply flash state/timer) — the component is gone, so there is
+      // nothing left to flash and no history stack of this instance to
+      // touch. The device is left mid-rewrite exactly like a
+      // partial-failure apply; the counts are still returned to the caller
+      // for its own error surfacing.
+      //
+      // Rewrite is a destructive one-shot (Plan-qwerty-select-no-rewrite v5
+      // 最終仕様), same class of operation as a snapshot/.vil restore: the
+      // moment ANY write actually landed, both undo/redo stacks are wiped
+      // rather than gaining a revertible batch entry — no history entry is
+      // ever pushed for a rewrite, success or partial failure alike.
+      // Recovery from a bad or partial rewrite is the user's own
+      // .vil/snapshot backup (the confirm modal recommends saving before
+      // applying), not Undo. A rewrite that touched nothing (table matched
+      // no live keycode, or the very first write itself failed) leaves
+      // history untouched — nothing was destroyed, so there's nothing to
+      // protect the user from.
+      //
+      // This clear fires on ANY landed write, including a partial failure —
+      // it is unconditional on `error`. The OTHER half of the destructive
+      // one-shot contract — resetting the footer's select back to QWERTY —
+      // lives one layer up, in `useKeymapApplyPrompt.handleApplyConfirm`,
+      // and fires ONLY on a clean (error-free) success; a partial failure
+      // leaves the select untouched there. Shared invariant: a rewrite
+      // leaves no undo trail; only a clean success returns the select to
+      // QWERTY.
+      if (applied.length > 0 && isMountedRef.current) {
+        history.clear()
+        // Flash the rewritten positions (see `useKeyFlash`) — only for a
+        // clean, error-free pass. A partial failure leaves the keymap
+        // mixed, which isn't the "here's what changed" story this visual
+        // is telling.
+        if (error === undefined) triggerFlash(applied)
+      }
+      return { appliedCount: applied.length, error }
+    } finally {
+      isApplyingRewriteRef.current = false
+    }
+  }, [keymap, encoderLayout, onSetKey, onSetEncoder, history, triggerFlash])
+
+  return { applyKeymapRewrite }
+}


### PR DESCRIPTION
## Summary
- Split `src/renderer/components/editors/KeymapEditor.tsx` (892 lines, UI Component cap 500) into a 495-line editor plus five new files — `use-keymap-rewrite.ts` (151: the destructive one-shot bulk-rewrite with its re-entrancy latch, unmount guard, and render-time keymap mirrors), `use-keymap-pack-tabs.ts` (158: pack/Base tab state, visibility predicates, the Base-tab keycode fetch), `KeymapTypingTestPane.tsx` (143), `KeymapPickerRegion.tsx` (142), `KeymapPrimaryPane.tsx` (134) — and absorptions into three existing siblings: `keymap-editor-toolbar.tsx` (ViewMatrixZoomRow + the tab-footer memo), `KeymapPackTabs.tsx` (KeymapPackApplyButton), `KeymapEditorModals.tsx` (KeymapApplyConfirmModal).
- The two extracted hooks map 1:1 onto the file's regression history: the #285/#286 bulk-rewrite cluster and the #300 pack-tab cluster.
- The imperative handle (`useImperativeHandle`) stays in KeymapEditor and is byte-identical to HEAD; `KeymapEditorHandle` remains re-exported from this module for existing importers.
- The component signature changed to `function KeymapEditor(props, ref)` so the three wrapper components receive `{...props}` plus explicit overrides for the values whose effective (defaulted/derived) form differs from the raw prop — `scale`, `layoutOptions`, `autoAdvance`, `typingTestSaveUnnamed` — each documented at the call site.
- The `applyButtonNode` construction moved behind its actual render branch (it was previously built and discarded in typing-test mode) — strictly less work, observably identical.

## Verification
- Full suite: 358 test files, 8,112 passed / 22 skipped — exact baseline match, zero test edits. The 15 KeymapEditor test files (5,179 lines) render the real component and pass unchanged, including the 905-line applyRewrite suite that pins re-entrancy, unmount-mid-rewrite, and concurrent-edit freshness.
- `pnpm run lint`, `pnpm typecheck`, `pnpm run build`, TDZ gate all clean.
- Testid multiset byte-identical to HEAD (including zoom-in/out-button appearing twice and the 13 picker-footer testIds used by e2e/doc-capture); keyboard-widget stays inside `keymap-surface` with the picker as its sibling.
- All hooks register above the `if (!layout)` early return; no new file imports from KeymapEditor; the sibling graph is acyclic.
- One benign effect-order note: the keyboardLayout reset effect (now in the pack-tabs hook) commits before the uid effect where HEAD had the reverse; both are idempotent resets to the same state.