### PR TITLE
feat(ui): reorganize the History modal into view and source tabs

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.59",
+  "version": "0.1.60",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -492,6 +492,8 @@
         "unnamed": "名称未設定",
         "mode": "モード",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
+        "tabAozora": "青空文庫",
         "tabFileImport": "ファイル取込",
         "tabText": "テキスト",
         "tabResults": "結果",

--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.58",
+  "version": "0.1.59",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -494,6 +494,9 @@
         "tabMonkeytype": "MonkeyType",
         "tabFileImport": "ファイル取込",
         "tabText": "テキスト",
+        "tabResults": "結果",
+        "tabAnalysis": "分析",
+        "viewTabsAriaLabel": "履歴の表示切替",
         "noResults": "結果がありません",
         "pb": "PB",
         "allModes": "すべて",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.58",
+  "version": "0.1.59",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -494,6 +494,9 @@
         "tabMonkeytype": "MonkeyType",
         "tabFileImport": "ファイル取込っしょ",
         "tabText": "テキスト",
+        "tabResults": "結果☆",
+        "tabAnalysis": "分析☆",
+        "viewTabsAriaLabel": "履歴の表示を切り替えるっしょ",
         "noResults": "結果ないじゃん",
         "pb": "PB☆",
         "allModes": "全部",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.59",
+  "version": "0.1.60",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -492,6 +492,8 @@
         "unnamed": "名前なし☆",
         "mode": "モード☆",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba☆",
+        "tabAozora": "青空文庫☆",
         "tabFileImport": "ファイル取込っしょ",
         "tabText": "テキスト",
         "tabResults": "結果☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.59",
+  "version": "0.1.60",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -492,6 +492,8 @@
         "unnamed": "名なしどすえ",
         "mode": "モード",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
+        "tabAozora": "青空文庫",
         "tabFileImport": "ファイル取込",
         "tabText": "テキスト",
         "tabResults": "結果",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.58",
+  "version": "0.1.59",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -494,6 +494,9 @@
         "tabMonkeytype": "MonkeyType",
         "tabFileImport": "ファイル取込",
         "tabText": "テキスト",
+        "tabResults": "結果",
+        "tabAnalysis": "分析",
+        "viewTabsAriaLabel": "履歴の表示を切り替えますえ",
         "noResults": "結果がおへんなぁ",
         "pb": "PB",
         "allModes": "全部",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.58",
+  "version": "0.1.59",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -494,6 +494,9 @@
         "tabMonkeytype": "MonkeyType",
         "tabFileImport": "書類の取込",
         "tabText": "文言",
+        "tabResults": "結果",
+        "tabAnalysis": "分析",
+        "viewTabsAriaLabel": "履歴の表示切替",
         "noResults": "記録はございません",
         "pb": "自己最高",
         "allModes": "すべて",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.59",
+  "version": "0.1.60",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -492,6 +492,8 @@
         "unnamed": "名もなし",
         "mode": "形式",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
+        "tabAozora": "青空文庫",
         "tabFileImport": "書類の取込",
         "tabText": "文言",
         "tabResults": "結果",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.59",
