### PR TITLE
feat(ui): render saved runs as a per-line keystroke timeline

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.60",
+  "version": "0.1.61",
   "name": "Japanese",
   "common": {
     "save": "保存",

--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -530,7 +530,9 @@
             "runWpm": "ラン全体のWPM",
             "accuracy": "正確度",
             "overlap": "重複率",
-            "duration": "所要時間"
+            "duration": "所要時間",
+            "kpm": "1分あたりの打鍵数",
+            "durationSeconds": "{{s}}秒"
           },
           "legend": {
             "normal": "通常の打鍵",
@@ -539,6 +541,8 @@
             "unjudged": "未判定（正誤データなし）",
             "blank": "ブランク（圧縮表示）",
             "leadIn": "ワード前の間",
+            "blankLine": "ブランク（250ms超、圧縮表示）",
+            "leadInLine": "行前の間",
             "correctedNote": "ミスの印には提出前に修正された打鍵も含まれます。ミスの印があっても正確度100%になることがあります。"
           },
           "axisNote": "ブランクは軸上で圧縮表示されています。表示される時間は全て実際の値です。",
@@ -557,7 +561,12 @@
             "correct": "正解",
             "offset": "+{{ms}}ms",
             "blankDuration": "ブランク: {{ms}}ms",
-            "leadInDuration": "ワード前の間: {{ms}}ms"
+            "leadInDuration": "ワード前の間: {{ms}}ms",
+            "leadInLineDuration": "行前の間: {{ms}}ms"
+          },
+          "line": {
+            "indexAria": "{{n}}行目",
+            "romajiAria": "ローマ字: {{text}}"
           }
         }
       },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -530,7 +530,9 @@
             "runWpm": "ラン全体のWPMじゃん☆",
             "accuracy": "正確度☆",
             "overlap": "重複率☆",
-            "duration": "所要時間☆"
+            "duration": "所要時間☆",
+            "kpm": "1分の打鍵数☆",
+            "durationSeconds": "{{s}}秒"
           },
           "legend": {
             "normal": "普通の打鍵",
@@ -539,6 +541,8 @@
             "unjudged": "未判定（正誤わかんないやつ）",
             "blank": "ブランク（圧縮表示だよ）",
             "leadIn": "ワード前の間",
+            "blankLine": "ブランク（250ms超、圧縮表示だよ）",
+            "leadInLine": "行前の間じゃん",
             "correctedNote": "ミスの印、提出前に直したのも入ってるから、印あっても正確度100%になることあるよ"
           },
           "axisNote": "ブランクは軸上で圧縮して表示してるけど、出てる時間は全部リアルな値だよ",
@@ -557,7 +561,12 @@
             "correct": "正解☆",
             "offset": "+{{ms}}ms",
             "blankDuration": "ブランク: {{ms}}ms",
-            "leadInDuration": "ワード前の間: {{ms}}ms"
+            "leadInDuration": "ワード前の間: {{ms}}ms",
+            "leadInLineDuration": "行前の間: {{ms}}ms"
+          },
+          "line": {
+            "indexAria": "{{n}}行目じゃん",
+            "romajiAria": "ローマ字: {{text}}"
           }
         }
       },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.60",
+  "version": "0.1.61",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.60",
+  "version": "0.1.61",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -530,7 +530,9 @@
             "runWpm": "ラン全体のWPMどすえ",
             "accuracy": "正確度どすえ",
             "overlap": "重複率どすえ",
-            "duration": "所要時間どすえ"
+            "duration": "所要時間どすえ",
+            "kpm": "1分あたりの打鍵数どすえ",
+            "durationSeconds": "{{s}}秒"
           },
           "legend": {
             "normal": "通常の打鍵どすえ",
@@ -539,6 +541,8 @@
             "unjudged": "未判定（正誤のデータがおへん）",
             "blank": "ブランク（圧縮して表示どすえ）",
             "leadIn": "ワード前の間どすえ",
+            "blankLine": "ブランク（250ms超、圧縮して表示どすえ）",
+            "leadInLine": "行前の間どすえ",
             "correctedNote": "ミスの印には提出前に直さはった打鍵も入ってますよって、印があっても正確度100%になることがおすえ"
           },
           "axisNote": "ブランクはこの軸の上で圧縮して表示してますけど、出てる時間はどれも本当の値どすえ",
@@ -557,7 +561,12 @@
             "correct": "正解どすえ",
             "offset": "+{{ms}}ms",
             "blankDuration": "ブランク: {{ms}}ms",
-            "leadInDuration": "ワード前の間: {{ms}}ms"
+            "leadInDuration": "ワード前の間: {{ms}}ms",
+            "leadInLineDuration": "行前の間: {{ms}}ms"
+          },
+          "line": {
+            "indexAria": "{{n}}行目どすえ",
+            "romajiAria": "ローマ字: {{text}}どすえ"
           }
         }
       },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -530,7 +530,9 @@
             "runWpm": "ラン全体のWPM",
             "accuracy": "正確度",
             "overlap": "重複率",
-            "duration": "所要時間"
+            "duration": "所要時間",
+            "kpm": "1分あたりの打鍵数",
+            "durationSeconds": "{{s}}秒"
           },
           "legend": {
             "normal": "通常の打鍵",
@@ -539,6 +541,8 @@
             "unjudged": "未判定（正誤のデータなし）",
             "blank": "間（圧縮して表示）",
             "leadIn": "ワード前の間",
+            "blankLine": "間（250ms超、圧縮して表示）",
+            "leadInLine": "行前の間",
             "correctedNote": "誤りの印には提出前に訂正された打鍵も含まれております。印があっても正確度100%となることがございます。"
           },
           "axisNote": "間は軸上で圧縮して表示しておりますが、表示される時間はいずれも実際の値でございます。",
@@ -557,7 +561,12 @@
             "correct": "正解",
             "offset": "+{{ms}}ms",
             "blankDuration": "間: {{ms}}ms",
-            "leadInDuration": "ワード前の間: {{ms}}ms"
+            "leadInDuration": "ワード前の間: {{ms}}ms",
+            "leadInLineDuration": "行前の間: {{ms}}ms"
+          },
+          "line": {
+            "indexAria": "{{n}}行目",
+            "romajiAria": "ローマ字: {{text}}でございます"
           }
         }
       },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.60",
+  "version": "0.1.61",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -530,7 +530,9 @@
             "runWpm": "Run WPM",
             "accuracy": "Accuracy",
             "overlap": "Overlap",
-            "duration": "Duration"
+            "duration": "Duration",
+            "kpm": "Keystrokes/min",
+            "durationSeconds": "{{s}}s"
           },
           "legend": {
             "normal": "Normal keystroke",
@@ -539,6 +541,8 @@
             "unjudged": "Unjudged (no correctness data)",
             "blank": "Pause (shown compressed)",
             "leadIn": "Pause before this word",
+            "blankLine": "Pause (>250ms, shown compressed)",
+            "leadInLine": "Pause before this line",
             "correctedNote": "Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy."
           },
           "axisNote": "Pauses are shown compressed on this axis; every duration shown is still the real one.",
@@ -557,7 +561,12 @@
             "correct": "correct",
             "offset": "+{{ms}}ms",
             "blankDuration": "Pause: {{ms}}ms",
-            "leadInDuration": "Pause before word: {{ms}}ms"
+            "leadInDuration": "Pause before word: {{ms}}ms",
+            "leadInLineDuration": "Pause before line: {{ms}}ms"
+          },
+          "line": {
+            "indexAria": "Line {{n}}",
+            "romajiAria": "Romaji: {{text}}"
           }
         }
       },

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.60",
+  "version": "0.1.61",
   "name": "English",
   "common": {
     "save": "Save",

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -82,6 +82,29 @@
   font-size: calc(var(--tt-font) * 1px);
 }
 
+/* Line timeline keystroke label overlay (LineTimelineRow.tsx): each
+   keystroke bar's HTML label wrapper opts into a CSS container query
+   (`container-type: inline-size`) so its own rendered WIDTH — which
+   tracks the shared zoom-driven canvas width, not the line's fixed
+   duration — decides whether the label glyph shows. Hidden by default;
+   the @container rule below reveals it once the bar is wide enough to
+   hold roughly one glyph of the text-2xs (10px) font. This makes
+   per-bar label visibility a pure CSS function of zoom: the row itself
+   never re-renders when the shared canvas width changes (see
+   WordTimelineView's DOM-only zoom invariant), so this could not be
+   done with a JS-computed class instead. */
+.line-timeline-label-cell {
+  container-type: inline-size;
+}
+.line-timeline-label-text {
+  display: none;
+}
+@container (min-width: 12px) {
+  .line-timeline-label-text {
+    display: block;
+  }
+}
+
 /* Interactive elements use pointer cursor */
 button:not(:disabled),
 a,

