### PR TITLE
fix(ui): keep History modal content inside its bounds

### DIFF
--- a/src/renderer/typing-test/HistorySections.tsx
+++ b/src/renderer/typing-test/HistorySections.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useTranslation } from 'react-i18next'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import type { TypingTestStats } from './history-stats'
+import { WpmSparkline } from './WpmSparkline'
+import { AccuracyTrendSection } from './AccuracyTrendSection'
+import { MistakeRankingSection } from './MistakeRankingSection'
+import { ErrorMixSection } from './ErrorMixSection'
+
+interface Props {
+  /** Active tab's unfiltered results (mode filter doesn't apply — each
+   *  section below scopes/filters independently, matching their own
+   *  prop docs in AccuracyTrendSection/MistakeRankingSection/ErrorMixSection). */
+  tabResults: TypingTestResult[]
+  /** Stats computed from the mode-filtered `filtered` set (not `tabResults`). */
+  stats: TypingTestStats
+  /** Sparkline series, already sliced/reversed from `filtered`. */
+  sparklineResults: TypingTestResult[]
+}
+
+interface StatItemProps {
+  label: string
+  value: number | string
+  highlight?: boolean
+}
+
+function StatItem({ label, value, highlight }: StatItemProps) {
+  return (
+    // Baseline-align so the mono value digits sit level with the sans label
+    // (their font metrics differ, so items-center looks vertically off).
+    <div className="flex items-baseline gap-1.5">
+      <span className="text-content-muted">{label}:</span>
+      <span className={`font-mono font-semibold ${highlight ? 'text-accent' : ''}`}>{value}</span>
+    </div>
+  )
+}
+
+/** Everything between the History modal's top tabs and its results table:
+ *  sparkline, stats summary, accuracy trend, mistake ranking, error mix.
+ *  Split out of `TypingTestHistory` purely to keep that file under the
+ *  500-line component cap (`.claude/rules/file-splitting.md`) — this wraps
+ *  in its own `min-h-0 shrink overflow-y-auto` container so a tall stack
+ *  (e.g. many mistake-ranking rows) scrolls independently instead of
+ *  pushing the results table past the modal's bottom edge (flex children
+ *  don't shrink below their content height otherwise). */
+export function HistorySections({ tabResults, stats, sparklineResults }: Props) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex min-h-0 shrink flex-col gap-3 overflow-y-auto" data-testid="history-sections">
+      {/* Sparkline — chart-above-stats, matching every other Analyze section's order */}
+      {sparklineResults.length >= 2 && (
+        <div className="flex justify-center" data-testid="history-sparkline">
+          <WpmSparkline results={sparklineResults} width={400} height={50} />
+        </div>
+      )}
+
+      {/* Stats summary */}
+      <div className="flex flex-wrap items-center gap-6 text-sm" data-testid="history-stats">
+        <StatItem label={t('editor.typingTest.history.bestWpm')} value={stats.bestWpm} highlight />
+        <StatItem label={t('editor.typingTest.history.avgWpm')} value={stats.avgWpm} />
+        <StatItem label={t('editor.typingTest.history.last10Avg')} value={stats.last10Avg} />
+        <StatItem label={t('editor.typingTest.history.totalTests')} value={stats.totalTests} />
+        <StatItem label={t('editor.typingTest.history.avgAccuracy')} value={`${stats.avgAccuracy}%`} />
+      </div>
+
+      <AccuracyTrendSection results={tabResults} />
+      <MistakeRankingSection results={tabResults} />
+      <ErrorMixSection results={tabResults} />
+    </div>
+  )
+}

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -7,10 +7,7 @@ import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import { buildCsv } from '../../shared/csv-export'
 import { computeStats } from './history-stats'
-import { WpmSparkline } from './WpmSparkline'
-import { AccuracyTrendSection } from './AccuracyTrendSection'
-import { MistakeRankingSection } from './MistakeRankingSection'
-import { ErrorMixSection } from './ErrorMixSection'
+import { HistorySections } from './HistorySections'
 import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
 import { resultKpm, resultKspc, buildResultNameChips } from './result-builder'
 import { formatKspc } from '../../shared/kspc'
