### PR TITLE
refactor(ui): split useInputModes into matrix, analytics, and result hooks

### DIFF
--- a/src/renderer/components/editors/use-matrix-tester.ts
+++ b/src/renderer/components/editors/use-matrix-tester.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
+
+export interface UseMatrixTesterOptions {
+  rows?: number
+  cols?: number
+  getMatrixState?: () => Promise<number[]>
+  unlocked?: boolean
+  onUnlock?: (options?: { macroWarning?: boolean }) => void
+  onMatrixModeChange?: (matrixMode: boolean, hasMatrixTester: boolean) => void
+}
+
+export interface UseMatrixTesterReturn {
+  matrixMode: boolean
+  pressedKeys: Set<string>
+  everPressedKeys: Set<string>
+  hasMatrixTester: boolean
+  handleMatrixToggle: () => void
+  /** Enters matrix mode directly, skipping the unlock gate — used by
+   *  useInputModes's beginTypingTest, which has already resolved unlock
+   *  itself before calling in (a typing test also drives the key matrix
+   *  as its input source). */
+  enterMatrixMode: () => void
+  /** Clears matrix state and exits matrix mode — also reused by the
+   *  typing-test lifecycle (host) when leaving the test view or when the
+   *  keyboard locks. */
+  resetMatrixState: () => void
+}
+
+/** Owns the key matrix tester: polling raw matrix state off the device,
+ *  tracking pressed/ever-pressed keys, and the unlock-gated enter/exit
+ *  flow. Also used as the typing test's input source, so `enterMatrixMode`
+ *  / `resetMatrixState` are exposed for the host to drive directly. */
+export function useMatrixTester({
+  rows,
+  cols,
+  getMatrixState,
+  unlocked,
+  onUnlock,
+  onMatrixModeChange,
+}: UseMatrixTesterOptions): UseMatrixTesterReturn {
+  const [matrixMode, setMatrixMode] = useState(false)
+  const [pressedKeys, setPressedKeys] = useState<Set<string>>(new Set())
+  const [everPressedKeys, setEverPressedKeys] = useState<Set<string>>(new Set())
+  const pollingRef = useRef(true)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  const hasMatrixTester = (getMatrixState != null && rows != null && cols != null) || matrixMode
+
+  useEffect(() => {
+    onMatrixModeChange?.(matrixMode, hasMatrixTester)
+  }, [matrixMode, hasMatrixTester, onMatrixModeChange])
+
+  // --- Matrix polling ---
+  const poll = useCallback(async () => {
+    if (!pollingRef.current || !getMatrixState || rows == null || cols == null) return
+    try {
+      const data = await getMatrixState()
+      if (!pollingRef.current) return
+      const pressed = parseMatrixState(data, rows, cols)
+      setPressedKeys(pressed)
+      setEverPressedKeys((prev) => {
+        const next = new Set(prev)
+        for (const key of pressed) next.add(key)
+        return next
+      })
+    } catch {
+      // device may disconnect
+    }
+    if (pollingRef.current) {
+      timerRef.current = setTimeout(poll, POLL_INTERVAL)
+    }
+  }, [getMatrixState, rows, cols])
+
+  useEffect(() => {
+    if (!matrixMode || !unlocked) return
+    pollingRef.current = true
+    poll()
+    return () => {
+      pollingRef.current = false
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [poll, matrixMode, unlocked])
+
+  // Deferred matrix mode entry
+  const [pendingMatrix, setPendingMatrix] = useState(false)
+
+  const enterMatrixMode = useCallback(() => {
+    setMatrixMode(true)
+  }, [])
+
+  useEffect(() => {
+    if (pendingMatrix && unlocked) {
+      setPendingMatrix(false)
+      enterMatrixMode()
+    }
+  }, [pendingMatrix, unlocked, enterMatrixMode])
+
+  const resetMatrixState = useCallback(() => {
+    setPressedKeys(new Set())
+    setEverPressedKeys(new Set())
+    setMatrixMode(false)
+  }, [])
+
+  // Exit key tester when the keyboard is locked
+  useEffect(() => {
+    if (!unlocked && matrixMode) resetMatrixState()
+  }, [unlocked, matrixMode, resetMatrixState])
+
+  const handleMatrixToggle = useCallback(() => {
+    if (matrixMode) {
+      resetMatrixState()
+    } else if (unlocked) {
+      enterMatrixMode()
+    } else {
+      setPendingMatrix(true)
+      onUnlock?.()
+    }
+  }, [matrixMode, unlocked, resetMatrixState, enterMatrixMode, onUnlock])
+
+  return {
+    matrixMode,
+    pressedKeys,
+    everPressedKeys,
+    hasMatrixTester,
+    handleMatrixToggle,
+    enterMatrixMode,
+    resetMatrixState,
+  }
+}

--- a/src/renderer/components/editors/use-typing-analytics-sink.ts
+++ b/src/renderer/components/editors/use-typing-analytics-sink.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useCallback, useRef } from 'react'
+import type { RefObject } from 'react'
+import { materialLabel } from '../../typing-test/result-builder'
+import type { TypingTestConfig } from '../../typing-test/types'
+import { useRunLogRecorder, type UseRunLogRecorderReturn } from './use-run-log-recorder'
+import type { TypingAnalyticsEventPayload, TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
+
+/** Analytics `typing_test` dimension label for the running test: the
+ *  imported text's name for fileImport, else `mode (language)` (e.g.
+ *  `words (english)`) so Analyze can slice normal runs by language too.
+ *  Delegates to `materialLabel` so the recording side and the Analyze run
+ *  filter produce the identical join key. */
+export function typingTestAnalyticsLabel(
+  config: TypingTestConfig,
+  language: string,
+  currentQuote: { source: string } | null,
+): string {
+  // Tatoeba's material label keys off the sentence-pack language (in the
+  // config), not the MonkeyType word language, so the recording side and the
+  // Analyze run filter still produce an identical join key.
+  const effectiveLanguage = config.mode === 'tatoeba' ? config.language : language
+  return materialLabel(config.mode, effectiveLanguage, currentQuote?.source)
+}
+
+/** Context captured by prepareAnalyticsEvent at press time and carried
+ *  opaquely through useTypingTest's ordering queue to emitAnalyticsEvent.
+ *  `typingTest`/`runId` are null for ordinary REC input (untagged); an
+ *  editor typing-test keystroke always has both set together. */
+export interface PreparedAnalyticsContext {
+  keyboard: TypingAnalyticsKeyboard
+  typingTest: string | null
+  runId: string | null
+  /** Window-focus state snapshotted at press time (see useTypingTest's
+   *  `onPrepareAnalyticsEvent` doc comment) — carried through to
+   *  `emitAnalyticsEvent` so the run-log recorder's defense-in-depth gate
+   *  (see run-log-recorder.ts's PRIVACY note) checks the value as of
+   *  when this keystroke actually happened, not whatever focus is by the
+   *  time a queued masked-key event finally ships. */
+  windowFocused: boolean
+}
+
+export interface UseTypingAnalyticsSinkOptions {
+  typingRecordKeyboard?: TypingAnalyticsKeyboard
+  /** Called once per matrix keystroke recorded while REC (Typing View
+   *  record toggle) is active — i.e. the same untagged events dispatched
+   *  to typingAnalyticsEvent, not the tagged editor-typing-test events.
+   *  Feeds the tray's session keystroke count (see useRecKeystrokeCounter
+   *  in App.tsx); this hook does no counting of its own. */
+  onRecKeystroke?: () => void
+  /** `AppConfig.typingRecordingConsentAccepted` — gates the per-run raw
+   *  keystroke log (see run-log-recorder.ts), independently of and
+   *  stricter than `typingRecordEnabled`'s per-minute analytics gate. */
+  recordingConsentAccepted?: boolean
+}
+
+export interface UseTypingAnalyticsSinkReturn {
+  /** The active keyboard, kept current here (not by the host) since
+   *  `typingRecordKeyboard` is an ordinary prop available before
+   *  useTypingTest is called. Exposed so use-typing-test-result-save can
+   *  read `.current?.uid` — deliberately as a ref, not a dep, in its
+   *  finish effect. */
+  keyboardRef: RefObject<TypingAnalyticsKeyboard | undefined>
+  /** Gates ambient REC input. Created here so `prepareAnalyticsEvent`
+   *  closes over a stable ref, but the host assigns `.current` from
+   *  `recordingActive` (view-only + record toggle) render-phase, since
+   *  useInputModes computes that condition itself. */
+  recordingActiveRef: RefObject<boolean>
+  /** Non-null while an editor typing-test run is the active tagged input
+   *  source. The host assigns `.current` render-phase from
+   *  `typingTest.state`, which only exists after the useTypingTest call —
+   *  this hook (and its refs) must be created before that call so
+   *  useTypingTest can capture the stable callbacks below on first
+   *  render. NEVER convert this assignment to a useEffect: it must be
+   *  visible to the same render's queue processing. */
+  testLabelRef: RefObject<string | null>
+  /** Travels with `testLabelRef` (run id) so each run's keystrokes are
+   *  separable — same host-assigns-render-phase contract. */
+  testRunIdRef: RefObject<string | null>
+  prepareAnalyticsEvent: (kind: 'matrix' | 'char', windowFocused: boolean) => PreparedAnalyticsContext | null
+  emitAnalyticsEvent: (context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload) => Promise<void>
+  flushAfterPendingEmits: (drained: Promise<void>, uid: string) => void
+  runLog: UseRunLogRecorderReturn
+}
+
+/** Owns the analytics event sink fed by useTypingTest's ordering queue:
+ *  the prepare/emit split (see prepareAnalyticsEvent's doc comment), the
+ *  per-emit IPC ordering chain, the flush-after-drain helper, and the
+ *  per-run raw keystroke log recorder (RunLogRecorder, one instance per
+ *  mount — see useRunLogRecorder). Called before useTypingTest so its
+ *  refs exist for the host to keep current and its callbacks can be
+ *  captured once by useTypingTest as stable references. */
+export function useTypingAnalyticsSink({
+  typingRecordKeyboard,
+  onRecKeystroke,
+  recordingConsentAccepted = false,
+}: UseTypingAnalyticsSinkOptions): UseTypingAnalyticsSinkReturn {
+  const keyboardRef = useRef(typingRecordKeyboard)
+  keyboardRef.current = typingRecordKeyboard
+  // Analytics event sink — two independent sources feed the same pipeline:
+  //   1. Typing View REC ambient typing — gated by recordingActiveRef
+  //      (record toggle ON + compact window open), emitted untagged.
+  //   2. A typing test running in the editor — gated by testLabelRef
+  //      (non-null while a test is the active input source), emitted with
+  //      a `typingTest` dimension tag so Analyze can slice by which test.
+  // recordingActiveRef/testLabelRef/testRunIdRef are updated by the host
+  // render-phase; keyboardRef/onRecKeystrokeRef are updated right here.
+  // Either way this stays a stable callback (useTypingTest captures it
+  // once).
+  const recordingActiveRef = useRef(false)
+  const testLabelRef = useRef<string | null>(null)
+  const testRunIdRef = useRef<string | null>(null)
+  const onRecKeystrokeRef = useRef(onRecKeystroke)
+  onRecKeystrokeRef.current = onRecKeystroke
+  // Per-run raw keystroke log recorder (see run-log-recorder.ts and
+  // use-run-log-recorder.ts) — one instance per editor session, mirroring
+  // matrixQueueRef's construction style in useTypingTest.ts.
+  const runLog = useRunLogRecorder({
+    recordingConsentAccepted,
+    keyboardUid: typingRecordKeyboard?.uid,
+    typingTestLabelRef: testLabelRef,
+  })
+  // The sink used to read recordingActiveRef / testLabelRef / testRunIdRef
+  // at the moment an event was actually sent, but a matrix event can now
+  // sit in useTypingTest's ordering queue for up to the tapping term
+  // (waiting on an unresolved tap-hold press ahead of it) before it gets
+  // that far. Reading live state that late meant a press authorized and
+  // tagged at press time could be silently dropped, or mistagged, by
+  // whatever the state had become by the time it was flushed — most
+  // visibly, stopping the record toggle mid-hold discarded every queued
+  // event instead of just the one it was meant to finalize.
+  //
+  // Splitting into prepare (called once, at press time) + emit (called
+  // once the event is actually ready to ship, immediately or off the
+  // back of the queue) fixes that: prepare captures the gate + tag
+  // decision when the keystroke happens and hands back an opaque
+  // context; emit only ever ships what prepare already decided.
+  const prepareAnalyticsEvent = useCallback((kind: 'matrix' | 'char', windowFocused: boolean): PreparedAnalyticsContext | null => {
+    const keyboard = keyboardRef.current
+    if (!keyboard) return null
+    const label = testLabelRef.current
+    if (!recordingActiveRef.current && !label) return null
+    // Tray keystroke count tracks REC only (untagged matrix events), not
+    // the editor typing-test practice mode — matches recordingActive's
+    // narrower definition (typingRecordEnabled && typingTestViewOnly).
+    // Counted here, at press time, rather than when the event eventually
+    // leaves the queue: the count is a live tray readout of physical
+    // keystrokes, and a masked key can otherwise sit unresolved for up to
+    // the tapping term before its emit — the user would see the tray lag
+    // behind their own typing. Firing once per authorized press here
+    // matches the previous call frequency (once per event that used to
+    // reach the sink) without that lag, and can't double-fire or fire for
+    // an unauthorized press since this whole branch is unreachable when
+    // this function returns null above.
+    if (!label && kind === 'matrix') {
+      onRecKeystrokeRef.current?.()
+    }
+    // A test keystroke carries both its material label and its run id; REC
+    // input carries neither (so it lands as the null run / null test).
+    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null, windowFocused }
+  }, [])
+  // Ordering contract, not an optimization: chaining every emit behind the
+  // previous one's IPC guarantees at most one typingAnalyticsEvent invoke
+  // is in flight at a time, so main's ingestEvent handlers can never
+  // interleave around their own internal `await resolveScope()` — the
+  // arrival order at main is always the call order here. Without this, a
+  // second event whose resolveScope() call resolves from a warm cache
+  // could reach the minute buffer before an earlier event still waiting
+  // on a cold-cache resolveScope(), reordering keystrokes.
+  //
+  // Four independent layers share the ordering job end to end, each
+  // covering what the one before it cannot:
+  //   - MatrixAnalyticsQueue (renderer): press-order classification —
+  //     decides tap vs. hold before anything reaches this sink.
+  //   - this chain (renderer): the arrival-order contract into main — at
+  //     most one IPC in flight, so decided order survives the IPC hop.
+  //   - MinuteBuffer retention (main): self-healing aggregation — a late
+  //     arrival re-dirties its entry instead of corrupting an already-flushed
+  //     minute, so a rare reorder or straggler heals on the next drain
+  //     rather than needing to never happen.
+  //   - `iki <= 0` guard (main, recordNgramChain): last-resort discard for
+  //     whatever tie/out-of-order pair still slips through all of the above.
+  const chainRef = useRef<Promise<void>>(Promise.resolve())
+  const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
+    // Run-keystroke-log capture — gates itself independently (see
+    // RunLogRecordContext); a no-op for ordinary REC input (context.typingTest
+    // null), without recording consent, or without window focus (see
+    // context.windowFocused's doc comment).
+    runLog.record({ typingTestLabel: context.typingTest, runId: context.runId, windowFocused: context.windowFocused }, payload)
+    const event = context.typingTest
+      ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
+      : { ...payload, keyboard: context.keyboard }
+    // The return value is only ever awaited by a forced drain
+    // (MatrixAnalyticsQueue.drainAll, via resetMatrixPressTracking) — the
+    // ordinary press/release/deadline paths call this and ignore it,
+    // staying fire-and-forget same as before. Caught here (not left to
+    // the caller) so a drain's Promise.all never rejects on an IPC error,
+    // and so one failed IPC doesn't stall every later link in the chain.
+    const next = chainRef.current
+      .then(() => window.vialAPI.typingAnalyticsEvent(event))
+      .catch(() => { /* fire-and-forget */ })
+    chainRef.current = next
+    return next
+  }, [])
+  /** Request a flush only after both `drained` and every event it just
+   * emitted have settled. `chainRef.current` must be read INSIDE the
+   * `.then()` — only after `drained` resolves — because draining is what
+   * pushes those emits onto the chain in the first place; reading it
+   * before `drained` resolves could capture the chain's state from
+   * before the drain ran. Shared by both flush sites (record-off, test
+   * finish): each has its own `drained` promise (from
+   * resetMatrixPressTracking) but the same requirement — main's
+   * ingestEvent does a real await (resolveScope) before an event reaches
+   * its minute buffer, so requesting the flush any earlier could have it
+   * serviced before a just-drained or still in-flight event lands,
+   * landing that event in a fresh buffer entry after the session it
+   * belonged to was already finalized.
+   *
+   * Reading `chainRef.current` here (rather than trusting emitAnalyticsEvent's
+   * return value alone) is also what survives a future refactor: useTypingTest's
+   * `onEmitAnalyticsEvent` is typed `=> void`, so nothing at the type level
+   * checks that emit keeps returning the chain tail — if a later change quietly
+   * dropped that return, this independent read of chainRef.current would still
+   * see the same in-flight state. */
+  const flushAfterPendingEmits = useCallback((drained: Promise<void>, uid: string): void => {
+    void drained
+      .then(() => chainRef.current)
+      .then(() => window.vialAPI.typingAnalyticsFlush(uid))
+      .catch(() => { /* fire-and-forget */ })
+  }, [])
+
+  return {
+    keyboardRef,
+    recordingActiveRef,
+    testLabelRef,
+    testRunIdRef,
+    prepareAnalyticsEvent,
+    emitAnalyticsEvent,
+    flushAfterPendingEmits,
+    runLog,
+  }
+}

