### PR TITLE
chore(ui): remove dead code and align types after the split refactors

### DIFF
--- a/src/renderer/components/AppDisconnectedView.tsx
+++ b/src/renderer/components/AppDisconnectedView.tsx
@@ -10,7 +10,7 @@ import { DataModal } from './DataModal'
 import { NotificationModal } from './NotificationModal'
 import { JaRemovedBanner } from './i18n-packs/JaRemovedBanner'
 import type { useDeviceConnection } from '../hooks/useDeviceConnection'
-import type { useSync } from '../hooks/useSync'
+import type { UseSyncReturn } from '../hooks/useSync'
 import type { useDeviceLifecycle } from '../hooks/useDeviceLifecycle'
 import type { useTheme } from '../hooks/useTheme'
 import type { UseDevicePrefsReturn } from '../hooks/useDevicePrefs'
@@ -21,7 +21,7 @@ import type { useStartupNotification } from '../hooks/useStartupNotification'
 interface Props {
   deviceSyncing: boolean
   device: ReturnType<typeof useDeviceConnection>
-  sync: ReturnType<typeof useSync>
+  sync: UseSyncReturn
   lifecycle: ReturnType<typeof useDeviceLifecycle>
   themeCtx: ReturnType<typeof useTheme>
   devicePrefs: UseDevicePrefsReturn

--- a/src/renderer/components/AppStatusBar.tsx
+++ b/src/renderer/components/AppStatusBar.tsx
@@ -8,7 +8,7 @@ import type { DeviceInfo } from '../../shared/types/protocol'
 import type { useKeyboard } from '../hooks/useKeyboard'
 import type { useEditorUIState } from '../hooks/useEditorUIState'
 import type { UseDevicePrefsReturn } from '../hooks/useDevicePrefs'
-import type { useSync } from '../hooks/useSync'
+import type { UseSyncReturn } from '../hooks/useSync'
 import type { useHubState } from '../hooks/useHubState'
 import type { useTheme } from '../hooks/useTheme'
 import type { useDeviceLifecycle } from '../hooks/useDeviceLifecycle'
@@ -19,7 +19,7 @@ interface Props {
   keyboard: ReturnType<typeof useKeyboard>
   editorUI: ReturnType<typeof useEditorUIState>
   devicePrefs: UseDevicePrefsReturn
-  sync: ReturnType<typeof useSync>
+  sync: UseSyncReturn
   hub: ReturnType<typeof useHubState>
   themeCtx: ReturnType<typeof useTheme>
   lifecycle: ReturnType<typeof useDeviceLifecycle>

--- a/src/renderer/components/analyze/AnalyzePaneChart.tsx
+++ b/src/renderer/components/analyze/AnalyzePaneChart.tsx
@@ -43,6 +43,8 @@ import { AppUsageChart } from './AppUsageChart'
 import { shiftLocalMonth } from './analyze-streak-goal'
 
 export interface AnalyzePaneChartProps {
+  // Identity / range / scopes — which chart tab and keyboard, the active
+  // time window, and the device/app/test/run scope filters.
   tid: (id: string) => string
   analysisTab: AnalysisTabKey
   selected: TypingKeyboardSummary
@@ -51,9 +53,14 @@ export interface AnalyzePaneChartProps {
   appScopes: string[]
   typingTestScopes: string[]
   runIdScopes: string[]
+  // Snapshot-derived values — keymap snapshot, per-finger assignment, and
+  // typing-test results resolved for the current scope.
   effectiveSnapshot: TypingKeymapSnapshot | null
   fingerAssignments: Record<string, FingerType>
   typingTestResults: TypingTestResult[]
+  // Filter state + setters — per-chart filter values (with setters where the
+  // chart can mutate them), plus the snapshot/connection status flags and the
+  // current-time value some of these filters read.
   wpmFilter: AnalyzeFiltersState['wpm']
   showBenchmark: boolean
   intervalFilter: AnalyzeFiltersState['interval']
@@ -70,6 +77,8 @@ export interface AnalyzePaneChartProps {
   bigramsFilter: AnalyzeFiltersState['bigrams']
   setBigrams: (patch: Partial<BigramFilters>) => void
   layoutComparisonFilter: AnalyzeFiltersState['layoutComparison']
+  // Callback — notifies the parent when the Skip% derived from the active
+  // filter changes.
   onSkipPercentChange?: (percent: number | null) => void
   layerFilter: AnalyzeFiltersState['layer']
   setLayer: (patch: Partial<LayerFilters>) => void

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -123,7 +123,6 @@ export function TypingTestPane({
     setViewOnlyControlsOpen,
     mouseOver,
     alwaysOnTopSupported,
-    controlsBarRef,
     paneWrapperRef,
     paneNaturalSizeRef,
     cssScale,
@@ -348,7 +347,6 @@ export function TypingTestPane({
           mouseOver={mouseOver}
           viewOnlyControlsOpen={viewOnlyControlsOpen}
           setViewOnlyControlsOpen={setViewOnlyControlsOpen}
-          controlsBarRef={controlsBarRef}
           menuTab={menuTab}
           onMenuTabChange={onMenuTabChange}
           getDefaultCompactSize={getDefaultCompactSize}

--- a/src/renderer/components/editors/TypingTestPaneViewOnlyMenu.tsx
+++ b/src/renderer/components/editors/TypingTestPaneViewOnlyMenu.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import type { RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TYPING_HEATMAP_WINDOW_OPTIONS } from '../../../shared/types/app-config'
 import type { TypingViewMenuTab } from '../../../shared/types/pipette-settings'
@@ -13,7 +12,6 @@ interface TypingTestPaneViewOnlyMenuProps {
   mouseOver: boolean
   viewOnlyControlsOpen: boolean
   setViewOnlyControlsOpen: (open: boolean) => void
-  controlsBarRef: RefObject<HTMLDivElement | null>
   menuTab: TypingViewMenuTab
   onMenuTabChange?: (tab: TypingViewMenuTab) => void
   getDefaultCompactSize: () => { width: number; height: number }
@@ -49,7 +47,6 @@ export function TypingTestPaneViewOnlyMenu({
   mouseOver,
   viewOnlyControlsOpen,
   setViewOnlyControlsOpen,
-  controlsBarRef,
   menuTab,
   onMenuTabChange,
   getDefaultCompactSize,
@@ -88,7 +85,7 @@ export function TypingTestPaneViewOnlyMenu({
           : t('editor.typingTest.recordingIndicator')}
       </span>
     </div>
-    <div ref={controlsBarRef} className="fixed bottom-0 right-0 z-50">
+    <div className="fixed bottom-0 right-0 z-50">
       <div
         id="view-only-panel"
         role="menu"

--- a/src/renderer/components/editors/use-typing-test-pane-window.ts
+++ b/src/renderer/components/editors/use-typing-test-pane-window.ts
@@ -53,7 +53,6 @@ export function useTypingTestPaneWindow({
   useEffect(() => {
     window.vialAPI.isAlwaysOnTopSupported().then(setAlwaysOnTopSupported).catch(() => {})
   }, [])
-  const controlsBarRef = useRef<HTMLDivElement>(null)
   // Assigned during render on purpose (NOT in an effect): the auto-fit effect
   // below reads this ref instead of taking the callback as a dep so it never
   // re-subscribes its resize listener, and an effect-based assignment would
@@ -203,7 +202,6 @@ export function useTypingTestPaneWindow({
     setViewOnlyControlsOpen,
     mouseOver,
     alwaysOnTopSupported,
-    controlsBarRef,
     paneWrapperRef,
     paneNaturalSizeRef,
     cssScale,

--- a/src/renderer/hooks/use-typing-recording-tray.ts
+++ b/src/renderer/hooks/use-typing-recording-tray.ts
@@ -3,15 +3,15 @@
 // tray status. Split out of App.tsx (Task-split-app-tsx).
 
 import { useCallback, useEffect, useRef } from 'react'
-import type { KeyboardState } from './keyboard-types'
 import type { UseDevicePrefsReturn } from './useDevicePrefs'
+import type { useKeyboard } from './useKeyboard'
 import { useRecKeystrokeCounter } from './useRecKeystrokeCounter'
 import { useTrayStatus } from './useTrayStatus'
 import { buildKeymapSnapshot } from '../components/analyze/keymap-snapshot-builder'
 import type { DeviceInfo } from '../../shared/types/protocol'
 
 interface Params {
-  keyboard: KeyboardState
+  keyboard: ReturnType<typeof useKeyboard>
   devicePrefs: Pick<UseDevicePrefsReturn, 'typingRecordEnabled' | 'typingTestViewOnly' | 'setTypingRecordEnabled'>
   typingTestMode: boolean
   isDummy: boolean
@@ -47,6 +47,9 @@ export function useTypingRecordingTray({
   // tagged by test/run, so without a snapshot the Analyze Heatmap /
   // Ergonomics / Layer-activations views have no layout to draw them on
   // ("No keymap snapshot recorded for this range").
+  // Guard must survive StrictMode's double-invoke: the ref keeps the prior
+  // { active, uid } across the extra mount/cleanup/mount pass, so the second
+  // pass still sees an unchanged (active, uid) as already snapshotted.
   const recordingSnapshotRef = useRef<{ active: boolean; uid: string }>({ active: false, uid: '' })
   useEffect(() => {
     const active = (devicePrefs.typingRecordEnabled && devicePrefs.typingTestViewOnly)

--- a/src/renderer/hooks/use-view-mode-routing.ts
+++ b/src/renderer/hooks/use-view-mode-routing.ts
@@ -85,7 +85,9 @@ export function useViewModeRouting({
     }).catch(() => {})
   }, [typingTestViewOnlyWindowSize, setTypingTestViewOnly, editorUI.typingTestMode])
 
-  // One-shot guard: prevents re-restoring the same uid after an initial restore
+  // One-shot guard: prevents re-restoring the same uid after an initial restore.
+  // Must survive StrictMode's double-invoke — the ref persists across the
+  // extra mount/cleanup/mount pass, so the second pass still sees it as fired.
   const restoreRequestedUidRef = useRef<string | null>(null)
 
   // Pending refs for deferred user intents (set while unlock dialog is open)
@@ -126,6 +128,9 @@ export function useViewModeRouting({
     setAnalyticsPageOpen, setViewMode, pendingTypingTestReentryRef,
   })
 
+  // Guard must survive StrictMode's double-invoke: the ref carries the prior
+  // connected value across the extra mount/cleanup/mount pass so cleanup only
+  // fires on a real connected -> disconnected transition, not a remount.
   const prevConnectedRef = useRef(device.connectedDevice)
   useEffect(() => {
     const wasConnected = prevConnectedRef.current

--- a/src/renderer/hooks/useFavoriteManage.ts
+++ b/src/renderer/hooks/useFavoriteManage.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useCallback, useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import type { FavoriteType, SavedFavoriteMeta } from '../../shared/types/favorite-store'
 import { FALLBACK_VIAL_PROTOCOL } from '../../shared/favorite-data'
 import type { FavoriteImportResultState } from './useFavoriteStore'
@@ -20,7 +19,6 @@ export interface UseFavoriteManageReturn {
 }
 
 export function useFavoriteManage(favoriteType: FavoriteType): UseFavoriteManageReturn {
-  const { t } = useTranslation()
   const [entries, setEntries] = useState<SavedFavoriteMeta[]>([])
   const [exporting, setExporting] = useState(false)
   const [importing, setImporting] = useState(false)
@@ -101,7 +99,7 @@ export function useFavoriteManage(favoriteType: FavoriteType): UseFavoriteManage
     } finally {
       setImporting(false)
     }
-  }, [refreshEntries, t])
+  }, [refreshEntries])
 
   return {
     entries,


### PR DESCRIPTION
## Summary
Five behavior-neutral leftovers from the split-refactor reviews (#346–#350), batched as one cleanup:
- Removed the dead `controlsBarRef` (created in the typing-test window hook, threaded through the pane, attached in the view-only menu, never read — dead since before the split). The controls-bar div and its inert spread are untouched.
- Unified type aliases: `AppStatusBar`/`AppDisconnectedView` now use the exported `UseSyncReturn` instead of `ReturnType<typeof useSync>`, and `use-typing-recording-tray` types its `keyboard` param as `ReturnType<typeof useKeyboard>` matching the sibling hooks (verified a strict structural superset of the previous `KeyboardState`).
- Added one-line StrictMode comments at the three ref guards whose no-op-on-double-invoke behavior is load-bearing (disconnect cleanup, one-shot restore, recording snapshot).
- Added section comments grouping `AnalyzePaneChartProps`' ~30 flat entries.
- Removed the unused `useTranslation`/`t` from `useFavoriteManage` (never called; only survived as a callback dep, subscribing the hook to language-change re-renders for nothing).

## Verification
- Full suite: 360 test files, 8,161 passed / 22 skipped — exact baseline match, zero test edits.
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` all clean.