@@ -207,8 +204,16 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
     }).slice(0, MAX_TABLE_ROWS)
   }, [filtered, sortColumn, sortDirection])
 
+  // min-h-0 flex-1 (not h-full) on the root below: this is a flex child of
+  // HistoryToggle's `flex h-modal-80vh flex-col` modal box, sitting below
+  // the title row. h-full resolves to 100% of the modal's own content-box
+  // height, ignoring the title row's share of that flex column, which
+  // pushed this div (and everything below it) a constant ~20px past the
+  // modal's bottom edge regardless of content or window size. flex-1
+  // (flex-basis:0 + grow) makes it consume exactly the space left over
+  // after the title row instead.
   return (
-    <div data-testid="typing-test-history" className="flex h-full max-w-4xl flex-col gap-3">
+    <div data-testid="typing-test-history" className="flex min-h-0 flex-1 max-w-4xl flex-col gap-3">
       {/* Top tabs: Monkeytype (words/time/quote) vs imported Text (fileImport). */}
       <div className="flex items-center gap-4 border-b border-edge">
         {(['monkeytype', 'text'] as HistoryTab[]).map((tb) => (
@@ -276,28 +281,10 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
         )}
       </div>
 
-      {/* Sparkline — chart-above-stats, matching every other Analyze section's order */}
-      {sparklineResults.length >= 2 && (
-        <div className="flex justify-center" data-testid="history-sparkline">
-          <WpmSparkline results={sparklineResults} width={400} height={50} />
-        </div>
-      )}
+      <HistorySections tabResults={tabResults} stats={stats} sparklineResults={sparklineResults} />
 
-      {/* Stats summary */}
-      <div className="flex flex-wrap items-center gap-6 text-sm" data-testid="history-stats">
-        <StatItem label={t('editor.typingTest.history.bestWpm')} value={stats.bestWpm} highlight />
-        <StatItem label={t('editor.typingTest.history.avgWpm')} value={stats.avgWpm} />
-        <StatItem label={t('editor.typingTest.history.last10Avg')} value={stats.last10Avg} />
-        <StatItem label={t('editor.typingTest.history.totalTests')} value={stats.totalTests} />
-        <StatItem label={t('editor.typingTest.history.avgAccuracy')} value={`${stats.avgAccuracy}%`} />
-      </div>
-
-      <AccuracyTrendSection results={tabResults} />
-      <MistakeRankingSection results={tabResults} />
-      <ErrorMixSection results={tabResults} />
-
-      {/* Results table — fills remaining height */}
-      <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-edge">
+      {/* Results table — fills remaining height, never collapses below min-h-48 */}
+      <div className="min-h-48 flex-1 overflow-y-auto rounded-lg border border-edge">
         {sorted.length > 0 ? (
           <table className="w-full text-left text-xs">
             <thead className="sticky top-0 bg-surface-alt text-content-muted">
@@ -423,23 +410,6 @@ function SortableHeader({
         {label}{isActive ? sortIndicator(sortDirection) : ''}
       </button>
     </th>
-  )
-}
-
-interface StatItemProps {
-  label: string
-  value: number | string
-  highlight?: boolean
-}
-
-function StatItem({ label, value, highlight }: StatItemProps) {
-  return (
-    // Baseline-align so the mono value digits sit level with the sans label
-    // (their font metrics differ, so items-center looks vertically off).
-    <div className="flex items-baseline gap-1.5">
-      <span className="text-content-muted">{label}:</span>
-      <span className={`font-mono font-semibold ${highlight ? 'text-accent' : ''}`}>{value}</span>
-    </div>
   )
 }
 

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -398,6 +398,56 @@ describe('TypingTestHistory', () => {
     expect(screen.getAllByText('kept').length).toBeGreaterThan(0)
   })
 
+  // Regression guard for the History modal overflow fix: the sections
+  // between the tabs and the results table (sparkline/stats/accuracy-trend/
+  // mistake-ranking/error-mix) must live inside their own scroll container,
+  // separate from the tabs above and the results table below, so a tall
+  // stack of sections can't push the table past the modal's bottom edge.
+  it('wraps the between-tabs-and-table sections in their own scroll container', () => {
+    const results = [
+      makeResult({ wpm: 60, accuracy: 90, mistakes: { a: 3, b: 2 } }),
+      makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 } }),
+    ]
+    renderWithI18n(<TypingTestHistory results={results} />)
+
+    // Root: min-h-0 flex-1 (NOT h-full) — it's a flex child of
+    // HistoryToggle's `flex h-modal-80vh flex-col` modal box, sitting
+    // below the title row. h-full resolves to 100% of the modal's own
+    // content-box height, ignoring the title row's share, which pushed
+    // this div (and everything below it) a constant ~20px past the
+    // modal's bottom edge regardless of content or window size. flex-1
+    // makes it consume exactly the space left over after the title row.
+    const root = screen.getByTestId('typing-test-history')
+    expect(root.className).toContain('min-h-0')
+    expect(root.className).toContain('flex-1')
+    expect(root.className).not.toContain('h-full')
+
+    const sections = screen.getByTestId('history-sections')
+    expect(sections.className).toContain('min-h-0')
+    expect(sections.className).toContain('shrink')
+    expect(sections.className).toContain('overflow-y-auto')
+
+    // Contains the three lower sections.
+    expect(sections.querySelector('[data-testid="typing-test-mistake-ranking"]')).toBeTruthy()
+    expect(sections.querySelector('[data-testid="typing-test-error-mix"]')).toBeTruthy()
+    expect(sections.querySelector('[data-testid="history-condition-filter"]')).toBeTruthy()
+
+    // Does NOT contain the tab buttons or the results table — both live
+    // outside the wrapper (tabs always visible above; table scrolls on its own below).
+    expect(sections.querySelector('[data-testid="history-tab-monkeytype"]')).toBeNull()
+    expect(sections.querySelector('table')).toBeNull()
+
+    // The results-table wrapper carries a min-h-48 floor so it never
+    // collapses to zero height when the sections region above it is tall.
+    const history = screen.getByTestId('typing-test-history')
+    const table = history.querySelector('table')
+    expect(table).toBeTruthy()
+    const tableWrapper = table!.parentElement as HTMLElement
+    expect(tableWrapper.className).toContain('min-h-48')
+    expect(tableWrapper.className).toContain('flex-1')
+    expect(tableWrapper.className).toContain('overflow-y-auto')
+  })
+
   describe('Accuracy Trend condition selector', () => {
     it('defaults to the latest run\'s condition and hides the chart below 2 same-condition runs', () => {
       // Newest-first, mirroring the real prop order (useDevicePrefs prepends


### PR DESCRIPTION
## Summary
- The History modal's content could overflow past the modal's bottom edge once the analysis sections grew tall (user-reported with a screenshot: Error Mix rendering on the backdrop). Two stacked flex bugs: the section stack could not shrink below its content height — squeezing the results table to ~1.6px and pushing the tail sections up to ~456px outside the modal — and the content root used `h-full` below the title row, adding a constant ~20-44px overflow on top regardless of content.
- The sections between the source tabs and the table now live in a shrinkable scroll region (`min-h-0 shrink overflow-y-auto`, extracted to `HistorySections.tsx` to stay under the 500-line cap), the table wrapper gains `min-h-48` so it never collapses, and the root switches to `min-h-0 flex-1` so it consumes exactly the space left after the title row.
- Normal case (everything fits) stays pixel-identical.

## Verification
- Structural regression test added (sections wrapper classes/membership, table min-height, root sizing) with red-run evidence for each change; full suite 8,284 passed / 22 skipped.
- Playwright check against the virtual device at a forced 1360×800 window with seeded mistake-heavy history: strict `getBoundingClientRect` containment passes (content root bottom 696.0 < modal bottom 720.0, zero elements bleeding past the modal edge; pre-fix A/B measured the 456px overflow).