### PR TITLE
fix(ui): apply inert to the closed view-only menu panel

### DIFF
--- a/src/renderer/components/editors/TypingTestPaneViewOnlyMenu.tsx
+++ b/src/renderer/components/editors/TypingTestPaneViewOnlyMenu.tsx
@@ -91,7 +91,7 @@ export function TypingTestPaneViewOnlyMenu({
         role="menu"
         className={`absolute bottom-0 right-0 flex flex-col gap-1.5 rounded-tl-lg bg-surface-alt/95 px-3 pt-3 pb-2 text-xs shadow-lg backdrop-blur-sm transition-all duration-200 ease-out ${viewOnlyControlsOpen ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-full overflow-hidden opacity-0'}`}
         onClick={(e) => e.stopPropagation()}
-        {...(!viewOnlyControlsOpen && { inert: '' } as Record<string, string>)}
+        inert={!viewOnlyControlsOpen}
       >
         {/* Tab row — Window (sizing + always-on-top) / REC
             (recording toggle + analytics entry) / Monitor App

--- a/src/renderer/components/editors/__tests__/TypingTestPaneViewOnlyMenu.inert.test.tsx
+++ b/src/renderer/components/editors/__tests__/TypingTestPaneViewOnlyMenu.inert.test.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('../../keyboard/KeyboardWidget', () => ({
+  KeyboardWidget: () => <div data-testid="keyboard-widget">KeyboardWidget</div>,
+}))
+
+import { TypingTestPane, type TypingTestPaneProps } from '../TypingTestPane'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../../typing-test/types'
+import { createInitialState } from '../../../typing-test/run-state'
+
+beforeEach(() => {
+  window.vialAPI = {
+    ...window.vialAPI,
+    isAlwaysOnTopSupported: () => Promise.resolve(false),
+    setWindowCompactMode: () => Promise.resolve(null),
+    setWindowAspectRatio: () => Promise.resolve(),
+    setWindowAlwaysOnTop: () => Promise.resolve(),
+  } as typeof window.vialAPI
+})
+
+// Minimal stub of useTypingTest's return value — only the fields the
+// view-only pane's rendering path actually reads.
+const fakeTypingTest = {
+  state: createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE),
+  wpm: 0,
+  kpm: 0,
+  accuracy: 100,
+  romajiGuide: null,
+  elapsedSeconds: 0,
+  remainingSeconds: null,
+  config: DEFAULT_CONFIG,
+  language: DEFAULT_LANGUAGE,
+  isLanguageLoading: false,
+  baseLayer: 0,
+  effectiveLayer: 0,
+  windowFocused: true,
+  processMatrixFrame: vi.fn(),
+  resetMatrixPressTracking: vi.fn(),
+  processKeyEvent: vi.fn(),
+  processCompositionStart: vi.fn(),
+  processCompositionUpdate: vi.fn(),
+  processCompositionEnd: vi.fn(),
+  restart: vi.fn(),
+  restartWithCountdown: vi.fn(),
+  setConfig: vi.fn(),
+  setLanguage: vi.fn(),
+  setBaseLayer: vi.fn(),
+  setWindowFocused: vi.fn(),
+  captureMemory: vi.fn(),
+  pause: vi.fn(),
+  restoreState: vi.fn(),
+} as unknown as TypingTestPaneProps['typingTest']
+
+function renderViewOnly(overrides: Partial<TypingTestPaneProps> = {}) {
+  const defaults: TypingTestPaneProps = {
+    typingTest: fakeTypingTest,
+    onConfigChange: vi.fn(),
+    onLanguageChange: vi.fn().mockResolvedValue(undefined),
+    layers: 1,
+    pressedKeys: new Set(),
+    keycodes: new Map(),
+    encoderKeycodes: new Map(),
+    remappedKeys: new Set(),
+    layoutOptions: new Map(),
+    scale: 1,
+    keys: [],
+    layerLabel: '',
+    viewOnly: true,
+    menuTab: 'window',
+  }
+  return render(<TypingTestPane {...defaults} {...overrides} />)
+}
+
+// The panel's click-to-toggle target has no data-testid — it's the
+// viewOnly pane wrapper in TypingTestPane.tsx that flips
+// viewOnlyControlsOpen on click. Selecting by its distinguishing class is
+// the only handle available without adding test-only markup.
+function clickPaneToToggleControls(container: HTMLElement): void {
+  const target = container.querySelector('.cursor-pointer')
+  if (!target) throw new Error('view-only pane click target not found')
+  fireEvent.click(target)
+}
+
+describe('TypingTestPaneViewOnlyMenu — inert while closed', () => {
+  it('marks the panel inert while the view-only controls are closed (mount default)', () => {
+    renderViewOnly()
+    const panel = screen.getByRole('menu')
+    expect(panel).toHaveAttribute('inert')
+  })
+
+  it('removes inert once the controls are opened', () => {
+    const { container } = renderViewOnly()
+    const panel = screen.getByRole('menu')
+    clickPaneToToggleControls(container)
+    expect(panel).not.toHaveAttribute('inert')
+  })
+
+  it('does not warn about an empty-string boolean attribute', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    renderViewOnly()
+    const inertWarning = spy.mock.calls.some((call) =>
+      typeof call[0] === 'string' && call[0].includes('empty string for a boolean attribute'))
+    expect(inertWarning).toBe(false)
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- The view-only menu panel spread `{ inert: '' }` when the controls were closed. React 19 warns on an empty string for a boolean attribute and treats it as false — verified empirically: the rendered DOM carried no `inert` attribute at all, so the closed panel's focus/interaction blocking was silently never applied. This predates the recent pane refactors.
- Fix is the React 19 idiom: `inert={!viewOnlyControlsOpen}` on the same panel element. True renders the bare attribute, false omits it — the closed panel is now genuinely inert and the console warning is gone.
- TDD: a new test mounts the real pane in view-only mode and asserts the panel (`role="menu"`) has the `inert` attribute while closed — it failed against the old code (`Received: null`) — plus an open-state absence test (driven by clicking the real toggle wrapper) and a no-warning console spy.

## Verification
- Full suite: 361 test files, 8,164 passed / 22 skipped (baseline + the 3 new tests); lint, typecheck, and build clean.