### PR TITLE
refactor(ui): extract the keystroke timeline into a shared panel

### DIFF
--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Content of the per-run keystroke timeline — unified stat block, legend,
+// zoom slider, and the line/word rows with their hover tooltip. Extracted
+// out of `WordTimelineView` (see .claude/plans/Plan-completion-timeline-view.md
+// PR-A spec point 1) so a later PR can render the identical content
+// inline on the typing-test completion screen, not only inside the
+// History modal. Deliberately has NO modal-specific assumptions: the
+// zoom's DOM-width-write invariant and the horizontal-scroll `overflow-auto`
+// wrapper both key off this component's own container width via
+// `ResizeObserver`, which works the same whether that container is a
+// modal panel or an inline block on another screen.
+
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AnalyzeStatGrid } from '../components/analyze/stat-card'
+import { TooltipShell, Stat } from '../components/analyze/analyze-tooltip'
+import { computeBubblePosition } from '../components/ui/Tooltip'
+import { fmtMs } from '../components/analyze/analyze-format'
+import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+import type { KeystrokeSegment } from './word-timeline'
+import { WordTimelineRow, type HoverTarget } from './word-timeline-row'
+import { LineTimelineRow, type LineHoverTarget } from './LineTimelineRow'
+import { TIMELINE_LEGEND, type TimelineFillKind } from './word-timeline-colors'
+import { useTimelineModel } from './use-timeline-model'
+import { buildTimelineStatItems } from './keystroke-timeline-stats'
+import { MissedCharsList, ErrorClassLine, type ErrorClassCounts } from './mistake-summary'
+
+/** Floor for the "fit" zoom level's canvas width — a run with a very
+ *  short `maxDisplayMs` (e.g. a single short word) would otherwise
+ *  compute a fit width narrower than the panel itself. */
+const CANVAS_MIN_WIDTH_PX = 480
+/** The zoom slider's max is this many times the fit level — "10x the
+ *  whole run visible at once" comfortably reaches individual-keystroke
+ *  detail without an unbounded range that makes the slider imprecise. */
+const ZOOM_MAX_FACTOR = 10
+
+const LEGEND_ORDER = Object.keys(TIMELINE_LEGEND) as TimelineFillKind[]
+
+interface Props {
+  log: RunKeystrokeLog
+  /** The already-displayed History row for this run, when known — reused
+   *  for the unified stat block so it reads identically to the row the
+   *  user opened this view from, rather than a second, possibly-divergent
+   *  computation over the same run. */
+  result?: TypingTestResult
+}
+
+interface LegendSwatchProps {
+  colorClass: string
+  labelKey: string
+}
+
+function LegendSwatch({ colorClass, labelKey }: LegendSwatchProps) {
+  const { t } = useTranslation()
+  return (
+    <span className="flex items-center gap-1.5 text-2xs text-content-secondary">
+      <span className={`inline-block h-2.5 w-2.5 rounded-sm ${colorClass}`} aria-hidden="true" />
+      {t(labelKey)}
+    </span>
+  )
+}
+
+/** Collapses a `boolean | undefined` tri-state into one of three i18n
+ *  keys — shared shape for "correctness" and "overlap", which were
+ *  previously two structurally identical nested ternaries. */
+function triLabel(
+  value: boolean | undefined,
+  yesKey: string,
+  noKey: string,
+  unknownKey: string,
+  t: (key: string) => string,
+): string {
+  if (value === true) return t(yesKey)
+  if (value === false) return t(noKey)
+  return t(unknownKey)
+}
+
+/** The legend's `blank`/`leadIn` entries carry a line-view specific
+ *  meaning (250ms cut, "before this line") distinct from the word view's
+ *  (1000ms cut, "before this word") — every other legend entry (normal,
+ *  mistake, overlap, unjudged) means the same thing in both modes. */
+function lineLegendLabelKey(kind: TimelineFillKind, displayMode: 'line' | 'word'): string {
+  if (displayMode === 'line' && kind === 'blank') return 'editor.typingTest.history.timeline.legend.blankLine'
+  if (displayMode === 'line' && kind === 'leadIn') return 'editor.typingTest.history.timeline.legend.leadInLine'
+  return TIMELINE_LEGEND[kind].labelKey
+}
+
+function keystrokeTooltipBody(word: string, seg: KeystrokeSegment, t: (key: string, opts?: Record<string, unknown>) => string) {
+  const correctnessText = triLabel(
+    seg.correct,
+    'editor.typingTest.history.timeline.tooltip.correct',
+    'editor.typingTest.history.timeline.tooltip.mistake',
+    'editor.typingTest.history.timeline.tooltip.unjudged',
+    t,
+  )
+  const overlapText = triLabel(
+    seg.overlapped,
+    'editor.typingTest.history.timeline.tooltip.overlapYes',
+    'editor.typingTest.history.timeline.tooltip.overlapNo',
+    'editor.typingTest.history.timeline.tooltip.overlapUnknown',
+    t,
+  )
+  const durationText = seg.openEnded
+    ? t('editor.typingTest.history.timeline.tooltip.releaseUnobserved')
+    : fmtMs(seg.endMs - seg.startMs)
+
+  return (
+    <TooltipShell header={`${word} · ${t('editor.typingTest.history.timeline.tooltip.offset', { ms: Math.round(seg.trueStartMs) })}`}>
+      <Stat label={seg.label || EMPTY_STAT_VALUE} value={durationText} />
+      <Stat label={t('editor.typingTest.history.timeline.stats.accuracy')} value={correctnessText} />
+      <Stat label={t('editor.typingTest.history.timeline.stats.overlap')} value={overlapText} />
+    </TooltipShell>
+  )
+}
+
+export function KeystrokeTimelinePanel({ log, result }: Props) {
+  const { t } = useTranslation()
+  const { displayMode, wordModel, lineModel, summary, activeMaxDisplayMs, activeCharCorrelationUnavailable } = useTimelineModel(log)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const [fitPxPerMs, setFitPxPerMs] = useState<number | null>(null)
+  // Bumped from the canvas ref callback once the element actually mounts
+  // — see the effect below for why this, not just `[displayMode]`, is
+  // needed.
+  const [canvasMountTick, setCanvasMountTick] = useState(0)
+  const setCanvasNode = useCallback((node: HTMLDivElement | null) => {
+    canvasRef.current = node
+    if (node) setCanvasMountTick((t) => t + 1)
+  }, [])
+
+  const applyZoom = useCallback((next: number) => {
+    if (!displayMode || !canvasRef.current) return
+    canvasRef.current.style.width = `${Math.round(activeMaxDisplayMs * next)}px`
+  }, [displayMode, activeMaxDisplayMs])
+
+  // Whether the canvas is still at the "fit whole run in view" width —
+  // true from mount until the user first drags the slider away from it
+  // (see `handleZoomInput`). Read by the resize-driven recompute below so
+  // a window resize only ever re-applies a new fit width automatically
+  // while the user hasn't already chosen a different zoom level; once
+  // they have, a resize still refreshes `fitPxPerMs` (so the slider's own
+  // `min` stays accurate) without silently yanking their chosen zoom.
+  const isAtFitRef = useRef(true)
+
+  // Recompute the "fit whole run in view" zoom level from the
+  // container's actual available width — subtracting its own horizontal
+  // padding (`getComputedStyle`, not a hardcoded pixel guess) since the
+  // canvas renders as a direct, unpadded child: using the container's
+  // raw `clientWidth` (which INCLUDES its own padding) sized the canvas
+  // 16px too wide, so the container always showed a horizontal
+  // scrollbar even for a run that fit. Falls back to `CANVAS_MIN_WIDTH_PX`
+  // when the resulting width would be narrower than that floor (a run
+  // with very little content, or — in tests — jsdom's `clientWidth`
+  // always reading 0 since it never implements layout).
+  const computeAndApplyFit = useCallback(() => {
+    if (!displayMode || activeMaxDisplayMs <= 0) return
+    const container = containerRef.current
+    if (!container) return
+    const styles = window.getComputedStyle(container)
+    const paddingX = parseFloat(styles.paddingLeft || '0') + parseFloat(styles.paddingRight || '0')
+    const width = Math.max(container.clientWidth - paddingX, CANVAS_MIN_WIDTH_PX)
+    const fit = width / activeMaxDisplayMs
+    setFitPxPerMs(fit)
+    if (isAtFitRef.current) applyZoom(fit)
+  }, [displayMode, activeMaxDisplayMs, applyZoom])
+
+  // Compute the fit level once the model is known AND the canvas has
+  // actually mounted. Keying only on `[displayMode]` (the original
+  // approach) breaks because the log/model can resolve on a render where
+  // the section gating the canvas hasn't yet painted it — `containerRef`/
+  // `canvasRef` are still null on that render, and the fit falls back to
+  // `CANVAS_MIN_WIDTH_PX` regardless of the real container width.
+  // Depending on the canvas's own mount (bumped from its ref callback)
+  // instead of just `displayMode` guarantees this runs again once the
+  // refs are live.
+  useEffect(() => {
+    if (!canvasRef.current) return
+    computeAndApplyFit()
+  }, [canvasMountTick, computeAndApplyFit])
+
+  // Re-fit on container resize (a maximize/restore, or the user dragging
+  // the window edge) — the initial-fit effect above only ever runs once
+  // per mount/model change, so without this a resize left the canvas at
+  // whatever width the ORIGINAL size computed, either wasting new space
+  // or reintroducing the very overflow this fix exists to remove.
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !displayMode) return
+    const observer = new ResizeObserver(() => computeAndApplyFit())
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [displayMode, computeAndApplyFit])
+
+  // Live drag: this fires on every tick (React's onChange for a range
+  // input maps to the native 'input' event) but only ever touches the
+  // DOM directly — no setState, so nothing in the row tree re-renders
+  // while dragging (rows are memoized on `word`/`maxDisplayMs`, neither
+  // of which this touches).
+  const handleZoomInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    isAtFitRef.current = Number(e.target.value) === fitPxPerMs
+    applyZoom(Number(e.target.value))
+  }, [applyZoom, fitPxPerMs])
+
+  // Discriminated union: word rows report a `WordTimelineWord`, line rows
+  // report the line's own joined text — the two modes are mutually
+  // exclusive (see `displayMode`), so only one branch is ever set, but
+  // both need distinct handlers to stay type-safe without threading a
+  // `word.display`-shaped fake through the line path.
+  type Hover = ({ kind: 'word' } & HoverTarget) | ({ kind: 'line' } & LineHoverTarget)
+  const [hover, setHover] = useState<Hover | null>(null)
+  const handleWordHover = useCallback((t: HoverTarget) => setHover({ kind: 'word', ...t }), [])
+  const handleLineHover = useCallback((t: LineHoverTarget) => setHover({ kind: 'line', ...t }), [])
+  const handleHoverEnd = useCallback(() => setHover(null), [])
+
+  // Tooltip position — measure-then-position, same idiom as
+  // `Tooltip.tsx`: read the bubble's own just-rendered size inside a
+  // layout effect (runs before paint) so the very first frame the user
+  // sees is already the clamped position, never the raw
+  // `hover.rect.left/bottom` math (which can render off-screen near the
+  // container's edge at high zoom).
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null)
+  useLayoutEffect(() => {
+    if (!hover || !tooltipRef.current) { setTooltipPos(null); return }
+    setTooltipPos(computeBubblePosition(
+      hover.rect,
+      tooltipRef.current.getBoundingClientRect(),
+      'bottom',
+      'start',
+      6,
+      { width: window.innerWidth, height: window.innerHeight },
+    ))
+  }, [hover])
+
+  const summaryItems = useMemo(() => buildTimelineStatItems(result, summary, log), [result, summary, log])
+
+  // Both-or-neither, mirroring `TypingTestResult.errorSubstitutions`
+  // et al.'s own storage contract — a result saved before error-class
+  // tracking existed (or a romaji/no-finalized-word run) has none of the
+  // three fields, and this reads that as "omit the line entirely" rather
+  // than fabricating a partial breakdown.
+  const errorClasses: ErrorClassCounts | null = result
+    && result.errorSubstitutions !== undefined
+    && result.errorOmissions !== undefined
+    && result.errorInsertions !== undefined
+    ? { substitutions: result.errorSubstitutions, omissions: result.errorOmissions, insertions: result.errorInsertions }
+    : null
+
+  if (!displayMode) return null
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3">
+      {/* Deliberate exception to the Analyze chart-above-stats rule
+          (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
+          this grid is the panel's summary header, not a chart-adjacent
+          stat row — it must sit above the legend/zoom controls and the
+          canvas, all of which the user reads top-to-bottom before ever
+          reaching the scrollable, flex-grow canvas below. */}
+      <AnalyzeStatGrid items={summaryItems} ariaLabelKey="editor.typingTest.history.timeline.modalTitle" />
+
+      {/* Missed characters / error-mix — result-only (see the module doc
+          comment): reconstructing either from the raw log would re-derive
+          scoring rules run-state.ts already owns. Both components render
+          nothing when their data is absent/empty, same convention the
+          completion screen (`TypingTestStatsRow`) already follows. */}
+      <MissedCharsList mistakes={result?.mistakes ?? {}} />
+      {errorClasses && <ErrorClassLine errorClasses={errorClasses} />}
+
+      {activeCharCorrelationUnavailable && (
+        <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
+          {t('editor.typingTest.history.timeline.correlationUnreliable')}
+        </p>
+      )}
+
+      {/* Legend — color alone never carries meaning elsewhere in
+          this view (tooltips spell everything out too), but this
+          is the at-a-glance key. Line-mode overrides the blank/
+          lead-in wording to the line-view's own meaning (a 250ms
+          cut and "before this line", not the word view's 1000ms /
+          "before this word") — every other entry, and the word
+          view's own wording, stays unchanged. */}
+      <div className="flex flex-wrap items-center gap-3 rounded-md border border-edge bg-surface px-3 py-1.5">
+        {LEGEND_ORDER.map((kind) => (
+          <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
+        ))}
+      </div>
+      <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.legend.correctedNote')}</p>
+      <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.axisNote')}</p>
+
+      {/* Zoom — same row shape as RGBConfigurator's brightness
+          slider (the only existing range-input precedent). The
+          slider only mounts once `fitPxPerMs` is known, so its
+          (uncontrolled) `defaultValue` is always correct at
+          first paint — no remount-on-resolve hack needed. The
+          WHOLE row (including its label) is gated on `fitPxPerMs`,
+          not just the input — a log with zero drawable content
+          (`maxDisplayMs <= 0`) never computes a fit level, and an
+          orphan "Zoom" label with no control under it read as
+          broken rather than as "nothing to zoom". */}
+      {fitPxPerMs !== null && (
+        <div className="flex items-center gap-3">
+          <label className="text-sm text-content-secondary">{t('editor.typingTest.history.timeline.zoom.label')}</label>
+          <input
+            type="range"
+            data-testid="word-timeline-zoom"
+            aria-label={t('editor.typingTest.history.timeline.zoom.aria')}
+            min={fitPxPerMs}
+            max={fitPxPerMs * ZOOM_MAX_FACTOR}
+            step={fitPxPerMs / 20}
+            defaultValue={fitPxPerMs}
+            onChange={handleZoomInput}
+            className="flex-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          />
+        </div>
+      )}
+
+      <div ref={containerRef} className="relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2">
+        <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
+          {displayMode === 'line' && lineModel
+            ? lineModel.lines.map((line) => (
+              <LineTimelineRow
+                key={line.lineIndex}
+                line={line}
+                maxDisplayMs={lineModel.maxDisplayMs}
+                romajiInput={log.romajiInput === true}
+                onHover={handleLineHover}
+                onHoverEnd={handleHoverEnd}
+              />
+            ))
+            : wordModel?.words.map((word) => (
+              <WordTimelineRow
+                key={word.index}
+                word={word}
+                maxDisplayMs={wordModel.maxDisplayMs}
+                onHover={handleWordHover}
+                onHoverEnd={handleHoverEnd}
+              />
+            ))}
+        </div>
+
+        {hover && (
+          <div
+            ref={tooltipRef}
+            className="pointer-events-none fixed z-70"
+            style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 6 }}
+            data-testid="word-timeline-tooltip"
+          >
+            {hover.segment.kind === 'keystroke'
+              ? keystrokeTooltipBody(hover.kind === 'word' ? hover.word.display : hover.lineText, hover.segment, t)
+              : (
+                <TooltipShell>
+                  <Stat
+                    label={t(lineLegendLabelKey(hover.segment.kind === 'blank' ? 'blank' : 'leadIn', hover.kind === 'line' ? 'line' : 'word'))}
+                    value={t(
+                      hover.segment.kind === 'blank'
+                        ? 'editor.typingTest.history.timeline.tooltip.blankDuration'
+                        : (hover.kind === 'line'
+                          ? 'editor.typingTest.history.timeline.tooltip.leadInLineDuration'
+                          : 'editor.typingTest.history.timeline.tooltip.leadInDuration'),
+                      { ms: Math.round(hover.segment.trueDurationMs) },
+                    )}
+                  />
+                </TooltipShell>
+              )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/typing-test/TypingTestStatsRow.tsx
+++ b/src/renderer/typing-test/TypingTestStatsRow.tsx
@@ -7,12 +7,7 @@ import type { TypingTestConfig } from './types'
 import type { ComparisonStats } from './comparison'
 import { isTimeBoundedRun } from './types'
 import { formatKspc } from '../../shared/kspc'
-
-// Completion screen's "missed characters" list (Phase 1 of mistake
-// analysis — see TypingTestState.mistakes) caps how many distinct
-// mistake keys are shown, so a run with many small errors doesn't turn
-// the results row into an unbounded wall of text.
-const MAX_MISTAKE_ENTRIES = 12
+import { MissedCharsList, ErrorClassLine } from './mistake-summary'
 
 function formatTime(seconds: number): string {
   const m = Math.floor(seconds / 60)
@@ -83,17 +78,6 @@ export function TypingTestStatsRow({
     sum += Math.min(state.currentWordIndex, Math.max(0, state.words.length - 1)) // separators passed
     return Math.min(sum, totalChars)
   }, [charProgress, state.words, state.currentWordIndex, state.currentInput, totalChars])
-
-  // Completion screen's missed-characters list: sorted by count DESC then
-  // key ASC (ties break deterministically instead of on object insertion
-  // order), capped to the top MAX_MISTAKE_ENTRIES.
-  const mistakeEntries = useMemo(
-    () =>
-      Object.entries(state.mistakes)
-        .sort(([keyA, countA], [keyB, countB]) => countB - countA || keyA.localeCompare(keyB))
-        .slice(0, MAX_MISTAKE_ENTRIES),
-    [state.mistakes],
-  )
 
   const displayTime = isTimeBoundedRun(config) && remainingSeconds !== null
     ? formatTime(remainingSeconds)
@@ -174,29 +158,8 @@ export function TypingTestStatsRow({
           </span>
         )}
       </div>
-      {state.status === 'finished' && mistakeEntries.length > 0 && (
-        <div data-testid="typing-test-mistakes" className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-content-muted">
-          <span>{t('editor.typingTest.results.mistakesLabel')}:</span>
-          {mistakeEntries.map(([key, count]) => (
-            <span key={key} data-testid={`typing-test-mistake-${key}`} className="font-mono">
-              {key}:{count}
-            </span>
-          ))}
-        </div>
-      )}
-      {state.status === 'finished' && errorClasses && (
-        <div data-testid="typing-test-error-classes" className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-content-muted">
-          <span data-testid="typing-test-error-substitutions">
-            {t('editor.typingTest.results.errorSubstitutions', { count: errorClasses.substitutions })}
-          </span>
-          <span data-testid="typing-test-error-omissions">
-            {t('editor.typingTest.results.errorOmissions', { count: errorClasses.omissions })}
-          </span>
-          <span data-testid="typing-test-error-insertions">
-            {t('editor.typingTest.results.errorInsertions', { count: errorClasses.insertions })}
-          </span>
-        </div>
-      )}
+      {state.status === 'finished' && <MissedCharsList mistakes={state.mistakes} />}
+      {state.status === 'finished' && errorClasses && <ErrorClassLine errorClasses={errorClasses} />}
     </div>
   )
 }

