### PR TITLE
refactor(ui): split both pack modals into mirrored sibling hooks

### DIFF
--- a/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
+++ b/src/renderer/components/i18n-packs/LanguagePacksModal.tsx
@@ -11,50 +11,30 @@
 // treatment, which mirrors Key Labels' built-in QWERTY: both drag
 // reorder and Name sort include it like any imported entry (see
 // `ensureBuiltinEnglishEntry` in main/i18n-pack-store.ts).
+//
+// The row model (built-in + installed + Hub browse), the per-row
+// actions, and the import surface each live in their own sibling hook
+// (Task-split-pack-modals) — this shell only owns the 7 top-level
+// state atoms, the on-close reset, and the JSX.
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useI18nPackStore } from '../../hooks/useI18nPackStore'
-import i18n from '../../i18n'
-import { validatePack, type ValidatePackResult } from '../../../shared/i18n/validate'
-import { computeCoverage } from '../../../shared/i18n/coverage'
-import { BASE_REVISION, ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
-import english from '../../i18n/locales/english.json'
-import { BUILTIN_ENGLISH_PACK_ID, type I18nPackMeta } from '../../../shared/types/i18n-store'
-import type { HubI18nPostListItem } from '../../../shared/types/hub'
+import { ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
 import { MissingKeysModal } from './MissingKeysModal'
-import { downloadJson } from '../../utils/download-json'
-import { buildHubI18nPackUrl, HUB_CATEGORY } from '../../../shared/hub-urls'
-import { useHubFreshness } from '../../hooks/useHubFreshness'
-import { localizeHubError } from '../../utils/hub-error-i18n'
+import { HUB_CATEGORY } from '../../../shared/hub-urls'
 import { PackManagerModal } from '../pack-modal/PackManagerModal'
 import { PackHubTab } from '../pack-modal/PackHubTab'
 import { PackSortButton } from '../pack-modal/PackSortButton'
-import { usePackCloudPull } from '../pack-modal/usePackCloudPull'
 import { useHubOrigin } from '../pack-modal/useHubOrigin'
-import { useHubSearchList } from '../pack-modal/useHubSearchList'
-import { useDragReorder } from '../pack-modal/useDragReorder'
-import { applyDragOrder } from '../pack-modal/drag-order'
-import { useNameSort } from '../pack-modal/useNameSort'
-import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
-import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
-import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
-import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
-import { isOwnPack } from '../pack-modal/ownership'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
-import {
-  LanguageInstalledRow,
-  LanguageHubRow,
-  type InstalledRow,
-  type HubRow,
-} from './LanguageInstalledRow'
-
-const APP_VERSION = (import.meta.env?.VITE_APP_VERSION as string | undefined) ?? '0.0.0'
-
-const BUILTIN_INTERNAL_ID = 'builtin:en'
+import { LanguageInstalledRow, LanguageHubRow } from './LanguageInstalledRow'
+import { useLanguagePackCoverage } from './use-language-pack-coverage'
+import { useLanguagePackList } from './use-language-pack-list'
+import { useLanguagePackActions } from './use-language-pack-actions'
+import { useLanguagePackImport } from './use-language-pack-import'
 
 export interface LanguagePacksModalProps {
   open: boolean
@@ -84,212 +64,25 @@ export function LanguagePacksModal({
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [missingKeysFor, setMissingKeysFor] = useState<{ name: string; keys: string[] } | null>(null)
 
-  const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
-  const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
-
   const hubOrigin = useHubOrigin(open)
 
-  useEffect(() => {
-    if (!open) return
-    // Built-in English is excluded: it never carries a `matchedBaseVersion`
-    // (that field only ever gets stamped on an *imported* pack whose
-    // coverage was measured against the baseline), so it would
-    // otherwise always show up "stale" here and cost a wasted
-    // i18nPackGet + coverage compute every time the modal opens, for a
-    // recheck that can never actually apply to it.
-    const stale = store.metas.filter((m) => !m.deletedAt && m.id !== BUILTIN_ENGLISH_PACK_ID && m.matchedBaseVersion !== BASE_REVISION)
-    if (stale.length === 0) return
-    let cancelled = false
-    void (async () => {
-      for (const meta of stale) {
-        if (cancelled) return
-        try {
-          const get = await window.vialAPI.i18nPackGet(meta.id)
-          if (cancelled || !get.success || !get.data) continue
-          const cov = computeCoverage(get.data.pack, ENGLISH_PACK_BODY)
-          if (cancelled || cov.coverageRatio !== 1) continue
-          await store.applyImport(get.data.pack, {
-            id: meta.id,
-            matchedBaseVersion: BASE_REVISION,
-            coverage: { totalKeys: cov.totalKeys, coveredKeys: cov.coveredKeys },
-          })
-        } catch {
-          continue
-        }
-      }
-      if (!cancelled) await store.refresh()
-    })()
-    return () => { cancelled = true }
-  }, [open, store.metas.length])
+  useLanguagePackCoverage({ open, store })
 
-  const activeLanguageId = appConfig.config.language ?? 'builtin:en'
-
-  // Built-in English's row shape is always this — hardcoded rather than
-  // read from the store meta, since the meta's own name/version/body is
-  // just a trivial placeholder (see `ensureBuiltinEnglishEntry`'s doc in
-  // main/i18n-pack-store.ts). Only `packId` varies: the real store id
-  // once `ensureBuiltinEnglishEntry` has run (normal case), or `null`
-  // during the brief pre-load window before `store.metas` has arrived —
-  // `null` also intentionally covers older/mocked stores in tests that
-  // don't include the entry, so this row's appearance never depends on
-  // the caller remembering to add it.
-  const builtinRow = useCallback((packId: string | null): InstalledRow => ({
-    reactKey: BUILTIN_INTERNAL_ID,
-    internalId: BUILTIN_INTERNAL_ID,
-    packId,
-    hubPostId: null,
-    name: builtinName,
-    version: builtinVersion,
-    updatedAt: __BUILD_TIME__,
-    uploaderName: 'pipette',
-    isBuiltin: true,
-    active: activeLanguageId === BUILTIN_INTERNAL_ID,
-    isComplete: true,
-  }), [builtinName, builtinVersion, activeLanguageId])
-
-  const installedRows: InstalledRow[] = useMemo(() => {
-    const rows: InstalledRow[] = []
-    let sawBuiltin = false
-    for (const meta of store.metas) {
-      if (meta.deletedAt) continue
-      if (meta.id === BUILTIN_ENGLISH_PACK_ID) {
-        sawBuiltin = true
-        rows.push(builtinRow(meta.id))
-        continue
-      }
-      const internalId = `pack:${meta.id}`
-      // A pack is "complete" only when its matchedBaseVersion equals
-      // the *current* English baseline. A stale match for an older
-      // baseline must surface as incomplete so the user sees the
-      // "not set keys" entry point against the new keys.
-      const isComplete = meta.matchedBaseVersion === BASE_REVISION
-      rows.push({
-        reactKey: meta.id,
-        internalId,
-        packId: meta.id,
-        hubPostId: meta.hubPostId ?? null,
-        name: meta.name,
-        // Display the English baseline version the pack proved it
-        // covers, not the pack's own semver. An empty string keeps
-        // the row visually consistent while signalling partial
-        // coverage to the user.
-        version: meta.matchedBaseVersion ?? '',
-        // Hub-side timestamp, not the local modification time — blank
-        // for never-uploaded local entries and legacy rows that
-        // predate this field, matching Key Labels' Updated column.
-        updatedAt: meta.hubUpdatedAt ?? '',
-        uploaderName: meta.uploaderName ?? '',
-        isBuiltin: false,
-        active: activeLanguageId === internalId,
-        coverage: meta.coverage,
-        isComplete,
-        meta,
-      })
-    }
-    if (!sawBuiltin) rows.unshift(builtinRow(null))
-    return rows
-  }, [store.metas, activeLanguageId, builtinRow])
-
-  const handleSelectLanguage = useCallback((internalId: string) => {
-    if (internalId === activeLanguageId) return
-    appConfig.set('language', internalId)
-    void i18n.changeLanguage(internalId)
-  }, [appConfig, activeLanguageId])
-
-  // Drag reorder + Name sort apply to every row with a real store id —
-  // now including built-in English once `ensureBuiltinEnglishEntry` has
-  // materialised it (see `installedRows` above). Only the transient
-  // pre-load fallback row (`packId === null`) is excluded, since there
-  // is no real id yet to persist an order against.
-  const draggableRows = useMemo(() => installedRows.filter((row) => row.packId !== null), [installedRows])
-  const dragReorderIds = useMemo(() => draggableRows.map((row) => row.packId as string), [draggableRows])
-  const drag = useDragReorder({
-    ids: dragReorderIds,
-    reorder: store.reorder,
-    onError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
-  })
-  const displayedRows = useMemo<InstalledRow[]>(() => {
-    const ordered = applyDragOrder(draggableRows, drag.dragOrder, (row) => row.packId as string)
-    // Only the pre-load fallback (no real builtin id yet) needs
-    // prepending by hand — the real entry already sits at its correct
-    // position within `draggableRows`/`drag.dragOrder`.
-    const fallbackBuiltin = installedRows.find((row) => row.isBuiltin && row.packId === null)
-    return fallbackBuiltin ? [fallbackBuiltin, ...ordered] : ordered
-  }, [installedRows, draggableRows, drag.dragOrder])
-
-  const nameSortEntries = useMemo(
-    () => draggableRows.map((row) => ({ id: row.packId as string, name: row.name })),
-    [draggableRows],
-  )
-  const nameSort = useNameSort({
-    open,
-    ready: !store.loading,
-    entries: nameSortEntries,
-    reorder: store.reorder,
-    onError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
-  })
-  const handleSortByName = useCallback((): void => {
-    void nameSort.toggle(draggableRows.map((row) => ({ id: row.packId as string, name: row.name })))
-  }, [nameSort, draggableRows])
-  const placement = useImportPlacement({
-    open,
-    entries: nameSortEntries,
-    direction: nameSort.direction,
-    reorder: store.reorder,
-    rowTestidPrefix: 'language-packs',
-    onReorderError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
-  })
-
-  // hubPostId-first + name-fallback (unified with Theme Packs / Key
-  // Labels — see installed-detection.ts). Built-in English counts as
-  // an "installed" name too, so a Hub pack literally named "English"
-  // shows Installed instead of a misleading Download. Sourced from
-  // `builtinName` (the authoritative bundled name), not the store
-  // meta's own (placeholder) `name` field — the real builtin-english
-  // meta is explicitly excluded below to avoid listing it twice.
-  const installedEntries = useMemo<InstalledDetectionEntry[]>(() => [
-    { name: builtinName },
-    ...store.metas
-      .filter((m) => !m.deletedAt && m.id !== BUILTIN_ENGLISH_PACK_ID)
-      .map((m) => ({ hubPostId: m.hubPostId, name: m.name })),
-  ], [store.metas, builtinName])
-
-  const { search, setSearch, hubResults, hubSearched, hubSearching, runSearch } = useHubSearchList<HubI18nPostListItem>({
-    open,
-    activeTab,
-    hubTabId: 'hub',
-    fetchPage: (query) => window.vialAPI.hubListI18nPosts({ q: query }),
-    errorMessage: (error) => error ?? t('i18n.errorGeneric'),
-    onSearchStart: () => setActionError(null),
-    onError: setActionError,
-  })
-
-  const hubRows: HubRow[] = useMemo(() => hubResults.map((item) => ({
-    reactKey: item.id,
-    hubPostId: item.id,
-    name: item.name,
-    version: item.version,
-    uploaderName: item.uploaderName ?? '',
-    alreadyInstalled: isHubItemInstalled(item, installedEntries),
-  })), [hubResults, installedEntries])
-
-  const freshnessCandidates = useMemo(
-    () => store.metas
-      .filter((m) => !m.deletedAt && !!m.hubPostId)
-      .map((m) => ({ localId: m.id, hubPostId: m.hubPostId as string })),
-    [store.metas],
-  )
-
-  const fetchTimestamps = useCallback(
-    (ids: string[]) => window.vialAPI.i18nPackHubTimestamps(ids),
-    [],
-  )
-
-  const hubFreshness = useHubFreshness({
-    enabled: open && activeTab === 'installed',
-    candidates: freshnessCandidates,
-    fetchTimestamps,
-  })
+  const {
+    handleSelectLanguage,
+    displayedRows,
+    drag,
+    nameSort,
+    handleSortByName,
+    placement,
+    search,
+    setSearch,
+    hubRows,
+    hubSearched,
+    hubSearching,
+    runSearch,
+    hubFreshness,
+  } = useLanguagePackList({ open, activeTab, store, appConfig, setActionError, t })
 
   useEffect(() => {
     if (!open) {
@@ -300,431 +93,49 @@ export function LanguagePacksModal({
     }
   }, [open])
 
-  const handleOpen = useCallback((row: InstalledRow): void => {
-    if (!row.hubPostId || !hubOrigin) return
-    void window.vialAPI.openExternal(buildHubI18nPackUrl(hubOrigin.replace(/\/$/, ''), row.hubPostId))
-  }, [hubOrigin])
-
-  const handleDelete = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.packId) return
-    // Delete is the strongest action: tombstone locally and, if the
-    // pack mirrors a Hub post *we own*, drop the post too so the user
-    // does not need to click Remove + Delete in sequence to fully
-    // clean up. If the Hub deletion fails, abort the cascade —
-    // proceeding to a local-only delete would strand an orphan post
-    // whose name can never be re-uploaded, exactly what the cascade is
-    // meant to avoid. That argument only holds for a post the user
-    // could actually re-upload themselves, though — a downloaded
-    // (foreign) pack also carries `hubPostId` (for Sync/freshness
-    // linkage), so gating on presence alone would attempt — and fail —
-    // a Hub delete the user has no rights to, then block the local
-    // delete on that failure. Not-owned entries delete locally only,
-    // no Hub call, same as Update/Remove's `isMine` gating.
-    const owned = row.hubPostId && isOwnPack(row.hubPostId, row.uploaderName, currentDisplayName ?? null)
-    setPendingId(row.packId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      if (owned) {
-        const hubResult = await window.vialAPI.hubDeleteI18nPost(row.hubPostId as string, row.packId)
-          .catch((err) => ({ success: false, error: err instanceof Error ? err.message : String(err) }))
-        if (!hubResult.success) {
-          setLastResult({ id: row.packId, kind: 'error', message: hubResult.error ?? t('i18n.errorGeneric') })
-          return
-        }
-      }
-      const result = await store.remove(row.packId)
-      if (!result.success) {
-        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
-        return
-      }
-      await store.refresh()
-    } finally {
-      setPendingId(null)
-      setConfirmDeleteId(null)
-    }
-  }, [store, t, currentDisplayName])
-
-  // Push the local pack body to its existing Hub post. Used by the
-  // explicit "Update" action and by the auto-sync paths below
-  // (rename / overwrite re-import). Returns the IPC-style result so
-  // callers can decide whether to surface the error inline.
-  const pushPackToHub = useCallback(async (
-    packId: string,
-    hubPostId: string,
-  ): Promise<{ success: boolean; error?: string }> => {
-    const get = await window.vialAPI.i18nPackGet(packId)
-    if (!get.success || !get.data) {
-      return { success: false, error: get.error ?? t('i18n.errorGeneric') }
-    }
-    const res = await window.vialAPI.hubUpdateI18nPost({
-      postId: hubPostId,
-      entryId: packId,
-      pack: get.data.pack as { version: string; name: string; [k: string]: unknown },
-    })
-    if (res.success) {
-      await store.refresh()
-      return { success: true }
-    }
-    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
-  }, [store, t])
-
-  const handleRenameCommit = useCallback(async (id: string): Promise<void> => {
-    // Guards on `useImportBatch`'s own re-entrancy ref (destructured as
-    // `isImportingRef` below) rather than a locally-mirrored ref — a
-    // ref written only inside an event handler (`runImport`), never
-    // during render, so it can't go stale under a discarded/interrupted
-    // concurrent render the way `someRef.current = someState` could.
-    // Referencing `isImportingRef` here, even though it is destructured
-    // further down in this file, is safe: this callback's body only
-    // runs later, in response to a real blur/Enter event, by which time
-    // the whole render (including that destructure) has long finished.
-    //
-    // A rename already committed its `store.rename` call the instant
-    // the underlying input blurred — including the blur a click on the
-    // Import button itself triggers, which fires before that click's
-    // own handler runs — so this check cannot intercept that exact
-    // call. It DOES catch every other path: a rename input left open
-    // when a batch was already running, and any stray commit that
-    // slips through after the cancel-on-import-start effect below has
-    // already reset the editor for this render.
-    if (isImportingRef.current) return
-    const newName = rename.commitRename(id)
-    if (!newName) return
-    setActionError(null)
-    setPendingId(id)
-    try {
-      const result = await store.rename(id, newName)
-      if (!result.success) {
-        setActionError(result.error ?? t('i18n.errorGeneric'))
-        return
-      }
-      // Auto-sync uploaded packs so the Hub post reflects the new
-      // name immediately. Show "Synced" so the user sees the second
-      // step completed; failure surfaces inline without rolling back.
-      if (result.meta?.hubPostId) {
-        const upd = await pushPackToHub(id, result.meta.hubPostId)
-        if (upd.success) {
-          setLastResult({ id, kind: 'success', message: t('common.synced') })
-        } else {
-          setActionError(upd.error ?? t('hub.updateFailed'))
-        }
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [rename, store, t, pushPackToHub])
-
-  const handleRenameKey = (event: React.KeyboardEvent<HTMLInputElement>, id: string): void => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      void handleRenameCommit(id)
-    } else if (event.key === 'Escape') {
-      event.preventDefault()
-      rename.cancelRename()
-    }
-  }
-
-  const handleSync = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.hubPostId) return
-    setPendingId(row.packId ?? row.hubPostId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await window.vialAPI.hubDownloadI18nPost(row.hubPostId)
-      if (!result.success || !result.data) {
-        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
-        return
-      }
-      // Re-import with the existing pack id so the entry stays linked
-      // to the Hub post and any prior `hubPostId` is retained. Recompute
-      // coverage / matchedBaseVersion against the *current* English so
-      // a Hub sync after a baseline bump correctly drops the row to
-      // "incomplete" instead of inheriting stale completeness.
-      const coverage = computeCoverage(result.data.pack, ENGLISH_PACK_BODY)
-      // Refresh the Author/Updated cache the same way upload/update do —
-      // the download body carries no metadata, so look the post back up
-      // by its (possibly just-changed) name via the Hub list endpoint.
-      const enriched = await fetchHubPackMeta(window.vialAPI.hubListI18nPosts, result.data.pack.name, row.hubPostId)
-      const apply = await store.applyImport(result.data.pack, {
-        id: row.packId ?? undefined,
-        hubPostId: row.hubPostId,
-        hubUpdatedAt: enriched.hubUpdatedAt,
-        uploaderName: enriched.uploaderName,
-        enabled: true,
-        appVersionAtImport: APP_VERSION,
-        matchedBaseVersion: coverage.coverageRatio === 1 ? BASE_REVISION : null,
-        coverage: { totalKeys: coverage.totalKeys, coveredKeys: coverage.coveredKeys },
-      })
-      if (apply.success) {
-        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'success', message: t('common.synced') })
-        await store.refresh()
-      } else {
-        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'error', message: apply.error ?? t('i18n.errorGeneric') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [store, t])
-
-  const handleUpdate = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.packId || !row.hubPostId) return
-    setPendingId(row.packId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await pushPackToHub(row.packId, row.hubPostId)
-      if (result.success) {
-        setLastResult({ id: row.packId, kind: 'success', message: t('hub.updateSuccess') })
-      } else {
-        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.updateFailed') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [pushPackToHub, t])
-
-  const handleRemove = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.packId || !row.hubPostId) return
-    setPendingId(row.packId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await window.vialAPI.hubDeleteI18nPost(row.hubPostId, row.packId)
-      if (result.success) {
-        setLastResult({ id: row.packId, kind: 'success', message: t('hub.removeSuccess') })
-        await store.refresh()
-      } else {
-        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.removeFailed') })
-      }
-    } finally {
-      setPendingId(null)
-      setConfirmRemoveId(null)
-    }
-  }, [store, t])
-
-  const handleUpload = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.packId) return
-    setPendingId(row.packId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const get = await window.vialAPI.i18nPackGet(row.packId)
-      if (!get.success || !get.data) {
-        setLastResult({ id: row.packId, kind: 'error', message: t('i18n.errorGeneric') })
-        return
-      }
-      const result = await window.vialAPI.hubUploadI18nPost({
-        entryId: row.packId,
-        pack: get.data.pack as { version: string; name: string; [k: string]: unknown },
-      })
-      if (result.success) {
-        setLastResult({ id: row.packId, kind: 'success', message: t('hub.uploadSuccess') })
-        // setHubPostId on the main side does not push a CustomEvent
-        // back to the renderer; refresh manually so the row picks up
-        // the new hubPostId and surfaces Update / Remove next render.
-        await store.refresh()
-      } else {
-        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.uploadFailed') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [store, t])
-
-  const handleNotSetKeys = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (!row.packId) return
-    setPendingId(row.packId)
-    setActionError(null)
-    try {
-      // Pull the body directly and compute coverage with no sample
-      // limit so the modal gets the full set of missing keys (the
-      // shared coverage-cache caps at 200 for status-line use).
-      const get = await window.vialAPI.i18nPackGet(row.packId)
-      if (!get.success || !get.data) {
-        setActionError(get.error ?? t('i18n.errorGeneric'))
-        return
-      }
-      const coverage = computeCoverage(get.data.pack, ENGLISH_PACK_BODY, { sampleLimit: Number.POSITIVE_INFINITY })
-      setMissingKeysFor({ name: row.name, keys: coverage.missingKeys })
-    } finally {
-      setPendingId(null)
-    }
-  }, [t])
-
-  const handleExport = useCallback(async (row: InstalledRow): Promise<void> => {
-    if (row.isBuiltin) {
-      // Builtin English ships with the renderer bundle; trigger an
-      // in-browser download instead of going through the main-side
-      // dialog so users can grab the canonical pack as a starting
-      // point for translations.
-      try {
-        downloadJson(row.name, english, { prefix: 'i18n-packs', fallback: 'English' })
-      } catch (err) {
-        setActionError(err instanceof Error ? err.message : String(err))
-      }
-      return
-    }
-    if (!row.packId) return
-    setPendingId(row.packId)
-    setActionError(null)
-    try {
-      const result = await window.vialAPI.i18nPackExport(row.packId)
-      if (!result.success) {
-        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [t])
-
-  // Core validate + coverage + persist step, shared by the single-item
-  // Hub-download path (`persistImportedPack` below) and the multi-file
-  // import batch (`collectImportResults`). Returns the outcome instead
-  // of touching state so each caller decides how to surface it (single
-  // banner vs. an accumulated batch summary).
-  const importOnePack = useCallback(async (
-    raw: unknown,
-  ): Promise<{ ok: true; meta: I18nPackMeta; validation: ValidatePackResult } | { ok: false; error: string }> => {
-    const validation = validatePack(raw)
-    if (!validation.ok) {
-      return { ok: false, error: validation.errors[0] ?? t('i18n.errorGeneric') }
-    }
-    if (validation.dangerousKeys.length > 0) {
-      return { ok: false, error: t('i18n.preview.dangerousWarning') }
-    }
-    const coverage = computeCoverage(raw, ENGLISH_PACK_BODY)
-    const result = await store.applyImport(raw, {
-      enabled: true,
-      appVersionAtImport: APP_VERSION,
-      matchedBaseVersion: coverage.coverageRatio === 1 ? BASE_REVISION : null,
-      coverage: { totalKeys: coverage.totalKeys, coveredKeys: coverage.coveredKeys },
-      dangerousKeyCount: validation.dangerousKeys.length,
-    })
-    if (!result.success || !result.meta) {
-      return { ok: false, error: result.error ?? t('i18n.errorGeneric') }
-    }
-    return { ok: true, meta: result.meta, validation }
-  }, [store, t])
-
-  // Single-item import path: Hub download funnels through here (the
-  // toolbar's own multi-file import now goes through `importOnePack`
-  // directly — see `collectImportResults` below). Failures surface
-  // through `setActionError` (the same banner KeyLabels uses) instead
-  // of opening a separate confirmation modal.
-  const persistImportedPack = useCallback(async (
-    raw: unknown,
-    extra: { hubPostId?: string } = {},
-  ): Promise<void> => {
-    setActionError(null)
-    setLastResult(null)
-    const beforeIds = placement.snapshotBeforeIds()
-    const imported = await importOnePack(raw)
-    if (!imported.ok) {
-      setActionError(imported.error)
-      return
-    }
-    const { meta, validation } = imported
-    setLastResult({ id: meta.id, kind: 'success', message: t('common.saved') })
-    handleSelectLanguage(`pack:${meta.id}`)
-    await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
-
-    if (extra.hubPostId) {
-      // Same Author/Updated enrichment as handleSync — the download
-      // body itself has no metadata, so look the post back up by name.
-      const enriched = validation.header
-        ? await fetchHubPackMeta(window.vialAPI.hubListI18nPosts, validation.header.name, extra.hubPostId)
-        : {}
-      void window.vialAPI.i18nPackSetHubPostId(meta.id, extra.hubPostId, enriched.uploaderName, enriched.hubUpdatedAt)
-      return
-    }
-    // Auto-sync to Hub when this overwrite landed on an entry that
-    // already mirrors a Hub post. Promote the inline badge from
-    // "Saved" to "Synced" so the user can see the second step
-    // completed; failure surfaces inline without rolling back local.
-    if (meta.hubPostId) {
-      const upd = await pushPackToHub(meta.id, meta.hubPostId)
-      if (upd.success) {
-        setLastResult({ id: meta.id, kind: 'success', message: t('common.synced') })
-      } else {
-        setActionError(upd.error ?? t('hub.updateFailed'))
-      }
-    }
-  }, [importOnePack, t, pushPackToHub, handleSelectLanguage, placement])
-
-  // Multi-file import batch: every selected file is parsed and saved
-  // independently here; dedupe, hub-sync, placement and the toolbar
-  // summary/failure banner are handled by the shared `useImportBatch`
-  // hook below (see its module doc for the extraction rationale). The
-  // snapshot is taken right after the "canceled" check — before any
-  // per-file save runs — matching `placement.snapshotEntries()`'s
-  // "before the batch's own mutations begin" contract.
-  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<I18nPackMeta> | null> => {
-    const dialogResult = await store.importFromDialog()
-    if (dialogResult.canceled) return null
-    const snapshot = placement.snapshotEntries()
-    const notSavedFailures: ImportBatchFailure[] = []
-    const successes: ImportBatchItem<I18nPackMeta>[] = []
-    for (const file of dialogResult.files) {
-      const fileName = basenameOf(file.filePath)
-      if (file.parseError || file.raw === undefined) {
-        notSavedFailures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
-        continue
-      }
-      const imported = await importOnePack(file.raw)
-      if (!imported.ok) {
-        notSavedFailures.push({ fileName, reason: imported.error })
-        continue
-      }
-      successes.push({ fileName, meta: imported.meta })
-    }
-    return { successes, notSavedFailures, snapshot }
-  }, [store, t, placement, importOnePack])
-
-  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<I18nPackMeta>({
-    open,
-    placement,
-    setLastResult,
-    setActionError,
+  const {
+    handleOpen,
+    handleDelete,
+    pushPackToHub,
+    handleSync,
+    handleUpdate,
+    handleRemove,
+    handleUpload,
+    handleNotSetKeys,
+    handleExport,
+  } = useLanguagePackActions({
+    store,
     t,
-    collectResults: collectImportResults,
-    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
-    onCollapsedToOne: (meta) => handleSelectLanguage(`pack:${meta.id}`),
+    hubOrigin,
+    currentDisplayName,
+    setPendingId,
+    setActionError,
+    setLastResult,
+    setConfirmDeleteId,
+    setConfirmRemoveId,
+    setMissingKeysFor,
   })
 
-  // Closes any inline rename that was already open the moment a batch
-  // starts, so its input unmounts instead of sitting there interactive
-  // (and committable) for the whole duration of the import — see
-  // `handleRenameCommit`'s own `isImportingRef` guard above for the one
-  // race this cannot cover (a rename input's blur, and the click that
-  // starts the batch, are the same user click; the blur's commit is
-  // already in flight before `importing` ever flips true).
-  useEffect(() => {
-    if (importing) rename.cancelRename()
-    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
-    // intentionally not in the deps array so this only re-fires when
-    // `importing` itself flips, not on every unrelated render.
-  }, [importing])
-
-  // Explicit cloud pull: a 'packs'-scoped download (i18n + theme packs
-  // only) — see usePackCloudPull's doc for the discovery-gap rationale.
-  const pull = usePackCloudPull(setActionError, t, 'i18n.errorGeneric')
-
-  const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
-    setPendingId(postId)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await window.vialAPI.hubDownloadI18nPost(postId)
-      if (!result.success || !result.data) {
-        setActionError(result.error ?? t('i18n.errorGeneric'))
-        return
-      }
-      await persistImportedPack(result.data.pack, { hubPostId: postId })
-    } finally {
-      setPendingId(null)
-    }
-  }, [persistImportedPack, t])
+  const {
+    importing,
+    importSummary,
+    runImport,
+    handleRenameCommit,
+    handleRenameKey,
+    pull,
+    handleHubDownload,
+  } = useLanguagePackImport({
+    open,
+    store,
+    t,
+    rename,
+    placement,
+    pushPackToHub,
+    handleSelectLanguage,
+    setPendingId,
+    setActionError,
+    setLastResult,
+  })
 
   return (
     <PackManagerModal
@@ -845,4 +256,3 @@ export function LanguagePacksModal({
     </PackManagerModal>
   )
 }
-

--- a/src/renderer/components/i18n-packs/use-language-pack-actions.ts
+++ b/src/renderer/components/i18n-packs/use-language-pack-actions.ts
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Per-row Installed-tab actions: Open on Hub, Sync / Update / Remove /
+// Upload / Delete, "not set keys" lookup, and Export (including the
+// built-in English browser-download branch). Split out of
+// LanguagePacksModal (Task-split-pack-modals) — `pushPackToHub` is
+// returned because the sibling import hook's rename-commit and
+// overwrite-reimport paths reuse it for their own auto-sync step.
+
+import { useCallback } from 'react'
+import type { TFunction } from 'i18next'
+import { computeCoverage } from '../../../shared/i18n/coverage'
+import { BASE_REVISION, ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
+import english from '../../i18n/locales/english.json'
+import { downloadJson } from '../../utils/download-json'
+import { buildHubI18nPackUrl } from '../../../shared/hub-urls'
+import { localizeHubError } from '../../utils/hub-error-i18n'
+import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
+import { isOwnPack } from '../pack-modal/ownership'
+import type { UseI18nPackStoreReturn } from '../../hooks/useI18nPackStore'
+import type { PackActionResult } from '../pack-modal/pack-modal-types'
+import type { InstalledRow } from './LanguageInstalledRow'
+
+const APP_VERSION = (import.meta.env?.VITE_APP_VERSION as string | undefined) ?? '0.0.0'
+
+export interface UseLanguagePackActionsOptions {
+  store: UseI18nPackStoreReturn
+  t: TFunction
+  hubOrigin: string
+  currentDisplayName?: string | null
+  setPendingId: (id: string | null) => void
+  setActionError: (error: string | null) => void
+  setLastResult: (result: PackActionResult | PackActionResult[] | null) => void
+  setConfirmDeleteId: (id: string | null) => void
+  setConfirmRemoveId: (id: string | null) => void
+  setMissingKeysFor: (value: { name: string; keys: string[] } | null) => void
+}
+
+export function useLanguagePackActions({
+  store,
+  t,
+  hubOrigin,
+  currentDisplayName,
+  setPendingId,
+  setActionError,
+  setLastResult,
+  setConfirmDeleteId,
+  setConfirmRemoveId,
+  setMissingKeysFor,
+}: UseLanguagePackActionsOptions) {
+  const handleOpen = useCallback((row: InstalledRow): void => {
+    if (!row.hubPostId || !hubOrigin) return
+    void window.vialAPI.openExternal(buildHubI18nPackUrl(hubOrigin.replace(/\/$/, ''), row.hubPostId))
+  }, [hubOrigin])
+
+  const handleDelete = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.packId) return
+    // Delete is the strongest action: tombstone locally and, if the
+    // pack mirrors a Hub post *we own*, drop the post too so the user
+    // does not need to click Remove + Delete in sequence to fully
+    // clean up. If the Hub deletion fails, abort the cascade —
+    // proceeding to a local-only delete would strand an orphan post
+    // whose name can never be re-uploaded, exactly what the cascade is
+    // meant to avoid. That argument only holds for a post the user
+    // could actually re-upload themselves, though — a downloaded
+    // (foreign) pack also carries `hubPostId` (for Sync/freshness
+    // linkage), so gating on presence alone would attempt — and fail —
+    // a Hub delete the user has no rights to, then block the local
+    // delete on that failure. Not-owned entries delete locally only,
+    // no Hub call, same as Update/Remove's `isMine` gating.
+    const owned = row.hubPostId && isOwnPack(row.hubPostId, row.uploaderName, currentDisplayName ?? null)
+    setPendingId(row.packId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      if (owned) {
+        const hubResult = await window.vialAPI.hubDeleteI18nPost(row.hubPostId as string, row.packId)
+          .catch((err) => ({ success: false, error: err instanceof Error ? err.message : String(err) }))
+        if (!hubResult.success) {
+          setLastResult({ id: row.packId, kind: 'error', message: hubResult.error ?? t('i18n.errorGeneric') })
+          return
+        }
+      }
+      const result = await store.remove(row.packId)
+      if (!result.success) {
+        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
+        return
+      }
+      await store.refresh()
+    } finally {
+      setPendingId(null)
+      setConfirmDeleteId(null)
+    }
+  }, [store, t, currentDisplayName])
+
+  // Push the local pack body to its existing Hub post. Used by the
+  // explicit "Update" action here and by the sibling import hook's
+  // auto-sync paths (rename / overwrite re-import). Returns the
+  // IPC-style result so callers can decide whether to surface the
+  // error inline.
+  const pushPackToHub = useCallback(async (
+    packId: string,
+    hubPostId: string,
+  ): Promise<{ success: boolean; error?: string }> => {
+    const get = await window.vialAPI.i18nPackGet(packId)
+    if (!get.success || !get.data) {
+      return { success: false, error: get.error ?? t('i18n.errorGeneric') }
+    }
+    const res = await window.vialAPI.hubUpdateI18nPost({
+      postId: hubPostId,
+      entryId: packId,
+      pack: get.data.pack as { version: string; name: string; [k: string]: unknown },
+    })
+    if (res.success) {
+      await store.refresh()
+      return { success: true }
+    }
+    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
+  }, [store, t])
+
+  const handleSync = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.hubPostId) return
+    setPendingId(row.packId ?? row.hubPostId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await window.vialAPI.hubDownloadI18nPost(row.hubPostId)
+      if (!result.success || !result.data) {
+        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
+        return
+      }
+      // Re-import with the existing pack id so the entry stays linked
+      // to the Hub post and any prior `hubPostId` is retained. Recompute
+      // coverage / matchedBaseVersion against the *current* English so
+      // a Hub sync after a baseline bump correctly drops the row to
+      // "incomplete" instead of inheriting stale completeness.
+      const coverage = computeCoverage(result.data.pack, ENGLISH_PACK_BODY)
+      // Refresh the Author/Updated cache the same way upload/update do —
+      // the download body carries no metadata, so look the post back up
+      // by its (possibly just-changed) name via the Hub list endpoint.
+      const enriched = await fetchHubPackMeta(window.vialAPI.hubListI18nPosts, result.data.pack.name, row.hubPostId)
+      const apply = await store.applyImport(result.data.pack, {
+        id: row.packId ?? undefined,
+        hubPostId: row.hubPostId,
+        hubUpdatedAt: enriched.hubUpdatedAt,
+        uploaderName: enriched.uploaderName,
+        enabled: true,
+        appVersionAtImport: APP_VERSION,
+        matchedBaseVersion: coverage.coverageRatio === 1 ? BASE_REVISION : null,
+        coverage: { totalKeys: coverage.totalKeys, coveredKeys: coverage.coveredKeys },
+      })
+      if (apply.success) {
+        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'success', message: t('common.synced') })
+        await store.refresh()
+      } else {
+        setLastResult({ id: row.packId ?? row.hubPostId, kind: 'error', message: apply.error ?? t('i18n.errorGeneric') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [store, t])
+
+  const handleUpdate = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.packId || !row.hubPostId) return
+    setPendingId(row.packId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await pushPackToHub(row.packId, row.hubPostId)
+      if (result.success) {
+        setLastResult({ id: row.packId, kind: 'success', message: t('hub.updateSuccess') })
+      } else {
+        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.updateFailed') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [pushPackToHub, t])
+
+  const handleRemove = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.packId || !row.hubPostId) return
+    setPendingId(row.packId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await window.vialAPI.hubDeleteI18nPost(row.hubPostId, row.packId)
+      if (result.success) {
+        setLastResult({ id: row.packId, kind: 'success', message: t('hub.removeSuccess') })
+        await store.refresh()
+      } else {
+        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.removeFailed') })
+      }
+    } finally {
+      setPendingId(null)
+      setConfirmRemoveId(null)
+    }
+  }, [store, t])
+
+  const handleUpload = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.packId) return
+    setPendingId(row.packId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const get = await window.vialAPI.i18nPackGet(row.packId)
+      if (!get.success || !get.data) {
+        setLastResult({ id: row.packId, kind: 'error', message: t('i18n.errorGeneric') })
+        return
+      }
+      const result = await window.vialAPI.hubUploadI18nPost({
+        entryId: row.packId,
+        pack: get.data.pack as { version: string; name: string; [k: string]: unknown },
+      })
+      if (result.success) {
+        setLastResult({ id: row.packId, kind: 'success', message: t('hub.uploadSuccess') })
+        // setHubPostId on the main side does not push a CustomEvent
+        // back to the renderer; refresh manually so the row picks up
+        // the new hubPostId and surfaces Update / Remove next render.
+        await store.refresh()
+      } else {
+        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('hub.uploadFailed') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [store, t])
+
+  const handleNotSetKeys = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (!row.packId) return
+    setPendingId(row.packId)
+    setActionError(null)
+    try {
+      // Pull the body directly and compute coverage with no sample
+      // limit so the modal gets the full set of missing keys (the
+      // shared coverage-cache caps at 200 for status-line use).
+      const get = await window.vialAPI.i18nPackGet(row.packId)
+      if (!get.success || !get.data) {
+        setActionError(get.error ?? t('i18n.errorGeneric'))
+        return
+      }
+      const coverage = computeCoverage(get.data.pack, ENGLISH_PACK_BODY, { sampleLimit: Number.POSITIVE_INFINITY })
+      setMissingKeysFor({ name: row.name, keys: coverage.missingKeys })
+    } finally {
+      setPendingId(null)
+    }
+  }, [t])
+
+  const handleExport = useCallback(async (row: InstalledRow): Promise<void> => {
+    if (row.isBuiltin) {
+      // Builtin English ships with the renderer bundle; trigger an
+      // in-browser download instead of going through the main-side
+      // dialog so users can grab the canonical pack as a starting
+      // point for translations.
+      try {
+        downloadJson(row.name, english, { prefix: 'i18n-packs', fallback: 'English' })
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : String(err))
+      }
+      return
+    }
+    if (!row.packId) return
+    setPendingId(row.packId)
+    setActionError(null)
+    try {
+      const result = await window.vialAPI.i18nPackExport(row.packId)
+      if (!result.success) {
+        setLastResult({ id: row.packId, kind: 'error', message: result.error ?? t('i18n.errorGeneric') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [t])
+
+  return {
+    handleOpen,
+    handleDelete,
+    pushPackToHub,
+    handleSync,
+    handleUpdate,
+    handleRemove,
+    handleUpload,
+    handleNotSetKeys,
+    handleExport,
+  }
+}

--- a/src/renderer/components/i18n-packs/use-language-pack-coverage.ts
+++ b/src/renderer/components/i18n-packs/use-language-pack-coverage.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Background recheck for installed language packs whose stored
+// `matchedBaseVersion` predates the current English baseline
+// (`BASE_REVISION` bump). Split out of LanguagePacksModal
+// (Task-split-pack-modals) — this effect only reads `store.metas` and
+// re-applies coverage-complete packs, so it does not touch any other
+// modal state.
+
+import { useEffect } from 'react'
+import { computeCoverage } from '../../../shared/i18n/coverage'
+import { BASE_REVISION, ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
+import { BUILTIN_ENGLISH_PACK_ID } from '../../../shared/types/i18n-store'
+import type { UseI18nPackStoreReturn } from '../../hooks/useI18nPackStore'
+
+export interface UseLanguagePackCoverageOptions {
+  open: boolean
+  store: UseI18nPackStoreReturn
+}
+
+export function useLanguagePackCoverage({ open, store }: UseLanguagePackCoverageOptions): void {
+  useEffect(() => {
+    if (!open) return
+    // Built-in English is excluded: it never carries a `matchedBaseVersion`
+    // (that field only ever gets stamped on an *imported* pack whose
+    // coverage was measured against the baseline), so it would
+    // otherwise always show up "stale" here and cost a wasted
+    // i18nPackGet + coverage compute every time the modal opens, for a
+    // recheck that can never actually apply to it.
+    const stale = store.metas.filter((m) => !m.deletedAt && m.id !== BUILTIN_ENGLISH_PACK_ID && m.matchedBaseVersion !== BASE_REVISION)
+    if (stale.length === 0) return
+    let cancelled = false
+    void (async () => {
+      for (const meta of stale) {
+        if (cancelled) return
+        try {
+          const get = await window.vialAPI.i18nPackGet(meta.id)
+          if (cancelled || !get.success || !get.data) continue
+          const cov = computeCoverage(get.data.pack, ENGLISH_PACK_BODY)
+          if (cancelled || cov.coverageRatio !== 1) continue
+          await store.applyImport(get.data.pack, {
+            id: meta.id,
+            matchedBaseVersion: BASE_REVISION,
+            coverage: { totalKeys: cov.totalKeys, coveredKeys: cov.coveredKeys },
+          })
+        } catch {
+          continue
+        }
+      }
+      if (!cancelled) await store.refresh()
+    })()
+    return () => { cancelled = true }
+  }, [open, store.metas.length])
+}

--- a/src/renderer/components/i18n-packs/use-language-pack-import.ts
+++ b/src/renderer/components/i18n-packs/use-language-pack-import.ts
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Import surface for Language Packs: inline rename commit (auto-sync on
+// a Hub-linked pack), single-item + multi-file import (validate →
+// coverage → persist → placement → Hub auto-sync), the explicit cloud
+// pull, and Hub-download-to-import. Split out of LanguagePacksModal
+// (Task-split-pack-modals) — rename lives here rather than in the
+// actions hook because it needs `useImportBatch`'s own `isImportingRef`
+// re-entrancy guard, which only exists once this hook creates it.
+
+import { useCallback, useEffect } from 'react'
+import type { TFunction } from 'i18next'
+import { validatePack, type ValidatePackResult } from '../../../shared/i18n/validate'
+import { computeCoverage } from '../../../shared/i18n/coverage'
+import { BASE_REVISION, ENGLISH_PACK_BODY } from '../../i18n/coverage-cache'
+import type { I18nPackMeta } from '../../../shared/types/i18n-store'
+import { usePackCloudPull } from '../pack-modal/usePackCloudPull'
+import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
+import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
+import type { UseImportPlacementResult } from '../pack-modal/useImportPlacement'
+import type { InlineRename } from '../../hooks/useInlineRename'
+import type { UseI18nPackStoreReturn } from '../../hooks/useI18nPackStore'
+import type { PackActionResult } from '../pack-modal/pack-modal-types'
+
+const APP_VERSION = (import.meta.env?.VITE_APP_VERSION as string | undefined) ?? '0.0.0'
+
+export interface UseLanguagePackImportOptions {
+  open: boolean
+  store: UseI18nPackStoreReturn
+  t: TFunction
+  rename: InlineRename<string>
+  placement: UseImportPlacementResult
+  pushPackToHub: (packId: string, hubPostId: string) => Promise<{ success: boolean; error?: string }>
+  handleSelectLanguage: (internalId: string) => void
+  setPendingId: (id: string | null) => void
+  setActionError: (error: string | null) => void
+  setLastResult: (result: PackActionResult | PackActionResult[] | null) => void
+}
+
+export function useLanguagePackImport({
+  open,
+  store,
+  t,
+  rename,
+  placement,
+  pushPackToHub,
+  handleSelectLanguage,
+  setPendingId,
+  setActionError,
+  setLastResult,
+}: UseLanguagePackImportOptions) {
+  const handleRenameCommit = useCallback(async (id: string): Promise<void> => {
+    // Guards on `useImportBatch`'s own re-entrancy ref (destructured as
+    // `isImportingRef` below) rather than a locally-mirrored ref — a
+    // ref written only inside an event handler (`runImport`), never
+    // during render, so it can't go stale under a discarded/interrupted
+    // concurrent render the way `someRef.current = someState` could.
+    // Referencing `isImportingRef` here, even though it is destructured
+    // further down in this file, is safe: this callback's body only
+    // runs later, in response to a real blur/Enter event, by which time
+    // the whole render (including that destructure) has long finished.
+    //
+    // A rename already committed its `store.rename` call the instant
+    // the underlying input blurred — including the blur a click on the
+    // Import button itself triggers, which fires before that click's
+    // own handler runs — so this check cannot intercept that exact
+    // call. It DOES catch every other path: a rename input left open
+    // when a batch was already running, and any stray commit that
+    // slips through after the cancel-on-import-start effect below has
+    // already reset the editor for this render.
+    if (isImportingRef.current) return
+    const newName = rename.commitRename(id)
+    if (!newName) return
+    setActionError(null)
+    setPendingId(id)
+    try {
+      const result = await store.rename(id, newName)
+      if (!result.success) {
+        setActionError(result.error ?? t('i18n.errorGeneric'))
+        return
+      }
+      // Auto-sync uploaded packs so the Hub post reflects the new
+      // name immediately. Show "Synced" so the user sees the second
+      // step completed; failure surfaces inline without rolling back.
+      if (result.meta?.hubPostId) {
+        const upd = await pushPackToHub(id, result.meta.hubPostId)
+        if (upd.success) {
+          setLastResult({ id, kind: 'success', message: t('common.synced') })
+        } else {
+          setActionError(upd.error ?? t('hub.updateFailed'))
+        }
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [rename, store, t, pushPackToHub])
+
+  const handleRenameKey = (event: React.KeyboardEvent<HTMLInputElement>, id: string): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      void handleRenameCommit(id)
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      rename.cancelRename()
+    }
+  }
+
+  // Core validate + coverage + persist step, shared by the single-item
+  // Hub-download path (`persistImportedPack` below) and the multi-file
+  // import batch (`collectImportResults` below). Returns the outcome
+  // instead of touching state so each caller decides how to surface it
+  // (single banner vs. an accumulated batch summary).
+  const importOnePack = useCallback(async (
+    raw: unknown,
+  ): Promise<{ ok: true; meta: I18nPackMeta; validation: ValidatePackResult } | { ok: false; error: string }> => {
+    const validation = validatePack(raw)
+    if (!validation.ok) {
+      return { ok: false, error: validation.errors[0] ?? t('i18n.errorGeneric') }
+    }
+    if (validation.dangerousKeys.length > 0) {
+      return { ok: false, error: t('i18n.preview.dangerousWarning') }
+    }
+    const coverage = computeCoverage(raw, ENGLISH_PACK_BODY)
+    const result = await store.applyImport(raw, {
+      enabled: true,
+      appVersionAtImport: APP_VERSION,
+      matchedBaseVersion: coverage.coverageRatio === 1 ? BASE_REVISION : null,
+      coverage: { totalKeys: coverage.totalKeys, coveredKeys: coverage.coveredKeys },
+      dangerousKeyCount: validation.dangerousKeys.length,
+    })
+    if (!result.success || !result.meta) {
+      return { ok: false, error: result.error ?? t('i18n.errorGeneric') }
+    }
+    return { ok: true, meta: result.meta, validation }
+  }, [store, t])
+
+  // Single-item import path: Hub download funnels through here (the
+  // toolbar's own multi-file import now goes through `importOnePack`
+  // directly — see `collectImportResults` below). Failures surface
+  // through `setActionError` (the same banner KeyLabels uses) instead
+  // of opening a separate confirmation modal.
+  const persistImportedPack = useCallback(async (
+    raw: unknown,
+    extra: { hubPostId?: string } = {},
+  ): Promise<void> => {
+    setActionError(null)
+    setLastResult(null)
+    const beforeIds = placement.snapshotBeforeIds()
+    const imported = await importOnePack(raw)
+    if (!imported.ok) {
+      setActionError(imported.error)
+      return
+    }
+    const { meta, validation } = imported
+    setLastResult({ id: meta.id, kind: 'success', message: t('common.saved') })
+    handleSelectLanguage(`pack:${meta.id}`)
+    await placement.place({ id: meta.id, name: meta.name }, { beforeIds })
+
+    if (extra.hubPostId) {
+      // Same Author/Updated enrichment as handleSync — the download
+      // body itself has no metadata, so look the post back up by name.
+      const enriched = validation.header
+        ? await fetchHubPackMeta(window.vialAPI.hubListI18nPosts, validation.header.name, extra.hubPostId)
+        : {}
+      void window.vialAPI.i18nPackSetHubPostId(meta.id, extra.hubPostId, enriched.uploaderName, enriched.hubUpdatedAt)
+      return
+    }
+    // Auto-sync to Hub when this overwrite landed on an entry that
+    // already mirrors a Hub post. Promote the inline badge from
+    // "Saved" to "Synced" so the user can see the second step
+    // completed; failure surfaces inline without rolling back local.
+    if (meta.hubPostId) {
+      const upd = await pushPackToHub(meta.id, meta.hubPostId)
+      if (upd.success) {
+        setLastResult({ id: meta.id, kind: 'success', message: t('common.synced') })
+      } else {
+        setActionError(upd.error ?? t('hub.updateFailed'))
+      }
+    }
+  }, [importOnePack, t, pushPackToHub, handleSelectLanguage, placement])
+
+  // Multi-file import batch: every selected file is parsed and saved
+  // independently here; dedupe, hub-sync, placement and the toolbar
+  // summary/failure banner are handled by the shared `useImportBatch`
+  // hook below (see its module doc for the extraction rationale). The
+  // snapshot is taken right after the "canceled" check — before any
+  // per-file save runs — matching `placement.snapshotEntries()`'s
+  // "before the batch's own mutations begin" contract.
+  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<I18nPackMeta> | null> => {
+    const dialogResult = await store.importFromDialog()
+    if (dialogResult.canceled) return null
+    const snapshot = placement.snapshotEntries()
+    const notSavedFailures: ImportBatchFailure[] = []
+    const successes: ImportBatchItem<I18nPackMeta>[] = []
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        notSavedFailures.push({ fileName, reason: file.parseError ?? t('i18n.errorInvalidJson') })
+        continue
+      }
+      const imported = await importOnePack(file.raw)
+      if (!imported.ok) {
+        notSavedFailures.push({ fileName, reason: imported.error })
+        continue
+      }
+      successes.push({ fileName, meta: imported.meta })
+    }
+    return { successes, notSavedFailures, snapshot }
+  }, [store, t, placement, importOnePack])
+
+  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<I18nPackMeta>({
+    open,
+    placement,
+    setLastResult,
+    setActionError,
+    t,
+    collectResults: collectImportResults,
+    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
+    onCollapsedToOne: (meta) => handleSelectLanguage(`pack:${meta.id}`),
+  })
+
+  // Closes any inline rename that was already open the moment a batch
+  // starts, so its input unmounts instead of sitting there interactive
+  // (and committable) for the whole duration of the import — see
+  // `handleRenameCommit`'s own `isImportingRef` guard above for the one
+  // race this cannot cover (a rename input's blur, and the click that
+  // starts the batch, are the same user click; the blur's commit is
+  // already in flight before `importing` ever flips true).
+  useEffect(() => {
+    if (importing) rename.cancelRename()
+    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
+    // intentionally not in the deps array so this only re-fires when
+    // `importing` itself flips, not on every unrelated render.
+  }, [importing])
+
+  // Explicit cloud pull: a 'packs'-scoped download (i18n + theme packs
+  // only) — see usePackCloudPull's doc for the discovery-gap rationale.
+  const pull = usePackCloudPull(setActionError, t, 'i18n.errorGeneric')
+
+  const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
+    setPendingId(postId)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await window.vialAPI.hubDownloadI18nPost(postId)
+      if (!result.success || !result.data) {
+        setActionError(result.error ?? t('i18n.errorGeneric'))
+        return
+      }
+      await persistImportedPack(result.data.pack, { hubPostId: postId })
+    } finally {
+      setPendingId(null)
+    }
+  }, [persistImportedPack, t])
+
+  return {
+    importing,
+    importSummary,
+    runImport,
+    handleRenameCommit,
+    handleRenameKey,
+    pull,
+    handleHubDownload,
+  }
+}