--- a/src/renderer/typing-test/LineTimelineRow.tsx
+++ b/src/renderer/typing-test/LineTimelineRow.tsx
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// One line's row inside WordTimelineView's line-view mode: a plain-HTML
+// header (index badge + line text + optional romaji reading + per-line
+// stats) and a single SVG strip — same shape as `word-timeline-row.tsx`'s
+// per-word row, just built from `LineTimelineLine` instead of
+// `WordTimelineWord`. The SVG deliberately has ZERO text elements, same
+// precedent as the word row (see that file's own doc comment) — word
+// labels live in the header, word BOUNDARIES render as subtle dividers
+// (`WORD_SEPARATOR_FILL`), never as in-SVG text.
+
+import { memo } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { LineTimelineLine } from './line-timeline'
+import type { WordTimelineSegment } from './word-timeline'
+import { fillForKeystroke, TIMELINE_FILL, WORD_SEPARATOR_FILL } from './word-timeline-colors'
+import { formatPercentLabel } from '../components/analyze/analyze-format'
+import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
+import { LANE_UNIT_PX } from './word-timeline-row'
+
+const BAR_INSET_PX = 2
+
+/** Per-line duration render — seconds with one decimal (matches the
+ *  mockup's "10.4秒"), deliberately NOT `analyze-format`'s
+ *  `formatDuration`: that's an mm:ss formatter built for the whole-run
+ *  INTEGER `TypingTestResult.durationSeconds` the word view's summary
+ *  card feeds it — `seconds % 60` with no rounding, so a line's
+ *  fractional true span (typically single-digit seconds) produced
+ *  garbage like "0:8.73". `LineTimelineStats.durationSeconds` is never
+ *  undefined (unlike `kpm`/`accuracy`/`overlapRate`, which mean "nothing
+ *  to show" when absent), so this always renders a real value — "0.0"
+ *  for a line with zero measurable span, never `EMPTY_STAT_VALUE`. */
+function formatLineDurationSeconds(seconds: number): string {
+  return seconds.toFixed(1)
+}
+
+export interface LineHoverTarget {
+  /** The line's own joined display text — reused as the tooltip header,
+   *  same role `HoverTarget.word.display` plays in the per-word row (see
+   *  `word-timeline-row.tsx`). */
+  lineText: string
+  segment: WordTimelineSegment
+  rect: DOMRect
+}
+
+interface Props {
+  line: LineTimelineLine
+  maxDisplayMs: number
+  /** `RunKeystrokeLog.romajiInput` — shows a second, monospace romaji
+   *  row (joined `typed` text) under the line text when true. */
+  romajiInput: boolean
+  onHover: (target: LineHoverTarget) => void
+  onHoverEnd: () => void
+}
+
+function LineTimelineRowInner({ line, maxDisplayMs, romajiInput, onHover, onHoverEnd }: Props) {
+  const { t } = useTranslation()
+  const rowHeight = Math.max(line.laneCount, 1) * LANE_UNIT_PX
+  const { stats } = line
+
+  const lineText = line.words.map((w) => w.display).join(' ')
+  const romajiText = romajiInput ? line.words.map((w) => w.typed).join(' ') : null
+
+  const statParts: string[] = []
+  // Integer, unlike the word view's one-decimal `wordPace` — matches the
+  // mockup's "144kpm" (a keystroke COUNT rate, where a fractional digit
+  // reads as false precision).
+  if (stats.kpm !== undefined) statParts.push(`${t('editor.typingTest.history.timeline.stats.kpm')} ${Math.round(stats.kpm)}`)
+  if (stats.accuracy !== undefined) statParts.push(`${t('editor.typingTest.history.timeline.stats.accuracy')} ${formatPercentLabel(stats.accuracy / 100)}`)
+  if (stats.overlapRate !== undefined) statParts.push(`${t('editor.typingTest.history.timeline.stats.overlap')} ${formatPercentLabel(stats.overlapRate)}`)
+  // No separate "Duration" label — the mockup shows the bare
+  // seconds+unit ("10.4秒"), so the whole fragment comes from one
+  // interpolated key rather than a label + formatted-value pair like the
+  // stats above.
+  statParts.push(t('editor.typingTest.history.timeline.stats.durationSeconds', { s: formatLineDurationSeconds(stats.durationSeconds) }))
+
+  const handleSegHover = (seg: WordTimelineSegment) => (e: React.MouseEvent<SVGRectElement>) =>
+    onHover({ lineText, segment: seg, rect: e.currentTarget.getBoundingClientRect() })
+
+  return (
+    <div className="flex flex-col gap-0.5" data-testid={`line-timeline-row-${line.lineIndex}`}>
+      <div className="flex items-baseline gap-2">
+        <span
+          className="rounded-full bg-surface-dim px-1.5 text-2xs font-semibold text-content-secondary"
+          aria-label={t('editor.typingTest.history.timeline.line.indexAria', { n: line.lineIndex + 1 })}
+        >
+          {line.lineIndex + 1}
+        </span>
+        <span className="font-mono text-xs text-content">{lineText || EMPTY_STAT_VALUE}</span>
+        <span className="text-2xs text-content-muted">{statParts.join(' · ')}</span>
+      </div>
+      {romajiText !== null && (
+        <span
+          className="font-mono text-2xs text-content-muted"
+          aria-label={t('editor.typingTest.history.timeline.line.romajiAria', { text: romajiText })}
+        >
+          {romajiText || EMPTY_STAT_VALUE}
+        </span>
+      )}
+      <svg
+        width="100%"
+        height={rowHeight}
+        viewBox={`0 0 ${Math.max(maxDisplayMs, 1)} ${rowHeight}`}
+        preserveAspectRatio="none"
+        aria-hidden="true"
+        data-testid={`line-timeline-svg-${line.lineIndex}`}
+      >
+        {line.segments.map((seg, i) => {
+          if (seg.kind === 'keystroke') {
+            return (
+              <rect
+                key={i}
+                data-testid="line-timeline-keystroke"
+                x={seg.startMs}
+                y={seg.lane * LANE_UNIT_PX + BAR_INSET_PX}
+                width={Math.max(seg.endMs - seg.startMs, 1)}
+                height={LANE_UNIT_PX - BAR_INSET_PX * 2}
+                fill={fillForKeystroke(seg)}
+                onMouseEnter={handleSegHover(seg)}
+                onMouseLeave={onHoverEnd}
+              />
+            )
+          }
+          if (seg.kind === 'blank') {
+            return (
+              <rect
+                key={i}
+                data-testid="line-timeline-blank"
+                x={seg.startMs}
+                y={0}
+                width={Math.max(seg.endMs - seg.startMs, 1)}
+                height={rowHeight}
+                fill={TIMELINE_FILL.blank}
+                fillOpacity={0.18}
+                onMouseEnter={handleSegHover(seg)}
+                onMouseLeave={onHoverEnd}
+              />
+            )
+          }
+          // leadInPause — always at the row's own start (a line-crossing
+          // pause, never a mid-line one — see `line-timeline.ts`'s
+          // `buildLine`).
+          return (
+            <rect
+              key={i}
+              data-testid="line-timeline-lead-in"
+              x={seg.startMs}
+              y={0}
+              width={Math.max(seg.endMs - seg.startMs, 1)}
+              height={rowHeight}
+              fill={TIMELINE_FILL.leadIn}
+              fillOpacity={0.28}
+              onMouseEnter={handleSegHover(seg)}
+              onMouseLeave={onHoverEnd}
+            />
+          )
+        })}
+        {/* Word-boundary separators — subtle vertical dividers, never
+            text (see the module doc comment). Skips the line's own
+            start (index 0 always begins at startMs 0, which needs no
+            divider from "nothing"). */}
+        {line.words.slice(1).map((w) => (
+          <rect
+            key={`sep-${w.index}`}
+            data-testid="line-timeline-separator"
+            x={Math.max(w.startMs - 0.5, 0)}
+            y={0}
+            width={1}
+            height={rowHeight}
+            fill={WORD_SEPARATOR_FILL}
+          />
+        ))}
+      </svg>
+    </div>
+  )
+}
+
+// Same memo rationale as `WordTimelineRow` — rows depend only on their
+// own line + the shared axis width, never on zoom (a direct DOM
+// `style.width` write on the shared canvas ancestor).
+export const LineTimelineRow = memo(LineTimelineRowInner)

--- a/src/renderer/typing-test/LineTimelineRow.tsx
+++ b/src/renderer/typing-test/LineTimelineRow.tsx
@@ -12,7 +12,7 @@ import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { LineTimelineLine } from './line-timeline'
 import type { WordTimelineSegment } from './word-timeline'
-import { fillForKeystroke, TIMELINE_FILL, WORD_SEPARATOR_FILL } from './word-timeline-colors'
+import { fillForKeystroke, labelClassForKeystroke, TIMELINE_FILL, WORD_SEPARATOR_FILL } from './word-timeline-colors'
 import { formatPercentLabel } from '../components/analyze/analyze-format'
 import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
 import { LANE_UNIT_PX } from './word-timeline-row'
@@ -96,80 +96,125 @@ function LineTimelineRowInner({ line, maxDisplayMs, romajiInput, onHover, onHove
           {romajiText || EMPTY_STAT_VALUE}
         </span>
       )}