--- a/src/renderer/typing-test/WordTimelineView.tsx
+++ b/src/renderer/typing-test/WordTimelineView.tsx
@@ -9,114 +9,29 @@
 // another modal (`useEscapeSwallow` alone would also block THIS view's
 // own close, since it swallows unconditionally with no action of its
 // own — see its doc comment).
+//
+// This component owns only the modal shell (backdrop, title, close
+// button) and the log fetch/loading/error states — the actual timeline
+// content (stat block, legend, zoom, rows) lives in
+// `KeystrokeTimelinePanel`, extracted out so a later PR can render the
+// identical content inline on the completion screen (see
+// .claude/plans/Plan-completion-timeline-view.md).
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ModalCloseButton } from '../components/editors/ModalCloseButton'
-import { AnalyzeStatGrid } from '../components/analyze/stat-card'
-import type { AnalyzeSummaryItem } from '../components/analyze/analyze-summary-table'
-import { TooltipShell, Stat } from '../components/analyze/analyze-tooltip'
-import { computeBubblePosition } from '../components/ui/Tooltip'
-import { formatDuration, formatPercentLabel, fmtMs } from '../components/analyze/analyze-format'
-import { formatWpm } from '../components/analyze/analyze-wpm'
-import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
 import { useEscapeCloseCapture } from '../hooks/useEscapeClose'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
