### PR TITLE
fix(hub): serialize favorite exports at the requested vial protocol

### DIFF
--- a/src/main/__tests__/favorite-store.test.ts
+++ b/src/main/__tests__/favorite-store.test.ts
@@ -42,6 +42,7 @@ vi.mock('../ipc-guard', async () => {
 import { ipcMain, dialog, BrowserWindow } from 'electron'
 import { notifyChange } from '../sync/sync-service'
 import { setupFavoriteStore } from '../favorite-store'
+import { serialize as serializeKeycode } from '../../shared/keycodes/keycodes'
 import { IpcChannels } from '../../shared/ipc/channels'
 
 type IpcHandler = (...args: unknown[]) => Promise<unknown>
@@ -500,6 +501,78 @@ describe('favorite-store', () => {
       // Only the valid entry should be exported
       expect(exported.categories.td).toHaveLength(1)
       expect(exported.categories.td[0].label).toBe('With Data')
+    })
+
+    // Regression: main always keeps its global keycode protocol at 6, but
+    // `vialProtocol` here can be any protocol the connected keyboard (or a
+    // legacy .vil load) reports. The serializer must run at *that* protocol,
+    // not main's global one, or the header/body pair mis-decodes on import.
+    //
+    // 0x7c00 is a deliberate collision: under protocol 6 it deserializes to
+    // QK_BOOT, but under protocol 5 it is RAG_T(kc) (masked). A layer-code
+    // fixture could false-pass via the template fallback in serializeInternal
+    // without RAWCODES_MAP actually being rebuilt for protocol 5 — this one
+    // cannot, because RAWCODES_MAP.get(0x7c00) resolves to a *different*
+    // keycode identity depending on which protocol rebuilt it.
+    const keyOverrideJsonWithCollisionCode = JSON.stringify({
+      type: 'keyOverride',
+      data: {
+        triggerKey: 0x7c00,
+        replacementKey: 0,
+        layers: 0,
+        triggerMods: 0,
+        negativeMods: 0,
+        suppressedMods: 0,
+        options: 0,
+        enabled: true,
+      },
+    })
+
+    it('serializes keycodes at the requested protocol, not main\'s global v6', async () => {
+      const saveHandler = getHandler(IpcChannels.FAVORITE_STORE_SAVE)
+      await saveHandler(fakeEvent, 'keyOverride', keyOverrideJsonWithCollisionCode, 'KO Entry')
+
+      const exportPath = join(mockUserDataPath, 'export-protocol5.json')
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
+
+      const handler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT)
+      const result = await handler(fakeEvent, 'keyOverride', 5) as { success: boolean }
+      expect(result.success).toBe(true)
+
+      const exported = JSON.parse(await readFile(exportPath, 'utf-8'))
+      expect(exported.vial_protocol).toBe(5)
+      expect(exported.categories.ko).toHaveLength(1)
+      // Under protocol 6 (main's global default) this would serialize as
+      // 'QK_BOOT' instead — proof the body was NOT re-serialized at v5.
+      expect(exported.categories.ko[0].data.triggerKey).toBe('RAG_T(KC_NO)')
+      // ...and main's global tables must be back at v6 afterwards. Covers the
+      // `finally` restore, including its second `recreateKeycodes()`: without
+      // that rebuild RAWCODES_MAP would still hold the v5 snapshot here.
+      expect(serializeKeycode(0x7c00)).toBe('QK_BOOT')
+    })
+
+    it('round-trips a protocol-5 export through export-current -> import-to-current', async () => {
+      const exportPath = join(mockUserDataPath, 'export-current-protocol5.json')
+      vi.mocked(dialog.showSaveDialog).mockResolvedValue({ canceled: false, filePath: exportPath })
+
+      const exportCurrentHandler = getHandler(IpcChannels.FAVORITE_STORE_EXPORT_CURRENT)
+      const exportResult = await exportCurrentHandler(
+        fakeEvent, 'keyOverride', 5, keyOverrideJsonWithCollisionCode,
+      ) as { success: boolean }
+      expect(exportResult.success).toBe(true)
+
+      vi.mocked(dialog.showOpenDialog).mockResolvedValue({ canceled: false, filePaths: [exportPath] })
+
+      const importToCurrentHandler = getHandler(IpcChannels.FAVORITE_STORE_IMPORT_TO_CURRENT)
+      const importResult = await importToCurrentHandler(fakeEvent, 'keyOverride') as {
+        success: boolean
+        data: Record<string, unknown>
+      }
+      expect(importResult.success).toBe(true)
+      // Must come back as the exact same raw code that went in. If the body
+      // had been serialized at v6 while the header said 5, this would
+      // deserialize to QK_BOOT's v5 numeric value (0x5c00) instead.
+      expect(importResult.data.triggerKey).toBe(0x7c00)
     })
   })
 

