### PR TITLE
feat(ui): show the keystroke timeline on the typing-test completion screen

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.65",
+  "version": "0.1.67",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -270,7 +270,6 @@
       "exitTypingMode": "タイピングテスト終了",
       "restart": "やり直す",
       "nextTest": "次のテスト",
-      "complete": "完了",
       "collapseSettings": "設定を閉じる",
       "expandSettings": "設定を開く",
       "keymapToggle": "キーマップ",
@@ -555,7 +554,8 @@
             "leadIn": "ワード前の間",
             "blankLine": "ブランク（250ms超、圧縮表示）",
             "leadInLine": "行前の間",
-            "correctedNote": "ミスの印には提出前に修正された打鍵も含まれます。ミスの印があっても正確度100%になることがあります。"
+            "correctedNote": "ミスの印には提出前に修正された打鍵も含まれます。ミスの印があっても正確度100%になることがあります。",
+            "infoAriaLabel": "凡例の補足情報"
           },
           "axisNote": "ブランクは軸上で圧縮表示されています。表示される時間は全て実際の値です。",
           "correlationUnreliable": "このランは正誤の印が不正確な場合があります（IME変換を経由した入力が含まれています）。",
@@ -586,7 +586,8 @@
         "mistakesLabel": "ミス文字",
         "errorSubstitutions": "置換 {{count}}",
         "errorOmissions": "脱字 {{count}}",
-        "errorInsertions": "衍字 {{count}}"
+        "errorInsertions": "衍字 {{count}}",
+        "timelineConsentHint": "打鍵タイムラインを表示するには、タイピングの記録を有効にしてください。"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.65",
+  "version": "0.1.67",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -270,7 +270,6 @@
       "exitTypingMode": "テスト終わりっしょ！",
       "restart": "もう一回☆",
       "nextTest": "次のテストいくよ☆",
-      "complete": "できたし！",
       "collapseSettings": "設定閉じるっしょ",
       "expandSettings": "設定開くっしょ",
       "keymapToggle": "キーマップ☆",
@@ -555,7 +554,8 @@
             "leadIn": "ワード前の間",
             "blankLine": "ブランク（250ms超、圧縮表示だよ）",
             "leadInLine": "行前の間じゃん",
-            "correctedNote": "ミスの印、提出前に直したのも入ってるから、印あっても正確度100%になることあるよ"
+            "correctedNote": "ミスの印、提出前に直したのも入ってるから、印あっても正確度100%になることあるよ",
+            "infoAriaLabel": "凡例の補足情報"
           },
           "axisNote": "ブランクは軸上で圧縮して表示してるけど、出てる時間は全部リアルな値だよ",
           "correlationUnreliable": "このラン、正誤の印あてにならないかも（IME変換通った入力あるから）",
@@ -586,7 +586,8 @@
         "mistakesLabel": "ミスった文字ｗ",
         "errorSubstitutions": "置換 {{count}}こ",
         "errorOmissions": "脱字 {{count}}こ",
-        "errorInsertions": "衍字 {{count}}こ"
+        "errorInsertions": "衍字 {{count}}こ",
+        "timelineConsentHint": "打鍵タイムライン見たいなら、タイピング記録オンにしてね☆"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.65",
+  "version": "0.1.67",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -270,7 +270,6 @@
       "exitTypingMode": "テスト終わりどすえ",
       "restart": "もういっぺんどすえ",
       "nextTest": "次のテストどすえ",
-      "complete": "できましたえ",
       "collapseSettings": "設定を閉じますえ",
       "expandSettings": "設定を開きますえ",
       "keymapToggle": "キーマップ",
@@ -555,7 +554,8 @@
             "leadIn": "ワード前の間どすえ",
             "blankLine": "ブランク（250ms超、圧縮して表示どすえ）",
             "leadInLine": "行前の間どすえ",
-            "correctedNote": "ミスの印には提出前に直さはった打鍵も入ってますよって、印があっても正確度100%になることがおすえ"
+            "correctedNote": "ミスの印には提出前に直さはった打鍵も入ってますよって、印があっても正確度100%になることがおすえ",
+            "infoAriaLabel": "凡例の補足情報"
           },
           "axisNote": "ブランクはこの軸の上で圧縮して表示してますけど、出てる時間はどれも本当の値どすえ",
           "correlationUnreliable": "このランは正誤の印が正しないことがおすえ（IME変換を通した入力が入ってますよって）",
@@ -586,7 +586,8 @@
         "mistakesLabel": "ミス文字どすえ",
         "errorSubstitutions": "置換 {{count}}どす",
         "errorOmissions": "脱字 {{count}}どす",
-        "errorInsertions": "衍字 {{count}}どす"
+        "errorInsertions": "衍字 {{count}}どす",
+        "timelineConsentHint": "打鍵タイムラインを見とうおすなら、タイピングの記録を有効にしておくれやすどす。"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.65",
+  "version": "0.1.67",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -270,7 +270,6 @@
       "exitTypingMode": "試練を終える",
       "restart": "初めから",
       "nextTest": "次なる試練へ",
-      "complete": "成就",
       "collapseSettings": "設定を畳む",
       "expandSettings": "設定を広げる",
       "keymapToggle": "配列表",
@@ -555,7 +554,8 @@
             "leadIn": "ワード前の間",
             "blankLine": "間（250ms超、圧縮して表示）",
             "leadInLine": "行前の間",
-            "correctedNote": "誤りの印には提出前に訂正された打鍵も含まれております。印があっても正確度100%となることがございます。"
+            "correctedNote": "誤りの印には提出前に訂正された打鍵も含まれております。印があっても正確度100%となることがございます。",
+            "infoAriaLabel": "凡例の補足情報"
           },
           "axisNote": "間は軸上で圧縮して表示しておりますが、表示される時間はいずれも実際の値でございます。",
           "correlationUnreliable": "このランは正誤の印が不正確な場合がございます（IME変換を経た入力が含まれております）。",
@@ -586,7 +586,8 @@
         "mistakesLabel": "過ちの文字",
         "errorSubstitutions": "置換 {{count}}",
         "errorOmissions": "脱字 {{count}}",
-        "errorInsertions": "衍字 {{count}}"
+        "errorInsertions": "衍字 {{count}}",
+        "timelineConsentHint": "打鍵タイムラインをご覧いただくには、タイピングの記録をお許しくださいませ。"
       }
     }
   },

--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -86,7 +86,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     matrixMode, pressedKeys, everPressedKeys, hasMatrixTester,
     handleMatrixToggle, handleTypingTestToggle,
     typingTest, handleTypingTestConfigChange, handleTypingTestLanguageChange,