-import type { KeystrokeSegment } from './word-timeline'
-import { WordTimelineRow, type HoverTarget } from './word-timeline-row'
-import { LineTimelineRow, type LineHoverTarget } from './LineTimelineRow'
-import { TIMELINE_LEGEND, type TimelineFillKind } from './word-timeline-colors'
-import { useTimelineModel } from './use-timeline-model'
-
-/** Floor for the "fit" zoom level's canvas width — a run with a very
- *  short `maxDisplayMs` (e.g. a single short word) would otherwise
- *  compute a fit width narrower than the modal itself. */
-const CANVAS_MIN_WIDTH_PX = 480
-/** The zoom slider's max is this many times the fit level — "10x the
- *  whole run visible at once" comfortably reaches individual-keystroke
- *  detail without an unbounded range that makes the slider imprecise. */
-const ZOOM_MAX_FACTOR = 10
-
-const LEGEND_ORDER = Object.keys(TIMELINE_LEGEND) as TimelineFillKind[]
+import { KeystrokeTimelinePanel } from './KeystrokeTimelinePanel'
 
 interface Props {
   uid: string
   runId: string
-  /** The already-displayed History row for this run, when known — reused
-   *  for the summary cards so they read identically to the row the user
-   *  opened this view from, rather than a second, possibly-divergent
-   *  computation over the same run. */
+  /** The already-displayed History row for this run, when known — see
+   *  `KeystrokeTimelinePanel`'s own doc comment on its `result` prop. */
   result?: TypingTestResult
   onClose: () => void
-}
-
-interface LegendSwatchProps {
-  colorClass: string
-  labelKey: string
-}
-
-function LegendSwatch({ colorClass, labelKey }: LegendSwatchProps) {
-  const { t } = useTranslation()
-  return (
-    <span className="flex items-center gap-1.5 text-2xs text-content-secondary">
-      <span className={`inline-block h-2.5 w-2.5 rounded-sm ${colorClass}`} aria-hidden="true" />
-      {t(labelKey)}
-    </span>
-  )
-}
-
-/** Collapses a `boolean | undefined` tri-state into one of three i18n
- *  keys — shared shape for "correctness" and "overlap", which were
- *  previously two structurally identical nested ternaries. */
-function triLabel(
-  value: boolean | undefined,
-  yesKey: string,
-  noKey: string,
-  unknownKey: string,
-  t: (key: string) => string,
-): string {
-  if (value === true) return t(yesKey)
-  if (value === false) return t(noKey)
-  return t(unknownKey)
-}
-
-/** The legend's `blank`/`leadIn` entries carry a line-view specific
- *  meaning (250ms cut, "before this line") distinct from the word view's
- *  (1000ms cut, "before this word") — every other legend entry (normal,
- *  mistake, overlap, unjudged) means the same thing in both modes. */
-function lineLegendLabelKey(kind: TimelineFillKind, displayMode: 'line' | 'word'): string {
-  if (displayMode === 'line' && kind === 'blank') return 'editor.typingTest.history.timeline.legend.blankLine'
-  if (displayMode === 'line' && kind === 'leadIn') return 'editor.typingTest.history.timeline.legend.leadInLine'
-  return TIMELINE_LEGEND[kind].labelKey
-}
-
-function keystrokeTooltipBody(word: string, seg: KeystrokeSegment, t: (key: string, opts?: Record<string, unknown>) => string) {
-  const correctnessText = triLabel(
-    seg.correct,
-    'editor.typingTest.history.timeline.tooltip.correct',
-    'editor.typingTest.history.timeline.tooltip.mistake',
-    'editor.typingTest.history.timeline.tooltip.unjudged',
-    t,
-  )
-  const overlapText = triLabel(
-    seg.overlapped,
-    'editor.typingTest.history.timeline.tooltip.overlapYes',
-    'editor.typingTest.history.timeline.tooltip.overlapNo',
-    'editor.typingTest.history.timeline.tooltip.overlapUnknown',
-    t,
-  )
-  const durationText = seg.openEnded
-    ? t('editor.typingTest.history.timeline.tooltip.releaseUnobserved')
-    : fmtMs(seg.endMs - seg.startMs)
-
-  return (
-    <TooltipShell header={`${word} · ${t('editor.typingTest.history.timeline.tooltip.offset', { ms: Math.round(seg.trueStartMs) })}`}>
-      <Stat label={seg.label || EMPTY_STAT_VALUE} value={durationText} />
-      <Stat label={t('editor.typingTest.history.timeline.stats.accuracy')} value={correctnessText} />
-      <Stat label={t('editor.typingTest.history.timeline.stats.overlap')} value={overlapText} />
-    </TooltipShell>
-  )
 }
 
 export function WordTimelineView({ uid, runId, result, onClose }: Props) {
@@ -143,160 +58,6 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
   // Nested inside the History modal — consume Escape in the capture
   // phase so History's own bubble-phase useEscapeClose never sees it.
   useEscapeCloseCapture(onClose)
-
-  const { displayMode, wordModel, lineModel, summary, activeMaxDisplayMs, activeCharCorrelationUnavailable } = useTimelineModel(log)
-
-  const containerRef = useRef<HTMLDivElement>(null)
-  const canvasRef = useRef<HTMLDivElement>(null)
-  const [fitPxPerMs, setFitPxPerMs] = useState<number | null>(null)
-  // Bumped from the canvas ref callback once the element actually mounts
-  // — see the effect below for why this, not just `[displayMode]`, is
-  // needed.
-  const [canvasMountTick, setCanvasMountTick] = useState(0)
-  const setCanvasNode = useCallback((node: HTMLDivElement | null) => {
-    canvasRef.current = node
-    if (node) setCanvasMountTick((t) => t + 1)
-  }, [])
-
-  const applyZoom = useCallback((next: number) => {
-    if (!displayMode || !canvasRef.current) return
-    canvasRef.current.style.width = `${Math.round(activeMaxDisplayMs * next)}px`
-  }, [displayMode, activeMaxDisplayMs])
-
-  // Whether the canvas is still at the "fit whole run in view" width —
-  // true from mount until the user first drags the slider away from it
-  // (see `handleZoomInput`). Read by the resize-driven recompute below so
-  // a window resize only ever re-applies a new fit width automatically
-  // while the user hasn't already chosen a different zoom level; once
-  // they have, a resize still refreshes `fitPxPerMs` (so the slider's own
-  // `min` stays accurate) without silently yanking their chosen zoom.
-  const isAtFitRef = useRef(true)
-
-  // Recompute the "fit whole run in view" zoom level from the
-  // container's actual available width — subtracting its own horizontal
-  // padding (`getComputedStyle`, not a hardcoded pixel guess) since the
-  // canvas renders as a direct, unpadded child: using the container's
-  // raw `clientWidth` (which INCLUDES its own padding) sized the canvas
-  // 16px too wide, so the container always showed a horizontal
-  // scrollbar even for a run that fit. Falls back to `CANVAS_MIN_WIDTH_PX`
-  // when the resulting width would be narrower than that floor (a run
-  // with very little content, or — in tests — jsdom's `clientWidth`
-  // always reading 0 since it never implements layout).
-  const computeAndApplyFit = useCallback(() => {
-    if (!displayMode || activeMaxDisplayMs <= 0) return
-    const container = containerRef.current
-    if (!container) return
-    const styles = window.getComputedStyle(container)
-    const paddingX = parseFloat(styles.paddingLeft || '0') + parseFloat(styles.paddingRight || '0')
-    const width = Math.max(container.clientWidth - paddingX, CANVAS_MIN_WIDTH_PX)
-    const fit = width / activeMaxDisplayMs
-    setFitPxPerMs(fit)
-    if (isAtFitRef.current) applyZoom(fit)
-  }, [displayMode, activeMaxDisplayMs, applyZoom])
-
-  // Compute the fit level once the model is known AND the canvas has
-  // actually mounted. Keying only on `[displayMode]` (the original
-  // approach) breaks because `setLog` and `setLoading` flush in separate
-  // microtasks: `displayMode` (derived from `log`) can become non-null
-  // on a render where `loading` is STILL true, before the JSX gating
-  // this section (`!loading && ... && displayMode`) has ever rendered
-  // the container/canvas — `containerRef`/`canvasRef` are still null on
-  // that render, and the fit falls back to `CANVAS_MIN_WIDTH_PX`
-  // regardless of the real container width. Depending on the canvas's
-  // own mount (bumped from its ref callback, which fires once loading
-  // has actually flipped and the section is in the DOM) instead of just
-  // `displayMode` guarantees this runs again once the refs are live.
-  useEffect(() => {
-    if (!canvasRef.current) return
-    computeAndApplyFit()
-  }, [canvasMountTick, computeAndApplyFit])
-
-  // Re-fit on window resize (a maximize/restore, or the user dragging the
-  // window edge) — the initial-fit effect above only ever runs once per
-  // mount/model change, so without this a resize left the canvas at
-  // whatever width the ORIGINAL window size computed, either wasting new
-  // space or reintroducing the very overflow this fix exists to remove.
-  useEffect(() => {
-    const container = containerRef.current
-    if (!container || !displayMode) return
-    const observer = new ResizeObserver(() => computeAndApplyFit())
-    observer.observe(container)
-    return () => observer.disconnect()
-  }, [displayMode, computeAndApplyFit])
-
-  // Live drag: this fires on every tick (React's onChange for a range
-  // input maps to the native 'input' event) but only ever touches the
-  // DOM directly — no setState, so nothing in the row tree re-renders
-  // while dragging (rows are memoized on `word`/`maxDisplayMs`, neither
-  // of which this touches).
-  const handleZoomInput = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    isAtFitRef.current = Number(e.target.value) === fitPxPerMs
-    applyZoom(Number(e.target.value))
-  }, [applyZoom, fitPxPerMs])
-
-  // Discriminated union: word rows report a `WordTimelineWord`, line rows
-  // report the line's own joined text — the two modes are mutually
-  // exclusive (see `displayMode`), so only one branch is ever set, but
-  // both need distinct handlers to stay type-safe without threading a
-  // `word.display`-shaped fake through the line path.
-  type Hover = ({ kind: 'word' } & HoverTarget) | ({ kind: 'line' } & LineHoverTarget)
-  const [hover, setHover] = useState<Hover | null>(null)
-  const handleWordHover = useCallback((t: HoverTarget) => setHover({ kind: 'word', ...t }), [])
-  const handleLineHover = useCallback((t: LineHoverTarget) => setHover({ kind: 'line', ...t }), [])
-  const handleHoverEnd = useCallback(() => setHover(null), [])
-
-  // Tooltip position — measure-then-position, same idiom as
-  // `Tooltip.tsx`: read the bubble's own just-rendered size inside a
-  // layout effect (runs before paint) so the very first frame the user
-  // sees is already the clamped position, never the raw
-  // `hover.rect.left/bottom` math (which can render off-screen near the
-  // modal's edge at high zoom).
-  const tooltipRef = useRef<HTMLDivElement>(null)
-  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null)
-  useLayoutEffect(() => {
-    if (!hover || !tooltipRef.current) { setTooltipPos(null); return }
-    setTooltipPos(computeBubblePosition(
-      hover.rect,
-      tooltipRef.current.getBoundingClientRect(),
-      'bottom',
-      'start',
-      6,
-      { width: window.innerWidth, height: window.innerHeight },
-    ))
-  }, [hover])
-
-  const summaryItems: AnalyzeSummaryItem[] = useMemo(() => {
-    if (!summary) return []
-    return [
-      {
-        // `result.wpm` is the run's own WPM (words/min over the whole run,
-        // the same figure History's own row shows) — a genuinely
-        // different metric from the model-derived `avgPace` (a
-        // char-weighted rate over words' own true spans, excluding
-        // inter-word time; see WordTimelineSummary.avgPace's doc
-        // comment). Distinct label so this card never claims to be
-        // "Word Pace" when it's actually showing the run-wide figure.
-        labelKey: result
-          ? 'editor.typingTest.history.timeline.stats.runWpm'
-          : 'editor.typingTest.history.timeline.stats.wordPace',
-        value: result ? formatWpm(result.wpm) : (summary.avgPace !== undefined ? formatWpm(summary.avgPace) : EMPTY_STAT_VALUE),
-      },
-      {
-        labelKey: 'editor.typingTest.history.timeline.stats.accuracy',
-        value: result
-          ? formatPercentLabel(result.accuracy / 100)
-          : formatPercentLabel(summary.avgAccuracy !== undefined ? summary.avgAccuracy / 100 : undefined),
-      },
-      {
-        labelKey: 'editor.typingTest.history.timeline.stats.overlap',
-        value: formatPercentLabel(summary.avgOverlap),
-      },
-      {
-        labelKey: 'editor.typingTest.history.timeline.stats.duration',
-        value: result ? formatDuration(result.durationSeconds) : EMPTY_STAT_VALUE,
-      },
-    ]
-  }, [summary, result])
 
   return (
     <div
@@ -338,116 +99,8 @@ export function WordTimelineView({ uid, runId, result, onClose }: Props) {
           </p>
         )}
 