+  "version": "0.1.60",
   "name": "English",
   "common": {
     "save": "Save",
@@ -492,6 +492,8 @@
         "unnamed": "Unnamed",
         "mode": "Mode",
         "tabMonkeytype": "MonkeyType",
+        "tabTatoeba": "Tatoeba",
+        "tabAozora": "Aozora",
         "tabFileImport": "File Import",
         "tabText": "Text",
         "tabResults": "Results",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.58",
+  "version": "0.1.59",
   "name": "English",
   "common": {
     "save": "Save",
@@ -494,6 +494,9 @@
         "tabMonkeytype": "MonkeyType",
         "tabFileImport": "File Import",
         "tabText": "Text",
+        "tabResults": "Results",
+        "tabAnalysis": "Analysis",
+        "viewTabsAriaLabel": "History view",
         "noResults": "No results yet",
         "pb": "PB",
         "allModes": "All",

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -19,7 +19,15 @@ import { WpmSparkline } from './WpmSparkline'
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
 type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
 type SortDirection = 'asc' | 'desc'
-export type { SortColumn, SortDirection }
+/** Source-tab split: MonkeyType (words/time/quote) keeps the mode dropdown;
+ *  Tatoeba has no sub-filter (the Analysis condition selector already
+ *  covers per-condition grouping); Aozora and File Import both scope the
+ *  text dropdown to their own subset of imported texts (source.provider
+ *  'aozora' vs everything else — see TypingTestHistory's classification).
+ *  'text' (not 'fileImport') is kept as the File Import tab's key to avoid
+ *  churn across existing testids/CSV slugs. */
+type HistoryTab = 'monkeytype' | 'tatoeba' | 'aozora' | 'text'
+export type { SortColumn, SortDirection, HistoryTab }
 
 const MAX_TABLE_ROWS = 20
 const MAX_SPARKLINE_RESULTS = 50
@@ -39,9 +47,11 @@ function modeDetail(r: TypingTestResult): string {
 }
 
 interface Props {
-  /** Mode filter (Monkeytype tab) vs text filter (Text tab) — the parent owns
-   *  the state and the filtered result set; this panel only renders the UI. */
-  isText: boolean
+  /** Active source tab. Drives which sub-filter (mode dropdown / text
+   *  dropdown / none) renders and the Mode-vs-Text column label below — the
+   *  parent owns the state and the filtered result set; this panel only
+   *  renders the UI. */
+  tab: HistoryTab
   modeFilter: ModeFilter
   onModeFilterChange: (mode: ModeFilter) => void
   /** Text-tab filter value, already resolved against `fileImportTexts` by the
@@ -83,7 +93,7 @@ interface Props {
  *  switch) stays under the 500-line component cap
  *  (`.claude/rules/file-splitting.md`). */
 export function HistoryResultsPanel({
-  isText,
+  tab,
   modeFilter,
   onModeFilterChange,
   effectiveTextFilter,
@@ -104,6 +114,13 @@ export function HistoryResultsPanel({
 }: Props) {
   const { t } = useTranslation()
   const [confirmDeleteDate, setConfirmDeleteDate] = useState<string | null>(null)
+
+  // Text-style rendering (imported-text name in the Mode/Text column instead
+  // of the mode label) applies to both Aozora and File Import — they're the
+  // same fileImport row shape, just scoped to a different text subset.
+  const isText = tab === 'aozora' || tab === 'text'
+  const showModeFilter = tab === 'monkeytype'
+  const showTextFilter = isText
 
   const stats = useMemo(() => computeStats(filtered), [filtered])
   const sparklineResults = useMemo(
@@ -154,7 +171,7 @@ export function HistoryResultsPanel({
           per-tab export. Both selects feed `filtered`, so the stats row and the
           sparkline reflect the current selection too. */}
       <div className="flex items-center gap-2">
-        {!isText && (
+        {showModeFilter && (
           <select
             data-testid="history-filter-mode"
             aria-label={t('editor.typingTest.history.filterMode')}
@@ -171,7 +188,7 @@ export function HistoryResultsPanel({
             ))}
           </select>
         )}
-        {isText && fileImportTexts.length > 0 && (
+        {showTextFilter && fileImportTexts.length > 0 && (
           <select
             data-testid="history-filter-text"
             aria-label={t('editor.typingTest.history.filterText')}

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Trophy, SquarePen } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import { computeStats } from './history-stats'
+import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
+import { resultKpm, buildResultNameChips } from './result-builder'
+import { formatConditionLabel } from './condition-label'
+import { ResultNameModal } from './ResultNameModal'
+import { Tooltip } from '../components/ui/Tooltip'
+import { formatDuration } from '../components/analyze/analyze-format'
+import { HistoryTimelineCell } from './HistoryTimelineCell'
+import { EMPTY_RUN_ID_SET } from '../hooks/useRunLogAvailability'
+import { WpmSparkline } from './WpmSparkline'
+
+type ModeFilter = 'all' | 'words' | 'time' | 'quote'
+type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
+type SortDirection = 'asc' | 'desc'
+export type { SortColumn, SortDirection }
+
+const MAX_TABLE_ROWS = 20
+const MAX_SPARKLINE_RESULTS = 50
+const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
+
+const EXPORT_BTN_CLASS = 'inline-flex h-8 items-center rounded-md border border-edge px-2.5 text-xs text-content-secondary transition-colors hover:text-content'
+
+/** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
+ *  name (falling back to the stable textId for legacy rows saved before the
+ *  name was captured); words/time/quote show their `mode2` value verbatim.
+ *  Tatoeba is NOT handled here — its `mode2` is a composite
+ *  `language|pattern|count` (see `deriveMode2`), so the Mode column renders
+ *  it via `formatConditionLabel` instead of this raw value. */
+function modeDetail(r: TypingTestResult): string {
+  if (r.mode === 'fileImport') return r.fileImportTextName ?? (r.mode2 != null ? String(r.mode2) : '')
+  return r.mode2 != null ? String(r.mode2) : ''
+}
+
+interface Props {
+  /** Mode filter (Monkeytype tab) vs text filter (Text tab) — the parent owns
+   *  the state and the filtered result set; this panel only renders the UI. */
+  isText: boolean
+  modeFilter: ModeFilter
+  onModeFilterChange: (mode: ModeFilter) => void
+  /** Text-tab filter value, already resolved against `fileImportTexts` by the
+   *  parent (falls back to 'all' when the selected text no longer exists). */
+  effectiveTextFilter: string
+  onTextFilterChange: (value: string) => void
+  fileImportTexts: { id: string, name: string }[]
+  /** Rows already scoped to the active source tab + mode/text filter. */
+  filtered: TypingTestResult[]
+  /** Sort state is owned by the parent (TypingTestHistory), not this panel —
+   *  this component unmounts while the Analysis view is active (conditional
+   *  render), so panel-local sort state would silently reset on every
+   *  Results→Analysis→Results round trip. Delete-confirm and the rename
+   *  modal stay panel-local below: both are transient interactions where a
+   *  reset on tab switch is expected/safe, unlike a deliberate sort choice. */
+  sortColumn: SortColumn
+  sortDirection: SortDirection
+  onSort: (column: SortColumn) => void
+  /** Bound export handler — `undefined` hides the button entirely (mirrors
+   *  the parent's optional `onExportCsv` prop). */
+  onExport?: () => void
+  onRename?: (date: string, name: string) => void
+  onDelete?: (date: string) => void
+  deviceName?: string
+  uid?: string
+  availableRunIds?: ReadonlySet<string>
+  /** ARIA tabpanel wiring for the History modal's Results/Analysis secondary
+   *  tabs (TypingTestHistory) — applied directly to this component's own
+   *  root div rather than an extra wrapper div in the caller. See
+   *  HistorySections' matching prop doc for why an intermediate plain block
+   *  div is unsafe here (breaks the flex min-h-0/shrink/overflow chain). */
+  id: string
+  ariaLabelledBy: string
+}
+
+/** Results view of the History modal: sub-filter row (mode/text dropdown +
+ *  Export CSV), sparkline, stats summary, results table. Split out of
+ *  `TypingTestHistory` so that file (which also owns the Analysis view
+ *  switch) stays under the 500-line component cap
+ *  (`.claude/rules/file-splitting.md`). */
+export function HistoryResultsPanel({
+  isText,
+  modeFilter,
+  onModeFilterChange,
+  effectiveTextFilter,
+  onTextFilterChange,
+  fileImportTexts,
+  filtered,
+  sortColumn,
+  sortDirection,
+  onSort,
+  onExport,
+  onRename,
+  onDelete,
+  deviceName,
+  uid,
+  availableRunIds,
+  id,
+  ariaLabelledBy,
+}: Props) {
+  const { t } = useTranslation()
+  const [confirmDeleteDate, setConfirmDeleteDate] = useState<string | null>(null)
+
+  const stats = useMemo(() => computeStats(filtered), [filtered])
+  const sparklineResults = useMemo(
+    () => filtered.slice(0, MAX_SPARKLINE_RESULTS).reverse(),
+    [filtered],
+  )
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let cmp = 0
+      switch (sortColumn) {
+        case 'date':
+          cmp = new Date(a.date).getTime() - new Date(b.date).getTime()
+          break
+        case 'wpm':
+          cmp = a.wpm - b.wpm
+          break
+        case 'kpm':
+          cmp = resultKpm(a) - resultKpm(b)
+          break
+        case 'accuracy':
+          cmp = a.accuracy - b.accuracy
+          break
+        case 'mode': {
+          // Sort by what the Mode column actually shows (text name for fileImport),
+          // so fileImport rows order by name rather than an opaque textId.
+          const modeA = `${a.mode ?? ''}${modeDetail(a)}`
+          const modeB = `${b.mode ?? ''}${modeDetail(b)}`
+          cmp = modeA.localeCompare(modeB)
+          break
+        }
+        case 'duration':
+          cmp = a.durationSeconds - b.durationSeconds
+          break
+      }
+      return sortDirection === 'asc' ? cmp : -cmp
+    }).slice(0, MAX_TABLE_ROWS)
+  }, [filtered, sortColumn, sortDirection])
+
+  return (
+    <div
+      role="tabpanel"
+      id={id}
+      aria-labelledby={ariaLabelledBy}
+      className="flex min-h-0 flex-1 flex-col gap-3"
+    >
+      {/* Sub-filter (mode dropdown for Monkeytype, text dropdown for Text) +
+          per-tab export. Both selects feed `filtered`, so the stats row and the
+          sparkline reflect the current selection too. */}
+      <div className="flex items-center gap-2">
+        {!isText && (
+          <select
+            data-testid="history-filter-mode"
+            aria-label={t('editor.typingTest.history.filterMode')}
+            className={FILTER_SELECT_CLASS}
+            value={modeFilter}
+            onChange={(e) => onModeFilterChange(e.target.value as ModeFilter)}
+          >
+            {MODE_FILTERS.map((mode) => (
+              <option key={mode} value={mode}>
+                {mode === 'all'
+                  ? t('editor.typingTest.history.allModes')
+                  : t(`editor.typingTest.mode.${mode}`)}
+              </option>
+            ))}
+          </select>
+        )}
+        {isText && fileImportTexts.length > 0 && (
+          <select
+            data-testid="history-filter-text"
+            aria-label={t('editor.typingTest.history.filterText')}
+            className={FILTER_SELECT_CLASS}
+            value={effectiveTextFilter}
+            onChange={(e) => onTextFilterChange(e.target.value)}
+          >
+            <option value="all">{t('editor.typingTest.history.allModes')}</option>
+            {fileImportTexts.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name || t('editor.typingTest.history.unnamed')}
+              </option>
+            ))}
+          </select>
+        )}
+        {onExport && (
+          <button
+            type="button"
+            data-testid="history-export-csv"
+            className={`ml-auto ${EXPORT_BTN_CLASS}`}
+            onClick={onExport}
+          >
+            {t('editor.typingTest.history.exportCsv')}
+          </button>
+        )}
+      </div>
+
+      {/* Sparkline — chart-above-stats, matching every other Analyze section's order */}
+      {sparklineResults.length >= 2 && (
+        <div className="flex justify-center" data-testid="history-sparkline">
+          <WpmSparkline results={sparklineResults} width={400} height={50} />
+        </div>
+      )}
+
+      {/* Stats summary */}
+      <div className="flex flex-wrap items-center gap-6 text-sm" data-testid="history-stats">
+        <StatItem label={t('editor.typingTest.history.bestWpm')} value={stats.bestWpm} highlight />
+        <StatItem label={t('editor.typingTest.history.avgWpm')} value={stats.avgWpm} />
+        <StatItem label={t('editor.typingTest.history.last10Avg')} value={stats.last10Avg} />
+        <StatItem label={t('editor.typingTest.history.totalTests')} value={stats.totalTests} />
+        <StatItem label={t('editor.typingTest.history.avgAccuracy')} value={`${stats.avgAccuracy}%`} />
+      </div>
+
+      {/* Results table — fills remaining height, never collapses below min-h-48 */}
+      <div className="min-h-48 flex-1 overflow-y-auto rounded-lg border border-edge">
+        {sorted.length > 0 ? (
+          <table className="w-full text-left text-xs">
+            <thead className="sticky top-0 bg-surface-alt text-content-muted">
+              <tr>
+                <th className="px-3 py-1.5">{t('editor.typingTest.history.name')}</th>
+                <SortableHeader column="date" label={t('editor.typingTest.history.date')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
+                {uid && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.timeline.modalTitle')} />}
+                {onDelete && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.delete')} />}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((r) => (
+                <tr
+                  key={r.date}
+                  className="border-t border-edge/50 transition-colors hover:bg-surface-alt/50"
+                >
+                  <NameCell result={r} onRename={onRename} deviceName={deviceName} />
+                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono">{r.accuracy}%</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
+                    {isText
+                      ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
+                      // Tatoeba's mode2 is a composite (language|pattern|count, see
+                      // deriveMode2) — formatConditionLabel already knows how to
+                      // render it (e.g. "Tatoeba 5 Lines (english)").
+                      : (r.mode === 'tatoeba'
+                        ? formatConditionLabel(r, t)
+                        : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">
+                    {formatDuration(r.durationSeconds)}
+                  </td>
+                  <td className="px-3 py-1.5">
+                    {r.isPb && <Trophy role="img" className="inline-block size-3.5 text-warning" aria-label={t('editor.typingTest.history.pb')} />}
+                  </td>
+                  {uid && <HistoryTimelineCell result={r} uid={uid} availableRunIds={availableRunIds ?? EMPTY_RUN_ID_SET} />}
+                  {onDelete && (
+                    <td className="px-3 py-1.5">
+                      {confirmDeleteDate === r.date ? (
+                        <div className="flex items-center gap-0.5">
+                          <button
+                            type="button"
+                            className={CONFIRM_DELETE_BTN}
+                            onClick={() => { onDelete(r.date); setConfirmDeleteDate(null) }}
+                            data-testid={`history-delete-confirm-${r.date}`}
+                          >
+                            {t('common.confirmDelete')}
+                          </button>
+                          <button
+                            type="button"
+                            className={ACTION_BTN}
+                            onClick={() => setConfirmDeleteDate(null)}
+                            data-testid={`history-delete-cancel-${r.date}`}
+                          >
+                            {t('common.cancel')}
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          className={DELETE_BTN}
+                          onClick={() => setConfirmDeleteDate(r.date)}
+                          data-testid={`history-delete-${r.date}`}
+                        >
+                          {t('common.delete')}
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="p-6 text-center text-sm text-content-muted">
+            {t('editor.typingTest.history.noResults')}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface StatItemProps {
+  label: string
+  value: number | string
+  highlight?: boolean
+}
+
+function StatItem({ label, value, highlight }: StatItemProps) {
+  return (
+    // Baseline-align so the mono value digits sit level with the sans label
+    // (their font metrics differ, so items-center looks vertically off).
+    <div className="flex items-baseline gap-1.5">
+      <span className="text-content-muted">{label}:</span>
+      <span className={`font-mono font-semibold ${highlight ? 'text-accent' : ''}`}>{value}</span>
+    </div>
+  )
+}
+
+function sortIndicator(direction: SortDirection): string {
+  return direction === 'asc' ? ' ▲' : ' ▼'
+}
+
+interface SortableHeaderProps {
+  column: SortColumn
+  label: string
+  sortColumn: SortColumn
+  sortDirection: SortDirection
+  onSort: (column: SortColumn) => void
+}
+
+function SortableHeader({
+  column,
+  label,
+  sortColumn,
+  sortDirection,
+  onSort,
+}: SortableHeaderProps) {
+  const isActive = column === sortColumn
+  const ariaSort = isActive
+    ? (sortDirection === 'asc' ? 'ascending' : 'descending')
+    : 'none'
+
+  return (
+    <th className="px-3 py-1.5" aria-sort={ariaSort}>
+      <button
+        type="button"
+        className="cursor-pointer select-none bg-transparent text-inherit"
+        onClick={() => onSort(column)}
+      >
+        {label}{isActive ? sortIndicator(sortDirection) : ''}
+      </button>
+    </th>
+  )
+}
+
+interface NameCellProps {
+  result: TypingTestResult
+  onRename?: (date: string, name: string) => void
+  deviceName?: string
+}
+
+/** Result label cell. A button (edit icon + current name / "Unnamed") that
+ *  opens the naming modal with quick-insert chips. Read-only when no rename
+ *  handler is provided. */
+function NameCell({ result, onRename, deviceName }: NameCellProps) {
+  const { t } = useTranslation()
+  const [modalOpen, setModalOpen] = useState(false)
+  const placeholder = t('editor.typingTest.history.unnamed')
+
+  const display = result.name || placeholder
+
+  if (!onRename) {
+    return (
+      <td className="max-w-[14rem] px-3 py-1.5 text-content-muted">
+        <Tooltip content={display} wrapperClassName="block max-w-full">
+          <span className="block truncate">{display}</span>
+        </Tooltip>
+      </td>
+    )
+  }
+
+  return (
+    <td className="max-w-[14rem] px-3 py-1.5">
+      <Tooltip content={display} wrapperClassName="block max-w-full">
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className={`flex w-full items-center gap-1.5 text-left transition-colors hover:text-content ${result.name ? 'text-content-secondary' : 'text-content-muted'}`}
+          data-testid={`history-name-${result.date}`}
+        >
+          <SquarePen size={ICON_SM} aria-hidden="true" className="shrink-0" />
+          <span className="min-w-0 truncate">{display}</span>
+        </button>
+      </Tooltip>
+      {modalOpen && (
+        <ResultNameModal
+          initialName={result.name ?? ''}
+          chips={buildResultNameChips(result, t, deviceName)}
+          onSave={(name) => onRename(result.date, name)}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </td>
+  )
+}
+
+export type { ModeFilter }

--- a/src/renderer/typing-test/HistorySections.tsx
+++ b/src/renderer/typing-test/HistorySections.tsx
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useTranslation } from 'react-i18next'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
-import type { TypingTestStats } from './history-stats'
-import { WpmSparkline } from './WpmSparkline'
 import { AccuracyTrendSection } from './AccuracyTrendSection'
 import { MistakeRankingSection } from './MistakeRankingSection'
 import { ErrorMixSection } from './ErrorMixSection'
@@ -13,58 +10,33 @@ interface Props {
    *  section below scopes/filters independently, matching their own
    *  prop docs in AccuracyTrendSection/MistakeRankingSection/ErrorMixSection). */
   tabResults: TypingTestResult[]
-  /** Stats computed from the mode-filtered `filtered` set (not `tabResults`). */
-  stats: TypingTestStats
-  /** Sparkline series, already sliced/reversed from `filtered`. */
-  sparklineResults: TypingTestResult[]
+  /** ARIA tabpanel wiring for the History modal's Results/Analysis secondary
+   *  tabs (TypingTestHistory). Applied directly to this component's own root
+   *  div — NOT an extra wrapper div in the caller — because a plain block
+   *  div in between would break the flex sizing chain: `min-h-0`/`shrink`
+   *  only take effect on a flex item, and the wrapper's default `display:
+   *  block` meant this div's own `min-h-0 shrink overflow-y-auto` had no
+   *  bounded height to measure against, so it grew to fit its content and
+   *  overflowed past the modal's bottom edge (the exact bug #377 fixed,
+   *  reappearing through this new layer). */
+  id: string
+  ariaLabelledBy: string
 }
 
-interface StatItemProps {
-  label: string
-  value: number | string
-  highlight?: boolean
-}
-
-function StatItem({ label, value, highlight }: StatItemProps) {
+/** The History modal's "Analysis" view: accuracy trend, mistake ranking,
+ *  error mix. Wraps in its own `min-h-0 shrink overflow-y-auto` container so
+ *  a tall stack (e.g. many mistake-ranking rows) scrolls independently
+ *  instead of pushing past the modal's bottom edge (flex children don't
+ *  shrink below their content height otherwise). */
+export function HistorySections({ tabResults, id, ariaLabelledBy }: Props) {
   return (
-    // Baseline-align so the mono value digits sit level with the sans label
-    // (their font metrics differ, so items-center looks vertically off).
-    <div className="flex items-baseline gap-1.5">
-      <span className="text-content-muted">{label}:</span>
-      <span className={`font-mono font-semibold ${highlight ? 'text-accent' : ''}`}>{value}</span>
-    </div>
-  )
-}
-
-/** Everything between the History modal's top tabs and its results table:
- *  sparkline, stats summary, accuracy trend, mistake ranking, error mix.
- *  Split out of `TypingTestHistory` purely to keep that file under the
- *  500-line component cap (`.claude/rules/file-splitting.md`) — this wraps
- *  in its own `min-h-0 shrink overflow-y-auto` container so a tall stack
- *  (e.g. many mistake-ranking rows) scrolls independently instead of
- *  pushing the results table past the modal's bottom edge (flex children
- *  don't shrink below their content height otherwise). */
-export function HistorySections({ tabResults, stats, sparklineResults }: Props) {
-  const { t } = useTranslation()
-
-  return (
-    <div className="flex min-h-0 shrink flex-col gap-3 overflow-y-auto" data-testid="history-sections">
-      {/* Sparkline — chart-above-stats, matching every other Analyze section's order */}
-      {sparklineResults.length >= 2 && (
-        <div className="flex justify-center" data-testid="history-sparkline">
-          <WpmSparkline results={sparklineResults} width={400} height={50} />
-        </div>
-      )}
-
-      {/* Stats summary */}
-      <div className="flex flex-wrap items-center gap-6 text-sm" data-testid="history-stats">
-        <StatItem label={t('editor.typingTest.history.bestWpm')} value={stats.bestWpm} highlight />
-        <StatItem label={t('editor.typingTest.history.avgWpm')} value={stats.avgWpm} />
-        <StatItem label={t('editor.typingTest.history.last10Avg')} value={stats.last10Avg} />
-        <StatItem label={t('editor.typingTest.history.totalTests')} value={stats.totalTests} />
-        <StatItem label={t('editor.typingTest.history.avgAccuracy')} value={`${stats.avgAccuracy}%`} />
-      </div>
-
+    <div
+      role="tabpanel"
+      id={id}
+      aria-labelledby={ariaLabelledBy}
+      className="flex min-h-0 shrink flex-col gap-3 overflow-y-auto"
+      data-testid="history-sections"
+    >
       <AccuracyTrendSection results={tabResults} />
       <MistakeRankingSection results={tabResults} />
       <ErrorMixSection results={tabResults} />

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useId, useRef } from 'react'
+import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Trophy, SquarePen } from 'lucide-react'
-import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import { buildCsv } from '../../shared/csv-export'
-import { computeStats } from './history-stats'
-import { HistorySections } from './HistorySections'
-import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
-import { resultKpm, resultKspc, buildResultNameChips } from './result-builder'
+import { resultKpm, resultKspc } from './result-builder'
 import { formatKspc } from '../../shared/kspc'
-import { formatConditionLabel } from './condition-label'
-import { ResultNameModal } from './ResultNameModal'
-import { Tooltip } from '../components/ui/Tooltip'
-import { formatDuration } from '../components/analyze/analyze-format'
-import { HistoryTimelineCell } from './HistoryTimelineCell'
-import { EMPTY_RUN_ID_SET } from '../hooks/useRunLogAvailability'
+import { HistorySections } from './HistorySections'
+import { HistoryResultsPanel } from './HistoryResultsPanel'
+import type { ModeFilter, SortColumn, SortDirection } from './HistoryResultsPanel'
 
-type ModeFilter = 'all' | 'words' | 'time' | 'quote'
-type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
-type SortDirection = 'asc' | 'desc'
 /** Top-level split: Monkeytype (words/time/quote) vs imported Text (fileImport).
  *  Their baselines aren't comparable, so stats / chart / export are separate. */
 type HistoryTab = 'monkeytype' | 'text'
+
+/** Secondary split, below the source tabs: Results (filter/sparkline/stats/
+ *  table) vs Analysis (accuracy trend / mistake ranking / error mix). Local
+ *  state, defaults to 'results', and persists across source-tab switches —
+ *  it's a separate axis from `tab` above. */
+type HistoryView = 'results' | 'analysis'
+
+/** Tab order for the secondary view tablist — drives both the rendered
+ *  button order and the APG roving-tabindex arrow-key navigation below. */
+const VIEW_TABS: HistoryView[] = ['results', 'analysis']
 
 interface Props {
   results: TypingTestResult[]
@@ -40,23 +40,6 @@ interface Props {
    *  `HistoryToggle`) — the timeline column is omitted when `uid` is unset. */
   uid?: string
   availableRunIds?: ReadonlySet<string>
-}
-
-const MAX_TABLE_ROWS = 20
-
-const EXPORT_BTN_CLASS = 'inline-flex h-8 items-center rounded-md border border-edge px-2.5 text-xs text-content-secondary transition-colors hover:text-content'
-
-const MAX_SPARKLINE_RESULTS = 50
-
-/** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
- *  name (falling back to the stable textId for legacy rows saved before the
- *  name was captured); words/time/quote show their `mode2` value verbatim.
- *  Tatoeba is NOT handled here — its `mode2` is a composite
- *  `language|pattern|count` (see `deriveMode2`), so the Mode column renders
- *  it via `formatConditionLabel` instead of this raw value. */
-function modeDetail(r: TypingTestResult): string {
-  if (r.mode === 'fileImport') return r.fileImportTextName ?? (r.mode2 != null ? String(r.mode2) : '')
-  return r.mode2 != null ? String(r.mode2) : ''
 }
 
 /** Stable filter key for an imported-text (fileImport) run; its textId is `mode2`. */
@@ -81,8 +64,6 @@ function exportFilterSlug(
   }
   return modeFilter === 'all' ? 'monkeytype' : `monkeytype-${modeFilter}`
 }
-
-const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
 // errorSubstitutions/errorOmissions/errorInsertions/errorTargetChars are
 // exported as their RAW counts (not a derived per-row rate like `kspc`
@@ -111,21 +92,69 @@ function buildResultsCsv(results: TypingTestResult[]): string {
   )
 }
 
+const VIEW_TAB_ACTIVE = 'border-b-2 border-accent px-1 pb-1 text-xs font-medium text-accent'
+const VIEW_TAB_INACTIVE = 'border-b-2 border-transparent px-1 pb-1 text-xs text-content-muted hover:text-content'
+
 export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, deviceName, uid, availableRunIds }: Props) {
   const { t } = useTranslation()
   const [tab, setTab] = useState<HistoryTab>('monkeytype')
+  const [view, setView] = useState<HistoryView>('results')
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
   // Text-tab filter, keyed by the stable textId (mode2). 'all' = no filter.
   const [textFilter, setTextFilter] = useState<string>('all')
-  const [sortColumn, setSortColumn] = useState<SortColumn>('date')
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
-  const [confirmDeleteDate, setConfirmDeleteDate] = useState<string | null>(null)
   const isText = tab === 'text'
 
+  // Sort state lives here (not in HistoryResultsPanel) because that panel
+  // unmounts while the Analysis view is active (conditional render below) —
+  // panel-local state would silently reset the sort on every
+  // Results→Analysis→Results round trip. Delete-confirm and the rename
+  // modal stay panel-local; both are transient interactions where a reset
+  // on tab switch is expected/safe, unlike a deliberate sort choice.
+  const [sortColumn, setSortColumn] = useState<SortColumn>('date')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
   const handleSort = useCallback((column: SortColumn) => {
     setSortDirection((prev) => (sortColumn === column && prev === 'desc') ? 'asc' : 'desc')
     setSortColumn(column)
   }, [sortColumn])
+
+  // Unique per-instance ids for the view tabs/panels (React 19 useId), so
+  // aria-controls/aria-labelledby never collide if two History modals ever
+  // mount at once — unlike the pre-existing source tabs above, which use
+  // static ids/no `role` and are left untouched (out of scope here).
+  const viewTabsIdBase = useId()
+  const viewTabId = useCallback((v: HistoryView) => `${viewTabsIdBase}-tab-${v}`, [viewTabsIdBase])
+  const viewPanelId = useCallback((v: HistoryView) => `${viewTabsIdBase}-panel-${v}`, [viewTabsIdBase])
+
+  // APG tabs pattern (automatic activation): arrow keys move focus AND
+  // selection between the two view tabs; Home/End jump to the first/last.
+  // Roving tabIndex (0 on the active tab, -1 otherwise) keeps the tablist a
+  // single Tab stop, per https://www.w3.org/WAI/ARIA/apg/patterns/tabs/.
+  const viewTabRefs = useRef<Partial<Record<HistoryView, HTMLButtonElement>>>({})
+  const focusAndSelectView = useCallback((v: HistoryView) => {
+    setView(v)
+    viewTabRefs.current[v]?.focus()
+  }, [])
+  const handleViewTabKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>, current: HistoryView) => {
+    const idx = VIEW_TABS.indexOf(current)
+    switch (e.key) {
+      case 'ArrowRight':
+        e.preventDefault()
+        focusAndSelectView(VIEW_TABS[(idx + 1) % VIEW_TABS.length])
+        break
+      case 'ArrowLeft':
+        e.preventDefault()
+        focusAndSelectView(VIEW_TABS[(idx - 1 + VIEW_TABS.length) % VIEW_TABS.length])
+        break
+      case 'Home':
+        e.preventDefault()
+        focusAndSelectView(VIEW_TABS[0])
+        break
+      case 'End':
+        e.preventDefault()
+        focusAndSelectView(VIEW_TABS[VIEW_TABS.length - 1])
+        break
+    }
+  }, [focusAndSelectView])
 
   // Active tab's rows: fileImport for Text, everything else for Monkeytype.
   const tabResults = useMemo(
@@ -166,44 +195,6 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
     onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(isText, modeFilter, effectiveTextFilter, fileImportTexts))
   }, [filtered, onExportCsv, isText, modeFilter, effectiveTextFilter, fileImportTexts])
 
-  const stats = useMemo(() => computeStats(filtered), [filtered])
-  const sparklineResults = useMemo(
-    () => filtered.slice(0, MAX_SPARKLINE_RESULTS).reverse(),
-    [filtered],
-  )
-
-  const sorted = useMemo(() => {
-    return [...filtered].sort((a, b) => {
-      let cmp = 0
-      switch (sortColumn) {
-        case 'date':
-          cmp = new Date(a.date).getTime() - new Date(b.date).getTime()
-          break
-        case 'wpm':
-          cmp = a.wpm - b.wpm
-          break
-        case 'kpm':
-          cmp = resultKpm(a) - resultKpm(b)
-          break
-        case 'accuracy':
-          cmp = a.accuracy - b.accuracy
-          break
-        case 'mode': {
-          // Sort by what the Mode column actually shows (text name for fileImport),
-          // so fileImport rows order by name rather than an opaque textId.
-          const modeA = `${a.mode ?? ''}${modeDetail(a)}`
-          const modeB = `${b.mode ?? ''}${modeDetail(b)}`
-          cmp = modeA.localeCompare(modeB)
-          break
-        }
-        case 'duration':
-          cmp = a.durationSeconds - b.durationSeconds
-          break
-      }
-      return sortDirection === 'asc' ? cmp : -cmp
-    }).slice(0, MAX_TABLE_ROWS)
-  }, [filtered, sortColumn, sortDirection])
-
   // min-h-0 flex-1 (not h-full) on the root below: this is a flex child of
   // HistoryToggle's `flex h-modal-80vh flex-col` modal box, sitting below
   // the title row. h-full resolves to 100% of the modal's own content-box
@@ -232,234 +223,73 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
         ))}
       </div>
 
-      {/* Sub-filter (mode dropdown for Monkeytype, text dropdown for Text) +
-          per-tab export. Both selects feed `filtered`, so the stats row and the
-          sparkline reflect the current selection too. */}
-      <div className="flex items-center gap-2">
-        {!isText && (
-          <select
-            data-testid="history-filter-mode"
-            aria-label={t('editor.typingTest.history.filterMode')}
-            className={FILTER_SELECT_CLASS}
-            value={modeFilter}
-            onChange={(e) => setModeFilter(e.target.value as ModeFilter)}
-          >
-            {MODE_FILTERS.map((mode) => (
-              <option key={mode} value={mode}>
-                {mode === 'all'
-                  ? t('editor.typingTest.history.allModes')
-                  : t(`editor.typingTest.mode.${mode}`)}
-              </option>
-            ))}
-          </select>
-        )}
-        {isText && fileImportTexts.length > 0 && (
-          <select
-            data-testid="history-filter-text"
-            aria-label={t('editor.typingTest.history.filterText')}
-            className={FILTER_SELECT_CLASS}
-            value={effectiveTextFilter}
-            onChange={(e) => setTextFilter(e.target.value)}
-          >
-            <option value="all">{t('editor.typingTest.history.allModes')}</option>
-            {fileImportTexts.map((c) => (
-              <option key={c.id} value={c.id}>
-                {c.name || t('editor.typingTest.history.unnamed')}
-              </option>
-            ))}
-          </select>
-        )}
-        {onExportCsv && (
-          <button
-            type="button"
-            data-testid="history-export-csv"
-            className={`ml-auto ${EXPORT_BTN_CLASS}`}
-            onClick={handleExport}
-          >
-            {t('editor.typingTest.history.exportCsv')}
-          </button>
-        )}
-      </div>
-
-      <HistorySections tabResults={tabResults} stats={stats} sparklineResults={sparklineResults} />
-
-      {/* Results table — fills remaining height, never collapses below min-h-48 */}
-      <div className="min-h-48 flex-1 overflow-y-auto rounded-lg border border-edge">
-        {sorted.length > 0 ? (
-          <table className="w-full text-left text-xs">
-            <thead className="sticky top-0 bg-surface-alt text-content-muted">
-              <tr>
-                <th className="px-3 py-1.5">{t('editor.typingTest.history.name')}</th>
-                <SortableHeader column="date" label={t('editor.typingTest.history.date')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={handleSort} />
-                <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
-                {uid && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.timeline.modalTitle')} />}
-                {onDelete && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.delete')} />}
-              </tr>
-            </thead>
-            <tbody>
-              {sorted.map((r) => (
-                <tr
-                  key={r.date}
-                  className="border-t border-edge/50 transition-colors hover:bg-surface-alt/50"
-                >
-                  <NameCell result={r} onRename={onRename} deviceName={deviceName} />
-                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">{formatDate(r.date)}</td>
-                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
-                  <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
-                  <td className="whitespace-nowrap px-3 py-1.5 font-mono">{r.accuracy}%</td>
-                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
-                    {isText
-                      ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
-                      // Tatoeba's mode2 is a composite (language|pattern|count, see
-                      // deriveMode2) — formatConditionLabel already knows how to
-                      // render it (e.g. "Tatoeba 5 Lines (english)").
-                      : (r.mode === 'tatoeba'
-                        ? formatConditionLabel(r, t)
-                        : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)}
-                  </td>
-                  <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">
-                    {formatDuration(r.durationSeconds)}
-                  </td>
-                  <td className="px-3 py-1.5">
-                    {r.isPb && <Trophy role="img" className="inline-block size-3.5 text-warning" aria-label={t('editor.typingTest.history.pb')} />}
-                  </td>
-                  {uid && <HistoryTimelineCell result={r} uid={uid} availableRunIds={availableRunIds ?? EMPTY_RUN_ID_SET} />}
-                  {onDelete && (
-                    <td className="px-3 py-1.5">
-                      {confirmDeleteDate === r.date ? (
-                        <div className="flex items-center gap-0.5">
-                          <button
-                            type="button"
-                            className={CONFIRM_DELETE_BTN}
-                            onClick={() => { onDelete(r.date); setConfirmDeleteDate(null) }}
-                            data-testid={`history-delete-confirm-${r.date}`}
-                          >
-                            {t('common.confirmDelete')}
-                          </button>
-                          <button
-                            type="button"
-                            className={ACTION_BTN}
-                            onClick={() => setConfirmDeleteDate(null)}
-                            data-testid={`history-delete-cancel-${r.date}`}
-                          >
-                            {t('common.cancel')}
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          type="button"
-                          className={DELETE_BTN}
-                          onClick={() => setConfirmDeleteDate(r.date)}
-                          data-testid={`history-delete-${r.date}`}
-                        >
-                          {t('common.delete')}
-                        </button>
-                      )}
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
-          <p className="p-6 text-center text-sm text-content-muted">
-            {t('editor.typingTest.history.noResults')}
-          </p>
-        )}
-      </div>
-    </div>
-  )
-}
-
-function sortIndicator(direction: SortDirection): string {
-  return direction === 'asc' ? ' \u25B2' : ' \u25BC'
-}
-
-interface SortableHeaderProps {
-  column: SortColumn
-  label: string
-  sortColumn: SortColumn
-  sortDirection: SortDirection
-  onSort: (column: SortColumn) => void
-}
-
-function SortableHeader({
-  column,
-  label,
-  sortColumn,
-  sortDirection,
-  onSort,
-}: SortableHeaderProps) {
-  const isActive = column === sortColumn
-  const ariaSort = isActive
-    ? (sortDirection === 'asc' ? 'ascending' : 'descending')
-    : 'none'
-
-  return (
-    <th className="px-3 py-1.5" aria-sort={ariaSort}>
-      <button
-        type="button"
-        className="cursor-pointer select-none bg-transparent text-inherit"
-        onClick={() => onSort(column)}
+      {/* Secondary tabs: Results (filter/sparkline/stats/table) vs Analysis
+          (accuracy trend / mistake ranking / error mix). Visually subordinate
+          to the source tabs above (smaller text, lighter weight) while
+          keeping the same border-b-2 accent indicator pattern
+          (.claude/DESIGN.md "Tabs"). Local state, persists across source-tab
+          switches. */}
+      <div
+        role="tablist"
+        aria-label={t('editor.typingTest.history.viewTabsAriaLabel')}
+        className="flex items-center gap-3 border-b border-edge/60"
       >
-        {label}{isActive ? sortIndicator(sortDirection) : ''}
-      </button>
-    </th>
-  )
-}
+        {VIEW_TABS.map((v) => (
+          <button
+            key={v}
+            ref={(el) => { viewTabRefs.current[v] = el ?? undefined }}
+            type="button"
+            role="tab"
+            id={viewTabId(v)}
+            aria-selected={view === v}
+            aria-controls={viewPanelId(v)}
+            tabIndex={view === v ? 0 : -1}
+            data-testid={`history-view-tab-${v}`}
+            className={view === v ? VIEW_TAB_ACTIVE : VIEW_TAB_INACTIVE}
+            onClick={() => setView(v)}
+            onKeyDown={(e) => handleViewTabKeyDown(e, v)}
+          >
+            {t(v === 'results' ? 'editor.typingTest.history.tabResults' : 'editor.typingTest.history.tabAnalysis')}
+          </button>
+        ))}
+      </div>
 
-interface NameCellProps {
-  result: TypingTestResult
-  onRename?: (date: string, name: string) => void
-  deviceName?: string
-}
-
-/** Result label cell. A button (edit icon + current name / "Unnamed") that
- *  opens the naming modal with quick-insert chips. Read-only when no rename
- *  handler is provided. */
-function NameCell({ result, onRename, deviceName }: NameCellProps) {
-  const { t } = useTranslation()
-  const [modalOpen, setModalOpen] = useState(false)
-  const placeholder = t('editor.typingTest.history.unnamed')
-
-  const display = result.name || placeholder
-
-  if (!onRename) {
-    return (
-      <td className="max-w-[14rem] px-3 py-1.5 text-content-muted">
-        <Tooltip content={display} wrapperClassName="block max-w-full">
-          <span className="block truncate">{display}</span>
-        </Tooltip>
-      </td>
-    )
-  }
-
-  return (
-    <td className="max-w-[14rem] px-3 py-1.5">
-      <Tooltip content={display} wrapperClassName="block max-w-full">
-        <button
-          type="button"
-          onClick={() => setModalOpen(true)}
-          className={`flex w-full items-center gap-1.5 text-left transition-colors hover:text-content ${result.name ? 'text-content-secondary' : 'text-content-muted'}`}
-          data-testid={`history-name-${result.date}`}
-        >
-          <SquarePen size={ICON_SM} aria-hidden="true" className="shrink-0" />
-          <span className="min-w-0 truncate">{display}</span>
-        </button>
-      </Tooltip>
-      {modalOpen && (
-        <ResultNameModal
-          initialName={result.name ?? ''}
-          chips={buildResultNameChips(result, t, deviceName)}
-          onSave={(name) => onRename(result.date, name)}
-          onClose={() => setModalOpen(false)}
+      {/* No extra wrapper div here: each panel component applies its own
+          role="tabpanel"/id/aria-labelledby directly to its existing root
+          div (which is already `flex ... min-h-0 ...`, part of this root's
+          flex-col chain). An intermediate plain block div would break that
+          chain — its default `display: block` can't propagate the
+          min-h-0/shrink sizing needed for HistorySections' overflow-y-auto
+          to actually engage, which silently reintroduces the #377 modal
+          overflow bug (confirmed via screenshot regression on this branch). */}
+      {view === 'results' ? (
+        <HistoryResultsPanel
+          id={viewPanelId('results')}
+          ariaLabelledBy={viewTabId('results')}
+          isText={isText}
+          modeFilter={modeFilter}
+          onModeFilterChange={setModeFilter}
+          effectiveTextFilter={effectiveTextFilter}
+          onTextFilterChange={setTextFilter}
+          fileImportTexts={fileImportTexts}
+          filtered={filtered}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+          onExport={onExportCsv ? handleExport : undefined}
+          onRename={onRename}
+          onDelete={onDelete}
+          deviceName={deviceName}
+          uid={uid}
+          availableRunIds={availableRunIds}
+        />
+      ) : (
+        <HistorySections
+          id={viewPanelId('analysis')}
+          ariaLabelledBy={viewTabId('analysis')}
+          tabResults={tabResults}
         />
       )}
-    </td>
+    </div>
   )
 }

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -4,16 +4,53 @@ import { useState, useMemo, useCallback, useId, useRef } from 'react'
 import type { KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 import { buildCsv } from '../../shared/csv-export'
 import { resultKpm, resultKspc } from './result-builder'
 import { formatKspc } from '../../shared/kspc'
+import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { HistorySections } from './HistorySections'
 import { HistoryResultsPanel } from './HistoryResultsPanel'
-import type { ModeFilter, SortColumn, SortDirection } from './HistoryResultsPanel'
+import type { ModeFilter, SortColumn, SortDirection, HistoryTab } from './HistoryResultsPanel'
 
-/** Top-level split: Monkeytype (words/time/quote) vs imported Text (fileImport).
- *  Their baselines aren't comparable, so stats / chart / export are separate. */
-type HistoryTab = 'monkeytype' | 'text'
+// Tab order for the source tablist — MonkeyType (words/time/quote), Tatoeba
+// (mode 'tatoeba'), Aozora (fileImport rows whose text meta was imported via
+// the Aozora Bunko catalog), File Import (every other fileImport row, plus
+// pre-rename legacy 'custom' rows). Each tab's baseline isn't comparable to
+// the others', so stats / chart / export stay scoped per tab.
+const HISTORY_TABS: HistoryTab[] = ['monkeytype', 'tatoeba', 'aozora', 'text']
+
+const HISTORY_TAB_LABEL_KEYS: Record<HistoryTab, string> = {
+  monkeytype: 'editor.typingTest.history.tabMonkeytype',
+  tatoeba: 'editor.typingTest.history.tabTatoeba',
+  aozora: 'editor.typingTest.history.tabAozora',
+  text: 'editor.typingTest.history.tabFileImport',
+}
+
+/** Set on a `TypingTestTextMeta.source.provider` when the text was imported
+ *  from the Aozora Bunko catalog (see AozoraCatalogTab/aozora-import.ts) —
+ *  duplicated here as a local literal rather than a shared export, matching
+ *  the existing per-file convention (AozoraCatalogTab.tsx also inlines it). */
+const AOZORA_PROVIDER = 'aozora'
+
+/** Classify a result into its source tab. `mode2` carries the imported
+ *  text's stable textId for fileImport rows — the same link the text
+ *  dropdown already uses (`fileImportTextId` below) — so looking it up in
+ *  `textMetaById` tells Aozora and File Import rows apart. A fileImport row
+ *  whose text no longer exists in the store (deleted) falls back to File
+ *  Import. Legacy rows saved before the fileImport rename used mode
+ *  'custom' — cast through `string` since that value predates (and isn't
+ *  part of) the current `TypingTestResult['mode']` union — and must land in
+ *  File Import too, not MonkeyType. */
+function classifyResultTab(r: TypingTestResult, textMetaById: Map<string, TypingTestTextMeta>): HistoryTab {
+  if (r.mode === 'tatoeba') return 'tatoeba'
+  if (r.mode === 'fileImport') {
+    const meta = textMetaById.get(fileImportTextId(r))
+    return meta?.source?.provider === AOZORA_PROVIDER ? 'aozora' : 'text'
+  }
+  if ((r.mode as string | undefined) === 'custom') return 'text'
+  return 'monkeytype'
+}
 
 /** Secondary split, below the source tabs: Results (filter/sparkline/stats/
  *  table) vs Analysis (accuracy trend / mistake ranking / error mix). Local
@@ -48,20 +85,21 @@ function fileImportTextId(r: TypingTestResult): string {
 }
 
 /** Filename slug describing the active export selection (tab + filter), so each
- *  filtered export lands in a distinct, self-describing file. Monkeytype-all and
- *  Text-all stay distinct via the tab prefix. */
+ *  filtered export lands in a distinct, self-describing file. Every tab's
+ *  "all" slug stays distinct via its own prefix. */
 function exportFilterSlug(
-  isText: boolean,
+  tab: HistoryTab,
   modeFilter: ModeFilter,
   textFilter: string,
   fileImportTexts: { id: string, name: string }[],
 ): string {
-  if (isText) {
-    if (textFilter === 'all') return 'text'
+  if (tab === 'aozora' || tab === 'text') {
+    if (textFilter === 'all') return tab
     // Fall back to the textId for an empty / missing name so the slug never
-    // ends in a bare `text-`.
-    return `text-${fileImportTexts.find((c) => c.id === textFilter)?.name || textFilter}`
+    // ends in a bare `aozora-`/`text-`.
+    return `${tab}-${fileImportTexts.find((c) => c.id === textFilter)?.name || textFilter}`
   }
+  if (tab === 'tatoeba') return 'tatoeba'
   return modeFilter === 'all' ? 'monkeytype' : `monkeytype-${modeFilter}`
 }
 
@@ -100,9 +138,16 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
   const [tab, setTab] = useState<HistoryTab>('monkeytype')
   const [view, setView] = useState<HistoryView>('results')
   const [modeFilter, setModeFilter] = useState<ModeFilter>('all')
-  // Text-tab filter, keyed by the stable textId (mode2). 'all' = no filter.
+  // Aozora/File Import tab filter, keyed by the stable textId (mode2).
+  // 'all' = no filter. Shared by both tabs (each falls back to 'all' below
+  // when the picked id isn't in that tab's own text list), matching the
+  // existing single-state pattern rather than adding a second filter state.
   const [textFilter, setTextFilter] = useState<string>('all')
-  const isText = tab === 'text'
+
+  // Imported-text metas, used to tell an Aozora-catalog fileImport row apart
+  // from a plain File Import one (see classifyResultTab above).
+  const { metas: textMetas } = useTypingTestTexts()
+  const textMetaById = useMemo(() => new Map(textMetas.map((m) => [m.id, m])), [textMetas])
 
   // Sort state lives here (not in HistoryResultsPanel) because that panel
   // unmounts while the Analysis view is active (conditional render below) —
@@ -156,44 +201,56 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
     }
   }, [focusAndSelectView])
 
-  // Active tab's rows: fileImport for Text, everything else for Monkeytype.
+  // Active tab's rows, per classifyResultTab above.
   const tabResults = useMemo(
-    () => results.filter((r) => isText ? r.mode === 'fileImport' : r.mode !== 'fileImport'),
-    [results, isText],
+    () => results.filter((r) => classifyResultTab(r, textMetaById) === tab),
+    [results, tab, textMetaById],
   )
 
-  // Distinct imported texts (fileImport rows), keyed by stable textId, displayed by
-  // the snapshotted name. Drives the Text-tab filter dropdown.
+  // Distinct imported texts (fileImport rows), keyed by stable textId,
+  // displayed by the snapshotted name — scoped to the active tab (Aozora
+  // gets only source.provider 'aozora' texts, File Import gets the rest).
+  // Drives that tab's filter dropdown; empty (and thus hidden) for
+  // MonkeyType/Tatoeba.
   const fileImportTexts = useMemo(() => {
+    if (tab !== 'aozora' && tab !== 'text') return []
     const seen = new Map<string, string>()
     for (const r of results) {
       if (r.mode !== 'fileImport') continue
       const id = fileImportTextId(r)
+      const isAozoraText = textMetaById.get(id)?.source?.provider === AOZORA_PROVIDER
+      if (isAozoraText !== (tab === 'aozora')) continue
       if (!seen.has(id)) seen.set(id, r.fileImportTextName ?? id)
     }
     return Array.from(seen, ([id, name]) => ({ id, name }))
-  }, [results])
+  }, [results, tab, textMetaById])
 
-  // Fall back to 'all' when the selected text no longer exists (e.g. all its
-  // rows were deleted), so the dropdown stays controlled and the stats/chart
-  // never collapse to an empty selection.
+  // Fall back to 'all' when the selected text no longer exists in this tab
+  // (e.g. all its rows were deleted, or the tab was just switched to one
+  // where that id doesn't belong), so the dropdown stays controlled and the
+  // stats/chart never collapse to an empty selection.
   const effectiveTextFilter = textFilter === 'all' || fileImportTexts.some((c) => c.id === textFilter)
     ? textFilter
     : 'all'
 
   const filtered = useMemo(() => {
-    if (isText) {
+    if (tab === 'aozora' || tab === 'text') {
       if (effectiveTextFilter === 'all') return tabResults
       return tabResults.filter((r) => fileImportTextId(r) === effectiveTextFilter)
     }
-    if (modeFilter === 'all') return tabResults
-    return tabResults.filter((r) => (r.mode ?? 'words') === modeFilter)
-  }, [tabResults, isText, modeFilter, effectiveTextFilter])
+    if (tab === 'monkeytype') {
+      if (modeFilter === 'all') return tabResults
+      return tabResults.filter((r) => (r.mode ?? 'words') === modeFilter)
+    }
+    // Tatoeba has no sub-filter — the Analysis condition selector already
+    // covers per-condition grouping.
+    return tabResults
+  }, [tabResults, tab, modeFilter, effectiveTextFilter])
 
   // Export is per-tab: only the rows currently shown.
   const handleExport = useCallback(() => {
-    onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(isText, modeFilter, effectiveTextFilter, fileImportTexts))
-  }, [filtered, onExportCsv, isText, modeFilter, effectiveTextFilter, fileImportTexts])
+    onExportCsv?.(buildResultsCsv(filtered), exportFilterSlug(tab, modeFilter, effectiveTextFilter, fileImportTexts))
+  }, [filtered, onExportCsv, tab, modeFilter, effectiveTextFilter, fileImportTexts])
 
   // min-h-0 flex-1 (not h-full) on the root below: this is a flex child of
   // HistoryToggle's `flex h-modal-80vh flex-col` modal box, sitting below
@@ -205,9 +262,11 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
   // after the title row instead.
   return (
     <div data-testid="typing-test-history" className="flex min-h-0 flex-1 max-w-4xl flex-col gap-3">
-      {/* Top tabs: Monkeytype (words/time/quote) vs imported Text (fileImport). */}
+      {/* Top tabs: MonkeyType (words/time/quote) / Tatoeba / Aozora
+          (fileImport rows imported from the Aozora Bunko catalog) / File
+          Import (everything else, per classifyResultTab above). */}
       <div className="flex items-center gap-4 border-b border-edge">
-        {(['monkeytype', 'text'] as HistoryTab[]).map((tb) => (
+        {HISTORY_TABS.map((tb) => (
           <button
             key={tb}
             type="button"
@@ -218,7 +277,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
               : 'border-b-2 border-transparent px-1 pb-1.5 text-sm text-content-secondary hover:text-content'}
             onClick={() => setTab(tb)}
           >
-            {t(tb === 'text' ? 'editor.typingTest.history.tabFileImport' : 'editor.typingTest.history.tabMonkeytype')}
+            {t(HISTORY_TAB_LABEL_KEYS[tb])}
           </button>
         ))}
       </div>
@@ -266,7 +325,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
         <HistoryResultsPanel
           id={viewPanelId('results')}
           ariaLabelledBy={viewTabId('results')}
-          isText={isText}
+          tab={tab}
           modeFilter={modeFilter}
           onModeFilterChange={setModeFilter}
           effectiveTextFilter={effectiveTextFilter}

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { TypingTestHistory } from '../TypingTestHistory'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { TypingTestTextMeta } from '../../../shared/types/typing-test-text-store'
 
 function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
   return {
@@ -26,6 +27,23 @@ function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult
 function renderWithI18n(ui: React.ReactElement) {
   return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
 }
+
+/** Minimal TypingTestTextMeta builder for source-tab classification tests —
+ *  only `source` (aozora-provider detection) and `id` matter here. */
+function textMeta(id: string, name: string, source?: { provider: string; workId: string }): TypingTestTextMeta {
+  return { id, name, wordCount: 10, filename: `${id}.json`, savedAt: '', updatedAt: '', source }
+}
+
+beforeEach(() => {
+  // TypingTestHistory now calls useTypingTestTexts() to classify fileImport
+  // rows into Aozora vs File Import — default to no imported texts so
+  // pre-existing tests (which don't care about the Aozora split) are
+  // unaffected. Tests below override this per-case.
+  window.vialAPI = {
+    ...window.vialAPI,
+    typingTestTextStoreList: vi.fn().mockResolvedValue({ success: true, data: [] }),
+  } as typeof window.vialAPI
+})
 
 describe('TypingTestHistory', () => {
   it('shows no results message when empty', () => {
@@ -744,6 +762,149 @@ describe('TypingTestHistory', () => {
       fireEvent.keyDown(analysisTab, { key: 'Home' })
       expect(document.activeElement).toBe(resultsTab)
       expect(resultsTab.getAttribute('aria-selected')).toBe('true')
+    })
+  })
+
+  describe('source tabs: Tatoeba and Aozora split out of MonkeyType/File Import', () => {
+    it('classifies mode "tatoeba" rows into their own tab, out of MonkeyType', () => {
+      const results = [
+        makeResult({ wpm: 81, mode: 'words', mode2: 30 }),
+        makeResult({ wpm: 77, mode: 'tatoeba', mode2: 'english|lines|5', language: 'english' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+
+      // MonkeyType tab (default): only the words row.
+      expect(screen.getAllByText('81').length).toBeGreaterThan(0)
+      expect(screen.queryByText('77')).toBeNull()
+
+      // Tatoeba tab: only the tatoeba row.
+      fireEvent.click(screen.getByTestId('history-tab-tatoeba'))
+      expect(screen.getAllByText('77').length).toBeGreaterThan(0)
+      expect(screen.queryByText('81')).toBeNull()
+    })
+
+    it('classifies a fileImport row whose text meta has source.provider "aozora" into the Aozora tab, not File Import', async () => {
+      window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+        success: true,
+        data: [textMeta('aozora-1', 'Kokoro', { provider: 'aozora', workId: 'works/42' })],
+      })
+      const results = [
+        makeResult({ wpm: 55, mode: 'fileImport', mode2: 'aozora-1', fileImportTextName: 'Kokoro' }),
+        makeResult({ wpm: 66, mode: 'fileImport', mode2: 'plain-1', fileImportTextName: 'my-notes.txt' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      await waitFor(() => expect(window.vialAPI.typingTestTextStoreList).toHaveBeenCalled())
+
+      // Aozora tab: only the aozora-provider row.
+      fireEvent.click(screen.getByTestId('history-tab-aozora'))
+      await waitFor(() => expect(screen.getAllByText('55').length).toBeGreaterThan(0))
+      expect(screen.queryByText('66')).toBeNull()
+
+      // File Import tab: only the plain (non-aozora) row.
+      fireEvent.click(screen.getByTestId('history-tab-text'))
+      expect(screen.getAllByText('66').length).toBeGreaterThan(0)
+      expect(screen.queryByText('55')).toBeNull()
+    })
+
+    it('classifies a fileImport row with no resolvable text meta, and a legacy mode "custom" row, into File Import', async () => {
+      window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({ success: true, data: [] })
+      const results = [
+        // fileImport row whose textId isn't in the text store (e.g. deleted text).
+        makeResult({ wpm: 71, mode: 'fileImport', mode2: 'gone-1', fileImportTextName: 'deleted.txt' }),
+        // Pre-rename legacy row — mode 'custom' predates the fileImport rename
+        // and must not fall through to MonkeyType.
+        makeResult({ wpm: 72, mode: 'custom' as TypingTestResult['mode'], mode2: 'legacy-1' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      await waitFor(() => expect(window.vialAPI.typingTestTextStoreList).toHaveBeenCalled())
+
+      // Neither row shows under MonkeyType.
+      expect(screen.queryByText('71')).toBeNull()
+      expect(screen.queryByText('72')).toBeNull()
+
+      // Both show under File Import.
+      fireEvent.click(screen.getByTestId('history-tab-text'))
+      expect(screen.getAllByText('71').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('72').length).toBeGreaterThan(0)
+
+      // Neither shows under Aozora.
+      fireEvent.click(screen.getByTestId('history-tab-aozora'))
+      expect(screen.queryByText('71')).toBeNull()
+      expect(screen.queryByText('72')).toBeNull()
+    })
+
+    it('hides the sub-filter dropdown entirely on the Tatoeba tab', () => {
+      const results = [
+        makeResult({ mode: 'tatoeba', mode2: 'english|lines|5', language: 'english' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-tab-tatoeba'))
+      expect(screen.queryByTestId('history-filter-mode')).toBeNull()
+      expect(screen.queryByTestId('history-filter-text')).toBeNull()
+    })
+
+    it('scopes the Aozora and File Import text dropdowns to only their own tab\'s texts', async () => {
+      window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+        success: true,
+        data: [textMeta('aozora-1', 'Kokoro', { provider: 'aozora', workId: 'works/42' })],
+      })
+      const results = [
+        makeResult({ wpm: 55, mode: 'fileImport', mode2: 'aozora-1', fileImportTextName: 'Kokoro' }),
+        makeResult({ wpm: 66, mode: 'fileImport', mode2: 'plain-1', fileImportTextName: 'my-notes.txt' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      await waitFor(() => expect(window.vialAPI.typingTestTextStoreList).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByTestId('history-tab-aozora'))
+      await waitFor(() => expect(screen.getByTestId('history-filter-text')).toBeTruthy())
+      let options = Array.from((screen.getByTestId('history-filter-text') as HTMLSelectElement).options).map((o) => o.value)
+      expect(options).toEqual(['all', 'aozora-1'])
+
+      fireEvent.click(screen.getByTestId('history-tab-text'))
+      options = Array.from((screen.getByTestId('history-filter-text') as HTMLSelectElement).options).map((o) => o.value)
+      expect(options).toEqual(['all', 'plain-1'])
+    })
+
+    it('feeds the Analysis view from the active source tab\'s results (Tatoeba)', () => {
+      const results = [
+        makeResult({ wpm: 81, mode: 'words', mode2: 30, accuracy: 90, mistakes: { a: 3 } }),
+        makeResult({ wpm: 77, mode: 'tatoeba', mode2: 'english|lines|5', language: 'english', accuracy: 88, mistakes: { b: 2 } }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-tab-tatoeba'))
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      expect(screen.getByTestId('history-sections')).toBeTruthy()
+      // The condition selector only has the tatoeba row's condition available
+      // when Tatoeba is the active source tab.
+      const select = screen.getByTestId('history-condition-filter') as HTMLSelectElement
+      expect(Array.from(select.options).every((o) => o.value.startsWith('tatoeba|'))).toBe(true)
+    })
+
+    it('extends the export filename slug for the new tabs (tatoeba, aozora / aozora-<textId>)', async () => {
+      window.vialAPI.typingTestTextStoreList = vi.fn().mockResolvedValue({
+        success: true,
+        data: [textMeta('aozora-1', 'Kokoro', { provider: 'aozora', workId: 'works/42' })],
+      })
+      const onExportCsv = vi.fn()
+      const results = [
+        makeResult({ wpm: 77, mode: 'tatoeba', mode2: 'english|lines|5', language: 'english' }),
+        makeResult({ wpm: 55, mode: 'fileImport', mode2: 'aozora-1', fileImportTextName: 'Kokoro' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+      await waitFor(() => expect(window.vialAPI.typingTestTextStoreList).toHaveBeenCalled())
+
+      fireEvent.click(screen.getByTestId('history-tab-tatoeba'))
+      fireEvent.click(screen.getByTestId('history-export-csv'))
+      expect(onExportCsv.mock.calls.at(-1)?.[1]).toBe('tatoeba')
+
+      fireEvent.click(screen.getByTestId('history-tab-aozora'))
+      await waitFor(() => expect(screen.getByTestId('history-export-csv')).toBeTruthy())
+      fireEvent.click(screen.getByTestId('history-export-csv'))
+      expect(onExportCsv.mock.calls.at(-1)?.[1]).toBe('aozora')
+
+      fireEvent.change(screen.getByTestId('history-filter-text'), { target: { value: 'aozora-1' } })
+      fireEvent.click(screen.getByTestId('history-export-csv'))
+      expect(onExportCsv.mock.calls.at(-1)?.[1]).toBe('aozora-Kokoro')
     })
   })
 })

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -399,11 +399,17 @@ describe('TypingTestHistory', () => {
   })
 
   // Regression guard for the History modal overflow fix: the sections
-  // between the tabs and the results table (sparkline/stats/accuracy-trend/
-  // mistake-ranking/error-mix) must live inside their own scroll container,
-  // separate from the tabs above and the results table below, so a tall
-  // stack of sections can't push the table past the modal's bottom edge.
-  it('wraps the between-tabs-and-table sections in their own scroll container', () => {
+  // between the tabs and the results table (accuracy-trend/mistake-ranking/
+  // error-mix) must live inside their own scroll container, separate from
+  // the tabs above and the results table below, so a tall stack of sections
+  // can't push the table past the modal's bottom edge.
+  //
+  // Updated for the Results/Analysis secondary-tab split: the three lower
+  // sections now render only under the Analysis view tab (the sparkline/
+  // stats moved into the Results view alongside the table), so this test
+  // checks the Results-view table floor first, then switches to Analysis to
+  // check the scroll wrapper.
+  it('wraps the Analysis sections in their own scroll container, and gives the Results table a min-height floor', () => {
     const results = [
       makeResult({ wpm: 60, accuracy: 90, mistakes: { a: 3, b: 2 } }),
       makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 } }),
@@ -422,6 +428,17 @@ describe('TypingTestHistory', () => {
     expect(root.className).toContain('flex-1')
     expect(root.className).not.toContain('h-full')
 
+    // Results view (default): the results-table wrapper carries a min-h-48
+    // floor so it never collapses to zero height.
+    const table = root.querySelector('table')
+    expect(table).toBeTruthy()
+    const tableWrapper = table!.parentElement as HTMLElement
+    expect(tableWrapper.className).toContain('min-h-48')
+    expect(tableWrapper.className).toContain('flex-1')
+    expect(tableWrapper.className).toContain('overflow-y-auto')
+
+    // Analysis view: the three lower sections live in their own scroll wrapper.
+    fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
     const sections = screen.getByTestId('history-sections')
     expect(sections.className).toContain('min-h-0')
     expect(sections.className).toContain('shrink')
@@ -433,22 +450,17 @@ describe('TypingTestHistory', () => {
     expect(sections.querySelector('[data-testid="history-condition-filter"]')).toBeTruthy()
 
     // Does NOT contain the tab buttons or the results table — both live
-    // outside the wrapper (tabs always visible above; table scrolls on its own below).
+    // outside the wrapper (tabs always visible above; the table is a
+    // different view, unmounted while Analysis is active).
     expect(sections.querySelector('[data-testid="history-tab-monkeytype"]')).toBeNull()
     expect(sections.querySelector('table')).toBeNull()
-
-    // The results-table wrapper carries a min-h-48 floor so it never
-    // collapses to zero height when the sections region above it is tall.
-    const history = screen.getByTestId('typing-test-history')
-    const table = history.querySelector('table')
-    expect(table).toBeTruthy()
-    const tableWrapper = table!.parentElement as HTMLElement
-    expect(tableWrapper.className).toContain('min-h-48')
-    expect(tableWrapper.className).toContain('flex-1')
-    expect(tableWrapper.className).toContain('overflow-y-auto')
   })
 
   describe('Accuracy Trend condition selector', () => {
+    // The three lower sections (Accuracy Trend / Mistake Ranking / Error Mix)
+    // now live under the secondary "Analysis" view tab (see the "secondary
+    // view tabs" describe block below), so every test here switches to it
+    // before touching `history-condition-filter` / `accuracy-trend-chart`.
     it('defaults to the latest run\'s condition and hides the chart below 2 same-condition runs', () => {
       // Newest-first, mirroring the real prop order (useDevicePrefs prepends
       // new runs) that the condition grouping relies on.
@@ -458,6 +470,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       const select = screen.getByTestId('history-condition-filter') as HTMLSelectElement
       expect(select.options.length).toBe(2)
       // The latest run (2026-01-03) is 'time', so it's the default selection.
@@ -472,6 +485,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.getByTestId('accuracy-trend-chart')).toBeTruthy()
     })
 
@@ -484,6 +498,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       // Default (latest = time|60) has only 1 run → no chart yet.
       expect(screen.queryByTestId('accuracy-trend-chart')).toBeNull()
 
@@ -500,17 +515,235 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.getByTestId('accuracy-trend-chart')).toBeTruthy()
-      // Switching the table's mode filter to a mode with zero matching rows
-      // must not affect the condition selector/chart, which is scoped to
-      // the whole tab's results, not the mode-filtered table.
+      // The mode filter dropdown lives in the Results view — switch there to
+      // reach it, change it, then switch back to Analysis. The condition
+      // selector/chart must be unaffected either way, since it's scoped to
+      // the whole tab's results (tabResults), not the mode-filtered table.
+      fireEvent.click(screen.getByTestId('history-view-tab-results'))
       fireEvent.change(screen.getByTestId('history-filter-mode'), { target: { value: 'time' } })
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.getByTestId('accuracy-trend-chart')).toBeTruthy()
     })
 
     it('is not shown when the active tab has no results', () => {
       renderWithI18n(<TypingTestHistory results={[]} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.queryByTestId('history-condition-filter')).toBeNull()
+    })
+  })
+
+  describe('secondary view tabs (Results / Analysis)', () => {
+    it('defaults to the Results view: table + sparkline/stats visible, analysis sections absent', () => {
+      const results = [
+        makeResult({ wpm: 80 }),
+        makeResult({ wpm: 60 }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      const history = screen.getByTestId('typing-test-history')
+      expect(history.querySelector('table')).toBeTruthy()
+      expect(screen.getByTestId('history-sparkline')).toBeTruthy()
+      expect(screen.getByTestId('history-stats')).toBeTruthy()
+      expect(screen.queryByTestId('history-sections')).toBeNull()
+      expect(screen.queryByTestId('typing-test-mistake-ranking')).toBeNull()
+      expect(screen.queryByTestId('typing-test-error-mix')).toBeNull()
+    })
+
+    it('switching to Analysis shows the three sections and hides the table/filter/sparkline/stats, then switching back restores Results', () => {
+      const results = [
+        makeResult({ wpm: 60, accuracy: 90, mistakes: { a: 3, b: 2 } }),
+        makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 } }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      expect(screen.getByTestId('history-sections')).toBeTruthy()
+      expect(screen.getByTestId('typing-test-mistake-ranking')).toBeTruthy()
+      expect(screen.getByTestId('typing-test-error-mix')).toBeTruthy()
+      expect(screen.getByTestId('typing-test-history').querySelector('table')).toBeNull()
+      expect(screen.queryByTestId('history-filter-mode')).toBeNull()
+      expect(screen.queryByTestId('history-sparkline')).toBeNull()
+      expect(screen.queryByTestId('history-stats')).toBeNull()
+
+      fireEvent.click(screen.getByTestId('history-view-tab-results'))
+      expect(screen.getByTestId('typing-test-history').querySelector('table')).toBeTruthy()
+      expect(screen.getByTestId('history-filter-mode')).toBeTruthy()
+      expect(screen.getByTestId('history-sparkline')).toBeTruthy()
+      expect(screen.getByTestId('history-stats')).toBeTruthy()
+      expect(screen.queryByTestId('history-sections')).toBeNull()
+    })
+
+    it('keeps the secondary view selection when switching the source (MonkeyType/Text) tab', () => {
+      const results = [
+        makeResult({ wpm: 81, mode: 'words', mode2: 30 }),
+        makeResult({ wpm: 82, mode: 'fileImport', mode2: 'id-1', fileImportTextName: 'novel.txt' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      expect(screen.getByTestId('history-sections')).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('history-tab-text'))
+      // Secondary tab selection persists across the source-tab switch.
+      expect(screen.getByTestId('history-sections')).toBeTruthy()
+      expect(screen.getByTestId('typing-test-history').querySelector('table')).toBeNull()
+    })
+
+    it('wires the secondary view tabs with a full ARIA tab pattern', () => {
+      renderWithI18n(<TypingTestHistory results={[makeResult()]} />)
+
+      const tablist = screen.getByRole('tablist', { name: 'History view' })
+      expect(tablist).toBeTruthy()
+
+      const resultsTab = screen.getByTestId('history-view-tab-results')
+      const analysisTab = screen.getByTestId('history-view-tab-analysis')
+      expect(resultsTab.getAttribute('role')).toBe('tab')
+      expect(analysisTab.getAttribute('role')).toBe('tab')
+      expect(resultsTab.getAttribute('aria-selected')).toBe('true')
+      expect(analysisTab.getAttribute('aria-selected')).toBe('false')
+
+      const resultsPanelId = resultsTab.getAttribute('aria-controls')
+      expect(resultsPanelId).toBeTruthy()
+      const resultsPanel = document.getElementById(resultsPanelId!)
+      expect(resultsPanel?.getAttribute('role')).toBe('tabpanel')
+      expect(resultsPanel?.getAttribute('aria-labelledby')).toBe(resultsTab.id)
+
+      fireEvent.click(analysisTab)
+      expect(analysisTab.getAttribute('aria-selected')).toBe('true')
+      expect(resultsTab.getAttribute('aria-selected')).toBe('false')
+
+      const analysisPanelId = analysisTab.getAttribute('aria-controls')
+      expect(analysisPanelId).toBeTruthy()
+      const analysisPanel = document.getElementById(analysisPanelId!)
+      expect(analysisPanel?.getAttribute('role')).toBe('tabpanel')
+      expect(analysisPanel?.getAttribute('aria-labelledby')).toBe(analysisTab.id)
+    })
+
+    // Regression guard: an earlier version of this split wrapped each panel
+    // component in its own plain `<div role="tabpanel" ...>` in
+    // TypingTestHistory, with the panel component's real content nested one
+    // level inside it. That extra div's default `display: block` broke the
+    // flex min-h-0/shrink chain HistorySections relies on for its
+    // overflow-y-auto scroll region to actually engage, silently
+    // reintroducing the #377 modal-overflow bug (caught via screenshot, not
+    // by DOM presence/absence assertions — hence this structural check).
+    // The fix makes each panel component apply role=tabpanel/id/
+    // aria-labelledby directly to its OWN existing root div, so the
+    // tabpanel element IS the flex/scroll container, not a wrapper around it.
+    it('keeps each view tabpanel as part of the flex sizing chain (no unconstrained wrapper div)', () => {
+      const results = [
+        makeResult({ wpm: 60, accuracy: 90, mistakes: { a: 3, b: 2 } }),
+        makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 } }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+
+      // Panel ids are React-useId-derived (not the static strings this test
+      // used before), so look them up via the tab's aria-controls rather
+      // than a hardcoded id.
+      const resultsTab = screen.getByTestId('history-view-tab-results')
+      const analysisTab = screen.getByTestId('history-view-tab-analysis')
+
+      // Results view: the tabpanel IS HistoryResultsPanel's own root div —
+      // continuing the parent's `flex flex-col` chain (flex + min-h-0 +
+      // flex-1), not a bare block div wrapping it.
+      const resultsPanel = document.getElementById(resultsTab.getAttribute('aria-controls')!)
+      expect(resultsPanel).toBeTruthy()
+      expect(resultsPanel!.className).toContain('flex')
+      expect(resultsPanel!.className).toContain('min-h-0')
+      expect(resultsPanel!.className).toContain('flex-1')
+
+      fireEvent.click(analysisTab)
+
+      // Analysis view: the tabpanel IS HistorySections' own scroll wrapper
+      // (same element as the `history-sections` testid) — its min-h-0/
+      // shrink/overflow-y-auto classes are what actually contain the tall
+      // section stack, so they must land on the tabpanel element itself.
+      const analysisPanel = document.getElementById(analysisTab.getAttribute('aria-controls')!)
+      expect(analysisPanel).toBeTruthy()
+      expect(analysisPanel).toBe(screen.getByTestId('history-sections'))
+      expect(analysisPanel!.className).toContain('flex')
+      expect(analysisPanel!.className).toContain('min-h-0')
+      expect(analysisPanel!.className).toContain('shrink')
+      expect(analysisPanel!.className).toContain('overflow-y-auto')
+    })
+
+    // P2-1 (codex review): sort state used to live inside HistoryResultsPanel,
+    // which unmounts whenever the Analysis view is active (conditional
+    // render) — so a chosen sort silently reset on every round trip through
+    // Analysis. The fix lifts sortColumn/sortDirection into TypingTestHistory
+    // itself, which never unmounts.
+    it('preserves the results-table sort selection across a Results→Analysis→Results round trip', () => {
+      const results = [
+        makeResult({ wpm: 60, date: '2025-01-03T00:00:00Z' }),
+        makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z' }),
+        makeResult({ wpm: 75, date: '2025-01-01T00:00:00Z' }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+
+      const rows = () => {
+        const history = screen.getByTestId('typing-test-history')
+        const trs = history.querySelectorAll('tbody tr')
+        return Array.from(trs).map((tr) => Number(tr.querySelectorAll('td')[2].textContent))
+      }
+
+      // Default sort is date desc (most recent first) → 60, 90, 75
+      expect(rows()).toEqual([60, 90, 75])
+
+      // Sort by WPM desc
+      const wpmButton = screen.getByRole('button', { name: /WPM/i })
+      fireEvent.click(wpmButton)
+      expect(rows()).toEqual([90, 75, 60])
+
+      // Round-trip through Analysis and back to Results — the sort
+      // selection must survive since HistoryResultsPanel fully unmounts
+      // while Analysis is active.
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      fireEvent.click(screen.getByTestId('history-view-tab-results'))
+      expect(rows()).toEqual([90, 75, 60])
+
+      // aria-sort on the WPM header should also reflect the preserved
+      // column/direction, not reset back to the date-desc default.
+      const activeHeader = screen.getByTestId('typing-test-history').querySelector('th[aria-sort="descending"]')
+      expect(activeHeader?.textContent).toContain('WPM')
+    })
+
+    // P2-2 (codex review): APG tabs pattern — arrow keys move focus AND
+    // selection between the two view tabs, roving tabIndex keeps the
+    // tablist a single Tab stop. Scoped to the NEW view tabs only; the
+    // pre-existing source tabs (MonkeyType/File Import) are untouched.
+    it('supports APG roving-tabindex arrow-key navigation between the view tabs', () => {
+      renderWithI18n(<TypingTestHistory results={[makeResult()]} />)
+      const resultsTab = screen.getByTestId('history-view-tab-results') as HTMLButtonElement
+      const analysisTab = screen.getByTestId('history-view-tab-analysis') as HTMLButtonElement
+
+      // Roving tabIndex: only the active tab is in the page's Tab order.
+      expect(resultsTab.tabIndex).toBe(0)
+      expect(analysisTab.tabIndex).toBe(-1)
+
+      resultsTab.focus()
+      fireEvent.keyDown(resultsTab, { key: 'ArrowRight' })
+      // Automatic activation: the arrow key moves both focus AND selection.
+      expect(document.activeElement).toBe(analysisTab)
+      expect(analysisTab.getAttribute('aria-selected')).toBe('true')
+      expect(resultsTab.getAttribute('aria-selected')).toBe('false')
+      expect(analysisTab.tabIndex).toBe(0)
+      expect(resultsTab.tabIndex).toBe(-1)
+      expect(screen.getByTestId('history-sections')).toBeTruthy()
+
+      fireEvent.keyDown(analysisTab, { key: 'ArrowLeft' })
+      expect(document.activeElement).toBe(resultsTab)
+      expect(resultsTab.getAttribute('aria-selected')).toBe('true')
+      expect(resultsTab.tabIndex).toBe(0)
+      expect(analysisTab.tabIndex).toBe(-1)
+
+      // Home/End jump to the first/last tab regardless of current position.
+      fireEvent.keyDown(resultsTab, { key: 'End' })
+      expect(document.activeElement).toBe(analysisTab)
+      expect(analysisTab.getAttribute('aria-selected')).toBe('true')
+
+      fireEvent.keyDown(analysisTab, { key: 'Home' })
+      expect(document.activeElement).toBe(resultsTab)
+      expect(resultsTab.getAttribute('aria-selected')).toBe('true')
     })
   })
 })


### PR DESCRIPTION
## Summary
- Split the History modal's stacked content into secondary [Results | Analysis] tabs: Results keeps the filter row, sparkline, stats, and the results table; Analysis holds Accuracy Trend, Most Missed, and Error Mix in their own scroll region. APG keyboard pattern (arrow keys, roving tabIndex, useId-derived ids), sort state lifted so table ordering survives tab switches, and the tab panels double as the flex scroll containers so content can never overflow the modal.
- Expand source tabs from [MonkeyType | File Import] to [MonkeyType | Tatoeba | Aozora | File Import]: tatoeba runs classify by mode, aozora by the linked text's source provider (via mode2/textId), legacy custom-mode rows stay under File Import, sub-filters and CSV export slugs scoped per tab.

## Verification
- 8,298 passed / 22 skipped (baseline +14 across both commits, red-run evidence per change; every edited legacy test flagged).
- Virtual-device Playwright checks: strict bounding-box containment on both view tabs at a 1360×800 window (0 offenders), and a 10-result seed classifying 3/2/2/3 across the four source tabs with DOM count assertions.
- i18n keys added to english.json and all four sample packs, version lockstep 0.1.60.