### PR TITLE
refactor(protocol): track the protocol keycode tables were built at

### DIFF
--- a/src/main/__tests__/hub-ipc-favorite.test.ts
+++ b/src/main/__tests__/hub-ipc-favorite.test.ts
@@ -107,6 +107,7 @@ vi.mock('../../shared/keycodes/keycodes', () => {
   return {
     serialize: vi.fn((code: number) => (mockProtocol === 6 ? `KC_${code}` : `KC_${code}_p${mockProtocol}`)),
     getProtocol: vi.fn(() => mockProtocol),
+    getRawcodesProtocol: vi.fn(() => mockProtocol),
     setProtocol: vi.fn((p: number) => { mockProtocol = p }),
     recreateKeycodes: vi.fn(),
   }

--- a/src/shared/keycodes/__tests__/with-protocol.test.ts
+++ b/src/shared/keycodes/__tests__/with-protocol.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { deserialize, getProtocol, recreateKeycodes, serialize, setProtocol } from '../keycodes'
+import { withDeserializeProtocol, withSerializeProtocol } from '../with-protocol'
+
+// 0x7c00 is a deliberate protocol collision (see
+// src/main/__tests__/favorite-store.test.ts:511 and
+// src/renderer/components/analyze/__tests__/key-heatmap-helpers-speed.test.ts:214):
+// QK_BOOT under v6, but the masked keycode RAG_T(kc) with a KC_NO inner
+// under v5. Serializing it only proves anything if RAWCODES_MAP was
+// actually rebuilt for the requested protocol -- a stale v6 map would
+// silently still resolve it to 'QK_BOOT'.
+const COLLISION_CODE = 0x7c00
+
+// Every test in this file runs at session protocol 6 (module default).
+// Restore it afterwards so state doesn't leak into other test files.
+afterEach(() => {
+  setProtocol(6)
+  recreateKeycodes()
+})
+
+describe('withSerializeProtocol', () => {
+  it('serializes at the requested protocol and fully restores the map and protocol on return', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const v5Label = withSerializeProtocol(5, () => serialize(COLLISION_CODE))
+    expect(v5Label).toBe('RAG_T(KC_NO)')
+
+    // Exit state: both the protocol variable and RAWCODES_MAP are back
+    // to the session's v6 build (not just the variable -- re-serializing
+    // proves the map itself was rebuilt on the way out).
+    expect(getProtocol()).toBe(6)
+    expect(serialize(COLLISION_CODE)).toBe('QK_BOOT')
+  })
+
+  it('passes undefined through without touching global protocol state', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const result = withSerializeProtocol(undefined, () => serialize(COLLISION_CODE))
+    expect(result).toBe('QK_BOOT')
+    expect(getProtocol()).toBe(6)
+  })
+
+  // THE NESTED CASE -- the reason this PR exists.
+  //
+  // Pre-hardening, withSerializeProtocol's fast path only checked
+  // `protocol === getProtocol()`. Nested inside withDeserializeProtocol(5,
+  // ...), the protocol variable is already 5 by the time the inner
+  // withSerializeProtocol(5, ...) runs, so the pre-hardening fast path
+  // would fire and skip the rebuild entirely -- even though RAWCODES_MAP
+  // is still the outer scope's session-6 build. serialize(0x7c00) would
+  // then wrongly resolve through the stale v6 map and return 'QK_BOOT'.
+  //
+  // Post-hardening, the fast path also requires
+  // `protocol === getRawcodesProtocol()`. The map was last built at 6,
+  // not 5, so that second condition fails and the rebuild runs for real.
+  it('rebuilds RAWCODES_MAP when nested inside a withDeserializeProtocol scope at the same protocol', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const result = withDeserializeProtocol(5, () =>
+      withSerializeProtocol(5, () => serialize(COLLISION_CODE)),
+    )
+    expect(result).toBe('RAG_T(KC_NO)')
+
+    // Exit state: fully unwound back to the session default, including
+    // RAWCODES_MAP (not just the protocol variable).
+    expect(getProtocol()).toBe(6)
+    expect(serialize(COLLISION_CODE)).toBe('QK_BOOT')
+  })
+})
+
+describe('withDeserializeProtocol', () => {
+  it('equality fast path: body observes the current protocol unchanged when it already matches', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const observed = withDeserializeProtocol(6, () => deserialize('QK_BOOT'))
+    expect(observed).toBe(0x7c00)
+    expect(getProtocol()).toBe(6)
+  })
+
+  it('sets and restores the protocol variable for a body run at a different protocol', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const observed = withDeserializeProtocol(5, () => deserialize('QK_BOOT'))
+    expect(observed).toBe(0x5c00)
+    expect(getProtocol()).toBe(6)
+  })
+
+  it('passes undefined through without touching global protocol state', () => {
+    setProtocol(6)
+    recreateKeycodes()
+
+    const observed = withDeserializeProtocol(undefined, () => deserialize('QK_BOOT'))
+    expect(observed).toBe(0x7c00)
+    expect(getProtocol()).toBe(6)
+  })
+})