--- a/src/renderer/components/i18n-packs/use-language-pack-list.ts
+++ b/src/renderer/components/i18n-packs/use-language-pack-list.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Installed-tab row model (built-in English synthesis + imported packs)
+// plus drag reorder / Name sort / import placement, and the Find-on-Hub
+// browse list (search + freshness). Split out of LanguagePacksModal
+// (Task-split-pack-modals) — everything here derives from `store.metas`
+// and the active language, and is consumed by both the shell's JSX and
+// the sibling import hook (`placement`, `handleSelectLanguage`).
+
+import { useCallback, useMemo } from 'react'
+import type { TFunction } from 'i18next'
+import english from '../../i18n/locales/english.json'
+import i18n from '../../i18n'
+import { BASE_REVISION } from '../../i18n/coverage-cache'
+import type { useAppConfig } from '../../hooks/useAppConfig'
+import type { UseI18nPackStoreReturn } from '../../hooks/useI18nPackStore'
+import { BUILTIN_ENGLISH_PACK_ID } from '../../../shared/types/i18n-store'
+import type { HubI18nPostListItem } from '../../../shared/types/hub'
+import { useHubFreshness } from '../../hooks/useHubFreshness'
+import { useHubSearchList } from '../pack-modal/useHubSearchList'
+import { useDragReorder } from '../pack-modal/useDragReorder'
+import { applyDragOrder } from '../pack-modal/drag-order'
+import { useNameSort } from '../pack-modal/useNameSort'
+import { useImportPlacement } from '../pack-modal/useImportPlacement'
+import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
+import type { PackManagerTabId } from '../pack-modal/pack-modal-types'
+import { type InstalledRow, type HubRow } from './LanguageInstalledRow'
+
+const BUILTIN_INTERNAL_ID = 'builtin:en'
+
+export interface UseLanguagePackListOptions {
+  open: boolean
+  activeTab: PackManagerTabId
+  store: UseI18nPackStoreReturn
+  appConfig: ReturnType<typeof useAppConfig>
+  setActionError: (error: string | null) => void
+  t: TFunction
+}
+
+export function useLanguagePackList({
+  open,
+  activeTab,
+  store,
+  appConfig,
+  setActionError,
+  t,
+}: UseLanguagePackListOptions) {
+  const builtinName = (english as Record<string, unknown>).name as string ?? 'English'
+  const builtinVersion = (english as Record<string, unknown>).version as string ?? '0.1.0'
+
+  const activeLanguageId = appConfig.config.language ?? 'builtin:en'
+
+  // Built-in English's row shape is always this — hardcoded rather than
+  // read from the store meta, since the meta's own name/version/body is
+  // just a trivial placeholder (see `ensureBuiltinEnglishEntry`'s doc in
+  // main/i18n-pack-store.ts). Only `packId` varies: the real store id
+  // once `ensureBuiltinEnglishEntry` has run (normal case), or `null`
+  // during the brief pre-load window before `store.metas` has arrived —
+  // `null` also intentionally covers older/mocked stores in tests that
+  // don't include the entry, so this row's appearance never depends on
+  // the caller remembering to add it.
+  const builtinRow = useCallback((packId: string | null): InstalledRow => ({
+    reactKey: BUILTIN_INTERNAL_ID,
+    internalId: BUILTIN_INTERNAL_ID,
+    packId,
+    hubPostId: null,
+    name: builtinName,
+    version: builtinVersion,
+    updatedAt: __BUILD_TIME__,
+    uploaderName: 'pipette',
+    isBuiltin: true,
+    active: activeLanguageId === BUILTIN_INTERNAL_ID,
+    isComplete: true,
+  }), [builtinName, builtinVersion, activeLanguageId])
+
+  const installedRows: InstalledRow[] = useMemo(() => {
+    const rows: InstalledRow[] = []
+    let sawBuiltin = false
+    for (const meta of store.metas) {
+      if (meta.deletedAt) continue
+      if (meta.id === BUILTIN_ENGLISH_PACK_ID) {
+        sawBuiltin = true
+        rows.push(builtinRow(meta.id))
+        continue
+      }
+      const internalId = `pack:${meta.id}`
+      // A pack is "complete" only when its matchedBaseVersion equals
+      // the *current* English baseline. A stale match for an older
+      // baseline must surface as incomplete so the user sees the
+      // "not set keys" entry point against the new keys.
+      const isComplete = meta.matchedBaseVersion === BASE_REVISION
+      rows.push({
+        reactKey: meta.id,
+        internalId,
+        packId: meta.id,
+        hubPostId: meta.hubPostId ?? null,
+        name: meta.name,
+        // Display the English baseline version the pack proved it
+        // covers, not the pack's own semver. An empty string keeps
+        // the row visually consistent while signalling partial
+        // coverage to the user.
+        version: meta.matchedBaseVersion ?? '',
+        // Hub-side timestamp, not the local modification time — blank
+        // for never-uploaded local entries and legacy rows that
+        // predate this field, matching Key Labels' Updated column.
+        updatedAt: meta.hubUpdatedAt ?? '',
+        uploaderName: meta.uploaderName ?? '',
+        isBuiltin: false,
+        active: activeLanguageId === internalId,
+        coverage: meta.coverage,
+        isComplete,
+        meta,
+      })
+    }
+    if (!sawBuiltin) rows.unshift(builtinRow(null))
+    return rows
+  }, [store.metas, activeLanguageId, builtinRow])
+
+  const handleSelectLanguage = useCallback((internalId: string) => {
+    if (internalId === activeLanguageId) return
+    appConfig.set('language', internalId)
+    void i18n.changeLanguage(internalId)
+  }, [appConfig, activeLanguageId])
+
+  // Drag reorder + Name sort apply to every row with a real store id —
+  // now including built-in English once `ensureBuiltinEnglishEntry` has
+  // materialised it (see `installedRows` above). Only the transient
+  // pre-load fallback row (`packId === null`) is excluded, since there
+  // is no real id yet to persist an order against.
+  const draggableRows = useMemo(() => installedRows.filter((row) => row.packId !== null), [installedRows])
+  const dragReorderIds = useMemo(() => draggableRows.map((row) => row.packId as string), [draggableRows])
+  const drag = useDragReorder({
+    ids: dragReorderIds,
+    reorder: store.reorder,
+    onError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
+  })
+  const displayedRows = useMemo<InstalledRow[]>(() => {
+    const ordered = applyDragOrder(draggableRows, drag.dragOrder, (row) => row.packId as string)
+    // Only the pre-load fallback (no real builtin id yet) needs
+    // prepending by hand — the real entry already sits at its correct
+    // position within `draggableRows`/`drag.dragOrder`.
+    const fallbackBuiltin = installedRows.find((row) => row.isBuiltin && row.packId === null)
+    return fallbackBuiltin ? [fallbackBuiltin, ...ordered] : ordered
+  }, [installedRows, draggableRows, drag.dragOrder])
+
+  const nameSortEntries = useMemo(
+    () => draggableRows.map((row) => ({ id: row.packId as string, name: row.name })),
+    [draggableRows],
+  )
+  const nameSort = useNameSort({
+    open,
+    ready: !store.loading,
+    entries: nameSortEntries,
+    reorder: store.reorder,
+    onError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
+  })
+  const handleSortByName = useCallback((): void => {
+    void nameSort.toggle(draggableRows.map((row) => ({ id: row.packId as string, name: row.name })))
+  }, [nameSort, draggableRows])
+  const placement = useImportPlacement({
+    open,
+    entries: nameSortEntries,
+    direction: nameSort.direction,
+    reorder: store.reorder,
+    rowTestidPrefix: 'language-packs',
+    onReorderError: (error) => setActionError(error ?? t('i18n.errorGeneric')),
+  })
+
+  // hubPostId-first + name-fallback (unified with Theme Packs / Key
+  // Labels — see installed-detection.ts). Built-in English counts as
+  // an "installed" name too, so a Hub pack literally named "English"
+  // shows Installed instead of a misleading Download. Sourced from
+  // `builtinName` (the authoritative bundled name), not the store
+  // meta's own (placeholder) `name` field — the real builtin-english
+  // meta is explicitly excluded below to avoid listing it twice.
+  const installedEntries = useMemo<InstalledDetectionEntry[]>(() => [
+    { name: builtinName },
+    ...store.metas
+      .filter((m) => !m.deletedAt && m.id !== BUILTIN_ENGLISH_PACK_ID)
+      .map((m) => ({ hubPostId: m.hubPostId, name: m.name })),
+  ], [store.metas, builtinName])
+
+  const { search, setSearch, hubResults, hubSearched, hubSearching, runSearch } = useHubSearchList<HubI18nPostListItem>({
+    open,
+    activeTab,
+    hubTabId: 'hub',
+    fetchPage: (query) => window.vialAPI.hubListI18nPosts({ q: query }),
+    errorMessage: (error) => error ?? t('i18n.errorGeneric'),
+    onSearchStart: () => setActionError(null),
+    onError: setActionError,
+  })
+
+  const hubRows: HubRow[] = useMemo(() => hubResults.map((item) => ({
+    reactKey: item.id,
+    hubPostId: item.id,
+    name: item.name,
+    version: item.version,
+    uploaderName: item.uploaderName ?? '',
+    alreadyInstalled: isHubItemInstalled(item, installedEntries),
+  })), [hubResults, installedEntries])
+
+  const freshnessCandidates = useMemo(
+    () => store.metas
+      .filter((m) => !m.deletedAt && !!m.hubPostId)
+      .map((m) => ({ localId: m.id, hubPostId: m.hubPostId as string })),
+    [store.metas],
+  )
+
+  const fetchTimestamps = useCallback(
+    (ids: string[]) => window.vialAPI.i18nPackHubTimestamps(ids),
+    [],
+  )
+
+  const hubFreshness = useHubFreshness({
+    enabled: open && activeTab === 'installed',
+    candidates: freshnessCandidates,
+    fetchTimestamps,
+  })
+
+  return {
+    handleSelectLanguage,
+    displayedRows,
+    drag,
+    nameSort,
+    handleSortByName,
+    placement,
+    search,
+    setSearch,
+    hubResults,
+    hubSearched,
+    hubSearching,
+    runSearch,
+    hubRows,
+    hubFreshness,
+  }
+}