--- a/src/main/__tests__/hub-ipc-favorite.test.ts
+++ b/src/main/__tests__/hub-ipc-favorite.test.ts
@@ -92,10 +92,24 @@ vi.mock('node:fs/promises', () => ({
   readFile: vi.fn(),
 }))
 
-// Mock keycodes serialize
-vi.mock('../../shared/keycodes/keycodes', () => ({
-  serialize: vi.fn((code: number) => `KC_${code}`),
-}))
+// Mock keycodes serialize. `serialize`'s output depends on a mutable
+// `mockProtocol` so tests can prove `withExportProtocol` actually switches
+// protocol around the serialize call (header/body agreement) instead of
+// always running at main's global v6 — without this, `getProtocol` /
+// `setProtocol` / `recreateKeycodes` would be undefined and
+// `withExportProtocol` (imported from the real `../favorite-store` module)
+// would throw. Default output format (`KC_${code}`) is unchanged from the
+// original stub so every existing protocol-6 assertion in this file keeps
+// passing untouched.
+vi.mock('../../shared/keycodes/keycodes', () => {
+  let mockProtocol = 6
+  return {
+    serialize: vi.fn((code: number) => (mockProtocol === 6 ? `KC_${code}` : `KC_${code}_p${mockProtocol}`)),
+    getProtocol: vi.fn(() => mockProtocol),
+    setProtocol: vi.fn((p: number) => { mockProtocol = p }),
+    recreateKeycodes: vi.fn(),
+  }
+})
 
 import { ipcMain } from 'electron'
 import { getIdToken } from '../sync/google-auth'
@@ -344,6 +358,37 @@ describe('hub-ipc favorite handlers', () => {
       expect(entry.data.onTapHold).toBe('KC_7')
       // Non-keycode field should remain as-is
       expect(entry.data.tappingTerm).toBe(200)
+    })
+
+    // Regression: the export body used to always serialize at main's
+    // global protocol (always 6) while the header stamped whatever
+    // `vialProtocol` was requested — a protocol-5 upload got header 5,
+    // body v6. Assert header and body now agree.
+    it('serializes keycode fields at the requested protocol (header/body agreement)', async () => {
+      mockHubAuth()
+      mockFavoriteFs()
+      vi.mocked(uploadFeaturePostToHub).mockResolvedValueOnce({
+        id: 'fav-post-3',
+        title: 'My Tap Dance',
+      })
+
+      const handler = getHandler()
+      await handler({}, {
+        type: 'tapDance',
+        entryId: 'entry-1',
+        vialProtocol: 5,
+        title: 'My Tap Dance',
+      })
+
+      const call = vi.mocked(uploadFeaturePostToHub).mock.calls[0]
+      const jsonFile = call[3] as { name: string; data: Buffer }
+      const parsed = JSON.parse(jsonFile.data.toString('utf-8'))
+      expect(parsed.vial_protocol).toBe(5)
+      const entry = parsed.categories.td[0]
+      // Body must reflect protocol 5 too, not main's global v6 default
+      // ('KC_4' would mean the body silently stayed at v6).
+      expect(entry.data.onTap).toBe('KC_4_p5')
+      expect(entry.data.onHold).toBe('KC_5_p5')
     })
   })
 

--- a/src/main/favorite-store.ts
+++ b/src/main/favorite-store.ts
@@ -7,7 +7,7 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { IpcChannels } from '../shared/ipc/channels'
 import { isValidFavoriteType, isValidVialProtocol, isFavoriteDataFile, FAV_EXPORT_KEY_MAP, FAV_TYPE_TO_EXPORT_KEY, isValidFavExportFile, buildFavExportFile, serializeFavData, deserializeFavData } from '../shared/favorite-data'
-import { serialize as serializeKeycode, deserialize as deserializeKeycode, getProtocol, setProtocol } from '../shared/keycodes/keycodes'
+import { serialize as serializeKeycode, deserialize as deserializeKeycode, getProtocol, setProtocol, recreateKeycodes } from '../shared/keycodes/keycodes'
 import { notifyChange } from './sync/sync-service'
 import { secureHandle } from './ipc-guard'
 import { isSafePathSegment, tsForFilename, tsForExportFilename } from './utils/safe-filename'
