### PR TITLE
fix(ui): highlight the Compare button while a baseline is active

### DIFF
--- a/src/renderer/components/editors/ComparisonToggle.tsx
+++ b/src/renderer/components/editors/ComparisonToggle.tsx
@@ -20,11 +20,19 @@ interface Props {
 
 const MAX_PINNABLE = 100
 
-// Compare opens a modal — a dialog trigger, not a stateful toggle — so it keeps
-// a single static style; the active baseline is conveyed by the button text
-// ("Compare - <baseline>") rather than an accent highlight.
-const COMPARE_BUTTON_CLASS =
-  'flex h-8 w-full items-center justify-center rounded-md border border-edge px-3 text-sm text-content-secondary transition-colors hover:text-content'
+// Compare opens a modal rather than toggling inline, but the baseline it
+// opens onto is still persistent state — so, like the other stateful config
+// buttons in this sidebar (e.g. optionButtonClass's Romaji/Pattern/Units
+// buttons in TypingTestSettingsBar), it shows an accent border + accent text
+// whenever a comparison is active (baseline.kind !== 'off'). The neutral
+// border/secondary-text style is kept only for kind === 'off', so the button
+// still reads as "off" at a glance in addition to its text.
+function compareButtonClass(active: boolean): string {
+  const base = 'flex h-8 w-full items-center justify-center rounded-md border px-3 text-sm transition-colors'
+  return active
+    ? `${base} border-accent bg-accent/10 font-semibold text-accent`
+    : `${base} border-edge text-content-secondary hover:text-content`
+}
 
 export function ComparisonToggle({ pool, baseline, onChange }: Props) {
   const { t } = useTranslation()
@@ -66,7 +74,7 @@ export function ComparisonToggle({ pool, baseline, onChange }: Props) {
       <button
         type="button"
         data-testid="typing-test-comparison-toggle"
-        className={COMPARE_BUTTON_CLASS}
+        className={compareButtonClass(baseline.kind !== 'off')}
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={openModal}

--- a/src/renderer/components/editors/__tests__/ComparisonToggle.test.tsx
+++ b/src/renderer/components/editors/__tests__/ComparisonToggle.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../../i18n'
+import { ComparisonToggle } from '../ComparisonToggle'
+import type { ComparisonBaselineKind } from '../../../../shared/types/pipette-settings'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+function getToggleButton() {
+  return screen.getByTestId('typing-test-comparison-toggle')
+}
+
+describe('ComparisonToggle — active-state accent color', () => {
+  it('renders the neutral (non-accent) style when the baseline is off', () => {
+    renderWithI18n(<ComparisonToggle pool={[]} baseline={{ kind: 'off' }} />)
+    const button = getToggleButton()
+    expect(button.className).toContain('border-edge')
+    expect(button.className).toContain('text-content-secondary')
+    expect(button.className).not.toContain('border-accent')
+    expect(button.className).not.toContain('text-accent')
+  })
+
+  it.each<ComparisonBaselineKind>(['previous', 'best', 'average', 'pinned'])(
+    'renders the accent style when the baseline is active (%s)',
+    (kind) => {
+      renderWithI18n(<ComparisonToggle pool={[]} baseline={{ kind }} />)
+      const button = getToggleButton()
+      expect(button.className).toContain('border-accent')
+      expect(button.className).toContain('text-accent')
+      expect(button.className).not.toContain('border-edge')
+    },
+  )
+})


### PR DESCRIPTION
## Summary
- The typing-test sidebar's "Compare - <baseline>" button always rendered the neutral dialog-trigger style, so an active comparison (Previous / Best / Average / Pinned) was easy to miss. Any kind other than Off now renders the same accent treatment (`border-accent bg-accent/10 font-semibold text-accent`) the sidebar's other stateful options (Romaji, pattern, units) already use; Off keeps the neutral style. The stale design comment arguing for a single static style was rewritten.

## Verification
- New ComparisonToggle test suite (none existed): neutral class for Off, accent class for each active kind — red-run evidence captured by stashing the fix (4/5 fail) and restoring it (5/5 pass). Editors suite 701 tests green; eslint and typecheck clean.
- Virtual-device Playwright check: baseline switched Off → Previous, DOM-asserting the class sets differ and match the Romaji button's active treatment (screenshots verified).