--- a/src/renderer/components/theme-packs/ThemeHubRow.tsx
+++ b/src/renderer/components/theme-packs/ThemeHubRow.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Find-on-Hub row for Theme Packs: wraps the shared PackHubResultRow
+// with a Preview toggle (leadingActions) ahead of the Download button.
+// Split out of ThemePacksModal (Task-split-pack-modals) — it was
+// already a standalone function component defined below the modal, so
+// this extraction only moves it into its own module.
+
+import { useTranslation } from 'react-i18next'
+import { PackHubResultRow } from '../pack-modal/PackHubResultRow'
+
+export interface ThemeHubRowData {
+  hubPostId: string
+  name: string
+  version: string
+  uploaderName: string
+  alreadyInstalled: boolean
+}
+
+export interface ThemeHubRowProps {
+  row: ThemeHubRowData
+  pendingId: string | null
+  /** Defensive: the Hub tab isn't meant to be operable mid-import
+   *  either, even though its own actions don't touch the Installed
+   *  list directly. */
+  importing: boolean
+  hubOrigin: string
+  previewPostId: string | null
+  onPreview: (postId: string) => void
+  onDownload: (postId: string) => void
+}
+
+export function ThemeHubRow({ row, pendingId, importing, previewPostId, onPreview, onDownload }: ThemeHubRowProps): JSX.Element {
+  const { t } = useTranslation()
+  const busy = pendingId === row.hubPostId || importing
+  return (
+    <PackHubResultRow
+      hubPostId={row.hubPostId}
+      testidPrefix="theme-packs"
+      name={row.name}
+      version={row.version}
+      uploaderName={row.uploaderName}
+      alreadyInstalled={row.alreadyInstalled}
+      busy={busy}
+      onDownload={() => onDownload(row.hubPostId)}
+      leadingActions={
+        <button
+          type="button"
+          className={`text-xs font-medium hover:underline disabled:opacity-50 ${
+            previewPostId === row.hubPostId ? 'text-success' : 'text-content-secondary'
+          }`}
+          onClick={() => onPreview(row.hubPostId)}
+          disabled={busy}
+          data-testid={`theme-packs-hub-preview-${row.hubPostId}`}
+        >
+          {previewPostId === row.hubPostId ? t('themePacks.previewing') : t('themePacks.preview')}
+        </button>
+      }
+    />
+  )
+}