--- a/src/renderer/components/editors/use-typing-test-result-save.ts
+++ b/src/renderer/components/editors/use-typing-test-result-save.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
+import type { useTypingTest } from '../../typing-test/useTypingTest'
+import { buildTypingTestResult, isPbForConfig } from '../../typing-test/result-builder'
+import { isRomajiInputActive } from '../../typing-test/romaji-input'
+import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
+import type { TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
+import type { UseRunLogRecorderReturn } from './use-run-log-recorder'
+
+export interface UseTypingTestResultSaveOptions {
+  typingTest: ReturnType<typeof useTypingTest>
+  typingTestViewOnly?: boolean
+  onSaveTypingTestResult?: (result: TypingTestResult) => void
+  saveUnnamed: boolean
+  typingTestHistory?: TypingTestResult[]
+  onRenameTypingTestResult?: (date: string, name: string) => void
+  /** Host-owned — a completed test makes any saved pause snapshot
+   *  obsolete. */
+  savedMemoryRef: RefObject<TypingTestMemory | undefined>
+  onMemoryChangeRef: RefObject<((memory: TypingTestMemory | undefined) => void) | undefined>
+  /** From use-typing-analytics-sink — read as a ref (not a dep) since the
+   *  active keyboard is deliberately excluded from the finish effect's
+   *  own dependency array. */
+  keyboardRef: RefObject<TypingAnalyticsKeyboard | undefined>
+  flushAfterPendingEmits: (drained: Promise<void>, uid: string) => void
+  runLog: UseRunLogRecorderReturn
+}
+
+export interface UseTypingTestResultSaveReturn {
+  /** The just-finished result — the held unsaved one when save-unnamed is off,
+   *  else the saved latest; null until a test finishes. For result-name chips. */
+  finishedResult: TypingTestResult | null
+  /** Name the just-finished result: persists a held unsaved result under the
+   *  name (save-unnamed off; blank → discarded) or renames the saved latest. */
+  nameFinishedResult: (name: string) => void
+}
+
+/** Owns the auto-save-on-finish lifecycle for an editor typing test run:
+ *  building and persisting the TypingTestResult row, flushing the run's
+ *  analytics, finalizing the per-run raw keystroke log (see
+ *  run-log-recorder.ts), and the save-unnamed naming flow. Called after
+ *  useTypingTest (needs `typingTest.state`) and after
+ *  use-typing-analytics-sink (consumes its keyboardRef/
+ *  flushAfterPendingEmits/runLog). */
+export function useTypingTestResultSave({
+  typingTest,
+  typingTestViewOnly,
+  onSaveTypingTestResult,
+  saveUnnamed,
+  typingTestHistory,
+  onRenameTypingTestResult,
+  savedMemoryRef,
+  onMemoryChangeRef,
+  keyboardRef,
+  flushAfterPendingEmits,
+  runLog,
+}: UseTypingTestResultSaveOptions): UseTypingTestResultSaveReturn {
+  const { resetMatrixPressTracking } = typingTest
+
+  // Auto-save typing test result when test finishes. With save-unnamed on
+  // (default) the result is persisted immediately; with it off the built
+  // result is held in `pendingUnnamedResult` and only saved once the user
+  // names it (commitPendingResult), so an unnamed run is discarded.
+  const savedResultRef = useRef(false)
+  const [pendingUnnamedResult, setPendingUnnamedResult] = useState<TypingTestResult | null>(null)
+  useEffect(() => {
+    if (typingTestViewOnly) return
+    if (typingTest.state.status === 'finished' && !savedResultRef.current && onSaveTypingTestResult) {
+      savedResultRef.current = true
+      const elapsed = typingTest.state.startTime && typingTest.state.endTime
+        ? typingTest.state.endTime - typingTest.state.startTime
+        : 0
+      const result = buildTypingTestResult({
+        correctChars: typingTest.state.correctChars,
+        incorrectChars: typingTest.state.incorrectChars,
+        wordCount: typingTest.state.currentWordIndex,
+        wpm: typingTest.wpm,
+        accuracy: typingTest.accuracy,
+        elapsedMs: elapsed,
+        config: typingTest.config,
+        language: typingTest.language,
+        wpmHistory: typingTest.state.wpmHistory,
+        fileImportTextName: typingTest.config.mode === 'fileImport' ? typingTest.state.currentQuote?.source : undefined,
+        runId: typingTest.state.runId,
+        romajiActive: isRomajiInputActive(typingTest.config, typingTest.language, typingTest.state.romajiCapable),
+        mistakes: typingTest.state.mistakes,
+        totalKeystrokes: typingTest.state.totalKeystrokes,
+        confirmedChars: typingTest.state.confirmedChars,
+        kspcUncomputable: typingTest.state.kspcUncomputable,
+        wordResults: typingTest.state.wordResults,
+      })
+      result.isPb = isPbForConfig(result, typingTestHistory ?? [])
+      if (saveUnnamed) {
+        onSaveTypingTestResult(result)
+      } else {
+        setPendingUnnamedResult(result)
+      }
+      // Flush the test's analytics so the just-finished minute/session
+      // lands in the cache promptly (Analyze can show it without waiting
+      // for the minute-close / before-quit flush). Keystrokes are recorded
+      // regardless of whether the result row is saved. See
+      // flushAfterPendingEmits for why the drain and the chain tail must
+      // both settle first.
+      const uid = keyboardRef.current?.uid
+      if (uid) flushAfterPendingEmits(resetMatrixPressTracking(), uid)
+      // The word the run ended on without submitting (e.g. a timed run
+      // expiring mid-word) — undefined when the run ended cleanly on a
+      // word boundary (currentWordIndex === words.length, every
+      // words/quote-mode finish) or with nothing typed into it yet.
+      // `currentInput` covers verbatim mode; `romajiKeystrokes` covers
+      // romaji mode (currentInput stays '' there — see handleRomajiChar
+      // in romaji-input.ts). See run-log-recorder.ts's `finish()`.
+      const typedSoFar = typingTest.state.currentInput || typingTest.state.romajiKeystrokes
+      const inFlightWord = typingTest.state.currentWordIndex < typingTest.state.words.length && typedSoFar.length > 0
+        ? { display: typingTest.state.words[typingTest.state.currentWordIndex], typed: typedSoFar }
+        : undefined
+      // Finalize the per-run raw keystroke log — discards outright when
+      // there's no active keyboard uid to save under; otherwise builds and
+      // saves it (itself a no-op unless this run was actually
+      // recorder-gated — see `record`'s own gate). Never
+      // truncated-and-saved: finish() refuses instead.
+      runLog.finishAndSave(uid, typingTest.state.wordResults, {
+        runId: typingTest.state.runId,
+        startedAtMs: typingTest.state.startTime ?? Date.now(),
+        durationMs: elapsed,
+        mode: typingTest.config.mode,
+        language: typingTest.language,
+        charCorrelationUnavailable: typingTest.state.kspcUncomputable,
+        // Reuse the same isRomajiInputActive determination already made
+        // for `result.romajiInput` above, rather than recomputing it —
+        // see RunLogFinishMeta.romajiInput's own doc comment.
+        romajiInput: result.romajiInput === true,
+        inFlightWord,
+      })
+      // A completed test makes any saved pause snapshot obsolete.
+      if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
+    }
+    if (typingTest.state.status !== 'finished') {
+      savedResultRef.current = false
+      // Leaving the finished state (next test / restart) drops an unsaved,
+      // still-unnamed result.
+      if (pendingUnnamedResult) setPendingUnnamedResult(null)
+    }
+  }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
+    typingTest.state.correctChars, typingTest.state.incorrectChars,
+    typingTest.state.currentWordIndex, typingTest.state.wpmHistory,
+    typingTest.state.currentQuote, typingTest.state.runId, typingTest.state.romajiCapable,
+    typingTest.state.totalKeystrokes, typingTest.state.confirmedChars, typingTest.state.kspcUncomputable,
+    typingTest.state.currentInput, typingTest.state.romajiKeystrokes, typingTest.state.words,
+    typingTest.wpm, typingTest.accuracy,
+    typingTest.config, typingTest.language,
+    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
+    resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave])
+
+  // The just-finished result, exposed so the pane can build name chips: the
+  // held unsaved one (save-unnamed off) until named, else the saved latest.
+  const finishedResult = typingTest.state.status === 'finished'
+    ? (pendingUnnamedResult ?? typingTestHistory?.[0] ?? null)
+    : null
+
+  // Name the just-finished result. A held unsaved result (save-unnamed off) is
+  // persisted under the name — blank keeps it discarded; otherwise the already
+  // saved latest result is renamed (save-unnamed on; blank clears its name).
+  const nameFinishedResult = useCallback((name: string) => {
+    if (pendingUnnamedResult) {
+      const trimmed = name.trim()
+      if (!trimmed) return
+      onSaveTypingTestResult?.({ ...pendingUnnamedResult, name: trimmed })
+      setPendingUnnamedResult(null)
+      return
+    }
+    const date = typingTestHistory?.[0]?.date
+    if (date) onRenameTypingTestResult?.(date, name)
+  }, [pendingUnnamedResult, onSaveTypingTestResult, onRenameTypingTestResult, typingTestHistory])
+
+  return { finishedResult, nameFinishedResult }
+}

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -2,49 +2,14 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { useTypingTest } from '../../typing-test/useTypingTest'
-import { buildTypingTestResult, isPbForConfig, materialLabel } from '../../typing-test/result-builder'
-import { isRomajiInputActive } from '../../typing-test/romaji-input'
 import type { TypingTestConfig } from '../../typing-test/types'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../typing-test/types'
