### PR TITLE
fix(ui): replace native title tooltips with the shared Tooltip component

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,24 @@ export default [
     }
   },
   {
+    // Native `title` attributes on DOM elements render the OS tooltip, not
+    // the app's styled bubble (src/renderer/components/ui/Tooltip.tsx) —
+    // forbidden by standing project rule. `title` PROPS on custom
+    // components (JSXIdentifier starting uppercase, e.g. `<PanelSection
+    // title=...>`) are unaffected since they're section headings / modal
+    // titles, not tooltips.
+    files: ['src/renderer/**/*.tsx'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'JSXOpeningElement[name.type="JSXIdentifier"][name.name=/^[a-z]/] > JSXAttribute[name.name="title"]',
+          message: 'Native `title` attributes render the OS tooltip, not the app-styled bubble. Wrap the element with <Tooltip> from src/renderer/components/ui/Tooltip.tsx instead.'
+        }
+      ]
+    }
+  },
+  {
     ignores: ['out/', 'dist/', 'node_modules/']
   }
 ]

--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -22,6 +22,7 @@ import { BTN_PRIMARY_XS, BTN_DANGER_XS } from '../../constants/ui-tokens'
 import type { HubEntryResult } from '../editors/layout-store-types'
 import type { AnalyzeFilterSnapshotMeta } from '../../../shared/types/analyze-filter-store'
 import { AnalyzeFilterStoreHubRow } from './AnalyzeFilterStoreHubRow'
+import { Tooltip } from '../ui/Tooltip'
 
 // Only one tab today — kept as a single-element tab bar for visual
 // parity with the keymap editor's overlay and so the structure is
@@ -273,14 +274,15 @@ export function AnalyzeFilterStorePanel({
                                 data-testid={`analyze-filter-store-rename-input-${entry.id}`}
                               />
                             ) : (
-                              <div
-                                className="cursor-pointer truncate text-sm font-semibold text-content"
-                                onClick={() => rename.startRename(entry.id, entry.label)}
-                                data-testid={`analyze-filter-store-entry-label-${entry.id}`}
-                                title={entry.label}
-                              >
-                                {entry.label || t('common.noLabel')}
-                              </div>
+                              <Tooltip content={entry.label} disabled={!entry.label} wrapperClassName="block max-w-full">
+                                <div
+                                  className="cursor-pointer truncate text-sm font-semibold text-content"
+                                  onClick={() => rename.startRename(entry.id, entry.label)}
+                                  data-testid={`analyze-filter-store-entry-label-${entry.id}`}
+                                >
+                                  {entry.label || t('common.noLabel')}
+                                </div>
+                              </Tooltip>
                             )}
                           </div>
 