--- a/src/renderer/components/theme-packs/ThemePacksModal.tsx
+++ b/src/renderer/components/theme-packs/ThemePacksModal.tsx
@@ -4,39 +4,33 @@
 //   - Built-in themes (System, Light, Dark) as a horizontal selector bar
 //   - Imported theme packs listed below with Select / Rename / Export / Delete
 //   - Import button in the Installed tab toolbar
+//
+// The row model (installed + Hub browse), Hub preview, the per-row
+// actions, and the import surface each live in their own sibling hook
+// (Task-split-pack-modals) — this shell only owns the 7 top-level
+// state atoms, the (non-preview) on-close reset, the built-in
+// System/Light/Dark selector, and the JSX.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Circle, CheckCircle2, Monitor, Sun, Moon } from 'lucide-react'
 import { ICON_MD } from '../../constants/ui-tokens'
 import { useAppConfig } from '../../hooks/useAppConfig'
 import { useInlineRename } from '../../hooks/useInlineRename'
 import { useThemePackStore } from '../../hooks/useThemePackStore'
-import { applyPackColors, clearPackColors, isPackTheme, extractPackId } from '../../hooks/useTheme'
-import type { ThemeColorScheme, ThemePackColors, ThemePackMeta } from '../../../shared/types/theme-store'
-import type { HubThemePostListItem, HubThemePackBody } from '../../../shared/types/hub'
 import { HUB_CATEGORY } from '../../../shared/hub-urls'
