### PR TITLE
fix(ui): resolve analyze labels from the snapshot keymap

### DIFF
--- a/src/renderer/components/analyze/BigramsChart.tsx
+++ b/src/renderer/components/analyze/BigramsChart.tsx
@@ -15,6 +15,7 @@ import type {
 } from '../../../shared/types/typing-analytics'
 import { fetchBigramAggregateForRange } from './analyze-fetch'
 import { useKeycodeFingerMap } from './use-keycode-finger-map'
+import { useSnapshotQmkByCode } from './use-snapshot-qmk-by-code'
 import { aggregateBigramClasses } from './analyze-bigram-classes'
 import { aggregateWordPosition } from './analyze-bigram-word-position'
 import { ALL_PAIRS_LIMIT } from './analyze-constants'
@@ -163,6 +164,12 @@ export function BigramsChart({
   // quadrant nobody sees.
   const classesFingerMap = useKeycodeFingerMap(showFingerIki ? snapshot : null, fingerOverrides)
   const classesEntries = showFingerIki ? entries : EMPTY_CLASSES_ENTRIES
+
+  // Snapshot's own `code -> qmkId` map — threaded into Top/Slow pair
+  // labels below so they resolve from the snapshot's own recorded
+  // keymap strings instead of the session's `RAWCODES_MAP` (see
+  // analyze-snapshot-codes.ts / Task-speed-ranking-snapshot-labels.md).
+  const qmkByCode = useSnapshotQmkByCode(snapshot)
   const classesAggregate = useMemo(
     () => aggregateBigramClasses(classesEntries, classesFingerMap),
     [classesEntries, classesFingerMap],
@@ -205,7 +212,7 @@ export function BigramsChart({
           />
         }
       >
-        <TopRanking entries={entries} listLimit={topLimit} gram={gram} />
+        <TopRanking entries={entries} listLimit={topLimit} gram={gram} qmkByCode={qmkByCode} vialProtocol={snapshot?.vialProtocol} />
       </Quadrant>
       {showFingerIki && (
         <Quadrant
@@ -269,6 +276,8 @@ export function BigramsChart({
           listLimit={slowLimit}
           minAvgIkiMs={pairIntervalThresholdMs}
           gram={gram}
+          qmkByCode={qmkByCode}
+          vialProtocol={snapshot?.vialProtocol}
         />
       </Quadrant>
       {showFingerIki && (

--- a/src/renderer/components/analyze/BigramsRankingTables.tsx
+++ b/src/renderer/components/analyze/BigramsRankingTables.tsx
@@ -6,7 +6,7 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingBigramTopEntry } from '../../../shared/types/typing-analytics'
-import { bigramPairLabel, rolloverRatioFromEntry } from './analyze-bigram-format'
+import { bigramPairLabels, rolloverRatioFromEntry } from './analyze-bigram-format'
 import { avgIkiAtOrAboveThreshold, percentileFromHist } from './analyze-bigram-heatmap'
 import { fmtMs, formatPercentLabel } from './analyze-format'
 import { EmptyQuadrant } from './bigrams-quadrant-ui'
@@ -86,28 +86,41 @@ interface TopRankingProps {
   entries: readonly TypingBigramTopEntry[]
   listLimit: number
   gram: 2 | 3
+  /** Snapshot-derived `code -> qmkId` map (see `useSnapshotQmkByCode`)
+   * threaded into `bigramPairLabels` so pair labels resolve from the
+   * snapshot's own recorded keymap instead of the session's
+   * `RAWCODES_MAP`. Optional so existing callers/tests keep working
+   * unedited — absent, `bigramPairLabels` falls back to its
+   * pre-existing behavior. */
+  qmkByCode?: ReadonlyMap<number, string>
+  vialProtocol?: number
 }
 
-/** `TypingBigramTopEntry` plus the derived rollover fraction, so
- * `compareBySortKey` can sort on it the same generic way it sorts on
- * count/avgIki/sd — those are raw wire fields, `rollover` is computed
- * once per row instead. */
+/** `TypingBigramTopEntry` plus the derived rollover fraction and
+ * resolved pair label, so `compareBySortKey` can sort on the former
+ * the same generic way it sorts on count/avgIki/sd — those are raw
+ * wire fields, `rollover`/`label` are computed once per visible row
+ * instead (label via a single batched `bigramPairLabels` call over the
+ * whole capped set, not one `bigramPairLabel` call per rendered row —
+ * see that function's doc comment for why that matters when the
+ * snapshot's protocol differs from the session's). */
 interface TopRow extends TypingBigramTopEntry {
   rollover: number | null
+  label: string
 }
 
-function TopRanking({ entries, listLimit, gram }: TopRankingProps): JSX.Element {
+function TopRanking({ entries, listLimit, gram, qmkByCode, vialProtocol }: TopRankingProps): JSX.Element {
   const { t } = useTranslation()
   const [sort, setSort] = useState<SortState<TopSortKey>>({ key: 'count', dir: 'desc' })
   const toggle = (key: TopSortKey): void => setSort((prev) => toggleSort(prev, key))
 
   const sliced = useMemo<TopRow[]>(() => {
-    const arr: TopRow[] = entries
-      .slice(0, Math.max(listLimit, 0))
-      .map((e) => ({ ...e, rollover: rolloverRatioFromEntry(e) }))
+    const capped = entries.slice(0, Math.max(listLimit, 0))
+    const labels = bigramPairLabels(capped.map((e) => e.ngramId), qmkByCode, vialProtocol)
+    const arr: TopRow[] = capped.map((e, i) => ({ ...e, rollover: rolloverRatioFromEntry(e), label: labels[i] }))
     arr.sort((a, b) => compareBySortKey(a, b, sort))
     return arr
-  }, [entries, listLimit, sort])
+  }, [entries, listLimit, sort, qmkByCode, vialProtocol])
 
   if (sliced.length === 0) {
     return <EmptyQuadrant text={t('analyze.bigrams.empty')} />
@@ -161,7 +174,7 @@ function TopRanking({ entries, listLimit, gram }: TopRankingProps): JSX.Element 
         {sliced.map((entry, i) => (
           <tr key={entry.ngramId} className="border-t border-surface-dim">
             <td className="px-1 py-1 text-right tabular-nums text-content-muted">{i + 1}</td>
-            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.ngramId)}</td>
+            <td className="px-2 py-1 font-mono">{entry.label}</td>
             <td className="px-2 py-1 text-right tabular-nums">{entry.count.toLocaleString()}</td>
             <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.avgIki)}</td>
             <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.sd)}</td>
@@ -181,6 +194,7 @@ interface SlowEntry {
   sd: number | null
   p95: number | null
   rollover: number | null
+  label: string
 }
 
 interface SlowRankingProps {
@@ -190,15 +204,18 @@ interface SlowRankingProps {
    * `avgIkiAtOrAboveThreshold` for the bucket-center caveat. */
   minAvgIkiMs: number
   gram: 2 | 3
+  /** See `TopRankingProps.qmkByCode`. */
+  qmkByCode?: ReadonlyMap<number, string>
+  vialProtocol?: number
 }
 
-function SlowRanking({ entries, listLimit, minAvgIkiMs, gram }: SlowRankingProps): JSX.Element {
+function SlowRanking({ entries, listLimit, minAvgIkiMs, gram, qmkByCode, vialProtocol }: SlowRankingProps): JSX.Element {
   const { t } = useTranslation()
   const [sort, setSort] = useState<SortState<SlowSortKey>>({ key: 'avgIki', dir: 'desc' })
   const toggle = (key: SlowSortKey): void => setSort((prev) => toggleSort(prev, key))
 
   const slowEntries = useMemo<SlowEntry[]>(() => {
-    const eligible: SlowEntry[] = []
+    const eligible: Omit<SlowEntry, 'label'>[] = []
     for (const entry of entries) {
       const avg = avgIkiAtOrAboveThreshold(entry.hist, minAvgIkiMs)
       if (avg === null) continue
@@ -213,8 +230,10 @@ function SlowRanking({ entries, listLimit, minAvgIkiMs, gram }: SlowRankingProps
       })
     }
     eligible.sort((a, b) => compareBySortKey(a, b, sort))
-    return eligible.slice(0, Math.max(listLimit, 0))
-  }, [entries, listLimit, minAvgIkiMs, sort])
+    const capped = eligible.slice(0, Math.max(listLimit, 0))
+    const labels = bigramPairLabels(capped.map((e) => e.ngramId), qmkByCode, vialProtocol)
+    return capped.map((e, i) => ({ ...e, label: labels[i] }))
+  }, [entries, listLimit, minAvgIkiMs, sort, qmkByCode, vialProtocol])
 
   if (slowEntries.length === 0) {
     return <EmptyQuadrant text={t('analyze.bigrams.empty')} />
@@ -271,7 +290,7 @@ function SlowRanking({ entries, listLimit, minAvgIkiMs, gram }: SlowRankingProps
         {slowEntries.map((entry, i) => (
           <tr key={entry.ngramId} className="border-t border-surface-dim">
             <td className="px-1 py-1 text-right tabular-nums text-content-muted">{i + 1}</td>
-            <td className="px-2 py-1 font-mono">{bigramPairLabel(entry.ngramId)}</td>
+            <td className="px-2 py-1 font-mono">{entry.label}</td>
             <td className="px-2 py-1 text-right tabular-nums">{entry.count.toLocaleString()}</td>
             <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.avgIki)}</td>
             <td className="px-2 py-1 text-right tabular-nums">{fmtMs(entry.sd)}</td>

--- a/src/renderer/components/analyze/KeyHeatmapChart.tsx
+++ b/src/renderer/components/analyze/KeyHeatmapChart.tsx
@@ -22,6 +22,7 @@ import {
   RankingTable,
 } from './key-heatmap-panels'
 import { HeatmapModeToggle, LayerToggleRow, RankingControls } from './key-heatmap-controls'
+import { useSnapshotQmkByCode } from './use-snapshot-qmk-by-code'
 import {
   MIN_DURATION_SAMPLE_COUNT,
   MIN_SPEED_SAMPLE_COUNT,
@@ -175,6 +176,14 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, typingTest
 
   const layout = snapshot.layout as KeyboardLayout | null
 
+  // Snapshot's own `code -> qmkId` map — threaded into the Speed
+  // ranking below so its labels/group-filter resolve from the
+  // snapshot's own recorded keymap strings instead of the session's
+  // `RAWCODES_MAP` (see analyze-snapshot-codes.ts /
+  // Task-speed-ranking-snapshot-labels.md). `buildSpeedFillByPos`
+  // doesn't need it — it only matches numeric codes, never labels.
+  const qmkByCode = useSnapshotQmkByCode(snapshot)
+
   const layerKeycodes = useMemo(() => {
     const m = new Map<number, LayerKeycodes>()
     for (const layer of selectedLayers) {
@@ -229,8 +238,8 @@ export function KeyHeatmapChart({ uid, range, deviceScope, appScopes, typingTest
     return result
   }, [mode, selectedLayers, layerKeycodes, positions, speedIntensityByCode, durationIntensityByCellKey, keyGroupFilter, effectiveTheme, snapshot.vialProtocol])
   const speedRanking = useMemo(
-    () => (mode === 'speed' ? buildSpeedRanking(speedMap, keyGroupFilter, frequentUsedN, snapshot.vialProtocol) : []),
-    [mode, speedMap, keyGroupFilter, frequentUsedN, snapshot.vialProtocol],
+    () => (mode === 'speed' ? buildSpeedRanking(speedMap, keyGroupFilter, frequentUsedN, snapshot.vialProtocol, qmkByCode) : []),
+    [mode, speedMap, keyGroupFilter, frequentUsedN, snapshot.vialProtocol, qmkByCode],
   )
   // Gated the same way `groupRankings` (Count) is below: without the
   // `mode === 'duration'` guard this recomputed on every ranking-control

--- a/src/renderer/components/analyze/__tests__/analyze-bigram-format.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-bigram-format.test.ts
@@ -1,7 +1,49 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { describe, it, expect } from 'vitest'
-import { bigramPairLabel, rolloverRatioFromEntry } from '../analyze-bigram-format'
+import { afterEach, describe, it, expect } from 'vitest'
+import { bigramPairLabel, bigramPairLabels, rolloverRatioFromEntry } from '../analyze-bigram-format'
+import { buildSnapshotQmkByCode } from '../analyze-snapshot-codes'
+import { recreateKeyboardKeycodes } from '../../../../shared/keycodes/keycodes'
+import type { TypingKeymapSnapshot } from '../../../../shared/types/typing-analytics'
+
+function snapshotWithKeymap(keymap: string[][][], vialProtocol?: number): TypingKeymapSnapshot {
+  return {
+    uid: '0x00',
+    machineHash: 'h',
+    productName: 'Test',
+    savedAt: 0,
+    layers: keymap.length,
+    matrix: { rows: keymap[0]?.length ?? 0, cols: keymap[0]?.[0]?.length ?? 0 },
+    keymap,
+    layout: null,
+    vialProtocol,
+  }
+}
+
+/** Registers the CURRENT session's keyboard as a small one — 4 layers,
+ * 16 macros — the same shape-mismatch setup as
+ * key-heatmap-helpers-speed.test.ts's `useSmallSessionKeyboard`. */
+function useSmallSessionKeyboard(): void {
+  recreateKeyboardKeycodes({
+    vialProtocol: 6,
+    layers: 4,
+    macroCount: 16,
+    tapDanceCount: 0,
+    customKeycodes: null,
+    midi: '',
+    supportedFeatures: new Set(),
+  })
+}
+
+// Re-pins the module-global keyboard registration to this same small
+// shape after every test in this file — see the matching afterEach in
+// key-heatmap-helpers-speed.test.ts for why it must be this exact
+// small shape and not a bigger "default" one (`qmkIdToKeycode` only
+// ever grows, so widening it here would permanently make `M20`
+// resolvable for the rest of this file's run).
+afterEach(() => {
+  useSmallSessionKeyboard()
+})
 
 describe('bigramPairLabel', () => {
   it('decodes a numeric pair id into prev → curr labels', () => {
@@ -44,6 +86,46 @@ describe('bigramPairLabel', () => {
     expect(label).toContain(' → ')
     // Right-hand side is KC_A, which is always populated.
     expect(label.endsWith('A')).toBe(true)
+  })
+
+  it('resolves a code from the snapshot\'s own qmk map instead of the session RAWCODES_MAP', () => {
+    // Session only knows about 4 layers / 16 macros; the snapshot was
+    // recorded by an 8-layer / 32-macro keyboard, so "M20" is a code
+    // this session can't round-trip through `serialize` on its own —
+    // see Task-speed-ranking-snapshot-labels.md.
+    useSmallSessionKeyboard()
+    const snapshot = snapshotWithKeymap([[['M20', 'KC_A']]])
+    const qmkByCode = buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    const m20Code = [...qmkByCode.entries()].find(([, id]) => id === 'M20')?.[0]
+    const aCode = [...qmkByCode.entries()].find(([, id]) => id === 'KC_A')?.[0]
+    expect(m20Code).toBeDefined()
+    expect(aCode).toBeDefined()
+
+    expect(bigramPairLabel(`${m20Code}_${aCode}`, qmkByCode, snapshot.vialProtocol)).toBe('M20 → A')
+  })
+
+  it('still falls back to codeToLabel for a code absent from the map (unedited call keeps working)', () => {
+    // No qmkByCode/vialProtocol passed — must match the pre-existing,
+    // wrapper-less behavior exactly.
+    expect(bigramPairLabel('4_11')).toBe('A → H')
+  })
+})
+
+describe('bigramPairLabels (batched sibling of bigramPairLabel)', () => {
+  it('resolves the same label per id as calling bigramPairLabel individually', () => {
+    const ids = ['4_11', '42_42', 'not-a-bigram', '4_11_42']
+    expect(bigramPairLabels(ids)).toEqual(ids.map((id) => bigramPairLabel(id)))
+  })
+
+  it('resolves every id\'s miss codes under a single shared protocol scope', () => {
+    useSmallSessionKeyboard()
+    const snapshot = snapshotWithKeymap([[['M20', 'KC_A']]])
+    const qmkByCode = buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    const m20Code = [...qmkByCode.entries()].find(([, id]) => id === 'M20')?.[0]
+    const aCode = [...qmkByCode.entries()].find(([, id]) => id === 'KC_A')?.[0]
+
+    const labels = bigramPairLabels([`${m20Code}_${aCode}`, '4_11'], qmkByCode, snapshot.vialProtocol)
+    expect(labels).toEqual(['M20 → A', 'A → H'])
   })
 })
 

--- a/src/renderer/components/analyze/__tests__/analyze-snapshot-codes.test.ts
+++ b/src/renderer/components/analyze/__tests__/analyze-snapshot-codes.test.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  buildSnapshotQmkByCode,
+  compactLayerOp,
+  decodeSnapshotQmkId,
+  snapshotCodeLabel,
+} from '../analyze-snapshot-codes'
+import {
+  deserialize,
+  getProtocol,
+  recreateKeyboardKeycodes,
+  setProtocol,
+} from '../../../../shared/keycodes/keycodes'
+import type { TypingKeymapSnapshot } from '../../../../shared/types/typing-analytics'
+
+function snapshotWithKeymap(keymap: string[][][], vialProtocol?: number): TypingKeymapSnapshot {
+  return {
+    uid: '0x00',
+    machineHash: 'h',
+    productName: 'Test',
+    savedAt: 0,
+    layers: keymap.length,
+    matrix: { rows: keymap[0]?.length ?? 0, cols: keymap[0]?.[0]?.length ?? 0 },
+    keymap,
+    layout: null,
+    vialProtocol,
+  }
+}
+
+/** Resolve `qmkId` to its numeric code under a specific protocol,
+ * restoring the global protocol afterwards. */
+function deserializeUnderProtocol(qmkId: string, protocol: number): number {
+  const prev = getProtocol()
+  setProtocol(protocol)
+  try {
+    return deserialize(qmkId)
+  } finally {
+    setProtocol(prev)
+  }
+}
+
+// A deliberately small "current session" keyboard context — 2 layers,
+// 4 macros — so `M20` / `LT3(...)` / `MO(6)` are all things this
+// session's registry does NOT know about, the same shape-mismatch a
+// snapshot from a bigger keyboard produces against a smaller session.
+beforeEach(() => {
+  recreateKeyboardKeycodes({
+    vialProtocol: 6,
+    layers: 2,
+    macroCount: 4,
+    tapDanceCount: 0,
+    customKeycodes: null,
+    midi: '',
+    supportedFeatures: new Set(),
+  })
+})
+
+describe('decodeSnapshotQmkId', () => {
+  it('trusts a nonzero deserialize result directly', () => {
+    expect(decodeSnapshotQmkId('KC_A')).toBe(deserialize('KC_A'))
+  })
+
+  it('treats KC_NO as a real 0, not a decode failure', () => {
+    expect(decodeSnapshotQmkId('KC_NO')).toBe(0)
+  })
+
+  it('falls back to resolve() when deserialize silently returns 0 for a macro the session does not know', () => {
+    // The session above only registered M0-M3 — deserialize('M20')
+    // resolves through decodeAnyKeycode, which doesn't recognize the
+    // bare identifier "M20" either (no session Keycode, no AnyKeycode
+    // alias/function match) and swallows the parse error, returning 0.
+    expect(deserialize('M20')).toBe(0)
+    // resolve() reads the protocol's static kc table (M0-M255 always
+    // fully generated) instead, so it succeeds where deserialize did not.
+    const decoded = decodeSnapshotQmkId('M20')
+    expect(decoded).toBeDefined()
+    expect(decoded).not.toBe(0)
+  })
+
+  it('falls back to resolve() for MO(6) even though the session only registered 2 layers', () => {
+    // Unlike M20, deserialize('MO(6)') already succeeds today (it goes
+    // through decodeAnyKeycode's generic MO() function, not a
+    // session-registered Keycode), so this exercises the "trust a
+    // nonzero deserialize result" branch rather than the resolve()
+    // fallback -- both paths must agree on the same numeric code.
+    const viaDeserialize = deserialize('MO(6)')
+    expect(viaDeserialize).not.toBe(0)
+    expect(decodeSnapshotQmkId('MO(6)')).toBe(viaDeserialize)
+  })
+
+  it('returns undefined when neither deserialize nor resolve can decode the id', () => {
+    expect(decodeSnapshotQmkId('NOT_A_REAL_KEYCODE')).toBeUndefined()
+  })
+})
+
+describe('buildSnapshotQmkByCode', () => {
+  it('builds a code -> qmkId map from every layer, not just layer 0', () => {
+    const snapshot = snapshotWithKeymap([
+      [['KC_A', 'KC_B']],
+      [['KC_C', 'M20']],
+    ])
+    const map = buildSnapshotQmkByCode(snapshot)
+    expect(map.get(deserialize('KC_A'))).toBe('KC_A')
+    expect(map.get(deserialize('KC_B'))).toBe('KC_B')
+    expect(map.get(deserialize('KC_C'))).toBe('KC_C')
+    expect(map.get(decodeSnapshotQmkId('M20')!)).toBe('M20')
+  })
+
+  it('first-writer-wins on a code recorded by more than one qmkId', () => {
+    const snapshot = snapshotWithKeymap([[['KC_A', 'KC_A']]])
+    const map = buildSnapshotQmkByCode(snapshot)
+    expect(map.size).toBe(1)
+    expect(map.get(deserialize('KC_A'))).toBe('KC_A')
+  })
+
+  it('skips empty cells and undecodable ids without throwing', () => {
+    const snapshot = snapshotWithKeymap([[['', 'NOT_A_REAL_KEYCODE', 'KC_A']]])
+    const map = buildSnapshotQmkByCode(snapshot)
+    expect(map.size).toBe(1)
+    expect(map.get(deserialize('KC_A'))).toBe('KC_A')
+  })
+
+  it('resolves under the snapshot\'s own vialProtocol', () => {
+    const v5BootCode = deserializeUnderProtocol('QK_BOOT', 5)
+    const v6BootCode = deserializeUnderProtocol('QK_BOOT', 6)
+    expect(v5BootCode).not.toBe(v6BootCode)
+
+    const snapshot = snapshotWithKeymap([[['QK_BOOT']]], 5)
+    const map = buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    expect(map.get(v5BootCode)).toBe('QK_BOOT')
+    expect(map.get(v6BootCode)).toBeUndefined()
+  })
+
+  it('restores the global protocol after resolving', () => {
+    const prev = getProtocol()
+    const snapshot = snapshotWithKeymap([[['KC_A']]], 5)
+    buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    expect(getProtocol()).toBe(prev)
+  })
+})
+
+describe('compactLayerOp', () => {
+  it('collapses the spaced layer-op form into the compact display form', () => {
+    // "LT 3" / "MO 6" — resolveSnapshotLabel's `${op} ${layer}` spaced
+    // form (see its LT/LM branch below), not the parens form.
+    expect(compactLayerOp('LT 3')).toBe('LT3')
+    expect(compactLayerOp('MO 6')).toBe('MO6')
+  })
+
+  it('leaves already-compact or unrelated labels unchanged', () => {
+    expect(compactLayerOp('A')).toBe('A')
+    expect(compactLayerOp('MO(6)')).toBe('MO(6)')
+  })
+})
+
+describe('snapshotCodeLabel', () => {
+  it('renders a masked keycode as outer(inner)', () => {
+    expect(snapshotCodeLabel('LSFT(KC_A)')).toBe('LSft(A)')
+  })
+
+  it('renders a layer-tap mask with the compact layer digit and inner label', () => {
+    // Session above only registered 2 layers, so LT3(kc) isn't a
+    // registered Keycode -- this exercises resolveSnapshotLabel's
+    // static-template fallback, same as a snapshot's own keymap
+    // reporting a layer index the session doesn't know about. Uses the
+    // canonical qmkId (KC_SPACE, what `serialize` actually records) —
+    // findKeycode isn't alias-aware, so an alias spelling like KC_SPC
+    // wouldn't resolve to a label here, but recorded snapshots never
+    // contain aliases in the first place.
+    expect(snapshotCodeLabel('LT3(KC_SPACE)')).toBe('LT3(Space)')
+  })
+
+  it('renders MO(N) for a layer index the session does not have', () => {
+    expect(snapshotCodeLabel('MO(6)')).toBe('MO(6)')
+  })
+
+  it('collapses to the outer alone when the inner resolves empty (RAG_T(KC_NO))', () => {
+    expect(snapshotCodeLabel('RAG_T(KC_NO)')).toBe('RAG_T')
+  })
+
+  it('strips newlines from a multi-line keycode label (QK_BOOT)', () => {
+    expect(snapshotCodeLabel('QK_BOOT')).toBe('Boot-loader')
+  })
+
+  it('falls back to the qmkId string for something resolveSnapshotLabel cannot classify further', () => {
+    expect(snapshotCodeLabel('M20')).toBe('M20')
+  })
+})

--- a/src/renderer/components/analyze/__tests__/key-heatmap-helpers-speed.test.ts
+++ b/src/renderer/components/analyze/__tests__/key-heatmap-helpers-speed.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { describe, it, expect } from 'vitest'
+import { afterEach, describe, it, expect } from 'vitest'
 import {
   MIN_SPEED_SAMPLE_COUNT,
   buildKeycodeSpeedMap,
@@ -10,9 +10,17 @@ import {
 } from '../key-heatmap-helpers'
 import type { KeySpeedStat } from '../key-heatmap-helpers'
 import type { LayerKeycodes } from '../key-heatmap-helpers'
-import { deserialize, getProtocol, recreateKeycodes, serialize, setProtocol } from '../../../../shared/keycodes/keycodes'
+import { buildSnapshotQmkByCode, decodeSnapshotQmkId } from '../analyze-snapshot-codes'
+import {
+  deserialize,
+  getProtocol,
+  recreateKeyboardKeycodes,
+  recreateKeycodes,
+  serialize,
+  setProtocol,
+} from '../../../../shared/keycodes/keycodes'
 import { PALETTE_MIN_T, paletteColorFromIntensity } from '../../../utils/chart-palette'
-import type { TypingBigramTopEntry } from '../../../../shared/types/typing-analytics'
+import type { TypingBigramTopEntry, TypingKeymapSnapshot } from '../../../../shared/types/typing-analytics'
 
 /** Resolve `qmkId` to its numeric code under a specific protocol,
  * restoring the global protocol afterwards. */
@@ -26,12 +34,58 @@ function deserializeUnderProtocol(qmkId: string, protocol: number): number {
   }
 }
 
+/** Registers the CURRENT session's keyboard as a small one — 4 layers,
+ * 16 macros — the same shape a snapshot recorded by a bigger keyboard
+ * (8 layers, 32 macros) leaves this session unable to fully resolve by
+ * itself (see Task-speed-ranking-snapshot-labels.md). */
+function useSmallSessionKeyboard(): void {
+  recreateKeyboardKeycodes({
+    vialProtocol: 6,
+    layers: 4,
+    macroCount: 16,
+    tapDanceCount: 0,
+    customKeycodes: null,
+    midi: '',
+    supportedFeatures: new Set(),
+  })
+}
+
+// Re-pins the module-global keyboard registration to this same small
+// shape after every test in this file, rather than to a bigger one.
+// `qmkIdToKeycode` (shared/keycodes/keycodes.ts) is a plain Map that
+// Keycode's constructor only ever ADDS to and nothing ever clears --
+// so restoring to a *larger* context here would permanently register
+// e.g. `M20` for the rest of this file's run, and a later
+// `useSmallSessionKeyboard()` call could no longer make `M20` look
+// unresolvable no matter what it passes as `macroCount` (a stale
+// Keycode object would still satisfy the `qmkIdToKeycode.get('M20')`
+// lookup `deserialize` makes). Restoring to this exact small shape
+// instead keeps the file's ambient state deterministic across test
+// reorders without ever widening what `qmkIdToKeycode` has registered.
+afterEach(() => {
+  useSmallSessionKeyboard()
+})
+
 function entry(ngramId: string, count: number, hist: number[] = [0, 0, 0, 0, 0, 0, 0, 0]): TypingBigramTopEntry {
   return { ngramId, count, hist, avgIki: null, sd: null }
 }
 
 function layerKeycodes(pairs: Record<string, string>): LayerKeycodes {
   return { keycodes: new Map(Object.entries(pairs)), labelOverrides: new Map() }
+}
+
+function snapshotWithKeymap(keymap: string[][][], vialProtocol?: number): TypingKeymapSnapshot {
+  return {
+    uid: '0x00',
+    machineHash: 'h',
+    productName: 'Test',
+    savedAt: 0,
+    layers: keymap.length,
+    matrix: { rows: keymap[0]?.length ?? 0, cols: keymap[0]?.[0]?.length ?? 0 },
+    keymap,
+    layout: null,
+    vialProtocol,
+  }
 }
 
 describe('buildKeycodeSpeedMap', () => {
@@ -182,6 +236,27 @@ describe('buildSpeedFillByPos', () => {
     buildSpeedFillByPos(layerKeycodes({ '0,0': 'KC_A' }), ['0,0'], new Map(), 'all', 'light', 5)
     expect(getProtocol()).toBe(prev)
   })
+
+  it('paints an M20 cell instead of treating it as an unresolvable (KC_NO-like) 0 code', () => {
+    // A snapshot recorded by a keyboard with 32 macros reports "M20" at
+    // this position, but the current session only registered 16 --
+    // `deserialize('M20')` silently returns 0 in that case (see
+    // decodeSnapshotQmkId's doc comment), which used to make this cell
+    // match whatever intensity happened to be keyed at 0 instead of
+    // painting nothing (or the correct M20 intensity).
+    useSmallSessionKeyboard()
+    expect(deserialize('M20')).toBe(0)
+    const m20Code = decodeSnapshotQmkId('M20')!
+    expect(m20Code).not.toBe(0)
+
+    const kc = layerKeycodes({ '0,0': 'M20' })
+    const intensityKeyedAtZero = new Map([[0, 1]])
+    // A stray intensity entry at 0 must NOT bleed onto the M20 cell.
+    expect(buildSpeedFillByPos(kc, ['0,0'], intensityKeyedAtZero, 'all', 'light').has('0,0')).toBe(false)
+
+    const intensityByM20Code = new Map([[m20Code, 1]])
+    expect(buildSpeedFillByPos(kc, ['0,0'], intensityByM20Code, 'all', 'light').get('0,0')).toMatch(/^hsl\(/)
+  })
 })
 
 describe('buildSpeedRanking', () => {
@@ -234,5 +309,53 @@ describe('buildSpeedRanking', () => {
     // map directly by re-serializing 0x7c00 back under v6.
     expect(getProtocol()).toBe(6)
     expect(serialize(0x7c00)).toBe('QK_BOOT')
+  })
+
+  it('resolves labels/groups from the snapshot\'s own qmk strings for keyboard-shape mismatches (M20, MO(6))', () => {
+    // Session only knows about 4 layers / 16 macros; the snapshot was
+    // recorded by an 8-layer / 32-macro keyboard, so `M20` and `MO(6)`
+    // are both codes this session's own `RAWCODES_MAP` can't round-trip
+    // through `serialize` -- M20 lands on bare hex, MO(6) lands in the
+    // 'other' group bucket instead of 'layerOp'. Building the map from
+    // the snapshot's own recorded qmk strings sidesteps the round-trip
+    // entirely (see Task-speed-ranking-snapshot-labels.md).
+    useSmallSessionKeyboard()
+    const snapshot = snapshotWithKeymap([[['M20', 'MO(6)']]])
+    const qmkByCode = buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    const m20Code = [...qmkByCode.entries()].find(([, id]) => id === 'M20')?.[0]
+    const mo6Code = [...qmkByCode.entries()].find(([, id]) => id === 'MO(6)')?.[0]
+    expect(m20Code).toBeDefined()
+    expect(mo6Code).toBeDefined()
+
+    const speedMap = new Map([
+      [m20Code!, { avgIki: 100, count: 10 }],
+      [mo6Code!, { avgIki: 200, count: 10 }],
+    ])
+
+    const allRanking = buildSpeedRanking(speedMap, 'all', 10, snapshot.vialProtocol, qmkByCode)
+    expect(allRanking.find((e) => e.avgIki === 100)?.keyLabel).toBe('M20')
+    expect(allRanking.find((e) => e.avgIki === 200)?.keyLabel).toBe('MO(6)')
+
+    // MO(6) must land in the 'layerOp' group filter, not 'other'.
+    const layerOpOnly = buildSpeedRanking(speedMap, 'layerOp', 10, snapshot.vialProtocol, qmkByCode)
+    expect(layerOpOnly).toHaveLength(1)
+    expect(layerOpOnly[0].keyLabel).toBe('MO(6)')
+  })
+
+  it('resolves RAG_T(KC_NO) to "RAG_T" (not the #359 fallback\'s "RAG_T(NO)") when the snapshot map has it', () => {
+    // Same 0x7c00-family collision code as the #359 test above, but
+    // this time the snapshot's own keymap literally recorded
+    // "RAG_T(KC_NO)" at v5, so the snapshot-string path resolves it
+    // directly instead of falling back to codeToLabel's serialize
+    // round-trip (which produces the differently-formatted "RAG_T(NO)").
+    const snapshot = snapshotWithKeymap([[['RAG_T(KC_NO)']]], 5)
+    const qmkByCode = buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+    const code = [...qmkByCode.entries()].find(([, id]) => id === 'RAG_T(KC_NO)')?.[0]
+    expect(code).toBeDefined()
+
+    const speedMap = new Map([[code!, { avgIki: 100, count: 10 }]])
+    const ranking = buildSpeedRanking(speedMap, 'all', 10, snapshot.vialProtocol, qmkByCode)
+    expect(ranking).toHaveLength(1)
+    expect(ranking[0].keyLabel).toBe('RAG_T')
   })
 })

--- a/src/renderer/components/analyze/analyze-bigram-format.ts
+++ b/src/renderer/components/analyze/analyze-bigram-format.ts
@@ -5,24 +5,89 @@
 // decode still surfaces actionable rows.
 
 import { codeToLabel } from '../../../shared/keycodes/keycodes'
+import { withSerializeProtocol } from '../../../shared/keycodes/with-protocol'
 import type { TypingBigramTopEntry } from '../../../shared/types/typing-analytics'
 import { rolloverRatio } from './analyze-rollover'
+import { snapshotCodeLabel } from './analyze-snapshot-codes'
 
-/** Convert a stored n-gram id — `"4_11"` (bigram) or `"4_11_42"`
- * (trigram) — into a display label such as `"A → H"` or
- * `"A → H → Bksp"`. Falls back to the raw id when the part count isn't
- * 2 or 3, any part is empty, or any part is not a finite number, so
- * the renderer never throws on schema drift. */
-export function bigramPairLabel(bigramId: string): string {
+/** Splits a stored n-gram id — `"4_11"` (bigram) or `"4_11_42"`
+ * (trigram) — into its numeric codes, or `null` when the part count
+ * isn't 2 or 3, any part is empty, or any part is not a finite number
+ * (shared validation for `bigramPairLabel`/`bigramPairLabels`). Reject
+ * empty parts explicitly: `Number('')` coerces to 0 rather than NaN,
+ * which would otherwise label `"4_"` as `"A → "` instead of falling
+ * back to the raw id. */
+function parseNgramCodes(bigramId: string): number[] | null {
   const parts = bigramId.split('_')
-  if (parts.length !== 2 && parts.length !== 3) return bigramId
-  // Reject empty parts explicitly: `Number('')` coerces to 0 rather
-  // than NaN, which would otherwise label `"4_"` as `"A → "` instead
-  // of returning the raw id.
-  if (parts.some((p) => p.length === 0)) return bigramId
+  if (parts.length !== 2 && parts.length !== 3) return null
+  if (parts.some((p) => p.length === 0)) return null
   const codes = parts.map(Number)
-  if (codes.some((n) => !Number.isFinite(n))) return bigramId
-  return codes.map((n) => codeToLabel(n)).join(' → ')
+  if (codes.some((n) => !Number.isFinite(n))) return null
+  return codes
+}
+
+/** Resolves one numeric n-gram code to a display label. When `code` is
+ * in `qmkByCode` (from `buildSnapshotQmkByCode`/`useSnapshotQmkByCode`),
+ * that's the snapshot's own recorded qmkId string, resolved via
+ * `snapshotCodeLabel` (no serialize round-trip, so it doesn't matter
+ * that the snapshot's keyboard may have had more layers/macros/TDs
+ * than the session currently sees). A code missing from the map falls
+ * back to `codeToLabel` — the caller is responsible for running that
+ * fallback under the snapshot's own protocol (see
+ * `withSerializeProtocol` callers below). */
+function resolveNgramLabel(code: number, qmkByCode?: ReadonlyMap<number, string>): string {
+  const qmkId = qmkByCode?.get(code)
+  return qmkId !== undefined ? snapshotCodeLabel(qmkId) : codeToLabel(code)
+}
+
+/** Convert a stored n-gram id into a display label such as `"A → H"`
+ * or `"A → H → Bksp"`. Falls back to the raw id when
+ * `parseNgramCodes` can't parse it, so the renderer never throws on
+ * schema drift.
+ *
+ * Any code missing from `qmkByCode` resolves via `codeToLabel`, scoped
+ * to the snapshot's own protocol via `withSerializeProtocol` — unlike
+ * before, where this fallback had NO protocol wrapper at all and
+ * resolved protocol-dependent codes (e.g. `QK_BOOT`) against whatever
+ * protocol happened to be globally active. Without `qmkByCode` every
+ * part takes the miss path, reproducing today's behavior exactly.
+ *
+ * For rendering many rows at once (a ranking table), prefer
+ * `bigramPairLabels` below — it resolves every row's miss codes under
+ * a single `withSerializeProtocol` scope instead of one
+ * `recreateKeycodes` round-trip per row. */
+export function bigramPairLabel(
+  bigramId: string,
+  qmkByCode?: ReadonlyMap<number, string>,
+  vialProtocol?: number,
+): string {
+  const codes = parseNgramCodes(bigramId)
+  if (!codes) return bigramId
+  const hasMiss = codes.some((n) => !qmkByCode?.has(n))
+  const labels = hasMiss
+    ? withSerializeProtocol(vialProtocol, () => codes.map((n) => resolveNgramLabel(n, qmkByCode)))
+    : codes.map((n) => resolveNgramLabel(n, qmkByCode))
+  return labels.join(' → ')
+}
+
+/** Batched sibling of `bigramPairLabel` for a whole ranking table's
+ * worth of rows: resolves every row's miss codes under ONE
+ * `withSerializeProtocol` scope instead of paying a `recreateKeycodes`
+ * round-trip per row (the same batching `buildSpeedRanking` in
+ * key-heatmap-helpers.ts applies to the Speed ranking). Order and
+ * malformed-id fallback match `bigramPairLabel` exactly, one label per
+ * input id. */
+export function bigramPairLabels(
+  bigramIds: readonly string[],
+  qmkByCode?: ReadonlyMap<number, string>,
+  vialProtocol?: number,
+): string[] {
+  const parsed = bigramIds.map(parseNgramCodes)
+  const hasAnyMiss = parsed.some((codes) => codes?.some((n) => !qmkByCode?.has(n)))
+  const resolveAll = (): string[] => parsed.map((codes, i) =>
+    codes ? codes.map((n) => resolveNgramLabel(n, qmkByCode)).join(' → ') : bigramIds[i],
+  )
+  return hasAnyMiss ? withSerializeProtocol(vialProtocol, resolveAll) : resolveAll()
 }
 
 /** This pair's own observed rollover rate — entry adapter over the

--- a/src/renderer/components/analyze/analyze-snapshot-codes.ts
+++ b/src/renderer/components/analyze/analyze-snapshot-codes.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Resolves Speed-ranking / bigram-pair labels straight from a
+// snapshot's OWN recorded qmk strings, instead of round-tripping a
+// numeric code back through the CURRENT session's `RAWCODES_MAP`
+// (option B from .claude/tasks/backlog/Task-speed-ranking-snapshot-labels.md,
+// the keyboard-shape follow-up to #359's protocol-version fix).
+//
+// The round-trip breaks whenever the snapshot's keyboard had more
+// layers/macros/tap-dances than the currently connected session:
+// `RAWCODES_MAP` is only populated for what the session's keyboard
+// context registered (see `recreateKeyboardKeycodes`), so a code like
+// `M20` recorded by a 32-macro keyboard falls through to raw hex, and
+// `MO(6)` on a keyboard the session sees as having < 7 layers lands in
+// the wrong group bucket (`serialize` can't find an exact
+// `RAWCODES_MAP` entry and returns bare hex instead of `"MO(6)"`).
+// Building `code -> qmkId` directly from the snapshot's own keymap
+// strings sidesteps that entirely: the string was already right at
+// record time, so this only ever needs the forward (string -> number)
+// direction, which is protocol-static rather than session-registry
+// dependent.
+
+import type { TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
+import { deserialize, resolve, resolveSnapshotLabel } from '../../../shared/keycodes/keycodes'
+import { withDeserializeProtocol } from '../../../shared/keycodes/with-protocol'
+
+// LT/LM write the layer digit directly after the op (`LT1 3`); MO-family
+// ops keep the digit inside parens (`MO(3)`) and never match this —
+// mirrors the layer-op compaction key-heatmap-helpers.ts's ranking rows
+// already apply to `resolveSnapshotLabel().outer`.
+const COMPACT_LAYER_OP_RE = /^(LT|LM|MO|DF|PDF|TG|TT|OSL|TO)\s(\d+)$/
+
+/** Collapses `resolveSnapshotLabel`'s spaced `"LT1 3"` outer form into
+ * the compact `"LT13"` display form the Analyze rankings use. A no-op
+ * for anything that doesn't match (already-compact ops, plain labels).
+ * Shared by `key-heatmap-helpers.ts`'s Count-mode rankings and
+ * `snapshotCodeLabel` below so both label styles agree. */
+export function compactLayerOp(label: string): string {
+  const m = label.match(COMPACT_LAYER_OP_RE)
+  return m ? `${m[1]}${m[2]}` : label
+}
+
+/**
+ * Decode one snapshot qmkId string to its numeric code, trusting a
+ * nonzero `deserialize` result and only falling back to `resolve` when
+ * `deserialize` reports 0 for something other than the real "no key"
+ * sentinel `KC_NO`.
+ *
+ * `deserialize('M20')` silently returns `0` (not a throw) whenever the
+ * CURRENT session's connected keyboard registered fewer than 21
+ * macros: `qmkIdToKeycode` only has `M0..M(macroCount-1)` entries for
+ * this session (see `recreateKeyboardKeycodes`), so the direct lookup
+ * misses and `deserialize` falls through to
+ * `decodeAnyKeycode('M20')` — which also doesn't know the bare
+ * identifier `M20` (only registered aliases and function-call forms
+ * resolve), swallows the parse error internally, and returns 0.
+ * `resolve('M20')`, in contrast, reads the protocol's static `kc`
+ * table (`keycodesV5`/`keycodesV6`), where `M0..M255` (and
+ * `TD(0..255)`) are always fully generated regardless of what the
+ * session's keyboard happens to report — so it succeeds exactly where
+ * `deserialize` silently didn't.
+ *
+ * Returns `undefined` when both resolution paths fail (a truly
+ * unrecognized qmkId) so callers can skip the entry instead of
+ * polluting a code map with a bogus 0.
+ */
+export function decodeSnapshotQmkId(qmkId: string): number | undefined {
+  let viaDeserialize: number
+  try {
+    viaDeserialize = deserialize(qmkId)
+  } catch {
+    viaDeserialize = 0
+  }
+  if (viaDeserialize !== 0 || qmkId === 'KC_NO') return viaDeserialize
+  try {
+    return resolve(qmkId)
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Builds a `code -> qmkId` reverse map from every layer of the
+ * snapshot's own keymap (not just the layers currently selected in the
+ * Heatmap tab — see `KeyHeatmapChart.tsx`'s `layerKeycodes` memo for
+ * that narrower, selection-scoped map). Runs under the snapshot's own
+ * `vialProtocol` since `deserialize`/`resolve` read the protocol
+ * variable for protocol-dependent bases (`QK_BOOT` et al.).
+ *
+ * First-writer-wins on a code recorded by more than one qmkId (layer
+ * order, then row-major within a layer) — an arbitrary but stable tie
+ * break; nothing in the recorded keymap distinguishes "which qmkId is
+ * canonical" for a colliding code.
+ */
+export function buildSnapshotQmkByCode(
+  snapshot: TypingKeymapSnapshot,
+  vialProtocol?: number,
+): ReadonlyMap<number, string> {
+  return withDeserializeProtocol(vialProtocol, () => {
+    const result = new Map<number, string>()
+    if (!Array.isArray(snapshot.keymap)) return result
+    for (const layer of snapshot.keymap) {
+      if (!Array.isArray(layer)) continue
+      for (const row of layer) {
+        if (!Array.isArray(row)) continue
+        for (const qmkId of row) {
+          if (typeof qmkId !== 'string' || qmkId.length === 0) continue
+          const code = decodeSnapshotQmkId(qmkId)
+          if (code === undefined || result.has(code)) continue
+          result.set(code, qmkId)
+        }
+      }
+    }
+    return result
+  })
+}
+
+/**
+ * Display label for a snapshot qmkId string — the label counterpart to
+ * `decodeSnapshotQmkId`'s numeric decode. Unlike `codeToLabel` (number
+ * -> label via `serialize`, which needs the session's `RAWCODES_MAP` to
+ * have registered the exact code), this starts from the qmkId string
+ * the snapshot already recorded, so it never depends on the session's
+ * keyboard shape.
+ *
+ * Masked ids render `outer(inner)` (`LSFT(KC_A)` -> `"LSft(A)"`,
+ * `LT3(KC_SPC)` -> `"LT3(Space)"`); an empty inner (e.g. `RAG_T(KC_NO)`,
+ * whose `KC_NO` inner resolves to an empty label) collapses to the
+ * outer alone (`"RAG_T"`) rather than leaving dangling parens. Newlines
+ * baked into a keycode's display label (`"Boot-\nloader"`) are joined
+ * without a space, matching how the label reads on a single-line
+ * physical keycap (`"Boot-loader"`) — deliberately different from
+ * `codeToLabel`'s space-joined fallback, since this is the "read the
+ * key as printed" path.
+ */
+export function snapshotCodeLabel(qmkId: string): string {
+  const resolved = resolveSnapshotLabel(qmkId)
+  const outer = compactLayerOp(resolved.outer)
+  const combined = resolved.inner ? `${outer}(${resolved.inner})` : outer
+  return combined.replace(/\n/g, '')
+}

--- a/src/renderer/components/analyze/key-heatmap-helpers.ts
+++ b/src/renderer/components/analyze/key-heatmap-helpers.ts
@@ -4,7 +4,7 @@
 
 import type { TypingBigramTopEntry, TypingDurationCell, TypingHeatmapByCell, TypingHeatmapCell, TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
 import type { KeyboardLayout } from '../../../shared/kle/types'
-import { resolveSnapshotLabel, keycodeGroup, deserialize, serialize, codeToLabel } from '../../../shared/keycodes/keycodes'
+import { resolveSnapshotLabel, keycodeGroup, serialize, codeToLabel } from '../../../shared/keycodes/keycodes'
 import type { KeycodeGroup } from '../../../shared/keycodes/keycodes'
 import { posKey } from '../../../shared/kle/pos-key'
 import { avgIkiFromHist, foldHist, HIST_BUCKETS, parseBigramId } from './analyze-bigram-heatmap'
@@ -13,12 +13,12 @@ import type { EffectiveTheme } from '../../hooks/useEffectiveTheme'
 import type { HeatmapNormalization, RangeMs } from './analyze-types'
 import type { AggregateMode, HeatmapFilters, KeyGroupFilter } from '../../../shared/types/analyze-filters'
 import { withDeserializeProtocol, withSerializeProtocol } from '../../../shared/keycodes/with-protocol'
+import { compactLayerOp, decodeSnapshotQmkId, snapshotCodeLabel } from './analyze-snapshot-codes'
 
 export { AGGREGATE_MODES, KEY_GROUPS, HEATMAP_MODES } from '../../../shared/types/analyze-filters'
 export type { AggregateMode, KeyGroupFilter, HeatmapMode } from '../../../shared/types/analyze-filters'
 
 const MASK_INNER_RE = /\((.+)\)$/
-const COMPACT_LAYER_OP_RE = /^(LT|LM|MO|DF|PDF|TG|TT|OSL|TO)\s(\d+)$/
 
 export type LabelOverride = { outer: string; inner: string; masked: boolean }
 
@@ -29,11 +29,6 @@ export type LayerKeycodes = {
 
 export function groupOf(groups: readonly number[][], layer: number): number {
   return groups.findIndex((g) => g.includes(layer))
-}
-
-export function compactLayerOp(label: string): string {
-  const m = label.match(COMPACT_LAYER_OP_RE)
-  return m ? `${m[1]}${m[2]}` : label
 }
 
 export function buildLayerKeycodes(snapshot: TypingKeymapSnapshot, layer: number): LayerKeycodes {
@@ -384,13 +379,14 @@ export function buildSpeedFillByPos(
       const qmkId = layerKeycodes.keycodes.get(pos) ?? ''
       if (!qmkId) continue
       if (keyGroupFilter !== 'all' && keycodeGroup(qmkId) !== keyGroupFilter) continue
-      let code: number
-      try {
-        code = deserialize(qmkId)
-      } catch {
-        continue
-      }
-      if (!Number.isFinite(code)) continue
+      // decodeSnapshotQmkId (not a bare deserialize) so a keycode this
+      // session's keyboard doesn't fully know about (e.g. `M20` when
+      // the session registered fewer than 21 macros) still resolves to
+      // its real numeric code instead of silently landing on 0 and
+      // being mistaken for a `KC_NO` cell — see that function's doc
+      // comment for why plain `deserialize` can't tell the two apart.
+      const code = decodeSnapshotQmkId(qmkId)
+      if (code === undefined || !Number.isFinite(code)) continue
       const intensity = intensityByCode.get(code)
       if (intensity === undefined) continue
       const fill = paletteColorFromIntensity(intensity, theme)
@@ -409,27 +405,59 @@ export interface SpeedRankingEntry {
 /** Ranks qualifying keycodes slowest-reach-first for the Speed
  * ranking table. Unlike the Count ranking, this isn't scoped to a
  * layer group — the bigram aggregate carries no layer tag, so one flat
- * ranking covers every selected layer. Labels and group filtering run
- * under the snapshot's protocol (see `withSerializeProtocol`)
- * since the numeric codes were recorded under it — this body calls
- * `serialize`/`codeToLabel` (number → qmkId/label), unlike
- * `buildSpeedFillByPos` above which only `deserialize`s, so it needs
- * the RAWCODES_MAP-rebuilding variant rather than the plain one. */
+ * ranking covers every selected layer.
+ *
+ * When `qmkByCode` (from `buildSnapshotQmkByCode`) has an entry for a
+ * code, that's the snapshot's own recorded qmkId string — resolve the
+ * group/label straight from it (`keycodeGroup(qmkId)` /
+ * `snapshotCodeLabel`), no serialize round-trip needed. A code missing
+ * from the map (a keycode observed by the bigram aggregate that the
+ * snapshot itself never recorded — e.g. a mid-recording remap) falls
+ * back to today's `serialize`/`codeToLabel` resolution, which needs
+ * the snapshot protocol's `RAWCODES_MAP` (see `withSerializeProtocol`)
+ * since the numeric codes were recorded under it. That fallback
+ * resolution runs ONCE for every miss code up front — `recreateKeycodes`
+ * inside `withSerializeProtocol` isn't free — then a single pass over
+ * `speedMap` in its original (stable-sort-preserving) insertion order
+ * builds the final entries from whichever path each code took. With
+ * `qmkByCode` absent every code takes the miss path, reproducing the
+ * pre-existing behavior exactly (byte-equivalent — see the #359
+ * regression test in key-heatmap-helpers-speed.test.ts). */
 export function buildSpeedRanking(
   speedMap: ReadonlyMap<number, KeySpeedStat>,
   keyGroupFilter: KeyGroupFilter,
   limit: number,
   vialProtocol?: number,
+  qmkByCode?: ReadonlyMap<number, string>,
 ): SpeedRankingEntry[] {
-  return withSerializeProtocol(vialProtocol, () => {
-    const entries: SpeedRankingEntry[] = []
-    for (const [code, stat] of speedMap) {
-      if (keyGroupFilter !== 'all' && keycodeGroup(serialize(code)) !== keyGroupFilter) continue
-      entries.push({ keyLabel: codeToLabel(code), avgIki: stat.avgIki, count: stat.count })
+  const missCodes: number[] = []
+  for (const code of speedMap.keys()) {
+    if (!qmkByCode?.has(code)) missCodes.push(code)
+  }
+  const missMeta = new Map<number, { label: string; group: KeycodeGroup }>()
+  if (missCodes.length > 0) {
+    withSerializeProtocol(vialProtocol, () => {
+      for (const code of missCodes) {
+        missMeta.set(code, { label: codeToLabel(code), group: keycodeGroup(serialize(code)) })
+      }
+    })
+  }
+
+  const entries: SpeedRankingEntry[] = []
+  for (const [code, stat] of speedMap) {
+    const qmkId = qmkByCode?.get(code)
+    if (qmkId !== undefined) {
+      if (keyGroupFilter !== 'all' && keycodeGroup(qmkId) !== keyGroupFilter) continue
+      entries.push({ keyLabel: snapshotCodeLabel(qmkId), avgIki: stat.avgIki, count: stat.count })
+      continue
     }
-    entries.sort((a, b) => b.avgIki - a.avgIki)
-    return entries.slice(0, Math.max(limit, 0))
-  })
+    const meta = missMeta.get(code)
+    if (!meta) continue
+    if (keyGroupFilter !== 'all' && meta.group !== keyGroupFilter) continue
+    entries.push({ keyLabel: meta.label, avgIki: stat.avgIki, count: stat.count })
+  }
+  entries.sort((a, b) => b.avgIki - a.avgIki)
+  return entries.slice(0, Math.max(limit, 0))
 }
 
 // --- Duration mode ---------------------------------------------------

--- a/src/renderer/components/analyze/use-snapshot-qmk-by-code.ts
+++ b/src/renderer/components/analyze/use-snapshot-qmk-by-code.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Memoised wrapper around `buildSnapshotQmkByCode`, mirroring
+// `use-keycode-finger-map.ts`'s shape: hides the null-snapshot
+// fallback so Speed-ranking / bigram-pair label callers (KeyHeatmapChart,
+// BigramsChart) don't repeat the same boilerplate. Returns an empty map
+// when the snapshot is missing, so callers can branch on `size === 0`
+// or simply pass the map straight through as an "always defined but
+// possibly empty" optional prop.
+
+import { useMemo } from 'react'
+import { buildSnapshotQmkByCode } from './analyze-snapshot-codes'
+import type { TypingKeymapSnapshot } from '../../../shared/types/typing-analytics'
+
+export function useSnapshotQmkByCode(
+  snapshot: TypingKeymapSnapshot | null,
+): ReadonlyMap<number, string> {
+  return useMemo(() => {
+    if (!snapshot) return new Map<number, string>()
+    return buildSnapshotQmkByCode(snapshot, snapshot.vialProtocol)
+  }, [snapshot])
+}


### PR DESCRIPTION
## Summary
- Analyze's Speed-ranking and bigram-pair labels previously serialized recorded raw codes against the CURRENT SESSION's keycode tables, so snapshots from keyboards with more layers/macros/tap-dances than the connected session rendered raw hex (`0x7714` instead of `M20`), and out-of-range layer ops fell into the wrong group bucket (`MO(6)` counted as "other" instead of layerOp). Labels now resolve from the snapshot's own recorded qmk strings: a new `buildSnapshotQmkByCode` walks every layer of the snapshot keymap into a `code → qmkId` map (memoized per snapshot), and both rankings prefer it, falling back to the previous session-table path — under the snapshot's protocol — only for codes absent from the snapshot (mid-run remaps, encoders).
- The decode helper embeds a non-obvious trap discovered during mapping: `deserialize('M20')` returns 0 rather than throwing when the session has fewer macros, so the helper trusts a nonzero `deserialize` and retries `resolve()` (whose protocol tables define `M0..M255`/`TD(0..255)` statically) before giving up. The same silent-zero hole existed in `buildSpeedFillByPos`, where an `M20` cell inherited whatever heat sat at code 0 — fixed with the shared helper.
- Visible changes: mostly-plain rows are unchanged; shape-mismatch rows are fixed (`M20`, `MO(6)`); masked keys unify with the Count/Duration rankings' style (`LSFT(A)` → `LSft(A)`, `LT3(SPACE)` → `LT3(Space)`). `bigramPairLabel` — previously unwrapped on both the protocol and shape axes — gains the same resolution plus a batched variant so a sorted 100-row table costs one protocol scope rather than per-row table rebuilds. Seeded doc-capture screenshots use only plain keys and are unaffected (review-verified).
- Review hardening: the snapshot-map builder guards malformed snapshots (loaded via unvalidated JSON.parse; an unguarded iteration would have thrown inside a render memo with no error boundary), and the new tests pin their keyboard-shape context with deterministic restores.

## Verification
- Full suite: 363 test files, 8,209 passed / 22 skipped (baseline + 25 new tests, including the shape-difference fixtures proven to fail pre-fix); the #359 protocol-regression test passes byte-unedited and keeps guarding the fallback path.
- `pnpm run lint`, `pnpm typecheck`, the hook-dep TDZ gate, and `pnpm run build` clean.