-    finishedResult, nameFinishedResult,
+    finishedResult, nameFinishedResult, lastFinishedLog,
     pauseTypingTest, resumeTypingTest, restartTypingTestFromStart,
   } = useInputModes({
     rows, cols, getMatrixState, unlocked, onUnlock, onMatrixModeChange, keymap,
@@ -390,6 +390,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
               hasSavedMemory={!!savedTypingTestMemory}
               finishedResult={finishedResult}
               onNameFinishedResult={nameFinishedResult}
+              lastFinishedLog={lastFinishedLog}
               onPauseTest={pauseTypingTest}
               onResumeTest={resumeTypingTest}
               onRestartTestFromStart={restartTypingTestFromStart}

--- a/src/renderer/components/editors/KeymapTypingTestPane.tsx
+++ b/src/renderer/components/editors/KeymapTypingTestPane.tsx
@@ -6,6 +6,7 @@ import type { KeymapEditorProps } from './keymap-editor-types'
 import type { KleKey } from '../../../shared/kle/types'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 import type { useTypingTest } from '../../typing-test/useTypingTest'
 import type { LineSnapshot } from '../../typing-test/TypingTestView'
 
@@ -34,6 +35,12 @@ export interface KeymapTypingTestPaneProps extends KeymapEditorProps {
   hasSavedMemory?: boolean
   finishedResult?: TypingTestResult | null
   onNameFinishedResult?: (name: string) => void
+  /** The just-finished run's in-memory raw keystroke log — forwarded to
+   *  `TypingTestPane`/`TypingTestView` so the completion screen can render
+   *  the shared `KeystrokeTimelinePanel` inline, no IPC round-trip needed
+   *  (Plan-completion-timeline-view PR-B). See `useTypingTestResultSave`'s
+   *  own doc comment on `lastFinishedLog`. */
+  lastFinishedLog?: RunKeystrokeLog | null
   onPauseTest?: () => void
   onResumeTest?: () => void
   onRestartTestFromStart?: () => void
@@ -59,7 +66,7 @@ export function KeymapTypingTestPane({
   remapLabel, layoutOptions, scale, keys, layerLabel, contentRef,
   hasSavedMemory, typingTestDisplayLines, typingTestFontSize, onTypingTestDisplayLinesChange, onTypingTestFontSizeChange,
   typingTestHideKeymap, typingTestHideStatsRow, typingTestHideControls, typingTestSaveUnnamed,
-  finishedResult, onNameFinishedResult, typingTestComparisonBaselines,
+  finishedResult, onNameFinishedResult, lastFinishedLog, typingTestComparisonBaselines,
   onTypingTestHideKeymapChange, onTypingTestHideStatsRowChange, onTypingTestHideControlsChange, onTypingTestSaveUnnamedChange, onTypingTestComparisonBaselineChange,
   typingTestSettingsPanelOpen, onTypingTestSettingsPanelOpenChange,
   onPauseTest, onResumeTest, onRestartTestFromStart,
@@ -109,6 +116,7 @@ export function KeymapTypingTestPane({
       saveUnnamed={typingTestSaveUnnamed}
       finishedResult={finishedResult}
       onNameFinishedResult={onNameFinishedResult}
+      lastFinishedLog={lastFinishedLog}
       comparisonBaselines={typingTestComparisonBaselines}
       onToggleHideKeymap={onTypingTestHideKeymapChange}
       onToggleHideStatsRow={onTypingTestHideStatsRowChange}

--- a/src/renderer/components/editors/TypingTestPane.tsx
+++ b/src/renderer/components/editors/TypingTestPane.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TypingTestView } from '../../typing-test/TypingTestView'
+import { TypingTestControlsRow } from '../../typing-test/TypingTestControlsRow'
 import { buildResultNameChips } from '../../typing-test/result-builder'
 import { PauseResumeModal } from '../../typing-test/PauseResumeModal'
 import { TypingRecordingConsentModal } from '../../typing-test/TypingRecordingConsentModal'
@@ -55,6 +56,7 @@ export function TypingTestPane({
   onToggleSaveUnnamed,
   finishedResult,
   onNameFinishedResult,
+  lastFinishedLog,
   comparisonBaselines,
   onComparisonBaselineChange,
   settingsPanelOpen = true,
@@ -183,6 +185,16 @@ export function TypingTestPane({
     setViewOnlyControlsOpen(true)
   }, [])
 
+  // Completion screen (Plan-completion-timeline-view PR-B): the keymap
+  // pane + its layer-tracking note describe the KEYMAP, which is no
+  // longer the point once a run finishes and the reading window gives
+  // way to the inline keystroke timeline (see TypingTestView) — hidden
+  // alongside it. Editor-only: view-only's own keyboard display is
+  // deliberately independent of both `hideKeymap` and this (see the
+  // existing "Keymap hidden only in the editor view" comment below), so
+  // a view-only run reaching 'finished' keeps showing its keyboard.
+  const hideKeyboardForFinish = !viewOnly && typingTest.state.status === 'finished'
+
   return (
     <>
       {showConsentModal && (
@@ -239,11 +251,18 @@ export function TypingTestPane({
           handleComparisonChange={handleComparisonChange}
         />
       )}
-      <div className={viewOnly ? 'contents' : 'flex min-w-0 flex-1 flex-col items-center'}>
+      {/* `min-h-0` (added alongside the pre-existing `flex-1`) is part of
+          the completion screen's flex-height chain — see
+          TypingTestView.tsx's own "Completion screen" comment for the
+          full chain this is one link of. Without it, this flex item
+          defaults to `min-height: auto` (its own content's natural
+          height), which can grow past what its parent (KeymapEditor's
+          `overflow-auto` content pane, several levels up) actually has
+          available, instead of correctly deferring to it. */}
+      <div className={viewOnly ? 'contents' : 'flex min-h-0 min-w-0 flex-1 flex-col items-center'}>
       {!viewOnly && (
         <TypingTestView
           hideStatsRow={hideStatsRow}
-          hideControls={hideControls}
           comparison={comparison}
           state={typingTest.state}
           wpm={typingTest.wpm}
@@ -273,6 +292,8 @@ export function TypingTestPane({
           onResume={() => setShowResumeModal(true)}
           hasSavedMemory={hasSavedMemory}
           lineSnapshotRef={lineSnapshotRef}
+          lastFinishedLog={lastFinishedLog}
+          finishedResult={finishedResult}
         />
       )}
       <div
@@ -293,8 +314,10 @@ export function TypingTestPane({
           <div className="shrink-0">
           <div className="w-fit">
           {/* Keymap hidden only in the editor view — view-only mode is
-              keyboard-focused, so the toggle never applies there. */}
-          {!(hideKeymap && !viewOnly) && (
+              keyboard-focused, so the toggle never applies there. Same
+              editor-only carve-out for the finished-state hide (see
+              `hideKeyboardForFinish`'s own doc comment above). */}
+          {!(hideKeymap && !viewOnly) && !hideKeyboardForFinish && (
             <KeyboardPane
               paneId="primary"
               isActive={false}
@@ -332,8 +355,10 @@ export function TypingTestPane({
               {t('editor.typingTest.heatmap.legend', { minutes: heatmapWindowMin ?? 5 })}
             </p>
           )}
-          {/* Layer-tracking note describes the keymap, so hide it with the keymap. */}
-          {!viewOnly && !hideKeymap && (
+          {/* Layer-tracking note describes the keymap, so hide it with the
+              keymap — and, like the keymap itself, with the finished
+              completion screen. */}
+          {!viewOnly && !hideKeymap && !hideKeyboardForFinish && (
             <p data-testid="typing-test-layer-note" className="text-center text-xs text-content-muted">
               {t('editor.typingTest.layerNote')}
             </p>
@@ -341,6 +366,29 @@ export function TypingTestPane({
         </div>
         </div>
       </div>
+      {/* Non-finished controls row (Next Test / Pause / Resume / Restart) —
+          moved here, BELOW the keyboard pane and its layer note, so the
+          reading window sits directly above the keyboard the user is
+          actually typing on. The finished-state row is unaffected — it
+          still renders inside TypingTestView, at the very bottom of the
+          completion screen (below the timeline panel), since the keyboard
+          itself is hidden once finished (hideKeyboardForFinish). Gated the
+          same way the old in-TypingTestView row was: !viewOnly (view-only
+          never showed this row) and !hideControls (the "operation"
+          toggle), plus the finished check TypingTestView itself no longer
+          needs to make since this row never renders for it. */}
+      {!viewOnly && typingTest.state.status !== 'finished' && !hideControls && (
+        <div className="mt-2 flex w-full justify-center">
+          <TypingTestControlsRow
+            state={typingTest.state}
+            config={typingTest.config}
+            onStart={() => typingTest.restart()}
+            onPause={() => onPauseTest?.()}
+            onResume={() => setShowResumeModal(true)}
+            hasSavedMemory={hasSavedMemory}
+          />
+        </div>
+      )}
       </div>
       </div>
       {viewOnly && (

--- a/src/renderer/components/editors/__tests__/TypingTestPane.controls-row-order.test.tsx
+++ b/src/renderer/components/editors/__tests__/TypingTestPane.controls-row-order.test.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// DOM-order coverage for the non-finished controls row (Next Test / Pause
+// / Resume / Restart), mirroring TypingTestView.test.tsx's own
+// finished-state order tests ("renders the Unnamed / Next Test controls
+// row AFTER the timeline panel..."). This row used to render inline
+// inside TypingTestView, above the keyboard pane (which TypingTestPane
+// renders separately); it now renders from TypingTestPane itself, BELOW
+// the keyboard pane and its layer note, so the reading window sits
+// directly above the keyboard the user is actually typing on. The
+// finished-state row is unaffected — it stays inside TypingTestView, at
+// the bottom of the completion screen, since the keyboard is hidden once
+// finished (see TypingTestPane.finished.test.tsx).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'editor.typingTest.layerNote': 'Only MO / LT / LM layer switches are tracked. Other layer keys and advanced features may not be reflected.',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../keyboard/KeyboardWidget', () => ({
+  KeyboardWidget: () => <div data-testid="keyboard-widget">KeyboardWidget</div>,
+}))
+
+import { TypingTestPane, type TypingTestPaneProps } from '../TypingTestPane'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../../typing-test/types'
+import { createInitialState } from '../../../typing-test/run-state'
+
+beforeEach(() => {
+  window.vialAPI = {
+    ...window.vialAPI,
+    isAlwaysOnTopSupported: () => Promise.resolve(false),
+    setWindowCompactMode: () => Promise.resolve(null),
+    setWindowAspectRatio: () => Promise.resolve(),
+    setWindowAlwaysOnTop: () => Promise.resolve(),
+  } as typeof window.vialAPI
+})
+
+function fakeTypingTest(status: 'waiting' | 'running' | 'finished') {
+  return {
+    state: createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE, status),
+    wpm: 0,
+    kpm: 0,
+    accuracy: 100,
+    romajiGuide: null,
+    elapsedSeconds: 0,
+    remainingSeconds: null,
+    config: DEFAULT_CONFIG,
+    language: DEFAULT_LANGUAGE,
+    isLanguageLoading: false,
+    baseLayer: 0,
+    effectiveLayer: 0,
+    windowFocused: true,
+    processMatrixFrame: vi.fn(),
+    resetMatrixPressTracking: vi.fn(),
+    processKeyEvent: vi.fn(),
+    processCompositionStart: vi.fn(),
+    processCompositionUpdate: vi.fn(),
+    processCompositionEnd: vi.fn(),
+    restart: vi.fn(),
+    restartWithCountdown: vi.fn(),
+    setConfig: vi.fn(),
+    setLanguage: vi.fn(),
+    setBaseLayer: vi.fn(),
+    setWindowFocused: vi.fn(),
+    captureMemory: vi.fn(),
+    pause: vi.fn(),
+    restoreState: vi.fn(),
+  } as unknown as TypingTestPaneProps['typingTest']
+}
+
+function renderPane(status: 'waiting' | 'running' | 'finished', overrides: Partial<TypingTestPaneProps> = {}) {
+  const defaults: TypingTestPaneProps = {
+    typingTest: fakeTypingTest(status),
+    onConfigChange: vi.fn(),
+    onLanguageChange: vi.fn().mockResolvedValue(undefined),
+    layers: 1,
+    pressedKeys: new Set(),
+    keycodes: new Map(),
+    encoderKeycodes: new Map(),
+    remappedKeys: new Set(),
+    layoutOptions: new Map(),
+    scale: 1,
+    keys: [],
+    layerLabel: '',
+  }
+  return render(<TypingTestPane {...defaults} {...overrides} />)
+}
+
+describe('TypingTestPane — non-finished controls row placement', () => {
+  it('renders the keyboard pane BEFORE the Next Test / controls row (running)', () => {
+    renderPane('running')
+    const keyboard = screen.getByTestId('keyboard-widget')
+    const restartButton = screen.getByTestId('typing-test-restart')
+    expect(keyboard.compareDocumentPosition(restartButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('renders the keyboard pane BEFORE the Next Test button (waiting)', () => {
+    renderPane('waiting')
+    const keyboard = screen.getByTestId('keyboard-widget')
+    const startButton = screen.getByTestId('typing-test-start')
+    expect(keyboard.compareDocumentPosition(startButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('renders the layer note BEFORE the controls row too (running)', () => {
+    renderPane('running')
+    const layerNote = screen.getByTestId('typing-test-layer-note')
+    const restartButton = screen.getByTestId('typing-test-restart')
+    expect(layerNote.compareDocumentPosition(restartButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('never renders the non-finished controls row once the run finishes (the finished row takes over, at the bottom of the completion screen)', () => {
+    renderPane('finished')
+    // 'Next Test' shows in both the non-finished and finished rows under
+    // the same testid, so this only checks there's exactly one — the
+    // finished-state one, owned by TypingTestView (see
+    // TypingTestPane.finished.test.tsx).
+    expect(screen.getAllByTestId('typing-test-start')).toHaveLength(1)
+  })
+
+  it('hides the non-finished controls row when hideControls is set (the "operation" toggle)', () => {
+    renderPane('running', { hideControls: true })
+    expect(screen.queryByTestId('typing-test-restart')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('typing-test-start')).not.toBeInTheDocument()
+  })
+
+  it('never renders the controls row in view-only mode', () => {
+    renderPane('running', { viewOnly: true })
+    expect(screen.queryByTestId('typing-test-restart')).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/editors/__tests__/TypingTestPane.finished.test.tsx
+++ b/src/renderer/components/editors/__tests__/TypingTestPane.finished.test.tsx
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Plan-completion-timeline-view PR-B, codex-review point (c): once a run
+// finishes, the keymap pane (and its layer-tracking note) give way to the
+// completion screen's inline keystroke timeline (rendered by
+// TypingTestView) — this only applies in the EDITOR view (`viewOnly`
+// false/undefined); view-only's own keyboard display stays independent of
+// both `hideKeymap` and the finished-state hide (see
+// TypingTestPane.tsx's `hideKeyboardForFinish` doc comment).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { RunKeystrokeLog } from '../../../../shared/types/typing-run-log'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'editor.typingTest.layerNote': 'Only MO / LT / LM layer switches are tracked. Other layer keys and advanced features may not be reflected.',
+      }
+      return map[key] ?? key
+    },
+  }),
+}))
+
+vi.mock('../../keyboard/KeyboardWidget', () => ({
+  KeyboardWidget: () => <div data-testid="keyboard-widget">KeyboardWidget</div>,
+}))
+
+import { TypingTestPane, type TypingTestPaneProps } from '../TypingTestPane'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../../typing-test/types'
+import { createInitialState } from '../../../typing-test/run-state'
+
+beforeEach(() => {
+  window.vialAPI = {
+    ...window.vialAPI,
+    isAlwaysOnTopSupported: () => Promise.resolve(false),
+    setWindowCompactMode: () => Promise.resolve(null),
+    setWindowAspectRatio: () => Promise.resolve(),
+    setWindowAlwaysOnTop: () => Promise.resolve(),
+  } as typeof window.vialAPI
+})
+
+function fakeTypingTest(status: 'waiting' | 'running' | 'finished') {
+  return {
+    state: createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE, status),
+    wpm: 0,
+    kpm: 0,
+    accuracy: 100,
+    romajiGuide: null,
+    elapsedSeconds: 0,
+    remainingSeconds: null,
+    config: DEFAULT_CONFIG,
+    language: DEFAULT_LANGUAGE,
+    isLanguageLoading: false,
+    baseLayer: 0,
+    effectiveLayer: 0,
+    windowFocused: true,
+    processMatrixFrame: vi.fn(),
+    resetMatrixPressTracking: vi.fn(),
+    processKeyEvent: vi.fn(),
+    processCompositionStart: vi.fn(),
+    processCompositionUpdate: vi.fn(),
+    processCompositionEnd: vi.fn(),
+    restart: vi.fn(),
+    restartWithCountdown: vi.fn(),
+    setConfig: vi.fn(),
+    setLanguage: vi.fn(),
+    setBaseLayer: vi.fn(),
+    setWindowFocused: vi.fn(),
+    captureMemory: vi.fn(),
+    pause: vi.fn(),
+    restoreState: vi.fn(),
+  } as unknown as TypingTestPaneProps['typingTest']
+}
+
+function renderPane(status: 'waiting' | 'running' | 'finished', overrides: Partial<TypingTestPaneProps> = {}) {
+  const defaults: TypingTestPaneProps = {
+    typingTest: fakeTypingTest(status),
+    onConfigChange: vi.fn(),
+    onLanguageChange: vi.fn().mockResolvedValue(undefined),
+    layers: 1,
+    pressedKeys: new Set(),
+    keycodes: new Map(),
+    encoderKeycodes: new Map(),
+    remappedKeys: new Set(),
+    layoutOptions: new Map(),
+    scale: 1,
+    keys: [],
+    layerLabel: '',
+  }
+  return render(<TypingTestPane {...defaults} {...overrides} />)
+}
+
+describe('TypingTestPane — keyboard hidden on the finished completion screen', () => {
+  it('shows the keymap pane and layer note while running (editor mode)', () => {
+    renderPane('running')
+    expect(screen.getByTestId('keyboard-widget')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-layer-note')).toBeInTheDocument()
+  })
+
+  it('hides the keymap pane and layer note once the run finishes (editor mode)', () => {
+    renderPane('finished')
+    expect(screen.queryByTestId('keyboard-widget')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('typing-test-layer-note')).not.toBeInTheDocument()
+  })
+
+  it('renders no Complete heading on the finished screen (removed)', () => {
+    renderPane('finished')
+    expect(screen.queryByTestId('typing-test-complete')).not.toBeInTheDocument()
+  })
+
+  it('keeps showing the keymap pane in view-only mode even once finished', () => {
+    renderPane('finished', { viewOnly: true })
+    expect(screen.getByTestId('keyboard-widget')).toBeInTheDocument()
+  })
+})
+
+describe('TypingTestPane — completion screen flex-height chain (no fixed vh cap)', () => {
+  it('the TypingTestView wrapper carries min-h-0 (alongside its pre-existing flex-1) — the link this component owns in the chain', () => {
+    renderPane('finished')
+    // TypingTestView's own root (testid="typing-test-view") is the next
+    // link down; its wrapper here (the one this component renders it
+    // inside) is the one this file is responsible for keeping correct.
+    const view = screen.getByTestId('typing-test-view')
+    const wrapper = view.parentElement!
+    expect(wrapper.className).toContain('min-h-0')
+    expect(wrapper.className).toContain('flex-1')
+  })
+
+  it('the chain reaches all the way down to the rows scrollport, still with no max-h-* cap anywhere', () => {
+    // A log (with a matching runId) is required for the inline timeline
+    // panel to actually render — otherwise TypingTestView falls back to
+    // the (non-scrolling) stats row, and there is no scrollport to check.
+    const typingTest = fakeTypingTest('finished')
+    const log: RunKeystrokeLog = {
+      runId: typingTest.state.runId,
+      uid: 'uid-1',
+      startedAt: '2026-01-01T00:00:00.000Z',
+      durationMs: 5000,
+      mode: 'words',
+      language: 'english',
+      words: [{ index: 0, display: 'hi', typed: 'hi', correct: true, keystrokes: [] }],
+    }
+    renderPane('finished', { typingTest, lastFinishedLog: log })
+    const scrollport = screen.getByTestId('word-timeline-canvas').parentElement!
+    expect(scrollport.className).toContain('flex-1')
+    expect(scrollport.className).toContain('min-h-0')
+    expect(scrollport.className).toContain('overflow-auto')
+    expect(scrollport.className).not.toMatch(/\bmax-h-/)
+  })
+})

--- a/src/renderer/components/editors/__tests__/TypingTestPaneSettingsPanel.test.tsx
+++ b/src/renderer/components/editors/__tests__/TypingTestPaneSettingsPanel.test.tsx
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../../i18n'
+import { TypingTestPaneSettingsPanel } from '../TypingTestPaneSettingsPanel'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../../../typing-test/types'
+import type { useTypingTest } from '../../../typing-test/useTypingTest'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+/** Minimal fake of useTypingTest's return value — only the fields this
+ *  panel (and the TypingTestSettingsBar it renders) actually reads are
+ *  populated; everything else is irrelevant to the "Lines" select this
+ *  file tests, so it's cast through `unknown` rather than hand-filling
+ *  every function useTypingTest returns. `layers` is left at 1 (the
+ *  default in the props below) so the Base Layer select — the only other
+ *  consumer of `typingTest.baseLayer`/`setBaseLayer` — never renders. */
+function fakeTypingTest(): ReturnType<typeof useTypingTest> {
+  return {
+    config: DEFAULT_CONFIG,
+    language: DEFAULT_LANGUAGE,
+    isLanguageLoading: false,
+    state: { currentQuote: null, romajiCapable: false },
+    baseLayer: 0,
+    setBaseLayer: vi.fn(),
+  } as unknown as ReturnType<typeof useTypingTest>
+}
+
+describe('TypingTestPaneSettingsPanel — Lines select', () => {
+  it('offers 1 as the first (smallest) option, one visible reading-window line', () => {
+    renderWithI18n(
+      <TypingTestPaneSettingsPanel
+        typingTest={fakeTypingTest()}
+        showLanguageModal={false}
+        onShowLanguageModal={vi.fn()}
+        onConfigChange={vi.fn()}
+        onLanguageChange={vi.fn()}
+        layers={1}
+        saveUnnamed
+        settingsPanelOpen
+        sameConditionResults={[]}
+        comparisonBaselineValue={{ kind: 'off' }}
+        handleComparisonChange={vi.fn()}
+      />,
+    )
+    const select = screen.getByTestId('display-lines-select') as HTMLSelectElement
+    const values = Array.from(select.options).map((o) => o.value)
+    expect(values[0]).toBe('1')
+    // Selecting it must not get silently clamped back to a higher value —
+    // the option itself exists and is independently selectable.
+    expect(values).toContain('1')
+  })
+})

--- a/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
+++ b/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Focused unit coverage for `finishAndSave`'s return value
+// (Plan-completion-timeline-view PR-B): it now returns the same
+// `RunKeystrokeLog | null` that `RunLogRecorder.finish()` produced (and
+// still hands to `typingRunLogSave`), so `useTypingTestResultSave` can
+// surface it as `lastFinishedLog` for the completion screen's inline
+// timeline panel — no IPC round-trip needed. The underlying join/finish
+// logic itself is already exhaustively covered by
+// `typing-test/__tests__/run-log-recorder.test.ts`; this file only
+// exercises the hook's own new passthrough.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useRunLogRecorder } from '../use-run-log-recorder'
+import { deserialize } from '../../../../shared/keycodes/keycodes'
+import type { WordResult } from '../../../typing-test/run-state'
+
+const KC_A = deserialize('KC_A')
+const mockTypingRunLogSave = vi.fn<(uid: string, log: unknown) => Promise<{ success: boolean }>>()
+
+beforeEach(() => {
+  mockTypingRunLogSave.mockReset().mockResolvedValue({ success: true })
+  window.vialAPI = {
+    ...window.vialAPI,
+    typingRunLogSave: mockTypingRunLogSave,
+  } as typeof window.vialAPI
+})
+
+function renderRecorder(recordingConsentAccepted = true) {
+  const typingTestLabelRef = { current: 'words (english)' as string | null }
+  const { result } = renderHook(() => useRunLogRecorder({ recordingConsentAccepted, typingTestLabelRef }))
+  return { result, typingTestLabelRef }
+}
+
+/** Drives one char-producing keystroke (registration + matrix + char)
+ *  through the hook's own call shapes — mirrors how useTypingTest wires
+ *  these three seams in useInputModes.ts. */
+function driveOneKeystroke(result: ReturnType<typeof renderRecorder>['result'], runId: string, wordIndex: number): void {
+  result.current.noteRegistration(runId, 0, 0, 1000, wordIndex, () => 'a', true)
+  result.current.record({ typingTestLabel: 'words (english)', runId, windowFocused: true }, {
+    kind: 'matrix', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1000,
+  })
+  result.current.record({ typingTestLabel: 'words (english)', runId, windowFocused: true }, {
+    kind: 'char', key: 'a', ts: 1005,
+  })
+}
+
+const wordResults: WordResult[] = [{ word: 'a', typed: 'a', correct: true }]
+
+describe('useRunLogRecorder — finishAndSave return value', () => {
+  it('returns null (and never saves) when there is no active keyboard uid', () => {
+    const { result } = renderRecorder(true)
+    driveOneKeystroke(result, 'run-1', 0)
+
+    const log = result.current.finishAndSave(undefined, wordResults, {
+      runId: 'run-1', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
+      charCorrelationUnavailable: false, romajiInput: false,
+    })
+
+    expect(log).toBeNull()
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+
+  it('returns the finished log — the same object handed to typingRunLogSave — when a real run was recorded', () => {
+    const { result } = renderRecorder(true)
+    driveOneKeystroke(result, 'run-1', 0)
+
+    const log = result.current.finishAndSave('kb-1', wordResults, {
+      runId: 'run-1', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
+      charCorrelationUnavailable: false, romajiInput: false,
+    })
+
+    expect(log).not.toBeNull()
+    expect(log?.runId).toBe('run-1')
+    expect(log?.uid).toBe('kb-1')
+    expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
+    expect(mockTypingRunLogSave).toHaveBeenCalledWith('kb-1', log)
+  })
+
+  it('returns null (and never saves) when nothing was ever buffered (e.g. consent was off throughout)', () => {
+    const { result } = renderRecorder(false)
+    // No noteRegistration/record calls succeed while consent is off — see
+    // the module's own gate — so the buffer stays empty.
+
+    const log = result.current.finishAndSave('kb-1', [], {
+      runId: 'run-1', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
+      charCorrelationUnavailable: false, romajiInput: false,
+    })
+
+    expect(log).toBeNull()
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+
+  it('returns null when meta.runId does not match the buffered run (stale buffer)', () => {
+    const { result } = renderRecorder(true)
+    driveOneKeystroke(result, 'run-1', 0)
+
+    const log = result.current.finishAndSave('kb-1', wordResults, {
+      runId: 'run-OTHER', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
+      charCorrelationUnavailable: false, romajiInput: false,
+    })
+
+    expect(log).toBeNull()
+    expect(mockTypingRunLogSave).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
+++ b/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
@@ -26,6 +26,7 @@ import type { LineSnapshot } from '../../../typing-test/TypingTestView'
 import { DEFAULT_CONFIG } from '../../../typing-test/types'
 import type { TypingTestConfig } from '../../../typing-test/types'
 import type { UseRunLogRecorderReturn } from '../use-run-log-recorder'
+import type { RunKeystrokeLog } from '../../../../shared/types/typing-run-log'
 
 // Real-line sources (word-supply.ts): both route through
 // parseFileImportText (typing-test-text-store.ts), so both carry genuine
@@ -309,5 +310,62 @@ describe('useTypingTestResultSave — lineBreaks derivation (line timeline PR1)'
       const { finishAndSave } = run({ lineBreaks: new Set(), runId: 'run-1', words: ['a', 'b', 'c', 'd'] }, null)
       expect(lineBreaksArg(finishAndSave)).toBeUndefined()
     })
+  })
+})
+
+// Plan-completion-timeline-view PR-B: `lastFinishedLog` surfaces whatever
+// `runLog.finishAndSave` returned for the just-finished run — a direct
+// passthrough (not re-derived), so the completion screen can render the
+// shared timeline panel from it inline. Cleared in the same
+// `status !== 'finished'` branch that resets `savedResultRef`.
+describe('useTypingTestResultSave — lastFinishedLog (completion timeline PR-B)', () => {
+  const FAKE_LOG: RunKeystrokeLog = {
+    runId: 'run-1', uid: 'kb-1', startedAt: new Date(1000).toISOString(), durationMs: 500,
+    mode: 'words', language: 'english', words: [],
+  }
+
+  function renderWithFinishAndSave(status: TypingTestState['status'], finishAndSaveReturn: RunKeystrokeLog | null) {
+    const finishAndSave = vi.fn().mockReturnValue(finishAndSaveReturn)
+    const runLog: UseRunLogRecorderReturn = {
+      record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(), finishAndSave, discardRun: vi.fn(),
+    }
+    const buildOptions = (s: TypingTestState['status']): UseTypingTestResultSaveOptions => ({
+      typingTest: makeTypingTest({ status: s }, DEFAULT_CONFIG),
+      onSaveTypingTestResult: vi.fn(),
+      saveUnnamed: true,
+      savedMemoryRef: { current: undefined } as RefObject<undefined>,
+      onMemoryChangeRef: { current: undefined } as RefObject<undefined>,
+      keyboardRef: { current: { uid: 'kb-1', vendorId: 1, productId: 1, productName: 'x' } } as UseTypingTestResultSaveOptions['keyboardRef'],
+      flushAfterPendingEmits: vi.fn(),
+      runLog,
+    })
+    const rendered = renderHook(
+      ({ s }: { s: TypingTestState['status'] }) => useTypingTestResultSave(buildOptions(s)),
+      { initialProps: { s: status } },
+    )
+    return { ...rendered, finishAndSave }
+  }
+
+  it('exposes the log finishAndSave returned once the run finishes', () => {
+    const { result } = renderWithFinishAndSave('finished', FAKE_LOG)
+    expect(result.current.lastFinishedLog).toBe(FAKE_LOG)
+  })
+
+  it('is null when finishAndSave returned null (no consent / no uid / nothing saveable)', () => {
+    const { result } = renderWithFinishAndSave('finished', null)
+    expect(result.current.lastFinishedLog).toBeNull()
+  })
+
+  it('clears lastFinishedLog once status leaves finished (Next Test / Restart)', () => {
+    const { result, rerender } = renderWithFinishAndSave('finished', FAKE_LOG)
+    expect(result.current.lastFinishedLog).toBe(FAKE_LOG)
+
+    rerender({ s: 'running' })
+    expect(result.current.lastFinishedLog).toBeNull()
+  })
+
+  it('starts null before any run has ever finished', () => {
+    const { result } = renderWithFinishAndSave('waiting', FAKE_LOG)
+    expect(result.current.lastFinishedLog).toBeNull()
   })
 })

--- a/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.analytics.test.tsx
@@ -144,7 +144,7 @@ describe('useInputModes — typing analytics dispatch', () => {
     expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
   })
 
-  it('does not tag editor-test keystrokes before the test is running', () => {
+  it('does not tag editor-test keystrokes before the test is running', async () => {
     // Entering the test view auto-starts a countdown on the default config,
     // so a press made before the run starts must NOT be recorded — otherwise
     // it lands as a phantom material (e.g. `words (english)`) for a run that
@@ -157,6 +157,42 @@ describe('useInputModes — typing analytics dispatch', () => {
     act(() => {
       result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
     })
+    await flushMicrotasks()
+
+    expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
+  })
+
+  it('does not tag (or even send) a per-minute analytics event for a press made while genuinely armed-waiting (gate split: P2 restored)', async () => {
+    // Distinct from the "pristine, never-restarted" case above: this
+    // scenario has ALREADY gone through the mount-time config-sync effect
+    // (flushed below), so `runLogLabelRef` (the run-log's own, broader
+    // tag — see useInputModes.ts) reads non-null here — status is
+    // genuinely-armed 'waiting', not the untouched pristine value. The
+    // per-minute analytics pipeline must still see nothing at all: no
+    // per-minute pre-start cutoff would otherwise let a modifier/no-op
+    // press during armed-waiting leak into the heatmap (codex safety
+    // review P2) — testLabelRef (this pipeline's OWN, narrower tag) stays
+    // 'running'-only regardless of runLogLabelRef.
+    const { result } = renderHook(() => useInputModes({
+      rows: 1,
+      cols: 1,
+      keymap: buildKeymap(),
+      typingTestMode: true,
+      typingTestViewOnly: false,
+      typingRecordKeyboard: sampleKeyboard,
+      typingRecordEnabled: false,
+      savedTypingTestConfig: { mode: 'time', duration: 30, punctuation: false, numbers: false },
+    }))
+    await flushMicrotasks()
+    expect(result.current.typingTest.state.status).toBe('waiting')
+
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), buildKeymap())
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), buildKeymap())
+    })
+    await flushMicrotasks()
 
     expect(mockTypingAnalyticsEvent).not.toHaveBeenCalled()
   })

--- a/src/renderer/components/editors/__tests__/useInputModes.run-log.test.tsx
+++ b/src/renderer/components/editors/__tests__/useInputModes.run-log.test.tsx
@@ -150,6 +150,152 @@ describe('useInputModes — run-log recording', () => {
     expect(savedLog.romajiInput).toBeUndefined()
   })
 
+  it('captures the run\'s very first keystroke — the one that transitions waiting -> running — not just the ones after it', async () => {
+    // Regression coverage for the missing-first-bar bug (user report: a
+    // run's first word always renders one bar short in the keystroke
+    // timeline). Root cause: useInputModes's testLabelRef gate (feeding
+    // both onNoteKeystrokeRegistration and prepareAnalyticsEvent) used to
+    // read `typingTest.state.status === 'running'` only — while status is
+    // still 'waiting' (true for every keystroke up to and including the
+    // one that flips it to 'running'), noteRegistration/prepare see a null
+    // label and drop the press outright, so the very first matrix press of
+    // any run was never buffered at all. Drives matrix-then-char per
+    // character (the same order the P1 test above uses) so this reliably
+    // exercises the registration gate, not just char-correlation.
+    const { result } = renderRunLogHook({ consent: true, wordCount: 1 })
+    const keymap = buildKeymap()
+
+    // Let useInputModes's mount-time "sync saved config" effect settle
+    // first — same reason the P1 test above does this: it fires once per
+    // mount and calls typingTest.setConfig(), which mints a fresh runId
+    // asynchronously (see pristineRunIdRef's own comment in
+    // useInputModes.ts). A real user's first keystroke always lands well
+    // after this microtask-scale async settles (human reaction time
+    // dwarfs it); only a synchronous test driver racing it without this
+    // await would see the still-pristine runId.
+    await flushMicrotasks()
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    const [word] = result.current.typingTest.state.words
+    for (const char of word) {
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processMatrixFrame(new Set(), keymap)
+      })
+      act(() => {
+        result.current.typingTest.processKeyEvent(char, false, false, false)
+      })
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
+    const [, savedLog] = mockTypingRunLogSave.mock.calls[0] as [string, { words: { keystrokes: unknown[] }[] }]
+    // Every character of the word must have produced a keystroke bar —
+    // not `word.length - 1`.
+    expect(savedLog.words[0].keystrokes).toHaveLength(word.length)
+  })
+
+  it('a config switch\'s async word-list load window never lets a phantom keystroke leak into the next real run\'s saved log (gate split: P1 verified safe)', async () => {
+    // codex safety review P1: setConfig updates `typingTest.config`
+    // synchronously, but `typingTest.state` (status/runId/words) stays
+    // whatever it was until the async createWordsForConfig() call
+    // resolves and calls setState(freshState(...)). During that narrow
+    // window, runLogLabelRef's `isArmedWaiting` can read true pairing the
+    // OLD (already non-pristine) runId with the NEW config's label — a
+    // transient phantom combination. This test proves that combination
+    // can never actually leak into a SAVED result: any keystroke
+    // registered under it is buffered under the OLD runId
+    // (RunLogRecorder.noteRegistration mints a buffer keyed by whatever
+    // runId it's given), which can never match the REAL run's own
+    // brand-new runId once the load resolves — RunLogRecorder.finish()'s
+    // `buf.runId !== meta.runId` check silently discards it, so only the
+    // real run's own keystrokes ever reach typingRunLogSave.
+    const onSaveTypingTestResult = vi.fn()
+    const keymap = buildKeymap()
+    const configA = { mode: 'words' as const, wordCount: 1, punctuation: false, numbers: false }
+    const configB = { mode: 'words' as const, wordCount: 2, punctuation: false, numbers: false }
+    const { result, rerender } = renderHook(
+      ({ savedTypingTestConfig }: { savedTypingTestConfig: typeof configA | typeof configB }) => useInputModes({
+        rows: 1,
+        cols: 1,
+        keymap,
+        unlocked: true,
+        typingTestMode: true,
+        typingTestViewOnly: false,
+        typingRecordKeyboard: sampleKeyboard,
+        onSaveTypingTestResult,
+        savedTypingTestConfig,
+        recordingConsentAccepted: true,
+      }),
+      { initialProps: { savedTypingTestConfig: configA } },
+    )
+
+    // Let the mount-time config-sync settle — status is now
+    // genuinely-armed 'waiting' under configA, non-pristine runId.
+    await flushMicrotasks()
+    act(() => {
+      result.current.typingTest.setWindowFocused(true)
+    })
+    expect(result.current.typingTest.state.status).toBe('waiting')
+    const runIdBeforeSwitch = result.current.typingTest.state.runId
+
+    // Switch config — `typingTest.config` updates towards configB
+    // essentially immediately (setConfigState is synchronous), but
+    // `typingTest.state` (status/runId/words) stays configA's until
+    // createWordsForConfig resolves. This is the P1 window.
+    rerender({ savedTypingTestConfig: configB })
+    expect(result.current.typingTest.state.runId).toBe(runIdBeforeSwitch)
+
+    // A press RIGHT NOW, before awaiting anything — the phantom-tag
+    // window the P1 review flagged.
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+    })
+    act(() => {
+      result.current.typingTest.processMatrixFrame(new Set(), keymap)
+    })
+
+    // Let configB's load resolve — a genuinely fresh runId mints.
+    await flushMicrotasks()
+    expect(result.current.typingTest.state.runId).not.toBe(runIdBeforeSwitch)
+    expect(result.current.typingTest.state.words).toHaveLength(2)
+
+    // Complete a REAL run under configB normally.
+    const [word1, word2] = result.current.typingTest.state.words
+    for (const word of [word1, word2]) {
+      for (const char of word) {
+        act(() => {
+          result.current.typingTest.processMatrixFrame(new Set(['0,0']), keymap)
+        })
+        act(() => {
+          result.current.typingTest.processMatrixFrame(new Set(), keymap)
+        })
+        act(() => {
+          result.current.typingTest.processKeyEvent(char, false, false, false)
+        })
+      }
+      if (word !== word2) {
+        act(() => {
+          result.current.typingTest.processKeyEvent(' ', false, false, false)
+        })
+      }
+    }
+    expect(result.current.typingTest.state.status).toBe('finished')
+    await flushMicrotasks()
+
+    expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
+    const [, savedLog] = mockTypingRunLogSave.mock.calls[0] as [string, { runId: string; words: { keystrokes: unknown[] }[] }]
+    expect(savedLog.runId).toBe(result.current.typingTest.state.runId)
+    const totalKeystrokes = savedLog.words.reduce((sum, w) => sum + w.keystrokes.length, 0)
+    // Exactly word1.length + word2.length — no extra keystroke leaked in
+    // from the phantom-tagged press made during the config-switch window.
+    expect(totalKeystrokes).toBe(word1.length + word2.length)
+  })
+
   it('never saves a run log without recording consent, even for a completed practice run', async () => {
     const { result } = renderRunLogHook({ consent: false, wordCount: 1 })
     const keymap = buildKeymap()
@@ -229,10 +375,7 @@ describe('useInputModes — run-log recording', () => {
   it('does not attribute matrix keystrokes registered while unfocused, but resumes once refocused (P1)', async () => {
     // Two words: the first is typed and submitted entirely while
     // focused, which puts the run solidly mid-'running' (regardless of
-    // either word's length) before the unfocused phase — avoids the
-    // waiting->running transition edge (see testLabelRef's own gating
-    // comment in useInputModes.ts), where the very first keystroke of a
-    // run goes untagged for an unrelated, pre-existing reason.
+    // either word's length) before the unfocused phase.
     const { result } = renderRunLogHook({ consent: true, wordCount: 2 })
     const keymap = buildKeymap()
 
@@ -310,12 +453,11 @@ describe('useInputModes — run-log recording', () => {
     expect(mockTypingRunLogSave).toHaveBeenCalledTimes(1)
     const [, savedLog] = mockTypingRunLogSave.mock.calls[0] as [string, { words: { keystrokes: unknown[] }[] }]
     const totalKeystrokes = savedLog.words.reduce((sum, w) => sum + w.keystrokes.length, 0)
-    // The very first char of word1 lands while status is still 'waiting'
-    // (untagged — an existing, unrelated trade-off, see testLabelRef's
-    // own comment), so exactly `word1.length - 1 + word2.length` presses
-    // are attributable in this exact drive pattern. The point of this
-    // assertion is that the unfocused press did not add a spurious +1.
-    expect(totalKeystrokes).toBe(word1.length - 1 + word2.length)
+    // Every char of both words is attributable (including word1's very
+    // first, transition-causing keystroke — see testLabelRef's own gating
+    // comment in useInputModes.ts) — the point of this assertion is that
+    // the unfocused press in between did not add a spurious +1.
+    expect(totalKeystrokes).toBe(word1.length + word2.length)
   })
 
   it('discards the buffer on pause, so a resumed-then-finished run saves no raw log (P3)', async () => {

--- a/src/renderer/components/editors/typing-test-pane-types.ts
+++ b/src/renderer/components/editors/typing-test-pane-types.ts
@@ -2,6 +2,7 @@
 
 import type { RefObject } from 'react'
 import type { TypingTestResult, TypingViewMenuTab, TypingTestComparisonBaseline, TypingTestComparisonBaselines } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 import type { TypingTestConfig } from '../../typing-test/types'
 import type { KleKey } from '../../../shared/kle/types'
 import type { useTypingTest } from '../../typing-test/useTypingTest'
@@ -60,6 +61,12 @@ export interface TypingTestPaneProps {
   finishedResult?: TypingTestResult | null
   /** Name the just-finished result (save under name when held, else rename). */
   onNameFinishedResult?: (name: string) => void
+  /** The just-finished run's in-memory raw keystroke log — forwarded to
+   *  `TypingTestView` so the completion screen can render the shared
+   *  `KeystrokeTimelinePanel` inline, no IPC round-trip needed
+   *  (Plan-completion-timeline-view PR-B). See `useTypingTestResultSave`'s
+   *  own doc comment on `lastFinishedLog`. */
+  lastFinishedLog?: RunKeystrokeLog | null
   /** Per-condition Measurement-row comparison baselines (persisted per
    *  keyboard, synced). Keyed by condition; the current condition's baseline
    *  is looked up and applied. */

--- a/src/renderer/components/editors/use-run-log-recorder.ts
+++ b/src/renderer/components/editors/use-run-log-recorder.ts
@@ -28,6 +28,7 @@ import { useCallback, useEffect, useRef } from 'react'
 import type { RefObject } from 'react'
 import { RunLogRecorder, type RunLogRecordContext, type RunLogFinishMeta } from '../../typing-test/run-log-recorder'
 import type { TypingAnalyticsEventPayload } from '../../../shared/types/typing-analytics'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 import type { WordResult } from '../../typing-test/run-state'
 
 export interface UseRunLogRecorderOptions {
@@ -36,7 +37,11 @@ export interface UseRunLogRecorderOptions {
   /** Active keyboard's uid, if any — the buffer is discarded (never
    *  saved) whenever this changes. */
   keyboardUid?: string
-  /** `useInputModes`'s own testLabelRef, forwarded BY REFERENCE (not by
+  /** `useInputModes`'s own `runLogLabelRef` — the run-log's OWN, broader
+   *  tag (running OR armed-waiting; see that ref's own doc comment in
+   *  useInputModes.ts and `PreparedAnalyticsContext`'s in
+   *  use-typing-analytics-sink.ts for why this is a SEPARATE ref from
+   *  `testLabelRef`, not the same one), forwarded BY REFERENCE (not by
    *  value): `noteRegistration` is called directly as useTypingTest's
    *  option, with no notion of tagging, so it must read the label live at
    *  invocation time rather than whatever it was when this hook last
@@ -53,7 +58,14 @@ export interface UseRunLogRecorderReturn {
   noteCharContext: (
     runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
   ) => void
-  finishAndSave: (uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>) => void
+  /** Returns the just-finished log (whatever `RunLogRecorder.finish`
+   *  produced), or null when there's no uid to save under or nothing was
+   *  actually saveable (see `finish()`'s own doc comment for every null
+   *  case) — the caller (`useTypingTestResultSave`) surfaces this as
+   *  `lastFinishedLog` for the completion screen's inline timeline panel
+   *  (Plan-completion-timeline-view PR-B), no IPC round-trip needed since
+   *  this is the exact object already handed to `typingRunLogSave`. */
+  finishAndSave: (uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>) => RunKeystrokeLog | null
   /** Discard `runId`'s buffer and block it from being re-buffered later
    *  under the same id — see the module doc comment's `discardRun`
    *  bullet and run-log-recorder.ts's `discardRun()`. */
@@ -112,13 +124,14 @@ export function useRunLogRecorder({
 
   const finishAndSave = useCallback((
     uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>,
-  ) => {
+  ): RunKeystrokeLog | null => {
     if (!uid) {
       recorderRef.current.discard()
-      return
+      return null
     }
     const log = recorderRef.current.finish(wordResults, { ...meta, uid })
     if (log) void window.vialAPI.typingRunLogSave(uid, log)
+    return log
   }, [])
 
   const discardRun = useCallback((runId: string) => {

--- a/src/renderer/components/editors/use-typing-analytics-sink.ts
+++ b/src/renderer/components/editors/use-typing-analytics-sink.ts
@@ -27,11 +27,39 @@ export function typingTestAnalyticsLabel(
 /** Context captured by prepareAnalyticsEvent at press time and carried
  *  opaquely through useTypingTest's ordering queue to emitAnalyticsEvent.
  *  `typingTest`/`runId` are null for ordinary REC input (untagged); an
- *  editor typing-test keystroke always has both set together. */
+ *  editor typing-test keystroke always has both set together.
+ *
+ *  GATE SPLIT (codex safety review of the missing-first-keystroke fix):
+ *  `typingTest` is the narrow, PER-MINUTE-ANALYTICS tag — non-null only
+ *  while `status === 'running'`, restored to its exact original (#203)
+ *  meaning. `runLogTest` is a SEPARATE, broader tag used ONLY by the
+ *  run-log recorder — non-null while running OR already "armed waiting"
+ *  for the run's first keystroke (see useInputModes.ts's
+ *  `runLogLabelRef`/`isArmedWaiting`). The two are deliberately allowed
+ *  to disagree (`runLogTest` non-null while `typingTest` is still null)
+ *  for exactly one narrow window per run — the armed-waiting keystrokes
+ *  before `status` flips to `running` — so the run-log can capture that
+ *  run's own first keystroke without also reopening the per-minute
+ *  pipeline's pre-start cutoff (a run-log-only event must never reach
+ *  `window.vialAPI.typingAnalyticsEvent` — see `perMinuteAuthorized` and
+ *  `emitAnalyticsEvent`'s own gate). */
 export interface PreparedAnalyticsContext {
   keyboard: TypingAnalyticsKeyboard
   typingTest: string | null
+  /** Run-log-only tag — see the module doc comment above. Always non-null
+   *  whenever `typingTest` is (running implies armed), but can be
+   *  non-null on its own during armed-waiting. */
+  runLogTest: string | null
+  /** Shared run id for both `typingTest` and `runLogTest` — the exact
+   *  same run either way, so one field suffices; non-null whenever
+   *  EITHER tag is non-null. */
   runId: string | null
+  /** Whether this event may reach the per-minute analytics pipeline at
+   *  all (REC toggle active OR `typingTest` non-null) — independent of
+   *  `runLogTest`. `emitAnalyticsEvent` must skip
+   *  `window.vialAPI.typingAnalyticsEvent` entirely when this is false,
+   *  even though `runLog.record` still runs — see its own gate for why. */
+  perMinuteAuthorized: boolean
   /** Window-focus state snapshotted at press time (see useTypingTest's
    *  `onPrepareAnalyticsEvent` doc comment) — carried through to
    *  `emitAnalyticsEvent` so the run-log recorder's defense-in-depth gate
@@ -76,8 +104,16 @@ export interface UseTypingAnalyticsSinkReturn {
    *  visible to the same render's queue processing. */
   testLabelRef: RefObject<string | null>
   /** Travels with `testLabelRef` (run id) so each run's keystrokes are
-   *  separable — same host-assigns-render-phase contract. */
+   *  separable — same host-assigns-render-phase contract. Also doubles
+   *  as `runLogLabelRef`'s own run id (see that ref's doc comment): both
+   *  reference the exact same run, so one id ref suffices. */
   testRunIdRef: RefObject<string | null>
+  /** GATE SPLIT: run-log-only tag, broader than `testLabelRef` — see
+   *  `PreparedAnalyticsContext`'s own doc comment for why these two must
+   *  stay separate. Same host-assigns-render-phase contract as
+   *  `testLabelRef`; passed to `useRunLogRecorder` as its
+   *  `typingTestLabelRef` INSTEAD of `testLabelRef`. */
+  runLogLabelRef: RefObject<string | null>
   prepareAnalyticsEvent: (kind: 'matrix' | 'char', windowFocused: boolean) => PreparedAnalyticsContext | null
   emitAnalyticsEvent: (context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload) => Promise<void>
   flushAfterPendingEmits: (drained: Promise<void>, uid: string) => void
@@ -111,15 +147,22 @@ export function useTypingAnalyticsSink({
   const recordingActiveRef = useRef(false)
   const testLabelRef = useRef<string | null>(null)
   const testRunIdRef = useRef<string | null>(null)
+  // GATE SPLIT: the run-log's OWN, broader tag — see
+  // `PreparedAnalyticsContext`'s doc comment. Kept as a fully separate ref
+  // (not derived from testLabelRef here) because the host
+  // (useInputModes.ts) computes it from a different condition
+  // (running OR armed-waiting) than testLabelRef (running only).
+  const runLogLabelRef = useRef<string | null>(null)
   const onRecKeystrokeRef = useRef(onRecKeystroke)
   onRecKeystrokeRef.current = onRecKeystroke
   // Per-run raw keystroke log recorder (see run-log-recorder.ts and
   // use-run-log-recorder.ts) — one instance per editor session, mirroring
-  // matrixQueueRef's construction style in useTypingTest.ts.
+  // matrixQueueRef's construction style in useTypingTest.ts. Fed
+  // `runLogLabelRef`, NOT `testLabelRef` — see the GATE SPLIT note above.
   const runLog = useRunLogRecorder({
     recordingConsentAccepted,
     keyboardUid: typingRecordKeyboard?.uid,
-    typingTestLabelRef: testLabelRef,
+    typingTestLabelRef: runLogLabelRef,
   })
   // The sink used to read recordingActiveRef / testLabelRef / testRunIdRef
   // at the moment an event was actually sent, but a matrix event can now
@@ -140,7 +183,17 @@ export function useTypingAnalyticsSink({
     const keyboard = keyboardRef.current
     if (!keyboard) return null
     const label = testLabelRef.current
-    if (!recordingActiveRef.current && !label) return null
+    const runLogLabel = runLogLabelRef.current
+    // GATE SPLIT: `perMinuteAuthorized` is EXACTLY the original (#203)
+    // authorization condition for the per-minute analytics pipeline —
+    // REC toggle active, or a running editor test. `runLogLabel` (broader
+    // — see PreparedAnalyticsContext's doc comment) can ALSO keep this
+    // function from returning null on its own, during armed-waiting, but
+    // must never by itself authorize a per-minute send — see
+    // emitAnalyticsEvent's own `perMinuteAuthorized` gate below, which is
+    // what actually enforces that split.
+    const perMinuteAuthorized = recordingActiveRef.current || label !== null
+    if (!perMinuteAuthorized && !runLogLabel) return null
     // Tray keystroke count tracks REC only (untagged matrix events), not
     // the editor typing-test practice mode — matches recordingActive's
     // narrower definition (typingRecordEnabled && typingTestViewOnly).
@@ -148,17 +201,18 @@ export function useTypingAnalyticsSink({
     // leaves the queue: the count is a live tray readout of physical
     // keystrokes, and a masked key can otherwise sit unresolved for up to
     // the tapping term before its emit — the user would see the tray lag
-    // behind their own typing. Firing once per authorized press here
-    // matches the previous call frequency (once per event that used to
-    // reach the sink) without that lag, and can't double-fire or fire for
-    // an unauthorized press since this whole branch is unreachable when
-    // this function returns null above.
-    if (!label && kind === 'matrix') {
+    // behind their own typing. Explicitly re-checks recordingActiveRef
+    // (not just `!label`) because reaching this line no longer implies
+    // recordingActiveRef is true — a run-log-only armed-waiting press
+    // (recordingActiveRef false, label null, runLogLabel non-null) must
+    // never count toward the REC tray, only genuine untagged REC presses.
+    if (!label && kind === 'matrix' && recordingActiveRef.current) {
       onRecKeystrokeRef.current?.()
     }
-    // A test keystroke carries both its material label and its run id; REC
-    // input carries neither (so it lands as the null run / null test).
-    return { keyboard, typingTest: label, runId: label ? testRunIdRef.current : null, windowFocused }
+    // A test keystroke (either tag) carries the shared run id; REC input
+    // carries none (so it lands as the null run).
+    const runId = (label !== null || runLogLabel !== null) ? testRunIdRef.current : null
+    return { keyboard, typingTest: label, runLogTest: runLogLabel, runId, perMinuteAuthorized, windowFocused }
   }, [])
   // Ordering contract, not an optimization: chaining every emit behind the
   // previous one's IPC guarantees at most one typingAnalyticsEvent invoke
@@ -184,10 +238,19 @@ export function useTypingAnalyticsSink({
   const chainRef = useRef<Promise<void>>(Promise.resolve())
   const emitAnalyticsEvent = useCallback((context: PreparedAnalyticsContext, payload: TypingAnalyticsEventPayload): Promise<void> => {
     // Run-keystroke-log capture — gates itself independently (see
-    // RunLogRecordContext); a no-op for ordinary REC input (context.typingTest
-    // null), without recording consent, or without window focus (see
-    // context.windowFocused's doc comment).
-    runLog.record({ typingTestLabel: context.typingTest, runId: context.runId, windowFocused: context.windowFocused }, payload)
+    // RunLogRecordContext), fed `runLogTest` (the broader, run-log-only
+    // tag), NOT `typingTest` — a no-op for ordinary REC input
+    // (context.runLogTest null), without recording consent, or without
+    // window focus (see context.windowFocused's doc comment).
+    runLog.record({ typingTestLabel: context.runLogTest, runId: context.runId, windowFocused: context.windowFocused }, payload)
+    // GATE SPLIT: a run-log-only event (armed-waiting, `perMinuteAuthorized`
+    // false) must never reach the per-minute analytics pipeline — this is
+    // what restores #203's original pre-start cutoff for that pipeline
+    // (codex safety review P2) even though prepareAnalyticsEvent no longer
+    // returns null for it. `chainRef` is deliberately left untouched here:
+    // this event was never sent, so it has nothing to add to the IPC
+    // ordering chain.
+    if (!context.perMinuteAuthorized) return Promise.resolve()
     const event = context.typingTest
       ? { ...payload, keyboard: context.keyboard, typingTest: context.typingTest, runId: context.runId ?? undefined }
       : { ...payload, keyboard: context.keyboard }
@@ -235,6 +298,7 @@ export function useTypingAnalyticsSink({
     recordingActiveRef,
     testLabelRef,
     testRunIdRef,
+    runLogLabelRef,
     prepareAnalyticsEvent,
     emitAnalyticsEvent,
     flushAfterPendingEmits,

--- a/src/renderer/components/editors/use-typing-test-result-save.ts
+++ b/src/renderer/components/editors/use-typing-test-result-save.ts
@@ -9,6 +9,7 @@ import type { TypingTestConfig } from '../../typing-test/types'
 import type { LineSnapshot } from '../../typing-test/TypingTestView'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 import type { UseRunLogRecorderReturn } from './use-run-log-recorder'
 
 /** A run's config carries REAL line semantics (a newline in the source
@@ -122,6 +123,18 @@ export interface UseTypingTestResultSaveReturn {
   /** Name the just-finished result: persists a held unsaved result under the
    *  name (save-unnamed off; blank → discarded) or renames the saved latest. */
   nameFinishedResult: (name: string) => void
+  /** The in-memory log `runLog.finishAndSave` just built for the run that
+   *  finished (null when recording consent was off / view-only / nothing
+   *  saveable) — surfaced so the completion screen can render the shared
+   *  `KeystrokeTimelinePanel` inline, without an IPC round-trip for the
+   *  log it already holds (Plan-completion-timeline-view PR-B). Cleared
+   *  in the same `status !== 'finished'` branch that resets
+   *  `savedResultRef`, so a Next Test / Restart never leaves a stale run's
+   *  log rendering on the fresh one — callers should also check
+   *  `lastFinishedLog.runId` against the current run before rendering it
+   *  (see the codex-review note in Plan-completion-timeline-view.md), as
+   *  a belt-and-braces guard against the effect's own timing. */
+  lastFinishedLog: RunKeystrokeLog | null
 }
 
 /** Owns the auto-save-on-finish lifecycle for an editor typing test run:
@@ -153,6 +166,7 @@ export function useTypingTestResultSave({
   // names it (commitPendingResult), so an unnamed run is discarded.
   const savedResultRef = useRef(false)
   const [pendingUnnamedResult, setPendingUnnamedResult] = useState<TypingTestResult | null>(null)
+  const [lastFinishedLog, setLastFinishedLog] = useState<RunKeystrokeLog | null>(null)
   useEffect(() => {
     if (typingTestViewOnly) return
     if (typingTest.state.status === 'finished' && !savedResultRef.current && onSaveTypingTestResult) {
@@ -218,7 +232,7 @@ export function useTypingTestResultSave({
       // saves it (itself a no-op unless this run was actually
       // recorder-gated — see `record`'s own gate). Never
       // truncated-and-saved: finish() refuses instead.
-      runLog.finishAndSave(uid, typingTest.state.wordResults, {
+      const finishedLog = runLog.finishAndSave(uid, typingTest.state.wordResults, {
         runId: typingTest.state.runId,
         startedAtMs: typingTest.state.startTime ?? Date.now(),
         durationMs: elapsed,
@@ -232,6 +246,7 @@ export function useTypingTestResultSave({
         inFlightWord,
         lineBreaks: lineBreaksForLog,
       })
+      setLastFinishedLog(finishedLog)
       // A completed test makes any saved pause snapshot obsolete.
       if (savedMemoryRef.current) onMemoryChangeRef.current?.(undefined)
     }
@@ -240,6 +255,10 @@ export function useTypingTestResultSave({
       // Leaving the finished state (next test / restart) drops an unsaved,
       // still-unnamed result.
       if (pendingUnnamedResult) setPendingUnnamedResult(null)
+      // ...and the just-finished run's raw log, so the completion screen's
+      // timeline panel never renders a stale run's data once a fresh one
+      // starts (see `lastFinishedLog`'s own doc comment).
+      if (lastFinishedLog) setLastFinishedLog(null)
     }
   }, [typingTest.state.status, typingTest.state.startTime, typingTest.state.endTime,
     typingTest.state.correctChars, typingTest.state.incorrectChars,
@@ -249,7 +268,7 @@ export function useTypingTestResultSave({
     typingTest.state.currentInput, typingTest.state.romajiKeystrokes, typingTest.state.words,
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
-    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult,
+    typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult, lastFinishedLog,
     resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave])
 
   // The just-finished result, exposed so the pane can build name chips: the
@@ -273,5 +292,5 @@ export function useTypingTestResultSave({
     if (date) onRenameTypingTestResult?.(date, name)
   }, [pendingUnnamedResult, onSaveTypingTestResult, onRenameTypingTestResult, typingTestHistory])
 
-  return { finishedResult, nameFinishedResult }
+  return { finishedResult, nameFinishedResult, lastFinishedLog }
 }

--- a/src/renderer/components/editors/useInputModes.ts
+++ b/src/renderer/components/editors/useInputModes.ts
@@ -11,6 +11,7 @@ import { useTypingAnalyticsSink, typingTestAnalyticsLabel } from './use-typing-a
 import { useTypingTestResultSave } from './use-typing-test-result-save'
 import type { TypingTestResult, TypingTestMemory } from '../../../shared/types/pipette-settings'
 import type { TypingAnalyticsKeyboard } from '../../../shared/types/typing-analytics'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 import { PROCESS_CODE_TO_KEY } from './keymap-editor-types'
 
 export interface UseInputModesOptions {
@@ -79,6 +80,11 @@ export interface UseInputModesReturn {
   /** Name the just-finished result: persists a held unsaved result under the
    *  name (save-unnamed off; blank → discarded) or renames the saved latest. */
   nameFinishedResult: (name: string) => void
+  /** The just-finished run's in-memory raw keystroke log (null when
+   *  recording consent was off, view-only, or nothing saveable) — see
+   *  `useTypingTestResultSave`'s own doc comment on its own
+   *  `lastFinishedLog`, which this is a direct passthrough of. */
+  lastFinishedLog: RunKeystrokeLog | null
   /** Memory mode (imported fileImport text). */
   savedTypingTestMemory?: TypingTestMemory
   pauseTypingTest: () => void
@@ -132,6 +138,7 @@ export function useInputModes({
     recordingActiveRef,
     testLabelRef,
     testRunIdRef,
+    runLogLabelRef,
     prepareAnalyticsEvent,
     emitAnalyticsEvent,
     flushAfterPendingEmits,
@@ -144,8 +151,13 @@ export function useInputModes({
     onEmitAnalyticsEvent: emitAnalyticsEvent,
     // A direct passthrough — runLog.noteRegistration re-checks the label/
     // consent gate itself (same privacy-critical gate `record` uses
-    // above), so ambient REC frames (testLabelRef null) never touch the
-    // recorder buffer at all, not even to register.
+    // above, fed runLogLabelRef — see the GATE SPLIT note below — NOT
+    // testLabelRef), so ambient REC frames (runLogLabelRef null) never
+    // touch the recorder buffer at all, not even to register. The call
+    // site itself (useTypingTestMatrix's `prepared == null continue`) is
+    // also gated on the union of both tags — see prepareAnalyticsEvent's
+    // `perMinuteAuthorized` split for why that's still safe for the
+    // per-minute pipeline.
     onNoteKeystrokeRegistration: runLog.noteRegistration,
     onNoteCharContext: runLog.noteCharContext,
     tappingTermMs,
@@ -158,6 +170,25 @@ export function useInputModes({
     processKeyEvent,
     setWindowFocused,
   } = typingTest
+
+  // The runId useTypingTest minted for its own untouched initial mount —
+  // `useRef`'s initializer runs once, so this never changes afterward,
+  // regardless of how many real sessions this useInputModes instance goes
+  // on to run. Every genuine "arm a session" entry point that can produce
+  // a 'waiting' status — restart, restartWithCountdown, setConfig,
+  // setLanguage (both its success and its error-fallback path), and
+  // setBaseLayer — goes through `freshState()`/`createInitialState()`,
+  // which mints a brand-new `crypto.randomUUID()` runId unconditionally
+  // (run-state.ts), so `runId !== pristineRunIdRef.current` is a reliable
+  // "this waiting state actually came from an explicit start action"
+  // signal — see runLogLabelRef's own gating comment below for why this
+  // distinction matters. `restoreState` (pause/resume) is NOT in this
+  // list: `buildRestoredState` only ever produces 'running' or 'paused'
+  // (typing-test-memory.ts), never 'waiting', so it can't affect this
+  // check either way — and it deliberately REUSES the paused run's own
+  // `memory.runId` rather than minting a fresh one, since a resumed run
+  // is the same logical run continuing, not a new one starting.
+  const pristineRunIdRef = useRef(typingTest.state.runId)
 
   const savedMemoryRef = useRef(savedTypingTestMemory)
   savedMemoryRef.current = savedTypingTestMemory
@@ -241,11 +272,88 @@ export function useInputModes({
   // 1-2 edge gap in the aggregate heatmap, accepted to avoid the phantom run.
   // ('finished' is intentionally excluded so idle presses after a test can't
   // re-introduce a phantom record.)
+  //
+  // GATE SPLIT (codex safety review of an earlier, broader-gate attempt at
+  // the missing-first-keystroke fix — see runLogLabelRef below for the
+  // actual fix): this condition is deliberately restored to EXACTLY its
+  // original (#203) shape. Broadening it to also cover armed-waiting (as
+  // a first attempt did) tags the per-minute analytics pipeline too
+  // eagerly in two ways that pipeline was never meant to tolerate:
+  //  - P1: `setConfig`/`setLanguage` update `config` synchronously but
+  //    the STATE stays whatever it was (old runId, possibly already
+  //    non-pristine from an earlier session) until their async word-list
+  //    load resolves and calls `setState(freshState(...))` — during that
+  //    window a broadened gate would tag the STALE run with the NEW
+  //    config's label, producing a phantom/orphan analytics run.
+  //  - P2: the per-minute pipeline has no notion of "pre-start" content
+  //    filtering — a broadened gate would tag every modifier/no-op press
+  //    made while armed-waiting (before the user's first real character)
+  //    into the heatmap unboundedly, not just the one keystroke that
+  //    actually starts the run.
+  // The run-log recorder needs the run's first keystroke for a different
+  // reason (a raw per-run log, not an aggregate heatmap) and tolerates
+  // pre-start junk fine (finish() drops anything preceding startedAtMs via
+  // the negative-pressMs filter — see run-log-recorder.ts), so it gets its
+  // OWN, separate, broader gate below instead of reusing this one.
   testLabelRef.current = typingTestMode && !typingTestViewOnly && typingTest.state.status === 'running'
     ? typingTestAnalyticsLabel(typingTest.config, typingTest.language, typingTest.state.currentQuote)
     : null
-  // Run id travels with the label so each run's keystrokes are separable.
-  testRunIdRef.current = testLabelRef.current ? typingTest.state.runId : null
+
+  // The run-log recorder's OWN tag — broader than testLabelRef above (see
+  // the GATE SPLIT note): non-null while running, OR already 'waiting'
+  // for the run's first keystroke under a session that was actually,
+  // explicitly armed (see pristineRunIdRef above). Two states stay
+  // excluded, same reasoning as testLabelRef:
+  //  - 'countdown' — the config hasn't settled yet.
+  //  - a 'waiting' that is still the component's untouched, pristine
+  //    initial mount value, OR one whose config just changed but whose
+  //    async word-list load (setConfig/setLanguage) hasn't resolved yet
+  //    (P1 above) — `runId !== pristineRunIdRef.current` catches the
+  //    mount case; the in-flight-reconfigure case is caught for free too,
+  //    since `state.runId` doesn't change until that same async load
+  //    itself calls `setState(freshState(...))` — until then, `state`
+  //    (config, words, runId) is still the COHERENT pre-reconfigure
+  //    snapshot (either the pristine mount, or an earlier session already
+  //    correctly tagged/untagged on its own terms), never a mix of the
+  //    new config with a stale runId.
+  // A GENUINELY armed 'waiting' — reached via restartWithCountdown's own
+  // timer once the countdown finishes, or directly via restart/setConfig/
+  // setLanguage/setBaseLayer once their async word-list load resolves —
+  // always carries a fresh runId (freshState()/createInitialState() mint
+  // one unconditionally — see pristineRunIdRef's own comment for why
+  // restoreState is excluded from this list), so by the time any of those
+  // produce 'waiting', the config has genuinely settled and this check
+  // already reads non-pristine.
+  //
+  // Unlike testLabelRef, admitting this broader 'waiting' here is safe:
+  // the run-log recorder's own finish() already drops (never tags/saves)
+  // any keystroke preceding the run's own startedAtMs via the negative-
+  // pressMs filter, so pre-start junk let in by this wider gate (a
+  // modifier key pressed while still armed-waiting, say) is filtered out
+  // downstream rather than needing to never enter the buffer at all. This
+  // is what fixes the run's own first keystroke: previously, gating on
+  // 'running' alone (i.e. reusing testLabelRef) meant the exact keystroke
+  // that flips 'waiting' -> 'running' was processed (both its matrix
+  // registration in useTypingTestMatrix and its own char-side prepare()
+  // in processKeyEvent) while that ref still read null from the render
+  // before — a one-render-late ref can never catch up to the very state
+  // transition it is itself gating, so that keystroke was silently
+  // dropped every single run (user report: a run's first word always
+  // renders one keystroke bar short in KeystrokeTimelinePanel).
+  // 'finished' stays excluded too, so idle presses after a test can't
+  // re-introduce a phantom record.
+  const isArmedWaiting = typingTest.state.status === 'waiting' && typingTest.state.runId !== pristineRunIdRef.current
+  runLogLabelRef.current = typingTestMode && !typingTestViewOnly
+    && (typingTest.state.status === 'running' || isArmedWaiting)
+    ? typingTestAnalyticsLabel(typingTest.config, typingTest.language, typingTest.state.currentQuote)
+    : null
+  // Shared run id: non-null whenever EITHER tag above is (testLabelRef's
+  // narrow condition is always a subset of runLogLabelRef's broader one,
+  // so this single check covers both) — both tags, when set, always
+  // refer to this exact same run. See PreparedAnalyticsContext's own doc
+  // comment (use-typing-analytics-sink.ts) for how prepareAnalyticsEvent
+  // reads this alongside each tag.
+  testRunIdRef.current = (testLabelRef.current !== null || runLogLabelRef.current !== null) ? typingTest.state.runId : null
 
   // Reset matrix press-edge tracking when keymap changes or recording toggles
   // so the next frame doesn't emit stale press events against an old state.
@@ -297,7 +405,7 @@ export function useInputModes({
     return () => document.removeEventListener('keydown', handler, true)
   }, [typingTestMode, typingTestViewOnly, processKeyEvent])
 
-  const { finishedResult, nameFinishedResult } = useTypingTestResultSave({
+  const { finishedResult, nameFinishedResult, lastFinishedLog } = useTypingTestResultSave({
     typingTest,
     typingTestViewOnly,
     onSaveTypingTestResult,
@@ -407,6 +515,7 @@ export function useInputModes({
     handleTypingTestLanguageChange,
     finishedResult,
     nameFinishedResult,
+    lastFinishedLog,
     savedTypingTestMemory,
     pauseTypingTest,
     resumeTypingTest,

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.65",
+  "version": "0.1.67",
   "name": "English",
   "common": {
     "save": "Save",
@@ -270,7 +270,6 @@
       "exitTypingMode": "Exit Typing Test",
       "restart": "Restart",
       "nextTest": "Next Test",
-      "complete": "Complete",
       "collapseSettings": "Collapse settings",
       "expandSettings": "Expand settings",
       "keymapToggle": "Keymap",
@@ -555,7 +554,8 @@
             "leadIn": "Pause before this word",
             "blankLine": "Pause (>250ms, shown compressed)",
             "leadInLine": "Pause before this line",
-            "correctedNote": "Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy."
+            "correctedNote": "Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy.",
+            "infoAriaLabel": "Legend notes"
           },
           "axisNote": "Pauses are shown compressed on this axis; every duration shown is still the real one.",
           "correlationUnreliable": "Correctness markers may be unreliable for this run — some input went through IME composition.",
@@ -586,7 +586,8 @@
         "mistakesLabel": "Missed",
         "errorSubstitutions": "Substitution {{count}}",
         "errorOmissions": "Omission {{count}}",
-        "errorInsertions": "Insertion {{count}}"
+        "errorInsertions": "Insertion {{count}}",
+        "timelineConsentHint": "Enable typing recording to see the keystroke timeline here."
       }
     }
   },

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -105,6 +105,32 @@
   }
 }
 
+/* Line timeline header pinning (KeystrokeTimelinePanel's scrollport +
+   LineTimelineRow.tsx): only the SVG bar strip below each row's header
+   should scroll/stretch with zoom — the header itself (index badge + line
+   text + right-aligned stats + optional romaji sub-line) must stay
+   pinned to the scrollport's own VISIBLE width at all times, even though
+   its row (a flex child stretched to the zoomed canvas's width) can be
+   far wider than the viewport. `.keystroke-timeline-scrollport` opts the
+   scrollport into `container-type: inline-size` so `100cqw` below
+   resolves to ITS width (the visible viewport, unaffected by zoom), not
+   the row's own zoomed width. `.line-timeline-header-sticky` then pins
+   the header horizontally (`position: sticky; left: 0`) within that
+   scrollport as the user scrolls right, and caps its own width to the
+   viewport so the header's `ml-auto` stats span lands at the visible
+   right edge, not the zoomed row's actual (offscreen) right edge. Applied
+   to the LINE view only — the word view's analogous per-word header (see
+   word-timeline-row.tsx) is a separate component with its own, shorter
+   stats string that hasn't been reported as scrolling out of view. */
+.keystroke-timeline-scrollport {
+  container-type: inline-size;
+}
+.line-timeline-header-sticky {
+  position: sticky;
+  left: 0;
+  width: 100cqw;
+}
+
 /* Interactive elements use pointer cursor */
 button:not(:disabled),
 a,

--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -12,11 +12,13 @@
 
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Info } from 'lucide-react'
 import { AnalyzeStatGrid } from '../components/analyze/stat-card'
 import { TooltipShell, Stat } from '../components/analyze/analyze-tooltip'
-import { computeBubblePosition } from '../components/ui/Tooltip'
+import { Tooltip, computeBubblePosition } from '../components/ui/Tooltip'
 import { fmtMs } from '../components/analyze/analyze-format'
 import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
+import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
 import type { KeystrokeSegment } from './word-timeline'
@@ -25,7 +27,7 @@ import { LineTimelineRow, type LineHoverTarget } from './LineTimelineRow'
 import { TIMELINE_LEGEND, type TimelineFillKind } from './word-timeline-colors'
 import { useTimelineModel } from './use-timeline-model'
 import { buildTimelineStatItems } from './keystroke-timeline-stats'
-import { MissedCharsList, ErrorClassLine, type ErrorClassCounts } from './mistake-summary'
+import { MissedCharsList } from './mistake-summary'
 
 /** Floor for the "fit" zoom level's canvas width — a run with a very
  *  short `maxDisplayMs` (e.g. a single short word) would otherwise
@@ -235,19 +237,16 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
     ))
   }, [hover])
 
+  // Substitution/Omission/Insertion now render as three more stat cards in
+  // `summaryItems` (see keystroke-timeline-stats.ts), not as their own
+  // line below — see the module's own doc comment for the fallback rule.
   const summaryItems = useMemo(() => buildTimelineStatItems(result, summary, log), [result, summary, log])
 
-  // Both-or-neither, mirroring `TypingTestResult.errorSubstitutions`
-  // et al.'s own storage contract — a result saved before error-class
-  // tracking existed (or a romaji/no-finalized-word run) has none of the
-  // three fields, and this reads that as "omit the line entirely" rather
-  // than fabricating a partial breakdown.
-  const errorClasses: ErrorClassCounts | null = result
-    && result.errorSubstitutions !== undefined
-    && result.errorOmissions !== undefined
-    && result.errorInsertions !== undefined
-    ? { substitutions: result.errorSubstitutions, omissions: result.errorOmissions, insertions: result.errorInsertions }
-    : null
+  // The legend's info icon tooltip content — both former standalone note
+  // paragraphs (corrected-mistake markers, compressed-pause axis), joined
+  // with a newline so BUBBLE_BASE's `whitespace-pre-line` renders them as
+  // two lines rather than one run-on sentence.
+  const legendNotes = `${t('editor.typingTest.history.timeline.legend.correctedNote')}\n${t('editor.typingTest.history.timeline.axisNote')}`
 
   if (!displayMode) return null
 
@@ -261,14 +260,6 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           reaching the scrollable, flex-grow canvas below. */}
       <AnalyzeStatGrid items={summaryItems} ariaLabelKey="editor.typingTest.history.timeline.modalTitle" />
 
-      {/* Missed characters / error-mix — result-only (see the module doc
-          comment): reconstructing either from the raw log would re-derive
-          scoring rules run-state.ts already owns. Both components render
-          nothing when their data is absent/empty, same convention the
-          completion screen (`TypingTestStatsRow`) already follows. */}
-      <MissedCharsList mistakes={result?.mistakes ?? {}} />
-      {errorClasses && <ErrorClassLine errorClasses={errorClasses} />}
-
       {activeCharCorrelationUnavailable && (
         <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
           {t('editor.typingTest.history.timeline.correlationUnreliable')}
@@ -281,14 +272,30 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           lead-in wording to the line-view's own meaning (a 250ms
           cut and "before this line", not the word view's 1000ms /
           "before this word") — every other entry, and the word
-          view's own wording, stays unchanged. */}
+          view's own wording, stays unchanged. The two longer-form
+          notes (corrected-mistake markers, compressed-pause axis)
+          used to render as their own paragraph lines below the
+          legend — collapsed into this single info icon (`ml-auto`,
+          right end of the row) so the legend reads as one compact
+          line; both notes still live in the tooltip, joined with a
+          newline (BUBBLE_BASE's `whitespace-pre-line` renders it as
+          two lines), same idiom as ErrorMixSection's row-label
+          tooltip. */}
       <div className="flex flex-wrap items-center gap-3 rounded-md border border-edge bg-surface px-3 py-1.5">
         {LEGEND_ORDER.map((kind) => (
           <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
         ))}
+        <Tooltip content={legendNotes} className="max-w-xs">
+          <button
+            type="button"
+            data-testid="word-timeline-legend-info"
+            aria-label={t('editor.typingTest.history.timeline.legend.infoAriaLabel')}
+            className="ml-auto rounded p-1 text-content-muted hover:text-content transition-colors"
+          >
+            <Info size={ICON_SM} aria-hidden="true" />
+          </button>
+        </Tooltip>
       </div>
-      <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.legend.correctedNote')}</p>
-      <p className="text-2xs text-content-muted">{t('editor.typingTest.history.timeline.axisNote')}</p>
 
       {/* Zoom — same row shape as RGBConfigurator's brightness
           slider (the only existing range-input precedent). The
@@ -317,7 +324,37 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
         </div>
       )}
 
-      <div ref={containerRef} className="relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2">
+      {/* `keystroke-timeline-scrollport` (style.css) opts this scroll
+          container into `container-type: inline-size` — the LINE view's
+          per-row header pins itself to this container's own visible
+          width via `100cqw` (see LineTimelineRow.tsx and
+          .line-timeline-header-sticky's own doc comment), independent of
+          how wide the zoomed canvas inside it grows. `overflow-auto`
+          already covers BOTH axes — a many-row run scrolls vertically
+          within this same element, not just horizontally on zoom; the
+          sticky header's `left: 0` pin is horizontal-axis only, so it is
+          unaffected by (and stays correctly positioned through) vertical
+          scrolling here.
+          `flex-1 min-h-0` is what makes that vertical scroll trigger AT
+          ALL — it relies entirely on an unbroken flex-height chain from
+          this element up to a real bounded ancestor (the editor's own
+          overflow-auto content pane). A fixed viewport-relative max-height
+          cap used to live here for the completion screen specifically
+          (which lacked that chain), but a fixed vh figure can't adapt to
+          how much OTHER chrome (Lines/Font sidebar controls, an
+          IME-composition warning, the Missed-chars line, ...) a given run
+          actually has above/below it — it either wastes space or (on a
+          shorter window, or a run with more of that chrome) still
+          overflows the pane. TypingTestView.tsx now instead extends this
+          same flex chain up through its own finished-state wrapper, so
+          this scrollport ends up correctly sized without any cap at all,
+          in both the modal and the completion-screen contexts alike —
+          see TypingTestView.tsx's own "Completion screen" comment for the
+          exact chain. */}
+      <div
+        ref={containerRef}
+        className="keystroke-timeline-scrollport relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2"
+      >
         <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
           {displayMode === 'line' && lineModel
             ? lineModel.lines.map((line) => (
@@ -367,6 +404,22 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
               )}
           </div>
         )}
+      </div>
+
+      {/* Missed characters — result-only (see the module doc comment):
+          reconstructing it from the raw log would re-derive scoring rules
+          run-state.ts already owns. Renders nothing when the result has
+          no mistakes, same convention the completion screen
+          (`TypingTestStatsRow`) already follows for its own copy of this
+          list. Substitution/Omission/Insertion render above, as stat
+          cards in `summaryItems`, not here. Moved below the rows
+          scrollport (was between the stat-card grid and the legend) so
+          the timeline itself reads first; `shrink-0` keeps it from being
+          squeezed by the scrollport's own `flex-1`, which must keep
+          absorbing all the remaining height in the flex-height chain
+          (see the scrollport's own comment above). */}
+      <div className="shrink-0">
+        <MissedCharsList mistakes={result?.mistakes ?? {}} />
       </div>
     </div>
   )

--- a/src/renderer/typing-test/LineTimelineRow.tsx
+++ b/src/renderer/typing-test/LineTimelineRow.tsx
@@ -78,24 +78,34 @@ function LineTimelineRowInner({ line, maxDisplayMs, romajiInput, onHover, onHove
 
   return (
     <div className="flex flex-col gap-0.5" data-testid={`line-timeline-row-${line.lineIndex}`}>
-      <div className="flex items-baseline gap-2">
-        <span
-          className="rounded-full bg-surface-dim px-1.5 text-2xs font-semibold text-content-secondary"
-          aria-label={t('editor.typingTest.history.timeline.line.indexAria', { n: line.lineIndex + 1 })}
-        >
-          {line.lineIndex + 1}
-        </span>
-        <span className="font-mono text-xs text-content">{lineText || EMPTY_STAT_VALUE}</span>
-        <span className="text-2xs text-content-muted">{statParts.join(' · ')}</span>
+      {/* Header (index badge + line text + right-aligned stats + romaji
+          sub-line) — pinned to the scrollport's own visible width via
+          `line-timeline-header-sticky` (style.css), so it never scrolls
+          out of view alongside the zoomed bar strip below it, which is
+          the only part of this row meant to stretch/scroll with zoom.
+          See that class's own doc comment for the container-query
+          mechanism (`.keystroke-timeline-scrollport` on the ancestor
+          scroll container). */}
+      <div className="line-timeline-header-sticky flex flex-col gap-0.5 bg-surface" data-testid={`line-timeline-header-${line.lineIndex}`}>
+        <div className="flex items-baseline gap-2">
+          <span
+            className="rounded-full bg-surface-dim px-1.5 text-2xs font-semibold text-content-secondary"
+            aria-label={t('editor.typingTest.history.timeline.line.indexAria', { n: line.lineIndex + 1 })}
+          >
+            {line.lineIndex + 1}
+          </span>
+          <span className="font-mono text-xs text-content">{lineText || EMPTY_STAT_VALUE}</span>
+          <span className="ml-auto text-2xs text-content-muted" data-testid={`line-timeline-stats-${line.lineIndex}`}>{statParts.join(' · ')}</span>
+        </div>
+        {romajiText !== null && (
+          <span
+            className="font-mono text-2xs text-content-muted"
+            aria-label={t('editor.typingTest.history.timeline.line.romajiAria', { text: romajiText })}
+          >
+            {romajiText || EMPTY_STAT_VALUE}
+          </span>
+        )}
       </div>
-      {romajiText !== null && (
-        <span
-          className="font-mono text-2xs text-content-muted"
-          aria-label={t('editor.typingTest.history.timeline.line.romajiAria', { text: romajiText })}
-        >
-          {romajiText || EMPTY_STAT_VALUE}
-        </span>
-      )}
       <div className="relative">
         <svg
           width="100%"

--- a/src/renderer/typing-test/TypingTestControlsRow.tsx
+++ b/src/renderer/typing-test/TypingTestControlsRow.tsx
@@ -2,8 +2,8 @@
 
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { SquarePen, Pause, Play, CircleCheck } from 'lucide-react'
-import { ICON_SM, ICON_LG } from '../constants/ui-tokens'
+import { SquarePen, Pause, Play } from 'lucide-react'
+import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestState } from './useTypingTest'
 import type { TypingTestConfig } from './types'
 import { ResultNameModal } from './ResultNameModal'
@@ -51,50 +51,42 @@ export function TypingTestControlsRow({
   const { t } = useTranslation()
 
   return (
-    <>
-      {state.status === 'finished' && (
-        <p data-testid="typing-test-complete" className="flex items-center gap-1.5 text-lg font-semibold text-accent">
-          <CircleCheck size={ICON_LG} aria-hidden="true" />
-          {t('editor.typingTest.complete')}
-        </p>
+    <div className="flex items-center gap-2">
+      {config.mode === 'fileImport' && (
+        state.status === 'running' ? (
+          <button
+            type="button"
+            data-testid="typing-memory-pause"
+            className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+            onClick={onPause}
+          >
+            <Pause size={ICON_SM} aria-hidden="true" />
+            <span>{t('editor.typingTest.memory.pause')}</span>
+          </button>
+        ) : (state.status === 'paused' || ((state.status === 'waiting' || state.status === 'countdown') && hasSavedMemory)) ? (
+          <button
+            type="button"
+            data-testid="typing-memory-resume"
+            className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-accent transition-colors hover:text-accent/80"
+            onClick={onResume}
+          >
+            <Play size={ICON_SM} aria-hidden="true" />
+            <span>{t('editor.typingTest.memory.resumeButton')}</span>
+          </button>
+        ) : null
       )}
-      <div className="flex items-center gap-2">
-        {config.mode === 'fileImport' && (
-          state.status === 'running' ? (
-            <button
-              type="button"
-              data-testid="typing-memory-pause"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-              onClick={onPause}
-            >
-              <Pause size={ICON_SM} aria-hidden="true" />
-              <span>{t('editor.typingTest.memory.pause')}</span>
-            </button>
-          ) : (state.status === 'paused' || ((state.status === 'waiting' || state.status === 'countdown') && hasSavedMemory)) ? (
-            <button
-              type="button"
-              data-testid="typing-memory-resume"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-edge px-2.5 text-sm text-accent transition-colors hover:text-accent/80"
-              onClick={onResume}
-            >
-              <Play size={ICON_SM} aria-hidden="true" />
-              <span>{t('editor.typingTest.memory.resumeButton')}</span>
-            </button>
-          ) : null
-        )}
-        {state.status === 'finished' && (
-          <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} chips={resultNameChips} />
-        )}
-        <button
-          type="button"
-          data-testid={state.status === 'running' || state.status === 'paused' ? 'typing-test-restart' : 'typing-test-start'}
-          className="flex h-8 items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
-          onClick={onStart}
-        >
-          {t(state.status === 'running' || state.status === 'paused' ? 'editor.typingTest.restart' : 'editor.typingTest.nextTest')}
-        </button>
-      </div>
-    </>
+      {state.status === 'finished' && (
+        <ResultNameField key={state.startTime ?? 'none'} onName={onNameResult} chips={resultNameChips} />
+      )}
+      <button
+        type="button"
+        data-testid={state.status === 'running' || state.status === 'paused' ? 'typing-test-restart' : 'typing-test-start'}
+        className="flex h-8 items-center rounded-md border border-edge px-2.5 text-sm text-content-secondary transition-colors hover:text-content"
+        onClick={onStart}
+      >
+        {t(state.status === 'running' || state.status === 'paused' ? 'editor.typingTest.restart' : 'editor.typingTest.nextTest')}
+      </button>
+    </div>
   )
 }
 

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -10,8 +10,11 @@ import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
 import { WordDisplay } from './WordDisplay'
 import { TypingTestControlsRow } from './TypingTestControlsRow'
 import { TypingTestStatsRow } from './TypingTestStatsRow'
+import { KeystrokeTimelinePanel } from './KeystrokeTimelinePanel'
 import { useVisualLines } from './useVisualLines'
 import { useLogicalWindowHeight } from './useLogicalWindowHeight'
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
 
 
 /** A tagged snapshot of this view's own realized line rows (`lines` below
@@ -51,9 +54,6 @@ interface Props {
   paused: boolean
   /** Hide the stats / results (WPM) row. Persisted per keyboard. */
   hideStatsRow?: boolean
-  /** Hide the operation (Next Test button) controls row. Persisted per
-   *  keyboard. Force-shown once a test finishes. */
-  hideControls?: boolean
   /** Baseline metrics for the Measurement-row comparison delta, or null when
    *  comparison is off / no matching history. */
   comparison?: ComparisonStats | null
@@ -97,6 +97,20 @@ interface Props {
    *  see `LineSnapshot`'s own doc comment. Optional so every existing
    *  mount (tests included) stays valid without threading it. */
   lineSnapshotRef?: RefObject<LineSnapshot | null>
+  /** The just-finished run's in-memory raw keystroke log (Plan-completion-
+   *  timeline-view PR-B) — null when recording consent was off, view-only,
+   *  or nothing was saveable. Rendered as the shared `KeystrokeTimelinePanel`
+   *  in place of the old stats row ONLY while `status === 'finished'` AND
+   *  `runId` matches the current run's own (see the codex-review note in
+   *  Plan-completion-timeline-view.md): a fresh run's finish effect can
+   *  otherwise briefly still be carrying the PREVIOUS run's log for one
+   *  render, which this guard exists to catch. */
+  lastFinishedLog?: RunKeystrokeLog | null
+  /** The just-finished result, reused as the panel's own `result` prop so
+   *  the completion screen's unified stat block reads exactly like
+   *  History's timeline modal for the same run (see
+   *  `KeystrokeTimelinePanel`'s own doc comment on that prop). */
+  finishedResult?: TypingTestResult | null
 }
 
 /** Group flat word indices into logical lines using the line-break set
@@ -139,7 +153,6 @@ export function TypingTestView({
   config,
   paused,
   hideStatsRow,
-  hideControls,
   comparison,
   onCompositionStart,
   onCompositionUpdate,
@@ -156,8 +169,19 @@ export function TypingTestView({
   hasSavedMemory,
   errorClasses = null,
   lineSnapshotRef,
+  lastFinishedLog = null,
+  finishedResult = null,
 }: Props) {
   const { t } = useTranslation()
+  // Completion screen (Plan-completion-timeline-view PR-B): once a run
+  // finishes, the reading window/romaji guide give way to the inline
+  // keystroke timeline — see the JSX below for where each is gated.
+  // `timelineLog` additionally requires the log's own `runId` to match
+  // the CURRENT run (see `lastFinishedLog`'s own doc comment on the
+  // stale-flash guard this exists to prevent); `isFinished` alone gates
+  // the reading window regardless of whether a log ends up available.
+  const isFinished = state.status === 'finished'
+  const timelineLog = isFinished && lastFinishedLog && lastFinishedLog.runId === state.runId ? lastFinishedLog : null
   const wordsRef = useRef<HTMLDivElement>(null)
   const imeInputRef = useRef<HTMLTextAreaElement>(null)
   const isComposingRef = useRef(false)
@@ -364,9 +388,20 @@ export function TypingTestView({
   }
 
   return (
-    <div data-testid="typing-test-view" className="flex w-full min-w-0 flex-col items-center gap-4 px-4 py-4">
+    // `min-h-0 flex-1` only once finished — see the "Completion screen"
+    // comment further down for why (the flex-height chain that lets the
+    // timeline panel's rows scroll internally instead of growing the
+    // whole pane). The running/waiting/paused states keep their original
+    // natural-content-height flow; they were never reported as
+    // overflowing and don't need this.
+    <div data-testid="typing-test-view" className={`flex w-full min-w-0 flex-col items-center gap-4 px-4 py-4${isFinished ? ' min-h-0 flex-1' : ''}`}>
       {/* Word display — fixed window with scroll. Word-flow modes show a
-          3-line window; imported fileImport text shows 4 lines (line-row layout). */}
+          3-line window; imported fileImport text shows 4 lines (line-row
+          layout). Hidden once the run finishes (Plan-completion-timeline-view
+          PR-B) — the completion screen's main content is the keystroke
+          timeline (or, without a log, the stats row below), not the
+          already-typed reading window. */}
+      {!isFinished && (
       <div
         data-testid="typing-test-words"
         className="relative w-full max-w-4xl font-mono leading-normal typing-multiline-window"
@@ -480,6 +515,7 @@ export function TypingTestView({
           </div>
         )}
       </div>
+      )}
 
       {/* Romaji guide — line-synchronized with the reading window's own
           word lines (real or synthetic — see `guideLines` above): each
@@ -503,8 +539,10 @@ export function TypingTestView({
           wrapping on wide windows, but its left edge is pinned to line up
           with the centered max-w-4xl reading window via the same
           --container-4xl token (pl-[calc((100%-min(var(--container-4xl),100%))/2)]
-          clamps to 0 once the pane is at or below that width). */}
-      {romajiGuide && (romajiGuide.showRow || imeDetected) && (
+          clamps to 0 once the pane is at or below that width). Hidden once
+          finished, alongside the reading window above (see its own
+          comment). */}
+      {!isFinished && romajiGuide && (romajiGuide.showRow || imeDetected) && (
         <div data-testid="typing-test-romaji-guide" className="flex w-full flex-col items-start gap-1 pl-[calc((100%-min(var(--container-4xl),100%))/2)] font-mono" style={romajiGuideStyle}>
           {romajiGuide.showRow && (
             guideLines ? (
@@ -533,48 +571,135 @@ export function TypingTestView({
         </div>
       )}
 
-      {/* State-based controls row, below the reading window:
-          - not started (waiting / countdown): Next Test (+ Resume if a run is
-            saved for imported fileImport text)
-          - in progress (running / paused): Pause or Resume (fileImport) + Restart
-          - finished: result name (fileImport) + Next Test
-          Next Test and Restart share the same action; only the label differs.
-          The "operation" toggle hides this controls row (and the Complete
-          message above it), but a finished test always shows it so the
-          result can be named and the next test started. */}
-      {(!hideControls || state.status === 'finished') && (
-        <TypingTestControlsRow
-          state={state}
-          config={config}
-          onNameResult={onNameResult}
-          resultNameChips={resultNameChips}
-          onStart={onStart}
-          onPause={onPause}
-          onResume={onResume}
-          hasSavedMemory={hasSavedMemory}
-        />
-      )}
+      {/* Non-finished controls row (not started: Next Test / Resume; in
+          progress: Pause or Resume / Restart) no longer renders here — it
+          moved to TypingTestPane, BELOW the keyboard pane and its layer
+          note, so the reading window sits directly above the keyboard the
+          user actually types on. TypingTestPane owns the `!hideControls`
+          gate for that row now (the "operation" toggle). The finished-state
+          row (result name + Next Test) stays here — it renders instead at
+          the BOTTOM of the completion screen, below the timeline panel (or
+          the fallback stats row) — see the render below — since the
+          keyboard itself is hidden once finished, so there's no "below the
+          keyboard" position for it to move to. */}
 
-      {/* Measurement / results row — below the reading window and the
-          Unnamed / Next Test row. Live metrics during a run; before measuring
-          (waiting / countdown) every value reads "-". The "measurement" toggle
-          hides the LIVE metrics during a run — once finished, the results
-          always show. */}
-      {(!hideStatsRow || state.status === 'finished') && (
-        <TypingTestStatsRow
-          state={state}
-          wpm={wpm}
-          kpm={kpm}
-          accuracy={accuracy}
-          kspc={kspc}
-          elapsedSeconds={elapsedSeconds}
-          remainingSeconds={remainingSeconds}
-          config={config}
-          comparison={comparison}
-          errorClasses={errorClasses}
-        />
-      )}
+      {/* Completion screen (Plan-completion-timeline-view PR-B): once a run
+          finishes WITH a matching in-memory log, the shared
+          KeystrokeTimelinePanel — same unified stat block, legend, zoom,
+          and rows as History's timeline modal — replaces the old compact
+          stats row entirely (it already contains the Missed/error-mix
+          lines the old row also showed, so both would otherwise
+          duplicate). Rendered above the finished-state controls row below
+          (moved to the bottom of the completion screen so the
+          timeline/stats content reads first).
 
+          FLEX-HEIGHT CHAIN (codex safety review of an earlier, fixed-vh
+          `rowsMaxHeightClass` cap — replaced because a fixed vh figure
+          can't adapt to how much OTHER chrome a given run actually has:
+          Lines=1 leaves less sidebar height claimed, an IME-composition
+          warning or the Missed-chars line adds MORE panel-internal
+          content, and the editor's own content pane doesn't reserve a
+          fixed fraction of the window either — any single vh number is
+          right for some combination of these and wrong for others). This
+          wrapper (`isFinished`-only) is the top of a chain that makes the
+          rows area the ONLY thing that scrolls, by making every link
+          between it and the nearest real bounded ancestor stretch instead
+          of taking its natural content height:
+            KeymapEditor.tsx's own `overflow-auto` content-pane row (the
+            true bound — pre-existing, unrelated to typing-test) → its
+            `keymap-surface` child (pre-existing `min-h-0 flex-1`) →
+            TypingTestPane.tsx's outer `items-stretch` row (pre-existing
+            `min-h-0 flex-1`) → TypingTestPane.tsx's `items-center` column
+            (now ALSO `min-h-0`, alongside its pre-existing `flex-1`) →
+            this component's own root (`min-h-0 flex-1`, but ONLY once
+            `isFinished` — see its own className comment above) → THIS
+            wrapper (`min-h-0 flex-1 flex-col`) → the timeline panel
+            (`min-h-0 flex-1`) → KeystrokeTimelinePanel's OWN root (already
+            `flex min-h-0 flex-1 flex-col gap-3` — unchanged) → its stat
+            grid / Missed-chars / legend / zoom (unchanged, naturally
+            sized — `shrink-0` by simply never being given `flex-1`) → the
+            rows scrollport (already `flex-1 min-h-0 overflow-auto` —
+            unchanged, this is the only element that actually scrolls).
+          The controls row below stays naturally sized (no flex-1) — it's
+          the last child of a `flex-col` wrapper, so it just takes
+          whatever height its own content needs and never grows, i.e. it
+          is `shrink-0` in effect without needing the class name (a flex
+          item's default `flex-shrink: 1` only matters when its siblings'
+          combined natural height already exceeds the wrapper — since the
+          rows area is the one absorbing the slack via its own `flex-1`,
+          the controls row is never asked to shrink below its content). */}
+      {isFinished ? (
+        <div data-testid="typing-test-finished-wrapper" className="flex min-h-0 w-full flex-1 flex-col items-center gap-4">
+          {timelineLog ? (
+            <div className="flex min-h-0 w-full flex-1 flex-col" data-testid="typing-test-timeline-panel">
+              <KeystrokeTimelinePanel log={timelineLog} result={finishedResult ?? undefined} />
+            </div>
+          ) : (
+            <>
+              <TypingTestStatsRow
+                state={state}
+                wpm={wpm}
+                kpm={kpm}
+                accuracy={accuracy}
+                kspc={kspc}
+                elapsedSeconds={elapsedSeconds}
+                remainingSeconds={remainingSeconds}
+                config={config}
+                comparison={comparison}
+                errorClasses={errorClasses}
+              />
+              {/* No log to show a timeline for (recording consent was off,
+                  view-only, or nothing saveable) — hint that enabling it
+                  would surface this same panel next time. Omitted for a
+                  stale-runId log (present but not yet matching this run)
+                  since that's a transient rendering edge, not "no
+                  consent". */}
+              {!lastFinishedLog && (
+                <p data-testid="typing-test-timeline-consent-hint" className="text-xs text-content-muted">
+                  {t('editor.typingTest.results.timelineConsentHint')}
+                </p>
+              )}
+            </>
+          )}
+          {/* Finished-state controls row (result name + Next Test) —
+              deliberately LAST, below the timeline panel (or the fallback
+              stats row + consent hint above), not above it — the
+              timeline/stats content is what the user reads first once a
+              run finishes; naming the result and starting the next one is
+              the closing action. */}
+          <TypingTestControlsRow
+            state={state}
+            config={config}
+            onNameResult={onNameResult}
+            resultNameChips={resultNameChips}
+            onStart={onStart}
+            onPause={onPause}
+            onResume={onResume}
+            hasSavedMemory={hasSavedMemory}
+          />
+        </div>
+      ) : (
+        // Measurement / results row — below the reading window, mid-run.
+        // Live metrics while running; before measuring (waiting /
+        // countdown) every value reads "-". The "operation"/"measurement"
+        // toggle (`hideStatsRow`) hides this row entirely while running —
+        // once finished, the branch above always shows a results summary
+        // regardless of that toggle, so there is nothing to gate here.
+        !hideStatsRow && (
+          <TypingTestStatsRow
+            state={state}
+            wpm={wpm}
+            kpm={kpm}
+            accuracy={accuracy}
+            kspc={kspc}
+            elapsedSeconds={elapsedSeconds}
+            remainingSeconds={remainingSeconds}
+            config={config}
+            comparison={comparison}
+            errorClasses={errorClasses}
+          />
+        )
+      )}
     </div>
   )
 }

--- a/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
+++ b/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { KeystrokeTimelinePanel } from '../KeystrokeTimelinePanel'
@@ -82,6 +82,27 @@ describe('KeystrokeTimelinePanel', () => {
     expect(statCardText('Overlap')).toContain('—')
   })
 
+  it('shows a LINES card (not Words) when the log carries lineBreaks, with the line count from the log', () => {
+    const lineLog: RunKeystrokeLog = { ...SAMPLE_LOG, lineBreaks: [0] } // 1 break -> 2 lines
+    renderWithI18n(<KeystrokeTimelinePanel log={lineLog} result={makeResult({ mode: 'words', wordCount: 999 })} />)
+    expect(statCardText('Lines')).toContain('2')
+    expect(screen.queryByText('Words')).toBeNull()
+  })
+
+  it('shows a LINES card for a tatoeba run with no log.lineBreaks, using result.wordCount as the line count', () => {
+    const tatoebaLog: RunKeystrokeLog = { ...SAMPLE_LOG, mode: 'tatoeba' }
+    renderWithI18n(<KeystrokeTimelinePanel log={tatoebaLog} result={makeResult({ mode: 'tatoeba', wordCount: 10 })} />)
+    expect(statCardText('Lines')).toContain('10')
+    expect(screen.queryByText('Words')).toBeNull()
+  })
+
+  it('keeps the WORDS card for a fileImport run with no log.lineBreaks (line count unknowable)', () => {
+    const fileImportLog: RunKeystrokeLog = { ...SAMPLE_LOG, mode: 'fileImport' }
+    renderWithI18n(<KeystrokeTimelinePanel log={fileImportLog} result={makeResult({ mode: 'fileImport', wordCount: 7 })} />)
+    expect(statCardText('Words')).toContain('7')
+    expect(screen.queryByText('Lines')).toBeNull()
+  })
+
   it('falls back to the model/log-derived values for WPM/Accuracy/Time, and EMPTY_STAT_VALUE for KPM/KSPC/Words, when no result is supplied', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
 
@@ -102,7 +123,79 @@ describe('KeystrokeTimelinePanel', () => {
     expect(screen.getAllByTestId('word-timeline-keystroke')).toHaveLength(2)
   })
 
-  it('shows the Missed characters list and error-mix line when the result carries them', () => {
+  it('opts the scroll container into container-type: inline-size, so a LINE row\'s sticky header can pin to its visible width via cqw', () => {
+    const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    const canvas = screen.getByTestId('word-timeline-canvas')
+    const scrollport = canvas.parentElement!
+    expect(scrollport.className).toContain('keystroke-timeline-scrollport')
+    expect(container.contains(scrollport)).toBe(true)
+  })
+
+  describe('rows scrollport height (flex-height chain, not a fixed cap)', () => {
+    // No `rowsMaxHeightClass`-style prop exists anymore (codex safety
+    // review of an earlier fixed-vh attempt — a fixed vh figure can't
+    // adapt to how much OTHER chrome a given run has, e.g. an
+    // IME-composition warning or the Missed-chars line). Instead this
+    // scrollport ALWAYS carries the same flex-1/min-h-0/overflow-auto
+    // classes regardless of caller — TypingTestView.tsx (completion
+    // screen) and WordTimelineView.tsx (History modal) now both provide
+    // a real bounded-height flex ancestor of their own, so this
+    // component needs no caller-supplied sizing prop of any kind. See
+    // TypingTestView.tsx's own "Completion screen" comment for that
+    // chain end to end.
+    it('the scrollport always carries flex-1 min-h-0 overflow-auto, with no caller-supplied sizing prop at all', () => {
+      const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const scrollport = within(container).getByTestId('word-timeline-canvas').parentElement!
+      expect(scrollport.className).toContain('flex-1')
+      expect(scrollport.className).toContain('min-h-0')
+      expect(scrollport.className).toContain('overflow-auto')
+      expect(scrollport.className).not.toMatch(/\bmax-h-/)
+      // Still carries the horizontal-scroll/sticky-header container-query
+      // opt-in.
+      expect(scrollport.className).toContain('keystroke-timeline-scrollport')
+    })
+
+    it('the panel\'s own root is flex-1 min-h-0 flex-col, so it correctly stretches within WHATEVER bounded ancestor the caller provides', () => {
+      const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const root = container.firstElementChild as HTMLElement
+      expect(root.className).toContain('flex')
+      expect(root.className).toContain('min-h-0')
+      expect(root.className).toContain('flex-1')
+      expect(root.className).toContain('flex-col')
+    })
+  })
+
+  it('collapses the two note paragraphs into a legend info icon, with no inline note text', () => {
+    const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    // The old standalone paragraphs are gone from the panel's own render
+    // tree entirely — the notes now live ONLY in the portaled tooltip
+    // (outside `container`, which is the panel's own DOM subtree), not as
+    // inline text in the flow.
+    expect(within(container).queryByText(/Mistake markers include keystrokes later corrected/)).toBeNull()
+    expect(within(container).queryByText(/Pauses are shown compressed on this axis/)).toBeNull()
+    // The info icon button sits at the legend row's right end, with an
+    // accessible name (no native title attribute — lint forbids it).
+    const infoButton = screen.getByTestId('word-timeline-legend-info')
+    expect(infoButton.tagName).toBe('BUTTON')
+    expect(infoButton.getAttribute('title')).toBeNull()
+    expect(infoButton).toHaveAccessibleName()
+    // Right end of the legend row (`ml-auto`), after every swatch.
+    expect(infoButton.className).toContain('ml-auto')
+    const legendRow = infoButton.closest('.rounded-md.border.border-edge.bg-surface')
+    expect(legendRow?.lastElementChild).toBe(infoButton.parentElement)
+  })
+
+  it('shows both note texts, joined as two lines, in the legend info tooltip', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    const tooltip = screen.getByRole('tooltip')
+    expect(tooltip.className).toContain('whitespace-pre-line')
+    expect(tooltip.textContent).toBe(
+      'Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy.'
+      + '\nPauses are shown compressed on this axis; every duration shown is still the real one.',
+    )
+  })
+
+  it('shows the Missed characters list when the result carries mistakes', () => {
     const result = makeResult({
       mistakes: { a: 3, b: 1 },
       errorSubstitutions: 2,
@@ -114,19 +207,59 @@ describe('KeystrokeTimelinePanel', () => {
 
     expect(screen.getByTestId('typing-test-mistakes')).toBeTruthy()
     expect(screen.getByTestId('typing-test-mistake-a').textContent).toBe('a:3')
-    expect(screen.getByTestId('typing-test-error-classes')).toBeTruthy()
-    expect(screen.getByTestId('typing-test-error-substitutions').textContent).toContain('2')
   })
 
-  it('omits the Missed/error-mix section entirely when the result has neither (not a "-" placeholder)', () => {
+  it('omits the Missed characters list entirely when the result has none (not a "-" placeholder)', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
     expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+  })
+
+  it('omits the Missed characters list when no result is supplied at all', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+  })
+
+  it('renders the Missed characters list AFTER the legend and the rows scrollport, not between the stat grid and the legend', () => {
+    const result = makeResult({ mistakes: { a: 3 } })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    const legendInfo = screen.getByTestId('word-timeline-legend-info')
+    const canvas = screen.getByTestId('word-timeline-canvas')
+    const mistakes = screen.getByTestId('typing-test-mistakes')
+
+    expect(legendInfo.compareDocumentPosition(mistakes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(canvas.compareDocumentPosition(mistakes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('shows Substitution/Omission/Insertion as stat cards, sourced from the result', () => {
+    const result = makeResult({
+      errorSubstitutions: 2,
+      errorOmissions: 1,
+      errorInsertions: 0,
+      errorTargetChars: 20,
+    })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    expect(statCardText('Substitution')).toContain('2')
+    expect(statCardText('Omission')).toContain('1')
+    expect(statCardText('Insertion')).toContain('0')
+    // The old standalone error-mix line is gone.
     expect(screen.queryByTestId('typing-test-error-classes')).toBeNull()
   })
 
-  it('omits the Missed/error-mix section when no result is supplied at all', () => {
+  it('shows EMPTY_STAT_VALUE for Substitution/Omission/Insertion when the result has no error-class fields', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
+
+    expect(statCardText('Substitution')).toContain('—')
+    expect(statCardText('Omission')).toContain('—')
+    expect(statCardText('Insertion')).toContain('—')
+  })
+
+  it('shows EMPTY_STAT_VALUE for Substitution/Omission/Insertion when no result is supplied at all', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
-    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
-    expect(screen.queryByTestId('typing-test-error-classes')).toBeNull()
+
+    expect(statCardText('Substitution')).toContain('—')
+    expect(statCardText('Omission')).toContain('—')
+    expect(statCardText('Insertion')).toContain('—')
   })
 })

--- a/src/renderer/typing-test/__tests__/LineTimelineRow.test.tsx
+++ b/src/renderer/typing-test/__tests__/LineTimelineRow.test.tsx
@@ -31,6 +31,60 @@ function makeLine(segments: LineTimelineLine['segments'], laneCount = 1): LineTi
   }
 }
 
+describe('LineTimelineRow — header layout', () => {
+  it('right-aligns the per-line stats span within the header row (ml-auto)', () => {
+    const line = makeLine([keystroke({ startMs: 0, endMs: 100, label: 'h' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const stats = screen.getByTestId('line-timeline-stats-0')
+    expect(stats.className).toContain('ml-auto')
+    // Sits after the line-text span, as the header row's last child — the
+    // index badge and line text stay in their original (start) position;
+    // only the stats span moves to the row's right end.
+    const header = stats.parentElement!
+    expect(header.className).toContain('flex')
+    expect(header.lastElementChild).toBe(stats)
+  })
+
+  it('pins the header (badge + line text + stats + romaji sub-line) to the scrollport via sticky + cqw, not the zoomed canvas', () => {
+    const line = makeLine([keystroke({ startMs: 0, endMs: 100, label: 'h' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const header = screen.getByTestId('line-timeline-header-0')
+    // `.line-timeline-header-sticky` (style.css) is `position: sticky;
+    // left: 0; width: 100cqw` — asserted here as class presence, since
+    // jsdom doesn't compute container-query/sticky layout; the actual
+    // pinned position is verified by the E2E completion-timeline script.
+    expect(header.className).toContain('line-timeline-header-sticky')
+    // The stats span (and the rest of the header) live INSIDE this pinned
+    // wrapper, not as a loose sibling.
+    expect(header.contains(screen.getByTestId('line-timeline-stats-0'))).toBe(true)
+  })
+
+  it('keeps the romaji sub-line inside the same pinned header wrapper as the badge/text/stats', () => {
+    const line = makeLine([keystroke({ startMs: 0, endMs: 100, label: 'h' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const header = screen.getByTestId('line-timeline-header-0')
+    const romajiLine = screen.getByLabelText(/Romaji:/)
+    expect(header.contains(romajiLine)).toBe(true)
+  })
+
+  it('never makes the SVG bar strip itself sticky — only the header pins, the strip keeps scrolling/zooming with the canvas', () => {
+    const line = makeLine([keystroke({ startMs: 0, endMs: 100, label: 'h' })])
+    renderWithI18n(
+      <LineTimelineRow line={line} maxDisplayMs={1000} romajiInput={false} onHover={vi.fn()} onHoverEnd={vi.fn()} />,
+    )
+    const header = screen.getByTestId('line-timeline-header-0')
+    const svg = screen.getByTestId('line-timeline-svg-0')
+    expect(header.contains(svg)).toBe(false)
+    expect(svg.closest('.line-timeline-header-sticky')).toBeNull()
+  })
+})
+
 describe('LineTimelineRow — on-bar keystroke labels', () => {
   it('renders one label overlay cell per keystroke segment, with the segment label as its text', () => {
     const line = makeLine([

--- a/src/renderer/typing-test/__tests__/TypingTestControlsRow.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestControlsRow.test.tsx
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Unit coverage for the per-status button set, independent of WHERE this
+// component is rendered — it used to be rendered inline by TypingTestView
+// for every non-finished status; it now renders from TypingTestPane
+// instead (below the keyboard pane — see TypingTestPane.controls-row-order
+// .test.tsx for that placement), while TypingTestView keeps rendering it
+// only for the finished state. Keeping this coverage at the component
+// level (not through either parent) means it stays valid regardless of
+// which parent owns the render site.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { TypingTestControlsRow } from '../TypingTestControlsRow'
+import type { TypingTestState } from '../useTypingTest'
+import type { TypingTestConfig } from '../types'
+import { DEFAULT_CONFIG } from '../types'
+
+function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
+  return {
+    status: 'waiting',
+    runId: 'test-run',
+    words: ['the', 'quick', 'brown'],
+    currentWordIndex: 0,
+    currentInput: '',
+    compositionText: '',
+    wordResults: [],
+    startTime: null,
+    endTime: null,
+    correctChars: 0,
+    incorrectChars: 0,
+    totalKeystrokes: 0,
+    confirmedChars: 0,
+    kspcUncomputable: false,
+    currentQuote: null,
+    wpmHistory: [],
+    lineBreaks: new Set(),
+    lineIndents: [],
+    romajiKeystrokes: '',
+    romajiCapable: false,
+    mistakes: {},
+    romajiSegmentErred: false,
+    missedPositions: [],
+    ...overrides,
+  }
+}
+
+function renderRow(props: Partial<Parameters<typeof TypingTestControlsRow>[0]> = {}) {
+  const defaults = { state: makeState(), config: DEFAULT_CONFIG as TypingTestConfig }
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <TypingTestControlsRow {...defaults} {...props} />
+    </I18nextProvider>,
+  )
+}
+
+describe('TypingTestControlsRow (state-based)', () => {
+  const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 'abc' }
+
+  it('shows Next Test (not Restart) before a run starts', () => {
+    renderRow({ config: fileImportConfig, state: makeState({ status: 'waiting' }) })
+    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+    expect(screen.queryByTestId('typing-test-restart')).toBeNull()
+  })
+
+  it('shows Pause + Restart while running (fileImport)', () => {
+    renderRow({ config: fileImportConfig, state: makeState({ status: 'running' }) })
+    expect(screen.getByTestId('typing-memory-pause')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
+  })
+
+  it('shows Resume + Restart while paused (fileImport)', () => {
+    renderRow({ config: fileImportConfig, state: makeState({ status: 'paused' }) })
+    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
+  })
+
+  it('shows Resume in the waiting state when a fileImport run is saved', () => {
+    renderRow({ config: fileImportConfig, state: makeState({ status: 'waiting' }), hasSavedMemory: true })
+    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
+  })
+
+  it('shows the result name field on finish for normal modes too', () => {
+    const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+    renderRow({ config: wordsConfig, state: makeState({ status: 'finished' }) })
+    expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
+  })
+
+  it('never shows Resume once finished, even with a saved memory', () => {
+    renderRow({ config: fileImportConfig, state: makeState({ status: 'finished' }), hasSavedMemory: true })
+    expect(screen.queryByTestId('typing-memory-resume')).toBeNull()
+    expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -10,6 +10,7 @@ import type { LineSnapshot } from '../TypingTestView'
 import type { TypingTestState } from '../useTypingTest'
 import type { TypingTestConfig } from '../types'
 import { DEFAULT_CONFIG } from '../types'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 
 function makeState(overrides: Partial<TypingTestState> = {}): TypingTestState {
   return {
@@ -411,31 +412,14 @@ describe('TypingTestView error-class line', () => {
   })
 })
 
-describe('TypingTestView controls row (state-based)', () => {
+describe('TypingTestView controls row (finished state only)', () => {
+  // Non-finished-status coverage (Next Test / Pause / Resume / Restart)
+  // moved to TypingTestControlsRow.test.tsx — TypingTestView no longer
+  // renders that row for any non-finished status (it moved to
+  // TypingTestPane, below the keyboard pane; see
+  // TypingTestPane.controls-row-order.test.tsx for its placement there).
+  // The finished-state row stays here since TypingTestView still owns it.
   const fileImportConfig: TypingTestConfig = { mode: 'fileImport', textId: 'abc' }
-
-  it('shows Next Test (not Restart) before a run starts', () => {
-    renderView({ config: fileImportConfig, state: makeState({ status: 'waiting' }) })
-    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
-    expect(screen.queryByTestId('typing-test-restart')).toBeNull()
-  })
-
-  it('shows Pause + Restart while running (fileImport)', () => {
-    renderView({ config: fileImportConfig, state: makeState({ status: 'running' }) })
-    expect(screen.getByTestId('typing-memory-pause')).toBeInTheDocument()
-    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
-  })
-
-  it('shows Resume + Restart while paused (fileImport)', () => {
-    renderView({ config: fileImportConfig, state: makeState({ status: 'paused' }) })
-    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
-    expect(screen.getByTestId('typing-test-restart')).toBeInTheDocument()
-  })
-
-  it('shows Resume in the waiting state when a fileImport run is saved', () => {
-    renderView({ config: fileImportConfig, state: makeState({ status: 'waiting' }), hasSavedMemory: true })
-    expect(screen.getByTestId('typing-memory-resume')).toBeInTheDocument()
-  })
 
   it('shows the result name field on finish for normal modes too', () => {
     const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
@@ -443,14 +427,10 @@ describe('TypingTestView controls row (state-based)', () => {
     expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
   })
 
-  it('shows the Complete message on the finished screen', () => {
+  it('renders no Complete heading on the finished screen (removed)', () => {
     renderView({ config: fileImportConfig, state: makeState({ status: 'finished' }) })
-    expect(screen.getByTestId('typing-test-complete')).toBeInTheDocument()
-  })
-
-  it('hides the Complete message while running', () => {
-    renderView({ config: fileImportConfig, state: makeState({ status: 'running' }) })
     expect(screen.queryByTestId('typing-test-complete')).toBeNull()
+    expect(screen.queryByText('Complete')).toBeNull()
   })
 
   it('never shows Resume on the finished screen, even with a saved memory', () => {
@@ -458,6 +438,17 @@ describe('TypingTestView controls row (state-based)', () => {
     expect(screen.queryByTestId('typing-memory-resume')).toBeNull()
     expect(screen.getByTestId('typing-test-result-name')).toBeInTheDocument()
     expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+  })
+
+  it('centers the finished-screen wrapper (Unnamed / Next Test row) instead of stretching it left', () => {
+    renderView({ config: fileImportConfig, state: makeState({ status: 'finished' }) })
+    const wrapper = screen.getByTestId('typing-test-finished-wrapper')
+    expect(wrapper.className).toContain('items-center')
+    // The row itself has no explicit width, so it relies on the wrapper's
+    // items-center to avoid stretching full-width and left-aligning its
+    // (justify-start) content.
+    const controlsRow = screen.getByTestId('typing-test-result-name').closest('.gap-2')
+    expect(controlsRow?.className).not.toContain('w-full')
   })
 })
 
@@ -1165,5 +1156,145 @@ describe('TypingTestView — logical-line window height (measured, synthetic mon
       state: makeState({ status: 'running', words: ['a', 'b', 'c'], lineBreaks: new Set() }),
     })
     expect(screen.getByTestId('typing-test-words').style.height).toBe('48px')
+  })
+})
+
+// Plan-completion-timeline-view PR-B: once a run finishes, the reading
+// window/romaji-guide give way to the shared KeystrokeTimelinePanel
+// (rendered inline, from the in-memory log — no IPC) whenever
+// `lastFinishedLog` is present AND its `runId` matches the current run
+// (the codex-review stale-flash guard). Without a matching log, the old
+// compact stats row + a consent hint render instead, same as before this
+// feature for the words/controls area.
+describe('TypingTestView — completion screen timeline panel (Plan-completion-timeline-view PR-B)', () => {
+  const SAMPLE_LOG: RunKeystrokeLog = {
+    runId: 'run-1',
+    uid: 'uid-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    durationMs: 5000,
+    mode: 'words',
+    language: 'english',
+    words: [
+      {
+        index: 0,
+        display: 'hi',
+        typed: 'hi',
+        correct: true,
+        keystrokes: [
+          { pressMs: 0, releaseMs: 60, keycode: 0, row: 0, col: 0, correct: true, expectedChar: 'h' },
+          { pressMs: 80, releaseMs: 140, keycode: 0, row: 0, col: 1, correct: true, expectedChar: 'i' },
+        ],
+      },
+    ],
+  }
+
+  it('hides the words/reading area once finished, regardless of whether a log is available', () => {
+    renderView({ state: makeState({ status: 'finished', runId: 'run-1' }), lastFinishedLog: null })
+    expect(screen.queryByTestId('typing-test-words')).toBeNull()
+  })
+
+  it('renders the timeline panel (and hides the old stats row) when the log matches the finished run', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-1' }),
+      lastFinishedLog: SAMPLE_LOG,
+    })
+    expect(screen.getByTestId('typing-test-timeline-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('typing-test-results')).toBeNull()
+    expect(screen.queryByTestId('typing-test-timeline-consent-hint')).toBeNull()
+    // The controls row stays, but the Complete heading is gone entirely.
+    expect(screen.queryByTestId('typing-test-complete')).toBeNull()
+    expect(screen.getByTestId('typing-test-start')).toBeInTheDocument()
+  })
+
+  it('builds an unbroken flex-height chain from the view root down to the rows scrollport once finished (no fixed vh cap)', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-1' }),
+      lastFinishedLog: SAMPLE_LOG,
+    })
+    // The view's own root gains min-h-0/flex-1 only once finished — see
+    // its className comment in TypingTestView.tsx.
+    const view = screen.getByTestId('typing-test-view')
+    expect(view.className).toContain('min-h-0')
+    expect(view.className).toContain('flex-1')
+
+    // The new finished-state wrapper (panel + controls row) is the chain's
+    // next link.
+    const panelTestid = screen.getByTestId('typing-test-timeline-panel')
+    const finishedWrapper = panelTestid.parentElement!
+    expect(finishedWrapper.className).toContain('min-h-0')
+    expect(finishedWrapper.className).toContain('flex-1')
+    expect(finishedWrapper.className).toContain('flex-col')
+    // Both the panel wrapper and the panel's own root stretch too.
+    expect(panelTestid.className).toContain('min-h-0')
+    expect(panelTestid.className).toContain('flex-1')
+
+    // No fixed viewport-relative cap anywhere in the chain — the
+    // scrollport is the only element that ever scrolls, sized purely by
+    // the flex chain above it.
+    const scrollport = screen.getByTestId('word-timeline-canvas').parentElement!
+    expect(scrollport.className).not.toMatch(/\bmax-h-/)
+    expect(scrollport.className).toContain('flex-1')
+    expect(scrollport.className).toContain('min-h-0')
+    expect(scrollport.className).toContain('overflow-auto')
+  })
+
+  it('does NOT add min-h-0/flex-1 to the view root while a run is still in progress (unaffected by the finished-only chain)', () => {
+    renderView({ state: makeState({ status: 'running' }) })
+    const view = screen.getByTestId('typing-test-view')
+    expect(view.className).not.toContain('min-h-0')
+    expect(view.className).not.toMatch(/\bflex-1\b/)
+  })
+
+  it('renders the Unnamed / Next Test controls row AFTER the timeline panel, as the last content block', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-1' }),
+      lastFinishedLog: SAMPLE_LOG,
+    })
+    const view = screen.getByTestId('typing-test-view')
+    const panel = screen.getByTestId('typing-test-timeline-panel')
+    const startButton = screen.getByTestId('typing-test-start')
+    expect(panel.compareDocumentPosition(startButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(view.lastElementChild?.contains(startButton)).toBe(true)
+  })
+
+  it('falls back to the old stats row + a consent hint when there is no log at all', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-1' }),
+      lastFinishedLog: null,
+    })
+    expect(screen.queryByTestId('typing-test-timeline-panel')).toBeNull()
+    expect(screen.getByTestId('typing-test-results')).toBeInTheDocument()
+    expect(screen.getByTestId('typing-test-timeline-consent-hint')).toBeInTheDocument()
+  })
+
+  it('renders the controls row AFTER the fallback stats row + consent hint, as the last content block', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-1' }),
+      lastFinishedLog: null,
+    })
+    const view = screen.getByTestId('typing-test-view')
+    const hint = screen.getByTestId('typing-test-timeline-consent-hint')
+    const startButton = screen.getByTestId('typing-test-start')
+    expect(hint.compareDocumentPosition(startButton) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(view.lastElementChild?.contains(startButton)).toBe(true)
+  })
+
+  it('never renders a stale-runId log\'s panel (Next Test already advanced to a new run)', () => {
+    renderView({
+      state: makeState({ status: 'finished', runId: 'run-2' }),
+      lastFinishedLog: { ...SAMPLE_LOG, runId: 'run-1' },
+    })
+    expect(screen.queryByTestId('typing-test-timeline-panel')).toBeNull()
+    // Falls back to the old stats row, same as the no-log case.
+    expect(screen.getByTestId('typing-test-results')).toBeInTheDocument()
+  })
+
+  it('never renders the panel while a run is still in progress, even if a stale log prop is passed', () => {
+    renderView({
+      state: makeState({ status: 'running', runId: 'run-1' }),
+      lastFinishedLog: SAMPLE_LOG,
+    })
+    expect(screen.queryByTestId('typing-test-timeline-panel')).toBeNull()
+    expect(screen.getByTestId('typing-test-words')).toBeInTheDocument()
   })
 })

--- a/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
@@ -207,6 +207,21 @@ describe('WordTimelineView', () => {
     expect(screen.getAllByTestId('line-timeline-keystroke')).toHaveLength(4)
   })
 
+  it('never caps the rows scrollport with a viewport-relative max-height — the modal box (h-modal-80vh) already bounds it via flex-1 min-h-0', async () => {
+    // KeystrokeTimelinePanel never applies a fixed vh cap to its rows
+    // scrollport (removed — a fixed vh figure can't adapt to how much
+    // other chrome a given run has). This modal's own `h-modal-80vh` box
+    // already bounds the panel via the ordinary flex-1/min-h-0 chain, the
+    // same mechanism the completion screen (TypingTestView) now also
+    // uses instead of a cap.
+    renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
+    await waitFor(() => expect(screen.getByTestId('word-timeline-canvas')).toBeTruthy())
+    const scrollport = screen.getByTestId('word-timeline-canvas').parentElement!
+    expect(scrollport.className).not.toMatch(/\bmax-h-/)
+    expect(scrollport.className).toContain('flex-1')
+    expect(scrollport.className).toContain('min-h-0')
+  })
+
   it('closes only itself on Escape, leaving an outer modal open (nested-modal Escape isolation)', async () => {
     const onCloseTimeline = vi.fn()
     const onCloseOuter = vi.fn()

--- a/src/renderer/typing-test/__tests__/display-prefs.test.ts
+++ b/src/renderer/typing-test/__tests__/display-prefs.test.ts
@@ -19,8 +19,12 @@ describe('clampDisplayLines', () => {
   })
   it('clamps below/above the range', () => {
     expect(clampDisplayLines(0)).toBe(DISPLAY_LINES_MIN)
-    expect(clampDisplayLines(1)).toBe(DISPLAY_LINES_MIN)
+    expect(clampDisplayLines(-5)).toBe(DISPLAY_LINES_MIN)
     expect(clampDisplayLines(99)).toBe(DISPLAY_LINES_MAX)
+  })
+  it('accepts 1 (a single visible line) without clamping it upward', () => {
+    expect(DISPLAY_LINES_MIN).toBe(1)
+    expect(clampDisplayLines(1)).toBe(1)
   })
   it('rounds fractional values', () => {
     expect(clampDisplayLines(4.6)).toBe(5)

--- a/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
+++ b/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { buildTimelineStatItems } from '../keystroke-timeline-stats'
+import type { WordTimelineSummary } from '../word-timeline'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
+import { EMPTY_STAT_VALUE } from '../../components/analyze/analyze-constants'
+
+const SUMMARY: WordTimelineSummary = {}
+
+function makeLog(overrides: Partial<RunKeystrokeLog> = {}): RunKeystrokeLog {
+  return {
+    runId: 'run-1',
+    uid: 'uid-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    durationMs: 5000,
+    mode: 'words',
+    language: 'english',
+    words: [],
+    ...overrides,
+  }
+}
+
+function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+  return {
+    date: '2026-01-01T00:00:00.000Z',
+    wpm: 42,
+    accuracy: 95,
+    wordCount: 10,
+    correctChars: 50,
+    incorrectChars: 2,
+    durationSeconds: 10,
+    ...overrides,
+  }
+}
+
+/** The 7th (Words/Lines) card is always index 5 in buildTimelineStatItems'
+ *  own fixed ordering (WPM, KPM, Accuracy, KSPC, Time, Words/Lines,
+ *  Overlap, Substitution, Omission, Insertion). */
+function wordsOrLinesItem(result: TypingTestResult | undefined, log: RunKeystrokeLog) {
+  return buildTimelineStatItems(result, SUMMARY, log)[5]
+}
+
+describe('buildTimelineStatItems — Words/Lines card branch table', () => {
+  it('branch 1: log.lineBreaks present -> Lines, value = lineBreaks.length + 1, REGARDLESS of result.mode', () => {
+    const log = makeLog({ lineBreaks: [2, 5] }) // 2 breaks -> 3 lines
+    const item = wordsOrLinesItem(makeResult({ mode: 'words', wordCount: 999 }), log)
+    expect(item.labelKey).toBe('editor.typingTest.lines')
+    expect(item.value).toBe(3)
+  })
+
+  it('branch 1b: log.lineBreaks present as an empty array ([]) still counts as PRESENT -> Lines, value = 1', () => {
+    // Presence, not emptiness, is the signal — see RunKeystrokeLog.lineBreaks's
+    // own doc comment (a real single-line source is a legitimate `[]`).
+    const log = makeLog({ lineBreaks: [] })
+    const item = wordsOrLinesItem(undefined, log)
+    expect(item.labelKey).toBe('editor.typingTest.lines')
+    expect(item.value).toBe(1)
+  })
+
+  it('branch 1c: log.lineBreaks present, no result at all -> still Lines from the log alone', () => {
+    const log = makeLog({ lineBreaks: [3] })
+    const item = wordsOrLinesItem(undefined, log)
+    expect(item.labelKey).toBe('editor.typingTest.lines')
+    expect(item.value).toBe(2)
+  })
+
+  it('branch 2: log.lineBreaks absent, result.mode === "tatoeba" -> Lines, value = result.wordCount (each unit is one line)', () => {
+    const log = makeLog({ mode: 'tatoeba' })
+    const item = wordsOrLinesItem(makeResult({ mode: 'tatoeba', wordCount: 10 }), log)
+    expect(item.labelKey).toBe('editor.typingTest.lines')
+    expect(item.value).toBe(10)
+  })
+
+  it('branch 3: log.lineBreaks absent, result.mode === "fileImport" -> keep Words (line count unknowable without the log\'s own lineBreaks)', () => {
+    const log = makeLog({ mode: 'fileImport' })
+    const item = wordsOrLinesItem(makeResult({ mode: 'fileImport', wordCount: 7 }), log)
+    expect(item.labelKey).toBe('editor.typingTest.words')
+    expect(item.value).toBe(7)
+  })
+
+  it('branch 4: Monkeytype modes (words/time/quote) -> keep Words, unchanged', () => {
+    for (const mode of ['words', 'time', 'quote'] as const) {
+      const log = makeLog({ mode })
+      const item = wordsOrLinesItem(makeResult({ mode, wordCount: 15 }), log)
+      expect(item.labelKey).toBe('editor.typingTest.words')
+      expect(item.value).toBe(15)
+    }
+  })
+
+  it('branch 5: no result and no log.lineBreaks -> Words card with EMPTY_STAT_VALUE (unchanged fallback)', () => {
+    const log = makeLog()
+    const item = wordsOrLinesItem(undefined, log)
+    expect(item.labelKey).toBe('editor.typingTest.words')
+    expect(item.value).toBe(EMPTY_STAT_VALUE)
+  })
+
+  it('branch 6: result present but result.mode undefined (legacy result, no log.lineBreaks) -> keep Words', () => {
+    const log = makeLog()
+    const item = wordsOrLinesItem(makeResult({ mode: undefined, wordCount: 4 }), log)
+    expect(item.labelKey).toBe('editor.typingTest.words')
+    expect(item.value).toBe(4)
+  })
+})

--- a/src/renderer/typing-test/keystroke-timeline-stats.ts
+++ b/src/renderer/typing-test/keystroke-timeline-stats.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Builds the unified stat-card list `KeystrokeTimelinePanel` shows — the
-// same seven figures (WPM, KPM, Accuracy, KSPC, Time, Words, Overlap) in
-// both the History timeline modal and (a later PR) the inline completion
-// screen, so a run reads identically in either place. See
-// .claude/plans/Plan-completion-timeline-view.md PR-A spec point 2.
+// same ten figures (WPM, KPM, Accuracy, KSPC, Time, Words, Overlap,
+// Substitution, Omission, Insertion) in both the History timeline modal
+// and the inline completion screen, so a run reads identically in either
+// place. See .claude/plans/Plan-completion-timeline-view.md PR-A spec
+// point 2.
 //
 // Fallback scope is deliberately narrow: only WPM, Accuracy, Time, and
 // Overlap have a value when `result` is absent —
@@ -16,13 +17,22 @@
 //    `KeystrokeTimelinePanel` always receives the log itself.
 //  - Overlap has no `TypingTestResult` equivalent at all (that field was
 //    never recorded on the result), so it is ALWAYS model-derived.
-// KPM, KSPC, and Words stay result-only: reconstructing them from the raw
-// log would mean re-deriving scoring rules run-state.ts already owns
-// (confirmed-char counting, romaji segment credit, KSPC's
-// IME-uncomputable gate, ...) — a second, possibly-diverging
-// implementation of the same math that this module deliberately avoids.
-// Without a result these three read as `EMPTY_STAT_VALUE`, the same
-// convention History already uses for a legacy/uncomputable row.
+// KPM, KSPC, and the three error-class counts stay result-only:
+// reconstructing them from the raw log would mean re-deriving scoring
+// rules run-state.ts already owns (confirmed-char counting, romaji
+// segment credit, KSPC's IME-uncomputable gate, WER/CER-style error
+// classification, ...) — a second, possibly-diverging implementation of
+// the same math that this module deliberately avoids. Without a result
+// (or on a result predating error-class tracking, e.g. a romaji run)
+// these read as `EMPTY_STAT_VALUE`, the same convention History already
+// uses for a legacy/uncomputable row — unlike `MissedCharsList`/the
+// former `ErrorClassLine` row below, these three are always-present
+// cards (same as Overlap), never omitted as a block.
+// The 7th card (Words/Lines) is the one exception to "result-only": when
+// `log.lineBreaks` is present it derives straight from the LOG (see
+// `wordsOrLinesCard`'s own doc comment), unconditionally — a line-based
+// run's line count is knowable even without a `result` at all, unlike
+// KPM/KSPC/error-class, which have no raw-log equivalent to fall back to.
 
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
@@ -33,6 +43,43 @@ import { formatWpm } from '../components/analyze/analyze-wpm'
 import { formatKspc } from '../../shared/kspc'
 import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
 import { resultKpm, resultKspc } from './result-builder'
+
+/** The 7th card's caption + value — "Words" for a normal (Monkeytype-style)
+ *  run, "Lines" for a line-based one (fileImport with real line structure,
+ *  or a tatoeba Lines-pattern run — each tatoeba "word" unit IS one line).
+ *  Reuses `editor.typingTest.lines`, the sidebar's own bare "Lines"
+ *  caption — no new i18n key needed, it's already the same shape as
+ *  `editor.typingTest.words` ("Words"), just for the other unit.
+ *
+ *  Two-tier signal, most-authoritative first:
+ *   1. `log.lineBreaks !== undefined` — the line-based signal actually
+ *      PERSISTED on this run's own log (see `RunKeystrokeLog.lineBreaks`'s
+ *      own doc comment). When present, the line count comes directly from
+ *      it (`lineBreaks.length + 1` — N breaks divide the run into N+1
+ *      lines), regardless of `result`/mode: this is ground truth for
+ *      exactly this run, the same way `deriveLineBreaksForLog` decided at
+ *      save time.
+ *   2. `result?.mode` — a coarser fallback for when the log itself carries
+ *      no `lineBreaks` (e.g. a legacy log saved before that field
+ *      existed). `'tatoeba'` can still be labeled Lines because that
+ *      mode's own word-flow architecture always maps 1 unit to 1 line, so
+ *      `result.wordCount` doubles as the line count without needing the
+ *      log's own field. `'fileImport'` WITHOUT a persisted `lineBreaks`
+ *      cannot: a fileImport text's own line layout (words per line) isn't
+ *      fixed, so there is no way to recover line count from `wordCount`
+ *      alone — this case deliberately falls through to the ordinary Words
+ *      card, "line count unknowable" rather than guessing. Monkeytype
+ *      modes (words/time/quote) and a missing `result` both fall through
+ *      to Words too, unchanged from before this card existed. */
+function wordsOrLinesCard(result: TypingTestResult | undefined, log: RunKeystrokeLog): AnalyzeSummaryItem {
+  if (log.lineBreaks !== undefined) {
+    return { labelKey: 'editor.typingTest.lines', value: log.lineBreaks.length + 1 }
+  }
+  if (result?.mode === 'tatoeba') {
+    return { labelKey: 'editor.typingTest.lines', value: result.wordCount }
+  }
+  return { labelKey: 'editor.typingTest.words', value: result ? result.wordCount : EMPTY_STAT_VALUE }
+}
 
 /** Ordered stat cards for `AnalyzeStatGrid` — see the module doc comment
  *  for the fallback rule each card follows. `summary` is `null` only
@@ -81,13 +128,26 @@ export function buildTimelineStatItems(
       labelKey: 'editor.typingTest.time',
       value: formatDuration(durationSeconds),
     },
-    {
-      labelKey: 'editor.typingTest.words',
-      value: result ? result.wordCount : EMPTY_STAT_VALUE,
-    },
+    wordsOrLinesCard(result, log),
     {
       labelKey: 'editor.typingTest.history.timeline.stats.overlap',
       value: formatPercentLabel(summary.avgOverlap),
+    },
+    // Reuses ErrorMixSection's own per-class caption keys (#332) rather
+    // than the `results.errorSubstitutions` et al. keys — those are
+    // "Substitution {{count}}"-style interpolated sentences meant for the
+    // completion screen's inline mistake line, not a bare card caption.
+    {
+      labelKey: 'editor.typingTest.history.errorMixLabelSubstitution',
+      value: result?.errorSubstitutions ?? EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.history.errorMixLabelOmission',
+      value: result?.errorOmissions ?? EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.history.errorMixLabelInsertion',
+      value: result?.errorInsertions ?? EMPTY_STAT_VALUE,
     },
   ]
 }

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -170,7 +170,10 @@ export function applyRomajiCaseStyle(guide: RomajiGuide, caseStyle: RomajiCaseSt
 }
 
 // Imported file-import-text display preferences (fileImport mode only).
-export const DISPLAY_LINES_MIN = 2
+// 1 is a valid choice — a single visible reading-window line — and is
+// handled generically by clampDisplayLines/logicalWindowHeight/the
+// --tt-lines CSS floor below; none of them special-case a >=2 minimum.
+export const DISPLAY_LINES_MIN = 1
 export const DISPLAY_LINES_MAX = 10
 export const DEFAULT_DISPLAY_LINES = 4
 export const FONT_SIZE_MIN = 14


### PR DESCRIPTION
## Summary
- Finishing a typing test now lands directly on the timeline: the words area and keyboard hide, and the shared `KeystrokeTimelinePanel` renders the unified stat cards (WPM/KPM/Accuracy/KSPC/Time/Words-or-Lines/Overlap plus per-class error cards), the legend (its two explanatory notes tucked into an info-icon tooltip), zoom, and the line rows — fed from the just-recorded in-memory log with zero IPC, with the old stats row plus a consent hint as the fallback when no log exists. The History modal shows the identical panel.
- Layout: the rows area sizes to the editor pane through an unbroken flex chain so only it scrolls (verified zero outer-pane overflow at 960px and 800px windows, with the IME-correlation banner present); row headers stay pinned (`sticky` + `100cqw`) while zoomed; per-line stats right-align; the Missed list sits below the rows; the centered Unnamed / Next Test controls close the screen, and mid-test they now render below the keymap. Line-based runs label their card "Lines" (from the log's lineBreaks; tatoeba by mode when no log). Lines can now be set to 1.
- Recording: the run's first keystroke is no longer dropped (pre-existing #203 gate — the keystroke that flips waiting→running could never be tagged by a ref computed from the previous render). The run-log path gets its own armed-waiting gate while the per-minute analytics gate stays strictly running-only, preserving the phantom-run protections (codex-reviewed; stale-runId buffers provably cannot reach a save).

## Verification
- Full suite 8,416+ passed / 22 skipped across the branch (net +60 new tests vs main, every behavioral change red-run first; two pre-existing false-positive tests found and fixed).
- Virtual-device Playwright flows: consent→run→completion (timeline main, buttons centered delta 0.00px), no-consent fallback with hint, 10-line internal-scroll scenario with per-ancestor zero-overflow asserts at two window heights, sticky headers under max zoom + scroll, first-keystroke bar present, LINES card value, Missed-below-rows order.
- eslint / typecheck clean; i18n keys across english + 4 packs with lockstep bumps (final 0.1.67).