### PR TITLE
fix(hub): use a valid fallback vial protocol for Data modal hub posts

### DIFF
--- a/src/main/__tests__/hub-ipc-favorite.test.ts
+++ b/src/main/__tests__/hub-ipc-favorite.test.ts
@@ -233,6 +233,24 @@ describe('hub-ipc favorite handlers', () => {
       expect(getIdToken).not.toHaveBeenCalled()
     })
 
+    // Regression: the Data modal (no keyboard connected) used to forward
+    // the emptyState sentinel -1 straight through to this handler, which
+    // reached the Hub server as `vial_protocol: -1` and got a confusing
+    // 400. It must now fail fast locally instead.
+    it('returns a local error for vialProtocol -1 instead of reaching the Hub', async () => {
+      const handler = getHandler()
+      const result = await handler({}, {
+        type: 'tapDance',
+        entryId: 'entry-1',
+        vialProtocol: -1,
+        title: 'Test',
+      })
+
+      expect(result).toEqual({ success: false, error: 'Invalid vialProtocol' })
+      expect(getIdToken).not.toHaveBeenCalled()
+      expect(uploadFeaturePostToHub).not.toHaveBeenCalled()
+    })
+
     it('returns error for missing title', async () => {
       const handler = getHandler()
 
@@ -372,6 +390,21 @@ describe('hub-ipc favorite handlers', () => {
           data: expect.any(Buffer),
         }),
       )
+    })
+
+    it('returns a local error for vialProtocol -1 instead of reaching the Hub', async () => {
+      const handler = getHandler()
+      const result = await handler({}, {
+        type: 'tapDance',
+        entryId: 'entry-1',
+        vialProtocol: -1,
+        title: 'Test',
+        postId: 'fav-post-1',
+      })
+
+      expect(result).toEqual({ success: false, error: 'Invalid vialProtocol' })
+      expect(getIdToken).not.toHaveBeenCalled()
+      expect(updateFeaturePostOnHub).not.toHaveBeenCalled()
     })
 
     it('returns error for invalid favorite type', async () => {

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -74,7 +74,7 @@ import { HUB_ERROR_KEY_LABEL_DUPLICATE, HUB_KEY_LABEL_TIMESTAMPS_BATCH_LIMIT } f
 import { getRecord, saveRecord, setHubPostId } from '../key-label-store'
 import type { SaveRecordInput } from '../key-label-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from '../../shared/types/key-label-store'
-import { isValidFavoriteType, isValidVialProtocol, FAV_TYPE_TO_EXPORT_KEY, serializeFavData, buildFavExportFile } from '../../shared/favorite-data'
+import { isValidFavoriteType, isValidHubVialProtocol, FAV_TYPE_TO_EXPORT_KEY, serializeFavData, buildFavExportFile } from '../../shared/favorite-data'
 import { serialize as serializeKeycode } from '../../shared/keycodes/keycodes'
 import type { FavoriteType, FavoriteIndex } from '../../shared/types/favorite-store'
 import { readFile } from 'node:fs/promises'
@@ -770,7 +770,11 @@ export function setupHubIpc(): void {
     params: HubUploadFavoritePostParams,
   ): Promise<{ title: string; postType: string; jsonFile: { name: string; data: Buffer } }> {
     if (!isValidFavoriteType(params.type)) throw new Error('Invalid favorite type')
-    if (!isValidVialProtocol(params.vialProtocol)) throw new Error('Invalid vialProtocol')
+    // Hub-specific: stricter than the general `isValidVialProtocol` (see
+    // favorite-data.ts) because a raw negative sentinel (e.g. -1, the
+    // disconnected-state placeholder) must fail fast locally with a clear
+    // error instead of reaching the Hub server as a confusing 400.
+    if (!isValidHubVialProtocol(params.vialProtocol)) throw new Error('Invalid vialProtocol')
     const title = validateTitle(params.title)
     const postType = FAV_TYPE_TO_EXPORT_KEY[params.type]
     const jsonStr = await buildFavoriteExportJson(params.type, params.entryId, params.vialProtocol)

--- a/src/renderer/components/data-modal/useSnapshotActions.ts
+++ b/src/renderer/components/data-modal/useSnapshotActions.ts
@@ -8,6 +8,7 @@ import { generateKeymapPdf } from '../../../shared/pdf-export'
 import { generatePdfThumbnail } from '../../utils/pdf-thumbnail'
 import { isVilFile, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
 import { vilToVialGuiJson } from '../../../shared/vil-compat'
+import { FALLBACK_VIAL_PROTOCOL } from '../../../shared/favorite-data'
 import {
   splitMacroBuffer,
   deserializeMacro,
@@ -54,7 +55,7 @@ function buildParams(vilData: VilFile) {
     ? (def.layouts.keymap as unknown[][]).flat().filter((k) => typeof k === 'string' && k.includes('\n\n\n\n\n\n\n\n\n\ne')).length
     : 0
   const macroCount = FALLBACK_MACRO_COUNT
-  const vialProtocol = vilData.vialProtocol ?? 9
+  const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
 
   return {
     layers: deriveLayerCount(vilData.keymap),
@@ -85,7 +86,7 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
       if (!vilData) return
       const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? 9
+      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
       const rows = def.matrix?.rows ?? 0
       const cols = def.matrix?.cols ?? 0
@@ -145,7 +146,7 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
       })
       const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? 9
+      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
       const rows = def.matrix?.rows ?? 0
       const cols = def.matrix?.cols ?? 0
@@ -184,7 +185,7 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
       })
       const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? 9
+      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
       const rows = def.matrix?.rows ?? 0
       const cols = def.matrix?.cols ?? 0

--- a/src/renderer/hooks/__tests__/useFavoriteManage.test.ts
+++ b/src/renderer/hooks/__tests__/useFavoriteManage.test.ts
@@ -83,8 +83,9 @@ describe('useFavoriteManage', () => {
       await result.current.exportAll()
     })
 
-    // The hook always passes the Data modal's fallback vial protocol (9).
-    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 9)
+    // The hook always passes the shared fallback vial protocol (6 — see
+    // FALLBACK_VIAL_PROTOCOL in shared/favorite-data.ts).
+    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 6)
   })
 
   it('exportEntry calls favoriteStoreExport with entryId', async () => {
@@ -94,7 +95,7 @@ describe('useFavoriteManage', () => {
       await result.current.exportEntry('e1')
     })
 
-    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 9, 'e1')
+    expect(mockFavoriteStoreExport).toHaveBeenCalledWith('tapDance', 6, 'e1')
   })
 
   it('importFavorites calls favoriteStoreImport and sets result', async () => {

--- a/src/renderer/hooks/__tests__/useHubState.test.ts
+++ b/src/renderer/hooks/__tests__/useHubState.test.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Regression coverage for the Data-modal favorite-Hub vial_protocol bug:
+// the Data modal renders on the disconnected screen, where `vialProtocol`
+// is the emptyState sentinel -1. useHubState must not forward that raw
+// sentinel to the Hub IPC calls — it should substitute the shared
+// FALLBACK_VIAL_PROTOCOL (6) instead, while passing through any real
+// (non-negative integer) protocol unchanged.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useHubState } from '../useHubState'
+import type { SavedFavoriteMeta } from '../../../shared/types/favorite-store'
+
+const { mockRequestUploadOptions } = vi.hoisted(() => ({
+  mockRequestUploadOptions: vi.fn(),
+}))
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('../useUploadConfirm', () => ({
+  useUploadConfirm: () => ({ requestUploadOptions: mockRequestUploadOptions, isOpen: false }),
+}))
+
+const mockHubGetOrigin = vi.fn().mockResolvedValue('https://hub.example')
+const mockFavoriteStoreList = vi.fn()
+const mockHubUploadFavoritePost = vi.fn()
+const mockHubUploadPrivateFavoritePost = vi.fn()
+const mockHubUpdateFavoritePost = vi.fn()
+const mockHubDeletePost = vi.fn()
+const mockHubDeletePrivatePost = vi.fn()
+const mockFavoriteStoreSetHubPostId = vi.fn().mockResolvedValue(undefined)
+const mockFavoriteStoreSetHubPrivate = vi.fn().mockResolvedValue(undefined)
+
+Object.defineProperty(window, 'vialAPI', {
+  value: {
+    hubGetOrigin: mockHubGetOrigin,
+    favoriteStoreList: mockFavoriteStoreList,
+    hubUploadFavoritePost: mockHubUploadFavoritePost,
+    hubUploadPrivateFavoritePost: mockHubUploadPrivateFavoritePost,
+    hubUpdateFavoritePost: mockHubUpdateFavoritePost,
+    hubDeletePost: mockHubDeletePost,
+    hubDeletePrivatePost: mockHubDeletePrivatePost,
+    favoriteStoreSetHubPostId: mockFavoriteStoreSetHubPostId,
+    favoriteStoreSetHubPrivate: mockFavoriteStoreSetHubPrivate,
+  },
+  writable: true,
+})
+
+function baseOptions(vialProtocol: number) {
+  return {
+    hubEnabled: false,
+    authenticated: false,
+    keyboardUid: 'uid-1',
+    layoutStoreEntries: [],
+    layoutStoreRefreshEntries: vi.fn(),
+    layoutStoreDeleteEntry: vi.fn(),
+    layoutStoreSaveLayout: vi.fn(),
+    layoutStoreRenameEntry: vi.fn(),
+    deviceName: 'Test KB',
+    effectiveIsDummy: false,
+    loadEntryVilData: vi.fn(),
+    buildHubPostParams: vi.fn(),
+    activityCount: 0,
+    pipetteFileSavedActivityRef: { current: 0 },
+    vialProtocol,
+  }
+}
+
+function entriesWith(overrides: Partial<SavedFavoriteMeta> = {}): SavedFavoriteMeta[] {
+  return [{ id: 'e1', label: 'Fav', savedAt: '2026-01-01T00:00:00.000Z', filename: 'e1.json', ...overrides }]
+}
+
+describe('useHubState favorite vialProtocol fallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockHubGetOrigin.mockResolvedValue('https://hub.example')
+    mockHubUploadFavoritePost.mockResolvedValue({ success: true, postId: 'post-1' })
+    mockHubUploadPrivateFavoritePost.mockResolvedValue({ success: true, id: 'priv-1', url: 'https://hub.example/p/priv-1', expiresAt: null })
+    mockHubUpdateFavoritePost.mockResolvedValue({ success: true, postId: 'post-1' })
+    mockHubDeletePost.mockResolvedValue({ success: true })
+    mockHubDeletePrivatePost.mockResolvedValue({ success: true })
+  })
+
+  // --- handleFavUploadToHub / upload public branch ---
+
+  it('substitutes the fallback protocol when uploading publicly with vialProtocol -1', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith() })
+
+    const { result } = renderHook(() => useHubState(baseOptions(-1)))
+    await act(async () => {
+      await result.current.handleFavUploadToHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tapDance', entryId: 'e1', vialProtocol: 6 }),
+    )
+  })
+
+  it('passes the real protocol through unchanged when uploading publicly with vialProtocol 5', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith() })
+
+    const { result } = renderHook(() => useHubState(baseOptions(5)))
+    await act(async () => {
+      await result.current.handleFavUploadToHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ vialProtocol: 5 }),
+    )
+  })
+
+  // --- handleFavUploadToHub / upload private branch ---
+
+  it('substitutes the fallback protocol when uploading privately with vialProtocol -1', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'private', expiresInDays: 7 })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith() })
+
+    const { result } = renderHook(() => useHubState(baseOptions(-1)))
+    await act(async () => {
+      await result.current.handleFavUploadToHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadPrivateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tapDance', entryId: 'e1', vialProtocol: 6 }),
+    )
+  })
+
+  it('passes the real protocol through unchanged when uploading privately with vialProtocol 5', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'private', expiresInDays: 7 })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith() })
+
+    const { result } = renderHook(() => useHubState(baseOptions(5)))
+    await act(async () => {
+      await result.current.handleFavUploadToHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadPrivateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ vialProtocol: 5 }),
+    )
+  })
+
+  // --- handleFavUpdateOnHub / update public->public branch ---
+
+  it('substitutes the fallback protocol on a public->public update with vialProtocol -1', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith({ hubPostId: 'post-1' }) })
+
+    const { result } = renderHook(() => useHubState(baseOptions(-1)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUpdateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tapDance', entryId: 'e1', postId: 'post-1', vialProtocol: 6 }),
+    )
+  })
+
+  it('passes the real protocol through unchanged on a public->public update with vialProtocol 5', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith({ hubPostId: 'post-1' }) })
+
+    const { result } = renderHook(() => useHubState(baseOptions(5)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUpdateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ vialProtocol: 5 }),
+    )
+  })
+
+  // --- handleFavUpdateOnHub / update private->public branch ---
+
+  it('substitutes the fallback protocol when switching private->public with vialProtocol -1', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({
+      success: true,
+      entries: entriesWith({ hubPrivate: { id: 'priv-1', url: 'https://hub.example/p/priv-1', expiresAt: null } }),
+    })
+
+    const { result } = renderHook(() => useHubState(baseOptions(-1)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tapDance', entryId: 'e1', vialProtocol: 6 }),
+    )
+  })
+
+  it('passes the real protocol through unchanged when switching private->public with vialProtocol 5', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'public', expiresInDays: null })
+    mockFavoriteStoreList.mockResolvedValue({
+      success: true,
+      entries: entriesWith({ hubPrivate: { id: 'priv-1', url: 'https://hub.example/p/priv-1', expiresAt: null } }),
+    })
+
+    const { result } = renderHook(() => useHubState(baseOptions(5)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ vialProtocol: 5 }),
+    )
+  })
+
+  // --- handleFavUpdateOnHub / update public->private branch ---
+
+  it('substitutes the fallback protocol when switching public->private with vialProtocol -1', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'private', expiresInDays: 7 })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith({ hubPostId: 'post-1' }) })
+
+    const { result } = renderHook(() => useHubState(baseOptions(-1)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadPrivateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'tapDance', entryId: 'e1', vialProtocol: 6 }),
+    )
+  })
+
+  it('passes the real protocol through unchanged when switching public->private with vialProtocol 5', async () => {
+    mockRequestUploadOptions.mockResolvedValue({ visibility: 'private', expiresInDays: 7 })
+    mockFavoriteStoreList.mockResolvedValue({ success: true, entries: entriesWith({ hubPostId: 'post-1' }) })
+
+    const { result } = renderHook(() => useHubState(baseOptions(5)))
+    await act(async () => {
+      await result.current.handleFavUpdateOnHub('tapDance', 'e1')
+    })
+
+    expect(mockHubUploadPrivateFavoritePost).toHaveBeenCalledWith(
+      expect.objectContaining({ vialProtocol: 5 }),
+    )
+  })
+})