-        {!loading && !loadError && displayMode && (
-          <div className="flex min-h-0 flex-1 flex-col gap-3">
-            {/* Deliberate exception to the Analyze chart-above-stats rule
-                (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
-                this grid is the modal's summary header, not a chart-adjacent
-                stat row — it must sit above the legend/zoom controls and the
-                canvas, all of which the user reads top-to-bottom before ever
-                reaching the scrollable, flex-grow canvas below. */}
-            <AnalyzeStatGrid items={summaryItems} ariaLabelKey="editor.typingTest.history.timeline.modalTitle" />
-
-            {activeCharCorrelationUnavailable && (
-              <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
-                {t('editor.typingTest.history.timeline.correlationUnreliable')}
-              </p>
-            )}
-
-            {/* Legend — color alone never carries meaning elsewhere in
-                this view (tooltips spell everything out too), but this
-                is the at-a-glance key. Line-mode overrides the blank/
-                lead-in wording to the line-view's own meaning (a 250ms
-                cut and "before this line", not the word view's 1000ms /
-                "before this word") — every other entry, and the word
-                view's own wording, stays unchanged. */}
-            <div className="flex flex-wrap items-center gap-3 rounded-md border border-edge bg-surface px-3 py-1.5">
-              {LEGEND_ORDER.map((kind) => (
-                <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
-              ))}
-            </div>
-            <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.legend.correctedNote')}</p>
-            <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.axisNote')}</p>
-
-            {/* Zoom — same row shape as RGBConfigurator's brightness
-                slider (the only existing range-input precedent). The
-                slider only mounts once `fitPxPerMs` is known, so its
-                (uncontrolled) `defaultValue` is always correct at
-                first paint — no remount-on-resolve hack needed. The
-                WHOLE row (including its label) is gated on `fitPxPerMs`,
-                not just the input — a log with zero drawable content
-                (`maxDisplayMs <= 0`) never computes a fit level, and an
-                orphan "Zoom" label with no control under it read as
-                broken rather than as "nothing to zoom". */}
-            {fitPxPerMs !== null && (
-              <div className="flex items-center gap-3">
-                <label className="text-sm text-content-secondary">{t('editor.typingTest.history.timeline.zoom.label')}</label>
-                <input
-                  type="range"
-                  data-testid="word-timeline-zoom"
-                  aria-label={t('editor.typingTest.history.timeline.zoom.aria')}
-                  min={fitPxPerMs}
-                  max={fitPxPerMs * ZOOM_MAX_FACTOR}
-                  step={fitPxPerMs / 20}
-                  defaultValue={fitPxPerMs}
-                  onChange={handleZoomInput}
-                  className="flex-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-                />
-              </div>
-            )}
-
-            <div ref={containerRef} className="relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2">
-              <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
-                {displayMode === 'line' && lineModel
-                  ? lineModel.lines.map((line) => (
-                    <LineTimelineRow
-                      key={line.lineIndex}
-                      line={line}
-                      maxDisplayMs={lineModel.maxDisplayMs}
-                      romajiInput={log?.romajiInput === true}
-                      onHover={handleLineHover}
-                      onHoverEnd={handleHoverEnd}
-                    />
-                  ))
-                  : wordModel?.words.map((word) => (
-                    <WordTimelineRow
-                      key={word.index}
-                      word={word}
-                      maxDisplayMs={wordModel.maxDisplayMs}
-                      onHover={handleWordHover}
-                      onHoverEnd={handleHoverEnd}
-                    />
-                  ))}
-              </div>
-
-              {hover && (
-                <div
-                  ref={tooltipRef}
-                  className="pointer-events-none fixed z-70"
-                  style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 6 }}
-                  data-testid="word-timeline-tooltip"
-                >
-                  {hover.segment.kind === 'keystroke'
-                    ? keystrokeTooltipBody(hover.kind === 'word' ? hover.word.display : hover.lineText, hover.segment, t)
-                    : (
-                      <TooltipShell>
-                        <Stat
-                          label={t(lineLegendLabelKey(hover.segment.kind === 'blank' ? 'blank' : 'leadIn', hover.kind === 'line' ? 'line' : 'word'))}
-                          value={t(
-                            hover.segment.kind === 'blank'
-                              ? 'editor.typingTest.history.timeline.tooltip.blankDuration'
-                              : (hover.kind === 'line'
-                                ? 'editor.typingTest.history.timeline.tooltip.leadInLineDuration'
-                                : 'editor.typingTest.history.timeline.tooltip.leadInDuration'),
-                            { ms: Math.round(hover.segment.trueDurationMs) },
-                          )}
-                        />
-                      </TooltipShell>
-                    )}
-                </div>
-              )}
-            </div>
-          </div>
+        {!loading && !loadError && log && (
+          <KeystrokeTimelinePanel log={log} result={result} />
         )}
       </div>
     </div>

