### PR TITLE
fix(ui): clear the typing-test reentry flag on disconnect

### DIFF
--- a/src/renderer/hooks/__tests__/use-view-mode-routing.test.tsx
+++ b/src/renderer/hooks/__tests__/use-view-mode-routing.test.tsx
@@ -250,16 +250,16 @@ describe('useViewModeRouting', () => {
       expect(mocks.setViewMode).not.toHaveBeenCalled()
     })
 
-    it('does NOT clear pendingTypingTestReentryRef on disconnect (known gap, Task-clear-typing-reentry-ref-on-disconnect.md)', async () => {
+    it('clears pendingTypingTestReentryRef on disconnect so a later unrelated Back does not spuriously re-enter the typing test (Task-clear-typing-reentry-ref-on-disconnect.md)', async () => {
       // pendingTypingTestReentryRef has no public getter, so this pins the
-      // gap through its one observable consequence: arm it while the
+      // fix through its one observable consequence: arm it while the
       // Analyze page is already closed (openRunTimeline's own
       // setAnalyticsPageOpen(false) is then a no-op, so React never reruns
       // the effect that would otherwise consume the ref in the very same
       // commit), disconnect+reconnect, then walk through Analyze via an
-      // *unrelated* 'editor' origin. If the fix in that task lands (ref
-      // reset alongside the other two on disconnect), this toggle call
-      // disappears and this assertion must flip to `.not.toHaveBeenCalled()`.
+      // *unrelated* 'editor' origin. The disconnect-cleanup effect now
+      // resets the ref alongside the other three, so this Back must NOT
+      // fire the toggle.
       const { result, update, mocks } = renderRouting({ typingTestMode: false })
 
       act(() => { result.current.openRunTimeline('run-1') })
@@ -274,10 +274,10 @@ describe('useViewModeRouting', () => {
 
       act(() => { result.current.handleAnalyticsBack() })
 
-      // Spurious: nothing about this 'editor'-origin Back should re-enter
-      // the typing test, yet the stale ref from the unrelated earlier
-      // openRunTimeline call fires it anyway.
-      expect(mocks.toggleTypingTest).toHaveBeenCalledTimes(1)
+      // The stale ref from the unrelated earlier openRunTimeline call was
+      // cleared on disconnect, so this 'editor'-origin Back does not
+      // re-enter the typing test.
+      expect(mocks.toggleTypingTest).not.toHaveBeenCalled()
     })
   })
 

--- a/src/renderer/hooks/use-view-mode-routing.ts
+++ b/src/renderer/hooks/use-view-mode-routing.ts
@@ -134,6 +134,7 @@ export function useViewModeRouting({
       restoreRequestedUidRef.current = null
       pendingViewOnlyRef.current = false
       pendingTypingTestSaveRef.current = false
+      pendingTypingTestReentryRef.current = false
       // Auto-detect polling disconnect bypasses lifecycle.handleDisconnect,
       // so ephemeral UI state (typingTestMode etc.) must be reset here too.
       resetUIState()


### PR DESCRIPTION
## Summary
- The disconnect-cleanup effect in `use-view-mode-routing.ts` reset three of the four pending-intent refs but left `pendingTypingTestReentryRef` armed. If a device disconnected while the flag was set (e.g. after opening the run timeline from Analyze), a later, unrelated analytics Back spuriously toggled the typing test via the editor's imperative handle.
- Fix is one line: reset the reentry flag alongside the other three refs in the same cleanup branch. Plan review confirmed no legitimate flow depends on the flag surviving a disconnect — reconnect restoration goes through the independent viewMode auto-restore path, an Analyze page still open re-arms the flag at Back time, and clearing prevents stale intent leaking across a device change.
- The unit test that deliberately pinned the old behavior (added with the routing-hook test suite in #351, with a comment anticipating this fix) is flipped to assert the ref is cleared; it was verified to fail against the unfixed hook before the change landed (TDD).

## Verification
- Full suite: 360 test files, 8,161 passed / 22 skipped — matches the main baseline exactly.
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` all clean; the routing-hook suite passes 30/30.