### PR TITLE
fix(ui): gate every favorite-store operation on the enabled flag

### DIFF
--- a/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
+++ b/src/renderer/hooks/__tests__/useFavoriteStore.test.ts
@@ -338,6 +338,19 @@ describe('useFavoriteStore – loadFavorite', () => {
     })
     expect(result.current.loading).toBe(false)
   })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.loadFavorite('fav-1')
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreLoad).not.toHaveBeenCalled()
+    expect(mockApply).not.toHaveBeenCalled()
+  })
 })
 
 describe('useFavoriteStore – renameEntry', () => {
@@ -369,6 +382,18 @@ describe('useFavoriteStore – renameEntry', () => {
 
     expect(ok).toBe(false)
   })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.renameEntry('fav-1', 'New')
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreRename).not.toHaveBeenCalled()
+  })
 })
 
 describe('useFavoriteStore – deleteEntry', () => {
@@ -396,6 +421,18 @@ describe('useFavoriteStore – deleteEntry', () => {
     })
 
     expect(ok).toBe(false)
+  })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.deleteEntry('fav-1')
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreDelete).not.toHaveBeenCalled()
   })
 })
 
@@ -591,6 +628,56 @@ describe('useFavoriteStore – importFavorites', () => {
       await promise!
     })
     expect(result.current.importing).toBe(false)
+  })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.importFavorites()
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreImport).not.toHaveBeenCalled()
+  })
+})
+
+describe('useFavoriteStore – importCurrent', () => {
+  it('calls favoriteStoreImportToCurrent and applies the result on success', async () => {
+    const mockFavoriteStoreImportToCurrent = vi.fn().mockResolvedValueOnce({ success: true, data: MOCK_TAP_DANCE_DATA })
+    window.vialAPI = {
+      ...window.vialAPI,
+      favoriteStoreImportToCurrent: mockFavoriteStoreImportToCurrent,
+    } as unknown as typeof window.vialAPI
+    const { result } = renderHook(() => useFavoriteStore(hookOpts()))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.importCurrent()
+    })
+
+    expect(ok).toBe(true)
+    expect(mockFavoriteStoreImportToCurrent).toHaveBeenCalledWith('tapDance')
+    expect(mockApply).toHaveBeenCalledWith(MOCK_TAP_DANCE_DATA)
+  })
+
+  it('returns false without IPC call when enabled is false', async () => {
+    const mockFavoriteStoreImportToCurrent = vi.fn()
+    window.vialAPI = {
+      ...window.vialAPI,
+      favoriteStoreImportToCurrent: mockFavoriteStoreImportToCurrent,
+    } as unknown as typeof window.vialAPI
+    const { result } = renderHook(() => useFavoriteStore(hookOpts({ enabled: false })))
+
+    let ok: boolean | undefined
+    await act(async () => {
+      ok = await result.current.importCurrent()
+    })
+
+    expect(ok).toBe(false)
+    expect(mockFavoriteStoreImportToCurrent).not.toHaveBeenCalled()
+    expect(mockApply).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/hooks/useFavoriteStore.ts
+++ b/src/renderer/hooks/useFavoriteStore.ts
@@ -100,6 +100,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
   }, [enabled, favoriteType, serialize, refreshEntries, t])
 
   const loadFavorite = useCallback(async (entryId: string): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     setLoading(true)
     try {
@@ -124,9 +125,10 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } finally {
       setLoading(false)
     }
-  }, [favoriteType, apply, t])
+  }, [enabled, favoriteType, apply, t])
 
   const renameEntry = useCallback(async (entryId: string, newLabel: string): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     try {
       const result = await window.vialAPI.favoriteStoreRename(favoriteType, entryId, newLabel)
@@ -138,9 +140,10 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } catch {
       return false
     }
-  }, [favoriteType, refreshEntries])
+  }, [enabled, favoriteType, refreshEntries])
 
   const deleteEntry = useCallback(async (entryId: string): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     try {
       const result = await window.vialAPI.favoriteStoreDelete(favoriteType, entryId)
@@ -152,7 +155,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } catch {
       return false
     }
-  }, [favoriteType, refreshEntries])
+  }, [enabled, favoriteType, refreshEntries])
 
   const exportCurrent = useCallback(async (): Promise<boolean> => {
     if (!enabled) return false
@@ -178,6 +181,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
   }, [enabled, favoriteType, serialize, vialProtocol, t])
 
   const importCurrent = useCallback(async (): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     try {
       const result = await window.vialAPI.favoriteStoreImportToCurrent(favoriteType)
@@ -193,7 +197,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
       setError(t('favoriteStore.importFailed'))
       return false
     }
-  }, [favoriteType, apply, t])
+  }, [enabled, favoriteType, apply, t])
 
   const doExport = useCallback(async (entryId?: string): Promise<boolean> => {
     if (!enabled) return false
@@ -227,6 +231,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
   }, [doExport])
 
   const importFavorites = useCallback(async (): Promise<boolean> => {
+    if (!enabled) return false
     setError(null)
     setImportResult(null)
     setImporting(true)
@@ -247,7 +252,7 @@ export function useFavoriteStore({ favoriteType, serialize, apply, enabled = tru
     } finally {
       setImporting(false)
     }
-  }, [refreshEntries, t])
+  }, [enabled, refreshEntries, t])
 
   return {
     entries,


### PR DESCRIPTION
## Summary
- `useFavoriteStore` takes an `enabled` option (callers pass `!isDummy` / the panel's showFavorites gate), but only `saveFavorite`, `exportCurrent`, and the export operations honored it — `loadFavorite`, `renameEntry`, `deleteEntry`, `importCurrent`, and `importFavorites` proceeded regardless, with `loadFavorite`/`importCurrent` even pushing data into the live editor via `apply(...)`. The gap was masked only by dummy panels unmounting their favorite UI.
- Every operation now starts with the same `if (!enabled) return false` guard (all signatures are `Promise<boolean>`, matching the already-guarded operations' no-op contract), with `enabled` added to each dependency array. The hook's contract is uniformly "enabled gates all operations".
- TDD: five new disabled-case tests each failed against the unguarded hook (the IPC/apply mocks were reached) and pass after the fix. `importCurrent` had no tests at all, so it also gained a success-path baseline. No production caller relied on an operation running while disabled (review-verified).

## Verification
- Full suite: 362 test files, 8,184 passed / 22 skipped (baseline + 6 new tests); lint, typecheck, and build clean. No existing assertion modified.