### PR TITLE
refactor(ui): split useDevicePrefs into composed preference hooks

### DIFF
--- a/src/renderer/hooks/device-prefs-types.ts
+++ b/src/renderer/hooks/device-prefs-types.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import type { KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
+import type { RemapKind } from '../components/keyboard/constants'
+import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestComparisonBaseline, TypingTestComparisonBaselines, ViewMatrixCell } from '../../shared/types/pipette-settings'
+import type { TypingTestConfig } from '../typing-test/types'
+import type { AutoLockMinutes, BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+
+export type { KeyboardLayoutId, AutoLockMinutes, BasicViewType, SplitKeyMode }
+
+export interface UseDevicePrefsReturn {
+  layout: KeyboardLayoutId
+  autoAdvance: boolean
+  layerPanelOpen: boolean
+  basicViewType: BasicViewType
+  splitKeyMode: SplitKeyMode
+  quickSelect: boolean
+  keymapScale: number
+  layerNames: string[]
+  typingTestResults: TypingTestResult[]
+  typingTestConfig: TypingTestConfig | undefined
+  typingTestMonkeytypeConfig: TypingTestConfig | undefined
+  typingTestLanguage: string | undefined
+  typingTestViewOnly: boolean
+  typingTestViewOnlyWindowSize: { width: number; height: number } | undefined
+  typingTestViewOnlyAlwaysOnTop: boolean
+  typingTestMemory: TypingTestMemory | undefined
+  typingTestDisplayLines: number
+  typingTestFontSize: number
+  typingTestHideKeymap: boolean
+  typingTestHideStatsRow: boolean
+  typingTestHideControls: boolean
+  typingTestSaveUnnamed: boolean
+  typingTestComparisonBaselines: TypingTestComparisonBaselines
+  typingTestSettingsPanelOpen: boolean
+  typingRecordEnabled: boolean
+  typingViewMenuTab: TypingViewMenuTab
+  viewMode: ViewMode
+  keyEditorZoom: number | undefined
+  viewMatrix: Record<string, ViewMatrixCell> | undefined
+  appliedUid: string | null
+  setLayout: (id: KeyboardLayoutId) => void
+  setAutoAdvance: (enabled: boolean) => void
+  setLayerPanelOpen: (open: boolean) => void
+  setBasicViewType: (type: BasicViewType) => void
+  setSplitKeyMode: (mode: SplitKeyMode) => void
+  setQuickSelect: (enabled: boolean) => void
+  setKeymapScale: (scale: number) => void
+  setLayerNames: (names: string[]) => void
+  addTypingTestResult: (result: TypingTestResult) => void
+  renameTypingTestResult: (date: string, name: string) => void
+  deleteTypingTestResult: (date: string) => void
+  setTypingTestConfig: (config: TypingTestConfig) => void
+  setTypingTestLanguage: (lang: string) => void
+  setTypingTestViewOnly: (enabled: boolean) => void
+  setTypingTestViewOnlyWindowSize: (size: { width: number; height: number }) => void
+  setTypingTestViewOnlyAlwaysOnTop: (enabled: boolean) => void
+  setTypingTestMemory: (memory: TypingTestMemory | undefined) => void
+  setTypingTestDisplayLines: (lines: number) => void
+  setTypingTestFontSize: (px: number) => void
+  setTypingTestHideKeymap: (hidden: boolean) => void
+  setTypingTestHideStatsRow: (hidden: boolean) => void
+  setTypingTestHideControls: (hidden: boolean) => void
+  setTypingTestSaveUnnamed: (enabled: boolean) => void
+  setTypingTestComparisonBaseline: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
+  setTypingTestSettingsPanelOpen: (open: boolean) => void
+  setTypingRecordEnabled: (enabled: boolean) => void
+  setTypingViewMenuTab: (tab: TypingViewMenuTab) => void
+  setViewMode: (mode: ViewMode) => void
+  setKeyEditorZoom: (zoom: number) => void
+  setViewMatrix: (next: Record<string, ViewMatrixCell> | undefined) => void
+  defaultLayout: KeyboardLayoutId
+  defaultAutoAdvance: boolean
+  defaultLayerPanelOpen: boolean
+  defaultBasicViewType: BasicViewType
+  defaultSplitKeyMode: SplitKeyMode
+  defaultQuickSelect: boolean
+  setDefaultLayout: (id: KeyboardLayoutId) => void
+  setDefaultAutoAdvance: (enabled: boolean) => void
+  setDefaultLayerPanelOpen: (open: boolean) => void
+  setDefaultBasicViewType: (type: BasicViewType) => void
+  setDefaultSplitKeyMode: (mode: SplitKeyMode) => void
+  setDefaultQuickSelect: (enabled: boolean) => void
+  autoLockTime: AutoLockMinutes
+  setAutoLockTime: (m: AutoLockMinutes) => void
+  applyDevicePrefs: (uid: string) => Promise<void>
+  /** Display label for a qmkId: the active Key Label pack's own label
+   *  (via `compositeLabels` -> `map`), falling back to the qmkId itself
+   *  when neither has an entry. This is what feeds the keymap surface
+   *  regardless of which of `KeymapEditor`'s tabs is showing (Plan-qwerty-
+   *  select-no-rewrite v7 — シミュレーションタブ方式): the simulation tab
+   *  renders it as-is, while the Base tab bypasses it entirely (its own
+   *  raw/identity keycode builder — see `KeymapEditor`'s `baseLayerKeycodes`
+   *  — never calls this at all). A Rewrite never leaves anything for this
+   *  to simulate either way, since it resets `layout` back to QWERTY
+   *  (raw/no-color) on success, which also makes the tabs disappear. */
+  remapLabel: (qmkId: string) => string
+  /** The blue "remapped" tint source: true whenever `remapLabel(qmkId)`
+   *  differs from `qmkId` itself — same rule every picker/palette consumer
+   *  applies. */
+  isRemapped: (qmkId: string) => boolean
+  /** Which remap tint `isRemapped`-tinted keys use on the keymap surface
+   *  (keymap pane + typing-test pane; the picker is untouched — see
+   *  `pickerRemapLabel` below). `'simulated'` iff an active (non-empty)
+   *  pack map is loaded and it's a pure permutation (same `.ok` verdict
+   *  `rewriteTableResult` already computes for the Rewrite gate) — the
+   *  "labels show what a Rewrite WOULD produce, pressing still types the
+   *  old character" case. `'actual'` otherwise: JIS-type display remaps
+   *  (truthful — the OS/IME really produces the shown char), QWERTY/no
+   *  pack (irrelevant since no key is ever tinted there), and
+   *  non-permutation deviation packs. */
+  remapKind: RemapKind
+  /** The active pack's own rewrite table, already resolved and validated —
+   *  `undefined` unless `remapKind === 'simulated'`. Lets
+   *  `useKeymapApplyPrompt.requestApply` skip a second async lookup for
+   *  the exact table `remapKind` itself already required to build. See
+   *  the hook body's own doc comment for the full rationale. */
+  activeRewriteTable?: KeymapRewriteTable
+  /** Display name of the active layout/pack — see `remapKind`'s sibling
+   *  doc comment on `activeLayoutName` in the hook body for what feeds it. */
+  activeLayoutName: string
+  /** Display label for a qmkId, but ONLY for the key PICKER surface
+   *  (`TabbedKeycodes` / `KeyPopover` → `PopoverTabKey`) — the keymap
+   *  legend itself (`useLayerKeycodes`, `KeyWidget`'s masked-inner label)
+   *  keeps using `remapLabel` above unconditionally.
+   *
+   *  Plan-qwerty-select-no-rewrite v6: the picker should only ever change
+   *  for a pack that deviates from ANSI (a symbol/label the picker can't
+   *  already show as-is — JIS shift pairs, kana, ...). A pure QWERTY-
+   *  keycode permutation pack (Colemak, Eucalyn, Dvorak, ...) swaps WHICH key
+   *  sends a character, but every character it swaps in already exists
+   *  somewhere in the picker — remapping the picker's own legends for
+   *  that case would just be noise (and would desync the picker's
+   *  legend from the keycode it actually inserts). So this identity-
+   *  passes for a permutation pack and only forwards to `remapLabel` once
+   *  the active pack fails the same `buildKeymapRewriteTable` check the
+   *  Key Label "apply to keymap" rewrite itself uses to decide
+   *  applicability — a deviation pack behaves exactly like `remapLabel`.
+   *  QWERTY/no pack has an empty map, which trivially passes the check
+   *  (nothing to permute), so it already resolves to identity without a
+   *  separate guard. */
+  pickerRemapLabel: (qmkId: string) => string
+}

--- a/src/renderer/hooks/device-prefs-validate.ts
+++ b/src/renderer/hooks/device-prefs-validate.ts
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
+import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestMemoryWord, TypingTestComparisonBaselines, ViewMatrixCell } from '../../shared/types/pipette-settings'
+import { VIEW_MODES, isTypingViewMenuTab, isTypingTestComparisonBaselines } from '../../shared/types/pipette-settings'
+import { isNonNegInt, isValidTypingTestResult, sanitizeTypingTestResult } from '../typing-test/typing-test-result-sanitize'
+import type { TypingTestConfig, RomajiDetailSettings, RomajiCaseStyle } from '../typing-test/types'
+import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, clampDisplayLines, clampFontSize } from '../typing-test/types'
+import type { RomajiStyle } from '../typing-test/romaji-engine'
+import type { BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+import { clampZoomFactor } from '../../shared/types/app-config'
+
+const VALID_QUOTE_LENGTHS: ReadonlySet<string> = new Set(['short', 'medium', 'long', 'all'])
+const VALID_ROMAJI_STYLES: ReadonlySet<string> = new Set([
+  'hepburn', 'kunrei',
+  'c', 'q', 'digraph', 'xSmall', 'lSmall', 'w', 'v', 'f', 'ye', 'xn', 'nApos',
+])
+const VALID_ROMAJI_CASE_STYLES: ReadonlySet<string> = new Set(['lower', 'capital', 'upper'])
+
+function isFinitePositiveInt(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0 && Number.isInteger(n)
+}
+
+function hasBooleanFields(obj: Record<string, unknown>, ...keys: string[]): boolean {
+  return keys.every((k) => typeof obj[k] === 'boolean')
+}
+
+/** Validates `config.romaji` (Romaji Settings modal fields) field-by-field:
+ *  an unknown/malformed field is dropped individually instead of rejecting
+ *  the whole nested object, so a stray/corrupted field never takes out
+ *  fields that did validate (Plan-typing-romaji-settings-modal design
+ *  judgement #9 — the same nested-config drop bug that hit `romajiInput`
+ *  before it was carried through explicitly below). Returns undefined when
+ *  `raw` isn't a plausible object, or every field turned out invalid. */
+function validateRomajiDetailSettings(raw: unknown): RomajiDetailSettings | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const obj = raw as Record<string, unknown>
+  const result: RomajiDetailSettings = {}
+  if (typeof obj.caseStyle === 'string' && VALID_ROMAJI_CASE_STYLES.has(obj.caseStyle)) {
+    result.caseStyle = obj.caseStyle as RomajiCaseStyle
+  }
+  // A persisted `fontSize` (from a build that still had the per-guide font
+  // control) is intentionally not read here — it silently falls through to
+  // "not set" now that the guide always tracks Settings > Font.
+  if (Array.isArray(obj.guideStyles)) {
+    // 'hepburn' is dropped here (unlike disabledStyles below, which keeps
+    // it): the Guide row's Base selection is single-select, and hepburn is
+    // its implicit default — the modal never writes 'hepburn' into
+    // guideStyles itself (see RomajiSettingsModal's selectGuideBase), and
+    // GUIDE_STYLE_PRIORITY in romaji-engine.ts has no 'hepburn' entry, so a
+    // stray 'hepburn' here would sit inert. Sanitizing it out keeps a
+    // hand-edited or legacy-written config equivalent to the canonical
+    // default rather than persisting a functionally meaningless entry.
+    const styles = obj.guideStyles.filter(
+      (s): s is RomajiStyle => typeof s === 'string' && VALID_ROMAJI_STYLES.has(s) && s !== 'hepburn',
+    )
+    if (styles.length > 0) result.guideStyles = styles
+  }
+  if (Array.isArray(obj.disabledStyles)) {
+    let styles = obj.disabledStyles.filter(
+      (s): s is RomajiStyle => typeof s === 'string' && VALID_ROMAJI_STYLES.has(s),
+    )
+    // At least one base system (hepburn/kunrei) must stay enabled — the
+    // Romaji Settings modal enforces this on the way in, but a persisted
+    // config could still carry both disabled (e.g. hand-edited, or written
+    // by a future version with looser rules). Sanitize deterministically
+    // by dropping 'kunrei' from the disabled set rather than rejecting the
+    // whole field, so kunrei-shiki wins and stays enabled.
+    if (styles.includes('hepburn') && styles.includes('kunrei')) {
+      styles = styles.filter((s) => s !== 'kunrei')
+    }
+    if (styles.length > 0) result.disabledStyles = styles
+  }
+  if (
+    typeof obj.guideWordCount === 'number'
+    && Number.isInteger(obj.guideWordCount)
+    && obj.guideWordCount >= 0
+    && obj.guideWordCount <= 3
+  ) {
+    result.guideWordCount = obj.guideWordCount
+  }
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const obj = raw as Record<string, unknown>
+  // Optional carry-through: keep a persisted boolean romajiInput on
+  // words/time/tatoeba/fileImport configs (every mode but quote), drop any
+  // other type silently (the field is optional, so a malformed value
+  // degrades to "not set" rather than rejecting the whole config). Same
+  // treatment for the nested `romaji` detail settings.
+  const romajiInput = typeof obj.romajiInput === 'boolean' ? { romajiInput: obj.romajiInput } : {}
+  const romaji = validateRomajiDetailSettings(obj.romaji)
+  const romajiDetail = romaji ? { romaji } : {}
+  switch (obj.mode) {
+    case 'words':
+      if (!isFinitePositiveInt(obj.wordCount) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
+      return { mode: 'words', wordCount: obj.wordCount, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput, ...romajiDetail }
+    case 'time':
+      if (!isFinitePositiveInt(obj.duration) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
+      return { mode: 'time', duration: obj.duration, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput, ...romajiDetail }
+    case 'quote':
+      if (typeof obj.quoteLength !== 'string' || !VALID_QUOTE_LENGTHS.has(obj.quoteLength)) return undefined
+      return { mode: 'quote', quoteLength: obj.quoteLength as 'short' | 'medium' | 'long' | 'all' }
+    case 'fileImport':
+      if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
+      return { mode: 'fileImport', textId: obj.textId, ...romajiInput, ...romajiDetail }
+    case 'tatoeba': {
+      if (typeof obj.language !== 'string' || obj.language.length === 0) return undefined
+      // Older configs (saved before Tatoeba gained its own Pattern/Units)
+      // lack pattern/lineCount/duration — default them rather than reject
+      // the whole config, same treatment as every other optional-carry-
+      // through field on this type.
+      const pattern = obj.pattern === 'time' ? 'time' : 'lines'
+      const lineCount = isFinitePositiveInt(obj.lineCount) ? obj.lineCount : 5
+      const duration = isFinitePositiveInt(obj.duration) ? obj.duration : 30
+      return { mode: 'tatoeba', language: obj.language, pattern, lineCount, duration, ...romajiInput, ...romajiDetail }
+    }
+    default:
+      return undefined
+  }
+}
+
+/** The MonkeyType-family modes whose config is remembered as the fallback
+ *  restored when leaving fileImport / tatoeba. */
+export function isMonkeytypeMode(mode: TypingTestConfig['mode']): boolean {
+  return mode === 'words' || mode === 'time' || mode === 'quote'
+}
+
+/** The MonkeyType fallback config must be a normal (words/time/quote) config.
+ *  Reject any fileImport / tatoeba value — including a stale one persisted by
+ *  an older build — so leaving those modes never restores them. */
+function validateMonkeytypeConfig(raw: unknown): TypingTestConfig | undefined {
+  const cfg = validateTypingTestConfig(raw)
+  return cfg && isMonkeytypeMode(cfg.mode) ? cfg : undefined
+}
+
+function validateTypingTestLanguage(raw: unknown): string | undefined {
+  if (typeof raw !== 'string' || raw.length === 0) return undefined
+  return raw
+}
+
+function validateTypingTestMemory(raw: unknown): TypingTestMemory | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const o = raw as Record<string, unknown>
+  if (typeof o.textId !== 'string' || o.textId.length === 0) return undefined
+  if (typeof o.currentWordIndex !== 'number' || !Number.isFinite(o.currentWordIndex) || o.currentWordIndex < 0) return undefined
+  if (typeof o.currentInput !== 'string') return undefined
+  if (typeof o.correctChars !== 'number' || typeof o.incorrectChars !== 'number') return undefined
+  if (typeof o.elapsedMs !== 'number' || !Number.isFinite(o.elapsedMs) || o.elapsedMs < 0) return undefined
+  if (!Array.isArray(o.wordResults)) return undefined
+  const rawResults = o.wordResults as unknown[]
+  const wordResults = rawResults.filter((w): w is TypingTestMemoryWord => {
+    if (typeof w !== 'object' || w === null) return false
+    const r = w as Record<string, unknown>
+    return typeof r.word === 'string' && typeof r.typed === 'string' && typeof r.correct === 'boolean'
+  })
+  // A malformed entry means the snapshot is untrustworthy — discard it.
+  if (wordResults.length !== rawResults.length) return undefined
+  const wpmHistory = Array.isArray(o.wpmHistory)
+    ? (o.wpmHistory as unknown[]).filter((n): n is number => typeof n === 'number')
+    : []
+  // All-or-nothing, mirroring how captureMemory always writes all three
+  // together (see TypingTestMemory's doc comment): a malformed/partial
+  // group degrades to "absent" rather than trusting a subset, so
+  // restoreState's legacy-format fallback (permanently uncomputable) kicks
+  // in exactly the same as for a memory saved before KSPC existed.
+  const validKspcGroup =
+    isNonNegInt(o.totalKeystrokes) && isNonNegInt(o.confirmedChars) && typeof o.kspcUncomputable === 'boolean'
+  return {
+    textId: o.textId,
+    currentWordIndex: o.currentWordIndex,
+    currentInput: o.currentInput,
+    wordResults,
+    correctChars: o.correctChars,
+    incorrectChars: o.incorrectChars,
+    elapsedMs: o.elapsedMs,
+    wpmHistory,
+    totalKeystrokes: validKspcGroup ? (o.totalKeystrokes as number) : undefined,
+    confirmedChars: validKspcGroup ? (o.confirmedChars as number) : undefined,
+    kspcUncomputable: validKspcGroup ? (o.kspcUncomputable as boolean) : undefined,
+    savedAt: typeof o.savedAt === 'string' ? o.savedAt : new Date(0).toISOString(),
+  }
+}
+
+const VALID_BASIC_VIEW_TYPES: ReadonlySet<string> = new Set(['ansi', 'iso', 'jis', 'list'])
+const LEGACY_BASIC_VIEW_MAP: Record<string, string> = { keyboard: 'ansi' }
+const VALID_SPLIT_KEY_MODES: ReadonlySet<string> = new Set(['split', 'flat'])
+const VALID_VIEW_MODES: ReadonlySet<string> = new Set(VIEW_MODES)
+
+export interface ValidatedPrefs {
+  keyboardLayout: KeyboardLayoutId
+  autoAdvance: boolean
+  layerPanelOpen: boolean
+  basicViewType: BasicViewType
+  splitKeyMode: SplitKeyMode
+  quickSelect: boolean
+  keymapScale: number
+  layerNames: string[]
+  typingTestResults: TypingTestResult[]
+  typingTestConfig?: TypingTestConfig
+  typingTestMonkeytypeConfig?: TypingTestConfig
+  typingTestLanguage?: string
+  typingTestViewOnly: boolean
+  typingTestViewOnlyWindowSize?: { width: number; height: number }
+  typingTestViewOnlyAlwaysOnTop: boolean
+  typingTestMemory?: TypingTestMemory
+  typingTestDisplayLines: number
+  typingTestFontSize: number
+  typingTestHideKeymap: boolean
+  typingTestHideStatsRow: boolean
+  typingTestHideControls: boolean
+  typingTestSaveUnnamed: boolean
+  typingTestComparisonBaselines: TypingTestComparisonBaselines
+  typingTestSettingsPanelOpen: boolean
+  typingRecordEnabled: boolean
+  typingViewMenuTab: TypingViewMenuTab
+  viewMode: ViewMode
+  keyEditorZoom?: number
+  viewMatrix?: Record<string, ViewMatrixCell>
+}
+
+export function validateIpcPrefs(
+  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestMonkeytypeConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestSaveUnnamed?: boolean; typingTestComparisonBaselines?: unknown; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown; viewMatrix?: Record<string, ViewMatrixCell> } | null,
+  defaultLayout: KeyboardLayoutId,
+  defaultAutoAdvance: boolean,
+  defaultLayerPanelOpen: boolean,
+  defaultBasicViewType: BasicViewType,
+  defaultSplitKeyMode: SplitKeyMode,
+  defaultQuickSelect: boolean,
+): ValidatedPrefs | null {
+  if (!data) return null
+
+  // After the Key Labels migration the built-in `LAYOUT_ID_SET` only
+  // covers QWERTY. Any saved id that is not empty is accepted here; the
+  // Key Label store is consulted at render time and falls back to
+  // QWERTY when the id is not (yet) installed locally.
+  const layout = typeof data.keyboardLayout === 'string' && data.keyboardLayout.length > 0
+    ? data.keyboardLayout
+    : null
+  const autoAdvance = typeof data.autoAdvance === 'boolean' ? data.autoAdvance : null
+  if (layout === null && autoAdvance === null) return null
+
+  const layerPanelOpen = typeof data.layerPanelOpen === 'boolean' ? data.layerPanelOpen : defaultLayerPanelOpen
+  const rawBasicView = typeof data.basicViewType === 'string'
+    ? (LEGACY_BASIC_VIEW_MAP[data.basicViewType] ?? data.basicViewType)
+    : null
+  const basicViewType = rawBasicView !== null && VALID_BASIC_VIEW_TYPES.has(rawBasicView)
+    ? rawBasicView as BasicViewType
+    : defaultBasicViewType
+  const splitKeyMode = typeof data.splitKeyMode === 'string' && VALID_SPLIT_KEY_MODES.has(data.splitKeyMode)
+    ? data.splitKeyMode as SplitKeyMode
+    : defaultSplitKeyMode
+  const quickSelect = typeof data.quickSelect === 'boolean' ? data.quickSelect : defaultQuickSelect
+  const keymapScale = typeof data.keymapScale === 'number' && data.keymapScale >= MIN_SCALE && data.keymapScale <= MAX_SCALE
+    ? Math.round(data.keymapScale * 10) / 10
+    : 1
+
+  const layerNames = Array.isArray(data.layerNames)
+    ? data.layerNames.filter((n): n is string => typeof n === 'string')
+    : []
+  const typingTestResults = Array.isArray(data.typingTestResults)
+    ? data.typingTestResults.filter(isValidTypingTestResult).map(sanitizeTypingTestResult)
+    : []
+
+  // Legacy migration: { mode: 'viewOnly' } → separate boolean
+  let typingTestConfig = validateTypingTestConfig(data.typingTestConfig)
+  let typingTestViewOnly = typeof data.typingTestViewOnly === 'boolean' ? data.typingTestViewOnly : false
+  if (!typingTestConfig && data.typingTestConfig != null) {
+    const raw = data.typingTestConfig as Record<string, unknown>
+    if (raw.mode === 'viewOnly') {
+      typingTestViewOnly = true
+      typingTestConfig = undefined
+    }
+  }
+
+  const viewMode: ViewMode = typeof data.viewMode === 'string' && VALID_VIEW_MODES.has(data.viewMode)
+    ? data.viewMode as ViewMode
+    : 'editor'
+
+  return {
+    keyboardLayout: layout ?? defaultLayout,
+    autoAdvance: autoAdvance ?? defaultAutoAdvance,
+    layerPanelOpen,
+    basicViewType,
+    splitKeyMode,
+    quickSelect,
+    keymapScale,
+    layerNames,
+    typingTestResults,
+    typingTestConfig,
+    typingTestMonkeytypeConfig: validateMonkeytypeConfig(data.typingTestMonkeytypeConfig),
+    typingTestLanguage: validateTypingTestLanguage(data.typingTestLanguage),
+    typingTestViewOnly,
+    typingTestViewOnlyWindowSize: validateWindowSize(data.typingTestViewOnlyWindowSize),
+    typingTestViewOnlyAlwaysOnTop: typeof data.typingTestViewOnlyAlwaysOnTop === 'boolean' ? data.typingTestViewOnlyAlwaysOnTop : false,
+    typingTestMemory: validateTypingTestMemory(data.typingTestMemory),
+    typingTestDisplayLines: typeof data.typingTestDisplayLines === 'number' ? clampDisplayLines(data.typingTestDisplayLines) : DEFAULT_DISPLAY_LINES,
+    typingTestFontSize: typeof data.typingTestFontSize === 'number' ? clampFontSize(data.typingTestFontSize) : DEFAULT_FONT_SIZE,
+    typingTestHideKeymap: data.typingTestHideKeymap === true,
+    typingTestHideStatsRow: data.typingTestHideStatsRow === true,
+    typingTestHideControls: data.typingTestHideControls === true,
+    // Default true: a finished result is auto-saved unless the user opts out.
+    typingTestSaveUnnamed: data.typingTestSaveUnnamed !== false,
+    typingTestComparisonBaselines: isTypingTestComparisonBaselines(data.typingTestComparisonBaselines) ? data.typingTestComparisonBaselines : {},
+    typingTestSettingsPanelOpen: typeof data.typingTestSettingsPanelOpen === 'boolean' ? data.typingTestSettingsPanelOpen : true,
+    typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
+    typingViewMenuTab: isTypingViewMenuTab(data.typingViewMenuTab) ? data.typingViewMenuTab : 'window',
+    viewMode,
+    keyEditorZoom: typeof data.keyEditorZoom === 'number' ? clampZoomFactor(data.keyEditorZoom) : undefined,
+    // Trusted as-is: the main process (pipette-settings-store's
+    // isValidViewMatrix) is the single validator for this shape, same as
+    // the other store-validated per-keyboard fields.
+    viewMatrix: data.viewMatrix,
+  }
+}
+
+function validateWindowSize(raw: unknown): { width: number; height: number } | undefined {
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
+  const obj = raw as Record<string, unknown>
+  if (typeof obj.width !== 'number' || typeof obj.height !== 'number') return undefined
+  if (obj.width <= 0 || obj.height <= 0) return undefined
+  return { width: obj.width, height: obj.height }
+}