@@ -64,6 +64,11 @@ async function findEntry(type: FavoriteType, entryId: string): Promise<{ index: 
  *
  * If `protocol` is undefined (legacy v2 file or out-of-spec v3 without
  * `vial_protocol`), runs `body` with the current default protocol.
+ *
+ * Deliberately skips `recreateKeycodes()` (unlike `withExportProtocol`
+ * below): `deserializeKeycode` resolves qmkId strings through
+ * `qmkIdToKeycode` + `resolve()`/`getProtocolValue()`, never through
+ * `RAWCODES_MAP`, so there is no frozen snapshot here that needs rebuilding.
  */
 function withImportProtocol<T>(protocol: number | undefined, body: () => T): T {
   if (protocol === undefined) return body()
@@ -73,6 +78,44 @@ function withImportProtocol<T>(protocol: number | undefined, body: () => T): T {
     return body()
   } finally {
     setProtocol(prev)
+  }
+}
+
+/**
+ * Run `body` with `getProtocol()` temporarily set to `protocol` so that
+ * `serializeKeycode` stamps keycode strings against the *requested* export
+ * protocol rather than main's global one (always 6). Restores the previous
+ * protocol in `finally`.
+ *
+ * `setProtocol` alone is NOT sufficient: `RAWCODES_MAP` (what `serialize`
+ * actually reads) is a frozen snapshot built by `recreateKeycodes()` — it
+ * has to be rebuilt for the new protocol before serializing, and rebuilt
+ * again on the way back out so callers after this function see main's
+ * normal v6 tables.
+ *
+ * `body` MUST be strictly synchronous. `protocol` is module-global state
+ * shared by every export in flight; an `await` inside `body` would let a
+ * second, interleaved export observe (or even restore) the wrong protocol.
+ *
+ * If `protocol` is undefined or already matches the current global
+ * protocol (the common case — main is always 6), this skips the
+ * set/recreate/restore cycle entirely and just runs `body`. That fast path
+ * relies on the invariant "protocol unchanged ⇒ `RAWCODES_MAP` already
+ * matches", which only holds because nothing in this module changes
+ * `getProtocol()` without also calling `recreateKeycodes()` — nesting this
+ * inside a `withImportProtocol` scope would violate that (unreachable
+ * today; do not nest).
+ */
+export function withExportProtocol<T>(protocol: number | undefined, body: () => T): T {
+  const prev = getProtocol()
+  if (protocol === undefined || protocol === prev) return body()
+  setProtocol(protocol)
+  recreateKeycodes()
+  try {
+    return body()
+  } finally {
+    setProtocol(prev)
+    recreateKeycodes()
   }
 }
 
@@ -223,7 +266,7 @@ export function setupFavoriteStore(): void {
             exportEntries.push({
               label: entry.label,
               savedAt: entry.savedAt,
-              data: serializeFavData(scope, parsed.data, serializeKeycode),
+              data: withExportProtocol(vialProtocol, () => serializeFavData(scope, parsed.data, serializeKeycode)),
             })
           } catch {
             // Skip unreadable entries
@@ -282,7 +325,7 @@ export function setupFavoriteStore(): void {
         if (parsed.data == null) return { success: false, error: 'Missing data field' }
 
         const exportKey = FAV_TYPE_TO_EXPORT_KEY[scope]
-        const serializedData = serializeFavData(scope, parsed.data, serializeKeycode)
+        const serializedData = withExportProtocol(vialProtocol, () => serializeFavData(scope, parsed.data, serializeKeycode))
 
         const now = new Date()
         const ts = tsForExportFilename(now)

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -76,6 +76,7 @@ import type { SaveRecordInput } from '../key-label-store'
 import type { KeyLabelMeta, KeyLabelRecord, KeyLabelStoreResult } from '../../shared/types/key-label-store'
 import { isValidFavoriteType, isValidHubVialProtocol, FAV_TYPE_TO_EXPORT_KEY, serializeFavData, buildFavExportFile } from '../../shared/favorite-data'
 import { serialize as serializeKeycode } from '../../shared/keycodes/keycodes'
+import { withExportProtocol } from '../favorite-store'
 import type { FavoriteType, FavoriteIndex } from '../../shared/types/favorite-store'
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
@@ -473,7 +474,7 @@ async function buildFavoriteExportJson(
   if (parsed.type !== type) throw new Error('Entry type mismatch')
 
   const exportKey = FAV_TYPE_TO_EXPORT_KEY[type]
-  const serializedData = serializeFavData(type, parsed.data, serializeKeycode)
+  const serializedData = withExportProtocol(vialProtocol, () => serializeFavData(type, parsed.data, serializeKeycode))
 
   const exportFile = buildFavExportFile(vialProtocol, {
     [exportKey]: [{

--- a/src/renderer/components/editors/KeymapEditorModals.tsx
+++ b/src/renderer/components/editors/KeymapEditorModals.tsx
@@ -8,6 +8,7 @@
 import { useTranslation } from 'react-i18next'
 import type { TapDanceEntry, ComboEntry, KeyOverrideEntry, AltRepeatKeyEntry } from '../../../shared/types/protocol'
 import type { FavoriteType } from '../../../shared/types/favorite-store'
+import { FALLBACK_VIAL_PROTOCOL } from '../../../shared/favorite-data'
 import type { BasicViewType, SplitKeyMode } from '../../../shared/types/app-config'
 import type { MacroAction } from '../../../preload/macro'
 import { TapDanceModal } from './TapDanceModal'
@@ -105,7 +106,7 @@ export function KeymapEditorModals({
           onSave={handleTdModalSave} onClose={handleTdModalClose} isDummy={isDummy}
           tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
           quickSelect={quickSelect} splitKeyMode={splitKeyMode} basicViewType={basicViewType}
-          vialProtocol={vialProtocol ?? 0}
+          vialProtocol={vialProtocol ?? FALLBACK_VIAL_PROTOCOL}
           hubOrigin={favHubOrigin} hubNeedsDisplayName={favHubNeedsDisplayName}
           hubUploading={favHubUploading} hubUploadResult={favHubUploadResult}
           onUploadToHub={onFavUploadToHub ? (entryId) => onFavUploadToHub('tapDance', entryId) : undefined}
@@ -116,7 +117,7 @@ export function KeymapEditorModals({
 
       {macroModalIndex !== null && macroBuffer && macroCount != null && onSaveMacros && (
         <MacroModal index={macroModalIndex} macroCount={macroCount} macroBufferSize={macroBufferSize ?? 0}
-          macroBuffer={macroBuffer} vialProtocol={vialProtocol ?? 0} onSaveMacros={onSaveMacros}
+          macroBuffer={macroBuffer} vialProtocol={vialProtocol ?? FALLBACK_VIAL_PROTOCOL} onSaveMacros={onSaveMacros}
           parsedMacros={parsedMacros} onClose={handleMacroModalClose} unlocked={unlocked} onUnlock={onUnlock}
           isDummy={isDummy} tapDanceEntries={tapDanceEntries} deserializedMacros={deserializedMacros}
           quickSelect={quickSelect} autoAdvance={autoAdvance} splitKeyMode={splitKeyMode} basicViewType={basicViewType}

--- a/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
+++ b/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
@@ -18,6 +18,7 @@ const mockFavoriteStoreLoad = vi.fn()
 const mockFavoriteStoreRename = vi.fn()
 const mockFavoriteStoreDelete = vi.fn()
 const mockFavoriteStoreExport = vi.fn()
+const mockFavoriteStoreExportCurrent = vi.fn()
 const mockFavoriteStoreImport = vi.fn()
 
 const MOCK_ENTRY: SavedFavoriteMeta = {
@@ -47,6 +48,7 @@ beforeEach(() => {
     favoriteStoreRename: mockFavoriteStoreRename,
     favoriteStoreDelete: mockFavoriteStoreDelete,
     favoriteStoreExport: mockFavoriteStoreExport,
+    favoriteStoreExportCurrent: mockFavoriteStoreExportCurrent,
     favoriteStoreImport: mockFavoriteStoreImport,
   } as unknown as typeof window.vialAPI
 })
@@ -468,6 +470,51 @@ describe('useFavoriteStore – exportFavorites', () => {
     })
     expect(result.current.exporting).toBe(false)
   })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.exportFavorites()
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreExport).not.toHaveBeenCalled()
+  })
+})
+
+describe('useFavoriteStore – exportCurrent', () => {
+  it('calls serialize and favoriteStoreExportCurrent with favoriteType, vialProtocol, and serialized json', async () => {
+    mockFavoriteStoreExportCurrent.mockResolvedValueOnce({ success: true })
+    const { result } = renderHook(() => useFavoriteStore(hookOpts()))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.exportCurrent()
+    })
+
+    expect(ok).toBe(true)
+    expect(mockSerialize).toHaveBeenCalled()
+    expect(mockFavoriteStoreExportCurrent).toHaveBeenCalledWith(
+      'tapDance',
+      6,
+      JSON.stringify({ type: 'tapDance', data: MOCK_TAP_DANCE_DATA }),
+    )
+  })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.exportCurrent()
+    })
+
+    expect(ok).toBe(false)
+    expect(mockSerialize).not.toHaveBeenCalled()
+    expect(mockFavoriteStoreExportCurrent).not.toHaveBeenCalled()
+  })
 })
 
 describe('useFavoriteStore – importFavorites', () => {
@@ -595,5 +642,17 @@ describe('useFavoriteStore – exportEntry', () => {
 
     expect(ok).toBe(false)
     expect(result.current.error).toBeNull()
+  })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.exportEntry('entry-123')
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreExport).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/hooks/useFavoriteStore.ts
+++ b/src/renderer/hooks/useFavoriteStore.ts
@@ -196,6 +196,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
   }, [favoriteType, apply, t])
 
   const doExport = useCallback(async (entryId?: string): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     setExporting(true)
     try {
@@ -215,7 +216,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } finally {
       setExporting(false)
     }
-  }, [favoriteType, vialProtocol, t])
+  }, [enabled, favoriteType, vialProtocol, t])
 
   const exportFavorites = useCallback(async (): Promise<boolean> => {
     return doExport()

--- a/src/shared/constants/protocol.ts
+++ b/src/shared/constants/protocol.ts
@@ -101,11 +101,12 @@ export const VIAL_MACRO_EXT_TAP = 0x05
 export const VIAL_MACRO_EXT_DOWN = 0x06
 export const VIAL_MACRO_EXT_UP = 0x07
 
-// --- Protocol version ranges ---
-export const SUPPORTED_VIA_PROTOCOLS = [-1, 9]
-export const SUPPORTED_VIAL_PROTOCOLS = [-1, 0, 1, 2, 3, 4, 5, 6]
-
 // --- Protocol version feature gates ---
+// vial-gui gates protocol compatibility with explicit value lists
+// (protocol/keyboard_comm.py SUPPORTED_VIA_PROTOCOL / SUPPORTED_VIAL_PROTOCOL,
+// checked at protocol/keyboard_comm.py:111). Pipette has no equivalent constant —
+// an incompatible board simply fails definition load and is disconnected
+// with error.notVialCompatible instead.
 export const VIAL_PROTOCOL_ADVANCED_MACROS = 2
 export const VIAL_PROTOCOL_MATRIX_TESTER = 3
 export const VIAL_PROTOCOL_DYNAMIC = 4


### PR DESCRIPTION
## Summary
- Favorite exports stamped `vial_protocol` with the requested protocol but always serialized keycodes at main's global protocol (permanently 6 — `recreateKeyboardKeycodes` is renderer-only). Re-import interprets the body via the stamped header, so exports from protocol-5 keyboards or legacy `.vil` loads could mis-decode: TDD proved a key-override `0x7c00` exported at protocol 5 came back as `0x5c00` after a round trip.
- Fix: a `withExportProtocol` wrapper in `favorite-store.ts` — fast path when the requested protocol already matches (every protocol-6 export pays nothing); otherwise `setProtocol` **plus `recreateKeycodes`** around a strictly synchronous serialize call, restoring both in `finally`. `setProtocol` alone is insufficient: `RAWCODES_MAP` is a frozen snapshot only `recreateKeycodes` rebuilds, so v5 raw codes colliding with v6 symbol numbers (the `0x7c00`/`QK_BOOT` case) still mis-serialized. Applied at all three serialize sites (hub upload, local all-entries export — wrapped per iteration so the module-global protocol never spans an `await` — and export-current).
- Protocol-5 test hardening: the `0x7c00 → RAG_T(KC_NO)` collision fixture (a layer-code fixture could false-pass via the template fallback), an export(5)→import round trip, a mutation-verified restore-leak assertion (deleting either `recreateKeycodes` call fails it), and a hub header/body agreement case.
- Related cleanups from the task: deleted the never-referenced `SUPPORTED_VIA_PROTOCOLS`/`SUPPORTED_VIAL_PROTOCOLS` (with a comment recording vial-gui's value-list gate vs Pipette's definition-load gate), added the missing `enabled` guard to `useFavoriteStore.doExport` (matching `exportCurrent`), and aligned `KeymapEditorModals`' unreachable `?? 0` protocol fallback with the documented `FALLBACK_VIAL_PROTOCOL`.
- Out of scope, tracked separately: the renderer's `withSnapshotProtocol` has the same defect class on the Analyze speed-ranking labels (backlog task filed), and the `enabled` guard remains absent on load/import paths.

## Verification
- Full suite: 361 test files, 8,172 passed / 22 skipped (baseline + 8 new tests); lint, typecheck, and build clean.
- No `await` inside any protocol-wrapped body; the hub test's keycodes mock was extended (not weakened — protocol-6 outputs byte-identical to before) to observe the wrapper flipping and restoring the protocol.