-import { useRunLogRecorder } from './use-run-log-recorder'
+import { useMatrixTester } from './use-matrix-tester'
+import { useTypingAnalyticsSink, typingTestAnalyticsLabel } from './use-typing-analytics-sink'
+import { useTypingTestResultSave } from './use-typing-test-result-save'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
-import type { TypingAnalyticsEventPayload, TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
-import { parseMatrixState, POLL_INTERVAL } from './matrix-utils'
+import type { TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
 import { PROCESS_CODE_TO_KEY } from './keymap-editor-types'
-
-/** Analytics `typing_test` dimension label for the running test: the
- *  imported text's name for fileImport, else `mode (language)` (e.g.
- *  `words (english)`) so Analyze can slice normal runs by language too.
- *  Delegates to `materialLabel` so the recording side and the Analyze run
- *  filter produce the identical join key. */
-function typingTestAnalyticsLabel(
-  config: TypingTestConfig,
-  language: string,
-  currentQuote: { source: string } | null,
-): string {
-  // Tatoeba's material label keys off the sentence-pack language (in the
-  // config), not the MonkeyType word language, so the recording side and the
-  // Analyze run filter still produce an identical join key.
-  const effectiveLanguage = config.mode === 'tatoeba' ? config.language : language
-  return materialLabel(config.mode, effectiveLanguage, currentQuote?.source)
-}
-
-/** Context captured by prepareAnalyticsEvent at press time and carried
- *  opaquely through useTypingTest's ordering queue to emitAnalyticsEvent.
- *  `typingTest`/`runId` are null for ordinary REC input (untagged); an
- *  editor typing-test keystroke always has both set together. */
-interface PreparedAnalyticsContext {
-  keyboard: TypingAnalyticsKeyboard
-  typingTest: string | null
-  runId: string | null
-  /** Window-focus state snapshotted at press time (see useTypingTest's
-   *  `onPrepareAnalyticsEvent` doc comment) — carried through to
-   *  `emitAnalyticsEvent` so the run-log recorder's defense-in-depth gate
-   *  (see run-log-recorder.ts's PRIVACY note) checks the value as of
-   *  when this keystroke actually happened, not whatever focus is by the
-   *  time a queued masked-key event finally ships. */
-  windowFocused: boolean
-}
 
 export interface UseInputModesOptions {
   rows?: number
@@ -142,218 +107,31 @@ export function useInputModes({
   tappingTermMs,
   recordingConsentAccepted = false,
 }: UseInputModesOptions): UseInputModesReturn {
-  // --- Matrix tester state ---
-  const [matrixMode, setMatrixMode] = useState(false)
-  const [pressedKeys, setPressedKeys] = useState<Set<string>>(new Set())
-  const [everPressedKeys, setEverPressedKeys] = useState<Set<string>>(new Set())
-  const pollingRef = useRef(true)
-  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  // --- Matrix tester ---
+  const {
+    matrixMode,
+    pressedKeys,
+    everPressedKeys,
+    hasMatrixTester,
+    handleMatrixToggle,
+    enterMatrixMode,
+    resetMatrixState,
+  } = useMatrixTester({ rows, cols, getMatrixState, unlocked, onUnlock, onMatrixModeChange })
 
-  const hasMatrixTester = (getMatrixState != null && rows != null && cols != null) || matrixMode
-
-  useEffect(() => {
-    onMatrixModeChange?.(matrixMode, hasMatrixTester)
-  }, [matrixMode, hasMatrixTester, onMatrixModeChange])
-
-  // --- Matrix polling ---
-  const poll = useCallback(async () => {
-    if (!pollingRef.current || !getMatrixState || rows == null || cols == null) return
-    try {
-      const data = await getMatrixState()
-      if (!pollingRef.current) return
-      const pressed = parseMatrixState(data, rows, cols)
-      setPressedKeys(pressed)
-      setEverPressedKeys((prev) => {
-        const next = new Set(prev)
-        for (const key of pressed) next.add(key)
-        return next
-      })
-    } catch {
-      // device may disconnect
-    }
-    if (pollingRef.current) {
-      timerRef.current = setTimeout(poll, POLL_INTERVAL)
-    }
-  }, [getMatrixState, rows, cols])
-
-  useEffect(() => {
-    if (!matrixMode || !unlocked) return
-    pollingRef.current = true
-    poll()
-    return () => {
-      pollingRef.current = false
-      if (timerRef.current) clearTimeout(timerRef.current)
-    }
-  }, [poll, matrixMode, unlocked])
-
-  // Deferred matrix mode entry
-  const [pendingMatrix, setPendingMatrix] = useState(false)
-
-  const enterMatrixMode = useCallback(() => {
-    setMatrixMode(true)
-  }, [])
-
-  useEffect(() => {
-    if (pendingMatrix && unlocked) {
-      setPendingMatrix(false)
-      enterMatrixMode()
-    }
-  }, [pendingMatrix, unlocked, enterMatrixMode])
-
-  const resetMatrixState = useCallback(() => {
-    setPressedKeys(new Set())
-    setEverPressedKeys(new Set())
-    setMatrixMode(false)
-  }, [])
-
-  // Exit key tester when the keyboard is locked
-  useEffect(() => {
-    if (!unlocked && matrixMode) resetMatrixState()
-  }, [unlocked, matrixMode, resetMatrixState])
-
-  const handleMatrixToggle = useCallback(() => {
-    if (matrixMode) {
-      resetMatrixState()
-    } else if (unlocked) {
-      enterMatrixMode()
-    } else {
-      setPendingMatrix(true)
-      onUnlock?.()
-    }
-  }, [matrixMode, unlocked, resetMatrixState, enterMatrixMode, onUnlock])
+  // --- Analytics sink (must be called before useTypingTest so its refs
+  // exist for useTypingTest to capture the stable callbacks below). ---
+  const {
+    keyboardRef,
+    recordingActiveRef,
+    testLabelRef,
+    testRunIdRef,
+    prepareAnalyticsEvent,
+    emitAnalyticsEvent,
+    flushAfterPendingEmits,
+    runLog,
+  } = useTypingAnalyticsSink({ typingRecordKeyboard, onRecKeystroke, recordingConsentAccepted })
 
   // --- Typing test ---
-  const keyboardRef = useRef(typingRecordKeyboard)
-  keyboardRef.current = typingRecordKeyboard
-  // Analytics event sink — two independent sources feed the same pipeline:
-  //   1. Typing View REC ambient typing — gated by recordingActiveRef
-  //      (record toggle ON + compact window open), emitted untagged.
-  //   2. A typing test running in the editor — gated by testLabelRef
-  //      (non-null while a test is the active input source), emitted with
-  //      a `typingTest` dimension tag so Analyze can slice by which test.
-  // Both refs are updated below from render so this stays a stable callback
-  // (useTypingTest captures it once).
-  const recordingActiveRef = useRef(false)
-  const testLabelRef = useRef<string | null>(null)
-  const testRunIdRef = useRef<string | null>(null)
-  const onRecKeystrokeRef = useRef(onRecKeystroke)
-  onRecKeystrokeRef.current = onRecKeystroke
-  // Per-run raw keystroke log recorder (see run-log-recorder.ts and
-  // use-run-log-recorder.ts) — one instance per editor session, mirroring
-  // matrixQueueRef's construction style in useTypingTest.ts.
-  const runLog = useRunLogRecorder({
-    recordingConsentAccepted,
-    keyboardUid: typingRecordKeyboard?.uid,
-    typingTestLabelRef: testLabelRef,
-  })
-  // The sink used to read recordingActiveRef / testLabelRef / testRunIdRef
-  // at the moment an event was actually sent, but a matrix event can now
-  // sit in useTypingTest's ordering queue for up to the tapping term
-  // (waiting on an unresolved tap-hold press ahead of it) before it gets
-  // that far. Reading live state that late meant a press authorized and
-  // tagged at press time could be silently dropped, or mistagged, by
-  // whatever the state had become by the time it was flushed — most
-  // visibly, stopping the record toggle mid-hold discarded every queued
-  // event instead of just the one it was meant to finalize.
-  //
-  // Splitting into prepare (called once, at press time) + emit (called
-  // once the event is actually ready to ship, immediately or off the
-  // back of the queue) fixes that: prepare captures the gate + tag
-  // decision when the keystroke happens and hands back an opaque
-  // context; emit only ever ships what prepare already decided.
-  const prepareAnalyticsEvent = useCallback((kind: 'matrix' | 'char', windowFocused: boolean): PreparedAnalyticsContext | null => {
-    const keyboard = keyboardRef.current
-    if (!keyboard) return null
-    const label = testLabelRef.current
-    if (!recordingActiveRef.current && !label) return null
-    // Tray keystroke count tracks REC only (untagged matrix events), not
-    // the editor typing-test practice mode — matches recordingActive's
-    // narrower definition (typingRecordEnabled && typingTestViewOnly).
-    // Counted here, at press time, rather than when the event eventually
-    // leaves the queue: the count is a live tray readout of physical
-    // keystrokes, and a masked key can otherwise sit unresolved for up to
-    // the tapping term before its emit — the user would see the tray lag
-    // behind their own typing. Firing once per authorized press here
-    // matches the previous call frequency (once per event that used to
-    // reach the sink) without that lag, and can't double-fire or fire for
-    // an unauthorized press since this whole branch is unreachable when
-    // this function returns null above.
-    if (!label && kind === 'matrix') {
-      onRecKeystrokeRef.current?.()
-    }
-    // A test keystroke carries both its material label and its run id; REC
-    // input carries neither (so it lands as the null run / null test).
-    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null, windowFocused }
-  }, [])
-  // Ordering contract, not an optimization: chaining every emit behind the
-  // previous one's IPC guarantees at most one typingAnalyticsEvent invoke
-  // is in flight at a time, so main's ingestEvent handlers can never
-  // interleave around their own internal `await resolveScope()` — the
-  // arrival order at main is always the call order here. Without this, a
-  // second event whose resolveScope() call resolves from a warm cache
-  // could reach the minute buffer before an earlier event still waiting
-  // on a cold-cache resolveScope(), reordering keystrokes.
-  //
-  // Four independent layers share the ordering job end to end, each
-  // covering what the one before it cannot:
-  //   - MatrixAnalyticsQueue (renderer): press-order classification —
-  //     decides tap vs. hold before anything reaches this sink.
-  //   - this chain (renderer): the arrival-order contract into main — at
-  //     most one IPC in flight, so decided order survives the IPC hop.
-  //   - MinuteBuffer retention (main): self-healing aggregation — a late
-  //     arrival re-dirties its entry instead of corrupting an already-flushed
-  //     minute, so a rare reorder or straggler heals on the next drain
-  //     rather than needing to never happen.
-  //   - `iki <= 0` guard (main, recordNgramChain): last-resort discard for
-  //     whatever tie/out-of-order pair still slips through all of the above.
-  const chainRef = useRef<Promise<void>>(Promise.resolve())
-  const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
-    // Run-keystroke-log capture — gates itself independently (see
-    // RunLogRecordContext); a no-op for ordinary REC input (context.typingTest
-    // null), without recording consent, or without window focus (see
-    // context.windowFocused's doc comment).
-    runLog.record({ typingTestLabel: context.typingTest, runId: context.runId, windowFocused: context.windowFocused }, payload)
-    const event = context.typingTest
-      ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
-      : { ...payload, keyboard: context.keyboard }
-    // The return value is only ever awaited by a forced drain
-    // (MatrixAnalyticsQueue.drainAll, via resetMatrixPressTracking) — the
-    // ordinary press/release/deadline paths call this and ignore it,
-    // staying fire-and-forget same as before. Caught here (not left to
-    // the caller) so a drain's Promise.all never rejects on an IPC error,
-    // and so one failed IPC doesn't stall every later link in the chain.
-    const next = chainRef.current
-      .then(() => window.vialAPI.typingAnalyticsEvent(event))
-      .catch(() => { /* fire-and-forget */ })
-    chainRef.current = next
-    return next
-  }, [])
-  /** Request a flush only after both `drained` and every event it just
-   * emitted have settled. `chainRef.current` must be read INSIDE the
-   * `.then()` — only after `drained` resolves — because draining is what
-   * pushes those emits onto the chain in the first place; reading it
-   * before `drained` resolves could capture the chain's state from
-   * before the drain ran. Shared by both flush sites (record-off, test
-   * finish): each has its own `drained` promise (from
-   * resetMatrixPressTracking) but the same requirement — main's
-   * ingestEvent does a real await (resolveScope) before an event reaches
-   * its minute buffer, so requesting the flush any earlier could have it
-   * serviced before a just-drained or still in-flight event lands,
-   * landing that event in a fresh buffer entry after the session it
-   * belonged to was already finalized.
-   *
-   * Reading `chainRef.current` here (rather than trusting emitAnalyticsEvent's
-   * return value alone) is also what survives a future refactor: useTypingTest's
-   * `onEmitAnalyticsEvent` is typed `=> void`, so nothing at the type level
-   * checks that emit keeps returning the chain tail — if a later change quietly
-   * dropped that return, this independent read of chainRef.current would still
-   * see the same in-flight state. */
-  const flushAfterPendingEmits = useCallback((drained: Promise<void>, uid: string): void => {
-    void drained
-      .then(() => chainRef.current)
-      .then(() => window.vialAPI.typingAnalyticsFlush(uid))
-      .catch(() => { /* fire-and-forget */ })
-  }, [])
   const typingTest = useTypingTest(savedTypingTestConfig, savedTypingTestLanguage, {
     onPrepareAnalyticsEvent: prepareAnalyticsEvent,
     onEmitAnalyticsEvent: emitAnalyticsEvent,
@@ -512,121 +290,19 @@ export function useInputModes({
     return () => document.removeEventListener('keydown', handler, true)
   }, [typingTestMode, typingTestViewOnly, processKeyEvent])
 
-  // Auto-save typing test result when test finishes. With save-unnamed on
-  // (default) the result is persisted immediately; with it off the built
-  // result is held in `pendingUnnamedResult` and only saved once the user
-  // names it (commitPendingResult), so an unnamed run is discarded.
-  const savedResultRef = useRef(false)
-  const [pendingUnnamedResult, setPendingUnnamedResult] = useState<TypingTestResult | null>(null)
-  useEffect(() => {
-    if (typingTestViewOnly) return
-    if (typingTest.state.status === 'finished' && !savedResultRef.current && onSaveTypingTestResult) {
-      savedResultRef.current = true
-      const elapsed = typingTest.state.startTime && typingTest.state.endTime
-        ? typingTest.state.endTime - typingTest.state.startTime
-        : 0
-      const result = buildTypingTestResult({
-        correctChars: typingTest.state.correctChars,
-        incorrectChars: typingTest.state.incorrectChars,
-        wordCount: typingTest.state.currentWordIndex,
-        wpm: typingTest.wpm,
-        accuracy: typingTest.accuracy,
-        elapsedMs: elapsed,
-        config: typingTest.config,
-        language: typingTest.language,
-        wpmHistory: typingTest.state.wpmHistory,
-        fileImportTextName: typingTest.config.mode === 'fileImport' ? typingTest.state.currentQuote?.source : undefined,
-        runId: typingTest.state.runId,
-        romajiActive: isRomajiInputActive(typingTest.config, typingTest.language, typingTest.state.romajiCapable),
-        mistakes: typingTest.state.mistakes,
-        totalKeystrokes: typingTest.state.totalKeystrokes,
-        confirmedChars: typingTest.state.confirmedChars,
-        kspcUncomputable: typingTest.state.kspcUncomputable,
-        wordResults: typingTest.state.wordResults,
-      })
-      result.isPb = isPbForConfig(result, typingTestHistory ?? [])
-      if (saveUnnamed) {
-        onSaveTypingTestResult(result)
-      } else {
-        setPendingUnnamedResult(result)
-      }
-      // Flush the test's analytics so the just-finished minute/session
-      // lands in the cache promptly (Analyze can show it without waiting
-      // for the minute-close / before-quit flush). Keystrokes are recorded
-      // regardless of whether the result row is saved. See
-      // flushAfterPendingEmits for why the drain and the chain tail must
-      // both settle first.
-      const uid = keyboardRef.current?.uid
-      if (uid) flushAfterPendingEmits(resetMatrixPressTracking(), uid)
-      // The word the run ended on without submitting (e.g. a timed run
-      // expiring mid-word) — undefined when the run ended cleanly on a
-      // word boundary (currentWordIndex === words.length, every
-      // words/quote-mode finish) or with nothing typed into it yet.
-      // `currentInput` covers verbatim mode; `romajiKeystrokes` covers
-      // romaji mode (currentInput stays '' there — see handleRomajiChar
-      // in romaji-input.ts). See run-log-recorder.ts's `finish()`.
-      const typedSoFar = typingTest.state.currentInput || typingTest.state.romajiKeystrokes
-      const inFlightWord = typingTest.state.currentWordIndex < typingTest.state.words.length && typedSoFar.length > 0
-        ? { display: typingTest.state.words[typingTest.state.currentWordIndex], typed: typedSoFar }
-        : undefined
-      // Finalize the per-run raw keystroke log — discards outright when
-      // there's no active keyboard uid to save under; otherwise builds and
-      // saves it (itself a no-op unless this run was actually
-      // recorder-gated — see `record`'s own gate). Never
-      // truncated-and-saved: finish() refuses instead.
-      runLog.finishAndSave(uid, typingTest.state.wordResults, {
-        runId: typingTest.state.runId,
-        startedAtMs: typingTest.state.startTime ?? Date.now(),
-        durationMs: elapsed,
-        mode: typingTest.config.mode,
-        language: typingTest.language,
-        charCorrelationUnavailable: typingTest.state.kspcUncomputable,
-        // Reuse the same isRomajiInputActive determination already made
-        // for `result.romajiInput` above, rather than recomputing it —
-        // see RunLogFinishMeta.romajiInput's own doc comment.
-        romajiInput: result.romajiInput === true,
-        inFlightWord,
-      })
-      // A completed test makes any saved pause snapshot obsolete.
-      if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
-    }
-    if (typingTest.state.status !== 'finished') {
-      savedResultRef.current = false
-      // Leaving the finished state (next test / restart) drops an unsaved,
-      // still-unnamed result.
-      if (pendingUnnamedResult) setPendingUnnamedResult(null)
-    }
-  }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
-    typingTest.state.correctChars, typingTest.state.incorrectChars,
-    typingTest.state.currentWordIndex, typingTest.state.wpmHistory,
-    typingTest.state.currentQuote, typingTest.state.runId, typingTest.state.romajiCapable,
-    typingTest.state.totalKeystrokes, typingTest.state.confirmedChars, typingTest.state.kspcUncomputable,
-    typingTest.state.currentInput, typingTest.state.romajiKeystrokes, typingTest.state.words,
-    typingTest.wpm, typingTest.accuracy,
-    typingTest.config, typingTest.language,
-    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
-    resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave])
-
-  // The just-finished result, exposed so the pane can build name chips: the
-  // held unsaved one (save-unnamed off) until named, else the saved latest.
-  const finishedResult = typingTest.state.status === 'finished'
-    ? (pendingUnnamedResult ?? typingTestHistory?.[0] ?? null)
-    : null
-
-  // Name the just-finished result. A held unsaved result (save-unnamed off) is
-  // persisted under the name — blank keeps it discarded; otherwise the already
-  // saved latest result is renamed (save-unnamed on; blank clears its name).
-  const nameFinishedResult = useCallback((name: string) => {
-    if (pendingUnnamedResult) {
-      const trimmed = name.trim()
-      if (!trimmed) return
-      onSaveTypingTestResult?.({ ...pendingUnnamedResult, name: trimmed })
-      setPendingUnnamedResult(null)
-      return
-    }
-    const date = typingTestHistory?.[0]?.date
-    if (date) onRenameTypingTestResult?.(date, name)
-  }, [pendingUnnamedResult, onSaveTypingTestResult, onRenameTypingTestResult, typingTestHistory])
+  const { finishedResult, nameFinishedResult } = useTypingTestResultSave({
+    typingTest,
+    typingTestViewOnly,
+    onSaveTypingTestResult,
+    saveUnnamed,
+    typingTestHistory,
+    onRenameTypingTestResult,
+    savedMemoryRef,
+    onMemoryChangeRef,
+    keyboardRef,
+    flushAfterPendingEmits,
+    runLog,
+  })
 
   // Sync saved config/language from device prefs into useTypingTest
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Split `src/renderer/components/editors/useInputModes.ts` (731 lines, Custom Hook cap 600 — it had crept up ~30 lines per PR through the run-log era) into a 407-line orchestrating host plus three hooks matching its three responsibilities: `use-matrix-tester.ts` (132 — matrix mode state, polling, unlock-gated entry/exit), `use-typing-analytics-sink.ts` (243 — the analytics refs, the press-time prepare/emit pipeline with its serial IPC ordering contract, flush gating, and sole ownership of the `RunLogRecorder` instance so the empty-dependency callbacks remain provably stable), and `use-typing-test-result-save.ts` (179 — the finished-run persistence effect and result-naming derivations).
- The timing-sensitive invariants are preserved and proven: hook call order keeps every effect at its original registration position; the render-phase ref writes for the recording label/run-id stay render-phase in the host (the sink creates and exposes the refs — the host assigns after `useTypingTest`, matching the recorder-hook precedent); the drain/flush effect pair stays in the host beside `resetMatrixPressTracking`; and the finish effect's 25-entry dependency array is byte-identical, with the keyboard still reaching it as a ref rather than a dependency.
- The 15-field return surface is unchanged (including the currently-unconsumed `savedTypingTestMemory`, kept deliberately — surface cleanup is out of scope for a behavior-preserving pass).

## Verification
- Full suite: 362 test files, 8,184 passed / 22 skipped — exact baseline match, zero test edits; the analytics-ordering suite (press-time gating, serial chain, tray counting) and the run-log privacy suite (consent gating, unfocused attribution, pause-discard) pass unedited.
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` clean; no new file imports the host.