### PR TITLE
feat(ui): persist typing-test line structure in run keystroke logs

### DIFF
--- a/src/main/__tests__/typing-run-log-store.test.ts
+++ b/src/main/__tests__/typing-run-log-store.test.ts
@@ -272,6 +272,86 @@ describe('typing-run-log-store', () => {
     })
   })
 
+  describe('lineBreaks (line timeline PR1)', () => {
+    // 4 words (indices 0-3) so the terminal boundary (words.length - 1 = 3)
+    // and the entry just before it (words.length - 2 = 2) are both
+    // meaningful against `words.length`.
+    function fourWordLog(overrides?: Partial<RunKeystrokeLog>): RunKeystrokeLog {
+      return makeLog({
+        words: [0, 1, 2, 3].map((i) => ({
+          index: i, display: `w${i}`, typed: `w${i}`, correct: true, keystrokes: [],
+        })),
+        ...overrides,
+      })
+    }
+
+    it('roundtrips a non-empty lineBreaks array', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [1, 2] }))
+      expect(result.success).toBe(true)
+      const fetched = await getRunLog('kb-1', 'run-1')
+      expect(fetched.data?.lineBreaks).toEqual([1, 2])
+    })
+
+    it('roundtrips an explicit empty lineBreaks array ("one line", not omitted)', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [] }))
+      expect(result.success).toBe(true)
+      const fetched = await getRunLog('kb-1', 'run-1')
+      expect(fetched.data?.lineBreaks).toEqual([])
+    })
+
+    it('accepts an absent lineBreaks (legacy log, falls back to per-word rendering)', async () => {
+      const result = await saveRunLog('kb-1', makeLog())
+      expect(result.success).toBe(true)
+      const fetched = await getRunLog('kb-1', 'run-1')
+      expect(fetched.data?.lineBreaks).toBeUndefined()
+    })
+
+    it('rejects a non-array lineBreaks', async () => {
+      const malformed = { ...fourWordLog(), lineBreaks: 'nope' }
+      const result = await saveRunLog('kb-1', malformed)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a non-integer entry', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [1.5] }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an unsorted lineBreaks array', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [2, 1] }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects duplicate entries (not strictly ascending)', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [1, 1] }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an out-of-range entry (>= words.length)', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [4] }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a negative entry', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [-1] }))
+      expect(result.success).toBe(false)
+    })
+
+    // P2-2 (codex review): a line break must have at least one word after
+    // it — the log's own last word (words.length - 1) can never be one.
+    it('rejects a terminal entry (index === words.length - 1, no word follows it)', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [3] }))
+      expect(result.success).toBe(false)
+    })
+
+    it('accepts an entry one before the terminal (index === words.length - 2)', async () => {
+      const result = await saveRunLog('kb-1', fourWordLog({ lineBreaks: [2] }))
+      expect(result.success).toBe(true)
+      const fetched = await getRunLog('kb-1', 'run-1')
+      expect(fetched.data?.lineBreaks).toEqual([2])
+    })
+  })
+
   describe('list / get roundtrip', () => {
     it('lists newest-first and gets the full payload', async () => {
       await saveRunLog('kb-1', makeLog({ runId: 'run-1', startedAt: '2026-01-01T00:00:00.000Z' }))

--- a/src/main/typing-run-log-store.ts
+++ b/src/main/typing-run-log-store.ts
@@ -144,6 +144,34 @@ function isValidKeystroke(value: unknown, durationMs: number): value is RunKeyst
   return true
 }
 
+/** `RunKeystrokeLog.lineBreaks` validation — sorted, unique, strictly
+ *  ascending, and every index STRICTLY less than `wordCount - 1` (the
+ *  log's OWN `words.length`, the same `persistedWordCount` the renderer
+ *  already clamped to before saving — see run-log-recorder.ts's
+ *  `RunLogFinishMeta.lineBreaks` doc comment). The `- 1` is deliberate,
+ *  not `wordCount` itself: a line break marks where a line ENDS before
+ *  ANOTHER FOLLOWS, so the log's own last word (index `wordCount - 1`,
+ *  which by definition has nothing after it) can never legitimately be
+ *  one — same bound `deriveLineBreaksForLog` (use-typing-test-result-
+ *  save.ts) enforces on the renderer side and `parseFileImportText`
+ *  enforces at its own source (typing-test-text-store.ts). Malformed
+ *  input rejects the WHOLE log (consistent with this function's
+ *  existing strictness for every other field), rather than silently
+ *  dropping just this one. */
+function isValidLineBreaks(value: unknown, wordCount: number): value is number[] {
+  if (!Array.isArray(value)) return false
+  let prev = -1
+  for (const entry of value) {
+    if (typeof entry !== 'number' || !Number.isInteger(entry)) return false
+    // Strictly greater than the previous entry enforces both ascending
+    // order and uniqueness in one comparison.
+    if (entry <= prev) return false
+    if (entry < 0 || entry >= wordCount - 1) return false
+    prev = entry
+  }
+  return true
+}
+
 function isValidWord(value: unknown, durationMs: number): value is RunWord {
   if (!value || typeof value !== 'object') return false
   const w = value as Record<string, unknown>
@@ -192,6 +220,15 @@ function validateRunLog(
   }
   if (eventCount > MAX_RUN_LOG_EVENTS) return { ok: false, error: 'Too many keystrokes' }
 
+  // Bounds-checked against `words.length` (the already-validated array
+  // above, including any trailing partial word) — this is exactly the
+  // `persistedWordCount` the renderer clamped lineBreaks to before saving.
+  let lineBreaks: number[] | undefined
+  if (log.lineBreaks !== undefined) {
+    if (!isValidLineBreaks(log.lineBreaks, words.length)) return { ok: false, error: 'Invalid lineBreaks' }
+    lineBreaks = log.lineBreaks
+  }
+
   let serialized: string
   try {
     serialized = JSON.stringify(log)
@@ -211,6 +248,11 @@ function validateRunLog(
       language: log.language,
       charCorrelationUnavailable: log.charCorrelationUnavailable,
       romajiInput: log.romajiInput,
+      // Explicit: the whitelist rebuild above drops any field not listed
+      // here, so an EMPTY `[]` (a legitimate "one line" value, distinct
+      // from omitted — see the field's own doc comment) must still be
+      // assigned, not left to fall through as undefined.
+      lineBreaks,
       words,
     },
     serialized,

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -29,6 +29,7 @@ import { useKeymapRewrite } from './use-keymap-rewrite'
 import { useKeymapPackTabs } from './use-keymap-pack-tabs'
 import { KeymapPickerRegion } from './KeymapPickerRegion'
 import { KeymapPrimaryPane } from './KeymapPrimaryPane'
+import type { LineSnapshot } from '../../typing-test/TypingTestView'
 
 export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEditorHandle, Props>(function KeymapEditor(props, ref) {
   // Kept as a whole object (not just destructured) so the typing-test
@@ -75,6 +76,10 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   } = props
   const { t } = useTranslation()
   const keyboardContentRef = useRef<HTMLDivElement>(null)
+  // Owned here — the lowest common ancestor of TypingTestView (written by,
+  // via KeymapTypingTestPane) and useInputModes's useTypingTestResultSave
+  // (read by, at finish time). See LineSnapshot's own doc comment.
+  const lineSnapshotRef = useRef<LineSnapshot | null>(null)
 
   // --- Input modes (matrix tester + typing test) ---
   const {
@@ -99,6 +104,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
         }
       : undefined,
     tappingTermMs,
+    lineSnapshotRef,
   })
 
   // --- Layout options ---
@@ -387,6 +393,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               onPauseTest={pauseTypingTest}
               onResumeTest={resumeTypingTest}
               onRestartTestFromStart={restartTypingTestFromStart}
+              lineSnapshotRef={lineSnapshotRef}
             />
           ) : (
             <>

--- a/src/renderer/components/editors/KeymapTypingTestPane.tsx
+++ b/src/renderer/components/editors/KeymapTypingTestPane.tsx
@@ -7,6 +7,7 @@ import type { KleKey } from '../../../shared/kle/types'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 import type { useTypingTest } from '../../typing-test/useTypingTest'
+import type { LineSnapshot } from '../../typing-test/TypingTestView'
 
 /** `KeymapEditorProps` covers every plain pass-through field below (layers,
  *  layerNames, typingTestHistory, every "typingTest"/"onTypingTest"-prefixed
@@ -36,6 +37,9 @@ export interface KeymapTypingTestPaneProps extends KeymapEditorProps {
   onPauseTest?: () => void
   onResumeTest?: () => void
   onRestartTestFromStart?: () => void
+  /** Owned by `KeymapEditor` (lowest common ancestor of this pane and
+   *  `useInputModes`) — see `LineSnapshot`'s own doc comment. */
+  lineSnapshotRef?: RefObject<LineSnapshot | null>
 }
 
 /** Renders the typing-test surface inside `KeymapEditor`'s keymap-surface
@@ -69,6 +73,7 @@ export function KeymapTypingTestPane({
   typingTrayResident, onTypingTrayResidentChange, typingStartInTray, onTypingStartInTrayChange,
   typingViewMenuTab, onTypingViewMenuTabChange,
   onViewAnalytics, keyboardUid, timelineHandoff,
+  lineSnapshotRef,
 }: KeymapTypingTestPaneProps): JSX.Element {
   return (
     <TypingTestPane
@@ -138,6 +143,7 @@ export function KeymapTypingTestPane({
       onViewAnalytics={onViewAnalytics}
       keyboardUid={keyboardUid}
       timelineHandoff={timelineHandoff}
+      lineSnapshotRef={lineSnapshotRef}
     />
   )
 }

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -84,6 +84,7 @@ export function TypingTestPane({
   onViewAnalytics,
   keyboardUid,
   timelineHandoff,
+  lineSnapshotRef,
 }: TypingTestPaneProps) {
   const { t } = useTranslation()
 
@@ -271,6 +272,7 @@ export function TypingTestPane({
           onPause={() => onPauseTest?.()}
           onResume={() => setShowResumeModal(true)}
           hasSavedMemory={hasSavedMemory}
+          lineSnapshotRef={lineSnapshotRef}
         />
       )}
       <div

--- a/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
+++ b/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Focused unit coverage for useTypingTestResultSave's `lineBreaks`
+// derivation at finish time (Plan-line-keystroke-timeline PR1) — see
+// .claude/tasks/backlog/Task-line-timeline-pr1-persist-linebreaks.md and
+// the P2 codex-review fixes: the source is chosen by `config.mode` (never
+// by `state.lineBreaks.size`, which can't tell "real single-line text"
+// apart from "no real line source"), and every clamp is STRICT
+// (`< persistedWordCount - 1`, not `< persistedWordCount`) since a line
+// break can never legitimately land on the run's own last persisted word.
+// Every other existing behavior of this hook (result build/save,
+// pending-unnamed naming, memory-clear-on-finish) is already covered
+// end-to-end via useInputModes.run-log.test.tsx and
+// useInputModes.analytics.test.tsx, so this file drives the hook
+// directly with a minimal stub `typingTest` rather than a full HID-driven
+// run.
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { RefObject } from 'react'
+import { useTypingTestResultSave } from '../use-typing-test-result-save'
+import type { UseTypingTestResultSaveOptions } from '../use-typing-test-result-save'
+import type { UseTypingTestReturn, TypingTestState } from '../../../typing-test/useTypingTest'
+import type { LineSnapshot } from '../../../typing-test/TypingTestView'
+import { DEFAULT_CONFIG } from '../../../typing-test/types'
+import type { TypingTestConfig } from '../../../typing-test/types'
+import type { UseRunLogRecorderReturn } from '../use-run-log-recorder'
+
+// Real-line sources (word-supply.ts): both route through
+// parseFileImportText (typing-test-text-store.ts), so both carry genuine
+// `state.lineBreaks` and both are subject to the terminal-break rule.
+const FILE_IMPORT_CONFIG: TypingTestConfig = { mode: 'fileImport', textId: 't' }
+const TATOEBA_TIME_CONFIG: TypingTestConfig = { mode: 'tatoeba', language: 'english', pattern: 'time', lineCount: 5, duration: 60 }
+
+function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
+  return {
+    status: 'finished',
+    runId: 'run-1',
+    words: ['a', 'b', 'c', 'd'],
+    currentWordIndex: 4,
+    currentInput: '',
+    compositionText: '',
+    wordResults: [
+      { word: 'a', typed: 'a', correct: true },
+      { word: 'b', typed: 'b', correct: true },
+      { word: 'c', typed: 'c', correct: true },
+      { word: 'd', typed: 'd', correct: true },
+    ],
+    startTime: 1000,
+    endTime: 2000,
+    correctChars: 4,
+    incorrectChars: 0,
+    totalKeystrokes: 4,
+    confirmedChars: 4,
+    kspcUncomputable: false,
+    currentQuote: null,
+    wpmHistory: [],
+    lineBreaks: new Set(),
+    lineIndents: [],
+    romajiKeystrokes: '',
+    romajiCapable: false,
+    mistakes: {},
+    romajiSegmentErred: false,
+    missedPositions: [],
+    ...overrides,
+  }
+}
+
+function makeTypingTest(stateOverrides: Partial<TypingTestState>, config: TypingTestConfig): UseTypingTestReturn {
+  return {
+    state: makeState(stateOverrides),
+    wpm: 50,
+    kpm: 0,
+    accuracy: 100,
+    kspc: null,
+    romajiGuide: null,
+    elapsedSeconds: 1,
+    remainingSeconds: null,
+    config,
+    language: 'english',
+    isLanguageLoading: false,
+    baseLayer: 0,
+    effectiveLayer: 0,
+    windowFocused: true,
+    processMatrixFrame: vi.fn(),
+    resetMatrixPressTracking: vi.fn().mockResolvedValue(undefined),
+    processKeyEvent: vi.fn(),
+    processCompositionStart: vi.fn(),
+    processCompositionUpdate: vi.fn(),
+    processCompositionEnd: vi.fn(),
+    restart: vi.fn(),
+    restartWithCountdown: vi.fn(),
+    setConfig: vi.fn(),
+    setLanguage: vi.fn(),
+    setBaseLayer: vi.fn(),
+    setWindowFocused: vi.fn(),
+    captureMemory: vi.fn(),
+    pause: vi.fn(),
+    restoreState: vi.fn(),
+  }
+}
+
+function run(
+  stateOverrides: Partial<TypingTestState>,
+  lineSnapshot: LineSnapshot | null = null,
+  config: TypingTestConfig = DEFAULT_CONFIG,
+): { finishAndSave: ReturnType<typeof vi.fn> } {
+  const finishAndSave = vi.fn()
+  const runLog: UseRunLogRecorderReturn = {
+    record: vi.fn(),
+    noteRegistration: vi.fn(),
+    noteCharContext: vi.fn(),
+    finishAndSave,
+    discardRun: vi.fn(),
+  }
+  const options: UseTypingTestResultSaveOptions = {
+    typingTest: makeTypingTest(stateOverrides, config),
+    onSaveTypingTestResult: vi.fn(),
+    saveUnnamed: true,
+    savedMemoryRef: { current: undefined } as RefObject<undefined>,
+    onMemoryChangeRef: { current: undefined } as RefObject<undefined>,
+    keyboardRef: { current: { uid: 'kb-1', vendorId: 1, productId: 1, productName: 'x' } } as UseTypingTestResultSaveOptions['keyboardRef'],
+    flushAfterPendingEmits: vi.fn(),
+    runLog,
+    lineSnapshotRef: { current: lineSnapshot },
+  }
+  renderHook(() => useTypingTestResultSave(options))
+  return { finishAndSave }
+}
+
+function lineBreaksArg(finishAndSave: ReturnType<typeof vi.fn>): number[] | undefined {
+  expect(finishAndSave).toHaveBeenCalledTimes(1)
+  const meta = finishAndSave.mock.calls[0][2] as { lineBreaks?: number[] }
+  return meta.lineBreaks
+}
+
+describe('useTypingTestResultSave — lineBreaks derivation (line timeline PR1)', () => {
+  describe('real-line sources (config.mode, not state.lineBreaks.size, selects this path)', () => {
+    it('fileImport: sorted, clamped strictly before the terminal word', () => {
+      const { finishAndSave } = run({
+        lineBreaks: new Set([3, 1, 6]), // out of order on purpose; 6 is far out of range
+        words: ['a', 'b', 'c', 'd', 'e'],
+        wordResults: [
+          { word: 'a', typed: 'a', correct: true },
+          { word: 'b', typed: 'b', correct: true },
+          { word: 'c', typed: 'c', correct: true },
+          { word: 'd', typed: 'd', correct: true },
+          { word: 'e', typed: 'e', correct: true },
+        ],
+        currentWordIndex: 5,
+        currentInput: '',
+      }, null, FILE_IMPORT_CONFIG)
+      // persistedWordCount = 5; bound is < 4 (5 - 1): 1 and 3 survive, 6 is dropped.
+      expect(lineBreaksArg(finishAndSave)).toEqual([1, 3])
+    })
+
+    it('single-line fileImport run persists explicit [] — never undefined, never snapshot-derived', () => {
+      // A tagged, otherwise-valid snapshot is present too, to prove the
+      // real (empty) source wins outright rather than merely being
+      // preferred when non-empty.
+      const { finishAndSave } = run(
+        { lineBreaks: new Set(), words: ['a', 'b'], wordResults: [{ word: 'a', typed: 'a', correct: true }, { word: 'b', typed: 'b', correct: true }] },
+        { runId: 'run-1', wordCount: 2, lines: [[0], [1]] },
+        FILE_IMPORT_CONFIG,
+      )
+      expect(lineBreaksArg(finishAndSave)).toEqual([])
+    })
+
+    it('a break at the terminal word (persistedWordCount - 1) is dropped', () => {
+      const { finishAndSave } = run({
+        lineBreaks: new Set([0, 2]),
+        words: ['a', 'b', 'c'],
+        wordResults: [
+          { word: 'a', typed: 'a', correct: true },
+          { word: 'b', typed: 'b', correct: true },
+          { word: 'c', typed: 'c', correct: true },
+        ],
+        currentWordIndex: 3,
+        currentInput: '',
+      }, null, FILE_IMPORT_CONFIG)
+      // persistedWordCount = 3; bound is < 2: 0 survives, 2 (the last
+      // word, index persistedWordCount - 1) is dropped — nothing follows it.
+      expect(lineBreaksArg(finishAndSave)).toEqual([0])
+    })
+
+    it('takes priority over a coincidentally present (and otherwise valid) snapshot', () => {
+      const { finishAndSave } = run(
+        {
+          lineBreaks: new Set([2]),
+          words: ['a', 'b', 'c', 'd'],
+          wordResults: [
+            { word: 'a', typed: 'a', correct: true },
+            { word: 'b', typed: 'b', correct: true },
+            { word: 'c', typed: 'c', correct: true },
+            { word: 'd', typed: 'd', correct: true },
+          ],
+        },
+        { runId: 'run-1', wordCount: 4, lines: [[0], [1], [2], [3]] },
+        FILE_IMPORT_CONFIG,
+      )
+      expect(lineBreaksArg(finishAndSave)).toEqual([2])
+    })
+
+    it('tatoeba time pattern: an in-flight word bumps persistedWordCount by 1, and the new terminal is still dropped', () => {
+      const { finishAndSave } = run({
+        lineBreaks: new Set([0, 2, 3]),
+        words: ['a', 'b', 'c', 'd'],
+        wordResults: [
+          { word: 'a', typed: 'a', correct: true },
+          { word: 'b', typed: 'b', correct: true },
+        ],
+        currentWordIndex: 2,
+        currentInput: 'c', // in-flight, interrupted word — persistedWordCount = 2 + 1 = 3
+      }, null, TATOEBA_TIME_CONFIG)
+      // Bound is < 2: only 0 survives; 2 (the new terminal, persistedWordCount - 1)
+      // and 3 (beyond it) are both dropped.
+      expect(lineBreaksArg(finishAndSave)).toEqual([0])
+    })
+  })
+
+  describe('monkeytype sources (words/time/quote) — snapshot fallback, never state.lineBreaks', () => {
+    it('a stray non-empty state.lineBreaks is ignored under a non-real-line config (mode decides, not Set size)', () => {
+      const { finishAndSave } = run(
+        { lineBreaks: new Set([1]), words: ['a', 'b'] },
+        null,
+        DEFAULT_CONFIG, // mode: 'words'
+      )
+      expect(lineBreaksArg(finishAndSave)).toBeUndefined()
+    })
+
+    it('a stray non-empty state.lineBreaks does not block the snapshot fallback either', () => {
+      const { finishAndSave } = run(
+        {
+          lineBreaks: new Set([1]),
+          words: ['a', 'b', 'c', 'd'],
+          wordResults: [
+            { word: 'a', typed: 'a', correct: true },
+            { word: 'b', typed: 'b', correct: true },
+            { word: 'c', typed: 'c', correct: true },
+            { word: 'd', typed: 'd', correct: true },
+          ],
+        },
+        { runId: 'run-1', wordCount: 4, lines: [[0], [1], [2], [3]] },
+        DEFAULT_CONFIG,
+      )
+      // Snapshot-derived (rows 0-2's own last index), NOT [1] from state.lineBreaks.
+      expect(lineBreaksArg(finishAndSave)).toEqual([0, 1, 2])
+    })
+
+    it('matching runId+wordCount derives line-end indices (last row excluded)', () => {
+      const { finishAndSave } = run(
+        { lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] },
+        { runId: 'run-1', wordCount: 4, lines: [[0, 1], [2, 3]] },
+      )
+      // Only the first row's last index (1) — the final row (3) is excluded.
+      expect(lineBreaksArg(finishAndSave)).toEqual([1])
+    })
+
+    it('a snapshot row landing exactly on the persisted-word boundary is dropped (terminal rule applies here too)', () => {
+      const { finishAndSave } = run(
+        {
+          lineBreaks: new Set(),
+          runId: 'run-1',
+          words: ['a', 'b', 'c', 'd', 'e', 'f'],
+          wordResults: [
+            { word: 'a', typed: 'a', correct: true },
+            { word: 'b', typed: 'b', correct: true },
+            { word: 'c', typed: 'c', correct: true },
+          ],
+          currentWordIndex: 3,
+          currentInput: 'd', // in-flight — persistedWordCount = 3 + 1 = 4
+        },
+        // wordCount matches the full (unfinished) state.words — a time-bounded
+        // run that generated more text than it finished typing.
+        { runId: 'run-1', wordCount: 6, lines: [[0, 1], [2, 3], [4, 5]] },
+      )
+      // Row ends (excluding the snapshot's own final row) are [1, 3]; the
+      // strict persisted-boundary bound (< persistedWordCount - 1 = 3)
+      // then drops 3 too, leaving only 1.
+      expect(lineBreaksArg(finishAndSave)).toEqual([1])
+    })
+
+    it('mismatched runId falls back to undefined', () => {
+      const { finishAndSave } = run(
+        { lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] },
+        { runId: 'run-OTHER', wordCount: 4, lines: [[0, 1], [2, 3]] },
+      )
+      expect(lineBreaksArg(finishAndSave)).toBeUndefined()
+    })
+
+    it('mismatched wordCount falls back to undefined', () => {
+      const { finishAndSave } = run(
+        { lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] },
+        { runId: 'run-1', wordCount: 3, lines: [[0, 1], [2]] },
+      )
+      expect(lineBreaksArg(finishAndSave)).toBeUndefined()
+    })
+
+    it('null lines (unmeasured) falls back to undefined', () => {
+      const { finishAndSave } = run(
+        { lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] },
+        { runId: 'run-1', wordCount: 4, lines: null },
+      )
+      expect(lineBreaksArg(finishAndSave)).toBeUndefined()
+    })
+
+    it('no source at all (no snapshot) yields undefined', () => {
+      const { finishAndSave } = run({ lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] }, null)
+      expect(lineBreaksArg(finishAndSave)).toBeUndefined()
+    })
+  })
+})

--- a/src/renderer/components/editors/typing-test-pane-types.ts
+++ b/src/renderer/components/editors/typing-test-pane-types.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import type { RefObject } from 'react'
 import type { TypingTestResult, TypingViewMenuTab, TypingTestComparisonBaseline, TypingTestComparisonBaselines } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { KleKey } from '../../../shared/kle/types'
 import type { useTypingTest } from '../../typing-test/useTypingTest'
+import type { LineSnapshot } from '../../typing-test/TypingTestView'
 import type { AnalyticsOrigin } from './keymap-editor-types'
 import type { TimelineHandoff } from '../../hooks/useRunTimelineHandoff'
 
@@ -127,4 +129,10 @@ export interface TypingTestPaneProps {
    * forwarded straight to HistoryToggle, which auto-opens History and
    * this run's keystroke timeline for it. */
   timelineHandoff?: TimelineHandoff | null
+  /** Forwarded to `TypingTestView` — see `LineSnapshot`'s own doc comment
+   *  and `useTypingTestResultSave`'s consumption of it at finish time
+   *  (Plan-line-keystroke-timeline PR1). Owned by `KeymapEditor` (the
+   *  lowest common ancestor of this view and `useInputModes`), not this
+   *  pane. */
+  lineSnapshotRef?: RefObject<LineSnapshot | null>
 }

--- a/src/renderer/components/editors/use-typing-test-result-save.ts
+++ b/src/renderer/components/editors/use-typing-test-result-save.ts
@@ -2,12 +2,94 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
-import type { useTypingTest } from '../../typing-test/useTypingTest'
+import type { useTypingTest, TypingTestState } from '../../typing-test/useTypingTest'
 import { buildTypingTestResult, isPbForConfig } from '../../typing-test/result-builder'
 import { isRomajiInputActive } from '../../typing-test/romaji-input'
+import type { TypingTestConfig } from '../../typing-test/types'
+import type { LineSnapshot } from '../../typing-test/TypingTestView'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
 import type { UseRunLogRecorderReturn } from './use-run-log-recorder'
+
+/** A run's config carries REAL line semantics (a newline in the source
+ *  text advances via Enter, not Space) only for `fileImport` and
+ *  `tatoeba` — the only two `createWordsForConfig*` branches
+ *  (word-supply.ts) that ever populate `WordsForConfig.lineBreaks` with
+ *  anything non-empty:
+ *   - `fileImportTextToWords` (word-supply.ts) forwards
+ *     `data.lineBreaks`, itself produced by `parseFileImportText`
+ *     (typing-test-text-store.ts) — used for BOTH a user's own imported
+ *     `.txt` file and an Aozora Bunko import (aozora-import.ts saves the
+ *     cleaned text through the same typing-test-text-store, so it's
+ *     just another `fileImport` `textId` by the time a run reads it —
+ *     no separate discriminator needed).
+ *   - `tatobaWordsForConfig` (word-supply.ts) spreads `tatoebaRun`
+ *     (tatoeba-pack.ts), which ALSO calls `parseFileImportText` under
+ *     the hood (one sampled sentence per line) — true for both the
+ *     Lines and Time tatoeba patterns, and for `refillTimeModeWords`'s
+ *     own tatoeba-time refill batches.
+ *  `quote`/`words`/`time` always return `lineBreaks: []` from every
+ *  `createWordsForConfig*` branch — never real, regardless of whether
+ *  `state.lineBreaks` happens to be empty at the moment this reads it.
+ *  This is why the source must be chosen by `config.mode`, not by
+ *  `state.lineBreaks.size` — an emptiness check can't tell "single-line
+ *  real text" (must still persist as explicit `[]`) apart from "no real
+ *  line source at all" (must fall through to the snapshot, or omit). */
+function hasRealLineStructure(mode: TypingTestConfig['mode']): boolean {
+  return mode === 'fileImport' || mode === 'tatoeba'
+}
+
+/** Derive `RunKeystrokeLog.lineBreaks` for the just-finished run —
+ *  Plan-line-keystroke-timeline PR1. Two sources, chosen by
+ *  `config.mode` (see `hasRealLineStructure`), both clamped to
+ *  `persistedWordCount` (the run can end with an in-flight word —
+ *  `wordResults` itself never counts it — see the caller) with a
+ *  STRICT bound: an index must be `< persistedWordCount - 1`, not just
+ *  `< persistedWordCount`. A line break describes where a line ENDS
+ *  before ANOTHER FOLLOWS — the run's own last persisted word can never
+ *  be one, mirroring `parseFileImportText`'s own terminal-break removal
+ *  (typing-test-text-store.ts) and `isValidLineBreaks`'s matching bound
+ *  (typing-run-log-store.ts):
+ *   1. `hasRealLineStructure(config.mode)` — REAL line breaks
+ *      (tatoeba/fileImport text, `state.lineBreaks`). Always used for
+ *      these modes, persisted EVEN WHEN EMPTY (a genuinely single-line
+ *      run) — `[]` is not "no line source", it means "one line".
+ *   2. Otherwise (`words`/`time`/`quote` — no real line source of their
+ *      own): the monkeytype line-row snapshot TypingTestView wrote into
+ *      `lineSnapshotRef`, only trusted when it's tagged for THIS exact
+ *      run (`runId` and `wordCount` both match the live state), so a
+ *      stale snapshot left over from a previous render (or run) can
+ *      never be misattributed. Line-end index = each row's own last
+ *      word index, EXCEPT the final row (its end is the run's own end,
+ *      not a line break) — the strict clamp above then also drops any
+ *      row whose last index still lands exactly on the persisted
+ *      boundary (e.g. a time-bounded run interrupted mid-row, before
+ *      `state.words` itself ran out).
+ *  Returns `undefined` (omit — the saved log falls back to per-word
+ *  rendering) when neither source applies. An empty REAL-source result
+ *  is returned as `[]`, never collapsed to `undefined` — see
+ *  `RunKeystrokeLog.lineBreaks`'s own doc comment. */
+function deriveLineBreaksForLog(
+  config: TypingTestConfig, state: TypingTestState, persistedWordCount: number, snapshot: LineSnapshot | null,
+): number[] | undefined {
+  if (hasRealLineStructure(config.mode)) {
+    return [...state.lineBreaks].filter((i) => i < persistedWordCount - 1).sort((a, b) => a - b)
+  }
+  if (
+    snapshot && snapshot.lines != null
+    && snapshot.runId === state.runId && snapshot.wordCount === state.words.length
+  ) {
+    const ends: number[] = []
+    // Every row but the last — the last row's own end is the run's end,
+    // not a line break.
+    for (let i = 0; i < snapshot.lines.length - 1; i++) {
+      const row = snapshot.lines[i]
+      if (row.length > 0) ends.push(row[row.length - 1])
+    }
+    return ends.filter((i) => i < persistedWordCount - 1)
+  }
+  return undefined
+}
 
 export interface UseTypingTestResultSaveOptions {
   typingTest: ReturnType<typeof useTypingTest>
@@ -26,6 +108,11 @@ export interface UseTypingTestResultSaveOptions {
   keyboardRef: RefObject<TypingAnalyticsKeyboard | undefined>
   flushAfterPendingEmits: (drained: Promise<void>, uid: string) => void
   runLog: UseRunLogRecorderReturn
+  /** TypingTestView's own realized-lines snapshot (monkeytype modes only
+   *  — see `deriveLineBreaksForLog`). Optional so a caller that never
+   *  renders TypingTestView (or an older test) doesn't have to thread
+   *  one. */
+  lineSnapshotRef?: RefObject<LineSnapshot | null>
 }
 
 export interface UseTypingTestResultSaveReturn {
@@ -56,6 +143,7 @@ export function useTypingTestResultSave({
   keyboardRef,
   flushAfterPendingEmits,
   runLog,
+  lineSnapshotRef,
 }: UseTypingTestResultSaveOptions): UseTypingTestResultSaveReturn {
   const { resetMatrixPressTracking } = typingTest
 
@@ -116,6 +204,15 @@ export function useTypingTestResultSave({
       const inFlightWord = typingTest.state.currentWordIndex < typingTest.state.words.length && typedSoFar.length > 0
         ? { display: typingTest.state.words[typingTest.state.currentWordIndex], typed: typedSoFar }
         : undefined
+      // Line structure for the saved log (Plan-line-keystroke-timeline
+      // PR1) — see `deriveLineBreaksForLog`'s own doc comment for the two
+      // sources and the persisted-word clamp (`wordResults` plus the
+      // in-flight word above, exactly what `runLog.finishAndSave` is
+      // about to persist as `words`).
+      const persistedWordCount = typingTest.state.wordResults.length + (inFlightWord ? 1 : 0)
+      const lineBreaksForLog = deriveLineBreaksForLog(
+        typingTest.config, typingTest.state, persistedWordCount, lineSnapshotRef?.current ?? null,
+      )
       // Finalize the per-run raw keystroke log — discards outright when
       // there's no active keyboard uid to save under; otherwise builds and
       // saves it (itself a no-op unless this run was actually
@@ -133,6 +230,7 @@ export function useTypingTestResultSave({
         // see RunLogFinishMeta.romajiInput's own doc comment.
         romajiInput: result.romajiInput === true,
         inFlightWord,
+        lineBreaks: lineBreaksForLog,
       })
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useState, useCallback, useEffect, useRef } from 'react'
+import type { RefObject } from 'react'
 import { useTypingTest } from '../../typing-test/useTypingTest'
 import type { TypingTestConfig } from '../../typing-test/types'
+import type { LineSnapshot } from '../../typing-test/TypingTestView'
 import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../typing-test/types'
 import { useMatrixTester } from './use-matrix-tester'
 import { useTypingAnalyticsSink, typingTestAnalyticsLabel } from './use-typing-analytics-sink'
@@ -55,6 +57,10 @@ export interface UseInputModesOptions {
    * keystroke log (see run-log-recorder.ts), independently of and
    * stricter than `typingRecordEnabled`'s per-minute analytics gate. */
   recordingConsentAccepted?: boolean
+  /** Owned by the caller (KeymapEditor) — the lowest common ancestor of
+   *  this hook and the TypingTestView it drives. Forwarded to
+   *  useTypingTestResultSave; see LineSnapshot's own doc comment. */
+  lineSnapshotRef?: RefObject<LineSnapshot | null>
 }
 
 export interface UseInputModesReturn {
@@ -106,6 +112,7 @@ export function useInputModes({
   onRecKeystroke,
   tappingTermMs,
   recordingConsentAccepted = false,
+  lineSnapshotRef,
 }: UseInputModesOptions): UseInputModesReturn {
   // --- Matrix tester ---
   const {
@@ -302,6 +309,7 @@ export function useInputModes({
     keyboardRef,
     flushAfterPendingEmits,
     runLog,
+    lineSnapshotRef,
   })
 
   // Sync saved config/language from device prefs into useTypingTest

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useRef, useEffect, useLayoutEffect, useCallback, useMemo, useState } from 'react'
-import type { CSSProperties } from 'react'
+import type { CSSProperties, RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingTestState } from './useTypingTest'
 import type { RomajiGuide, TypingTestConfig } from './types'
@@ -13,6 +13,28 @@ import { TypingTestStatsRow } from './TypingTestStatsRow'
 import { useVisualLines } from './useVisualLines'
 import { useLogicalWindowHeight } from './useLogicalWindowHeight'
 
+
+/** A tagged snapshot of this view's own realized line rows (`lines` below
+ *  — real or synthetic, same `number[][]` shape either way), written by
+ *  a `useLayoutEffect` (never during render) into a caller-owned ref.
+ *  `use-typing-test-result-save.ts` reads it at finish time to derive
+ *  `RunKeystrokeLog.lineBreaks` for monkeytype modes (words/time/quote),
+ *  which have no real `state.lineBreaks` of their own — see that file's
+ *  own doc comment for the runId/wordCount match it requires before
+ *  trusting a stale snapshot. `runId`/`wordCount` are the tag: a
+ *  consumer must check both against its own current state before using
+ *  `lines`, since this ref can otherwise still hold the PREVIOUS run's
+ *  last-measured value for one render (the effect that clears it runs
+ *  after the consumer's own effect in the same commit is not guaranteed
+ *  to have fired first). `lines: null` means unmeasured (jsdom, or
+ *  before the first paint) — distinct from an absent snapshot
+ *  altogether (`lineSnapshotRef.current === null`, i.e. the effect has
+ *  never run at all). */
+export interface LineSnapshot {
+  runId: string
+  wordCount: number
+  lines: number[][] | null
+}
 
 interface Props {
   state: TypingTestState
@@ -71,6 +93,10 @@ interface Props {
    *  KSPC) "the metric doesn't apply to this run" is common, not an
    *  in-progress state. */
   errorClasses?: { substitutions: number; omissions: number; insertions: number } | null
+  /** Host-owned ref this view snapshots its own realized `lines` into —
+   *  see `LineSnapshot`'s own doc comment. Optional so every existing
+   *  mount (tests included) stays valid without threading it. */
+  lineSnapshotRef?: RefObject<LineSnapshot | null>
 }
 
 /** Group flat word indices into logical lines using the line-break set
@@ -129,6 +155,7 @@ export function TypingTestView({
   onResume,
   hasSavedMemory,
   errorClasses = null,
+  lineSnapshotRef,
 }: Props) {
   const { t } = useTranslation()
   const wordsRef = useRef<HTMLDivElement>(null)
@@ -159,6 +186,17 @@ export function TypingTestView({
   const monkeytypeActive = realLines === null
   const { lines: visualLines, mirrorRef } = useVisualLines(wordsRef, state.words, fontSize, monkeytypeActive)
   const lines = realLines ?? visualLines
+  // Snapshot this view's own realized `lines` into the host-owned ref —
+  // see `LineSnapshot`'s doc comment. A pure ref write (never setState),
+  // and deliberately in a layout effect (not during render, not a plain
+  // effect): render must stay a pure function of props/state, and a
+  // layout effect (vs. a passive one) guarantees the snapshot is current
+  // before the browser paints, matching the other layout effects in this
+  // component that also read post-render measurements.
+  useLayoutEffect(() => {
+    if (!lineSnapshotRef) return
+    lineSnapshotRef.current = { runId: state.runId, wordCount: state.words.length, lines }
+  }, [lineSnapshotRef, lines, state.runId, state.words.length])
   // Romaji guide line-sync: which line rows to preview in the guide row
   // below the reading window, anchored to whichever row the current word
   // sits on (real or synthetic — same `lines` shape either way). `null`

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { TypingTestView } from '../TypingTestView'
+import type { LineSnapshot } from '../TypingTestView'
 import type { TypingTestState } from '../useTypingTest'
 import type { TypingTestConfig } from '../types'
 import { DEFAULT_CONFIG } from '../types'
@@ -872,6 +873,71 @@ describe('TypingTestView — imported fileImport text (line breaks)', () => {
     expect(container.querySelectorAll('[data-line-row]')).toHaveLength(0)
     // Flat word-flow still uses the shared var-driven window (no line rows).
     expect(screen.getByTestId('typing-test-words').className).toContain('typing-multiline-window')
+  })
+})
+
+// Plan-line-keystroke-timeline PR1: TypingTestView snapshots its own
+// realized `lines` into a caller-owned ref (consumed at finish time by
+// use-typing-test-result-save.ts) via a useLayoutEffect, never during
+// render.
+describe('TypingTestView — lineSnapshotRef (line timeline PR1)', () => {
+  it('writes {runId, wordCount, lines} once real (state.lineBreaks) lines render', () => {
+    const ref: { current: LineSnapshot | null } = { current: null }
+    renderView({
+      lineSnapshotRef: ref,
+      state: makeState({
+        status: 'running',
+        runId: 'run-xyz',
+        words: ['a', 'b', 'c', 'd'],
+        lineBreaks: new Set([1]),
+      }),
+    })
+    expect(ref.current).toEqual({ runId: 'run-xyz', wordCount: 4, lines: [[0, 1], [2, 3]] })
+  })
+
+  it('writes null lines when content is flat/unmeasured (jsdom monkeytype fallback)', () => {
+    const ref: { current: LineSnapshot | null } = { current: null }
+    renderView({
+      lineSnapshotRef: ref,
+      state: makeState({
+        status: 'running',
+        runId: 'run-flat',
+        words: ['a', 'b'],
+        lineBreaks: new Set(),
+      }),
+    })
+    expect(ref.current).toEqual({ runId: 'run-flat', wordCount: 2, lines: null })
+  })
+
+  it('updates the ref when runId/words change across a rerender', () => {
+    const ref: { current: LineSnapshot | null } = { current: null }
+    const { rerender } = renderView({
+      lineSnapshotRef: ref,
+      state: makeState({ status: 'running', runId: 'run-1', words: ['a', 'b'], lineBreaks: new Set([0]) }),
+    })
+    expect(ref.current).toEqual({ runId: 'run-1', wordCount: 2, lines: [[0], [1]] })
+
+    rerender(
+      <I18nextProvider i18n={i18n}>
+        <TypingTestView
+          lineSnapshotRef={ref}
+          state={makeState({ status: 'running', runId: 'run-2', words: ['x', 'y', 'z'], lineBreaks: new Set([1]) })}
+          wpm={0}
+          accuracy={100}
+          elapsedSeconds={0}
+          remainingSeconds={null}
+          config={DEFAULT_CONFIG}
+          paused={false}
+        />
+      </I18nextProvider>,
+    )
+    expect(ref.current).toEqual({ runId: 'run-2', wordCount: 3, lines: [[0, 1], [2]] })
+  })
+
+  it('does nothing when lineSnapshotRef is not provided (optional prop)', () => {
+    expect(() => renderView({
+      state: makeState({ status: 'running', words: ['a', 'b'], lineBreaks: new Set([0]) }),
+    })).not.toThrow()
   })
 })
 

--- a/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
+++ b/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
@@ -678,6 +678,35 @@ describe('RunLogRecorder', () => {
     })
   })
 
+  describe('lineBreaks passthrough (line timeline PR1)', () => {
+    it('forwards a non-empty meta.lineBreaks verbatim into the saved log', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ lineBreaks: [1, 3] }))
+      expect(log?.lineBreaks).toEqual([1, 3])
+    })
+
+    it('forwards an explicit empty meta.lineBreaks as [] (not collapsed to omitted)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+
+      const log = recorder.finish(oneWordResult(), finishMeta({ lineBreaks: [] }))
+      expect(log?.lineBreaks).toEqual([])
+    })
+
+    it('leaves lineBreaks undefined when meta omits it (legacy / no known line structure)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress())
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      expect(log?.lineBreaks).toBeUndefined()
+    })
+  })
+
   describe('discard()', () => {
     it('clears the buffer (unmount / keyboard-switch cleanup)', () => {
       const recorder = new RunLogRecorder()

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -165,6 +165,20 @@ export interface RunLogFinishMeta {
    *  this as a trailing `partial: true` RunWord instead of silently
    *  dropping its keystrokes. */
   inFlightWord?: { display: string; typed: string }
+  /** Forwarded verbatim to `RunKeystrokeLog.lineBreaks` — `finish()` does
+   *  no derivation or clamping of its own; the caller (see
+   *  `useTypingTestResultSave`'s `deriveLineBreaksForLog`) has already
+   *  chosen the source by `config.mode` (never by `state.lineBreaks`
+   *  emptiness — an empty REAL source is a legitimate single-line `[]`,
+   *  not "no line structure") and clamped every index to be STRICTLY
+   *  less than the last persisted word's own index (`persistedWordCount
+   *  - 1`), since a line break can never legitimately land on the run's
+   *  own final word. Omitted (not `undefined`-then-dropped — it's
+   *  already optional) for a run with no known line structure, same
+   *  convention as this module's other optional fields; an explicit `[]`
+   *  is preserved as-is (see that field's own doc comment for why it
+   *  must not collapse to omitted). */
+  lineBreaks?: number[]
 }
 
 /** Buffered keystroke, kept in absolute-ms form (`Date.now()` values)
@@ -690,6 +704,7 @@ export class RunLogRecorder {
       language: meta.language,
       charCorrelationUnavailable: meta.charCorrelationUnavailable || undefined,
       romajiInput: meta.romajiInput || undefined,
+      lineBreaks: meta.lineBreaks,
       words,
     }
   }

--- a/src/shared/types/typing-run-log.ts
+++ b/src/shared/types/typing-run-log.ts
@@ -110,6 +110,28 @@ export interface RunKeystrokeLog {
    *  the pre-existing (and only slightly wrong, not nonsensical) verbatim
    *  scoring is preferred over guessing. */
   romajiInput?: boolean
+  /** Sorted, unique, ascending line-end word indices (into `words`) — the
+   *  reading window's logical line structure at the moment this run
+   *  finished, so a saved run can later be re-rendered as per-line
+   *  timeline rows instead of one flat per-word list. Every index is
+   *  STRICTLY less than `words.length - 1` — a line break describes
+   *  where a line ENDS before ANOTHER FOLLOWS, so the last word in
+   *  `words` (which has nothing after it) can never be one; see
+   *  `isValidLineBreaks` (typing-run-log-store.ts) for the enforced
+   *  bound and `parseFileImportText`'s matching terminal-break removal
+   *  (typing-test-text-store.ts). FIELD PRESENCE (not emptiness)
+   *  selects rendering mode: `[]` legitimately means "the run was one
+   *  line" (still line-mode — a single row), while the field being
+   *  absent altogether means a log saved before this feature existed,
+   *  which falls back to the original per-word rendering. Never sent to
+   *  Hub — this field lives inside the same opaque log payload that
+   *  already isn't (see the module doc comment). See
+   *  TypingTestView.tsx's `LineSnapshot` (the live source for
+   *  monkeytype modes) and `useTypingTestResultSave`'s
+   *  `deriveLineBreaksForLog` (real `state.lineBreaks` for
+   *  tatoeba/fileImport — chosen by `config.mode`, never by whether
+   *  `state.lineBreaks` happens to be empty — the snapshot otherwise). */
+  lineBreaks?: number[]
   words: RunWord[]
 }
 


### PR DESCRIPTION
## Summary
- Add optional `RunKeystrokeLog.lineBreaks` (sorted line-end word indices): field presence selects per-line rendering downstream, `[]` legitimately means a single-line run, and absent means legacy (per-word fallback). Groundwork for the per-line keystroke timeline (PR2).
- Real line sources (file import / tatoeba — chosen by mode, not by set emptiness) persist their own breaks, explicitly `[]` for single-line texts. Monkeytype modes (words/time/quote) snapshot the DOM-measured visual rows at finish via a tagged `{runId, wordCount, lines}` ref written in a layout effect — consumed only when both tags match the finishing run, so a stale layout is never misattributed.
- Terminal breaks are dropped on both producer paths (`< persistedWordCount - 1`, which also excludes the in-flight word) and rejected by the main-process validator (`>= words.length - 1`): a line break must have at least one word after it, mirroring `parseFileImportText`'s terminal-break removal.
- Sync/merge/retention untouched — the log payload stays opaque to them.

## Verification
- TDD: 31 new tests across recorder / store / result-save / view suites, with red-run evidence for each behavioral change (including a scripted revert proving 7 failures on the review fixes).
- Full suite 8,283 passed / 22 skipped (baseline +31 exactly, zero existing-test edits beyond the rewritten result-save suite).
- eslint and typecheck clean.