--- a/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
+++ b/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { KeystrokeTimelinePanel } from '../KeystrokeTimelinePanel'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+/** No keystroke carries an `overlapped` verdict — keeps `avgOverlap`
+ *  (and thus the Overlap card) deterministically `undefined` regardless
+ *  of which fixture variant a test uses, so tests don't have to hand-
+ *  compute the pooled overlap ratio just to assert on unrelated cards. */
+const SAMPLE_LOG: RunKeystrokeLog = {
+  runId: 'run-1',
+  uid: 'uid-1',
+  startedAt: '2026-01-01T00:00:00.000Z',
+  durationMs: 5000,
+  mode: 'words',
+  language: 'english',
+  words: [
+    {
+      index: 0,
+      display: 'hi',
+      typed: 'hi',
+      correct: true,
+      keystrokes: [
+        { pressMs: 0, releaseMs: 60, keycode: 0, row: 0, col: 0, correct: true, expectedChar: 'h' },
+        { pressMs: 80, releaseMs: 140, keycode: 0, row: 0, col: 1, correct: true, expectedChar: 'i' },
+      ],
+    },
+  ],
+}
+
+function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+  return {
+    date: '2026-01-01T00:00:00.000Z',
+    wpm: 42,
+    accuracy: 95,
+    wordCount: 10,
+    correctChars: 50,
+    incorrectChars: 2,
+    durationSeconds: 10,
+    ...overrides,
+  }
+}
+
+/** Finds the StatCard for a given label text and returns its whole
+ *  textContent (label + value + unit + context) — StatCard doesn't
+ *  expose a per-card testid via `AnalyzeStatGrid`, so this walks up from
+ *  the label span to the card's own container div. */
+function statCardText(labelText: string): string {
+  const label = screen.getByText(labelText)
+  return label.parentElement?.textContent ?? ''
+}
+
+describe('KeystrokeTimelinePanel', () => {
+  it('shows every unified stat card sourced from the result when one is supplied', () => {
+    const result = makeResult({
+      wpm: 42,
+      accuracy: 95,
+      wordCount: 10,
+      durationSeconds: 10,
+      kspcKeystrokes: 12,
+      kspcChars: 10,
+    })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    expect(statCardText('Run WPM')).toContain('42.0')
+    expect(statCardText('KPM')).toContain('300') // (50 correctChars * 60) / 10s
+    expect(statCardText('Accuracy')).toContain('95.0%')
+    expect(statCardText('KSPC')).toContain('1.20') // 12 keystrokes / 10 chars
+    expect(statCardText('Time')).toContain('0:10')
+    expect(statCardText('Words')).toContain('10')
+    // No keystroke in the fixture carries an overlap verdict.
+    expect(statCardText('Overlap')).toContain('—')
+  })
+
+  it('falls back to the model/log-derived values for WPM/Accuracy/Time, and EMPTY_STAT_VALUE for KPM/KSPC/Words, when no result is supplied', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+
+    expect(screen.getByText('Word Pace')).toBeTruthy()
+    expect(screen.queryByText('Run WPM')).toBeNull()
+    // Time falls back to the resolved log's own durationMs (5000ms -> 5s).
+    expect(statCardText('Time')).toContain('0:05')
+    expect(statCardText('KPM')).toContain('—')
+    expect(statCardText('KSPC')).toContain('—')
+    expect(statCardText('Words')).toContain('—')
+  })
+
+  it('renders the legend and one row per word', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    expect(screen.getByText('Normal keystroke')).toBeTruthy()
+    expect(screen.getByText('Mistake')).toBeTruthy()
+    expect(screen.getByTestId('word-timeline-row-0')).toBeTruthy()
+    expect(screen.getAllByTestId('word-timeline-keystroke')).toHaveLength(2)
+  })
+
+  it('shows the Missed characters list and error-mix line when the result carries them', () => {
+    const result = makeResult({
+      mistakes: { a: 3, b: 1 },
+      errorSubstitutions: 2,
+      errorOmissions: 1,
+      errorInsertions: 0,
+      errorTargetChars: 20,
+    })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    expect(screen.getByTestId('typing-test-mistakes')).toBeTruthy()
+    expect(screen.getByTestId('typing-test-mistake-a').textContent).toBe('a:3')
+    expect(screen.getByTestId('typing-test-error-classes')).toBeTruthy()
+    expect(screen.getByTestId('typing-test-error-substitutions').textContent).toContain('2')
+  })
+
+  it('omits the Missed/error-mix section entirely when the result has neither (not a "-" placeholder)', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
+    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+    expect(screen.queryByTestId('typing-test-error-classes')).toBeNull()
+  })
+
+  it('omits the Missed/error-mix section when no result is supplied at all', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+    expect(screen.queryByTestId('typing-test-error-classes')).toBeNull()
+  })
+})