@@ -332,13 +334,14 @@ export function AnalyzeFilterStorePanel({
                         </div>
 
                         {entry.summary && (
-                          <div
-                            className="mb-1 truncate text-xs text-content-muted"
-                            title={entry.summary}
-                            data-testid={`analyze-filter-store-entry-summary-${entry.id}`}
-                          >
-                            {entry.summary}
-                          </div>
+                          <Tooltip content={entry.summary} wrapperClassName="block max-w-full">
+                            <div
+                              className="mb-1 truncate text-xs text-content-muted"
+                              data-testid={`analyze-filter-store-entry-summary-${entry.id}`}
+                            >
+                              {entry.summary}
+                            </div>
+                          </Tooltip>
                         )}
 
                         {/* Row 2: date + .csv export */}

--- a/src/renderer/components/analyze/AnalyzeFilterSummaryChip.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterSummaryChip.tsx
@@ -9,6 +9,7 @@
 import { useTranslation } from 'react-i18next'
 import { ChevronDown, Filter } from 'lucide-react'
 import { ICON_SM, ICON_XS } from '../../constants/ui-tokens'
+import { Tooltip } from '../ui/Tooltip'
 
 interface Props {
   keyboardLabel: string
@@ -37,26 +38,27 @@ export function AnalyzeFilterSummaryChip({
 }: Props) {
   const { t } = useTranslation()
   return (
-    <button
-      type="button"
-      className={`${CHIP_BUTTON_CLASS} min-w-0 text-content`}
-      onClick={onClick}
-      title={`${keyboardLabel} · ${deviceLabel} · ${sourceLabel} · ${periodLabel}`}
-      data-testid={testId}
-    >
-      {/* The visible segment text is the accessible name; the sr-only
-        * hint appends the action ("edit filter conditions") for
-        * assistive tech without an aria-label overriding the labels. */}
-      <span className="sr-only">{t('analyze.filters.chipAriaLabel')}</span>
-      <Filter size={ICON_SM} className="shrink-0 text-content-muted" aria-hidden="true" />
-      <span className={SEGMENT_CLASS} data-testid={`${testId}-keyboard`}>{keyboardLabel}</span>
-      <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
-      <span className={SEGMENT_CLASS} data-testid={`${testId}-device`}>{deviceLabel}</span>
-      <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
-      <span className={SEGMENT_CLASS} data-testid={`${testId}-source`}>{sourceLabel}</span>
-      <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
-      <span className={SEGMENT_CLASS} data-testid={`${testId}-period`}>{periodLabel}</span>
-      <ChevronDown size={ICON_XS} className="shrink-0 text-content-muted" aria-hidden="true" />
-    </button>
+    <Tooltip content={`${keyboardLabel} · ${deviceLabel} · ${sourceLabel} · ${periodLabel}`}>
+      <button
+        type="button"
+        className={`${CHIP_BUTTON_CLASS} min-w-0 text-content`}
+        onClick={onClick}
+        data-testid={testId}
+      >
+        {/* The visible segment text is the accessible name; the sr-only
+          * hint appends the action ("edit filter conditions") for
+          * assistive tech without an aria-label overriding the labels. */}
+        <span className="sr-only">{t('analyze.filters.chipAriaLabel')}</span>
+        <Filter size={ICON_SM} className="shrink-0 text-content-muted" aria-hidden="true" />
+        <span className={SEGMENT_CLASS} data-testid={`${testId}-keyboard`}>{keyboardLabel}</span>
+        <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
+        <span className={SEGMENT_CLASS} data-testid={`${testId}-device`}>{deviceLabel}</span>
+        <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
+        <span className={SEGMENT_CLASS} data-testid={`${testId}-source`}>{sourceLabel}</span>
+        <span className="shrink-0 text-content-muted" aria-hidden="true">·</span>
+        <span className={SEGMENT_CLASS} data-testid={`${testId}-period`}>{periodLabel}</span>
+        <ChevronDown size={ICON_XS} className="shrink-0 text-content-muted" aria-hidden="true" />
+      </button>
+    </Tooltip>
   )
 }

--- a/src/renderer/components/analyze/BigramsClassesQuadrant.tsx
+++ b/src/renderer/components/analyze/BigramsClassesQuadrant.tsx
@@ -16,6 +16,7 @@ import {
 import type { WordPositionAggregate } from './analyze-bigram-word-position'
 import { EMPTY_STAT_VALUE } from './analyze-constants'
 import { fmtMs } from './analyze-format'
+import { Tooltip } from '../ui/Tooltip'
 
 interface BigramClassesQuadrantProps {
   /** Classes aggregate computed once by the parent `BigramsChart` and
@@ -169,15 +170,16 @@ function BigramClassesTable({
           ))}
         </tbody>
       </table>
-      <div
-        className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-content-muted"
-        data-testid="analyze-bigrams-classes-delta"
-        title={t('analyze.bigrams.classes.deltaTooltip')}
-      >
-        <span>{t('analyze.bigrams.classes.deltaLeft')}: {fmtDelta(deltaLeft)}</span>
-        <span>{t('analyze.bigrams.classes.deltaRight')}: {fmtDelta(deltaRight)}</span>
-        <span>{t('analyze.bigrams.classes.deltaInitiation')}: {fmtDelta(deltaInitiation)}</span>
-      </div>
+      <Tooltip content={t('analyze.bigrams.classes.deltaTooltip')} wrapperClassName="block w-full">
+        <div
+          className="flex flex-wrap gap-x-3 gap-y-1 text-xs text-content-muted"
+          data-testid="analyze-bigrams-classes-delta"
+        >
+          <span>{t('analyze.bigrams.classes.deltaLeft')}: {fmtDelta(deltaLeft)}</span>
+          <span>{t('analyze.bigrams.classes.deltaRight')}: {fmtDelta(deltaRight)}</span>
+          <span>{t('analyze.bigrams.classes.deltaInitiation')}: {fmtDelta(deltaInitiation)}</span>
+        </div>
+      </Tooltip>
       {wordPositionAggregate.excludedCount > 0 && (
         <div className="text-xs text-content-muted" data-testid="analyze-bigrams-classes-excluded-note">
           {t('analyze.bigrams.classes.excludedNote', { count: wordPositionAggregate.excludedCount })}

--- a/src/renderer/components/analyze/BigramsRankingTables.tsx
+++ b/src/renderer/components/analyze/BigramsRankingTables.tsx
@@ -10,6 +10,7 @@ import { bigramPairLabels, rolloverRatioFromEntry } from './analyze-bigram-forma
 import { avgIkiAtOrAboveThreshold, percentileFromHist } from './analyze-bigram-heatmap'
 import { fmtMs, formatPercentLabel } from './analyze-format'
 import { EmptyQuadrant } from './bigrams-quadrant-ui'
+import { Tooltip } from '../ui/Tooltip'
 
 type SortKey = 'count' | 'avgIki' | 'sd' | 'p95' | 'rollover'
 /** Columns `TopRanking` sorts on. */
@@ -59,25 +60,24 @@ interface SortHeaderProps {
   align: 'left' | 'right'
   active: boolean
   onClick: () => void
-  /** Header tooltip (native `title`). Absent by default — only the
-   * trigram Avg IKI header sets one today. */
+  /** Header tooltip. Absent by default — only the trigram Avg IKI header
+   * sets one today. */
   title?: string
 }
 
 function SortHeader({ label, indicator, align, active, onClick, title }: SortHeaderProps): JSX.Element {
   return (
-    <th
-      className={`select-none px-2 py-1 font-medium ${align === 'right' ? 'text-right' : 'text-left'}`}
-      title={title}
-    >
-      <button
-        type="button"
-        onClick={onClick}
-        className={`cursor-pointer ${active ? 'text-content' : 'text-content-muted hover:text-content'}`}
-      >
-        {label}
-        {indicator}
-      </button>
+    <th className={`select-none px-2 py-1 font-medium ${align === 'right' ? 'text-right' : 'text-left'}`}>
+      <Tooltip content={title ?? ''} disabled={!title}>
+        <button
+          type="button"
+          onClick={onClick}
+          className={`cursor-pointer ${active ? 'text-content' : 'text-content-muted hover:text-content'}`}
+        >
+          {label}
+          {indicator}
+        </button>
+      </Tooltip>
     </th>
   )
 }

--- a/src/renderer/components/analyze/DeviceMultiSelect.tsx
+++ b/src/renderer/components/analyze/DeviceMultiSelect.tsx
@@ -104,7 +104,6 @@ export function DeviceMultiSelect({
           <option
             key={info.machineHash}
             value={optionValue}
-            title={info.machineHash}
             data-testid={`${testId}-option-${optionValue}`}
           >
             {formatDeviceLabel(info)}

--- a/src/renderer/components/analyze/MultiSelectPopover.tsx
+++ b/src/renderer/components/analyze/MultiSelectPopover.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AnchoredPopover } from '../ui/AnchoredPopover'
+import { Tooltip } from '../ui/Tooltip'
 import { FILTER_SELECT } from './analyze-filter-styles'
 
 export interface MultiSelectOption {
@@ -72,19 +73,20 @@ export function MultiSelectPopover({ options, value, onChange, i18nPrefix, ariaL
 
   return (
     <>
-      <button
-        ref={triggerRef}
-        type="button"
-        className={`${FILTER_SELECT} max-w-filter-trigger truncate text-left`}
-        onClick={() => setOpen((prev) => !prev)}
-        aria-label={ariaLabel}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        title={buttonLabel}
-        data-testid={testId}
-      >
-        {buttonLabel}
-      </button>
+      <Tooltip content={buttonLabel} wrapperClassName="block max-w-full">
+        <button
+          ref={triggerRef}
+          type="button"
+          className={`${FILTER_SELECT} max-w-filter-trigger truncate text-left`}
+          onClick={() => setOpen((prev) => !prev)}
+          aria-label={ariaLabel}
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          data-testid={testId}
+        >
+          {buttonLabel}
+        </button>
+      </Tooltip>
       <AnchoredPopover
         anchorRef={triggerRef}
         open={open}

--- a/src/renderer/components/analyze/TypingAnalyticsView.tsx
+++ b/src/renderer/components/analyze/TypingAnalyticsView.tsx
@@ -14,6 +14,7 @@ import type { TypingKeyboardSummary } from '../../../shared/types/typing-analyti
 import { AnalyzePane } from './AnalyzePane'
 import type { ConnectedTappingTerm } from './analyze-types'
 import { formatSharePercent } from './analyze-format'
+import { Tooltip } from '../ui/Tooltip'
 
 // Below this viewport width the two panes can't fit side-by-side
 // without crushing the per-tab filter row, so the toggle is disabled
@@ -173,22 +174,23 @@ export function TypingAnalyticsView({ initialUid, onBack, connectedTappingTerm, 
         >
           {skipWarningMessage}
         </div>
-        <button
-          type="button"
-          role="switch"
-          className={`${FOOTER_BUTTON_BASE} disabled:cursor-not-allowed disabled:opacity-50 ${
-            splitVisible
-              ? 'border-accent bg-accent/10 text-accent'
-              : 'border-edge text-content-secondary hover:text-content'
-          }`}
-          onClick={handleToggleSplit}
-          disabled={!isWideViewport}
-          aria-checked={splitEnabled}
-          title={!isWideViewport ? t('analyze.splitView.narrowWindow') : undefined}
-          data-testid="analyze-split-toggle"
-        >
-          {t('analyze.splitView.toggle')}
-        </button>
+        <Tooltip content={t('analyze.splitView.narrowWindow')} disabled={isWideViewport}>
+          <button
+            type="button"
+            role="switch"
+            className={`${FOOTER_BUTTON_BASE} disabled:cursor-not-allowed disabled:opacity-50 ${
+              splitVisible
+                ? 'border-accent bg-accent/10 text-accent'
+                : 'border-edge text-content-secondary hover:text-content'
+            }`}
+            onClick={handleToggleSplit}
+            disabled={!isWideViewport}
+            aria-checked={splitEnabled}
+            data-testid="analyze-split-toggle"
+          >
+            {t('analyze.splitView.toggle')}
+          </button>
+        </Tooltip>
         {onBack && (
           <button
             type="button"

--- a/src/renderer/components/analyze/__tests__/MultiSelectPopover.test.tsx
+++ b/src/renderer/components/analyze/__tests__/MultiSelectPopover.test.tsx
@@ -3,7 +3,9 @@
 // Trigger-truncation regression: a long single-selection label (e.g. a
 // TypingTest material name) used to render at full width with no cap,
 // which widened the whole filter grid (max-content columns). The trigger
-// button must clamp + truncate and expose the full label via `title`.
+// button must clamp + truncate and expose the full label via the shared
+// Tooltip component (src/renderer/components/ui/Tooltip.tsx) — native
+// `title` attributes on DOM elements are forbidden project-wide.
 
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
@@ -20,7 +22,7 @@ vi.mock('react-i18next', () => ({
 const LONG_LABEL = 'A very long imported typing-test material name that would otherwise stretch the filter row'
 
 describe('MultiSelectPopover trigger', () => {
-  it('truncates a long single-selection label and exposes it via title', () => {
+  it('truncates a long single-selection label and exposes it via the shared Tooltip', () => {
     render(
       <MultiSelectPopover
         options={[{ value: 'long', label: LONG_LABEL }]}
@@ -34,10 +36,13 @@ describe('MultiSelectPopover trigger', () => {
     expect(trigger).toHaveTextContent(LONG_LABEL)
     expect(trigger.className).toContain('truncate')
     expect(trigger.className).toContain('max-w-filter-trigger')
-    expect(trigger).toHaveAttribute('title', LONG_LABEL)
+    expect(trigger).not.toHaveAttribute('title')
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.textContent).toBe(LONG_LABEL)
+    expect(trigger.getAttribute('aria-describedby')).toBe(bubble.id)
   })
 
-  it('shows the none-selected label as the title when nothing is picked', () => {
+  it('shows the none-selected label via the shared Tooltip when nothing is picked', () => {
     render(
       <MultiSelectPopover
         options={[{ value: 'a', label: 'A' }]}
@@ -48,7 +53,8 @@ describe('MultiSelectPopover trigger', () => {
       />,
     )
     const trigger = screen.getByTestId('analyze-filter-app')
-    expect(trigger).toHaveAttribute('title', 'analyze.filters.appOption.none')
+    expect(trigger).not.toHaveAttribute('title')
+    expect(screen.getByRole('tooltip').textContent).toBe('analyze.filters.appOption.none')
   })
 })
 

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -8,6 +8,7 @@ import { serialize, keycodeTooltip, isMask } from '../../../shared/keycodes/keyc
 import { KeyWidget } from '../keyboard/KeyWidget'
 import type { KleKey } from '../../../shared/kle/types'
 import { KEY_UNIT, KEY_SPACING, KEY_FACE_INSET } from '../keyboard/constants'
+import { Tooltip } from '../ui/Tooltip'
 
 interface Props {
   value: number
@@ -104,34 +105,35 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
   )
 
   const keyButton = (
-    <button
-      type="button"
-      aria-label={label}
-      aria-pressed={selected}
-      title={tooltip}
-      data-testid="keycode-field"
-      disabled={disabled}
-      className={`flex shrink-0 rounded ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
-      onClick={handleClick}
-      onDoubleClick={isMasked ? undefined : handleDoubleClick}
-    >
-      <svg
-        width={KEYCODE_FIELD_SIZE}
-        height={KEYCODE_FIELD_SIZE}
-        viewBox={`${FACE_ORIGIN} ${FACE_ORIGIN} ${FACE_SIZE} ${FACE_SIZE}`}
+    <Tooltip content={tooltip ?? ''} disabled={!tooltip}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={selected}
+        data-testid="keycode-field"
+        disabled={disabled}
+        className={`flex shrink-0 rounded ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
+        onClick={handleClick}
+        onDoubleClick={isMasked ? undefined : handleDoubleClick}
       >
-        <KeyWidget
-          kleKey={FIELD_KEY}
-          keycode={qmkId}
-          selected={selected}
-          selectedMaskPart={selectedMaskPart}
-          selectedFill={false}
-          onClick={isMasked ? handleKeyWidgetClick : undefined}
-          onDoubleClick={isMasked ? handleKeyWidgetDoubleClick : undefined}
-          hoverMaskParts={isMasked}
-        />
-      </svg>
-    </button>
+        <svg
+          width={KEYCODE_FIELD_SIZE}
+          height={KEYCODE_FIELD_SIZE}
+          viewBox={`${FACE_ORIGIN} ${FACE_ORIGIN} ${FACE_SIZE} ${FACE_SIZE}`}
+        >
+          <KeyWidget
+            kleKey={FIELD_KEY}
+            keycode={qmkId}
+            selected={selected}
+            selectedMaskPart={selectedMaskPart}
+            selectedFill={false}
+            onClick={isMasked ? handleKeyWidgetClick : undefined}
+            onDoubleClick={isMasked ? handleKeyWidgetDoubleClick : undefined}
+            hoverMaskParts={isMasked}
+          />
+        </svg>
+      </button>
+    </Tooltip>
   )
 
   if (!onDelete) return keyButton

--- a/src/renderer/components/editors/TypingTestPaneSettingsPanel.tsx
+++ b/src/renderer/components/editors/TypingTestPaneSettingsPanel.tsx
@@ -16,6 +16,7 @@ import type { useTypingTest } from '../../typing-test/useTypingTest'
 import { ToggleRow } from './modal-controls'
 import { PANEL_COLLAPSED_WIDTH } from './keymap-editor-types'
 import type { TimelineHandoff } from '../../hooks/useRunTimelineHandoff'
+import { Tooltip } from '../ui/Tooltip'
 
 const LINE_OPTIONS = Array.from({ length: DISPLAY_LINES_MAX - DISPLAY_LINES_MIN + 1 }, (_, i) => DISPLAY_LINES_MIN + i)
 
@@ -152,16 +153,17 @@ export function TypingTestPaneSettingsPanel({
             fileImport); quote uses it to pick the quote source language. */}
         <div className="flex w-full flex-col items-start gap-1">
           <span className="text-sm text-content-muted">{t('editor.typingTest.modeLabel')}({modeType})</span>
-          <button
-            type="button"
-            data-testid="language-selector"
-            title={modeLabel}
-            className="flex h-8 w-full items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-            onClick={() => onShowLanguageModal(true)}
-            disabled={typingTest.isLanguageLoading}
-          >
-            <span className="truncate">{modeLabel}</span>
-          </button>
+          <Tooltip content={modeLabel} wrapperClassName="w-full">
+            <button
+              type="button"
+              data-testid="language-selector"
+              className="flex h-8 w-full items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+              onClick={() => onShowLanguageModal(true)}
+              disabled={typingTest.isLanguageLoading}
+            >
+              <span className="truncate">{modeLabel}</span>
+            </button>
+          </Tooltip>
         </div>
         {showLanguageModal && (
           <LanguageSelectorModal
@@ -316,16 +318,17 @@ export function TypingTestPaneSettingsPanel({
       )}
       {/* Collapse / expand toggle — pinned to the bottom (mt-auto). */}
       <div className="mt-auto shrink-0 border-t border-edge p-2">
-        <button
-          type="button"
-          data-testid="typing-settings-panel-toggle"
-          title={t(settingsCollapsed ? 'editor.typingTest.expandSettings' : 'editor.typingTest.collapseSettings')}
-          aria-label={t(settingsCollapsed ? 'editor.typingTest.expandSettings' : 'editor.typingTest.collapseSettings')}
-          className="flex items-center justify-center rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content"
-          onClick={() => onToggleSettingsPanel?.(settingsCollapsed)}
-        >
-          {settingsCollapsed ? <ChevronsRight size={ICON_SM} aria-hidden="true" /> : <ChevronsLeft size={ICON_SM} aria-hidden="true" />}
-        </button>
+        <Tooltip content={t(settingsCollapsed ? 'editor.typingTest.expandSettings' : 'editor.typingTest.collapseSettings')}>
+          <button
+            type="button"
+            data-testid="typing-settings-panel-toggle"
+            aria-label={t(settingsCollapsed ? 'editor.typingTest.expandSettings' : 'editor.typingTest.collapseSettings')}
+            className="flex items-center justify-center rounded-md p-1 text-content-muted transition-colors hover:bg-surface-dim hover:text-content"
+            onClick={() => onToggleSettingsPanel?.(settingsCollapsed)}
+          >
+            {settingsCollapsed ? <ChevronsRight size={ICON_SM} aria-hidden="true" /> : <ChevronsLeft size={ICON_SM} aria-hidden="true" />}
+          </button>
+        </Tooltip>
       </div>
     </div>
   )

--- a/src/renderer/components/editors/__tests__/KeycodeField.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeycodeField.test.tsx
@@ -49,19 +49,27 @@ describe('KeycodeField', () => {
     expect(screen.getByTestId('keycode-field')).toHaveAttribute('aria-pressed', 'true')
   })
 
-  it('sets title from keycodeTooltip', () => {
+  it('exposes keycodeTooltip via the shared Tooltip, not a native title', () => {
     render(<KeycodeField value={4} selected={false} onSelect={() => {}} />)
-    expect(screen.getByTestId('keycode-field')).toHaveAttribute('title', 'Tooltip: KC_4')
+    const btn = screen.getByTestId('keycode-field')
+    expect(btn).not.toHaveAttribute('title')
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.textContent).toBe('Tooltip: KC_4')
+    expect(btn.getAttribute('aria-describedby')).toBe(bubble.id)
   })
 
-  it('does not set title when tooltip is undefined', () => {
+  it('does not render a tooltip when keycodeTooltip is undefined', () => {
     render(<KeycodeField value={0} selected={false} onSelect={() => {}} />)
-    expect(screen.getByTestId('keycode-field')).not.toHaveAttribute('title')
+    const btn = screen.getByTestId('keycode-field')
+    expect(btn).not.toHaveAttribute('title')
+    expect(screen.queryByRole('tooltip')).toBeNull()
   })
 
-  it('suppresses title when noTooltip is true', () => {
+  it('suppresses the tooltip when noTooltip is true', () => {
     render(<KeycodeField value={4} selected={false} onSelect={() => {}} noTooltip />)
-    expect(screen.getByTestId('keycode-field')).not.toHaveAttribute('title')
+    const btn = screen.getByTestId('keycode-field')
+    expect(btn).not.toHaveAttribute('title')
+    expect(screen.queryByRole('tooltip')).toBeNull()
   })
 
   it('delays onSelect when onDoubleClick is provided', () => {

--- a/src/renderer/components/editors/modal-controls.tsx
+++ b/src/renderer/components/editors/modal-controls.tsx
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+import { Tooltip } from '../ui/Tooltip'
+
 const TOGGLE_TRACK_BASE = 'relative inline-flex h-5 w-9 items-center rounded-full transition-colors'
 const TOGGLE_KNOB_BASE = 'inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform'
 
@@ -31,18 +33,19 @@ export function ToggleRow({ label, on, onToggle, title, testid }: {
   return (
     <div className={`${ROW_CLASS} w-full`} data-testid={`${testid}-row`}>
       <span className="min-w-0 truncate text-sm font-medium text-content">{label}</span>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={on}
-        aria-label={label}
-        title={title}
-        className={`${toggleTrackClass(on)} shrink-0`}
-        onClick={onToggle}
-        data-testid={testid}
-      >
-        <span className={toggleKnobClass(on)} />
-      </button>
+      <Tooltip content={title ?? ''} disabled={!title}>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={on}
+          aria-label={label}
+          className={`${toggleTrackClass(on)} shrink-0`}
+          onClick={onToggle}
+          data-testid={testid}
+        >
+          <span className={toggleKnobClass(on)} />
+        </button>
+      </Tooltip>
     </div>
   )
 }

--- a/src/renderer/components/i18n-packs/CoverageBadge.tsx
+++ b/src/renderer/components/i18n-packs/CoverageBadge.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useState } from 'react'
 import { getCachedCoverage, subscribeCoverage, refreshCoverageFromIpc } from '../../i18n/coverage-cache'
 import type { CoverageResult } from '../../../shared/i18n/coverage'
+import { Tooltip } from '../ui/Tooltip'
 
 interface CoverageBadgeProps {
   packId: string
@@ -59,12 +60,13 @@ export function CoverageBadge({ packId, packVersion }: CoverageBadgeProps): JSX.
   const pct = Math.round(coverage.coverageRatio * 100)
   const tooltip = `${String(coverage.coveredKeys)} / ${String(coverage.totalKeys)} keys`
   return (
-    <span
-      className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${bandClass(coverage.coverageRatio)}`}
-      title={tooltip}
-      data-testid={`coverage-badge-${packId}`}
-    >
-      {String(pct)}%
-    </span>
+    <Tooltip content={tooltip} wrapperAs="span">
+      <span
+        className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${bandClass(coverage.coverageRatio)}`}
+        data-testid={`coverage-badge-${packId}`}
+      >
+        {String(pct)}%
+      </span>
+    </Tooltip>
   )
 }

--- a/src/renderer/components/keycodes/KeyPopover.tsx
+++ b/src/renderer/components/keycodes/KeyPopover.tsx
@@ -9,6 +9,7 @@ import { PopoverTabCode } from './PopoverTabCode'
 import { ModifierCheckboxStrip } from './ModifierCheckboxStrip'
 import { LayerSelector } from './LayerSelector'
 import { usePopoverKeycodeWorkflow, type WrapperMode } from './use-popover-keycode-workflow'
+import { Tooltip } from '../ui/Tooltip'
 
 type Tab = 'key' | 'code'
 
@@ -232,20 +233,20 @@ export function KeyPopover({
           data-testid="popover-layer-sidebar"
         >
           {Array.from({ length: layers }, (_, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => handleLayerSidebarClick(i)}
-              className={`w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 text-xs font-semibold tabular-nums transition-colors ${
-                currentLayer === i
-                  ? 'border-accent bg-accent text-content-inverse'
-                  : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
-              }`}
-              title={layerNames?.[i] || undefined}
-              data-testid={`popover-layer-${i}`}
-            >
-              {i}
-            </button>
+            <Tooltip key={i} content={layerNames?.[i] || ''} disabled={!layerNames?.[i]} side="right">
+              <button
+                type="button"
+                onClick={() => handleLayerSidebarClick(i)}
+                className={`w-8 shrink-0 rounded-md border flex items-center justify-center py-1.5 text-xs font-semibold tabular-nums transition-colors ${
+                  currentLayer === i
+                    ? 'border-accent bg-accent text-content-inverse'
+                    : 'border-edge bg-surface/20 text-content-muted hover:bg-surface-dim'
+                }`}
+                data-testid={`popover-layer-${i}`}
+              >
+                {i}
+              </button>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/src/renderer/typing-test/HistoryTimelineCell.tsx
+++ b/src/renderer/typing-test/HistoryTimelineCell.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { ChartNoAxesGantt } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import { Tooltip } from '../components/ui/Tooltip'
 import { WordTimelineView } from './WordTimelineView'
 
 interface Props {
@@ -29,16 +30,17 @@ export function HistoryTimelineCell({ result, uid, availableRunIds }: Props) {
 
   return (
     <td className="px-3 py-1.5">
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="rounded p-1 text-content-muted transition-colors hover:text-content"
-        aria-label={t('editor.typingTest.history.timeline.openButton')}
-        title={t('editor.typingTest.history.timeline.openButton')}
-        data-testid={`history-timeline-open-${result.date}`}
-      >
-        <ChartNoAxesGantt size={ICON_SM} aria-hidden="true" />
-      </button>
+      <Tooltip content={t('editor.typingTest.history.timeline.openButton')}>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className="rounded p-1 text-content-muted transition-colors hover:text-content"
+          aria-label={t('editor.typingTest.history.timeline.openButton')}
+          data-testid={`history-timeline-open-${result.date}`}
+        >
+          <ChartNoAxesGantt size={ICON_SM} aria-hidden="true" />
+        </button>
+      </Tooltip>
       {open && (
         <WordTimelineView
           uid={uid}

--- a/src/renderer/typing-test/TypingTestControlsRow.tsx
+++ b/src/renderer/typing-test/TypingTestControlsRow.tsx
@@ -7,6 +7,7 @@ import { ICON_SM, ICON_LG } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig } from './types'
 import { ResultNameModal } from './ResultNameModal'
+import { Tooltip } from '../components/ui/Tooltip'
 
 interface Props {
   state: TypingTestState
@@ -113,17 +114,18 @@ function ResultNameField({ onName, chips }: { onName?: (name: string) => void; c
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setModalOpen(true)}
-        title={t('editor.typingTest.nameResult')}
-        aria-label={t('editor.typingTest.nameResult')}
-        className={`flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm transition-colors hover:text-content ${name ? 'text-content-secondary' : 'text-content-muted'}`}
-        data-testid="typing-test-result-name"
-      >
-        <SquarePen size={ICON_SM} aria-hidden="true" />
-        <span>{name || t('editor.typingTest.history.unnamed')}</span>
-      </button>
+      <Tooltip content={t('editor.typingTest.nameResult')}>
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          aria-label={t('editor.typingTest.nameResult')}
+          className={`flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm transition-colors hover:text-content ${name ? 'text-content-secondary' : 'text-content-muted'}`}
+          data-testid="typing-test-result-name"
+        >
+          <SquarePen size={ICON_SM} aria-hidden="true" />
+          <span>{name || t('editor.typingTest.history.unnamed')}</span>
+        </button>
+      </Tooltip>
       {modalOpen && (
         <ResultNameModal
           initialName={name}

--- a/src/renderer/typing-test/__tests__/HistoryTimelineCell.test.tsx
+++ b/src/renderer/typing-test/__tests__/HistoryTimelineCell.test.tsx
@@ -44,4 +44,13 @@ describe('HistoryTimelineCell', () => {
     fireEvent.click(btn)
     expect(screen.getByTestId('word-timeline-modal')).toBeTruthy()
   })
+
+  it('has no native title attribute and exposes the label via the shared Tooltip instead', () => {
+    renderWithI18n(<HistoryTimelineCell result={makeResult({ runId: 'run-1' })} uid="uid-1" availableRunIds={new Set(['run-1'])} />)
+    const btn = screen.getByTestId('history-timeline-open-2026-01-01T00:00:00.000Z')
+    expect(btn).not.toHaveAttribute('title')
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.textContent).toBe(i18n.t('editor.typingTest.history.timeline.openButton'))
+    expect(btn.getAttribute('aria-describedby')).toBe(bubble.id)
+  })
 })

--- a/src/renderer/typing-test/list-parts.tsx
+++ b/src/renderer/typing-test/list-parts.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Trash2 } from 'lucide-react'
 import { ICON_SM } from '../constants/ui-tokens'
 import { optionButtonClass } from './TypingTestSettingsBar'
+import { Tooltip } from '../components/ui/Tooltip'
 
 interface SectionHeaderProps {
   label: string
@@ -47,17 +48,18 @@ interface RomajiFilterToggleProps {
 export function RomajiFilterToggle({ active, onToggle }: RomajiFilterToggleProps) {
   const { t } = useTranslation()
   return (
-    <button
-      type="button"
-      data-testid="romaji-filter-toggle"
-      aria-pressed={active}
-      title={t('editor.typingTest.language.romajiFilter')}
-      aria-label={t('editor.typingTest.language.romajiFilter')}
-      onClick={onToggle}
-      className={`${optionButtonClass(active, 'px-2.5')} shrink-0`}
-    >
-      {t('editor.typingTest.language.romajiBadge')}
-    </button>
+    <Tooltip content={t('editor.typingTest.language.romajiFilter')} wrapperClassName="shrink-0">
+      <button
+        type="button"
+        data-testid="romaji-filter-toggle"
+        aria-pressed={active}
+        aria-label={t('editor.typingTest.language.romajiFilter')}
+        onClick={onToggle}
+        className={`${optionButtonClass(active, 'px-2.5')} shrink-0`}
+      >
+        {t('editor.typingTest.language.romajiBadge')}
+      </button>
+    </Tooltip>
   )
 }
 


### PR DESCRIPTION
## Summary
- Hovering the History timeline button (and ~20 other spots across the renderer) showed the OS-native delayed tooltip instead of the app's own Tooltip bubble. Every native `title` attribute on a DOM element now renders through the shared `components/ui/Tooltip`, following the codebase's established wrapper patterns (disabled buttons per keymap-editor-toolbar, truncated text per HistoryResultsPanel, grid children per RomajiSettingsModal). Shared controls (`ToggleRow`, `SortHeader`) were fixed centrally so all their call sites inherit the change.
- One flagged exception: a native `<option>` cannot host a portaled component, so its hash hint was dropped in favor of the select's existing aria-label.
- `title` props that feed headings/modal titles (PanelSection, JsonEditorModal, …) are not tooltips and were left untouched.
- A scoped eslint `no-restricted-syntax` rule now rejects `title` attributes on lowercase JSX elements in `src/renderer`, so the pattern cannot creep back.

## Verification
- Full suite 8,325 passed / 22 skipped (+1 regression test asserting the timeline button renders a Tooltip and no native title; 5 existing title-attribute assertions updated to Tooltip-structure assertions, each flagged).
- Virtual-device Playwright check: hovering the timeline icon shows the styled bubble with role=tooltip and the expected text.
- Lint rule verified to fire on a synthetic violation and pass on component title props.