### PR TITLE
fix(ui): rebuild keycode tables when labeling speed ranking snapshots

### DIFF
--- a/src/renderer/components/analyze/__tests__/key-heatmap-helpers-speed.test.ts
+++ b/src/renderer/components/analyze/__tests__/key-heatmap-helpers-speed.test.ts
@@ -10,7 +10,7 @@ import {
 } from '../key-heatmap-helpers'
 import type { KeySpeedStat } from '../key-heatmap-helpers'
 import type { LayerKeycodes } from '../key-heatmap-helpers'
-import { deserialize, getProtocol, setProtocol } from '../../../../shared/keycodes/keycodes'
+import { deserialize, getProtocol, recreateKeycodes, serialize, setProtocol } from '../../../../shared/keycodes/keycodes'
 import { PALETTE_MIN_T, paletteColorFromIntensity } from '../../../utils/chart-palette'
 import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
 
@@ -211,17 +211,28 @@ describe('buildSpeedRanking', () => {
     expect(buildSpeedRanking(new Map(), 'all', 10)).toEqual([])
   })
 
-  it('ranks protocol-dependent codes and restores the global protocol', () => {
-    // Label rendering for protocol-dependent codes additionally depends
-    // on session-level keycode tables (RAWCODES_MAP), so this asserts
-    // the protocol plumbing (entry survives, global protocol restored)
-    // rather than a specific label string.
-    const prev = getProtocol()
-    const v5BootCode = deserializeUnderProtocol('QK_BOOT', 5)
-    const speedMap = new Map([[v5BootCode, { avgIki: 100, count: 10 }]])
+  it('ranks protocol-dependent codes using the snapshot protocol\'s own label and restores the global RAWCODES_MAP', () => {
+    // 0x7c00 is QK_BOOT under v6 but the masked keycode RAG_T(kc) with a
+    // KC_NO inner under v5 (src/shared/keycodes/keycodes-v5.ts:75) — the
+    // same v6-session-viewing-v5-snapshot collision code as the
+    // favorite-store 0x7c00 case (src/main/__tests__/favorite-store.test.ts:551).
+    // Establish the v6 map explicitly first so this doesn't depend on
+    // leftover state from earlier tests in this file.
+    setProtocol(6)
+    recreateKeycodes()
+
+    const speedMap = new Map([[0x7c00, { avgIki: 100, count: 10 }]])
     const ranking = buildSpeedRanking(speedMap, 'all', 10, 5)
     expect(ranking).toHaveLength(1)
     expect(ranking[0].avgIki).toBe(100)
-    expect(getProtocol()).toBe(prev)
+    // Masked RAG_T(kc) + KC_NO inner, stripped of prefixes by codeToLabel.
+    expect(ranking[0].keyLabel).toBe('RAG_T(NO)')
+
+    // Restore leg is the mutation-killer: without recreateKeycodes() on
+    // the way out, getProtocol() alone would already read 6 here even
+    // though RAWCODES_MAP was left rebuilt for v5 — assert the rebuilt
+    // map directly by re-serializing 0x7c00 back under v6.
+    expect(getProtocol()).toBe(6)
+    expect(serialize(0x7c00)).toBe('QK_BOOT')
   })
 })

--- a/src/renderer/components/analyze/analyze-protocol.ts
+++ b/src/renderer/components/analyze/analyze-protocol.ts
@@ -4,7 +4,7 @@
 // Lives outside any single Analyze view (heatmap, finger IKI, ...) so
 // both can depend on it without one view importing from another.
 
-import { getProtocol, setProtocol } from '../../../shared/keycodes/keycodes'
+import { getProtocol, recreateKeycodes, setProtocol } from '../../../shared/keycodes/keycodes'
 
 /** Run `body` with `getProtocol()` temporarily set to `protocol` so
  * keycode string↔number conversion resolves against the snapshot's own
@@ -15,7 +15,15 @@ import { getProtocol, setProtocol } from '../../../shared/keycodes/keycodes'
  * the current global protocol would mismatch a v5 snapshot viewed in a
  * v6 session. Mirrors `withImportProtocol` in
  * `src/main/favorite-store.ts`; `undefined` (older snapshots without
- * `vialProtocol`) keeps the current default. */
+ * `vialProtocol`) keeps the current default.
+ *
+ * Deliberately skips `recreateKeycodes()` (unlike
+ * `withSnapshotSerializeProtocol` below): every current caller only
+ * `deserialize`s a qmkId string to a number, which resolves through
+ * `qmkIdToKeycode` + `resolve()`/`getProtocolValue()`, never through
+ * `RAWCODES_MAP` — there is no frozen snapshot here that needs
+ * rebuilding. Use `withSnapshotSerializeProtocol` for any body that
+ * calls `serialize`/`codeToLabel` (number → qmkId/label). */
 export function withSnapshotProtocol<T>(protocol: number | undefined, body: () => T): T {
   if (protocol === undefined) return body()
   const prev = getProtocol()
@@ -24,5 +32,47 @@ export function withSnapshotProtocol<T>(protocol: number | undefined, body: () =
     return body()
   } finally {
     setProtocol(prev)
+  }
+}
+
+/** Run `body` with `getProtocol()` temporarily set to `protocol` AND
+ * `RAWCODES_MAP` rebuilt for it, so `serialize`/`codeToLabel` resolve a
+ * snapshot-recorded numeric code against the snapshot's own protocol
+ * version instead of the current session's. Restores both in `finally`.
+ *
+ * `setProtocol` alone is NOT sufficient here: `RAWCODES_MAP` (what
+ * `serialize` actually reads for non-trivial/masked codes) is a frozen
+ * snapshot built by `recreateKeycodes()` under whatever protocol was
+ * active at the time — it has to be rebuilt for the requested protocol
+ * before serializing, and rebuilt again on the way back out so callers
+ * after this function see the renderer's normal session-protocol
+ * tables. Mirrors `withExportProtocol` in `src/main/favorite-store.ts`.
+ *
+ * `body` MUST be strictly synchronous: `protocol`/`RAWCODES_MAP` are
+ * module-global state; an `await` inside `body` would let interleaved
+ * work (including a second call into this function) observe or restore
+ * the wrong protocol/map.
+ *
+ * If `protocol` is undefined or already matches the current global
+ * protocol, this skips the set/recreate/restore cycle entirely and just
+ * runs `body`.
+ *
+ * NESTING WARNING: the plain `withSnapshotProtocol` above changes
+ * protocol WITHOUT rebuilding `RAWCODES_MAP`. Nesting this function
+ * inside a `withSnapshotProtocol` scope with a matching protocol would
+ * fast-path over a stale map. No such nesting exists today — do not add
+ * any. Use the plain wrapper for deserialize-only bodies (cheaper —
+ * `deserialize` never reads `RAWCODES_MAP`); use this one only for
+ * bodies that serialize numeric codes back to qmkId/label strings. */
+export function withSnapshotSerializeProtocol<T>(protocol: number | undefined, body: () => T): T {
+  const prev = getProtocol()
+  if (protocol === undefined || protocol === prev) return body()
+  setProtocol(protocol)
+  recreateKeycodes()
+  try {
+    return body()
+  } finally {
+    setProtocol(prev)
+    recreateKeycodes()
   }
 }

