### PR TITLE
fix(ui): scope the finger-assignment testid per analyze pane

### DIFF
--- a/src/renderer/components/analyze/AnalyzePaneFilterRow.tsx
+++ b/src/renderer/components/analyze/AnalyzePaneFilterRow.tsx
@@ -150,7 +150,14 @@ export function AnalyzePaneFilterRow({
             type="button"
             className="ml-auto shrink-0 rounded-md border border-edge bg-surface px-3 py-1 text-xs text-content-secondary transition-colors hover:border-accent hover:text-content"
             onClick={onOpenFingerModal}
-            data-testid="analyze-finger-assignment-open"
+            // Wrapped in `tid()` like every other testid in this pane —
+            // pane A stays unsuffixed (tid is identity there), so the
+            // external selectors (TypingAnalyticsView.test.tsx,
+            // e2e/analyze.test.ts, doc-capture.ts) that target the bare
+            // `analyze-finger-assignment-open` id keep resolving to
+            // pane A only; pane B's button gets the `-b` suffix so
+            // split view no longer renders a duplicate testid.
+            data-testid={tid('analyze-finger-assignment-open')}
           >
             {t('analyze.fingerAssignment.button')}
           </button>

--- a/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
+++ b/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
@@ -561,6 +561,36 @@ describe('TypingAnalyticsView', () => {
     hashSpy.mockRestore()
   })
 
+  it('gives split-view panes distinct finger-assignment button testids', async () => {
+    // Split view needs a wide-enough viewport for the toggle to be
+    // enabled (SPLIT_MIN_WIDTH_PX in TypingAnalyticsView.tsx); jsdom's
+    // default width is narrower than that.
+    const originalInnerWidth = window.innerWidth
+    Object.defineProperty(window, 'innerWidth', { configurable: true, value: 1400 })
+    try {
+      mockListKeyboards.mockResolvedValue(SAMPLE)
+      mockGetSnapshot.mockResolvedValue(SNAPSHOT)
+      const { TypingAnalyticsView } = await importView()
+      render(<TypingAnalyticsView />)
+      await waitFor(() => expect(screen.getByTestId('analyze-filter-chip')).toBeInTheDocument())
+      fireEvent.click(screen.getByTestId('analyze-split-toggle'))
+      await waitFor(() => expect(screen.getByTestId('analyze-filter-chip-b')).toBeInTheDocument())
+      // Move both panes to a tab that renders the finger-assignment
+      // button (Ergonomics is one of FINGER_ASSIGNMENT_TABS).
+      fireEvent.click(screen.getByTestId('analyze-tab-ergonomics'))
+      fireEvent.click(screen.getByTestId('analyze-tab-ergonomics-b'))
+      // Pane A keeps the historical unsuffixed testid (the three
+      // external consumers — TypingAnalyticsView.test.tsx itself,
+      // e2e/analyze.test.ts, doc-capture.ts — all target it
+      // unsuffixed), so exactly one element should carry it; pane B's
+      // must be disambiguated with the `-b` suffix.
+      await waitFor(() => expect(screen.getAllByTestId('analyze-finger-assignment-open')).toHaveLength(1))
+      expect(screen.getByTestId('analyze-finger-assignment-open-b')).toBeInTheDocument()
+    } finally {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: originalInnerWidth })
+    }
+  })
+
   it('falls back to own when a persisted hash is missing from the remote list', async () => {
     mockListKeyboards.mockResolvedValue(SAMPLE)
     const getSpy = vi.spyOn(window.vialAPI, 'pipetteSettingsGet').mockResolvedValue({


### PR DESCRIPTION
## Summary
- The finger-assignment button in the Analyze pane emitted `data-testid="analyze-finger-assignment-open"` without the pane's `tid()` wrapper, so split view (two pane instances) rendered a duplicate testid and `getByTestId` was ambiguous. The non-wrapping had been preserved verbatim through the pane split because external selectors depend on the unsuffixed value.
- Fix: wrap with `tid()` like every sibling testid in the row. Pane A's `tid` is the identity function, so the three external consumers (the unit test, `e2e/analyze.test.ts`, `e2e/helpers/doc-capture.ts`) keep resolving unchanged to pane A; pane B now gets the `-b` suffix.
- TDD: a new split-view test asserts exactly one unsuffixed testid plus the suffixed pane-B one — it failed (`expected 1, got 2`) against the old code. No existing test or e2e selector was modified.

## Verification
- Full suite: 361 test files, 8,165 passed / 22 skipped (baseline + the new test); lint, typecheck, and build clean.