-      <svg
-        width="100%"
-        height={rowHeight}
-        viewBox={`0 0 ${Math.max(maxDisplayMs, 1)} ${rowHeight}`}
-        preserveAspectRatio="none"
-        aria-hidden="true"
-        data-testid={`line-timeline-svg-${line.lineIndex}`}
-      >
-        {line.segments.map((seg, i) => {
-          if (seg.kind === 'keystroke') {
+      <div className="relative">
+        <svg
+          width="100%"
+          height={rowHeight}
+          viewBox={`0 0 ${Math.max(maxDisplayMs, 1)} ${rowHeight}`}
+          preserveAspectRatio="none"
+          aria-hidden="true"
+          className="block"
+          data-testid={`line-timeline-svg-${line.lineIndex}`}
+        >
+          {line.segments.map((seg, i) => {
+            if (seg.kind === 'keystroke') {
+              return (
+                <rect
+                  key={i}
+                  data-testid="line-timeline-keystroke"
+                  x={seg.startMs}
+                  y={seg.lane * LANE_UNIT_PX + BAR_INSET_PX}
+                  width={Math.max(seg.endMs - seg.startMs, 1)}
+                  height={LANE_UNIT_PX - BAR_INSET_PX * 2}
+                  fill={fillForKeystroke(seg)}
+                  onMouseEnter={handleSegHover(seg)}
+                  onMouseLeave={onHoverEnd}
+                />
+              )
+            }
+            if (seg.kind === 'blank') {
+              return (
+                <rect
+                  key={i}
+                  data-testid="line-timeline-blank"
+                  x={seg.startMs}
+                  y={0}
+                  width={Math.max(seg.endMs - seg.startMs, 1)}
+                  height={rowHeight}
+                  fill={TIMELINE_FILL.blank}
+                  fillOpacity={0.18}
+                  onMouseEnter={handleSegHover(seg)}
+                  onMouseLeave={onHoverEnd}
+                />
+              )
+            }
+            // leadInPause — always at the row's own start (a line-crossing
+            // pause, never a mid-line one — see `line-timeline.ts`'s
+            // `buildLine`).
             return (
               <rect
                 key={i}
-                data-testid="line-timeline-keystroke"
-                x={seg.startMs}
-                y={seg.lane * LANE_UNIT_PX + BAR_INSET_PX}
-                width={Math.max(seg.endMs - seg.startMs, 1)}
-                height={LANE_UNIT_PX - BAR_INSET_PX * 2}
-                fill={fillForKeystroke(seg)}
-                onMouseEnter={handleSegHover(seg)}
-                onMouseLeave={onHoverEnd}
-              />
-            )
-          }
-          if (seg.kind === 'blank') {
-            return (
-              <rect
-                key={i}
-                data-testid="line-timeline-blank"
+                data-testid="line-timeline-lead-in"
                 x={seg.startMs}
                 y={0}
                 width={Math.max(seg.endMs - seg.startMs, 1)}
                 height={rowHeight}
-                fill={TIMELINE_FILL.blank}
-                fillOpacity={0.18}
+                fill={TIMELINE_FILL.leadIn}
+                fillOpacity={0.28}
                 onMouseEnter={handleSegHover(seg)}
                 onMouseLeave={onHoverEnd}
               />
             )
-          }
-          // leadInPause — always at the row's own start (a line-crossing
-          // pause, never a mid-line one — see `line-timeline.ts`'s
-          // `buildLine`).
-          return (
+          })}
+          {/* Word-boundary separators — subtle vertical dividers, never
+              text (see the module doc comment). Skips the line's own
+              start (index 0 always begins at startMs 0, which needs no
+              divider from "nothing"). */}
+          {line.words.slice(1).map((w) => (
             <rect
-              key={i}
-              data-testid="line-timeline-lead-in"
-              x={seg.startMs}
+              key={`sep-${w.index}`}
+              data-testid="line-timeline-separator"
+              x={Math.max(w.startMs - 0.5, 0)}
               y={0}
-              width={Math.max(seg.endMs - seg.startMs, 1)}
+              width={1}
               height={rowHeight}
-              fill={TIMELINE_FILL.leadIn}
-              fillOpacity={0.28}
-              onMouseEnter={handleSegHover(seg)}
-              onMouseLeave={onHoverEnd}
+              fill={WORD_SEPARATOR_FILL}
             />
-          )
-        })}
-        {/* Word-boundary separators — subtle vertical dividers, never
-            text (see the module doc comment). Skips the line's own
-            start (index 0 always begins at startMs 0, which needs no
-            divider from "nothing"). */}
-        {line.words.slice(1).map((w) => (
-          <rect
-            key={`sep-${w.index}`}
-            data-testid="line-timeline-separator"
-            x={Math.max(w.startMs - 0.5, 0)}
-            y={0}
-            width={1}
-            height={rowHeight}
-            fill={WORD_SEPARATOR_FILL}
-          />
-        ))}
-      </svg>
+          ))}
+        </svg>
+        {/* On-bar keystroke labels — an HTML overlay laid exactly over the
+            SVG strip above rather than SVG `<text>` (see the module doc
+            comment for why the SVG itself stays text-free: zoom is a
+            non-uniform `preserveAspectRatio="none"` width-only scale, which
+            would distort any in-SVG glyph). Geometry uses the SAME shared
+            axis (`maxDisplayMs`, not this line's own duration) the SVG
+            viewBox above uses, expressed in % so it tracks the zoom-driven
+            canvas width for free — the row itself never re-renders on zoom
+            (`WordTimelineView`'s DOM-only zoom invariant). Per-bar
+            visibility at a given zoom is a pure CSS container-query
+            decision (`style.css`), not something computed here. */}
+        <div
+          className="pointer-events-none absolute inset-0"
+          aria-hidden="true"
+          data-testid={`line-timeline-label-layer-${line.lineIndex}`}
+        >
+          {line.segments.map((seg, i) => {
+            if (seg.kind !== 'keystroke') return null
+            const axisMs = Math.max(maxDisplayMs, 1)
+            const leftPct = (seg.startMs / axisMs) * 100
+            const widthPct = (Math.max(seg.endMs - seg.startMs, 1) / axisMs) * 100
+            return (
+              <div
+                key={i}
+                data-testid="line-timeline-label-cell"
+                className="line-timeline-label-cell absolute overflow-hidden"
+                style={{
+                  left: `${leftPct}%`,
+                  width: `${widthPct}%`,
+                  top: seg.lane * LANE_UNIT_PX + BAR_INSET_PX,
+                  height: LANE_UNIT_PX - BAR_INSET_PX * 2,
+                }}
+              >
+                <span
+                  className={`line-timeline-label-text flex h-full items-center justify-center text-2xs font-semibold leading-none ${labelClassForKeystroke(seg)}`}
+                >
+                  {seg.label}
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/typing-test/WordTimelineView.tsx
+++ b/src/renderer/typing-test/WordTimelineView.tsx
@@ -23,9 +23,11 @@ import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
 import { useEscapeCloseCapture } from '../hooks/useEscapeClose'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
-import { buildWordTimeline, buildWordTimelineSummary, type WordTimelineModel, type KeystrokeSegment } from './word-timeline'
+import type { KeystrokeSegment } from './word-timeline'
 import { WordTimelineRow, type HoverTarget } from './word-timeline-row'
+import { LineTimelineRow, type LineHoverTarget } from './LineTimelineRow'
 import { TIMELINE_LEGEND, type TimelineFillKind } from './word-timeline-colors'
+import { useTimelineModel } from './use-timeline-model'
 
 /** Floor for the "fit" zoom level's canvas width — a run with a very
  *  short `maxDisplayMs` (e.g. a single short word) would otherwise
@@ -77,6 +79,16 @@ function triLabel(
   if (value === true) return t(yesKey)
   if (value === false) return t(noKey)
   return t(unknownKey)
+}
+
+/** The legend's `blank`/`leadIn` entries carry a line-view specific
+ *  meaning (250ms cut, "before this line") distinct from the word view's
+ *  (1000ms cut, "before this word") — every other legend entry (normal,
+ *  mistake, overlap, unjudged) means the same thing in both modes. */
+function lineLegendLabelKey(kind: TimelineFillKind, displayMode: 'line' | 'word'): string {
+  if (displayMode === 'line' && kind === 'blank') return 'editor.typingTest.history.timeline.legend.blankLine'
+  if (displayMode === 'line' && kind === 'leadIn') return 'editor.typingTest.history.timeline.legend.leadInLine'
+  return TIMELINE_LEGEND[kind].labelKey
 }
 
 function keystrokeTooltipBody(word: string, seg: KeystrokeSegment, t: (key: string, opts?: Record<string, unknown>) => string) {
@@ -132,14 +144,14 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
   // phase so History's own bubble-phase useEscapeClose never sees it.
   useEscapeCloseCapture(onClose)
 
-  const model = useMemo<WordTimelineModel | null>(() => (log ? buildWordTimeline(log) : null), [log])
-  const summary = useMemo(() => (model ? buildWordTimelineSummary(model) : null), [model])
+  const { displayMode, wordModel, lineModel, summary, activeMaxDisplayMs, activeCharCorrelationUnavailable } = useTimelineModel(log)
 
   const containerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLDivElement>(null)
   const [fitPxPerMs, setFitPxPerMs] = useState<number | null>(null)
   // Bumped from the canvas ref callback once the element actually mounts
-  // — see the effect below for why this, not just `[model]`, is needed.
+  // — see the effect below for why this, not just `[displayMode]`, is
+  // needed.
   const [canvasMountTick, setCanvasMountTick] = useState(0)
   const setCanvasNode = useCallback((node: HTMLDivElement | null) => {
     canvasRef.current = node
@@ -147,9 +159,9 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
   }, [])
 
   const applyZoom = useCallback((next: number) => {
-    if (!model || !canvasRef.current) return
-    canvasRef.current.style.width = `${Math.round(model.maxDisplayMs * next)}px`
-  }, [model])
+    if (!displayMode || !canvasRef.current) return
+    canvasRef.current.style.width = `${Math.round(activeMaxDisplayMs * next)}px`
+  }, [displayMode, activeMaxDisplayMs])
 
   // Whether the canvas is still at the "fit whole run in view" width —
   // true from mount until the user first drags the slider away from it
@@ -171,29 +183,29 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
   // with very little content, or — in tests — jsdom's `clientWidth`
   // always reading 0 since it never implements layout).
   const computeAndApplyFit = useCallback(() => {
-    if (!model || model.maxDisplayMs <= 0) return
+    if (!displayMode || activeMaxDisplayMs <= 0) return
     const container = containerRef.current
     if (!container) return
     const styles = window.getComputedStyle(container)
     const paddingX = parseFloat(styles.paddingLeft || '0') + parseFloat(styles.paddingRight || '0')
     const width = Math.max(container.clientWidth - paddingX, CANVAS_MIN_WIDTH_PX)
-    const fit = width / model.maxDisplayMs
+    const fit = width / activeMaxDisplayMs
     setFitPxPerMs(fit)
     if (isAtFitRef.current) applyZoom(fit)
-  }, [model, applyZoom])
+  }, [displayMode, activeMaxDisplayMs, applyZoom])
 
   // Compute the fit level once the model is known AND the canvas has
-  // actually mounted. Keying only on `[model]` (the original approach)
-  // breaks because `setLog` and `setLoading` flush in separate
-  // microtasks: `model` (derived from `log`) can become non-null on a
-  // render where `loading` is STILL true, before the JSX gating this
-  // section (`!loading && ... && model`) has ever rendered the
-  // container/canvas — `containerRef`/`canvasRef` are still null on that
-  // render, and the fit falls back to `CANVAS_MIN_WIDTH_PX` regardless of
-  // the real container width. Depending on the canvas's own mount
-  // (bumped from its ref callback, which fires once loading has actually
-  // flipped and the section is in the DOM) instead of just `model`
-  // guarantees this runs again once the refs are live.
+  // actually mounted. Keying only on `[displayMode]` (the original
+  // approach) breaks because `setLog` and `setLoading` flush in separate
+  // microtasks: `displayMode` (derived from `log`) can become non-null
+  // on a render where `loading` is STILL true, before the JSX gating
+  // this section (`!loading && ... && displayMode`) has ever rendered
+  // the container/canvas — `containerRef`/`canvasRef` are still null on
+  // that render, and the fit falls back to `CANVAS_MIN_WIDTH_PX`
+  // regardless of the real container width. Depending on the canvas's
+  // own mount (bumped from its ref callback, which fires once loading
+  // has actually flipped and the section is in the DOM) instead of just
+  // `displayMode` guarantees this runs again once the refs are live.
   useEffect(() => {
     if (!canvasRef.current) return
     computeAndApplyFit()
@@ -206,11 +218,11 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
   // space or reintroducing the very overflow this fix exists to remove.
   useEffect(() => {
     const container = containerRef.current
-    if (!container || !model) return
+    if (!container || !displayMode) return
     const observer = new ResizeObserver(() => computeAndApplyFit())
     observer.observe(container)
     return () => observer.disconnect()
-  }, [model, computeAndApplyFit])
+  }, [displayMode, computeAndApplyFit])
 
   // Live drag: this fires on every tick (React's onChange for a range
   // input maps to the native 'input' event) but only ever touches the
@@ -222,7 +234,15 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
     applyZoom(Number(e.target.value))
   }, [applyZoom, fitPxPerMs])
 
-  const [hover, setHover] = useState<HoverTarget | null>(null)
+  // Discriminated union: word rows report a `WordTimelineWord`, line rows
+  // report the line's own joined text — the two modes are mutually
+  // exclusive (see `displayMode`), so only one branch is ever set, but
+  // both need distinct handlers to stay type-safe without threading a
+  // `word.display`-shaped fake through the line path.
+  type Hover = ({ kind: 'word' } & HoverTarget) | ({ kind: 'line' } & LineHoverTarget)
+  const [hover, setHover] = useState<Hover | null>(null)
+  const handleWordHover = useCallback((t: HoverTarget) => setHover({ kind: 'word', ...t }), [])
+  const handleLineHover = useCallback((t: LineHoverTarget) => setHover({ kind: 'line', ...t }), [])
   const handleHoverEnd = useCallback(() => setHover(null), [])
 
   // Tooltip position — measure-then-position, same idiom as
@@ -318,7 +338,7 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
           </p>
         )}
 