--- a/src/renderer/typing-test/keystroke-timeline-stats.ts
+++ b/src/renderer/typing-test/keystroke-timeline-stats.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Builds the unified stat-card list `KeystrokeTimelinePanel` shows — the
+// same seven figures (WPM, KPM, Accuracy, KSPC, Time, Words, Overlap) in
+// both the History timeline modal and (a later PR) the inline completion
+// screen, so a run reads identically in either place. See
+// .claude/plans/Plan-completion-timeline-view.md PR-A spec point 2.
+//
+// Fallback scope is deliberately narrow: only WPM, Accuracy, Time, and
+// Overlap have a value when `result` is absent —
+//  - WPM/Accuracy fall back to the run-wide pooled figures
+//    `WordTimelineSummary` already computed pre-unification
+//    (`avgPace`/`avgAccuracy`), the same fallback the modal's summary
+//    cards used before this module existed.
+//  - Time falls back to the resolved log's own `durationMs` — a raw log
+//    fact, not a model derivation, but available unconditionally since
+//    `KeystrokeTimelinePanel` always receives the log itself.
+//  - Overlap has no `TypingTestResult` equivalent at all (that field was
+//    never recorded on the result), so it is ALWAYS model-derived.
+// KPM, KSPC, and Words stay result-only: reconstructing them from the raw
+// log would mean re-deriving scoring rules run-state.ts already owns
+// (confirmed-char counting, romaji segment credit, KSPC's
+// IME-uncomputable gate, ...) — a second, possibly-diverging
+// implementation of the same math that this module deliberately avoids.
+// Without a result these three read as `EMPTY_STAT_VALUE`, the same
+// convention History already uses for a legacy/uncomputable row.
+
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+import type { WordTimelineSummary } from './word-timeline'
+import type { AnalyzeSummaryItem } from '../components/analyze/analyze-summary-table'
+import { formatDuration, formatPercentLabel } from '../components/analyze/analyze-format'
+import { formatWpm } from '../components/analyze/analyze-wpm'
+import { formatKspc } from '../../shared/kspc'
+import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
+import { resultKpm, resultKspc } from './result-builder'
+
+/** Ordered stat cards for `AnalyzeStatGrid` — see the module doc comment
+ *  for the fallback rule each card follows. `summary` is `null` only
+ *  while the model hasn't resolved yet (never true once
+ *  `KeystrokeTimelinePanel` actually renders this row; kept nullable so
+ *  callers can gate the whole grid on it same as before). */
+export function buildTimelineStatItems(
+  result: TypingTestResult | undefined,
+  summary: WordTimelineSummary | null,
+  log: RunKeystrokeLog,
+): AnalyzeSummaryItem[] {
+  if (!summary) return []
+
+  const kspc = result ? resultKspc(result) : null
+  const durationSeconds = result ? result.durationSeconds : Math.round(log.durationMs / 1000)
+
+  return [
+    {
+      // `result.wpm` is the run's own WPM (words/min over the whole run,
+      // the same figure History's own row shows) — a genuinely different
+      // metric from the model-derived `avgPace` (a char-weighted rate
+      // over words' own true spans, excluding inter-word time; see
+      // `WordTimelineSummary.avgPace`'s doc comment). Distinct label so
+      // this card never claims to be "Word Pace" when it's actually
+      // showing the run-wide figure.
+      labelKey: result
+        ? 'editor.typingTest.history.timeline.stats.runWpm'
+        : 'editor.typingTest.history.timeline.stats.wordPace',
+      value: result ? formatWpm(result.wpm) : (summary.avgPace !== undefined ? formatWpm(summary.avgPace) : EMPTY_STAT_VALUE),
+    },
+    {
+      labelKey: 'editor.typingTest.kpm',
+      value: result ? resultKpm(result) : EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.history.timeline.stats.accuracy',
+      value: result
+        ? formatPercentLabel(result.accuracy / 100)
+        : formatPercentLabel(summary.avgAccuracy !== undefined ? summary.avgAccuracy / 100 : undefined),
+    },
+    {
+      labelKey: 'editor.typingTest.kspc',
+      value: kspc !== null ? formatKspc(kspc) : EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.time',
+      value: formatDuration(durationSeconds),
+    },
+    {
+      labelKey: 'editor.typingTest.words',
+      value: result ? result.wordCount : EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.history.timeline.stats.overlap',
+      value: formatPercentLabel(summary.avgOverlap),
+    },
+  ]
+}