--- a/src/renderer/components/analyze/key-heatmap-helpers.ts
+++ b/src/renderer/components/analyze/key-heatmap-helpers.ts
@@ -12,7 +12,7 @@ import { PALETTE_MIN_T, paletteColorFromIntensity } from '../../utils/chart-pale
 import type { EffectiveTheme } from '../../hooks/useEffectiveTheme'
 import type { HeatmapNormalization, RangeMs } from './analyze-types'
 import type { AggregateMode, HeatmapFilters, KeyGroupFilter } from '../../../shared/types/analyze-filters'
-import { withSnapshotProtocol } from './analyze-protocol'
+import { withSnapshotProtocol, withSnapshotSerializeProtocol } from './analyze-protocol'
 
 export { AGGREGATE_MODES, KEY_GROUPS, HEATMAP_MODES } from '../../../shared/types/analyze-filters'
 export type { AggregateMode, KeyGroupFilter, HeatmapMode } from '../../../shared/types/analyze-filters'
@@ -410,15 +410,18 @@ export interface SpeedRankingEntry {
  * ranking table. Unlike the Count ranking, this isn't scoped to a
  * layer group — the bigram aggregate carries no layer tag, so one flat
  * ranking covers every selected layer. Labels and group filtering run
- * under the snapshot's protocol (see `withSnapshotProtocol`) since the
- * numeric codes were recorded under it. */
+ * under the snapshot's protocol (see `withSnapshotSerializeProtocol`)
+ * since the numeric codes were recorded under it — this body calls
+ * `serialize`/`codeToLabel` (number → qmkId/label), unlike
+ * `buildSpeedFillByPos` above which only `deserialize`s, so it needs
+ * the RAWCODES_MAP-rebuilding variant rather than the plain one. */
 export function buildSpeedRanking(
   speedMap: ReadonlyMap<number, KeySpeedStat>,
   keyGroupFilter: KeyGroupFilter,
   limit: number,
   vialProtocol?: number,
 ): SpeedRankingEntry[] {
-  return withSnapshotProtocol(vialProtocol, () => {
+  return withSnapshotSerializeProtocol(vialProtocol, () => {
     const entries: SpeedRankingEntry[] = []
     for (const [code, stat] of speedMap) {
       if (keyGroupFilter !== 'all' && keycodeGroup(serialize(code)) !== keyGroupFilter) continue


### PR DESCRIPTION
## Summary
- The renderer twin of #358: `withSnapshotProtocol` sets the keycode protocol without rebuilding `RAWCODES_MAP` (a frozen snapshot only `recreateKeycodes` refreshes). The one body that serializes inside it — `buildSpeedRanking`, which turns recorded raw codes into Speed-ranking labels — therefore read the session's v6-built map at the snapshot's protocol, so viewing a protocol-5 snapshot in a v6 session produced wrong labels (raw `0x7c00` showed the v6 `Boot-loader` instead of the v5 `RAG_T(NO)`).
- Fix: a `withSnapshotSerializeProtocol` variant mirroring `withExportProtocol` from #358 — fast path when the snapshot protocol matches the session's, otherwise `setProtocol` + `recreateKeycodes` around the strictly synchronous body, restoring both in `finally`. Applied only at the `buildSpeedRanking` call site; the other seven wrapper bodies are deserialize-only (deserialize never reads `RAWCODES_MAP`) and stay on the cheap plain wrapper, which now cross-references the variant and documents the do-not-nest constraint.
- TDD: the existing test that explicitly declined to assert labels ("depends on session-level keycode tables") now asserts the concrete v5 label — it failed against the old code with `expected 'Boot- loader' to be 'RAG_T(NO)'` — plus restore-leg assertions (`getProtocol()` back and `serialize(0x7c00) === 'QK_BOOT'`, the mutation-killer for the second rebuild).
- Tracked separately (backlog): serialize-free labels via the snapshot's own qmk strings (fixes the keyboard-shape axis this can't — snapshots from keyboards with more layers/macros than the session — and the unwrapped `bigramPairLabel`), and consolidating the three protocol-scoping helpers into a shared module.

## Verification
- Full suite: 361 test files, 8,172 passed / 22 skipped — exact baseline (test upgraded in place); lint, typecheck, and build clean.