--- a/src/renderer/hooks/use-device-prefs-defaults.ts
+++ b/src/renderer/hooks/use-device-prefs-defaults.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback } from 'react'
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import type { AppConfig, AutoLockMinutes, BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+
+interface UseDevicePrefsDefaultsArgs {
+  config: AppConfig
+  set: <K extends keyof AppConfig>(key: K, value: AppConfig[K]) => void
+}
+
+export function useDevicePrefsDefaults({ config, set }: UseDevicePrefsDefaultsArgs) {
+  // Accept any non-empty id; Key Labels installed via the modal are
+  // valid even though they are not in the built-in `LAYOUT_ID_SET`.
+  const defaultLayout = typeof config.defaultKeyboardLayout === 'string'
+    && config.defaultKeyboardLayout.length > 0
+    ? config.defaultKeyboardLayout
+    : 'qwerty'
+  const defaultAutoAdvance = config.defaultAutoAdvance
+  const defaultLayerPanelOpen = config.defaultLayerPanelOpen
+  const defaultBasicViewType = config.defaultBasicViewType
+  const defaultSplitKeyMode = config.defaultSplitKeyMode ?? 'split'
+  const defaultQuickSelect = config.defaultQuickSelect ?? false
+
+  const setDefaultLayout = useCallback((id: KeyboardLayoutId) => {
+    set('defaultKeyboardLayout', id)
+  }, [set])
+
+  const setDefaultAutoAdvance = useCallback((enabled: boolean) => {
+    set('defaultAutoAdvance', enabled)
+  }, [set])
+
+  const setDefaultLayerPanelOpen = useCallback((open: boolean) => {
+    set('defaultLayerPanelOpen', open)
+  }, [set])
+
+  const setDefaultBasicViewType = useCallback((type: BasicViewType) => {
+    set('defaultBasicViewType', type)
+  }, [set])
+
+  const setDefaultSplitKeyMode = useCallback((mode: SplitKeyMode) => {
+    set('defaultSplitKeyMode', mode)
+  }, [set])
+
+  const setDefaultQuickSelect = useCallback((enabled: boolean) => {
+    set('defaultQuickSelect', enabled)
+  }, [set])
+
+  const setAutoLockTime = useCallback((m: AutoLockMinutes) => {
+    set('autoLockTime', m)
+  }, [set])
+
+  return {
+    defaultLayout,
+    defaultAutoAdvance,
+    defaultLayerPanelOpen,
+    defaultBasicViewType,
+    defaultSplitKeyMode,
+    defaultQuickSelect,
+    setDefaultLayout,
+    setDefaultAutoAdvance,
+    setDefaultLayerPanelOpen,
+    setDefaultBasicViewType,
+    setDefaultSplitKeyMode,
+    setDefaultQuickSelect,
+    autoLockTime: config.autoLockTime,
+    setAutoLockTime,
+  }
+}

--- a/src/renderer/hooks/use-device-prefs-remap.ts
+++ b/src/renderer/hooks/use-device-prefs-remap.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback, useEffect, useMemo } from 'react'
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import { useKeyLabelLookup } from './useKeyLabelLookup'
+import { buildKeymapRewriteTable, type KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
+import type { RemapKind } from '../components/keyboard/constants'
+
+export function useDevicePrefsRemap(layout: KeyboardLayoutId) {
+  const lookup = useKeyLabelLookup()
+
+  // Trigger an IPC fetch for non-built-in layouts so the remap callbacks
+  // see the map / compositeLabels as soon as the store responds.
+  useEffect(() => {
+    void lookup.ensure(layout)
+  }, [lookup, layout])
+
+  // Single source of truth for "does this pack's map build a rewrite
+  // table" — `packIsPurePermutation` (Phase P, picker gate) needs the same
+  // `.ok` verdict `buildKeymapRewriteTable` computes for the Key Label
+  // "apply to keymap" rewrite.
+  //
+  // Memoized on the pack map's own object reference (stable per cache
+  // entry, see `useKeyLabelLookup.getMap`) rather than on `lookup` itself
+  // (a fresh object literal every render), so this only rebuilds when the
+  // pack data actually changes. QWERTY/no pack: `map` is `undefined` (not
+  // yet loaded) or an empty object (built-in QWERTY, or an uninstalled
+  // pack that never resolves) — an empty map trivially passes
+  // `buildKeymapRewriteTable` (there is nothing to permute).
+  const activeMap = lookup.getMap(layout)
+  const rewriteTableResult = useMemo(
+    () => (activeMap ? buildKeymapRewriteTable(activeMap) : undefined),
+    [activeMap],
+  )
+
+  // Picker-only gate (Plan-qwerty-select-no-rewrite v6, Phase P): a pure
+  // QWERTY-keycode permutation pack (Colemak, Eucalyn, Dvorak, ...) must
+  // leave the key PICKER raw — see `pickerRemapLabel`'s doc comment below.
+  // Re-derives the same `.ok` verdict `buildKeymapRewriteTable` already
+  // computes for the Key Label "apply to keymap" rewrite, rather than
+  // consulting `getKeymapApplicable` (an author-supplied hint the rewrite
+  // path deliberately treats as advisory only, not authoritative). An
+  // undefined `rewriteTableResult` (no pack loaded) defaults to "pure
+  // permutation" too since `remapLabel` is already identity in that state
+  // regardless of this flag.
+  const packIsPurePermutation = !rewriteTableResult || rewriteTableResult.ok
+
+  // Author-supplied "wants a keymap rewrite" hint (Plan-key-label-keymap-
+  // apply) — `false` for built-in QWERTY and for any pack not yet loaded.
+  // Combined with `packIsPurePermutation` below (the structural `.ok`
+  // verdict) into the single Plan-qwerty-select-no-rewrite v7 predicate:
+  // `keymapApplicable && buildKeymapRewriteTable(map).ok`. That predicate —
+  // not `.ok` alone — is what `remapKind` now gates on, so it doubles as
+  // the simulation-tab / Apply-eligibility signal `KeymapEditor` consumes
+  // via `remapKind === 'simulated'` (tab visibility, Apply button, and the
+  // simulated tint all read the exact same boolean, never three separately
+  // maintained checks).
+  const keymapApplicable = !!activeMap && lookup.getKeymapApplicable(layout)
+
+  // Which remap tint `isRemapped`-tinted keys use on the keymap surface
+  // (see the `remapKind` field's own doc comment on the return type).
+  // "An active pack map is loaded" is checked directly against `activeMap`
+  // rather than `rewriteTableResult` — QWERTY's map is `{}` (truthy,
+  // trivially a pure permutation) but has nothing to tint, so gating on
+  // "non-empty" here avoids relying on `rewriteTableResult`'s undefined-
+  // ness to mean "no pack" (it doesn't for QWERTY, which is why
+  // `packIsPurePermutation`'s own doc comment calls that state out
+  // separately). `keymapApplicable` is the addition over the old
+  // `.ok`-only check: a pack that structurally permutes but was never
+  // flagged applicable (the author's own opt-out) now renders with the
+  // ACTUAL tint in place, same as a JIS-type deviation pack, instead of
+  // simulating a Rewrite nothing downstream will actually offer.
+  const remapKind: RemapKind = useMemo(() => {
+    const hasActivePackMap = !!activeMap && Object.keys(activeMap).length > 0
+    return hasActivePackMap && keymapApplicable && packIsPurePermutation ? 'simulated' : 'actual'
+  }, [activeMap, keymapApplicable, packIsPurePermutation])
+
+  // The active pack's own rewrite table, exposed ONLY while it's actually
+  // eligible for a keymap Rewrite (`remapKind === 'simulated'` — the exact
+  // state `KeymapEditor` requires before it ever renders the simulation
+  // tab / Apply button in the first place). `useKeymapApplyPrompt
+  // .requestApply` reads this directly instead of re-resolving the same
+  // map through its own `useKeyLabelLookup` instance: by the time the
+  // Apply button is reachable at all, `rewriteTableResult` above has
+  // already built successfully for this exact `layout`, so there is
+  // nothing left to look up. `undefined` (not `remapKind !== 'simulated'`
+  // alone) is the guard `requestApply` no-ops on, mirroring the old
+  // resolver's own null-return contract.
+  const activeRewriteTable = remapKind === 'simulated' && rewriteTableResult?.ok
+    ? rewriteTableResult.table
+    : undefined
+
+  // Display name for the active pack — used by `KeymapEditor`'s simulation
+  // tab label when `remapKind === 'simulated'`. Falls back to the raw id
+  // (same fallback `useKeyLabelLookup.getName` documents) so a not-yet-
+  // loaded pack never renders an empty tab.
+  const activeLayoutName = lookup.getName(layout) ?? layout
+
+  // The active Key Label pack's own labels, resolved through its
+  // compositeLabels -> map lookup order and falling back to qmkId itself
+  // when neither has an entry. QWERTY's map/compositeLabels are always
+  // empty (`BUILTIN_QWERTY_LAYOUT_ID` in keyboard-layouts.ts), so it
+  // resolves to identity without a separate guard. Feeds the key picker
+  // unconditionally, and the keymap surface too EXCEPT `KeymapEditor`'s
+  // Base tab, which reads its own raw/identity keycode builder instead of
+  // calling this at all (Plan-qwerty-select-no-rewrite v7 — シミュレーション
+  // タブ方式: the simulation tab shows exactly what this resolves to, Base
+  // shows the real keymap regardless of it). A Rewrite never leaves
+  // anything for this to simulate — it resets `layout` back to QWERTY on
+  // success (raw characters, no color, no tabs), the same clean state a
+  // snapshot/.vil restore leaves.
+  const remapLabel = useCallback(
+    (qmkId: string): string => {
+      const composite = lookup.getCompositeLabels(layout)?.[qmkId]
+      if (composite !== undefined) return composite
+      const mapped = lookup.getMap(layout)?.[qmkId]
+      if (mapped !== undefined) return mapped
+      return qmkId
+    },
+    [lookup, layout],
+  )
+
+  // The blue "remapped" tint: true whenever the resolved label differs from
+  // the qmkId itself — the same `remapLabel(x) !== x` rule every picker/
+  // palette consumer (KeycodeGrid.getRemapDisplayLabel) already uses.
+  const isRemapped = useCallback(
+    (qmkId: string): boolean => remapLabel(qmkId) !== qmkId,
+    [remapLabel],
+  )
+
+  // Delegates to `remapLabel` itself for the deviation-pack branch (rather
+  // than re-resolving compositeLabels/map independently) so the picker and
+  // keymap legend can never disagree on what a deviation pack's label is —
+  // only WHETHER it's shown differs between the two surfaces.
+  const pickerRemapLabel = useCallback(
+    (qmkId: string): string => (packIsPurePermutation ? qmkId : remapLabel(qmkId)),
+    [packIsPurePermutation, remapLabel],
+  )
+
+  return {
+    remapLabel,
+    isRemapped,
+    remapKind,
+    activeRewriteTable: activeRewriteTable as KeymapRewriteTable | undefined,
+    activeLayoutName,
+    pickerRemapLabel,
+  }
+}

--- a/src/renderer/hooks/use-device-prefs-state.ts
+++ b/src/renderer/hooks/use-device-prefs-state.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useCallback, useRef } from 'react'
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestComparisonBaselines, ViewMatrixCell } from '../../shared/types/pipette-settings'
+import type { TypingTestConfig } from '../typing-test/types'
+import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from '../typing-test/types'
+import type { BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+import type { ValidatedPrefs } from './device-prefs-validate'
+
+/**
+ * Pairs a state value with a ref that always holds the latest value.
+ * The ref is needed so that saveCurrentPrefs can read current values
+ * inside a stable (never-recreated) callback.
+ */
+function useStateRef<T>(initial: T): [T, (v: T) => void, React.RefObject<T>] {
+  const [value, setValue] = useState<T>(initial)
+  const ref = useRef(value)
+  const update = useCallback((v: T) => {
+    ref.current = v
+    setValue(v)
+  }, [])
+  return [value, update, ref]
+}
+
+export interface DevicePrefsInitialDefaults {
+  defaultLayout: KeyboardLayoutId
+  defaultAutoAdvance: boolean
+  defaultLayerPanelOpen: boolean
+  defaultBasicViewType: BasicViewType
+  defaultSplitKeyMode: SplitKeyMode
+  defaultQuickSelect: boolean
+}
+
+export function useDevicePrefsState(defaults: DevicePrefsInitialDefaults) {
+  const [layout, updateLayout, layoutRef] = useStateRef<KeyboardLayoutId>(defaults.defaultLayout)
+  const [autoAdvance, updateAutoAdvance, autoAdvanceRef] = useStateRef<boolean>(defaults.defaultAutoAdvance)
+  const [layerPanelOpen, updateLayerPanelOpen, layerPanelOpenRef] = useStateRef<boolean>(defaults.defaultLayerPanelOpen)
+  const [basicViewType, updateBasicViewType, basicViewTypeRef] = useStateRef<BasicViewType>(defaults.defaultBasicViewType)
+  const [splitKeyMode, updateSplitKeyMode, splitKeyModeRef] = useStateRef<SplitKeyMode>(defaults.defaultSplitKeyMode)
+  const [quickSelect, updateQuickSelect, quickSelectRef] = useStateRef<boolean>(defaults.defaultQuickSelect)
+  const [keymapScale, updateKeymapScale, keymapScaleRef] = useStateRef<number>(1)
+  const [layerNames, updateLayerNames, layerNamesRef] = useStateRef<string[]>([])
+  const [typingTestResults, updateTypingTestResults, typingTestResultsRef] = useStateRef<TypingTestResult[]>([])
+  const [typingTestConfig, updateTypingTestConfig, typingTestConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
+  const [typingTestMonkeytypeConfig, updateTypingTestMonkeytypeConfig, typingTestMonkeytypeConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
+  const [typingTestLanguage, updateTypingTestLanguage, typingTestLanguageRef] = useStateRef<string | undefined>(undefined)
+  const [typingTestViewOnly, updateTypingTestViewOnly, typingTestViewOnlyRef] = useStateRef<boolean>(false)
+  const [typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize, typingTestViewOnlyWindowSizeRef] = useStateRef<{ width: number; height: number } | undefined>(undefined)
+  const [typingTestViewOnlyAlwaysOnTop, updateTypingTestViewOnlyAlwaysOnTop, typingTestViewOnlyAlwaysOnTopRef] = useStateRef<boolean>(false)
+  const [typingTestMemory, updateTypingTestMemory, typingTestMemoryRef] = useStateRef<TypingTestMemory | undefined>(undefined)
+  const [typingTestDisplayLines, updateTypingTestDisplayLines, typingTestDisplayLinesRef] = useStateRef<number>(DEFAULT_DISPLAY_LINES)
+  const [typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef] = useStateRef<number>(DEFAULT_FONT_SIZE)
+  const [typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef] = useStateRef<boolean>(false)
+  const [typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef] = useStateRef<boolean>(false)
+  const [typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef] = useStateRef<boolean>(false)
+  const [typingTestSaveUnnamed, updateTypingTestSaveUnnamed, typingTestSaveUnnamedRef] = useStateRef<boolean>(true)
+  const [typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef] = useStateRef<TypingTestComparisonBaselines>({})
+  const [typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef] = useStateRef<boolean>(true)
+  const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
+  const [typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef] = useStateRef<TypingViewMenuTab>('window')
+  const [viewMode, updateViewMode, viewModeRef] = useStateRef<ViewMode>('editor')
+  const [keyEditorZoom, updateKeyEditorZoom, keyEditorZoomRef] = useStateRef<number | undefined>(undefined)
+  const [viewMatrix, updateViewMatrix, viewMatrixRef] = useStateRef<Record<string, ViewMatrixCell> | undefined>(undefined)
+  const [appliedUid, setAppliedUid] = useState<string | null>(null)
+
+  const uidRef = useRef('')
+  const applySeqRef = useRef(0)
+
+  const saveCurrentPrefs = useCallback(() => {
+    const uid = uidRef.current
+    if (!uid) return
+    window.vialAPI.pipetteSettingsPatch(uid, {
+      _rev: 1,
+      keyboardLayout: layoutRef.current,
+      autoAdvance: autoAdvanceRef.current,
+      layerPanelOpen: layerPanelOpenRef.current,
+      basicViewType: basicViewTypeRef.current,
+      splitKeyMode: splitKeyModeRef.current,
+      quickSelect: quickSelectRef.current,
+      keymapScale: keymapScaleRef.current,
+      keyEditorZoom: keyEditorZoomRef.current,
+      layerNames: layerNamesRef.current,
+      typingTestResults: typingTestResultsRef.current,
+      typingTestConfig: typingTestConfigRef.current as Record<string, unknown> | undefined,
+      typingTestMonkeytypeConfig: typingTestMonkeytypeConfigRef.current as Record<string, unknown> | undefined,
+      typingTestLanguage: typingTestLanguageRef.current,
+      typingTestViewOnly: typingTestViewOnlyRef.current,
+      typingTestViewOnlyWindowSize: typingTestViewOnlyWindowSizeRef.current,
+      typingTestViewOnlyAlwaysOnTop: typingTestViewOnlyAlwaysOnTopRef.current,
+      // `null` clears the persisted memory; the field-level PATCH skips
+      // `undefined`, so a bare `undefined` would leave a stale paused run
+      // on disk after finish / restart.
+      typingTestMemory: typingTestMemoryRef.current ?? null,
+      typingTestDisplayLines: typingTestDisplayLinesRef.current,
+      typingTestFontSize: typingTestFontSizeRef.current,
+      typingTestHideKeymap: typingTestHideKeymapRef.current,
+      typingTestHideStatsRow: typingTestHideStatsRowRef.current,
+      typingTestHideControls: typingTestHideControlsRef.current,
+      typingTestSaveUnnamed: typingTestSaveUnnamedRef.current,
+      typingTestComparisonBaselines: typingTestComparisonBaselinesRef.current,
+      typingTestSettingsPanelOpen: typingTestSettingsPanelOpenRef.current,
+      typingRecordEnabled: typingRecordEnabledRef.current,
+      typingViewMenuTab: typingViewMenuTabRef.current,
+      viewMode: viewModeRef.current,
+      // `null` clears the persisted overrides when the ref holds `undefined`
+      // (reset), mirroring `typingTestMemory` above — a bare `undefined`
+      // would leave a stale map on disk instead of clearing it.
+      viewMatrix: viewMatrixRef.current ?? null,
+    }).catch(() => {
+      // IPC failure — best-effort save
+    })
+  }, [])
+
+  /** Applies a resolved (defaulted/migrated) prefs snapshot to every state
+   *  slot in one synchronous pass — no await between updates, so a caller
+   *  can follow it immediately with `setAppliedUid` and rely on state being
+   *  fully settled by then (view-mode routing gates on `appliedUid`). */
+  const applyValidated = useCallback((resolved: ValidatedPrefs) => {
+    updateLayout(resolved.keyboardLayout)
+    updateAutoAdvance(resolved.autoAdvance)
+    updateLayerPanelOpen(resolved.layerPanelOpen)
+    updateBasicViewType(resolved.basicViewType)
+    updateSplitKeyMode(resolved.splitKeyMode)
+    updateQuickSelect(resolved.quickSelect)
+    updateKeymapScale(resolved.keymapScale)
+    updateLayerNames(resolved.layerNames)
+    updateTypingTestResults(resolved.typingTestResults)
+    updateTypingTestConfig(resolved.typingTestConfig)
+    updateTypingTestMonkeytypeConfig(resolved.typingTestMonkeytypeConfig)
+    updateTypingTestLanguage(resolved.typingTestLanguage)
+    updateTypingTestViewOnly(resolved.typingTestViewOnly)
+    updateTypingTestViewOnlyWindowSize(resolved.typingTestViewOnlyWindowSize)
+    updateTypingTestViewOnlyAlwaysOnTop(resolved.typingTestViewOnlyAlwaysOnTop)
+    updateTypingTestMemory(resolved.typingTestMemory)
+    updateTypingTestDisplayLines(resolved.typingTestDisplayLines)
+    updateTypingTestFontSize(resolved.typingTestFontSize)
+    updateTypingTestHideKeymap(resolved.typingTestHideKeymap)
+    updateTypingTestHideStatsRow(resolved.typingTestHideStatsRow)
+    updateTypingTestHideControls(resolved.typingTestHideControls)
+    updateTypingTestSaveUnnamed(resolved.typingTestSaveUnnamed)
+    updateTypingTestComparisonBaselines(resolved.typingTestComparisonBaselines)
+    updateTypingTestSettingsPanelOpen(resolved.typingTestSettingsPanelOpen)
+    updateTypingRecordEnabled(resolved.typingRecordEnabled)
+    updateTypingViewMenuTab(resolved.typingViewMenuTab)
+    updateViewMode(resolved.viewMode)
+    updateKeyEditorZoom(resolved.keyEditorZoom)
+    updateViewMatrix(resolved.viewMatrix)
+  }, [])
+
+  return {
+    layout, updateLayout, layoutRef,
+    autoAdvance, updateAutoAdvance, autoAdvanceRef,
+    layerPanelOpen, updateLayerPanelOpen, layerPanelOpenRef,
+    basicViewType, updateBasicViewType, basicViewTypeRef,
+    splitKeyMode, updateSplitKeyMode, splitKeyModeRef,
+    quickSelect, updateQuickSelect, quickSelectRef,
+    keymapScale, updateKeymapScale, keymapScaleRef,
+    layerNames, updateLayerNames, layerNamesRef,
+    typingTestResults, updateTypingTestResults, typingTestResultsRef,
+    typingTestConfig, updateTypingTestConfig, typingTestConfigRef,
+    typingTestMonkeytypeConfig, updateTypingTestMonkeytypeConfig, typingTestMonkeytypeConfigRef,
+    typingTestLanguage, updateTypingTestLanguage, typingTestLanguageRef,
+    typingTestViewOnly, updateTypingTestViewOnly, typingTestViewOnlyRef,
+    typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize, typingTestViewOnlyWindowSizeRef,
+    typingTestViewOnlyAlwaysOnTop, updateTypingTestViewOnlyAlwaysOnTop, typingTestViewOnlyAlwaysOnTopRef,
+    typingTestMemory, updateTypingTestMemory, typingTestMemoryRef,
+    typingTestDisplayLines, updateTypingTestDisplayLines, typingTestDisplayLinesRef,
+    typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef,
+    typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef,
+    typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef,
+    typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef,
+    typingTestSaveUnnamed, updateTypingTestSaveUnnamed, typingTestSaveUnnamedRef,
+    typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef,
+    typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef,
+    typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef,
+    typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef,
+    viewMode, updateViewMode, viewModeRef,
+    keyEditorZoom, updateKeyEditorZoom, keyEditorZoomRef,
+    viewMatrix, updateViewMatrix, viewMatrixRef,
+    appliedUid, setAppliedUid,
+    uidRef, applySeqRef,
+    saveCurrentPrefs,
+    applyValidated,
+  }
+}
+
+export type DevicePrefsState = ReturnType<typeof useDevicePrefsState>

--- a/src/renderer/hooks/use-typing-test-prefs.ts
+++ b/src/renderer/hooks/use-typing-test-prefs.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback } from 'react'
+import type { TypingTestResult, TypingTestMemory, TypingTestComparisonBaseline, TypingTestComparisonBaselines, TypingViewMenuTab } from '../../shared/types/pipette-settings'
+import { trimResults } from '../typing-test/result-builder'
+import type { TypingTestConfig } from '../typing-test/types'
+import { clampDisplayLines, clampFontSize } from '../typing-test/types'
+import { isMonkeytypeMode } from './device-prefs-validate'
+
+interface UseTypingTestPrefsArgs {
+  typingTestResultsRef: React.RefObject<TypingTestResult[]>
+  updateTypingTestResults: (results: TypingTestResult[]) => void
+  typingTestConfigRef: React.RefObject<TypingTestConfig | undefined>
+  updateTypingTestConfig: (config: TypingTestConfig | undefined) => void
+  updateTypingTestMonkeytypeConfig: (config: TypingTestConfig | undefined) => void
+  updateTypingTestLanguage: (lang: string | undefined) => void
+  updateTypingTestViewOnly: (enabled: boolean) => void
+  updateTypingTestViewOnlyWindowSize: (size: { width: number; height: number } | undefined) => void
+  updateTypingTestViewOnlyAlwaysOnTop: (enabled: boolean) => void
+  typingTestMemoryRef: React.RefObject<TypingTestMemory | undefined>
+  updateTypingTestMemory: (memory: TypingTestMemory | undefined) => void
+  typingTestDisplayLinesRef: React.RefObject<number>
+  updateTypingTestDisplayLines: (lines: number) => void
+  typingTestFontSizeRef: React.RefObject<number>
+  updateTypingTestFontSize: (px: number) => void
+  typingTestHideKeymapRef: React.RefObject<boolean>
+  updateTypingTestHideKeymap: (hidden: boolean) => void
+  typingTestHideStatsRowRef: React.RefObject<boolean>
+  updateTypingTestHideStatsRow: (hidden: boolean) => void
+  typingTestHideControlsRef: React.RefObject<boolean>
+  updateTypingTestHideControls: (hidden: boolean) => void
+  typingTestSaveUnnamedRef: React.RefObject<boolean>
+  updateTypingTestSaveUnnamed: (enabled: boolean) => void
+  typingTestComparisonBaselinesRef: React.RefObject<TypingTestComparisonBaselines>
+  updateTypingTestComparisonBaselines: (baselines: TypingTestComparisonBaselines) => void
+  typingTestSettingsPanelOpenRef: React.RefObject<boolean>
+  updateTypingTestSettingsPanelOpen: (open: boolean) => void
+  typingRecordEnabledRef: React.RefObject<boolean>
+  updateTypingRecordEnabled: (enabled: boolean) => void
+  typingViewMenuTabRef: React.RefObject<TypingViewMenuTab>
+  updateTypingViewMenuTab: (tab: TypingViewMenuTab) => void
+  saveCurrentPrefs: () => void
+}
+
+const MAX_TYPING_TEST_RESULTS = 500
+
+export function useTypingTestPrefs(args: UseTypingTestPrefsArgs) {
+  const {
+    typingTestResultsRef, updateTypingTestResults,
+    typingTestConfigRef, updateTypingTestConfig, updateTypingTestMonkeytypeConfig,
+    updateTypingTestLanguage,
+    updateTypingTestViewOnly,
+    updateTypingTestViewOnlyWindowSize,
+    updateTypingTestViewOnlyAlwaysOnTop,
+    typingTestMemoryRef, updateTypingTestMemory,
+    typingTestDisplayLinesRef, updateTypingTestDisplayLines,
+    typingTestFontSizeRef, updateTypingTestFontSize,
+    typingTestHideKeymapRef, updateTypingTestHideKeymap,
+    typingTestHideStatsRowRef, updateTypingTestHideStatsRow,
+    typingTestHideControlsRef, updateTypingTestHideControls,
+    typingTestSaveUnnamedRef, updateTypingTestSaveUnnamed,
+    typingTestComparisonBaselinesRef, updateTypingTestComparisonBaselines,
+    typingTestSettingsPanelOpenRef, updateTypingTestSettingsPanelOpen,
+    typingRecordEnabledRef, updateTypingRecordEnabled,
+    typingViewMenuTabRef, updateTypingViewMenuTab,
+    saveCurrentPrefs,
+  } = args
+
+  const addTypingTestResult = useCallback((result: TypingTestResult) => {
+    const updated = trimResults([result, ...typingTestResultsRef.current], MAX_TYPING_TEST_RESULTS)
+    updateTypingTestResults(updated)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestResults])
+
+  /** Label a saved result (keyed by its ISO date) for run comparison. An
+   *  empty name clears the label. No-op when nothing changed. */
+  const renameTypingTestResult = useCallback((date: string, name: string) => {
+    const nextName = name.trim() || undefined
+    let changed = false
+    const updated = typingTestResultsRef.current.map((r) => {
+      if (r.date !== date || (r.name ?? '') === (nextName ?? '')) return r
+      changed = true
+      return { ...r, name: nextName }
+    })
+    if (!changed) return
+    updateTypingTestResults(updated)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestResults])
+
+  /** Remove a single saved result (keyed by its ISO date). */
+  const deleteTypingTestResult = useCallback((date: string) => {
+    const updated = typingTestResultsRef.current.filter((r) => r.date !== date)
+    if (updated.length === typingTestResultsRef.current.length) return
+    updateTypingTestResults(updated)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestResults])
+
+  const setTypingTestConfig = useCallback((cfg: TypingTestConfig) => {
+    const prev = typingTestConfigRef.current
+    updateTypingTestConfig(cfg)
+    // Remember the last normal (words/time/quote) config so it survives a
+    // switch into a non-normal mode (fileImport / tatoeba) and back. When
+    // entering such a mode, capture the outgoing normal config too — covers old
+    // prefs where typingTestMonkeytypeConfig was never saved. tatoeba must NOT
+    // be cached here, else selecting a MonkeyType language would restore it.
+    if (isMonkeytypeMode(cfg.mode)) updateTypingTestMonkeytypeConfig(cfg)
+    else if (prev && isMonkeytypeMode(prev.mode)) updateTypingTestMonkeytypeConfig(prev)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestConfig, updateTypingTestMonkeytypeConfig])
+
+  const setTypingTestLanguage = useCallback((lang: string) => {
+    updateTypingTestLanguage(lang)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestLanguage])
+
+  const setTypingTestViewOnly = useCallback((enabled: boolean) => {
+    updateTypingTestViewOnly(enabled)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestViewOnly])
+
+  const setTypingTestViewOnlyWindowSize = useCallback((size: { width: number; height: number }) => {
+    updateTypingTestViewOnlyWindowSize(size)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestViewOnlyWindowSize])
+
+
+  const setTypingTestViewOnlyAlwaysOnTop = useCallback((enabled: boolean) => {
+    updateTypingTestViewOnlyAlwaysOnTop(enabled)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestViewOnlyAlwaysOnTop])
+
+  const setTypingTestMemory = useCallback((memory: TypingTestMemory | undefined) => {
+    // Skip the full-prefs write when nothing changed — most commonly a
+    // clear (undefined) issued while already cleared (finish / restart).
+    if (typingTestMemoryRef.current === memory) return
+    updateTypingTestMemory(memory)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestMemory])
+
+  const setTypingTestDisplayLines = useCallback((lines: number) => {
+    const clamped = clampDisplayLines(lines)
+    if (typingTestDisplayLinesRef.current === clamped) return
+    updateTypingTestDisplayLines(clamped)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestDisplayLines])
+
+  const setTypingTestFontSize = useCallback((px: number) => {
+    const clamped = clampFontSize(px)
+    if (typingTestFontSizeRef.current === clamped) return
+    updateTypingTestFontSize(clamped)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestFontSize])
+
+  const setTypingTestHideKeymap = useCallback((hidden: boolean) => {
+    if (typingTestHideKeymapRef.current === hidden) return
+    updateTypingTestHideKeymap(hidden)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestHideKeymap])
+
+  const setTypingTestHideStatsRow = useCallback((hidden: boolean) => {
+    if (typingTestHideStatsRowRef.current === hidden) return
+    updateTypingTestHideStatsRow(hidden)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestHideStatsRow])
+
+  const setTypingTestHideControls = useCallback((hidden: boolean) => {
+    if (typingTestHideControlsRef.current === hidden) return
+    updateTypingTestHideControls(hidden)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestHideControls])
+
+  const setTypingTestSaveUnnamed = useCallback((enabled: boolean) => {
+    if (typingTestSaveUnnamedRef.current === enabled) return
+    updateTypingTestSaveUnnamed(enabled)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestSaveUnnamed])
+
+  const setTypingTestComparisonBaseline = useCallback((conditionKey: string, baseline: TypingTestComparisonBaseline) => {
+    updateTypingTestComparisonBaselines({ ...typingTestComparisonBaselinesRef.current, [conditionKey]: baseline })
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef])
+
+  const setTypingTestSettingsPanelOpen = useCallback((open: boolean) => {
+    if (typingTestSettingsPanelOpenRef.current === open) return
+    updateTypingTestSettingsPanelOpen(open)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingTestSettingsPanelOpen])
+
+  const setTypingRecordEnabled = useCallback((enabled: boolean) => {
+    if (typingRecordEnabledRef.current === enabled) return
+    updateTypingRecordEnabled(enabled)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingRecordEnabled])
+
+  const setTypingViewMenuTab = useCallback((tab: TypingViewMenuTab) => {
+    if (typingViewMenuTabRef.current === tab) return
+    updateTypingViewMenuTab(tab)
+    saveCurrentPrefs()
+  }, [saveCurrentPrefs, updateTypingViewMenuTab])
+
+  return {
+    addTypingTestResult,
+    renameTypingTestResult,
+    deleteTypingTestResult,
+    setTypingTestConfig,
+    setTypingTestLanguage,
+    setTypingTestViewOnly,
+    setTypingTestViewOnlyWindowSize,
+    setTypingTestViewOnlyAlwaysOnTop,
+    setTypingTestMemory,
+    setTypingTestDisplayLines,
+    setTypingTestFontSize,
+    setTypingTestHideKeymap,
+    setTypingTestHideStatsRow,
+    setTypingTestHideControls,
+    setTypingTestSaveUnnamed,
+    setTypingTestComparisonBaseline,
+    setTypingTestSettingsPanelOpen,
+    setTypingRecordEnabled,
+    setTypingViewMenuTab,
+  }
+}

--- a/src/renderer/hooks/useDevicePrefs.ts
+++ b/src/renderer/hooks/useDevicePrefs.ts
@@ -1,580 +1,69 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
-import type { KeyboardLayoutId } from '../data/keyboard-layouts'
-import { useKeyLabelLookup } from './useKeyLabelLookup'
-import { buildKeymapRewriteTable, type KeymapRewriteTable } from '../../shared/keymap/keymap-apply'
-import type { RemapKind } from '../components/keyboard/constants'
+import { useCallback } from 'react'
 import { useAppConfig } from './useAppConfig'
 import { MIN_SCALE, MAX_SCALE } from '../components/editors/keymap-editor-types'
-import type { TypingTestResult, TypingViewMenuTab, ViewMode, TypingTestMemory, TypingTestMemoryWord, TypingTestComparisonBaseline, TypingTestComparisonBaselines, ViewMatrixCell } from '../../shared/types/pipette-settings'
-import { VIEW_MODES, isTypingViewMenuTab, isTypingTestComparisonBaselines } from '../../shared/types/pipette-settings'
-import { trimResults } from '../typing-test/result-builder'
-import { isNonNegInt, isValidTypingTestResult, sanitizeTypingTestResult } from '../typing-test/typing-test-result-sanitize'
-import type { TypingTestConfig, RomajiDetailSettings, RomajiCaseStyle } from '../typing-test/types'
-import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE, clampDisplayLines, clampFontSize } from '../typing-test/types'
-import type { RomajiStyle } from '../typing-test/romaji-engine'
-import type { AutoLockMinutes, BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from '../typing-test/types'
 import { clampZoomFactor } from '../../shared/types/app-config'
+import { validateIpcPrefs, type ValidatedPrefs } from './device-prefs-validate'
+import { useDevicePrefsState } from './use-device-prefs-state'
+import { useDevicePrefsDefaults } from './use-device-prefs-defaults'
+import { useTypingTestPrefs } from './use-typing-test-prefs'
+import { useDevicePrefsRemap } from './use-device-prefs-remap'
+import type { UseDevicePrefsReturn } from './device-prefs-types'
+import type { KeyboardLayoutId } from '../data/keyboard-layouts'
+import type { BasicViewType, SplitKeyMode } from '../../shared/types/app-config'
+import type { ViewMode, ViewMatrixCell } from '../../shared/types/pipette-settings'
 
-export type { KeyboardLayoutId, AutoLockMinutes, BasicViewType, SplitKeyMode }
-
-const VALID_QUOTE_LENGTHS: ReadonlySet<string> = new Set(['short', 'medium', 'long', 'all'])
-const VALID_ROMAJI_STYLES: ReadonlySet<string> = new Set([
-  'hepburn', 'kunrei',
-  'c', 'q', 'digraph', 'xSmall', 'lSmall', 'w', 'v', 'f', 'ye', 'xn', 'nApos',
-])
-const VALID_ROMAJI_CASE_STYLES: ReadonlySet<string> = new Set(['lower', 'capital', 'upper'])
-
-function isFinitePositiveInt(n: unknown): n is number {
-  return typeof n === 'number' && Number.isFinite(n) && n > 0 && Number.isInteger(n)
-}
-
-function hasBooleanFields(obj: Record<string, unknown>, ...keys: string[]): boolean {
-  return keys.every((k) => typeof obj[k] === 'boolean')
-}
-
-/** Validates `config.romaji` (Romaji Settings modal fields) field-by-field:
- *  an unknown/malformed field is dropped individually instead of rejecting
- *  the whole nested object, so a stray/corrupted field never takes out
- *  fields that did validate (Plan-typing-romaji-settings-modal design
- *  judgement #9 — the same nested-config drop bug that hit `romajiInput`
- *  before it was carried through explicitly below). Returns undefined when
- *  `raw` isn't a plausible object, or every field turned out invalid. */
-function validateRomajiDetailSettings(raw: unknown): RomajiDetailSettings | undefined {
-  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
-  const obj = raw as Record<string, unknown>
-  const result: RomajiDetailSettings = {}
-  if (typeof obj.caseStyle === 'string' && VALID_ROMAJI_CASE_STYLES.has(obj.caseStyle)) {
-    result.caseStyle = obj.caseStyle as RomajiCaseStyle
-  }
-  // A persisted `fontSize` (from a build that still had the per-guide font
-  // control) is intentionally not read here — it silently falls through to
-  // "not set" now that the guide always tracks Settings > Font.
-  if (Array.isArray(obj.guideStyles)) {
-    // 'hepburn' is dropped here (unlike disabledStyles below, which keeps
-    // it): the Guide row's Base selection is single-select, and hepburn is
-    // its implicit default — the modal never writes 'hepburn' into
-    // guideStyles itself (see RomajiSettingsModal's selectGuideBase), and
-    // GUIDE_STYLE_PRIORITY in romaji-engine.ts has no 'hepburn' entry, so a
-    // stray 'hepburn' here would sit inert. Sanitizing it out keeps a
-    // hand-edited or legacy-written config equivalent to the canonical
-    // default rather than persisting a functionally meaningless entry.
-    const styles = obj.guideStyles.filter(
-      (s): s is RomajiStyle => typeof s === 'string' && VALID_ROMAJI_STYLES.has(s) && s !== 'hepburn',
-    )
-    if (styles.length > 0) result.guideStyles = styles
-  }
-  if (Array.isArray(obj.disabledStyles)) {
-    let styles = obj.disabledStyles.filter(
-      (s): s is RomajiStyle => typeof s === 'string' && VALID_ROMAJI_STYLES.has(s),
-    )
-    // At least one base system (hepburn/kunrei) must stay enabled — the
-    // Romaji Settings modal enforces this on the way in, but a persisted
-    // config could still carry both disabled (e.g. hand-edited, or written
-    // by a future version with looser rules). Sanitize deterministically
-    // by dropping 'kunrei' from the disabled set rather than rejecting the
-    // whole field, so kunrei-shiki wins and stays enabled.
-    if (styles.includes('hepburn') && styles.includes('kunrei')) {
-      styles = styles.filter((s) => s !== 'kunrei')
-    }
-    if (styles.length > 0) result.disabledStyles = styles
-  }
-  if (
-    typeof obj.guideWordCount === 'number'
-    && Number.isInteger(obj.guideWordCount)
-    && obj.guideWordCount >= 0
-    && obj.guideWordCount <= 3
-  ) {
-    result.guideWordCount = obj.guideWordCount
-  }
-  return Object.keys(result).length > 0 ? result : undefined
-}
-
-function validateTypingTestConfig(raw: unknown): TypingTestConfig | undefined {
-  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
-  const obj = raw as Record<string, unknown>
-  // Optional carry-through: keep a persisted boolean romajiInput on
-  // words/time/tatoeba/fileImport configs (every mode but quote), drop any
-  // other type silently (the field is optional, so a malformed value
-  // degrades to "not set" rather than rejecting the whole config). Same
-  // treatment for the nested `romaji` detail settings.
-  const romajiInput = typeof obj.romajiInput === 'boolean' ? { romajiInput: obj.romajiInput } : {}
-  const romaji = validateRomajiDetailSettings(obj.romaji)
-  const romajiDetail = romaji ? { romaji } : {}
-  switch (obj.mode) {
-    case 'words':
-      if (!isFinitePositiveInt(obj.wordCount) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
-      return { mode: 'words', wordCount: obj.wordCount, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput, ...romajiDetail }
-    case 'time':
-      if (!isFinitePositiveInt(obj.duration) || !hasBooleanFields(obj, 'punctuation', 'numbers')) return undefined
-      return { mode: 'time', duration: obj.duration, punctuation: obj.punctuation as boolean, numbers: obj.numbers as boolean, ...romajiInput, ...romajiDetail }
-    case 'quote':
-      if (typeof obj.quoteLength !== 'string' || !VALID_QUOTE_LENGTHS.has(obj.quoteLength)) return undefined
-      return { mode: 'quote', quoteLength: obj.quoteLength as 'short' | 'medium' | 'long' | 'all' }
-    case 'fileImport':
-      if (typeof obj.textId !== 'string' || obj.textId.length === 0) return undefined
-      return { mode: 'fileImport', textId: obj.textId, ...romajiInput, ...romajiDetail }
-    case 'tatoeba': {
-      if (typeof obj.language !== 'string' || obj.language.length === 0) return undefined
-      // Older configs (saved before Tatoeba gained its own Pattern/Units)
-      // lack pattern/lineCount/duration — default them rather than reject
-      // the whole config, same treatment as every other optional-carry-
-      // through field on this type.
-      const pattern = obj.pattern === 'time' ? 'time' : 'lines'
-      const lineCount = isFinitePositiveInt(obj.lineCount) ? obj.lineCount : 5
-      const duration = isFinitePositiveInt(obj.duration) ? obj.duration : 30
-      return { mode: 'tatoeba', language: obj.language, pattern, lineCount, duration, ...romajiInput, ...romajiDetail }
-    }
-    default:
-      return undefined
-  }
-}
-
-/** The MonkeyType-family modes whose config is remembered as the fallback
- *  restored when leaving fileImport / tatoeba. */
-function isMonkeytypeMode(mode: TypingTestConfig['mode']): boolean {
-  return mode === 'words' || mode === 'time' || mode === 'quote'
-}
-
-/** The MonkeyType fallback config must be a normal (words/time/quote) config.
- *  Reject any fileImport / tatoeba value — including a stale one persisted by
- *  an older build — so leaving those modes never restores them. */
-function validateMonkeytypeConfig(raw: unknown): TypingTestConfig | undefined {
-  const cfg = validateTypingTestConfig(raw)
-  return cfg && isMonkeytypeMode(cfg.mode) ? cfg : undefined
-}
-
-function validateTypingTestLanguage(raw: unknown): string | undefined {
-  if (typeof raw !== 'string' || raw.length === 0) return undefined
-  return raw
-}
-
-function validateTypingTestMemory(raw: unknown): TypingTestMemory | undefined {
-  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
-  const o = raw as Record<string, unknown>
-  if (typeof o.textId !== 'string' || o.textId.length === 0) return undefined
-  if (typeof o.currentWordIndex !== 'number' || !Number.isFinite(o.currentWordIndex) || o.currentWordIndex < 0) return undefined
-  if (typeof o.currentInput !== 'string') return undefined
-  if (typeof o.correctChars !== 'number' || typeof o.incorrectChars !== 'number') return undefined
-  if (typeof o.elapsedMs !== 'number' || !Number.isFinite(o.elapsedMs) || o.elapsedMs < 0) return undefined
-  if (!Array.isArray(o.wordResults)) return undefined
-  const rawResults = o.wordResults as unknown[]
-  const wordResults = rawResults.filter((w): w is TypingTestMemoryWord => {
-    if (typeof w !== 'object' || w === null) return false
-    const r = w as Record<string, unknown>
-    return typeof r.word === 'string' && typeof r.typed === 'string' && typeof r.correct === 'boolean'
-  })
-  // A malformed entry means the snapshot is untrustworthy — discard it.
-  if (wordResults.length !== rawResults.length) return undefined
-  const wpmHistory = Array.isArray(o.wpmHistory)
-    ? (o.wpmHistory as unknown[]).filter((n): n is number => typeof n === 'number')
-    : []
-  // All-or-nothing, mirroring how captureMemory always writes all three
-  // together (see TypingTestMemory's doc comment): a malformed/partial
-  // group degrades to "absent" rather than trusting a subset, so
-  // restoreState's legacy-format fallback (permanently uncomputable) kicks
-  // in exactly the same as for a memory saved before KSPC existed.
-  const validKspcGroup =
-    isNonNegInt(o.totalKeystrokes) && isNonNegInt(o.confirmedChars) && typeof o.kspcUncomputable === 'boolean'
-  return {
-    textId: o.textId,
-    currentWordIndex: o.currentWordIndex,
-    currentInput: o.currentInput,
-    wordResults,
-    correctChars: o.correctChars,
-    incorrectChars: o.incorrectChars,
-    elapsedMs: o.elapsedMs,
-    wpmHistory,
-    totalKeystrokes: validKspcGroup ? (o.totalKeystrokes as number) : undefined,
-    confirmedChars: validKspcGroup ? (o.confirmedChars as number) : undefined,
-    kspcUncomputable: validKspcGroup ? (o.kspcUncomputable as boolean) : undefined,
-    savedAt: typeof o.savedAt === 'string' ? o.savedAt : new Date(0).toISOString(),
-  }
-}
-
-const VALID_BASIC_VIEW_TYPES: ReadonlySet<string> = new Set(['ansi', 'iso', 'jis', 'list'])
-const LEGACY_BASIC_VIEW_MAP: Record<string, string> = { keyboard: 'ansi' }
-const VALID_SPLIT_KEY_MODES: ReadonlySet<string> = new Set(['split', 'flat'])
-const VALID_VIEW_MODES: ReadonlySet<string> = new Set(VIEW_MODES)
-
-interface ValidatedPrefs {
-  keyboardLayout: KeyboardLayoutId
-  autoAdvance: boolean
-  layerPanelOpen: boolean
-  basicViewType: BasicViewType
-  splitKeyMode: SplitKeyMode
-  quickSelect: boolean
-  keymapScale: number
-  layerNames: string[]
-  typingTestResults: TypingTestResult[]
-  typingTestConfig?: TypingTestConfig
-  typingTestMonkeytypeConfig?: TypingTestConfig
-  typingTestLanguage?: string
-  typingTestViewOnly: boolean
-  typingTestViewOnlyWindowSize?: { width: number; height: number }
-  typingTestViewOnlyAlwaysOnTop: boolean
-  typingTestMemory?: TypingTestMemory
-  typingTestDisplayLines: number
-  typingTestFontSize: number
-  typingTestHideKeymap: boolean
-  typingTestHideStatsRow: boolean
-  typingTestHideControls: boolean
-  typingTestSaveUnnamed: boolean
-  typingTestComparisonBaselines: TypingTestComparisonBaselines
-  typingTestSettingsPanelOpen: boolean
-  typingRecordEnabled: boolean
-  typingViewMenuTab: TypingViewMenuTab
-  viewMode: ViewMode
-  keyEditorZoom?: number
-  viewMatrix?: Record<string, ViewMatrixCell>
-}
-
-function validateIpcPrefs(
-  data: { keyboardLayout: string; autoAdvance: boolean; layerPanelOpen?: boolean; basicViewType?: string; splitKeyMode?: string; quickSelect?: boolean; keymapScale?: number; keyEditorZoom?: number; layerNames?: string[]; typingTestResults?: TypingTestResult[]; typingTestConfig?: unknown; typingTestMonkeytypeConfig?: unknown; typingTestLanguage?: unknown; typingTestViewOnly?: boolean; typingTestViewOnlyWindowSize?: unknown; typingTestViewOnlyAlwaysOnTop?: boolean; typingTestMemory?: unknown; typingTestDisplayLines?: unknown; typingTestFontSize?: unknown; typingTestHideKeymap?: boolean; typingTestHideStatsRow?: boolean; typingTestHideControls?: boolean; typingTestSaveUnnamed?: boolean; typingTestComparisonBaselines?: unknown; typingTestSettingsPanelOpen?: boolean; typingRecordEnabled?: boolean; typingViewMenuTab?: unknown; viewMode?: unknown; viewMatrix?: Record<string, ViewMatrixCell> } | null,
-  defaultLayout: KeyboardLayoutId,
-  defaultAutoAdvance: boolean,
-  defaultLayerPanelOpen: boolean,
-  defaultBasicViewType: BasicViewType,
-  defaultSplitKeyMode: SplitKeyMode,
-  defaultQuickSelect: boolean,
-): ValidatedPrefs | null {
-  if (!data) return null
-
-  // After the Key Labels migration the built-in `LAYOUT_ID_SET` only
-  // covers QWERTY. Any saved id that is not empty is accepted here; the
-  // Key Label store is consulted at render time and falls back to
-  // QWERTY when the id is not (yet) installed locally.
-  const layout = typeof data.keyboardLayout === 'string' && data.keyboardLayout.length > 0
-    ? data.keyboardLayout
-    : null
-  const autoAdvance = typeof data.autoAdvance === 'boolean' ? data.autoAdvance : null
-  if (layout === null && autoAdvance === null) return null
-
-  const layerPanelOpen = typeof data.layerPanelOpen === 'boolean' ? data.layerPanelOpen : defaultLayerPanelOpen
-  const rawBasicView = typeof data.basicViewType === 'string'
-    ? (LEGACY_BASIC_VIEW_MAP[data.basicViewType] ?? data.basicViewType)
-    : null
-  const basicViewType = rawBasicView !== null && VALID_BASIC_VIEW_TYPES.has(rawBasicView)
-    ? rawBasicView as BasicViewType
-    : defaultBasicViewType
-  const splitKeyMode = typeof data.splitKeyMode === 'string' && VALID_SPLIT_KEY_MODES.has(data.splitKeyMode)
-    ? data.splitKeyMode as SplitKeyMode
-    : defaultSplitKeyMode
-  const quickSelect = typeof data.quickSelect === 'boolean' ? data.quickSelect : defaultQuickSelect
-  const keymapScale = typeof data.keymapScale === 'number' && data.keymapScale >= MIN_SCALE && data.keymapScale <= MAX_SCALE
-    ? Math.round(data.keymapScale * 10) / 10
-    : 1
-
-  const layerNames = Array.isArray(data.layerNames)
-    ? data.layerNames.filter((n): n is string => typeof n === 'string')
-    : []
-  const typingTestResults = Array.isArray(data.typingTestResults)
-    ? data.typingTestResults.filter(isValidTypingTestResult).map(sanitizeTypingTestResult)
-    : []
-
-  // Legacy migration: { mode: 'viewOnly' } → separate boolean
-  let typingTestConfig = validateTypingTestConfig(data.typingTestConfig)
-  let typingTestViewOnly = typeof data.typingTestViewOnly === 'boolean' ? data.typingTestViewOnly : false
-  if (!typingTestConfig && data.typingTestConfig != null) {
-    const raw = data.typingTestConfig as Record<string, unknown>
-    if (raw.mode === 'viewOnly') {
-      typingTestViewOnly = true
-      typingTestConfig = undefined
-    }
-  }
-
-  const viewMode: ViewMode = typeof data.viewMode === 'string' && VALID_VIEW_MODES.has(data.viewMode)
-    ? data.viewMode as ViewMode
-    : 'editor'
-
-  return {
-    keyboardLayout: layout ?? defaultLayout,
-    autoAdvance: autoAdvance ?? defaultAutoAdvance,
-    layerPanelOpen,
-    basicViewType,
-    splitKeyMode,
-    quickSelect,
-    keymapScale,
-    layerNames,
-    typingTestResults,
-    typingTestConfig,
-    typingTestMonkeytypeConfig: validateMonkeytypeConfig(data.typingTestMonkeytypeConfig),
-    typingTestLanguage: validateTypingTestLanguage(data.typingTestLanguage),
-    typingTestViewOnly,
-    typingTestViewOnlyWindowSize: validateWindowSize(data.typingTestViewOnlyWindowSize),
-    typingTestViewOnlyAlwaysOnTop: typeof data.typingTestViewOnlyAlwaysOnTop === 'boolean' ? data.typingTestViewOnlyAlwaysOnTop : false,
-    typingTestMemory: validateTypingTestMemory(data.typingTestMemory),
-    typingTestDisplayLines: typeof data.typingTestDisplayLines === 'number' ? clampDisplayLines(data.typingTestDisplayLines) : DEFAULT_DISPLAY_LINES,
-    typingTestFontSize: typeof data.typingTestFontSize === 'number' ? clampFontSize(data.typingTestFontSize) : DEFAULT_FONT_SIZE,
-    typingTestHideKeymap: data.typingTestHideKeymap === true,
-    typingTestHideStatsRow: data.typingTestHideStatsRow === true,
-    typingTestHideControls: data.typingTestHideControls === true,
-    // Default true: a finished result is auto-saved unless the user opts out.
-    typingTestSaveUnnamed: data.typingTestSaveUnnamed !== false,
-    typingTestComparisonBaselines: isTypingTestComparisonBaselines(data.typingTestComparisonBaselines) ? data.typingTestComparisonBaselines : {},
-    typingTestSettingsPanelOpen: typeof data.typingTestSettingsPanelOpen === 'boolean' ? data.typingTestSettingsPanelOpen : true,
-    typingRecordEnabled: typeof data.typingRecordEnabled === 'boolean' ? data.typingRecordEnabled : false,
-    typingViewMenuTab: isTypingViewMenuTab(data.typingViewMenuTab) ? data.typingViewMenuTab : 'window',
-    viewMode,
-    keyEditorZoom: typeof data.keyEditorZoom === 'number' ? clampZoomFactor(data.keyEditorZoom) : undefined,
-    // Trusted as-is: the main process (pipette-settings-store's
-    // isValidViewMatrix) is the single validator for this shape, same as
-    // the other store-validated per-keyboard fields.
-    viewMatrix: data.viewMatrix,
-  }
-}
-
-function validateWindowSize(raw: unknown): { width: number; height: number } | undefined {
-  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) return undefined
-  const obj = raw as Record<string, unknown>
-  if (typeof obj.width !== 'number' || typeof obj.height !== 'number') return undefined
-  if (obj.width <= 0 || obj.height <= 0) return undefined
-  return { width: obj.width, height: obj.height }
-}
-
-export interface UseDevicePrefsReturn {
-  layout: KeyboardLayoutId
-  autoAdvance: boolean
-  layerPanelOpen: boolean
-  basicViewType: BasicViewType
-  splitKeyMode: SplitKeyMode
-  quickSelect: boolean
-  keymapScale: number
-  layerNames: string[]
-  typingTestResults: TypingTestResult[]
-  typingTestConfig: TypingTestConfig | undefined
-  typingTestMonkeytypeConfig: TypingTestConfig | undefined
-  typingTestLanguage: string | undefined
-  typingTestViewOnly: boolean
-  typingTestViewOnlyWindowSize: { width: number; height: number } | undefined
-  typingTestViewOnlyAlwaysOnTop: boolean
-  typingTestMemory: TypingTestMemory | undefined
-  typingTestDisplayLines: number
-  typingTestFontSize: number
-  typingTestHideKeymap: boolean
-  typingTestHideStatsRow: boolean
-  typingTestHideControls: boolean
-  typingTestSaveUnnamed: boolean
-  typingTestComparisonBaselines: TypingTestComparisonBaselines
-  typingTestSettingsPanelOpen: boolean
-  typingRecordEnabled: boolean
-  typingViewMenuTab: TypingViewMenuTab
-  viewMode: ViewMode
-  keyEditorZoom: number | undefined
-  viewMatrix: Record<string, ViewMatrixCell> | undefined
-  appliedUid: string | null
-  setLayout: (id: KeyboardLayoutId) => void
-  setAutoAdvance: (enabled: boolean) => void
-  setLayerPanelOpen: (open: boolean) => void
-  setBasicViewType: (type: BasicViewType) => void
-  setSplitKeyMode: (mode: SplitKeyMode) => void
-  setQuickSelect: (enabled: boolean) => void
-  setKeymapScale: (scale: number) => void
-  setLayerNames: (names: string[]) => void
-  addTypingTestResult: (result: TypingTestResult) => void
-  renameTypingTestResult: (date: string, name: string) => void
-  deleteTypingTestResult: (date: string) => void
-  setTypingTestConfig: (config: TypingTestConfig) => void
-  setTypingTestLanguage: (lang: string) => void
-  setTypingTestViewOnly: (enabled: boolean) => void
-  setTypingTestViewOnlyWindowSize: (size: { width: number; height: number }) => void
-  setTypingTestViewOnlyAlwaysOnTop: (enabled: boolean) => void
-  setTypingTestMemory: (memory: TypingTestMemory | undefined) => void
-  setTypingTestDisplayLines: (lines: number) => void
-  setTypingTestFontSize: (px: number) => void
-  setTypingTestHideKeymap: (hidden: boolean) => void
-  setTypingTestHideStatsRow: (hidden: boolean) => void
-  setTypingTestHideControls: (hidden: boolean) => void
-  setTypingTestSaveUnnamed: (enabled: boolean) => void
-  setTypingTestComparisonBaseline: (conditionKey: string, baseline: TypingTestComparisonBaseline) => void
-  setTypingTestSettingsPanelOpen: (open: boolean) => void
-  setTypingRecordEnabled: (enabled: boolean) => void
-  setTypingViewMenuTab: (tab: TypingViewMenuTab) => void
-  setViewMode: (mode: ViewMode) => void
-  setKeyEditorZoom: (zoom: number) => void
-  setViewMatrix: (next: Record<string, ViewMatrixCell> | undefined) => void
-  defaultLayout: KeyboardLayoutId
-  defaultAutoAdvance: boolean
-  defaultLayerPanelOpen: boolean
-  defaultBasicViewType: BasicViewType
-  defaultSplitKeyMode: SplitKeyMode
-  defaultQuickSelect: boolean
-  setDefaultLayout: (id: KeyboardLayoutId) => void
-  setDefaultAutoAdvance: (enabled: boolean) => void
-  setDefaultLayerPanelOpen: (open: boolean) => void
-  setDefaultBasicViewType: (type: BasicViewType) => void
-  setDefaultSplitKeyMode: (mode: SplitKeyMode) => void
-  setDefaultQuickSelect: (enabled: boolean) => void
-  autoLockTime: AutoLockMinutes
-  setAutoLockTime: (m: AutoLockMinutes) => void
-  applyDevicePrefs: (uid: string) => Promise<void>
-  /** Display label for a qmkId: the active Key Label pack's own label
-   *  (via `compositeLabels` -> `map`), falling back to the qmkId itself
-   *  when neither has an entry. This is what feeds the keymap surface
-   *  regardless of which of `KeymapEditor`'s tabs is showing (Plan-qwerty-
-   *  select-no-rewrite v7 — シミュレーションタブ方式): the simulation tab
-   *  renders it as-is, while the Base tab bypasses it entirely (its own
-   *  raw/identity keycode builder — see `KeymapEditor`'s `baseLayerKeycodes`
-   *  — never calls this at all). A Rewrite never leaves anything for this
-   *  to simulate either way, since it resets `layout` back to QWERTY
-   *  (raw/no-color) on success, which also makes the tabs disappear. */
-  remapLabel: (qmkId: string) => string
-  /** The blue "remapped" tint source: true whenever `remapLabel(qmkId)`
-   *  differs from `qmkId` itself — same rule every picker/palette consumer
-   *  applies. */
-  isRemapped: (qmkId: string) => boolean
-  /** Which remap tint `isRemapped`-tinted keys use on the keymap surface
-   *  (keymap pane + typing-test pane; the picker is untouched — see
-   *  `pickerRemapLabel` below). `'simulated'` iff an active (non-empty)
-   *  pack map is loaded and it's a pure permutation (same `.ok` verdict
-   *  `rewriteTableResult` already computes for the Rewrite gate) — the
-   *  "labels show what a Rewrite WOULD produce, pressing still types the
-   *  old character" case. `'actual'` otherwise: JIS-type display remaps
-   *  (truthful — the OS/IME really produces the shown char), QWERTY/no
-   *  pack (irrelevant since no key is ever tinted there), and
-   *  non-permutation deviation packs. */
-  remapKind: RemapKind
-  /** The active pack's own rewrite table, already resolved and validated —
-   *  `undefined` unless `remapKind === 'simulated'`. Lets
-   *  `useKeymapApplyPrompt.requestApply` skip a second async lookup for
-   *  the exact table `remapKind` itself already required to build. See
-   *  the hook body's own doc comment for the full rationale. */
-  activeRewriteTable?: KeymapRewriteTable
-  /** Display name of the active layout/pack — see `remapKind`'s sibling
-   *  doc comment on `activeLayoutName` in the hook body for what feeds it. */
-  activeLayoutName: string
-  /** Display label for a qmkId, but ONLY for the key PICKER surface
-   *  (`TabbedKeycodes` / `KeyPopover` → `PopoverTabKey`) — the keymap
-   *  legend itself (`useLayerKeycodes`, `KeyWidget`'s masked-inner label)
-   *  keeps using `remapLabel` above unconditionally.
-   *
-   *  Plan-qwerty-select-no-rewrite v6: the picker should only ever change
-   *  for a pack that deviates from ANSI (a symbol/label the picker can't
-   *  already show as-is — JIS shift pairs, kana, ...). A pure QWERTY-
-   *  keycode permutation (Colemak, Eucalyn, Dvorak, ...) swaps WHICH key
-   *  sends a character, but every character it swaps in already exists
-   *  somewhere in the picker — remapping the picker's own legends for
-   *  that case would just be noise (and would desync the picker's
-   *  legend from the keycode it actually inserts). So this identity-
-   *  passes for a permutation pack and only forwards to `remapLabel` once
-   *  the active pack fails the same `buildKeymapRewriteTable` check the
-   *  Key Label "apply to keymap" rewrite itself uses to decide
-   *  applicability — a deviation pack behaves exactly like `remapLabel`.
-   *  QWERTY/no pack has an empty map, which trivially passes the check
-   *  (nothing to permute), so it already resolves to identity without a
-   *  separate guard. */
-  pickerRemapLabel: (qmkId: string) => string
-}
-
-/**
- * Pairs a state value with a ref that always holds the latest value.
- * The ref is needed so that saveCurrentPrefs can read current values
- * inside a stable (never-recreated) callback.
- */
-function useStateRef<T>(initial: T): [T, (v: T) => void, React.RefObject<T>] {
-  const [value, setValue] = useState<T>(initial)
-  const ref = useRef(value)
-  const update = useCallback((v: T) => {
-    ref.current = v
-    setValue(v)
-  }, [])
-  return [value, update, ref]
-}
+export type { KeyboardLayoutId, AutoLockMinutes, BasicViewType, SplitKeyMode } from './device-prefs-types'
+export type { UseDevicePrefsReturn } from './device-prefs-types'
 
 export function useDevicePrefs(): UseDevicePrefsReturn {
   const { config, set } = useAppConfig()
 
-  // Accept any non-empty id; Key Labels installed via the modal are
-  // valid even though they are not in the built-in `LAYOUT_ID_SET`.
-  const defaultLayout = typeof config.defaultKeyboardLayout === 'string'
-    && config.defaultKeyboardLayout.length > 0
-    ? config.defaultKeyboardLayout
-    : 'qwerty'
-  const defaultAutoAdvance = config.defaultAutoAdvance
-  const defaultLayerPanelOpen = config.defaultLayerPanelOpen
-  const defaultBasicViewType = config.defaultBasicViewType
-  const defaultSplitKeyMode = config.defaultSplitKeyMode ?? 'split'
-  const defaultQuickSelect = config.defaultQuickSelect ?? false
+  const {
+    defaultLayout, defaultAutoAdvance, defaultLayerPanelOpen, defaultBasicViewType, defaultSplitKeyMode, defaultQuickSelect,
+    setDefaultLayout, setDefaultAutoAdvance, setDefaultLayerPanelOpen, setDefaultBasicViewType, setDefaultSplitKeyMode, setDefaultQuickSelect,
+    autoLockTime, setAutoLockTime,
+  } = useDevicePrefsDefaults({ config, set })
 
-  const [layout, updateLayout, layoutRef] = useStateRef<KeyboardLayoutId>(defaultLayout)
-  const [autoAdvance, updateAutoAdvance, autoAdvanceRef] = useStateRef<boolean>(defaultAutoAdvance)
-  const [layerPanelOpen, updateLayerPanelOpen, layerPanelOpenRef] = useStateRef<boolean>(defaultLayerPanelOpen)
-  const [basicViewType, updateBasicViewType, basicViewTypeRef] = useStateRef<BasicViewType>(defaultBasicViewType)
-  const [splitKeyMode, updateSplitKeyMode, splitKeyModeRef] = useStateRef<SplitKeyMode>(defaultSplitKeyMode)
-  const [quickSelect, updateQuickSelect, quickSelectRef] = useStateRef<boolean>(defaultQuickSelect)
-  const [keymapScale, updateKeymapScale, keymapScaleRef] = useStateRef<number>(1)
-  const [layerNames, updateLayerNames, layerNamesRef] = useStateRef<string[]>([])
-  const [typingTestResults, updateTypingTestResults, typingTestResultsRef] = useStateRef<TypingTestResult[]>([])
-  const [typingTestConfig, updateTypingTestConfig, typingTestConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
-  const [typingTestMonkeytypeConfig, updateTypingTestMonkeytypeConfig, typingTestMonkeytypeConfigRef] = useStateRef<TypingTestConfig | undefined>(undefined)
-  const [typingTestLanguage, updateTypingTestLanguage, typingTestLanguageRef] = useStateRef<string | undefined>(undefined)
-  const [typingTestViewOnly, updateTypingTestViewOnly, typingTestViewOnlyRef] = useStateRef<boolean>(false)
-  const [typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize, typingTestViewOnlyWindowSizeRef] = useStateRef<{ width: number; height: number } | undefined>(undefined)
-  const [typingTestViewOnlyAlwaysOnTop, updateTypingTestViewOnlyAlwaysOnTop, typingTestViewOnlyAlwaysOnTopRef] = useStateRef<boolean>(false)
-  const [typingTestMemory, updateTypingTestMemory, typingTestMemoryRef] = useStateRef<TypingTestMemory | undefined>(undefined)
-  const [typingTestDisplayLines, updateTypingTestDisplayLines, typingTestDisplayLinesRef] = useStateRef<number>(DEFAULT_DISPLAY_LINES)
-  const [typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef] = useStateRef<number>(DEFAULT_FONT_SIZE)
-  const [typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef] = useStateRef<boolean>(false)
-  const [typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef] = useStateRef<boolean>(false)
-  const [typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef] = useStateRef<boolean>(false)
-  const [typingTestSaveUnnamed, updateTypingTestSaveUnnamed, typingTestSaveUnnamedRef] = useStateRef<boolean>(true)
-  const [typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef] = useStateRef<TypingTestComparisonBaselines>({})
-  const [typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef] = useStateRef<boolean>(true)
-  const [typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef] = useStateRef<boolean>(false)
-  const [typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef] = useStateRef<TypingViewMenuTab>('window')
-  const [viewMode, updateViewMode, viewModeRef] = useStateRef<ViewMode>('editor')
-  const [keyEditorZoom, updateKeyEditorZoom, keyEditorZoomRef] = useStateRef<number | undefined>(undefined)
-  const [viewMatrix, updateViewMatrix, viewMatrixRef] = useStateRef<Record<string, ViewMatrixCell> | undefined>(undefined)
-  const [appliedUid, setAppliedUid] = useState<string | null>(null)
-
-  const uidRef = useRef('')
-  const applySeqRef = useRef(0)
-
-  const saveCurrentPrefs = useCallback(() => {
-    const uid = uidRef.current
-    if (!uid) return
-    window.vialAPI.pipetteSettingsPatch(uid, {
-      _rev: 1,
-      keyboardLayout: layoutRef.current,
-      autoAdvance: autoAdvanceRef.current,
-      layerPanelOpen: layerPanelOpenRef.current,
-      basicViewType: basicViewTypeRef.current,
-      splitKeyMode: splitKeyModeRef.current,
-      quickSelect: quickSelectRef.current,
-      keymapScale: keymapScaleRef.current,
-      keyEditorZoom: keyEditorZoomRef.current,
-      layerNames: layerNamesRef.current,
-      typingTestResults: typingTestResultsRef.current,
-      typingTestConfig: typingTestConfigRef.current as Record<string, unknown> | undefined,
-      typingTestMonkeytypeConfig: typingTestMonkeytypeConfigRef.current as Record<string, unknown> | undefined,
-      typingTestLanguage: typingTestLanguageRef.current,
-      typingTestViewOnly: typingTestViewOnlyRef.current,
-      typingTestViewOnlyWindowSize: typingTestViewOnlyWindowSizeRef.current,
-      typingTestViewOnlyAlwaysOnTop: typingTestViewOnlyAlwaysOnTopRef.current,
-      // `null` clears the persisted memory; the field-level PATCH skips
-      // `undefined`, so a bare `undefined` would leave a stale paused run
-      // on disk after finish / restart.
-      typingTestMemory: typingTestMemoryRef.current ?? null,
-      typingTestDisplayLines: typingTestDisplayLinesRef.current,
-      typingTestFontSize: typingTestFontSizeRef.current,
-      typingTestHideKeymap: typingTestHideKeymapRef.current,
-      typingTestHideStatsRow: typingTestHideStatsRowRef.current,
-      typingTestHideControls: typingTestHideControlsRef.current,
-      typingTestSaveUnnamed: typingTestSaveUnnamedRef.current,
-      typingTestComparisonBaselines: typingTestComparisonBaselinesRef.current,
-      typingTestSettingsPanelOpen: typingTestSettingsPanelOpenRef.current,
-      typingRecordEnabled: typingRecordEnabledRef.current,
-      typingViewMenuTab: typingViewMenuTabRef.current,
-      viewMode: viewModeRef.current,
-      // `null` clears the persisted overrides when the ref holds `undefined`
-      // (reset), mirroring `typingTestMemory` above — a bare `undefined`
-      // would leave a stale map on disk instead of clearing it.
-      viewMatrix: viewMatrixRef.current ?? null,
-    }).catch(() => {
-      // IPC failure — best-effort save
-    })
-  }, [])
+  const {
+    layout, updateLayout,
+    autoAdvance, updateAutoAdvance,
+    layerPanelOpen, updateLayerPanelOpen,
+    basicViewType, updateBasicViewType,
+    splitKeyMode, updateSplitKeyMode,
+    quickSelect, updateQuickSelect,
+    keymapScale, updateKeymapScale,
+    layerNames, updateLayerNames,
+    typingTestResults, updateTypingTestResults, typingTestResultsRef,
+    typingTestConfig, updateTypingTestConfig, typingTestConfigRef,
+    typingTestMonkeytypeConfig, updateTypingTestMonkeytypeConfig,
+    typingTestLanguage, updateTypingTestLanguage,
+    typingTestViewOnly, updateTypingTestViewOnly,
+    typingTestViewOnlyWindowSize, updateTypingTestViewOnlyWindowSize,
+    typingTestViewOnlyAlwaysOnTop, updateTypingTestViewOnlyAlwaysOnTop,
+    typingTestMemory, updateTypingTestMemory, typingTestMemoryRef,
+    typingTestDisplayLines, updateTypingTestDisplayLines, typingTestDisplayLinesRef,
+    typingTestFontSize, updateTypingTestFontSize, typingTestFontSizeRef,
+    typingTestHideKeymap, updateTypingTestHideKeymap, typingTestHideKeymapRef,
+    typingTestHideStatsRow, updateTypingTestHideStatsRow, typingTestHideStatsRowRef,
+    typingTestHideControls, updateTypingTestHideControls, typingTestHideControlsRef,
+    typingTestSaveUnnamed, updateTypingTestSaveUnnamed, typingTestSaveUnnamedRef,
+    typingTestComparisonBaselines, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef,
+    typingTestSettingsPanelOpen, updateTypingTestSettingsPanelOpen, typingTestSettingsPanelOpenRef,
+    typingRecordEnabled, updateTypingRecordEnabled, typingRecordEnabledRef,
+    typingViewMenuTab, updateTypingViewMenuTab, typingViewMenuTabRef,
+    viewMode, updateViewMode, viewModeRef,
+    keyEditorZoom, updateKeyEditorZoom, keyEditorZoomRef,
+    viewMatrix, updateViewMatrix,
+    appliedUid, setAppliedUid,
+    uidRef, applySeqRef,
+    saveCurrentPrefs,
+    applyValidated,
+  } = useDevicePrefsState({
+    defaultLayout, defaultAutoAdvance, defaultLayerPanelOpen, defaultBasicViewType, defaultSplitKeyMode, defaultQuickSelect,
+  })
 
   const setLayout = useCallback((id: KeyboardLayoutId) => {
     updateLayout(id)
@@ -617,139 +106,46 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateLayerNames])
 
-  const MAX_TYPING_TEST_RESULTS = 500
-
-  const addTypingTestResult = useCallback((result: TypingTestResult) => {
-    const updated = trimResults([result, ...typingTestResultsRef.current], MAX_TYPING_TEST_RESULTS)
-    updateTypingTestResults(updated)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestResults])
-
-  /** Label a saved result (keyed by its ISO date) for run comparison. An
-   *  empty name clears the label. No-op when nothing changed. */
-  const renameTypingTestResult = useCallback((date: string, name: string) => {
-    const nextName = name.trim() || undefined
-    let changed = false
-    const updated = typingTestResultsRef.current.map((r) => {
-      if (r.date !== date || (r.name ?? '') === (nextName ?? '')) return r
-      changed = true
-      return { ...r, name: nextName }
-    })
-    if (!changed) return
-    updateTypingTestResults(updated)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestResults])
-
-  /** Remove a single saved result (keyed by its ISO date). */
-  const deleteTypingTestResult = useCallback((date: string) => {
-    const updated = typingTestResultsRef.current.filter((r) => r.date !== date)
-    if (updated.length === typingTestResultsRef.current.length) return
-    updateTypingTestResults(updated)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestResults])
-
-  const setTypingTestConfig = useCallback((cfg: TypingTestConfig) => {
-    const prev = typingTestConfigRef.current
-    updateTypingTestConfig(cfg)
-    // Remember the last normal (words/time/quote) config so it survives a
-    // switch into a non-normal mode (fileImport / tatoeba) and back. When
-    // entering such a mode, capture the outgoing normal config too — covers old
-    // prefs where typingTestMonkeytypeConfig was never saved. tatoeba must NOT
-    // be cached here, else selecting a MonkeyType language would restore it.
-    if (isMonkeytypeMode(cfg.mode)) updateTypingTestMonkeytypeConfig(cfg)
-    else if (prev && isMonkeytypeMode(prev.mode)) updateTypingTestMonkeytypeConfig(prev)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestConfig, updateTypingTestMonkeytypeConfig])
-
-  const setTypingTestLanguage = useCallback((lang: string) => {
-    updateTypingTestLanguage(lang)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestLanguage])
-
-  const setTypingTestViewOnly = useCallback((enabled: boolean) => {
-    updateTypingTestViewOnly(enabled)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestViewOnly])
-
-  const setTypingTestViewOnlyWindowSize = useCallback((size: { width: number; height: number }) => {
-    updateTypingTestViewOnlyWindowSize(size)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestViewOnlyWindowSize])
-
-
-  const setTypingTestViewOnlyAlwaysOnTop = useCallback((enabled: boolean) => {
-    updateTypingTestViewOnlyAlwaysOnTop(enabled)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestViewOnlyAlwaysOnTop])
-
-  const setTypingTestMemory = useCallback((memory: TypingTestMemory | undefined) => {
-    // Skip the full-prefs write when nothing changed — most commonly a
-    // clear (undefined) issued while already cleared (finish / restart).
-    if (typingTestMemoryRef.current === memory) return
-    updateTypingTestMemory(memory)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestMemory])
-
-  const setTypingTestDisplayLines = useCallback((lines: number) => {
-    const clamped = clampDisplayLines(lines)
-    if (typingTestDisplayLinesRef.current === clamped) return
-    updateTypingTestDisplayLines(clamped)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestDisplayLines])
-
-  const setTypingTestFontSize = useCallback((px: number) => {
-    const clamped = clampFontSize(px)
-    if (typingTestFontSizeRef.current === clamped) return
-    updateTypingTestFontSize(clamped)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestFontSize])
-
-  const setTypingTestHideKeymap = useCallback((hidden: boolean) => {
-    if (typingTestHideKeymapRef.current === hidden) return
-    updateTypingTestHideKeymap(hidden)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestHideKeymap])
-
-  const setTypingTestHideStatsRow = useCallback((hidden: boolean) => {
-    if (typingTestHideStatsRowRef.current === hidden) return
-    updateTypingTestHideStatsRow(hidden)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestHideStatsRow])
-
-  const setTypingTestHideControls = useCallback((hidden: boolean) => {
-    if (typingTestHideControlsRef.current === hidden) return
-    updateTypingTestHideControls(hidden)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestHideControls])
-
-  const setTypingTestSaveUnnamed = useCallback((enabled: boolean) => {
-    if (typingTestSaveUnnamedRef.current === enabled) return
-    updateTypingTestSaveUnnamed(enabled)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestSaveUnnamed])
-
-  const setTypingTestComparisonBaseline = useCallback((conditionKey: string, baseline: TypingTestComparisonBaseline) => {
-    updateTypingTestComparisonBaselines({ ...typingTestComparisonBaselinesRef.current, [conditionKey]: baseline })
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestComparisonBaselines, typingTestComparisonBaselinesRef])
-
-  const setTypingTestSettingsPanelOpen = useCallback((open: boolean) => {
-    if (typingTestSettingsPanelOpenRef.current === open) return
-    updateTypingTestSettingsPanelOpen(open)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingTestSettingsPanelOpen])
-
-  const setTypingRecordEnabled = useCallback((enabled: boolean) => {
-    if (typingRecordEnabledRef.current === enabled) return
-    updateTypingRecordEnabled(enabled)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingRecordEnabled])
-
-  const setTypingViewMenuTab = useCallback((tab: TypingViewMenuTab) => {
-    if (typingViewMenuTabRef.current === tab) return
-    updateTypingViewMenuTab(tab)
-    saveCurrentPrefs()
-  }, [saveCurrentPrefs, updateTypingViewMenuTab])
+  const {
+    addTypingTestResult,
+    renameTypingTestResult,
+    deleteTypingTestResult,
+    setTypingTestConfig,
+    setTypingTestLanguage,
+    setTypingTestViewOnly,
+    setTypingTestViewOnlyWindowSize,
+    setTypingTestViewOnlyAlwaysOnTop,
+    setTypingTestMemory,
+    setTypingTestDisplayLines,
+    setTypingTestFontSize,
+    setTypingTestHideKeymap,
+    setTypingTestHideStatsRow,
+    setTypingTestHideControls,
+    setTypingTestSaveUnnamed,
+    setTypingTestComparisonBaseline,
+    setTypingTestSettingsPanelOpen,
+    setTypingRecordEnabled,
+    setTypingViewMenuTab,
+  } = useTypingTestPrefs({
+    typingTestResultsRef, updateTypingTestResults,
+    typingTestConfigRef, updateTypingTestConfig, updateTypingTestMonkeytypeConfig,
+    updateTypingTestLanguage,
+    updateTypingTestViewOnly,
+    updateTypingTestViewOnlyWindowSize,
+    updateTypingTestViewOnlyAlwaysOnTop,
+    typingTestMemoryRef, updateTypingTestMemory,
+    typingTestDisplayLinesRef, updateTypingTestDisplayLines,
+    typingTestFontSizeRef, updateTypingTestFontSize,
+    typingTestHideKeymapRef, updateTypingTestHideKeymap,
+    typingTestHideStatsRowRef, updateTypingTestHideStatsRow,
+    typingTestHideControlsRef, updateTypingTestHideControls,
+    typingTestSaveUnnamedRef, updateTypingTestSaveUnnamed,
+    typingTestComparisonBaselinesRef, updateTypingTestComparisonBaselines,
+    typingTestSettingsPanelOpenRef, updateTypingTestSettingsPanelOpen,
+    typingRecordEnabledRef, updateTypingRecordEnabled,
+    typingViewMenuTabRef, updateTypingViewMenuTab,
+    saveCurrentPrefs,
+  })
 
   const setViewMode = useCallback((mode: ViewMode) => {
     if (viewModeRef.current === mode) return
@@ -769,34 +165,6 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     updateKeyEditorZoom(clamped)
     saveCurrentPrefs()
   }, [saveCurrentPrefs, updateKeyEditorZoom])
-
-  const setDefaultLayout = useCallback((id: KeyboardLayoutId) => {
-    set('defaultKeyboardLayout', id)
-  }, [set])
-
-  const setDefaultAutoAdvance = useCallback((enabled: boolean) => {
-    set('defaultAutoAdvance', enabled)
-  }, [set])
-
-  const setDefaultLayerPanelOpen = useCallback((open: boolean) => {
-    set('defaultLayerPanelOpen', open)
-  }, [set])
-
-  const setDefaultBasicViewType = useCallback((type: BasicViewType) => {
-    set('defaultBasicViewType', type)
-  }, [set])
-
-  const setDefaultSplitKeyMode = useCallback((mode: SplitKeyMode) => {
-    set('defaultSplitKeyMode', mode)
-  }, [set])
-
-  const setDefaultQuickSelect = useCallback((enabled: boolean) => {
-    set('defaultQuickSelect', enabled)
-  }, [set])
-
-  const setAutoLockTime = useCallback((m: AutoLockMinutes) => {
-    set('autoLockTime', m)
-  }, [set])
 
   const applyDevicePrefs = useCallback(async (uid: string) => {
     uidRef.current = uid
@@ -837,171 +205,22 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
       typingViewMenuTab: 'window',
       viewMode: 'editor',
     }
-    updateLayout(resolved.keyboardLayout)
-    updateAutoAdvance(resolved.autoAdvance)
-    updateLayerPanelOpen(resolved.layerPanelOpen)
-    updateBasicViewType(resolved.basicViewType)
-    updateSplitKeyMode(resolved.splitKeyMode)
-    updateQuickSelect(resolved.quickSelect)
-    updateKeymapScale(resolved.keymapScale)
-    updateLayerNames(resolved.layerNames)
-    updateTypingTestResults(resolved.typingTestResults)
-    updateTypingTestConfig(resolved.typingTestConfig)
-    updateTypingTestMonkeytypeConfig(resolved.typingTestMonkeytypeConfig)
-    updateTypingTestLanguage(resolved.typingTestLanguage)
-    updateTypingTestViewOnly(resolved.typingTestViewOnly)
-    updateTypingTestViewOnlyWindowSize(resolved.typingTestViewOnlyWindowSize)
-    updateTypingTestViewOnlyAlwaysOnTop(resolved.typingTestViewOnlyAlwaysOnTop)
-    updateTypingTestMemory(resolved.typingTestMemory)
-    updateTypingTestDisplayLines(resolved.typingTestDisplayLines)
-    updateTypingTestFontSize(resolved.typingTestFontSize)
-    updateTypingTestHideKeymap(resolved.typingTestHideKeymap)
-    updateTypingTestHideStatsRow(resolved.typingTestHideStatsRow)
-    updateTypingTestHideControls(resolved.typingTestHideControls)
-    updateTypingTestSaveUnnamed(resolved.typingTestSaveUnnamed)
-    updateTypingTestComparisonBaselines(resolved.typingTestComparisonBaselines)
-    updateTypingTestSettingsPanelOpen(resolved.typingTestSettingsPanelOpen)
-    updateTypingRecordEnabled(resolved.typingRecordEnabled)
-    updateTypingViewMenuTab(resolved.typingViewMenuTab)
-    updateViewMode(resolved.viewMode)
-    updateKeyEditorZoom(resolved.keyEditorZoom)
-    updateViewMatrix(resolved.viewMatrix)
+    applyValidated(resolved)
     setAppliedUid(uid)
 
     if (!prefs) {
       saveCurrentPrefs()
     }
-  }, [saveCurrentPrefs, defaultLayout, defaultAutoAdvance, defaultLayerPanelOpen, defaultBasicViewType, defaultSplitKeyMode, defaultQuickSelect])
+  }, [saveCurrentPrefs, applyValidated, defaultLayout, defaultAutoAdvance, defaultLayerPanelOpen, defaultBasicViewType, defaultSplitKeyMode, defaultQuickSelect])
 
-  const lookup = useKeyLabelLookup()
-
-  // Trigger an IPC fetch for non-built-in layouts so the remap callbacks
-  // see the map / compositeLabels as soon as the store responds.
-  useEffect(() => {
-    void lookup.ensure(layout)
-  }, [lookup, layout])
-
-  // Single source of truth for "does this pack's map build a rewrite
-  // table" — `packIsPurePermutation` (Phase P, picker gate) needs the same
-  // `.ok` verdict `buildKeymapRewriteTable` computes for the Key Label
-  // "apply to keymap" rewrite.
-  //
-  // Memoized on the pack map's own object reference (stable per cache
-  // entry, see `useKeyLabelLookup.getMap`) rather than on `lookup` itself
-  // (a fresh object literal every render), so this only rebuilds when the
-  // pack data actually changes. QWERTY/no pack: `map` is `undefined` (not
-  // yet loaded) or an empty object (built-in QWERTY, or an uninstalled
-  // pack that never resolves) — an empty map trivially passes
-  // `buildKeymapRewriteTable` (there is nothing to permute).
-  const activeMap = lookup.getMap(layout)
-  const rewriteTableResult = useMemo(
-    () => (activeMap ? buildKeymapRewriteTable(activeMap) : undefined),
-    [activeMap],
-  )
-
-  // Picker-only gate (Plan-qwerty-select-no-rewrite v6, Phase P): a pure
-  // QWERTY-keycode permutation pack (Colemak, Eucalyn, Dvorak, ...) must
-  // leave the key PICKER raw — see `pickerRemapLabel`'s doc comment below.
-  // Re-derives the same `.ok` verdict `buildKeymapRewriteTable` already
-  // computes for the Key Label "apply to keymap" rewrite, rather than
-  // consulting `getKeymapApplicable` (an author-supplied hint the rewrite
-  // path deliberately treats as advisory only, not authoritative). An
-  // undefined `rewriteTableResult` (no pack loaded) defaults to "pure
-  // permutation" too since `remapLabel` is already identity in that state
-  // regardless of this flag.
-  const packIsPurePermutation = !rewriteTableResult || rewriteTableResult.ok
-
-  // Author-supplied "wants a keymap rewrite" hint (Plan-key-label-keymap-
-  // apply) — `false` for built-in QWERTY and for any pack not yet loaded.
-  // Combined with `packIsPurePermutation` below (the structural `.ok`
-  // verdict) into the single Plan-qwerty-select-no-rewrite v7 predicate:
-  // `keymapApplicable && buildKeymapRewriteTable(map).ok`. That predicate —
-  // not `.ok` alone — is what `remapKind` now gates on, so it doubles as
-  // the simulation-tab / Apply-eligibility signal `KeymapEditor` consumes
-  // via `remapKind === 'simulated'` (tab visibility, Apply button, and the
-  // simulated tint all read the exact same boolean, never three separately
-  // maintained checks).
-  const keymapApplicable = !!activeMap && lookup.getKeymapApplicable(layout)
-
-  // Which remap tint `isRemapped`-tinted keys use on the keymap surface
-  // (see the `remapKind` field's own doc comment on the return type).
-  // "An active pack map is loaded" is checked directly against `activeMap`
-  // rather than `rewriteTableResult` — QWERTY's map is `{}` (truthy,
-  // trivially a pure permutation) but has nothing to tint, so gating on
-  // "non-empty" here avoids relying on `rewriteTableResult`'s undefined-
-  // ness to mean "no pack" (it doesn't for QWERTY, which is why
-  // `packIsPurePermutation`'s own doc comment calls that state out
-  // separately). `keymapApplicable` is the addition over the old
-  // `.ok`-only check: a pack that structurally permutes but was never
-  // flagged applicable (the author's own opt-out) now renders with the
-  // ACTUAL tint in place, same as a JIS-type deviation pack, instead of
-  // simulating a Rewrite nothing downstream will actually offer.
-  const remapKind: RemapKind = useMemo(() => {
-    const hasActivePackMap = !!activeMap && Object.keys(activeMap).length > 0
-    return hasActivePackMap && keymapApplicable && packIsPurePermutation ? 'simulated' : 'actual'
-  }, [activeMap, keymapApplicable, packIsPurePermutation])
-
-  // The active pack's own rewrite table, exposed ONLY while it's actually
-  // eligible for a keymap Rewrite (`remapKind === 'simulated'` — the exact
-  // state `KeymapEditor` requires before it ever renders the simulation
-  // tab / Apply button in the first place). `useKeymapApplyPrompt
-  // .requestApply` reads this directly instead of re-resolving the same
-  // map through its own `useKeyLabelLookup` instance: by the time the
-  // Apply button is reachable at all, `rewriteTableResult` above has
-  // already built successfully for this exact `layout`, so there is
-  // nothing left to look up. `undefined` (not `remapKind !== 'simulated'`
-  // alone) is the guard `requestApply` no-ops on, mirroring the old
-  // resolver's own null-return contract.
-  const activeRewriteTable = remapKind === 'simulated' && rewriteTableResult?.ok
-    ? rewriteTableResult.table
-    : undefined
-
-  // Display name for the active pack — used by `KeymapEditor`'s simulation
-  // tab label when `remapKind === 'simulated'`. Falls back to the raw id
-  // (same fallback `useKeyLabelLookup.getName` documents) so a not-yet-
-  // loaded pack never renders an empty tab.
-  const activeLayoutName = lookup.getName(layout) ?? layout
-
-  // The active Key Label pack's own labels, resolved through its
-  // compositeLabels -> map lookup order and falling back to qmkId itself
-  // when neither has an entry. QWERTY's map/compositeLabels are always
-  // empty (`BUILTIN_QWERTY_LAYOUT_ID` in keyboard-layouts.ts), so it
-  // resolves to identity without a separate guard. Feeds the key picker
-  // unconditionally, and the keymap surface too EXCEPT `KeymapEditor`'s
-  // Base tab, which reads its own raw/identity keycode builder instead of
-  // calling this at all (Plan-qwerty-select-no-rewrite v7 — シミュレーション
-  // タブ方式: the simulation tab shows exactly what this resolves to, Base
-  // shows the real keymap regardless of it). A Rewrite never leaves
-  // anything for this to simulate — it resets `layout` back to QWERTY on
-  // success (raw characters, no color, no tabs), the same clean state a
-  // snapshot/.vil restore leaves.
-  const remapLabel = useCallback(
-    (qmkId: string): string => {
-      const composite = lookup.getCompositeLabels(layout)?.[qmkId]
-      if (composite !== undefined) return composite
-      const mapped = lookup.getMap(layout)?.[qmkId]
-      if (mapped !== undefined) return mapped
-      return qmkId
-    },
-    [lookup, layout],
-  )
-
-  // The blue "remapped" tint: true whenever the resolved label differs from
-  // the qmkId itself — the same `remapLabel(x) !== x` rule every picker/
-  // palette consumer (KeycodeGrid.getRemapDisplayLabel) already uses.
-  const isRemapped = useCallback(
-    (qmkId: string): boolean => remapLabel(qmkId) !== qmkId,
-    [remapLabel],
-  )
-
-  // Delegates to `remapLabel` itself for the deviation-pack branch (rather
-  // than re-resolving compositeLabels/map independently) so the picker and
-  // keymap legend can never disagree on what a deviation pack's label is —
-  // only WHETHER it's shown differs between the two surfaces.
-  const pickerRemapLabel = useCallback(
-    (qmkId: string): string => (packIsPurePermutation ? qmkId : remapLabel(qmkId)),
-    [packIsPurePermutation, remapLabel],
-  )
+  const {
+    remapLabel,
+    isRemapped,
+    remapKind,
+    activeRewriteTable,
+    activeLayoutName,
+    pickerRemapLabel,
+  } = useDevicePrefsRemap(layout)
 
   return {
     layout,
@@ -1076,7 +295,7 @@ export function useDevicePrefs(): UseDevicePrefsReturn {
     setDefaultBasicViewType,
     setDefaultSplitKeyMode,
     setDefaultQuickSelect,
-    autoLockTime: config.autoLockTime,
+    autoLockTime,
     setAutoLockTime,
     applyDevicePrefs,
     remapLabel,


### PR DESCRIPTION
## Summary
- Split `src/renderer/hooks/useDevicePrefs.ts` (1,089 lines, Custom Hook cap 600) into a 308-line facade composing six modules: pure validators (`device-prefs-validate`, 326), the type surface (`device-prefs-types`, 144 — keeping the alias re-exports two settings-modal files import), the state core (`use-device-prefs-state`, 188 — the `useStateRef` helper, all 29 state slots, and the shared `saveCurrentPrefs`), app-config defaults (69), the typing-test cluster (222), and the key-label remap cluster (148). The hook's export, `UseDevicePrefsReturn`, and all 81 returned fields are unchanged, so none of the nine consumer files changes an import.
- The load-bearing invariants were preserved and proven: `saveCurrentPrefs` remains one zero-dependency callback issuing a single `pipetteSettingsPatch` whose payload block byte-diffs empty against HEAD (including the `?? null` force-clears e2e depends on); the `applyDevicePrefs` sequence (race guards → validate → fallback → 29 updates → `setAppliedUid` → bootstrap save) stays synchronous after the awaited get with the update order diff-identical; the ~14 no-op setter guards and every memo dependency array are verbatim — the lazy-pack test that pins remap-memo identity changing exactly once still passes.
- One bug was caught during implementation itself: an early draft initialized the six config-derived state slots from literals instead of the AppConfig defaults; fixed by threading a defaults parameter from the defaults hook into the state hook before verification.

## Verification
- Full suite: 362 test files, 8,184 passed / 22 skipped — exact baseline match, zero test edits (the 2,320-line hook suite, the lazy-pack identity test, and the routing-hook suite all pass unedited).
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` clean; `window.vialAPI` is reachable only from the state module and the facade, matching HEAD.