--- a/src/renderer/typing-test/mistake-summary.tsx
+++ b/src/renderer/typing-test/mistake-summary.tsx
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Shared "missed characters" list + error-class (Substitution/Omission/
+// Insertion) line — extracted out of `TypingTestStatsRow` (the
+// completion screen's finished-state summary) so `KeystrokeTimelinePanel`
+// can show the identical presentation for a `TypingTestResult` without a
+// second, drifting implementation of the same sort/slice/testid logic.
+// See .claude/plans/Plan-completion-timeline-view.md PR-A spec point 2.
+
+import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+
+// Caps how many distinct mistake keys are shown, so a run with many
+// small errors doesn't turn the list into an unbounded wall of text.
+export const MAX_MISTAKE_ENTRIES = 12
+
+/** Sorted by count DESC then key ASC (ties break deterministically
+ *  instead of on object insertion order), capped to `max` entries. */
+export function sortedMistakeEntries(mistakes: Record<string, number>, max: number = MAX_MISTAKE_ENTRIES): [string, number][] {
+  return Object.entries(mistakes)
+    .sort(([keyA, countA], [keyB, countB]) => countB - countA || keyA.localeCompare(keyB))
+    .slice(0, max)
+}
+
+interface MissedCharsListProps {
+  mistakes: Record<string, number>
+}
+
+/** Renders nothing when `mistakes` has no entries — omitted entirely
+ *  rather than a '-' placeholder, matching this run's "the metric
+ *  doesn't apply" convention (a run with zero mistakes is common, not an
+ *  in-progress state). */
+export function MissedCharsList({ mistakes }: MissedCharsListProps) {
+  const { t } = useTranslation()
+  const entries = useMemo(() => sortedMistakeEntries(mistakes), [mistakes])
+  if (entries.length === 0) return null
+  return (
+    <div data-testid="typing-test-mistakes" className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-content-muted">
+      <span>{t('editor.typingTest.results.mistakesLabel')}:</span>
+      {entries.map(([key, count]) => (
+        <span key={key} data-testid={`typing-test-mistake-${key}`} className="font-mono">
+          {key}:{count}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export interface ErrorClassCounts {
+  substitutions: number
+  omissions: number
+  insertions: number
+}
+
+interface ErrorClassLineProps {
+  errorClasses: ErrorClassCounts
+}
+
+/** Raw Substitution/Omission/Insertion counts (see
+ *  `TypingTestResult.errorSubstitutions` et al.) — the caller withholds
+ *  this entirely (never renders a '-' row) when the run has no error-class
+ *  group at all (romaji run, no finalized words, legacy result). */
+export function ErrorClassLine({ errorClasses }: ErrorClassLineProps) {
+  const { t } = useTranslation()
+  return (
+    <div data-testid="typing-test-error-classes" className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-content-muted">
+      <span data-testid="typing-test-error-substitutions">
+        {t('editor.typingTest.results.errorSubstitutions', { count: errorClasses.substitutions })}
+      </span>
+      <span data-testid="typing-test-error-omissions">
+        {t('editor.typingTest.results.errorOmissions', { count: errorClasses.omissions })}
+      </span>
+      <span data-testid="typing-test-error-insertions">
+        {t('editor.typingTest.results.errorInsertions', { count: errorClasses.insertions })}
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Extracts the Keystroke Timeline modal's content (zoom, hover tooltips, legend, line/word rows) into `KeystrokeTimelinePanel`, a pure component taking an already-resolved log — groundwork for rendering the timeline inline on the typing-test completion screen (follow-up PR). `WordTimelineView` shrinks 456→108 lines to a modal shell + log fetch.
- Unifies the stats both surfaces show: RUN WPM / KPM / Accuracy / KSPC / Time / Words / Overlap cards plus the Missed list and Substitution/Omission/Insertion counts, sourced from the result with model-derived fallbacks (overlap, duration, pace/accuracy) — the completion screen's own mistake-summary pieces were extracted (`mistake-summary.tsx`) and reused rather than duplicated; the stat builder lives in `keystroke-timeline-stats.ts` for isolated testing.
- Zero new i18n keys (existing typing-test labels reused; "Duration" card deliberately renamed to the shared "Time" label).

## Verification
- Behavior-preserving: all 15 pre-existing WordTimelineView tests pass unmodified; measured baseline 8,349 → 8,355 passed / 22 skipped (+6 = the new panel suite exactly).
- Virtual-device Playwright check: real consent→run→History→timeline flow asserting every unified stat card's value in the modal DOM.
- eslint / typecheck clean; all files within size caps.