--- a/src/renderer/hooks/useFavoriteManage.ts
+++ b/src/renderer/hooks/useFavoriteManage.ts
@@ -3,6 +3,7 @@
 import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { FavoriteType, SavedFavoriteMeta } from '../../shared/types/favorite-store'
+import { FALLBACK_VIAL_PROTOCOL } from '../../shared/favorite-data'
 import type { FavoriteImportResultState } from './useFavoriteStore'
 
 export interface UseFavoriteManageReturn {
@@ -17,11 +18,6 @@ export interface UseFavoriteManageReturn {
   exportEntry: (entryId: string) => Promise<boolean>
   importFavorites: () => Promise<boolean>
 }
-
-// The Data modal has no connected keyboard, so use the same fallback
-// vial protocol the snapshot exports use (see useSnapshotActions). The
-// value only stamps the export file's `vial_protocol` header field.
-const FALLBACK_VIAL_PROTOCOL = 9
 
 export function useFavoriteManage(favoriteType: FavoriteType): UseFavoriteManageReturn {
   const { t } = useTranslation()

--- a/src/renderer/hooks/useHubState.ts
+++ b/src/renderer/hooks/useHubState.ts
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import type { HubMyPost, HubUploadResult, HubPaginationMeta, HubFetchMyPostsParams } from '../../shared/types/hub'
 import type { HubPrivateLink } from '../../shared/types/hub-private'
 import { HUB_ERROR_DISPLAY_NAME_CONFLICT, HUB_ERROR_ACCOUNT_DEACTIVATED, HUB_ERROR_RATE_LIMITED } from '../../shared/types/hub'
+import { FALLBACK_VIAL_PROTOCOL, isValidHubVialProtocol } from '../../shared/favorite-data'
 import { useUploadConfirm } from './useUploadConfirm'
 import { linkFromResult } from '../utils/hub-private-link'
 import type { HubEntryResult } from '../components/editors/LayoutStoreModal'
@@ -61,6 +62,15 @@ export function useHubState(options: Options) {
 
   const { t } = useTranslation()
   const { requestUploadOptions } = useUploadConfirm()
+
+  // Favorite Hub uploads read this instead of the raw `vialProtocol` prop.
+  // The Data modal (the only caller that can reach these handlers with no
+  // keyboard connected) passes the emptyState sentinel -1 here, which the
+  // Hub server rejects outright — substitute the shared fallback protocol
+  // in that case. Any other value (a real connected protocol, e.g. 5 or 6)
+  // passes through unchanged. Reusing the same predicate `hub-ipc.ts`
+  // validates with keeps this sanitizer from drifting out of lockstep.
+  const favVialProtocol = isValidHubVialProtocol(vialProtocol) ? vialProtocol : FALLBACK_VIAL_PROTOCOL
 
   const [hubMyPosts, setHubMyPosts] = useState<HubMyPost[]>([])
   const [hubMyPostsPagination, setHubMyPostsPagination] = useState<HubPaginationMeta | undefined>()
@@ -519,7 +529,7 @@ export function useHubState(options: Options) {
       try {
         if (choice.visibility === 'public') {
           const result = await window.vialAPI.hubUploadFavoritePost({
-            type, entryId, title: entry.label || type, vialProtocol,
+            type, entryId, title: entry.label || type, vialProtocol: favVialProtocol,
           })
           if (result.success) {
             if (result.postId) await persistFavHubPostId(type, entryId, result.postId)
@@ -530,7 +540,7 @@ export function useHubState(options: Options) {
           return
         }
         const result = await window.vialAPI.hubUploadPrivateFavoritePost({
-          type, entryId, title: entry.label || type, vialProtocol, expiresInDays: choice.expiresInDays,
+          type, entryId, title: entry.label || type, vialProtocol: favVialProtocol, expiresInDays: choice.expiresInDays,
         })
         if (result.success) {
           await persistFavHubPrivate(type, entryId, linkFromResult(result))
@@ -542,7 +552,7 @@ export function useHubState(options: Options) {
         setFavHubUploadResult({ kind: 'error', message: t('hub.uploadFailed'), entryId })
       }
     })
-  }, [requestUploadOptions, runFavHubOperation, persistFavHubPostId, persistFavHubPrivate, markAccountDeactivated, t, vialProtocol])
+  }, [requestUploadOptions, runFavHubOperation, persistFavHubPostId, persistFavHubPrivate, markAccountDeactivated, t, favVialProtocol])
 
   const handleFavUpdateOnHub = useCallback(async (type: FavoriteType, entryId: string) => {
     const listResult = await window.vialAPI.favoriteStoreList(type)
@@ -560,7 +570,7 @@ export function useHubState(options: Options) {
         // public → public is a plain in-place update (URL preserved).
         if (currentVisibility === 'public' && choice.visibility === 'public') {
           const result = await window.vialAPI.hubUpdateFavoritePost({
-            type, entryId, title: entry.label || type, postId: entry.hubPostId!, vialProtocol,
+            type, entryId, title: entry.label || type, postId: entry.hubPostId!, vialProtocol: favVialProtocol,
           })
           if (result.success) {
             setFavHubUploadResult({ kind: 'success', message: t('hub.updateSuccess'), entryId })
@@ -579,7 +589,7 @@ export function useHubState(options: Options) {
 
         if (choice.visibility === 'public') {
           const result = await window.vialAPI.hubUploadFavoritePost({
-            type, entryId, title: entry.label || type, vialProtocol,
+            type, entryId, title: entry.label || type, vialProtocol: favVialProtocol,
           })
           if (result.success) {
             if (result.postId) await persistFavHubPostId(type, entryId, result.postId)
@@ -590,7 +600,7 @@ export function useHubState(options: Options) {
           return
         }
         const result = await window.vialAPI.hubUploadPrivateFavoritePost({
-          type, entryId, title: entry.label || type, vialProtocol, expiresInDays: choice.expiresInDays,
+          type, entryId, title: entry.label || type, vialProtocol: favVialProtocol, expiresInDays: choice.expiresInDays,
         })
         if (result.success) {
           await persistFavHubPrivate(type, entryId, linkFromResult(result))
@@ -602,7 +612,7 @@ export function useHubState(options: Options) {
         setFavHubUploadResult({ kind: 'error', message: t('hub.updateFailed'), entryId })
       }
     })
-  }, [requestUploadOptions, runFavHubOperation, persistFavHubPostId, persistFavHubPrivate, markAccountDeactivated, t, vialProtocol])
+  }, [requestUploadOptions, runFavHubOperation, persistFavHubPostId, persistFavHubPrivate, markAccountDeactivated, t, favVialProtocol])
 
   const handleFavRemoveFromHub = useCallback(async (type: FavoriteType, entryId: string) => {
     await runFavHubOperation(type, entryId, true, async (entry) => {

--- a/src/renderer/hooks/useKeyboardLoaders.ts
+++ b/src/renderer/hooks/useKeyboardLoaders.ts
@@ -89,6 +89,16 @@ export function useKeyboardLoaders(
     newState.isDummy = true
     // Use protocol versions from file if available, otherwise default to latest
     newState.viaProtocol = vil.viaProtocol ?? 9
+    // Deliberately NOT FALLBACK_VIAL_PROTOCOL (favorite-data.ts) — that
+    // constant means "no keyboard context" (Data modal, disconnected
+    // screen) and resolves 6, the v6 keycode table. This 9 means "unknown
+    // legacy file era": a foreign/legacy .vil with no vial_protocol field
+    // predates the v3 export format, so it's treated as v5-era and its
+    // keycodes are interpreted via the v5 map on load (see `resolve` in
+    // keycodes-utils.ts: only protocol 6 selects v6, everything else —
+    // including 9 — falls through to v5). Any favorite exported later
+    // from this loaded state stamps `vial_protocol: 9` accordingly,
+    // consistent with how its keycodes were read in.
     newState.vialProtocol = vil.vialProtocol ?? 9
     newState.definition = definition
     newState.rows = definition.matrix.rows

--- a/src/shared/__tests__/favorite-data.test.ts
+++ b/src/shared/__tests__/favorite-data.test.ts
@@ -8,6 +8,9 @@ import {
   FAV_TYPE_TO_EXPORT_KEY,
   FAV_KEYCODE_FIELDS,
   isValidFavExportFile,
+  isValidVialProtocol,
+  isValidHubVialProtocol,
+  FALLBACK_VIAL_PROTOCOL,
   serializeFavData,
   deserializeFavData,
 } from '../favorite-data'
@@ -170,6 +173,54 @@ describe('isFavoriteDataFile', () => {
     it('rejects missing data field', () => {
       expect(isFavoriteDataFile({ type: 'tapDance' }, 'tapDance')).toBe(false)
     })
+  })
+})
+
+describe('isValidVialProtocol / isValidHubVialProtocol', () => {
+  // Regression guard: `isValidVialProtocol` is the local (non-Hub)
+  // export/import boundary in `favorite-store.ts`, and it stays loose on
+  // purpose — no caller passes -1 today, so tightening it there would be
+  // an unforced, non-Hub-related behavior change. The only place -1
+  // comes from is `emptyState()` in `keyboard-types.ts` (the disconnected
+  // screen); only the Hub upload boundary (`isValidHubVialProtocol`)
+  // needs to reject it.
+  it('isValidVialProtocol still accepts -1', () => {
+    expect(isValidVialProtocol(-1)).toBe(true)
+  })
+
+  it('isValidVialProtocol accepts any finite number', () => {
+    expect(isValidVialProtocol(0)).toBe(true)
+    expect(isValidVialProtocol(6)).toBe(true)
+    expect(isValidVialProtocol(1.5)).toBe(true)
+  })
+
+  it('isValidVialProtocol rejects non-numbers', () => {
+    expect(isValidVialProtocol('6')).toBe(false)
+    expect(isValidVialProtocol(null)).toBe(false)
+    expect(isValidVialProtocol(undefined)).toBe(false)
+    expect(isValidVialProtocol(NaN)).toBe(false)
+  })
+
+  it('isValidHubVialProtocol rejects the -1 sentinel (Hub upload boundary is stricter)', () => {
+    expect(isValidHubVialProtocol(-1)).toBe(false)
+  })
+
+  it('isValidHubVialProtocol accepts non-negative integers', () => {
+    expect(isValidHubVialProtocol(0)).toBe(true)
+    expect(isValidHubVialProtocol(5)).toBe(true)
+    expect(isValidHubVialProtocol(6)).toBe(true)
+  })
+
+  it('isValidHubVialProtocol rejects non-integers and non-numbers', () => {
+    expect(isValidHubVialProtocol(1.5)).toBe(false)
+    expect(isValidHubVialProtocol('6')).toBe(false)
+    expect(isValidHubVialProtocol(null)).toBe(false)
+    expect(isValidHubVialProtocol(undefined)).toBe(false)
+    expect(isValidHubVialProtocol(NaN)).toBe(false)
+  })
+
+  it('FALLBACK_VIAL_PROTOCOL is 6, not 9 (the v6 keycode table resolver requirement)', () => {
+    expect(FALLBACK_VIAL_PROTOCOL).toBe(6)
   })
 })
 

--- a/src/shared/favorite-data.ts
+++ b/src/shared/favorite-data.ts
@@ -39,6 +39,38 @@ export function isValidVialProtocol(v: unknown): v is number {
   return typeof v === 'number' && Number.isFinite(v)
 }
 
+/**
+ * Fallback vial protocol used when a favorite Hub export/upload happens
+ * with no keyboard connected (the Data modal only renders on the
+ * disconnected screen, where `vialProtocol` is the emptyState sentinel
+ * -1 — see `keyboard-types.ts`). 6, not 9: on import this value is fed
+ * to `setProtocol` (`withImportProtocol` in `main/favorite-store.ts`),
+ * and the keycode resolver behind `deserialize` treats *only* protocol 6
+ * as the v6 keycode table (`resolve` in `keycodes-utils.ts`: `protocol
+ * === 6 ? keycodesV6.kc : keycodesV5.kc`). 9 would silently fall through
+ * to the v5 map and mis-import protocol-specific keycodes.
+ */
+export const FALLBACK_VIAL_PROTOCOL = 6
+
+/**
+ * Stricter than {@link isValidVialProtocol} — used only at the Hub
+ * upload boundary (`hub-ipc.ts`), where a raw negative protocol should
+ * fail fast locally instead of reaching the server as a confusing 400.
+ * `isValidVialProtocol` itself stays loose on purpose: it's the local
+ * (non-Hub) export/import boundary in `favorite-store.ts`, and tightening
+ * it there is a separate, non-breaking-guaranteed change no caller
+ * currently needs — no caller passes -1 today. (A connected device can
+ * never actually hold -1: preload's protocol read ends in `>>> 0`, so
+ * `vialProtocol` is unsigned once connected, and a genuinely VIA-only
+ * board never reaches the connected state — `useDeviceLifecycle`
+ * disconnects it with `error.notVialCompatible` first. The only place
+ * -1 comes from is `emptyState()` in `keyboard-types.ts`, on the
+ * disconnected screen.)
+ */
+export function isValidHubVialProtocol(v: unknown): v is number {
+  return typeof v === 'number' && Number.isInteger(v) && v >= 0
+}
+
 export function buildFavExportFile(
   vialProtocol: number,
   categories: Record<string, FavoriteExportEntry[]>,


### PR DESCRIPTION
## Summary
- Hub favorite Update/Upload/private-upload from the Data modal failed with a server 400 (`vial_protocol is required for FavoriteExportFile v3`). The Data modal only renders on the disconnected screen, where `keyboard.vialProtocol` is the `-1` sentinel; `useHubState` passed it through to all five favorite-post IPC calls and the Hub server rejects negative values. The editor-side panels work because a connected device supplies a real protocol — both UIs share the same handlers.
- Fix: a shared `FALLBACK_VIAL_PROTOCOL = 6` plus a hub-strict `isValidHubVialProtocol` in `src/shared/favorite-data.ts`. `useHubState` sanitizes once with that same predicate and uses the result at the five favorite-post sites, so the renderer can never emit a value the main-process validator rejects; `prepareFavoritePost` in `hub-ipc.ts` now uses the strict predicate too, turning a raw `-1` into a clear local error instead of a confusing server 400. Connected keyboards are pure pass-through.
- The fallback is 6, not the 9 previously used by the Data modal's file-export path (`useFavoriteManage`, `useSnapshotActions` — both now use the shared constant): the keycode resolver maps only protocol 6 to the v6 table, so files stamped 9 were re-imported through the v5 map while their keycodes were serialized at v6 — a latent round-trip mis-decode this change also closes.
- The loose `isValidVialProtocol` is deliberately unchanged (local export/import boundary; a regression test pins that `-1` is still accepted). The legacy-`.vil` load fallback (`vialProtocol ?? 9` in `useKeyboardLoaders`) is deliberately kept and documented: it means "unknown legacy file era" (v5-map interpretation), not "no keyboard context", and changing it would flip keycode-table interpretation for those loads.

## Verification
- TDD: 19 new tests — a new `useHubState` harness covering all five call sites × {-1 → 6, real protocol → pass-through}, `hub-ipc` local-rejection cases for upload/update (asserting the short-circuit happens before any auth/network work), and `favorite-data` pins for both predicates and the fallback value. The only existing-test edits are the two approved 9→6 expectation updates in `useFavoriteManage.test.ts`.
- Full suite: 360 test files, 8,161 passed / 22 skipped; lint, typecheck, and build clean.
- Reviewed: no remaining favorite-post path passes a raw protocol; the header/serializer divergence for connected protocol-5 keyboards is pre-existing and tracked separately.