-        {!loading && !loadError && model && (
+        {!loading && !loadError && displayMode && (
           <div className="flex min-h-0 flex-1 flex-col gap-3">
             {/* Deliberate exception to the Analyze chart-above-stats rule
                 (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
@@ -328,7 +348,7 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
                 reaching the scrollable, flex-grow canvas below. */}
             <AnalyzeStatGrid items={summaryItems} ariaLabelKey="editor.typingTest.history.timeline.modalTitle" />
 
-            {model.charCorrelationUnavailable && (
+            {activeCharCorrelationUnavailable && (
               <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
                 {t('editor.typingTest.history.timeline.correlationUnreliable')}
               </p>
@@ -336,10 +356,14 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
 
             {/* Legend — color alone never carries meaning elsewhere in
                 this view (tooltips spell everything out too), but this
-                is the at-a-glance key. */}
+                is the at-a-glance key. Line-mode overrides the blank/
+                lead-in wording to the line-view's own meaning (a 250ms
+                cut and "before this line", not the word view's 1000ms /
+                "before this word") — every other entry, and the word
+                view's own wording, stays unchanged. */}
             <div className="flex flex-wrap items-center gap-3 rounded-md border border-edge bg-surface px-3 py-1.5">
               {LEGEND_ORDER.map((kind) => (
-                <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={TIMELINE_LEGEND[kind].labelKey} />
+                <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
               ))}
             </div>
             <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.legend.correctedNote')}</p>
@@ -374,15 +398,26 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
 
             <div ref={containerRef} className="relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2">
               <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
-                {model.words.map((word) => (
-                  <WordTimelineRow
-                    key={word.index}
-                    word={word}
-                    maxDisplayMs={model.maxDisplayMs}
-                    onHover={setHover}
-                    onHoverEnd={handleHoverEnd}
-                  />
-                ))}
+                {displayMode === 'line' && lineModel
+                  ? lineModel.lines.map((line) => (
+                    <LineTimelineRow
+                      key={line.lineIndex}
+                      line={line}
+                      maxDisplayMs={lineModel.maxDisplayMs}
+                      romajiInput={log?.romajiInput === true}
+                      onHover={handleLineHover}
+                      onHoverEnd={handleHoverEnd}
+                    />
+                  ))
+                  : wordModel?.words.map((word) => (
+                    <WordTimelineRow
+                      key={word.index}
+                      word={word}
+                      maxDisplayMs={wordModel.maxDisplayMs}
+                      onHover={handleWordHover}
+                      onHoverEnd={handleHoverEnd}
+                    />
+                  ))}
               </div>
 
               {hover && (
@@ -393,17 +428,17 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
                   data-testid="word-timeline-tooltip"
                 >
                   {hover.segment.kind === 'keystroke'
-                    ? keystrokeTooltipBody(hover.word.display, hover.segment, t)
+                    ? keystrokeTooltipBody(hover.kind === 'word' ? hover.word.display : hover.lineText, hover.segment, t)
                     : (
                       <TooltipShell>
                         <Stat
-                          label={hover.segment.kind === 'blank'
-                            ? t('editor.typingTest.history.timeline.legend.blank')
-                            : t('editor.typingTest.history.timeline.legend.leadIn')}
+                          label={t(lineLegendLabelKey(hover.segment.kind === 'blank' ? 'blank' : 'leadIn', hover.kind === 'line' ? 'line' : 'word'))}
                           value={t(
                             hover.segment.kind === 'blank'
                               ? 'editor.typingTest.history.timeline.tooltip.blankDuration'
-                              : 'editor.typingTest.history.timeline.tooltip.leadInDuration',
+                              : (hover.kind === 'line'
+                                ? 'editor.typingTest.history.timeline.tooltip.leadInLineDuration'
+                                : 'editor.typingTest.history.timeline.tooltip.leadInDuration'),
                             { ms: Math.round(hover.segment.trueDurationMs) },
                           )}
                         />

--- a/src/renderer/typing-test/__tests__/LineTimelineRow.test.tsx
+++ b/src/renderer/typing-test/__tests__/LineTimelineRow.test.tsx
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { LineTimelineRow } from '../LineTimelineRow'
+import type { LineTimelineLine } from '../line-timeline'
+import type { KeystrokeSegment, BlankSegment } from '../word-timeline'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+function keystroke(overrides: Partial<KeystrokeSegment> & { startMs: number; endMs: number; label: string }): KeystrokeSegment {
+  return { kind: 'keystroke', trueStartMs: overrides.startMs, lane: 0, ...overrides }
+}
+
+function blank(startMs: number, endMs: number): BlankSegment {
+  return { kind: 'blank', startMs, endMs, trueDurationMs: endMs - startMs }
+}
+
+function makeLine(segments: LineTimelineLine['segments'], laneCount = 1): LineTimelineLine {
+  return {
+    lineIndex: 0,
+    words: [{ index: 0, display: 'hi', typed: 'hi', partial: false, startMs: 0 }],
+    segments,
+    laneCount,
+    stats: { durationSeconds: 1 },
+  }
+}
+
+describe('LineTimelineRow — on-bar keystroke labels', () => {
+  it('renders one label overlay cell per keystroke segment, with the segment label as its text', () => {
+    const line = makeLine([
+      keystroke({ startMs: 0, endMs: 100, label: 'h' }),
+      blank(100, 150),
+      keystroke({ startMs: 150, endMs: 250, label: 'i' }),
+    ])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const cells = screen.getAllByTestId('line-timeline-label-cell')
+    expect(cells).toHaveLength(2)
+    expect(cells[0].textContent).toBe('h')
+    expect(cells[1].textContent).toBe('i')
+  })
+
+  it('positions each label cell in % of the shared maxDisplayMs axis, not the line\'s own duration', () => {
+    const line = makeLine([keystroke({ startMs: 250, endMs: 500, label: 'x' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const cell = screen.getByTestId('line-timeline-label-cell')
+    expect(cell.style.left).toBe('25%')
+    expect(cell.style.width).toBe('25%')
+  })
+
+  it('marks the overlay layer aria-hidden and pointer-events-none so it never intercepts hover/click', () => {
+    const line = makeLine([keystroke({ startMs: 0, endMs: 100, label: 'a' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const layer = screen.getByTestId('line-timeline-label-layer-0')
+    expect(layer.getAttribute('aria-hidden')).toBe('true')
+    expect(layer.className).toContain('pointer-events-none')
+  })
+
+  it('picks a distinct label-color class per segment kind (normal/mistake/overlap/unjudged)', () => {
+    const line = makeLine([
+      keystroke({ startMs: 0, endMs: 100, label: 'n', correct: true }),
+      keystroke({ startMs: 100, endMs: 200, label: 'm', correct: false }),
+      keystroke({ startMs: 200, endMs: 300, label: 'o', overlapped: true }),
+      keystroke({ startMs: 300, endMs: 400, label: 'u' }),
+    ])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const labelSpans = screen.getAllByTestId('line-timeline-label-cell').map((cell) => cell.querySelector('.line-timeline-label-text')!)
+    expect(labelSpans[0].className).toContain('text-content-inverse')
+    expect(labelSpans[1].className).toContain('text-content-inverse')
+    expect(labelSpans[2].className).toContain('text-content')
+    expect(labelSpans[2].className).toContain('dark:text-content-inverse')
+    expect(labelSpans[3].className).toContain('text-content')
+    expect(labelSpans[3].className).not.toContain('dark:text-content-inverse')
+  })
+})

--- a/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
@@ -32,6 +32,45 @@ const SAMPLE_LOG: RunKeystrokeLog = {
   ],
 }
 
+const SAMPLE_LOG_WITH_LINES: RunKeystrokeLog = {
+  ...SAMPLE_LOG,
+  words: [
+    ...SAMPLE_LOG.words,
+    {
+      index: 1,
+      display: 'go',
+      typed: 'go',
+      correct: true,
+      keystrokes: [
+        { pressMs: 500, releaseMs: 560, keycode: 0, row: 0, col: 0, correct: true, expectedChar: 'g' },
+        { pressMs: 580, releaseMs: 640, keycode: 0, row: 0, col: 1, correct: true, expectedChar: 'o' },
+      ],
+    },
+  ],
+  lineBreaks: [0],
+}
+
+// A single line whose true span is 8.73s — fractional, sub-second
+// precision, matching the shape `analyze-format`'s mm:ss `formatDuration`
+// mishandles (no rounding on the seconds field: "0:8.73"). Regression
+// fixture for the line-view duration display bug (see LineTimelineRow's
+// own doc comment on `formatLineDurationSeconds`).
+const SAMPLE_LOG_LINE_DURATION: RunKeystrokeLog = {
+  ...SAMPLE_LOG,
+  words: [
+    {
+      index: 0,
+      display: 'hi',
+      typed: 'hi',
+      correct: true,
+      keystrokes: [
+        { pressMs: 0, releaseMs: 8730, keycode: 0, row: 0, col: 0, correct: true, expectedChar: 'h' },
+      ],
+    },
+  ],
+  lineBreaks: [],
+}
+
 beforeEach(() => {
   window.vialAPI = {
     typingRunLogGet: vi.fn().mockResolvedValue({ success: true, data: SAMPLE_LOG }),
@@ -122,6 +161,50 @@ describe('WordTimelineView', () => {
     await waitFor(() => expect(screen.getByTestId('word-timeline-canvas')).toBeTruthy())
     expect(screen.queryByTestId('word-timeline-zoom')).toBeNull()
     expect(screen.queryByText('Zoom')).toBeNull()
+  })
+
+  it('auto-selects line rows (never word rows) once the log has a lineBreaks field, and legend uses the line-view blank wording', async () => {
+    window.vialAPI.typingRunLogGet = vi.fn().mockResolvedValue({ success: true, data: SAMPLE_LOG_WITH_LINES })
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('line-timeline-row-0')).toBeTruthy())
+    expect(screen.queryByTestId('word-timeline-row-0')).toBeNull()
+    expect(screen.getByText('Pause (>250ms, shown compressed)')).toBeTruthy()
+    expect(screen.queryByText('Pause (shown compressed)')).toBeNull()
+  })
+
+  it('treats an empty lineBreaks array ([]) as a single-line log, still line mode (field PRESENCE, not emptiness, selects the mode)', async () => {
+    window.vialAPI.typingRunLogGet = vi.fn().mockResolvedValue({
+      success: true,
+      data: { ...SAMPLE_LOG, lineBreaks: [] },
+    })
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('line-timeline-row-0')).toBeTruthy())
+    expect(screen.queryByTestId('word-timeline-row-0')).toBeNull()
+  })
+
+  it('falls back to word rows (and the word-view legend wording) for a legacy log with no lineBreaks field at all', async () => {
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('word-timeline-row-0')).toBeTruthy())
+    expect(screen.queryByTestId('line-timeline-row-0')).toBeNull()
+    expect(screen.getByText('Pause (shown compressed)')).toBeTruthy()
+    expect(screen.queryByText('Pause (>250ms, shown compressed)')).toBeNull()
+  })
+
+  it('renders a fractional line duration as seconds-with-one-decimal ("8.7s"), never mm:ss ("0:8...")', async () => {
+    window.vialAPI.typingRunLogGet = vi.fn().mockResolvedValue({ success: true, data: SAMPLE_LOG_LINE_DURATION })
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('line-timeline-row-0')).toBeTruthy())
+    const row = screen.getByTestId('line-timeline-row-0')
+    expect(row.textContent).toContain('8.7s')
+    expect(row.textContent).not.toMatch(/0:8/)
+  })
+
+  it('renders one row per line, grouping words per lineBreaks (2 words across 2 lines -> 2 line rows, not 1)', async () => {
+    window.vialAPI.typingRunLogGet = vi.fn().mockResolvedValue({ success: true, data: SAMPLE_LOG_WITH_LINES })
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('line-timeline-row-0')).toBeTruthy())
+    expect(screen.getByTestId('line-timeline-row-1')).toBeTruthy()
+    expect(screen.getAllByTestId('line-timeline-keystroke')).toHaveLength(4)
   })
 
   it('closes only itself on Escape, leaving an outer modal open (nested-modal Escape isolation)', async () => {

--- a/src/renderer/typing-test/__tests__/line-timeline.test.ts
+++ b/src/renderer/typing-test/__tests__/line-timeline.test.ts
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { deserialize } from '../../../shared/keycodes/keycodes'
+import { GAP_DISPLAY_CAP_MS, type KeystrokeSegment } from '../word-timeline'
+import {
+  buildLineTimeline,
+  groupWordsIntoLines,
+  LINE_BLANK_THRESHOLD_MS,
+  type LineTimelineModel,
+} from '../line-timeline'
+import type { RunKeystroke, RunKeystrokeLog, RunWord } from '../../../shared/types/typing-run-log'
+
+const KC_A = deserialize('KC_A')
+
+function keystroke(overrides: Partial<RunKeystroke> & { pressMs: number }): RunKeystroke {
+  return { keycode: KC_A, row: 0, col: 0, ...overrides }
+}
+
+function word(overrides: Partial<RunWord> & { index: number; keystrokes: RunKeystroke[] }): RunWord {
+  return { display: 'a', typed: 'a', correct: true, ...overrides }
+}
+
+function log(words: RunWord[], lineBreaks: number[], overrides: Partial<RunKeystrokeLog> = {}): RunKeystrokeLog & { lineBreaks: number[] } {
+  return {
+    runId: 'run-1',
+    uid: 'uid-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    durationMs: 60_000,
+    mode: 'words',
+    language: 'english',
+    words,
+    lineBreaks,
+    ...overrides,
+  }
+}
+
+function keystrokeSegments(segments: LineTimelineModel['lines'][number]['segments']): KeystrokeSegment[] {
+  return segments.filter((s): s is KeystrokeSegment => s.kind === 'keystroke')
+}
+
+describe('groupWordsIntoLines', () => {
+  it('splits words into lines at each break (break index = last word of that line)', () => {
+    const words = [
+      word({ index: 0, keystrokes: [] }),
+      word({ index: 1, keystrokes: [] }),
+      word({ index: 2, keystrokes: [] }),
+      word({ index: 3, keystrokes: [] }),
+    ]
+    const lines = groupWordsIntoLines(words, [1])
+    expect(lines).toHaveLength(2)
+    expect(lines[0].map((w) => w.index)).toEqual([0, 1])
+    expect(lines[1].map((w) => w.index)).toEqual([2, 3])
+  })
+
+  it('treats an empty lineBreaks array as a single line spanning every word', () => {
+    const words = [word({ index: 0, keystrokes: [] }), word({ index: 1, keystrokes: [] })]
+    const lines = groupWordsIntoLines(words, [])
+    expect(lines).toHaveLength(1)
+    expect(lines[0].map((w) => w.index)).toEqual([0, 1])
+  })
+
+  it('handles multiple breaks producing 3+ lines', () => {
+    const words = [0, 1, 2, 3, 4, 5].map((i) => word({ index: i, keystrokes: [] }))
+    const lines = groupWordsIntoLines(words, [0, 2])
+    expect(lines.map((l) => l.map((w) => w.index))).toEqual([[0], [1, 2], [3, 4, 5]])
+  })
+})
+
+describe('buildLineTimeline', () => {
+  it('produces one line per lineBreaks group, and a single line for an empty lineBreaks array', () => {
+    const single = buildLineTimeline(log(
+      [word({ index: 0, keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] })],
+      [],
+    ))
+    expect(single.lines).toHaveLength(1)
+
+    const twoLines = buildLineTimeline(log(
+      [
+        word({ index: 0, keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+        word({ index: 1, keystrokes: [keystroke({ pressMs: 100, releaseMs: 150 })] }),
+      ],
+      [0],
+    ))
+    expect(twoLines.lines).toHaveLength(2)
+    expect(twoLines.lines[0].words.map((w) => w.index)).toEqual([0])
+    expect(twoLines.lines[1].words.map((w) => w.index)).toEqual([1])
+  })
+
+  it('does not emit a blank marker for a 249ms intra-line gap but does at exactly 250ms (LINE_BLANK_THRESHOLD_MS)', () => {
+    expect(LINE_BLANK_THRESHOLD_MS).toBe(250)
+
+    const below = buildLineTimeline(log([
+      word({
+        index: 0,
+        keystrokes: [
+          keystroke({ pressMs: 0, releaseMs: 50 }),
+          keystroke({ pressMs: 50 + 249, releaseMs: 50 + 249 + 40 }),
+        ],
+      }),
+    ], []))
+    expect(below.lines[0].segments.some((s) => s.kind === 'blank')).toBe(false)
+
+    const atThreshold = buildLineTimeline(log([
+      word({
+        index: 0,
+        keystrokes: [
+          keystroke({ pressMs: 0, releaseMs: 50 }),
+          keystroke({ pressMs: 50 + 250, releaseMs: 50 + 250 + 40 }),
+        ],
+      }),
+    ], []))
+    const blank = atThreshold.lines[0].segments.find((s) => s.kind === 'blank')
+    expect(blank).toBeDefined()
+    if (blank?.kind !== 'blank') throw new Error('expected blank segment')
+    expect(blank.trueDurationMs).toBe(250)
+    expect(blank.endMs - blank.startMs).toBe(GAP_DISPLAY_CAP_MS)
+  })
+
+  it('builds ONE shared continuous axis per line spanning every word\'s keystrokes (no per-word cursor reset)', () => {
+    const model = buildLineTimeline(log([
+      word({ index: 0, display: 'hi', typed: 'hi', keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, display: 'go', typed: 'go', keystrokes: [keystroke({ pressMs: 100, releaseMs: 150 })] }),
+    ], []))
+    const segs = keystrokeSegments(model.lines[0].segments)
+    expect(segs).toHaveLength(2)
+    // Second word's keystroke starts at the true press-to-press offset on
+    // the SAME axis as the first word's — not reset to 0.
+    expect(segs[0].startMs).toBe(0)
+    expect(segs[1].startMs).toBe(100)
+  })
+
+  it('emits a line-start lead-in marker when the gap since the previous line\'s last observed boundary exceeds LINE_BLANK_THRESHOLD_MS, never for the first line', () => {
+    const model = buildLineTimeline(log([
+      word({ index: 0, keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, keystrokes: [keystroke({ pressMs: 50 + LINE_BLANK_THRESHOLD_MS + 500, releaseMs: 50 + LINE_BLANK_THRESHOLD_MS + 550 })] }),
+    ], [0]))
+    expect(model.lines[0].segments.some((s) => s.kind === 'leadInPause')).toBe(false)
+    const leadIn = model.lines[1].segments.find((s) => s.kind === 'leadInPause')
+    expect(leadIn).toBeDefined()
+    if (leadIn?.kind !== 'leadInPause') throw new Error('expected leadInPause segment')
+    expect(leadIn.trueDurationMs).toBe(LINE_BLANK_THRESHOLD_MS + 500)
+    const [seg] = keystrokeSegments(model.lines[1].segments)
+    expect(seg.startMs).toBe(GAP_DISPLAY_CAP_MS)
+  })
+
+  it('does NOT emit a per-word lead-in marker for a pause between two words inside the SAME line (only line-crossing pauses get a marker)', () => {
+    // Gap between word 0 and word 1 is huge (well past both thresholds),
+    // but both words are in the SAME line — this must render as an
+    // ordinary (capped) blank segment on the shared axis, never a
+    // leadInPause (leadInPause is reserved for line boundaries).
+    const model = buildLineTimeline(log([
+      word({ index: 0, keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, keystrokes: [keystroke({ pressMs: 50 + 10_000, releaseMs: 50 + 10_000 + 40 })] }),
+    ], []))
+    expect(model.lines[0].segments.some((s) => s.kind === 'leadInPause')).toBe(false)
+    expect(model.lines[0].segments.some((s) => s.kind === 'blank')).toBe(true)
+  })
+
+  it('renders a partial word\'s segments but withholds it from the line\'s accuracy pooling', () => {
+    const model = buildLineTimeline(log([
+      word({
+        index: 0,
+        partial: true,
+        display: 'wor',
+        typed: 'wo',
+        keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 }), keystroke({ pressMs: 60, releaseMs: 110 })],
+      }),
+    ], []))
+    const line = model.lines[0]
+    expect(keystrokeSegments(line.segments)).toHaveLength(2)
+    expect(line.words[0].partial).toBe(true)
+    expect(line.stats.accuracy).toBeUndefined()
+  })
+
+  it('withholds the +1 separator credit ONLY for the run\'s actual final word, never at every line end', () => {
+    // Two lines, one word each. Word 0 is line 0's own last word but NOT
+    // the run's last word overall -> keeps the credit. Word 1 IS the
+    // run's last word -> credit withheld. Both words are otherwise
+    // identical in shape.
+    const model = buildLineTimeline(log([
+      word({ index: 0, display: 'hi', typed: 'hi', keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 }), keystroke({ pressMs: 60, releaseMs: 6060 })] }),
+      word({ index: 1, display: 'go', typed: 'go', keystrokes: [keystroke({ pressMs: 7000, releaseMs: 7050 }), keystroke({ pressMs: 7060, releaseMs: 13060 })] }),
+    ], [0]))
+    // Line 0 (word 0, credited: correct = 3, incorrect = 0 -> 100%).
+    expect(model.lines[0].stats.accuracy).toBe(100)
+    // Line 1 (word 1, the run's last word, uncredited: correct = 2,
+    // incorrect = 0 -> still 100%, but via a different correct count —
+    // verified precisely in the dedicated per-line stats math test below).
+    expect(model.lines[1].stats.accuracy).toBe(100)
+  })
+
+  it('computes per-line stats (kpm, accuracy, overlap, durationSeconds) via pooled math over the line\'s own words/keystrokes', () => {
+    const model = buildLineTimeline(log([
+      // Single line, single word, run's only (hence last) word: no
+      // separator credit. 2 correct chars, 0 incorrect -> accuracy 100%.
+      // 2 keystrokes over a 6000ms true span -> kpm = 2 / (6000/60000) = 20.
+      word({
+        index: 0,
+        display: 'hi',
+        typed: 'hi',
+        keystrokes: [
+          keystroke({ pressMs: 0, releaseMs: 50, overlapped: false }),
+          keystroke({ pressMs: 60, releaseMs: 6000, overlapped: true }),
+        ],
+      }),
+    ], []))
+    const stats = model.lines[0].stats
+    expect(stats.durationSeconds).toBeCloseTo(6, 5)
+    expect(stats.kpm).toBeCloseTo(2 / (6000 / 60_000), 5)
+    expect(stats.accuracy).toBe(100)
+    expect(stats.overlapRate).toBe(0.5)
+  })
+
+  it('reports word-boundary marker offsets: each word\'s startMs is where its own first keystroke segment begins on the shared axis', () => {
+    const model = buildLineTimeline(log([
+      word({ index: 0, display: 'hi', typed: 'hi', keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, display: 'go', typed: 'go', keystrokes: [keystroke({ pressMs: 200, releaseMs: 250 })] }),
+    ], []))
+    const line = model.lines[0]
+    expect(line.words[0].startMs).toBe(0)
+    expect(line.words[1].startMs).toBe(200)
+  })
+
+  it('gives an empty (zero-keystroke) word the same marker offset as wherever the axis stood after the previous word', () => {
+    const model = buildLineTimeline(log([
+      word({ index: 0, display: 'hi', typed: 'hi', keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, display: '', typed: '', keystrokes: [] }),
+      word({ index: 2, display: 'go', typed: 'go', keystrokes: [keystroke({ pressMs: 200, releaseMs: 250 })] }),
+    ], []))
+    const line = model.lines[0]
+    expect(line.words[1].startMs).toBe(50) // end of word 0's own segment
+    expect(line.words[2].startMs).toBe(200)
+  })
+
+  it('shares one maxDisplayMs across all lines, driven by the longest line', () => {
+    const model = buildLineTimeline(log([
+      word({ index: 0, keystrokes: [keystroke({ pressMs: 0, releaseMs: 50 })] }),
+      word({ index: 1, keystrokes: [keystroke({ pressMs: 100, releaseMs: 5150 })] }),
+    ], [0]))
+    const rowMax = (i: number) => Math.max(...keystrokeSegments(model.lines[i].segments).map((s) => s.endMs), 0)
+    expect(model.maxDisplayMs).toBe(Math.max(rowMax(0), rowMax(1)))
+  })
+
+  it('passes charCorrelationUnavailable through, defaulting to false', () => {
+    const withFlag = buildLineTimeline(log([word({ index: 0, keystrokes: [] })], [], { charCorrelationUnavailable: true }))
+    expect(withFlag.charCorrelationUnavailable).toBe(true)
+    const withoutFlag = buildLineTimeline(log([word({ index: 0, keystrokes: [] })], []))
+    expect(withoutFlag.charCorrelationUnavailable).toBe(false)
+  })
+
+  it('withholds accuracy for a romaji-input run\'s lines (typed/display live in different text spaces) while overlap stays', () => {
+    const model = buildLineTimeline(log([
+      word({
+        index: 0,
+        display: 'あ',
+        typed: 'a',
+        keystrokes: [keystroke({ pressMs: 0, releaseMs: 50, overlapped: true })],
+      }),
+    ], [], { romajiInput: true }))
+    expect(model.lines[0].stats.accuracy).toBeUndefined()
+    expect(model.lines[0].stats.overlapRate).toBe(1)
+  })
+
+  it('handles a fully empty line (a lone zero-keystroke word) without crashing, reporting zero/undefined stats', () => {
+    const model = buildLineTimeline(log([word({ index: 0, display: '', typed: '', keystrokes: [] })], []))
+    const line = model.lines[0]
+    expect(line.segments).toEqual([])
+    expect(line.laneCount).toBe(0)
+    expect(line.stats.durationSeconds).toBe(0)
+    expect(line.stats.kpm).toBeUndefined()
+    expect(line.stats.accuracy).toBeUndefined()
+  })
+})

--- a/src/renderer/typing-test/__tests__/word-timeline.test.ts
+++ b/src/renderer/typing-test/__tests__/word-timeline.test.ts
@@ -5,7 +5,7 @@ import { deserialize } from '../../../shared/keycodes/keycodes'
 import {
   buildWordTimeline,
   buildWordTimelineSummary,
-  BLANK_THRESHOLD_MS,
+  WORD_BLANK_THRESHOLD_MS as BLANK_THRESHOLD_MS,
   GAP_DISPLAY_CAP_MS,
   MIN_BAR_MS,
   type KeystrokeSegment,

--- a/src/renderer/typing-test/line-timeline.ts
+++ b/src/renderer/typing-test/line-timeline.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Pure log → display model for the per-LINE keystroke timeline (see
+// .claude/tasks/backlog/Task-line-timeline-pr2-line-view.md and
+// .claude/plans/Plan-line-keystroke-timeline.md). Sibling of
+// `word-timeline.ts`: a "line" groups one or more `RunWord`s onto ONE
+// shared display-ms axis (built once via `buildKeystrokeStream`, never
+// per-word — see that function's own doc comment), rather than resetting
+// the display cursor at every word boundary the way the per-word view
+// does. Selected by `WordTimelineView` whenever `RunKeystrokeLog.lineBreaks`
+// is PRESENT (see that field's own doc comment on why presence, not
+// emptiness, is the switch) — a legacy log with no `lineBreaks` never
+// reaches this module.
+
+import type { RunKeystrokeLog, RunWord } from '../../shared/types/typing-run-log'
+import {
+  buildKeystrokeStream,
+  computeScoredWordCharCounts,
+  GAP_DISPLAY_CAP_MS,
+  type WordTimelineSegment,
+  type KeystrokeSegment,
+} from './word-timeline'
+
+/** Blank-gap threshold for the LINE view, deliberately far below
+ *  `WORD_BLANK_THRESHOLD_MS` (1000ms) — matches the timeline modal's
+ *  line-view legend (">250ms"). A line's shared axis already spans
+ *  several words' worth of ordinary inter-word rhythm; the word view's
+ *  coarser 1000ms cut would hide exactly the kind of pause a line view
+ *  exists to surface. Also doubles as the cross-line lead-in trigger
+ *  (see `buildLine`) — one constant serving both roles mirrors
+ *  `WORD_BLANK_THRESHOLD_MS`'s own dual role in `buildWord`. */
+export const LINE_BLANK_THRESHOLD_MS = 250
+
+/** One word's position on its line's shared display-ms axis — enough for
+ *  the row (`LineTimelineRow.tsx`) to draw a subtle word-boundary
+ *  separator and to reconstruct the line's own display/typed text by
+ *  joining `display`/`typed` across `LineTimelineLine.words` in order. */
+export interface LineWordBoundary {
+  index: number
+  display: string
+  typed: string
+  partial: boolean
+  /** Display-ms offset where this word's own content starts on the
+   *  line's shared axis — the position of its first keystroke segment,
+   *  or (a word with no keystrokes of its own) wherever the axis stood
+   *  right after the previous word — see `buildLine`. */
+  startMs: number
+}
+
+export interface LineTimelineStats {
+  /** Raw keystroke count / true active-duration minutes — a RATE
+   *  distinct from `WordTimelineStats.wordPace` (which is correct-chars
+   *  based): a line groups multiple words, so "words per minute" stops
+   *  being a meaningful per-row figure the way it is for a single word;
+   *  "keystrokes per minute" doesn't have that problem. Undefined when
+   *  the line has no measurable span (no keystrokes, or zero duration). */
+  kpm?: number
+  /** Char-weighted accuracy pooled across the line's own scored words —
+   *  Σ correct / Σ (correct + incorrect), the same pooling
+   *  `buildWordTimelineSummary` uses for the whole run, just scoped to
+   *  one line's words (see `computeScoredWordCharCounts`). Undefined
+   *  when no word in the line is scoreable (every word partial, romaji,
+   *  or keystroke-less). */
+  accuracy?: number
+  /** Keystroke-weighted overlap ratio over the line's own keystrokes —
+   *  Σ overlapTrue / Σ overlapObserved. Undefined when nothing in the
+   *  line has an observed overlap verdict. */
+  overlapRate?: number
+  /** True elapsed seconds from the line's first press to its last
+   *  observed boundary (mirrors `WordTimelineStats.durationMs`, just in
+   *  seconds and at line scope — see `AnalyzeStatGrid`'s duration card
+   *  convention, `formatDuration`, which this is meant to feed). */
+  durationSeconds: number
+}
+
+export interface LineTimelineLine {
+  lineIndex: number
+  words: LineWordBoundary[]
+  segments: WordTimelineSegment[]
+  /** Lane count for this line's row — drives the row's SVG height, same
+   *  convention as `WordTimelineWord.laneCount`. */
+  laneCount: number
+  stats: LineTimelineStats
+}
+
+export interface LineTimelineModel {
+  lines: LineTimelineLine[]
+  /** Shared display-ms width every line's row uses for its `viewBox` —
+   *  the run's longest LINE decides it (mirrors
+   *  `WordTimelineModel.maxDisplayMs`, just at line granularity). */
+  maxDisplayMs: number
+  charCorrelationUnavailable: boolean
+}
+
+/** Splits a run's words into lines at each break — `lineBreaks[i]` is the
+ *  index (into `words`) of that line's LAST word (see
+ *  `RunKeystrokeLog.lineBreaks`'s own doc comment for the validated
+ *  invariants this relies on: sorted, unique, strictly ascending, and
+ *  never `words.length - 1`). An empty `lineBreaks` array produces a
+ *  single line spanning every word — see that same doc comment on why
+ *  presence, not emptiness, is what selects line-view rendering in the
+ *  first place; this function only ever runs once that selection has
+ *  already been made. */
+export function groupWordsIntoLines(words: RunWord[], lineBreaks: number[]): RunWord[][] {
+  const lines: RunWord[][] = []
+  let start = 0
+  for (const brk of lineBreaks) {
+    lines.push(words.slice(start, brk + 1))
+    start = brk + 1
+  }
+  lines.push(words.slice(start))
+  return lines
+}
+
+interface LineBuildResult {
+  words: LineWordBoundary[]
+  segments: WordTimelineSegment[]
+  laneCount: number
+  maxEndMs: number
+  stats: LineTimelineStats
+  /** Carried forward as the NEXT line's own cross-line lead-in
+   *  comparison point — undefined when this line had no keystrokes at
+   *  all (mirrors `WordBuildResult.lastObservedTrueMs`: an empty line
+   *  never updates the carry-over). */
+  lastObservedTrueMs?: number
+}
+
+/** Builds one line's shared-axis model. `lineWords` is the contiguous
+ *  slice of `RunWord`s this line owns (from `groupWordsIntoLines`);
+ *  `startGlobalWordIdx` is that slice's own offset into the RUN's full
+ *  word list — needed (alongside `totalWordsInRun`) to identify the
+ *  run's actual last word for separator-credit purposes, since that rule
+ *  is a RUN-wide fact, not a line-local one (see
+ *  `computeScoredWordCharCounts`'s own doc comment: withheld only for
+ *  the run's final word, never at every line's own last word). */
+function buildLine(
+  lineWords: RunWord[],
+  crossLineLastObservedMs: number | null,
+  startGlobalWordIdx: number,
+  totalWordsInRun: number,
+  romajiInput: boolean,
+): LineBuildResult {
+  // Flatten every word's keystrokes onto one line-wide list, tagging each
+  // with which word (by position within THIS line) it came from, then
+  // sort once by press order — mirrors `buildWord`'s own per-word sort,
+  // just widened to span the whole line so gaps between words inside the
+  // same line become ordinary (capped) blank segments on the shared axis
+  // instead of a per-word cursor reset.
+  const tagged: { keystroke: RunWord['keystrokes'][number]; wordLocalIdx: number }[] = []
+  lineWords.forEach((w, li) => {
+    for (const k of w.keystrokes) tagged.push({ keystroke: k, wordLocalIdx: li })
+  })
+  tagged.sort((a, b) => a.keystroke.pressMs - b.keystroke.pressMs)
+
+  if (tagged.length === 0) {
+    const words: LineWordBoundary[] = lineWords.map((w) => ({
+      index: w.index,
+      display: w.display,
+      typed: w.typed,
+      partial: w.partial ?? false,
+      startMs: 0,
+    }))
+    return {
+      words,
+      segments: [],
+      laneCount: 0,
+      maxEndMs: 0,
+      stats: { durationSeconds: 0 },
+    }
+  }
+
+  const flatKeystrokes = tagged.map((t) => t.keystroke)
+  const segments: WordTimelineSegment[] = []
+  let displayCursor = 0
+
+  // Line-crossing hesitation ONLY — a pause between two words INSIDE the
+  // same line is never promoted to a leadInPause marker (that would
+  // wrongly imply a line-boundary transition); it renders as an ordinary
+  // blank segment on the shared axis via `buildKeystrokeStream` below.
+  // See the task's binding scoring rule: "a pause crossing a line
+  // boundary becomes a line-start lead-in marker ... never at every line
+  // end" — the same logic applies symmetrically at the START of a line.
+  const firstPressMs = flatKeystrokes[0].pressMs
+  if (crossLineLastObservedMs !== null) {
+    const leadGap = firstPressMs - crossLineLastObservedMs
+    if (leadGap >= LINE_BLANK_THRESHOLD_MS) {
+      segments.push({ kind: 'leadInPause', startMs: 0, endMs: GAP_DISPLAY_CAP_MS, trueDurationMs: leadGap })
+      displayCursor += GAP_DISPLAY_CAP_MS
+    }
+  }
+
+  const stream = buildKeystrokeStream(flatKeystrokes, LINE_BLANK_THRESHOLD_MS, displayCursor)
+  // Blanks first (background), keystrokes last (foreground) — same
+  // paint-order convention as `buildWord`.
+  segments.push(...stream.blankSegments, ...stream.keystrokeSegments)
+
+  // Word-boundary marker offsets: for each word (by its LOCAL position in
+  // this line), the display-ms of its own first keystroke segment on the
+  // shared axis — found via the FIRST occurrence of that word's local
+  // index in the press-sorted `tagged` list, which is index-aligned 1:1
+  // with `stream.keystrokeSegments` (see `buildKeystrokeStream`'s own
+  // doc comment: it preserves input order). A word with no keystrokes of
+  // its own never appears in `tagged`, so it falls back to `carryOffset`
+  // — wherever the axis stood right after the previous word — rather
+  // than fabricating a position (mirrors an empty word contributing zero
+  // width in the per-word view).
+  const wordFirstOffset = new Map<number, number>()
+  const wordMaxEnd = new Map<number, number>()
+  tagged.forEach((t, i) => {
+    const seg = stream.keystrokeSegments[i]
+    if (!wordFirstOffset.has(t.wordLocalIdx)) wordFirstOffset.set(t.wordLocalIdx, seg.startMs)
+    wordMaxEnd.set(t.wordLocalIdx, Math.max(wordMaxEnd.get(t.wordLocalIdx) ?? -Infinity, seg.endMs))
+  })
+
+  let carryOffset = 0
+  const words: LineWordBoundary[] = lineWords.map((w, li) => {
+    const startMs = wordFirstOffset.get(li) ?? carryOffset
+    carryOffset = wordMaxEnd.get(li) ?? carryOffset
+    return { index: w.index, display: w.display, typed: w.typed, partial: w.partial ?? false, startMs }
+  })
+
+  // Per-line stats — pooled the same way `buildWordTimelineSummary`
+  // pools the whole run's, just scoped to this line's own words/
+  // keystrokes (see `LineTimelineStats`'s own field doc comments).
+  const durationMs = stream.lastObservedTrueMs - firstPressMs
+  const durationSeconds = durationMs / 1000
+  const kpm = durationMs > 0 ? flatKeystrokes.length / (durationMs / 60_000) : undefined
+  const overlapRate = stream.overlapObserved !== undefined ? stream.overlapTrue! / stream.overlapObserved : undefined
+
+  let correctSum = 0
+  let incorrectSum = 0
+  let anyScored = false
+  lineWords.forEach((w, li) => {
+    const globalIdx = startGlobalWordIdx + li
+    const scored = computeScoredWordCharCounts(w, globalIdx === totalWordsInRun - 1, romajiInput)
+    if (!scored) return
+    const totalChars = scored.correct + scored.incorrect
+    if (totalChars <= 0) return
+    anyScored = true
+    correctSum += scored.correct
+    incorrectSum += scored.incorrect
+  })
+  const accuracy = anyScored ? (correctSum / (correctSum + incorrectSum)) * 100 : undefined
+
+  return {
+    words,
+    segments,
+    laneCount: stream.laneCount,
+    maxEndMs: stream.maxEndMs,
+    stats: { kpm, accuracy, overlapRate, durationSeconds },
+    lastObservedTrueMs: stream.lastObservedTrueMs,
+  }
+}
+
+/** Build the zoom-independent per-LINE display model for a run's raw
+ *  keystroke log — the line-view counterpart to `buildWordTimeline`.
+ *  Callers must only invoke this once `log.lineBreaks` is known to be
+ *  present (the type parameter enforces it) — see the module doc
+ *  comment. */
+export function buildLineTimeline(log: RunKeystrokeLog & { lineBreaks: number[] }): LineTimelineModel {
+  const lineGroups = groupWordsIntoLines(log.words, log.lineBreaks)
+  const romajiInput = log.romajiInput === true
+
+  let crossLineLastObservedMs: number | null = null
+  let maxDisplayMs = 0
+  let globalWordIdx = 0
+
+  const lines: LineTimelineLine[] = lineGroups.map((lineWords, lineIndex) => {
+    const built = buildLine(lineWords, crossLineLastObservedMs, globalWordIdx, log.words.length, romajiInput)
+    globalWordIdx += lineWords.length
+    if (built.lastObservedTrueMs !== undefined) crossLineLastObservedMs = built.lastObservedTrueMs
+    if (built.maxEndMs > maxDisplayMs) maxDisplayMs = built.maxEndMs
+
+    return {
+      lineIndex,
+      words: built.words,
+      segments: built.segments,
+      laneCount: built.laneCount,
+      stats: built.stats,
+    }
+  })
+
+  return {
+    lines,
+    maxDisplayMs,
+    charCorrelationUnavailable: log.charCorrelationUnavailable ?? false,
+  }
+}
+
+// Re-exported for callers (`LineTimelineRow.tsx`) that need to
+// distinguish a keystroke segment from a blank/leadIn one when rendering
+// hover targets — mirrors `word-timeline-row.tsx`'s own use of this type
+// from `word-timeline.ts`.
+export type { KeystrokeSegment }

--- a/src/renderer/typing-test/use-timeline-model.ts
+++ b/src/renderer/typing-test/use-timeline-model.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Model-selection hook for `WordTimelineView` — picks per-word vs.
+// per-line rendering based on `RunKeystrokeLog.lineBreaks` FIELD
+// PRESENCE (see that field's own doc comment in typing-run-log.ts: `[]`
+// means "one line", still line-mode; absent means a legacy log, always
+// word-mode). Extracted out of the view component itself to keep
+// WordTimelineView.tsx under its file-splitting cap (see
+// .claude/rules/file-splitting.md) — this hook owns every `useMemo` that
+// derives from `log`, the view owns only rendering + zoom/hover DOM
+// wiring.
+
+import { useMemo } from 'react'
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+import { buildWordTimeline, buildWordTimelineSummary, type WordTimelineModel, type WordTimelineSummary } from './word-timeline'
+import { buildLineTimeline, type LineTimelineModel } from './line-timeline'
+
+export type TimelineDisplayMode = 'line' | 'word'
+
+export interface TimelineModelResult {
+  displayMode: TimelineDisplayMode | null
+  wordModel: WordTimelineModel | null
+  lineModel: LineTimelineModel | null
+  /** Whole-run pooled averages (Word Pace / Accuracy / Overlap) for the
+   *  modal's summary cards — always derived from the WORD-level model
+   *  regardless of `displayMode`: these are run-wide totals, not a
+   *  function of how the rows below happen to be grouped, so switching
+   *  to line-mode rendering must never change what the summary cards
+   *  report. */
+  summary: WordTimelineSummary | null
+  /** The active row model's own shared axis width — line-mode's rows use
+   *  `lineModel.maxDisplayMs`, word-mode's use `wordModel.maxDisplayMs`
+   *  (the two are NOT interchangeable: a line's axis spans multiple
+   *  words on a 250ms blank threshold, a word's spans one on a 1000ms
+   *  threshold — see each builder's own doc comment). */
+  activeMaxDisplayMs: number
+  activeCharCorrelationUnavailable: boolean
+}
+
+export function useTimelineModel(log: RunKeystrokeLog | null): TimelineModelResult {
+  const displayMode: TimelineDisplayMode | null = log ? (log.lineBreaks !== undefined ? 'line' : 'word') : null
+
+  // Always built (even in line-mode) — the summary cards below need it
+  // regardless of which rows are on screen, and a run log is capped at
+  // MAX_RUN_LOG_EVENTS keystrokes, so a second pass over it is cheap.
+  const wordModel = useMemo<WordTimelineModel | null>(() => (log ? buildWordTimeline(log) : null), [log])
+  const summary = useMemo(() => (wordModel ? buildWordTimelineSummary(wordModel) : null), [wordModel])
+
+  const lineModel = useMemo<LineTimelineModel | null>(
+    () => (log && log.lineBreaks !== undefined ? buildLineTimeline(log as RunKeystrokeLog & { lineBreaks: number[] }) : null),
+    [log],
+  )
+
+  const activeMaxDisplayMs = displayMode === 'line' ? (lineModel?.maxDisplayMs ?? 0) : (wordModel?.maxDisplayMs ?? 0)
+  const activeCharCorrelationUnavailable = displayMode === 'line'
+    ? (lineModel?.charCorrelationUnavailable ?? false)
+    : (wordModel?.charCorrelationUnavailable ?? false)
+
+  return { displayMode, wordModel, lineModel, summary, activeMaxDisplayMs, activeCharCorrelationUnavailable }
+}

--- a/src/renderer/typing-test/word-timeline-colors.ts
+++ b/src/renderer/typing-test/word-timeline-colors.ts
@@ -46,6 +46,15 @@ export const TIMELINE_LEGEND: Record<TimelineFillKind, TimelineLegendEntry> = {
   leadIn: { swatchClass: 'bg-edge-strong', labelKey: 'editor.typingTest.history.timeline.legend.leadIn' },
 }
 
+/** Fill for a word-boundary divider inside a LINE row's SVG strip
+ *  (`LineTimelineRow.tsx`) — purely structural (marks where one word's
+ *  keystrokes end and the next begins on the line's shared axis), not a
+ *  semantic "kind" like the ones above, so it has no `TIMELINE_LEGEND`
+ *  entry of its own. Uses the same subtle hairline-divider token
+ *  `style.css` reserves for this purpose elsewhere (`--color-edge-subtle`
+ *  — see `.claude/DESIGN.md`'s Elevation & Depth table). */
+export const WORD_SEPARATOR_FILL = 'var(--color-edge-subtle)'
+
 /** Priority order for a keystroke's fill when more than one condition
  *  applies (e.g. a mistake that also overlapped the previous key):
  *  overlap first (this view exists to make overlap visible even on an

--- a/src/renderer/typing-test/word-timeline-colors.ts
+++ b/src/renderer/typing-test/word-timeline-colors.ts
@@ -67,3 +67,45 @@ export function fillForKeystroke(seg: KeystrokeSegment): string {
   if (seg.correct === undefined) return TIMELINE_FILL.unjudged
   return TIMELINE_FILL.normal
 }
+
+/** Per-fill-kind label TEXT color for the LINE view's on-bar keystroke
+ *  labels (`LineTimelineRow.tsx`) — same philosophy as `KeyWidget`'s
+ *  `FILL_INVERT_TABLE` (`.claude/rules/coding-ui.md`): every fill a
+ *  keystroke can render as gets an explicit, theme-aware class instead of
+ *  one default that quietly breaks on fills bright enough to need dark
+ *  text. `normal`/`mistake` are safe with the plain inverse token in both
+ *  themes — their fills (`accent`/`danger`) swap SATURATION, not
+ *  lightness, across the theme pair, so `content-inverse`'s own light/dark
+ *  flip already lands on a readable color both times. `overlap` (warning)
+ *  and `unjudged` (muted) don't get that lucky symmetry:
+ *  - `unjudged`'s fill (`content-muted`) is lighter in the light theme and
+ *    darker in the dark theme — exactly the shape `text-content` (not
+ *    `-inverse`) already flips to match, so it needs no `dark:` override.
+ *  - `overlap`'s fill (`warning`) is a MID orange in light but a bright
+ *    yellow in dark (`--warning` actually gets LIGHTER in dark mode, the
+ *    one fill that doesn't track the usual "brighten for dark bg"
+ *    pattern) — both instances need dark text, so this is the one entry
+ *    that pins to `text-content` unconditionally in the base class and
+ *    overrides to `content-inverse` under `dark:` (which happens to also
+ *    resolve dark, since `content-inverse` itself is near-black in the
+ *    dark theme).
+ *  Expressed purely as Tailwind classes (`dark:` variant) rather than a
+ *  JS theme read — the row picks up the right color for free from
+ *  whichever CSS rule matches, the same way the SVG fills above already
+ *  do via CSS custom properties. */
+export const TIMELINE_LABEL_CLASS: Record<'normal' | 'mistake' | 'overlap' | 'unjudged', string> = {
+  normal: 'text-content-inverse',
+  mistake: 'text-content-inverse',
+  overlap: 'text-content dark:text-content-inverse',
+  unjudged: 'text-content',
+}
+
+/** Mirrors `fillForKeystroke`'s own branching (see its doc comment for
+ *  the priority order) — returns the on-bar label's text color class
+ *  instead of the bar's own fill. */
+export function labelClassForKeystroke(seg: KeystrokeSegment): string {
+  if (seg.overlapped === true) return TIMELINE_LABEL_CLASS.overlap
+  if (seg.correct === false) return TIMELINE_LABEL_CLASS.mistake
+  if (seg.correct === undefined) return TIMELINE_LABEL_CLASS.unjudged
+  return TIMELINE_LABEL_CLASS.normal
+}

--- a/src/renderer/typing-test/word-timeline.ts
+++ b/src/renderer/typing-test/word-timeline.ts
@@ -28,8 +28,17 @@ export const MIN_BAR_MS = 30
  *  a gap stops being ordinary signal and starts being a hole in normal
  *  behavior — but this constant answers a different question (human
  *  hesitation vs HID poll starvation), so it is deliberately a different,
- *  much larger value. */
-export const BLANK_THRESHOLD_MS = 1000
+ *  much larger value.
+ *
+ *  Named WORD-specific (not just `BLANK_THRESHOLD_MS`) now that
+ *  `line-timeline.ts` exists alongside this module with its own, much
+ *  smaller `LINE_BLANK_THRESHOLD_MS` (250ms, matching the timeline
+ *  modal's line-view legend) — a per-word row and a per-line row draw the
+ *  line between "ordinary rhythm" and "a pause worth marking" at
+ *  deliberately different places, since a line's shared axis already
+ *  spans several words' worth of ordinary inter-word rhythm that would
+ *  read as noise at the word view's coarser 1000ms cut. */
+export const WORD_BLANK_THRESHOLD_MS = 1000
 
 /** Every inter-keystroke gap's axis contribution is capped at this many
  *  display-ms — legibility AND monotonicity, together:
@@ -268,30 +277,42 @@ function trueObservedEnd(k: RunKeystroke): number {
   return k.releaseMs ?? k.pressMs
 }
 
-function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordBuildResult {
-  const keystrokes = [...word.keystrokes].sort((a, b) => a.pressMs - b.pressMs)
+export interface KeystrokeStreamResult {
+  keystrokeSegments: KeystrokeSegment[]
+  blankSegments: BlankSegment[]
+  /** See `assignLanes` — computed over `keystrokeSegments` alone. */
+  laneCount: number
+  maxEndMs: number
+  /** MAX observed boundary across every keystroke in the stream — see
+   *  `WordBuildResult.lastObservedTrueMs`'s doc comment for why this is a
+   *  MAX, not just the last press-ordered keystroke's own end. Always
+   *  defined: callers only ever invoke this with a non-empty
+   *  `keystrokes` array. */
+  lastObservedTrueMs: number
+  overlapObserved?: number
+  overlapTrue?: number
+}
 
-  if (keystrokes.length === 0) {
-    return { segments: [], laneCount: 0, maxEndMs: 0, durationMs: 0 }
-  }
-
-  const segments: WordTimelineSegment[] = []
+/** Builds one continuous run of keystroke + blank segments over an
+ *  already press-sorted, NON-EMPTY keystroke array, starting the display
+ *  axis at `startCursor` (already past any leadInPause marker the caller
+ *  chose to insert — see `buildWord`). This is the shared axis-building
+ *  core behind both the per-word row (`buildWord`, one call per word,
+ *  cursor reset to a fresh `startCursor` each time) and the per-line row
+ *  (`line-timeline.ts`'s `buildLine`, ONE call over an entire line's
+ *  keystrokes flattened across all its words) — the two differ only in
+ *  which keystrokes they hand this function and which `blankThresholdMs`
+ *  applies (`WORD_BLANK_THRESHOLD_MS` vs `LINE_BLANK_THRESHOLD_MS`).
+ *  Cross-word / cross-line lead-in markers are each caller's own concern
+ *  (via `startCursor`), never this function's. */
+export function buildKeystrokeStream(
+  keystrokes: RunKeystroke[],
+  blankThresholdMs: number,
+  startCursor: number,
+): KeystrokeStreamResult {
   const keystrokeSegments: KeystrokeSegment[] = []
-  let displayCursor = 0
-
-  // Between-word hesitation: compare this word's first press against the
-  // last OBSERVED instant anywhere in the run so far. A single marker at
-  // the word's start, not folded into the first keystroke's own gap —
-  // the pause belongs to the transition, not to either word.
-  const first = keystrokes[0]
-  if (crossWordLastObservedMs !== null) {
-    const leadGap = first.pressMs - crossWordLastObservedMs
-    if (leadGap >= BLANK_THRESHOLD_MS) {
-      segments.push({ kind: 'leadInPause', startMs: 0, endMs: GAP_DISPLAY_CAP_MS, trueDurationMs: leadGap })
-      displayCursor += GAP_DISPLAY_CAP_MS
-    }
-  }
-
+  const blankSegments: BlankSegment[] = []
+  let displayCursor = startCursor
   let observedOverlapCount = 0
   let overlappedTrueCount = 0
 
@@ -303,14 +324,14 @@ function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordB
         // A gap is only ever MEASURED from an observed release — see the
         // module doc comment on RunKeystroke.releaseMs. Every gap's axis
         // contribution is capped at GAP_DISPLAY_CAP_MS regardless of
-        // whether it crosses BLANK_THRESHOLD_MS (see that constant's own
+        // whether it crosses `blankThresholdMs` (see that constant's own
         // doc comment for the monotonicity argument) — a negative gap
         // (real overlap) is always below the cap, so overlap depth still
         // stays exactly proportional in that case.
         const gapTrue = k.pressMs - prev.releaseMs
         gapDisplay = Math.min(gapTrue, GAP_DISPLAY_CAP_MS)
-        if (gapTrue >= BLANK_THRESHOLD_MS) {
-          segments.push({ kind: 'blank', startMs: displayCursor, endMs: displayCursor + gapDisplay, trueDurationMs: gapTrue })
+        if (gapTrue >= blankThresholdMs) {
+          blankSegments.push({ kind: 'blank', startMs: displayCursor, endMs: displayCursor + gapDisplay, trueDurationMs: gapTrue })
         }
       } else {
         // The previous release was never observed, so there is no
@@ -354,25 +375,60 @@ function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordB
   })
 
   const laneCount = assignLanes(keystrokeSegments)
-  segments.push(...keystrokeSegments)
-
-  // MAX observed boundary across every keystroke, not just the last
-  // press-ordered one's own end — see `WordBuildResult.lastObservedTrueMs`'s
-  // doc comment for why (a long hold released after a later keystroke's
-  // own end must still count).
   const lastObservedTrueMs = Math.max(...keystrokes.map(trueObservedEnd))
-  const durationMs = lastObservedTrueMs - first.pressMs
   const maxEndMs = Math.max(...keystrokeSegments.map((s) => s.endMs))
 
   return {
-    segments,
+    keystrokeSegments,
+    blankSegments,
     laneCount,
     maxEndMs,
-    durationMs,
-    overlapRate: observedOverlapCount > 0 ? overlappedTrueCount / observedOverlapCount : undefined,
+    lastObservedTrueMs,
     overlapObserved: observedOverlapCount > 0 ? observedOverlapCount : undefined,
     overlapTrue: observedOverlapCount > 0 ? overlappedTrueCount : undefined,
-    lastObservedTrueMs,
+  }
+}
+
+function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordBuildResult {
+  const keystrokes = [...word.keystrokes].sort((a, b) => a.pressMs - b.pressMs)
+
+  if (keystrokes.length === 0) {
+    return { segments: [], laneCount: 0, maxEndMs: 0, durationMs: 0 }
+  }
+
+  const segments: WordTimelineSegment[] = []
+  let displayCursor = 0
+
+  // Between-word hesitation: compare this word's first press against the
+  // last OBSERVED instant anywhere in the run so far. A single marker at
+  // the word's start, not folded into the first keystroke's own gap —
+  // the pause belongs to the transition, not to either word.
+  const first = keystrokes[0]
+  if (crossWordLastObservedMs !== null) {
+    const leadGap = first.pressMs - crossWordLastObservedMs
+    if (leadGap >= WORD_BLANK_THRESHOLD_MS) {
+      segments.push({ kind: 'leadInPause', startMs: 0, endMs: GAP_DISPLAY_CAP_MS, trueDurationMs: leadGap })
+      displayCursor += GAP_DISPLAY_CAP_MS
+    }
+  }
+
+  const stream = buildKeystrokeStream(keystrokes, WORD_BLANK_THRESHOLD_MS, displayCursor)
+  // Blanks first (background layer), keystrokes last (foreground) — SVG
+  // paints later elements on top, so a keystroke bar always renders over
+  // any blank it happens to visually overlap.
+  segments.push(...stream.blankSegments, ...stream.keystrokeSegments)
+
+  const durationMs = stream.lastObservedTrueMs - first.pressMs
+
+  return {
+    segments,
+    laneCount: stream.laneCount,
+    maxEndMs: stream.maxEndMs,
+    durationMs,
+    overlapRate: stream.overlapObserved !== undefined ? stream.overlapTrue! / stream.overlapObserved : undefined,
+    overlapObserved: stream.overlapObserved,
+    overlapTrue: stream.overlapTrue,
+    lastObservedTrueMs: stream.lastObservedTrueMs,
   }
 }
 
@@ -399,6 +455,28 @@ interface BuildStatsExtras {
   romajiInput: boolean
 }
 
+export interface ScoredCharCounts {
+  correct: number
+  incorrect: number
+}
+
+/** The scored (post separator-credit adjustment) char counts behind a
+ *  word's `accuracy`/`wordPace` — factored out of `buildStats` so
+ *  `line-timeline.ts` can pool the exact same per-word counts into a
+ *  per-LINE accuracy figure instead of re-deriving the scoring rules.
+ *  Returns undefined under the same "nothing to score" conditions
+ *  `buildStats` itself withholds accuracy/wordPace for — see
+ *  `BuildStatsExtras`'s field doc comments (partial word, no keystrokes,
+ *  or a romaji-mode run). */
+export function computeScoredWordCharCounts(word: RunWord, isRunLastWord: boolean, romajiInput: boolean): ScoredCharCounts | undefined {
+  if (word.partial || word.keystrokes.length === 0 || romajiInput) return undefined
+  const counts = computeWordCharCounts(word.display, word.typed)
+  // Withhold the separator credit for the run's actual last word — see
+  // `BuildStatsExtras.isRunLastWord`'s doc comment.
+  const correct = isRunLastWord ? counts.correct - 1 : counts.correct
+  return { correct, incorrect: counts.incorrect }
+}
+
 function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras): WordTimelineStats {
   const { overlapObserved, overlapTrue } = extras
   const overlapRate = overlapObserved !== undefined ? overlapTrue! / overlapObserved : undefined
@@ -410,15 +488,13 @@ function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras)
   // to score either — undefined (unscoreable), not a misleading number.
   // A romaji-mode run withholds the same two fields for every word — see
   // `BuildStatsExtras.romajiInput`'s doc comment.
-  if (word.partial || word.keystrokes.length === 0 || extras.romajiInput) {
+  const scored = computeScoredWordCharCounts(word, extras.isRunLastWord, extras.romajiInput)
+  if (!scored) {
     return { durationMs, overlapRate, overlapObserved, overlapTrue }
   }
 
-  const counts = computeWordCharCounts(word.display, word.typed)
-  // Withhold the separator credit for the run's actual last word — see
-  // `BuildStatsExtras.isRunLastWord`'s doc comment.
-  const correct = extras.isRunLastWord ? counts.correct - 1 : counts.correct
-  const totalChars = correct + counts.incorrect
+  const { correct, incorrect } = scored
+  const totalChars = correct + incorrect
   const accuracy = totalChars > 0 ? (correct / totalChars) * 100 : undefined
   const minutes = durationMs / 60_000
   const wordPace = minutes > 0 ? (correct / 5) / minutes : undefined
@@ -430,7 +506,7 @@ function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras)
     overlapObserved,
     overlapTrue,
     correctChars: totalChars > 0 ? correct : undefined,
-    incorrectChars: totalChars > 0 ? counts.incorrect : undefined,
+    incorrectChars: totalChars > 0 ? incorrect : undefined,
     durationMs,
   }
 }


### PR DESCRIPTION
## Summary
- Render a saved run's timeline as per-line tracks when its log carries `lineBreaks` (PR #376): one shared time axis per line with word-boundary markers, per-line stats (integer kpm, accuracy %, overlap %, one-decimal seconds), overlap lanes, miss markers, and >250ms blank gaps (`LINE_BLANK_THRESHOLD_MS`; the word view keeps its own 1000ms threshold untouched — its 31 tests pass with a 1-line import alias as the only edit). Legacy logs without `lineBreaks` keep the per-word view.
- Label every keystroke bar with its key: an HTML overlay (SVG text would stretch with zoom) whose per-bar visibility is a pure CSS container query — the fit view stays clean, zooming in reveals every key, and the no-re-render zoom invariant holds. Label colors come from a per-fill map so text stays readable on every bar kind in both themes.
- Extracted `buildKeystrokeStream` from `buildWord` so both views share one segment builder without behavior drift; new `line-timeline.ts` model + `LineTimelineRow` + a small `use-timeline-model` hook keep every file under its size cap.
- i18n: new timeline keys in english.json and all four sample packs; versions lockstep-bumped to 0.1.61 (one extra bump after rebasing over #378, which had shipped 0.1.60 with a different key set).

## Verification
- 8,324 passed / 22 skipped after rebase onto #378 (exact union of both branches' test deltas; red-run evidence per change).
- Virtual-device Playwright checks: a real consent→type→finish run persisting `lineBreaks: [0,1]`, the History timeline opening in line mode (3 rows, 1:1 romaji correspondence, overlap marker from real input), zoom growing the canvas 833→8288px, and label visibility flipping 0/451 → 451/451 across the zoom threshold.