-import { useHubFreshness } from '../../hooks/useHubFreshness'
-import { localizeHubError } from '../../utils/hub-error-i18n'
 import type { ThemeMode, ThemeSelection } from '../../../shared/types/app-config'
 import { PackRow } from './ThemePackRow'
+import { ThemeHubRow } from './ThemeHubRow'
 import { PackManagerModal } from '../pack-modal/PackManagerModal'
 import { PackHubTab } from '../pack-modal/PackHubTab'
-import { PackHubResultRow } from '../pack-modal/PackHubResultRow'
 import { PackSortButton } from '../pack-modal/PackSortButton'
-import { usePackCloudPull } from '../pack-modal/usePackCloudPull'
 import { useHubOrigin } from '../pack-modal/useHubOrigin'
-import { useHubSearchList } from '../pack-modal/useHubSearchList'
-import { useDragReorder } from '../pack-modal/useDragReorder'
-import { applyDragOrder } from '../pack-modal/drag-order'
-import { useNameSort } from '../pack-modal/useNameSort'
-import { useImportPlacement } from '../pack-modal/useImportPlacement'
-import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
-import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
-import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
-import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
-import { isOwnPack } from '../pack-modal/ownership'
 import type { PackActionResult, PackManagerTabId } from '../pack-modal/pack-modal-types'