--- a/src/shared/keycodes/keycodes-utils.ts
+++ b/src/shared/keycodes/keycodes-utils.ts
@@ -595,6 +595,18 @@ export function getKeycodeRevision(): number {
   return keycodeRevision
 }
 
+// Protocol RAWCODES_MAP was last *successfully* built at. Init value 6
+// matches the module-load build below (`_initRecreateKeycodes()` in
+// keycodes.ts runs before any `setProtocolValue` call, so it builds at
+// the default protocol 6). Only updated at the very end of
+// `recreateKeycodes()`, after the rebuild completes without throwing --
+// a failed rebuild must not claim the map matches a protocol it never
+// finished building for.
+let rawcodesProtocol = 6
+export function getRawcodesProtocol(): number {
+  return rawcodesProtocol
+}
+
 export function recreateKeycodes(): void {
   keycodeRevision++
   KEYCODES.length = 0
@@ -632,6 +644,9 @@ export function recreateKeycodes(): void {
   }
   // Reset lazy LM mod value map so it rebuilds with current protocol
   lmModValueMap = null
+  // Last statement: only record the protocol this build matches once
+  // every step above has completed without throwing.
+  rawcodesProtocol = getProtocolValue()
 }
 
 // --- User keycodes ---

--- a/src/shared/keycodes/keycodes.ts
+++ b/src/shared/keycodes/keycodes.ts
@@ -1238,6 +1238,7 @@ export {
   keycodeGroup,
   getLayerOpTarget,
   getKeycodeRevision,
+  getRawcodesProtocol,
   recreateKeycodes,
   createUserKeycodes,
   createCustomUserKeycodes,

--- a/src/shared/keycodes/with-protocol.ts
+++ b/src/shared/keycodes/with-protocol.ts
@@ -7,7 +7,7 @@
 // that actually differ: deserialize-only (no RAWCODES_MAP rebuild
 // needed) and serialize-safe (rebuild required).
 
-import { getProtocol, setProtocol, recreateKeycodes } from './keycodes'
+import { getProtocol, getRawcodesProtocol, setProtocol, recreateKeycodes } from './keycodes'
 
 /**
  * Run `body` with `getProtocol()` temporarily set to `protocol` so
@@ -27,15 +27,16 @@ import { getProtocol, setProtocol, recreateKeycodes } from './keycodes'
  * `withSerializeProtocol` for a body that calls
  * `serialize`/`codeToLabel` (number -> qmkId/label).
  *
- * No `protocol === getProtocol()` fast path here (unlike
- * `withSerializeProtocol` below) — intentionally not added in this
- * pass. It would be an observable no-op (`setProtocolValue` is a plain
- * assignment), but is left out to keep this a pure carry-over of the
- * two deserialize-only helpers it replaces, both of which always ran
- * the set/finally-restore cycle whenever `protocol` was defined.
+ * Fast path: if `protocol` is undefined or already matches the current
+ * global protocol, skips the set/restore cycle and just runs `body`.
+ * Unlike `withSerializeProtocol` below, this checks protocol-variable
+ * equality ONLY -- there is no second `RAWCODES_MAP`-freshness
+ * condition to check, because (per the module doc above) `deserialize`
+ * never reads `RAWCODES_MAP`; the protocol variable is the only piece
+ * of state this helper's body can observe.
  */
 export function withDeserializeProtocol<T>(protocol: number | undefined, body: () => T): T {
-  if (protocol === undefined) return body()
+  if (protocol === undefined || protocol === getProtocol()) return body()
   const prev = getProtocol()
   setProtocol(protocol)
   try {
@@ -64,28 +65,51 @@ export function withDeserializeProtocol<T>(protocol: number | undefined, body: (
  * concurrent call into this function) observe or restore the wrong
  * protocol/map.
  *
- * If `protocol` is undefined or already matches the current global
- * protocol, this skips the set/recreate/restore cycle entirely and just
- * runs `body`.
+ * Fast path requires BOTH conditions to hold, unlike
+ * `withDeserializeProtocol`'s single check: `body` may itself call
+ * `deserialize` (which reads the protocol variable via
+ * `getProtocolValue()`), AND `serialize` needs `RAWCODES_MAP` built at
+ * that same protocol. So this skips the set/recreate/restore cycle
+ * only when `protocol` is undefined, or matches BOTH the current
+ * protocol variable AND the protocol `RAWCODES_MAP` was last
+ * successfully built at (`getRawcodesProtocol()`). If the map is stale
+ * relative to the protocol variable -- which happens when this call is
+ * nested inside a `withDeserializeProtocol` scope that changed the
+ * protocol variable without rebuilding the map -- the second condition
+ * fails and the full rebuild runs, even though the first condition
+ * alone would have looked like a match.
  *
- * NESTING WARNING: `withDeserializeProtocol` above changes protocol
- * WITHOUT rebuilding `RAWCODES_MAP`. Nesting this function inside a
- * `withDeserializeProtocol` scope with a matching protocol would
- * fast-path over a stale map. No such nesting exists today -- do not
- * add any. Use `withDeserializeProtocol` for deserialize-only bodies
+ * On the way out, the `finally` restores `RAWCODES_MAP` to the protocol
+ * it was built at on entry (`prevBuilt`), then restores the protocol
+ * variable to its entry value (`prevProtocol`). Restoring in that order
+ * means that under nesting inside `withDeserializeProtocol`, this
+ * reproduces the exact state the outer scope had set up -- the map
+ * rebuild targets the outer scope's protocol, not the just-restored
+ * variable. The inner `try/finally` guarantees `prevProtocol` is
+ * restored even if the restore-leg `recreateKeycodes()` itself throws.
+ *
+ * ENFORCED INVARIANT (formerly a nesting warning): nesting this
+ * function inside a `withDeserializeProtocol` scope with a matching
+ * protocol no longer fast-paths over a stale map -- the `prevBuilt`
+ * check above forces the rebuild whenever the map doesn't already match
+ * `protocol`. Use `withDeserializeProtocol` for deserialize-only bodies
  * (cheaper -- `deserialize` never reads `RAWCODES_MAP`); use this one
- * only for bodies that serialize numeric codes back to qmkId/label
- * strings.
+ * for bodies that serialize numeric codes back to qmkId/label strings.
  */
 export function withSerializeProtocol<T>(protocol: number | undefined, body: () => T): T {
-  const prev = getProtocol()
-  if (protocol === undefined || protocol === prev) return body()
+  const prevProtocol = getProtocol()
+  const prevBuilt = getRawcodesProtocol()
+  if (protocol === undefined || (protocol === prevProtocol && protocol === prevBuilt)) return body()
   setProtocol(protocol)
   recreateKeycodes()
   try {
     return body()
   } finally {
-    setProtocol(prev)
-    recreateKeycodes()
+    setProtocol(prevBuilt)
+    try {
+      recreateKeycodes()
+    } finally {
+      setProtocol(prevProtocol)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Follow-up hardening to #360: the serialize-safe wrapper's fast path rested on the implicit invariant "protocol unchanged ⇒ RAWCODES_MAP already matches", which held only by convention (nothing changed the protocol without rebuilding) and was guarded by a do-not-nest docblock warning. `recreateKeycodes` now records the protocol the tables were last successfully built at (`rawcodesProtocol`, set as the rebuild's final statement so a throwing rebuild records nothing), and `withSerializeProtocol`'s fast path requires both the protocol variable AND the built-at protocol to match — nesting it inside `withDeserializeProtocol` with an equal protocol now forces the rebuild instead of silently serializing against a stale table.
- The restore leg is exception-safe: it rebuilds at the entry built-at protocol inside a nested `try/finally` so the protocol variable is restored even if that rebuild throws, and under nesting it reproduces the exact entry state (map at its built-at protocol, variable at the outer wrapper's value). The nesting warnings are rewritten as statements of the now-enforced invariant.
- `withDeserializeProtocol` gains the equality fast path deferred from #360 (protocol variable only — deserialize never reads the tables; the docblock explains why the two variants' conditions differ).
- First direct unit tests for `with-protocol.ts` (6 tests) using the `0x7c00` v5/v6 collision fixture, including the nested regression case — verified by stashing the hardening and watching it fail with `expected 'QK_BOOT' to be 'RAG_T(KC_NO)'`, exactly the stale-map serialization the invariant now prevents.

## Verification
- Full suite: 362 test files, 8,178 passed / 22 skipped (baseline + the new file's 6 tests); lint, typecheck, and build clean.
- No behavior change at any current call site (no nesting exists today; main is pinned at protocol 6, and the renderer's only serialize-in-wrapper call runs outside all wrapper scopes). The only existing-test edit is one added line in the hub test's keycodes mock factory for the new export.