+import { useThemePreview } from './use-theme-preview'
+import { useThemePackList } from './use-theme-pack-list'
+import { useThemePackActions } from './use-theme-pack-actions'
+import { useThemePackImport } from './use-theme-pack-import'
 
 export interface ThemePacksModalProps {
   open: boolean
@@ -72,461 +66,85 @@ export function ThemePacksModal({
   const [pendingId, setPendingId] = useState<string | null>(null)
   const [lastResult, setLastResult] = useState<PackActionResult | PackActionResult[] | null>(null)
   const [previewPostId, setPreviewPostId] = useState<string | null>(null)
-  const previewSeqRef = useRef(0)
-  const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
-  const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
 
   const activeTheme = appConfig.config.theme
   const hubOrigin = useHubOrigin(open)
 
-  // hubPostId-first + name-fallback (unified with Language Packs / Key
-  // Labels — see installed-detection.ts).
-  const installedEntries = useMemo<InstalledDetectionEntry[]>(
-    () => store.metas.filter((m) => !m.deletedAt).map((m) => ({ hubPostId: m.hubPostId, name: m.name })),
-    [store.metas],
-  )
-
-  // Drag reorder + Name sort. The built-in System/Light/Dark selector
-  // bar is a separate UI block above this list (not a PackListRow),
-  // so every entry here is a real, draggable/sortable store pack.
-  const dragReorderIds = useMemo(() => store.metas.map((meta) => meta.id), [store.metas])
-  const drag = useDragReorder({
-    ids: dragReorderIds,
-    reorder: store.reorder,
-    onError: (error) => setActionError(error ?? t('themePacks.parseError')),
-  })
-  const displayedMetas = useMemo(
-    () => applyDragOrder(store.metas, drag.dragOrder, (meta) => meta.id),
-    [store.metas, drag.dragOrder],
-  )
-  const nameSortEntries = useMemo(
-    () => store.metas.map((meta) => ({ id: meta.id, name: meta.name })),
-    [store.metas],
-  )
-  const nameSort = useNameSort({
+  const { handlePreview, handleTabChange } = useThemePreview({
     open,
-    ready: !store.loading,
-    entries: nameSortEntries,
-    reorder: store.reorder,
-    onError: (error) => setActionError(error ?? t('themePacks.parseError')),
-  })
-  const handleSortByName = useCallback((): void => {
-    void nameSort.toggle(store.metas.map((meta) => ({ id: meta.id, name: meta.name })))
-  }, [nameSort, store.metas])
-  const placement = useImportPlacement({
-    open,
-    entries: nameSortEntries,
-    direction: nameSort.direction,
-    reorder: store.reorder,
-    rowTestidPrefix: 'theme-packs',
-    onReorderError: (error) => { if (error) setActionError(error) },
+    activeTheme,
+    previewPostId,
+    setPreviewPostId,
+    setActiveTab,
+    setPendingId,
   })
 
-  const freshnessCandidates = useMemo(
-    () => store.metas
-      .filter((m) => !m.deletedAt && !!m.hubPostId)
-      .map((m) => ({ localId: m.id, hubPostId: m.hubPostId as string })),
-    [store.metas],
-  )
-
-  const fetchTimestamps = useCallback(
-    (ids: string[]) => window.vialAPI.themePackHubTimestamps(ids),
-    [],
-  )
-
-  const hubFreshness = useHubFreshness({
-    enabled: open && activeTab === 'installed',
-    candidates: freshnessCandidates,
-    fetchTimestamps,
-  })
-
-  const { search, setSearch, hubResults, hubSearched, hubSearching, runSearch } = useHubSearchList<HubThemePostListItem>({
-    open,
-    activeTab,
-    hubTabId: 'hub',
-    fetchPage: (query) => window.vialAPI.hubListThemePosts({ q: query }),
-    errorMessage: (error) => error ?? t('themePacks.hubEmpty'),
-    onSearchStart: () => setActionError(null),
-    onError: setActionError,
-  })
-
-  const hubRows = useMemo(() => hubResults.map((item) => ({
-    hubPostId: item.id,
-    name: item.name,
-    version: item.version,
-    uploaderName: item.uploaderName ?? '',
-    alreadyInstalled: isHubItemInstalled(item, installedEntries),
-  })), [hubResults, installedEntries])
-
-  const restoreActiveTheme = useCallback(() => {
-    clearPackColors()
-    if (isPackTheme(activeTheme)) {
-      const packId = extractPackId(activeTheme)
-      const cached = activePackCacheRef.current
-      if (cached && cached.id === packId) {
-        applyPackColors(cached.colors, cached.colorScheme)
-      } else {
-        void window.vialAPI.themePackGet(packId).then((result) => {
-          if (result.success && result.data) {
-            activePackCacheRef.current = { id: packId, colors: result.data.pack.colors, colorScheme: result.data.pack.colorScheme }
-            applyPackColors(result.data.pack.colors, result.data.pack.colorScheme)
-          }
-        })
-      }
-    }
-    setPreviewPostId(null)
-  }, [activeTheme])
-
-  const handlePreview = useCallback(async (postId: string): Promise<void> => {
-    if (previewPostId === postId) {
-      restoreActiveTheme()
-      return
-    }
-    const cached = hubPreviewCacheRef.current.get(postId)
-    if (cached) {
-      applyPackColors(cached.colors as ThemePackColors, cached.colorScheme)
-      setPreviewPostId(postId)
-      return
-    }
-    const seq = ++previewSeqRef.current
-    setPendingId(postId)
-    try {
-      const result = await window.vialAPI.hubDownloadThemePost(postId)
-      if (!result.success || !result.data || previewSeqRef.current !== seq) return
-      hubPreviewCacheRef.current.set(postId, result.data)
-      applyPackColors(result.data.colors as ThemePackColors, result.data.colorScheme)
-      setPreviewPostId(postId)
-    } finally {
-      if (previewSeqRef.current === seq) setPendingId(null)
-    }
-  }, [previewPostId, restoreActiveTheme])
+  const {
+    displayedMetas,
+    drag,
+    nameSort,
+    handleSortByName,
+    placement,
+    hubFreshness,
+    search,
+    setSearch,
+    hubSearched,
+    hubSearching,
+    runSearch,
+    hubRows,
+    handleSelectTheme,
+  } = useThemePackList({ open, activeTab, store, activeTheme, onThemeChange, setActionError, t })
 
   useEffect(() => {
     if (!open) {
-      if (previewPostId) restoreActiveTheme()
       setActionError(null)
       setLastResult(null)
       setConfirmDeleteId(null)
       setConfirmRemoveId(null)
-      hubPreviewCacheRef.current.clear()
-      activePackCacheRef.current = null
     }
-  }, [open, previewPostId, restoreActiveTheme])
+  }, [open])
 
-  useEffect(() => {
-    activePackCacheRef.current = null
-  }, [activeTheme])
-
-  const pushPackToHub = useCallback(async (
-    packId: string,
-    hubPostId: string,
-  ): Promise<{ success: boolean; error?: string }> => {
-    const get = await window.vialAPI.themePackGet(packId)
-    if (!get.success || !get.data) {
-      return { success: false, error: get.error ?? t('themePacks.parseError') }
-    }
-    const res = await window.vialAPI.hubUpdateThemePost({
-      postId: hubPostId,
-      entryId: packId,
-      pack: get.data.pack as HubThemePackBody,
-    })
-    if (res.success) {
-      await store.refresh()
-      return { success: true }
-    }
-    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
-  }, [store, t])
-
-  const handleTabChange = useCallback((tab: PackManagerTabId) => {
-    if (tab === 'installed' && previewPostId) restoreActiveTheme()
-    setActiveTab(tab)
-  }, [previewPostId, restoreActiveTheme])
-
-  const handleSelectTheme = useCallback((selection: ThemeSelection) => {
-    if (selection === activeTheme) return
-    setActionError(null)
-    onThemeChange(selection)
-  }, [activeTheme, onThemeChange])
-
-  const handleExport = useCallback(async (id: string) => {
-    setActionError(null)
-    setPendingId(id)
-    try {
-      const result = await store.exportPack(id)
-      if (!result.success && result.error) setActionError(result.error)
-    } finally {
-      setPendingId(null)
-    }
-  }, [store])
-
-  const handleDelete = useCallback(async (id: string) => {
-    setActionError(null)
-    setLastResult(null)
-    setPendingId(id)
-    try {
-      const meta = store.metas.find((m) => m.id === id)
-      // Cascade to Hub only for posts *we* own — the orphan-post
-      // prevention argument (a local-only delete would strand a name
-      // nobody can re-upload) only holds for a post the user could
-      // actually re-upload themselves. A downloaded (foreign) pack
-      // also carries `hubPostId` (for Sync/freshness linkage), so
-      // gating on presence alone would attempt — and fail — a Hub
-      // delete the user has no rights to, then block the local delete
-      // on that failure. Not-owned entries delete locally only, no
-      // Hub call, same as Update/Remove's `isMine` gating.
-      if (meta?.hubPostId && isOwnPack(meta.hubPostId, meta.uploaderName ?? '', currentDisplayName)) {
-        // If the Hub deletion fails, abort the cascade — proceeding to
-        // a local-only delete would strand an orphan post whose name
-        // can never be re-uploaded, exactly what the cascade is meant
-        // to avoid.
-        const hubResult = await window.vialAPI.hubDeleteThemePost(meta.hubPostId, id)
-          .catch((err) => ({ success: false, error: err instanceof Error ? err.message : String(err) }))
-        if (!hubResult.success) {
-          setLastResult({ id, kind: 'error', message: hubResult.error ?? t('themePacks.parseError') })
-          return
-        }
-      }
-      const result = await store.remove(id)
-      if (!result.success && result.error) setActionError(result.error)
-      if (result.success && isPackTheme(activeTheme) && extractPackId(activeTheme) === id) {
-        onThemeChange('system')
-      }
-    } finally {
-      setPendingId(null)
-      setConfirmDeleteId(null)
-    }
-  }, [store, activeTheme, onThemeChange, t, currentDisplayName])
-
-  // Multi-file import batch: every selected file is saved independently
-  // here (theme pack validation lives entirely main-side in `savePack`,
-  // so there is no renderer-side pre-check to run first, unlike
-  // Language Packs); dedupe, hub-sync, placement and the toolbar
-  // summary/failure banner are handled by the shared `useImportBatch`
-  // hook below (see its module doc for the extraction rationale). The
-  // snapshot is taken right after the "canceled" check — before any
-  // per-file save runs — matching `placement.snapshotEntries()`'s
-  // "before the batch's own mutations begin" contract.
-  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<ThemePackMeta> | null> => {
-    const dialogResult = await store.importFromDialog()
-    if (dialogResult.canceled) return null
-    const snapshot = placement.snapshotEntries()
-    const notSavedFailures: ImportBatchFailure[] = []
-    const successes: ImportBatchItem<ThemePackMeta>[] = []
-    for (const file of dialogResult.files) {
-      const fileName = basenameOf(file.filePath)
-      if (file.parseError || file.raw === undefined) {
-        notSavedFailures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
-        continue
-      }
-      try {
-        const result = await store.applyImport(file.raw)
-        if (!result.success || !result.meta) {
-          notSavedFailures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
-          continue
-        }
-        successes.push({ fileName, meta: result.meta })
-      } catch {
-        notSavedFailures.push({ fileName, reason: t('themePacks.parseError') })
-      }
-    }
-    return { successes, notSavedFailures, snapshot }
-  }, [store, t, placement])
-
-  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<ThemePackMeta>({
-    open,
-    placement,
-    setLastResult,
-    setActionError,
+  const {
+    pushPackToHub,
+    handleExport,
+    handleDelete,
+    handleUpload,
+    handleUpdate,
+    handleSync,
+    handleRemove,
+  } = useThemePackActions({
+    store,
     t,
-    collectResults: collectImportResults,
-    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
-    onCollapsedToOne: (meta) => handleSelectTheme(`pack:${meta.id}`),
+    activeTheme,
+    onThemeChange,
+    currentDisplayName,
+    setPendingId,
+    setActionError,
+    setLastResult,
+    setConfirmDeleteId,
+    setConfirmRemoveId,
   })
 
-  // Closes any inline rename that was already open the moment a batch
-  // starts, so its input unmounts instead of sitting there interactive
-  // (and committable) for the whole duration of the import — see
-  // `handleRenameCommit`'s own `isImportingRef` guard below for the one
-  // race this cannot cover (a rename input's blur, and the click that
-  // starts the batch, are the same user click; the blur's commit is
-  // already in flight before `importing` ever flips true).
-  useEffect(() => {
-    if (importing) rename.cancelRename()
-    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
-    // intentionally not in the deps array so this only re-fires when
-    // `importing` itself flips, not on every unrelated render.
-  }, [importing])
-
-  const handleRenameCommit = useCallback(async (id: string) => {
-    // Guards on `useImportBatch`'s own re-entrancy ref rather than a
-    // locally-mirrored one — written only inside an event handler
-    // (`runImport`), never during render, so it can't go stale under a
-    // discarded/interrupted concurrent render. Referencing
-    // `isImportingRef` here, defined further up via `useImportBatch`,
-    // is safe regardless: this callback's body only runs later, on a
-    // real blur/Enter event, well after the full render has finished.
-    //
-    // A rename already committed its `store.rename` call the instant
-    // the underlying input blurred — including the blur a click on the
-    // Import button itself triggers, which fires before that click's
-    // own handler runs — so this check cannot intercept that exact
-    // call. It DOES catch every other path: a rename input left open
-    // when a batch was already running, and any stray commit that
-    // slips through after the cancel-on-import-start effect above has
-    // already reset the editor for this render.
-    if (isImportingRef.current) return
-    const newName = rename.commitRename(id)
-    if (!newName) return
-    setActionError(null)
-    setPendingId(id)
-    try {
-      const result = await store.rename(id, newName)
-      if (!result.success && result.error) {
-        setActionError(result.error)
-        return
-      }
-      const meta = store.metas.find((m) => m.id === id)
-      if (meta?.hubPostId) {
-        const upd = await pushPackToHub(id, meta.hubPostId)
-        if (upd.success) {
-          setLastResult({ id, kind: 'success', message: t('common.synced') })
-        } else {
-          setActionError(upd.error ?? t('hub.updateFailed'))
-        }
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [rename, store, t, pushPackToHub])
-
-  const handleUpload = useCallback(async (id: string): Promise<void> => {
-    setPendingId(id)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const get = await window.vialAPI.themePackGet(id)
-      if (!get.success || !get.data) {
-        setLastResult({ id, kind: 'error', message: get.error ?? t('themePacks.parseError') })
-        return
-      }
-      const result = await window.vialAPI.hubUploadThemePost({
-        entryId: id,
-        pack: get.data.pack as HubThemePackBody,
-      })
-      if (result.success) {
-        setLastResult({ id, kind: 'success', message: t('hub.uploadSuccess') })
-        await store.refresh()
-      } else {
-        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.uploadFailed') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [store, t])
-
-  const handleUpdate = useCallback(async (id: string): Promise<void> => {
-    const meta = store.metas.find((m) => m.id === id)
-    if (!meta?.hubPostId) return
-    setPendingId(id)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await pushPackToHub(id, meta.hubPostId)
-      if (result.success) {
-        setLastResult({ id, kind: 'success', message: t('hub.updateSuccess') })
-      } else {
-        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.updateFailed') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [store.metas, pushPackToHub, t])
-
-  const handleSync = useCallback(async (id: string): Promise<void> => {
-    const meta = store.metas.find((m) => m.id === id)
-    if (!meta?.hubPostId) return
-    setPendingId(id)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await window.vialAPI.hubDownloadThemePost(meta.hubPostId)
-      if (!result.success || !result.data) {
-        setLastResult({ id, kind: 'error', message: result.error ?? t('themePacks.parseError') })
-        return
-      }
-      // Refresh the Author/Updated cache the same way upload/update do —
-      // the download body carries no metadata, so look the post back up
-      // by its (possibly just-changed) name via the Hub list endpoint.
-      const enriched = await fetchHubPackMeta(window.vialAPI.hubListThemePosts, result.data.name, meta.hubPostId)
-      const apply = await store.applyImport(result.data, {
-        id,
-        hubPostId: meta.hubPostId,
-        hubUpdatedAt: enriched.hubUpdatedAt,
-        uploaderName: enriched.uploaderName,
-      })
-      if (apply.success) {
-        setLastResult({ id, kind: 'success', message: t('common.synced') })
-        await store.refresh()
-      } else {
-        setLastResult({ id, kind: 'error', message: apply.error ?? t('themePacks.parseError') })
-      }
-    } finally {
-      setPendingId(null)
-    }
-  }, [store, t])
-
-  const handleRemove = useCallback(async (id: string): Promise<void> => {
-    const meta = store.metas.find((m) => m.id === id)
-    if (!meta?.hubPostId) return
-    setPendingId(id)
-    setActionError(null)
-    setLastResult(null)
-    try {
-      const result = await window.vialAPI.hubDeleteThemePost(meta.hubPostId, id)
-      if (result.success) {
-        setLastResult({ id, kind: 'success', message: t('hub.removeSuccess') })
-        await store.refresh()
-      } else {
-        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.removeFailed') })
-      }
-    } finally {
-      setPendingId(null)
-      setConfirmRemoveId(null)
-    }
-  }, [store, t])
-
-  // Explicit cloud pull: a 'packs'-scoped download (i18n + theme packs
-  // only) — see usePackCloudPull's doc for the discovery-gap rationale.
-  const pull = usePackCloudPull(setActionError, t, 'themePacks.parseError')
-
-  const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
-    setPendingId(postId)
-    setActionError(null)
-    try {
-      const result = await window.vialAPI.hubDownloadThemePost(postId)
-      if (!result.success || !result.data) {
-        setActionError(result.error ?? t('themePacks.hubEmpty'))
-        return
-      }
-      const beforeIds = placement.snapshotBeforeIds()
-      const enriched = await fetchHubPackMeta(window.vialAPI.hubListThemePosts, result.data.name, postId)
-      const apply = await store.applyImport(result.data, { hubPostId: postId, hubUpdatedAt: enriched.hubUpdatedAt, uploaderName: enriched.uploaderName })
-      if (!apply.success || !apply.meta) return
-      await placement.place({ id: apply.meta.id, name: apply.meta.name }, { beforeIds })
-    } finally {
-      setPendingId(null)
-    }
-  }, [store, t, placement])
-
-  const handleRenameKey = (event: React.KeyboardEvent<HTMLInputElement>, id: string): void => {
-    if (event.key === 'Enter') {
-      event.preventDefault()
-      void handleRenameCommit(id)
-    } else if (event.key === 'Escape') {
-      event.preventDefault()
-      rename.cancelRename()
-    }
-  }
+  const {
+    importing,
+    importSummary,
+    runImport,
+    handleRenameCommit,
+    handleRenameKey,
+    pull,
+    handleHubDownload,
+  } = useThemePackImport({
+    open,
+    store,
+    t,
+    rename,
+    placement,
+    pushPackToHub,
+    handleSelectTheme,
+    setPendingId,
+    setActionError,
+    setLastResult,
+  })
 
   return (
     <PackManagerModal
@@ -668,58 +286,5 @@ export function ThemePacksModal({
         />
       )}
     </PackManagerModal>
-  )
-}
-
-/* ------------------------------------------------------------------ */
-
-interface ThemeHubRowData {
-  hubPostId: string
-  name: string
-  version: string
-  uploaderName: string
-  alreadyInstalled: boolean
-}
-
-interface ThemeHubRowProps {
-  row: ThemeHubRowData
-  pendingId: string | null
-  /** Defensive: the Hub tab isn't meant to be operable mid-import
-   *  either, even though its own actions don't touch the Installed
-   *  list directly. */
-  importing: boolean
-  hubOrigin: string
-  previewPostId: string | null
-  onPreview: (postId: string) => void
-  onDownload: (postId: string) => void
-}
-
-function ThemeHubRow({ row, pendingId, importing, previewPostId, onPreview, onDownload }: ThemeHubRowProps): JSX.Element {
-  const { t } = useTranslation()
-  const busy = pendingId === row.hubPostId || importing
-  return (
-    <PackHubResultRow
-      hubPostId={row.hubPostId}
-      testidPrefix="theme-packs"
-      name={row.name}
-      version={row.version}
-      uploaderName={row.uploaderName}
-      alreadyInstalled={row.alreadyInstalled}
-      busy={busy}
-      onDownload={() => onDownload(row.hubPostId)}
-      leadingActions={
-        <button
-          type="button"
-          className={`text-xs font-medium hover:underline disabled:opacity-50 ${
-            previewPostId === row.hubPostId ? 'text-success' : 'text-content-secondary'
-          }`}
-          onClick={() => onPreview(row.hubPostId)}
-          disabled={busy}
-          data-testid={`theme-packs-hub-preview-${row.hubPostId}`}
-        >
-          {previewPostId === row.hubPostId ? t('themePacks.previewing') : t('themePacks.preview')}
-        </button>
-      }
-    />
   )
 }

--- a/src/renderer/components/theme-packs/use-theme-pack-actions.ts
+++ b/src/renderer/components/theme-packs/use-theme-pack-actions.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Per-row Installed-tab actions for Theme Packs: Export, Delete (with
+// the owned-post Hub cascade), Upload / Update / Sync / Remove.
+// Split out of ThemePacksModal (Task-split-pack-modals) — mirrors
+// use-language-pack-actions.ts; `pushPackToHub` is returned because the
+// sibling import hook's rename-commit and multi-file batch reuse it for
+// their own auto-sync step.
+
+import { useCallback } from 'react'
+import type { TFunction } from 'i18next'
+import { isPackTheme, extractPackId } from '../../hooks/useTheme'
+import { localizeHubError } from '../../utils/hub-error-i18n'
+import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
+import { isOwnPack } from '../pack-modal/ownership'
+import type { HubThemePackBody } from '../../../shared/types/hub'
+import type { ThemeSelection } from '../../../shared/types/app-config'
+import type { UseThemePackStoreReturn } from '../../hooks/useThemePackStore'
+import type { PackActionResult } from '../pack-modal/pack-modal-types'
+
+export interface UseThemePackActionsOptions {
+  store: UseThemePackStoreReturn
+  t: TFunction
+  activeTheme: ThemeSelection
+  onThemeChange: (mode: ThemeSelection) => void
+  currentDisplayName: string | null
+  setPendingId: (id: string | null) => void
+  setActionError: (error: string | null) => void
+  setLastResult: (result: PackActionResult | PackActionResult[] | null) => void
+  setConfirmDeleteId: (id: string | null) => void
+  setConfirmRemoveId: (id: string | null) => void
+}
+
+export function useThemePackActions({
+  store,
+  t,
+  activeTheme,
+  onThemeChange,
+  currentDisplayName,
+  setPendingId,
+  setActionError,
+  setLastResult,
+  setConfirmDeleteId,
+  setConfirmRemoveId,
+}: UseThemePackActionsOptions) {
+  const pushPackToHub = useCallback(async (
+    packId: string,
+    hubPostId: string,
+  ): Promise<{ success: boolean; error?: string }> => {
+    const get = await window.vialAPI.themePackGet(packId)
+    if (!get.success || !get.data) {
+      return { success: false, error: get.error ?? t('themePacks.parseError') }
+    }
+    const res = await window.vialAPI.hubUpdateThemePost({
+      postId: hubPostId,
+      entryId: packId,
+      pack: get.data.pack as HubThemePackBody,
+    })
+    if (res.success) {
+      await store.refresh()
+      return { success: true }
+    }
+    return { success: false, error: localizeHubError(res.error, 'hub.updateFailed', t) }
+  }, [store, t])
+
+  const handleExport = useCallback(async (id: string) => {
+    setActionError(null)
+    setPendingId(id)
+    try {
+      const result = await store.exportPack(id)
+      if (!result.success && result.error) setActionError(result.error)
+    } finally {
+      setPendingId(null)
+    }
+  }, [store])
+
+  const handleDelete = useCallback(async (id: string) => {
+    setActionError(null)
+    setLastResult(null)
+    setPendingId(id)
+    try {
+      const meta = store.metas.find((m) => m.id === id)
+      // Cascade to Hub only for posts *we* own — the orphan-post
+      // prevention argument (a local-only delete would strand a name
+      // nobody can re-upload) only holds for a post the user could
+      // actually re-upload themselves. A downloaded (foreign) pack
+      // also carries `hubPostId` (for Sync/freshness linkage), so
+      // gating on presence alone would attempt — and fail — a Hub
+      // delete the user has no rights to, then block the local delete
+      // on that failure. Not-owned entries delete locally only, no
+      // Hub call, same as Update/Remove's `isMine` gating.
+      if (meta?.hubPostId && isOwnPack(meta.hubPostId, meta.uploaderName ?? '', currentDisplayName)) {
+        // If the Hub deletion fails, abort the cascade — proceeding to
+        // a local-only delete would strand an orphan post whose name
+        // can never be re-uploaded, exactly what the cascade is meant
+        // to avoid.
+        const hubResult = await window.vialAPI.hubDeleteThemePost(meta.hubPostId, id)
+          .catch((err) => ({ success: false, error: err instanceof Error ? err.message : String(err) }))
+        if (!hubResult.success) {
+          setLastResult({ id, kind: 'error', message: hubResult.error ?? t('themePacks.parseError') })
+          return
+        }
+      }
+      const result = await store.remove(id)
+      if (!result.success && result.error) setActionError(result.error)
+      if (result.success && isPackTheme(activeTheme) && extractPackId(activeTheme) === id) {
+        onThemeChange('system')
+      }
+    } finally {
+      setPendingId(null)
+      setConfirmDeleteId(null)
+    }
+  }, [store, activeTheme, onThemeChange, t, currentDisplayName])
+
+  const handleUpload = useCallback(async (id: string): Promise<void> => {
+    setPendingId(id)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const get = await window.vialAPI.themePackGet(id)
+      if (!get.success || !get.data) {
+        setLastResult({ id, kind: 'error', message: get.error ?? t('themePacks.parseError') })
+        return
+      }
+      const result = await window.vialAPI.hubUploadThemePost({
+        entryId: id,
+        pack: get.data.pack as HubThemePackBody,
+      })
+      if (result.success) {
+        setLastResult({ id, kind: 'success', message: t('hub.uploadSuccess') })
+        await store.refresh()
+      } else {
+        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.uploadFailed') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [store, t])
+
+  const handleUpdate = useCallback(async (id: string): Promise<void> => {
+    const meta = store.metas.find((m) => m.id === id)
+    if (!meta?.hubPostId) return
+    setPendingId(id)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await pushPackToHub(id, meta.hubPostId)
+      if (result.success) {
+        setLastResult({ id, kind: 'success', message: t('hub.updateSuccess') })
+      } else {
+        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.updateFailed') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [store.metas, pushPackToHub, t])
+
+  const handleSync = useCallback(async (id: string): Promise<void> => {
+    const meta = store.metas.find((m) => m.id === id)
+    if (!meta?.hubPostId) return
+    setPendingId(id)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await window.vialAPI.hubDownloadThemePost(meta.hubPostId)
+      if (!result.success || !result.data) {
+        setLastResult({ id, kind: 'error', message: result.error ?? t('themePacks.parseError') })
+        return
+      }
+      // Refresh the Author/Updated cache the same way upload/update do —
+      // the download body carries no metadata, so look the post back up
+      // by its (possibly just-changed) name via the Hub list endpoint.
+      const enriched = await fetchHubPackMeta(window.vialAPI.hubListThemePosts, result.data.name, meta.hubPostId)
+      const apply = await store.applyImport(result.data, {
+        id,
+        hubPostId: meta.hubPostId,
+        hubUpdatedAt: enriched.hubUpdatedAt,
+        uploaderName: enriched.uploaderName,
+      })
+      if (apply.success) {
+        setLastResult({ id, kind: 'success', message: t('common.synced') })
+        await store.refresh()
+      } else {
+        setLastResult({ id, kind: 'error', message: apply.error ?? t('themePacks.parseError') })
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [store, t])
+
+  const handleRemove = useCallback(async (id: string): Promise<void> => {
+    const meta = store.metas.find((m) => m.id === id)
+    if (!meta?.hubPostId) return
+    setPendingId(id)
+    setActionError(null)
+    setLastResult(null)
+    try {
+      const result = await window.vialAPI.hubDeleteThemePost(meta.hubPostId, id)
+      if (result.success) {
+        setLastResult({ id, kind: 'success', message: t('hub.removeSuccess') })
+        await store.refresh()
+      } else {
+        setLastResult({ id, kind: 'error', message: result.error ?? t('hub.removeFailed') })
+      }
+    } finally {
+      setPendingId(null)
+      setConfirmRemoveId(null)
+    }
+  }, [store, t])
+
+  return {
+    pushPackToHub,
+    handleExport,
+    handleDelete,
+    handleUpload,
+    handleUpdate,
+    handleSync,
+    handleRemove,
+  }
+}

--- a/src/renderer/components/theme-packs/use-theme-pack-import.ts
+++ b/src/renderer/components/theme-packs/use-theme-pack-import.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Import surface for Theme Packs: multi-file import batch, inline
+// rename commit (auto-sync on a Hub-linked pack), the explicit cloud
+// pull, and Hub-download-to-import. Split out of ThemePacksModal
+// (Task-split-pack-modals) — mirrors use-language-pack-import.ts; rename
+// lives here rather than in the actions hook because it needs
+// `useImportBatch`'s own `isImportingRef` re-entrancy guard, which only
+// exists once this hook creates it.
+
+import { useCallback, useEffect } from 'react'
+import type { TFunction } from 'i18next'
+import type { ThemePackMeta } from '../../../shared/types/theme-store'
+import { usePackCloudPull } from '../pack-modal/usePackCloudPull'
+import { useImportBatch, type CollectedImportBatch, type ImportBatchItem } from '../pack-modal/useImportBatch'
+import { basenameOf, type ImportBatchFailure } from '../pack-modal/import-batch-summary'
+import { fetchHubPackMeta } from '../pack-modal/fetch-hub-pack-meta'
+import type { UseImportPlacementResult } from '../pack-modal/useImportPlacement'
+import type { InlineRename } from '../../hooks/useInlineRename'
+import type { UseThemePackStoreReturn } from '../../hooks/useThemePackStore'
+import type { ThemeSelection } from '../../../shared/types/app-config'
+import type { PackActionResult } from '../pack-modal/pack-modal-types'
+
+export interface UseThemePackImportOptions {
+  open: boolean
+  store: UseThemePackStoreReturn
+  t: TFunction
+  rename: InlineRename<string>
+  placement: UseImportPlacementResult
+  pushPackToHub: (packId: string, hubPostId: string) => Promise<{ success: boolean; error?: string }>
+  handleSelectTheme: (selection: ThemeSelection) => void
+  setPendingId: (id: string | null) => void
+  setActionError: (error: string | null) => void
+  setLastResult: (result: PackActionResult | PackActionResult[] | null) => void
+}
+
+export function useThemePackImport({
+  open,
+  store,
+  t,
+  rename,
+  placement,
+  pushPackToHub,
+  handleSelectTheme,
+  setPendingId,
+  setActionError,
+  setLastResult,
+}: UseThemePackImportOptions) {
+  // Multi-file import batch: every selected file is saved independently
+  // here (theme pack validation lives entirely main-side in `savePack`,
+  // so there is no renderer-side pre-check to run first, unlike
+  // Language Packs); dedupe, hub-sync, placement and the toolbar
+  // summary/failure banner are handled by the shared `useImportBatch`
+  // hook below (see its module doc for the extraction rationale). The
+  // snapshot is taken right after the "canceled" check — before any
+  // per-file save runs — matching `placement.snapshotEntries()`'s
+  // "before the batch's own mutations begin" contract.
+  const collectImportResults = useCallback(async (): Promise<CollectedImportBatch<ThemePackMeta> | null> => {
+    const dialogResult = await store.importFromDialog()
+    if (dialogResult.canceled) return null
+    const snapshot = placement.snapshotEntries()
+    const notSavedFailures: ImportBatchFailure[] = []
+    const successes: ImportBatchItem<ThemePackMeta>[] = []
+    for (const file of dialogResult.files) {
+      const fileName = basenameOf(file.filePath)
+      if (file.parseError || file.raw === undefined) {
+        notSavedFailures.push({ fileName, reason: file.parseError ?? t('themePacks.parseError') })
+        continue
+      }
+      try {
+        const result = await store.applyImport(file.raw)
+        if (!result.success || !result.meta) {
+          notSavedFailures.push({ fileName, reason: result.error ?? t('themePacks.parseError') })
+          continue
+        }
+        successes.push({ fileName, meta: result.meta })
+      } catch {
+        notSavedFailures.push({ fileName, reason: t('themePacks.parseError') })
+      }
+    }
+    return { successes, notSavedFailures, snapshot }
+  }, [store, t, placement])
+
+  const { importing, importSummary, runImport, isImportingRef } = useImportBatch<ThemePackMeta>({
+    open,
+    placement,
+    setLastResult,
+    setActionError,
+    t,
+    collectResults: collectImportResults,
+    hubSync: (meta) => pushPackToHub(meta.id, meta.hubPostId!),
+    onCollapsedToOne: (meta) => handleSelectTheme(`pack:${meta.id}`),
+  })
+
+  // Closes any inline rename that was already open the moment a batch
+  // starts, so its input unmounts instead of sitting there interactive
+  // (and committable) for the whole duration of the import — see
+  // `handleRenameCommit`'s own `isImportingRef` guard below for the one
+  // race this cannot cover (a rename input's blur, and the click that
+  // starts the batch, are the same user click; the blur's commit is
+  // already in flight before `importing` ever flips true).
+  useEffect(() => {
+    if (importing) rename.cancelRename()
+    // `rename.cancelRename` is a stable (`useCallback([])`) identity —
+    // intentionally not in the deps array so this only re-fires when
+    // `importing` itself flips, not on every unrelated render.
+  }, [importing])
+
+  const handleRenameCommit = useCallback(async (id: string) => {
+    // Guards on `useImportBatch`'s own re-entrancy ref rather than a
+    // locally-mirrored one — written only inside an event handler
+    // (`runImport`), never during render, so it can't go stale under a
+    // discarded/interrupted concurrent render. Referencing
+    // `isImportingRef` here, defined further up via `useImportBatch`,
+    // is safe regardless: this callback's body only runs later, on a
+    // real blur/Enter event, well after the full render has finished.
+    //
+    // A rename already committed its `store.rename` call the instant
+    // the underlying input blurred — including the blur a click on the
+    // Import button itself triggers, which fires before that click's
+    // own handler runs — so this check cannot intercept that exact
+    // call. It DOES catch every other path: a rename input left open
+    // when a batch was already running, and any stray commit that
+    // slips through after the cancel-on-import-start effect above has
+    // already reset the editor for this render.
+    if (isImportingRef.current) return
+    const newName = rename.commitRename(id)
+    if (!newName) return
+    setActionError(null)
+    setPendingId(id)
+    try {
+      const result = await store.rename(id, newName)
+      if (!result.success && result.error) {
+        setActionError(result.error)
+        return
+      }
+      const meta = store.metas.find((m) => m.id === id)
+      if (meta?.hubPostId) {
+        const upd = await pushPackToHub(id, meta.hubPostId)
+        if (upd.success) {
+          setLastResult({ id, kind: 'success', message: t('common.synced') })
+        } else {
+          setActionError(upd.error ?? t('hub.updateFailed'))
+        }
+      }
+    } finally {
+      setPendingId(null)
+    }
+  }, [rename, store, t, pushPackToHub])
+
+  // Explicit cloud pull: a 'packs'-scoped download (i18n + theme packs
+  // only) — see usePackCloudPull's doc for the discovery-gap rationale.
+  const pull = usePackCloudPull(setActionError, t, 'themePacks.parseError')
+
+  const handleHubDownload = useCallback(async (postId: string): Promise<void> => {
+    setPendingId(postId)
+    setActionError(null)
+    try {
+      const result = await window.vialAPI.hubDownloadThemePost(postId)
+      if (!result.success || !result.data) {
+        setActionError(result.error ?? t('themePacks.hubEmpty'))
+        return
+      }
+      const beforeIds = placement.snapshotBeforeIds()
+      const enriched = await fetchHubPackMeta(window.vialAPI.hubListThemePosts, result.data.name, postId)
+      const apply = await store.applyImport(result.data, { hubPostId: postId, hubUpdatedAt: enriched.hubUpdatedAt, uploaderName: enriched.uploaderName })
+      if (!apply.success || !apply.meta) return
+      await placement.place({ id: apply.meta.id, name: apply.meta.name }, { beforeIds })
+    } finally {
+      setPendingId(null)
+    }
+  }, [store, t, placement])
+
+  const handleRenameKey = (event: React.KeyboardEvent<HTMLInputElement>, id: string): void => {
+    if (event.key === 'Enter') {
+      event.preventDefault()
+      void handleRenameCommit(id)
+    } else if (event.key === 'Escape') {
+      event.preventDefault()
+      rename.cancelRename()
+    }
+  }
+
+  return {
+    importing,
+    importSummary,
+    runImport,
+    handleRenameCommit,
+    handleRenameKey,
+    pull,
+    handleHubDownload,
+  }
+}

--- a/src/renderer/components/theme-packs/use-theme-pack-list.ts
+++ b/src/renderer/components/theme-packs/use-theme-pack-list.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Installed-tab row model (drag reorder / Name sort / import placement)
+// plus the Find-on-Hub browse list (search + freshness), and theme
+// selection. Split out of ThemePacksModal (Task-split-pack-modals) —
+// mirrors use-language-pack-list.ts; the built-in System/Light/Dark
+// selector bar itself stays in the shell's JSX since it isn't a store
+// row.
+
+import { useCallback, useMemo } from 'react'
+import type { TFunction } from 'i18next'
+import type { HubThemePostListItem } from '../../../shared/types/hub'
+import type { ThemeSelection } from '../../../shared/types/app-config'
+import type { UseThemePackStoreReturn } from '../../hooks/useThemePackStore'
+import { useHubFreshness } from '../../hooks/useHubFreshness'
+import { useHubSearchList } from '../pack-modal/useHubSearchList'
+import { useDragReorder } from '../pack-modal/useDragReorder'
+import { applyDragOrder } from '../pack-modal/drag-order'
+import { useNameSort } from '../pack-modal/useNameSort'
+import { useImportPlacement } from '../pack-modal/useImportPlacement'
+import { isHubItemInstalled, type InstalledDetectionEntry } from '../pack-modal/installed-detection'
+import type { PackManagerTabId } from '../pack-modal/pack-modal-types'
+
+export interface UseThemePackListOptions {
+  open: boolean
+  activeTab: PackManagerTabId
+  store: UseThemePackStoreReturn
+  activeTheme: ThemeSelection
+  onThemeChange: (mode: ThemeSelection) => void
+  setActionError: (error: string | null) => void
+  t: TFunction
+}
+
+export function useThemePackList({
+  open,
+  activeTab,
+  store,
+  activeTheme,
+  onThemeChange,
+  setActionError,
+  t,
+}: UseThemePackListOptions) {
+  // hubPostId-first + name-fallback (unified with Language Packs / Key
+  // Labels — see installed-detection.ts).
+  const installedEntries = useMemo<InstalledDetectionEntry[]>(
+    () => store.metas.filter((m) => !m.deletedAt).map((m) => ({ hubPostId: m.hubPostId, name: m.name })),
+    [store.metas],
+  )
+
+  // Drag reorder + Name sort. The built-in System/Light/Dark selector
+  // bar is a separate UI block above this list (not a PackListRow),
+  // so every entry here is a real, draggable/sortable store pack.
+  const dragReorderIds = useMemo(() => store.metas.map((meta) => meta.id), [store.metas])
+  const drag = useDragReorder({
+    ids: dragReorderIds,
+    reorder: store.reorder,
+    onError: (error) => setActionError(error ?? t('themePacks.parseError')),
+  })
+  const displayedMetas = useMemo(
+    () => applyDragOrder(store.metas, drag.dragOrder, (meta) => meta.id),
+    [store.metas, drag.dragOrder],
+  )
+  const nameSortEntries = useMemo(
+    () => store.metas.map((meta) => ({ id: meta.id, name: meta.name })),
+    [store.metas],
+  )
+  const nameSort = useNameSort({
+    open,
+    ready: !store.loading,
+    entries: nameSortEntries,
+    reorder: store.reorder,
+    onError: (error) => setActionError(error ?? t('themePacks.parseError')),
+  })
+  const handleSortByName = useCallback((): void => {
+    void nameSort.toggle(store.metas.map((meta) => ({ id: meta.id, name: meta.name })))
+  }, [nameSort, store.metas])
+  const placement = useImportPlacement({
+    open,
+    entries: nameSortEntries,
+    direction: nameSort.direction,
+    reorder: store.reorder,
+    rowTestidPrefix: 'theme-packs',
+    onReorderError: (error) => { if (error) setActionError(error) },
+  })
+
+  const freshnessCandidates = useMemo(
+    () => store.metas
+      .filter((m) => !m.deletedAt && !!m.hubPostId)
+      .map((m) => ({ localId: m.id, hubPostId: m.hubPostId as string })),
+    [store.metas],
+  )
+
+  const fetchTimestamps = useCallback(
+    (ids: string[]) => window.vialAPI.themePackHubTimestamps(ids),
+    [],
+  )
+
+  const hubFreshness = useHubFreshness({
+    enabled: open && activeTab === 'installed',
+    candidates: freshnessCandidates,
+    fetchTimestamps,
+  })
+
+  const { search, setSearch, hubResults, hubSearched, hubSearching, runSearch } = useHubSearchList<HubThemePostListItem>({
+    open,
+    activeTab,
+    hubTabId: 'hub',
+    fetchPage: (query) => window.vialAPI.hubListThemePosts({ q: query }),
+    errorMessage: (error) => error ?? t('themePacks.hubEmpty'),
+    onSearchStart: () => setActionError(null),
+    onError: setActionError,
+  })
+
+  const hubRows = useMemo(() => hubResults.map((item) => ({
+    hubPostId: item.id,
+    name: item.name,
+    version: item.version,
+    uploaderName: item.uploaderName ?? '',
+    alreadyInstalled: isHubItemInstalled(item, installedEntries),
+  })), [hubResults, installedEntries])
+
+  const handleSelectTheme = useCallback((selection: ThemeSelection) => {
+    if (selection === activeTheme) return
+    setActionError(null)
+    onThemeChange(selection)
+  }, [activeTheme, onThemeChange])
+
+  return {
+    displayedMetas,
+    drag,
+    nameSort,
+    handleSortByName,
+    placement,
+    hubFreshness,
+    search,
+    setSearch,
+    hubResults,
+    hubSearched,
+    hubSearching,
+    runSearch,
+    hubRows,
+    handleSelectTheme,
+  }
+}

--- a/src/renderer/components/theme-packs/use-theme-preview.ts
+++ b/src/renderer/components/theme-packs/use-theme-preview.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Hub-preview plumbing for Theme Packs: applying/restoring live theme
+// colors while browsing the Find-on-Hub tab, and the caches that keep
+// repeat previews / the active theme's own colors from re-fetching.
+// Split out of ThemePacksModal (Task-split-pack-modals) — `previewPostId`
+// itself is one of the shell's 7 state atoms and stays there; this hook
+// owns the refs and the effects/handlers that read and clear them.
+
+import { useCallback, useEffect, useRef } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { applyPackColors, clearPackColors, isPackTheme, extractPackId } from '../../hooks/useTheme'
+import type { ThemeColorScheme, ThemePackColors } from '../../../shared/types/theme-store'
+import type { HubThemePackBody } from '../../../shared/types/hub'
+import type { ThemeSelection } from '../../../shared/types/app-config'
+import type { PackManagerTabId } from '../pack-modal/pack-modal-types'
+
+export interface UseThemePreviewOptions {
+  open: boolean
+  activeTheme: ThemeSelection
+  previewPostId: string | null
+  setPreviewPostId: Dispatch<SetStateAction<string | null>>
+  setActiveTab: Dispatch<SetStateAction<PackManagerTabId>>
+  setPendingId: (id: string | null) => void
+}
+
+export function useThemePreview({
+  open,
+  activeTheme,
+  previewPostId,
+  setPreviewPostId,
+  setActiveTab,
+  setPendingId,
+}: UseThemePreviewOptions) {
+  const previewSeqRef = useRef(0)
+  const hubPreviewCacheRef = useRef(new Map<string, HubThemePackBody>())
+  const activePackCacheRef = useRef<{ id: string; colors: ThemePackColors; colorScheme: ThemeColorScheme } | null>(null)
+
+  const restoreActiveTheme = useCallback(() => {
+    clearPackColors()
+    if (isPackTheme(activeTheme)) {
+      const packId = extractPackId(activeTheme)
+      const cached = activePackCacheRef.current
+      if (cached && cached.id === packId) {
+        applyPackColors(cached.colors, cached.colorScheme)
+      } else {
+        void window.vialAPI.themePackGet(packId).then((result) => {
+          if (result.success && result.data) {
+            activePackCacheRef.current = { id: packId, colors: result.data.pack.colors, colorScheme: result.data.pack.colorScheme }
+            applyPackColors(result.data.pack.colors, result.data.pack.colorScheme)
+          }
+        })
+      }
+    }
+    setPreviewPostId(null)
+  }, [activeTheme])
+
+  const handlePreview = useCallback(async (postId: string): Promise<void> => {
+    if (previewPostId === postId) {
+      restoreActiveTheme()
+      return
+    }
+    const cached = hubPreviewCacheRef.current.get(postId)
+    if (cached) {
+      applyPackColors(cached.colors as ThemePackColors, cached.colorScheme)
+      setPreviewPostId(postId)
+      return
+    }
+    const seq = ++previewSeqRef.current
+    setPendingId(postId)
+    try {
+      const result = await window.vialAPI.hubDownloadThemePost(postId)
+      if (!result.success || !result.data || previewSeqRef.current !== seq) return
+      hubPreviewCacheRef.current.set(postId, result.data)
+      applyPackColors(result.data.colors as ThemePackColors, result.data.colorScheme)
+      setPreviewPostId(postId)
+    } finally {
+      if (previewSeqRef.current === seq) setPendingId(null)
+    }
+  }, [previewPostId, restoreActiveTheme])
+
+  // Preview-specific half of the on-close reset — the shell's own
+  // effect handles the non-preview state resets (action error / last
+  // result / confirm ids). Restoring the live theme and clearing the
+  // preview caches only matters while a preview was actually active.
+  useEffect(() => {
+    if (!open) {
+      if (previewPostId) restoreActiveTheme()
+      hubPreviewCacheRef.current.clear()
+      activePackCacheRef.current = null
+    }
+  }, [open, previewPostId, restoreActiveTheme])
+
+  useEffect(() => {
+    activePackCacheRef.current = null
+  }, [activeTheme])
+
+  const handleTabChange = useCallback((tab: PackManagerTabId) => {
+    if (tab === 'installed' && previewPostId) restoreActiveTheme()
+    setActiveTab(tab)
+  }, [previewPostId, restoreActiveTheme])
+
+  return {
+    restoreActiveTheme,
+    handlePreview,
+    handleTabChange,
+  }
+}


### PR DESCRIPTION
## Summary
- Split both pack-manager modal shells — `LanguagePacksModal.tsx` (848 lines) and `ThemePacksModal.tsx` (725 lines), UI Component cap 500 — in one pass with deliberately mirrored boundaries, since the two are near-twins (the shared `pack-modal/` layer is already mature; the residue is per-pack orchestration). i18n lands at 258 lines + `use-language-pack-{coverage,list,actions,import}`; theme lands at 290 lines + `ThemeHubRow` + `use-theme-{preview,pack-list,pack-actions,pack-import}`. No new shared code was introduced: the identified generification candidates are deferred so that a future dedup is a mechanical two-file diff of mirrored hooks.
- Constraints held: all extracted hooks are flat siblings of their modal (the test suites mock dependency modules by relative path, so a subdirectory would silently un-mock them); the seven state atoms stay in each shell with setters passed down; every dependency array was copied verbatim (verified line-by-line against HEAD — including the deliberately narrow coverage-effect and cancel-rename deps); both `testids` blocks passed to `PackManagerModal` are byte-identical, keeping the doc-capture selector contract.
- Two intentional non-pure-move notes: the rename handlers moved into each import hook, making the previous forward reference to `useImportBatch`'s importing ref local; and theme's single on-close effect is now two effects split by concern (shell keeps the non-preview state resets, the preview hook owns `restoreActiveTheme` and its now-hook-local caches) — the combined reset set was reviewed as identical.

## Verification
- Full suite: 362 test files, 8,184 passed / 22 skipped — exact baseline match, zero test edits (both modal suites, 1,489 + 1,209 lines, pass unedited; QuickSettingsSelects' named-export stubs unaffected).
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` clean; no hook imports its modal; export surfaces unchanged.