### PR TITLE
feat(ui): break down missed characters with recorded mistake details

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.67",
+  "version": "0.1.72",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -538,7 +538,7 @@
           "partialBadge": "未完了",
           "stats": {
             "wordPace": "ワード速度",
-            "runWpm": "ラン全体のWPM",
+            "runWpm": "WPM",
             "accuracy": "正確度",
             "overlap": "重複率",
             "duration": "所要時間",
@@ -587,7 +587,11 @@
         "errorSubstitutions": "置換 {{count}}",
         "errorOmissions": "脱字 {{count}}",
         "errorInsertions": "衍字 {{count}}",
-        "timelineConsentHint": "打鍵タイムラインを表示するには、タイピングの記録を有効にしてください。"
+        "timelineConsentHint": "打鍵タイムラインを表示するには、タイピングの記録を有効にしてください。",
+        "missedBarTypedLine": "代わりに入力: {{chars}}",
+        "missedBarCorrectedLine": "Backspaceで修正: {{count}}",
+        "missedBarMovedOnLine": "未修正のまま次へ: {{count}}",
+        "missedBarNoDetail": "この記録には打鍵ごとの詳細がありません"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.67",
+  "version": "0.1.72",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -538,7 +538,7 @@
           "partialBadge": "途中",
           "stats": {
             "wordPace": "ワード速度☆",
-            "runWpm": "ラン全体のWPMじゃん☆",
+            "runWpm": "WPM",
             "accuracy": "正確度☆",
             "overlap": "重複率☆",
             "duration": "所要時間☆",
@@ -587,7 +587,11 @@
         "errorSubstitutions": "置換 {{count}}こ",
         "errorOmissions": "脱字 {{count}}こ",
         "errorInsertions": "衍字 {{count}}こ",
-        "timelineConsentHint": "打鍵タイムライン見たいなら、タイピング記録オンにしてね☆"
+        "timelineConsentHint": "打鍵タイムライン見たいなら、タイピング記録オンにしてね☆",
+        "missedBarTypedLine": "代わりに打ってたの: {{chars}}",
+        "missedBarCorrectedLine": "Backspaceで直したの: {{count}}こ",
+        "missedBarMovedOnLine": "直さず次いっちゃったの: {{count}}こ",
+        "missedBarNoDetail": "この記録、打鍵ごとの詳細ないみたい"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.67",
+  "version": "0.1.72",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -538,7 +538,7 @@
           "partialBadge": "未完了どすえ",
           "stats": {
             "wordPace": "ワード速度どすえ",
-            "runWpm": "ラン全体のWPMどすえ",
+            "runWpm": "WPM",
             "accuracy": "正確度どすえ",
             "overlap": "重複率どすえ",
             "duration": "所要時間どすえ",
@@ -587,7 +587,11 @@
         "errorSubstitutions": "置換 {{count}}どす",
         "errorOmissions": "脱字 {{count}}どす",
         "errorInsertions": "衍字 {{count}}どす",
-        "timelineConsentHint": "打鍵タイムラインを見とうおすなら、タイピングの記録を有効にしておくれやすどす。"
+        "timelineConsentHint": "打鍵タイムラインを見とうおすなら、タイピングの記録を有効にしておくれやすどす。",
+        "missedBarTypedLine": "代わりに打ちはったんは: {{chars}}",
+        "missedBarCorrectedLine": "Backspaceで直しはったんは: {{count}}どす",
+        "missedBarMovedOnLine": "直さんまま次へ行かはったんは: {{count}}どす",
+        "missedBarNoDetail": "この記録には打鍵ごとの詳細がおへんどす"
       }
     }
   },

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.67",
+  "version": "0.1.72",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -538,7 +538,7 @@
           "partialBadge": "未完了",
           "stats": {
             "wordPace": "ワード速度",
-            "runWpm": "ラン全体のWPM",
+            "runWpm": "WPM",
             "accuracy": "正確度",
             "overlap": "重複率",
             "duration": "所要時間",
@@ -587,7 +587,11 @@
         "errorSubstitutions": "置換 {{count}}",
         "errorOmissions": "脱字 {{count}}",
         "errorInsertions": "衍字 {{count}}",
-        "timelineConsentHint": "打鍵タイムラインをご覧いただくには、タイピングの記録をお許しくださいませ。"
+        "timelineConsentHint": "打鍵タイムラインをご覧いただくには、タイピングの記録をお許しくださいませ。",
+        "missedBarTypedLine": "代わりに入力された文字: {{chars}}",
+        "missedBarCorrectedLine": "Backspaceで修正された回数: {{count}}",
+        "missedBarMovedOnLine": "未修正のまま進まれた回数: {{count}}",
+        "missedBarNoDetail": "この記録には打鍵ごとの詳細情報がございません"
       }
     }
   },

--- a/src/main/__tests__/typing-run-log-store.test.ts
+++ b/src/main/__tests__/typing-run-log-store.test.ts
@@ -223,6 +223,69 @@ describe('typing-run-log-store', () => {
       expect(result.error).toMatch(/romajiInput/i)
     })
 
+    it('accepts and persists typedChar/mistakeKey on an incorrect keystroke', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'hello', typed: 'xello', correct: false,
+          keystrokes: [
+            { pressMs: 0, keycode: 1, row: 0, col: 0, expectedChar: 'h', correct: false, typedChar: 'x', mistakeKey: 'h' },
+          ],
+        }],
+      }))
+      expect(result.success).toBe(true)
+
+      const dataPath = join(mockUserDataPath, 'sync', 'keyboards', 'kb-1', 'runs', result.entry!.filename)
+      const saved = JSON.parse(await readFile(dataPath, 'utf-8')) as RunKeystrokeLog
+      const [k] = saved.words[0].keystrokes
+      expect(k.typedChar).toBe('x')
+      expect(k.mistakeKey).toBe('h')
+    })
+
+    it('accepts an absent typedChar/mistakeKey (legacy log, pre-dating the field)', async () => {
+      const result = await saveRunLog('kb-1', makeLog())
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects a non-string typedChar', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'x', typed: 'y', correct: false,
+          keystrokes: [{ pressMs: 0, keycode: 1, row: 0, col: 0, typedChar: 42 as unknown as string }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects a non-string mistakeKey', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'x', typed: 'y', correct: false,
+          keystrokes: [{ pressMs: 0, keycode: 1, row: 0, col: 0, mistakeKey: 42 as unknown as string }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an absurdly long typedChar', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'x', typed: 'y', correct: false,
+          keystrokes: [{ pressMs: 0, keycode: 1, row: 0, col: 0, typedChar: 'x'.repeat(1000) }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects an absurdly long mistakeKey', async () => {
+      const result = await saveRunLog('kb-1', makeLog({
+        words: [{
+          index: 0, display: 'x', typed: 'y', correct: false,
+          keystrokes: [{ pressMs: 0, keycode: 1, row: 0, col: 0, mistakeKey: 'x'.repeat(1000) }],
+        }],
+      }))
+      expect(result.success).toBe(false)
+    })
+
     it('saving the same runId twice leaves exactly one payload file on disk (P7)', async () => {
       // Fake timers guarantee the two saves land at different millisecond
       // timestamps — the filename prefix — so the second save's filename

--- a/src/main/typing-run-log-store.ts
+++ b/src/main/typing-run-log-store.ts
@@ -46,6 +46,14 @@ import {
  *  absolute-time leak) — see `validateRunLog`. */
 const TIMESTAMP_SLACK_MS = 5000
 
+/** Max length for `RunKeystroke.typedChar`/`mistakeKey` — both are
+ *  ordinarily a single character (verbatim) or a handful (a romaji kana
+ *  segment's canonical spelling, e.g. "kyaa"); this is a generous
+ *  multiple of the longest real spelling, just enough to reject an
+ *  absurd/malicious payload rather than to fit any legitimate value
+ *  exactly. See `isValidKeystroke`. */
+const MAX_MISTAKE_FIELD_LENGTH = 32
+
 function getStoreDir(uid: string): string {
   return join(app.getPath('userData'), 'sync', 'keyboards', uid, 'runs')
 }
@@ -141,6 +149,8 @@ function isValidKeystroke(value: unknown, durationMs: number): value is RunKeyst
   if (k.expectedChar !== undefined && typeof k.expectedChar !== 'string') return false
   if (k.correct !== undefined && typeof k.correct !== 'boolean') return false
   if (k.overlapped !== undefined && typeof k.overlapped !== 'boolean') return false
+  if (k.typedChar !== undefined && (typeof k.typedChar !== 'string' || k.typedChar.length > MAX_MISTAKE_FIELD_LENGTH)) return false
+  if (k.mistakeKey !== undefined && (typeof k.mistakeKey !== 'string' || k.mistakeKey.length > MAX_MISTAKE_FIELD_LENGTH)) return false
   return true
 }
 

--- a/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
+++ b/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
@@ -38,7 +38,7 @@ function renderRecorder(recordingConsentAccepted = true) {
  *  through the hook's own call shapes — mirrors how useTypingTest wires
  *  these three seams in useInputModes.ts. */
 function driveOneKeystroke(result: ReturnType<typeof renderRecorder>['result'], runId: string, wordIndex: number): void {
-  result.current.noteRegistration(runId, 0, 0, 1000, wordIndex, () => 'a', true)
+  result.current.noteRegistration(runId, 0, 0, 1000, wordIndex, () => 'a', () => undefined, true)
   result.current.record({ typingTestLabel: 'words (english)', runId, windowFocused: true }, {
     kind: 'matrix', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1000,
   })

--- a/src/renderer/components/editors/use-run-log-recorder.ts
+++ b/src/renderer/components/editors/use-run-log-recorder.ts
@@ -53,10 +53,11 @@ export interface UseRunLogRecorderReturn {
   record: (tag: Pick<RunLogRecordContext, 'typingTestLabel' | 'runId' | 'windowFocused'>, payload: TypingAnalyticsEventPayload) => void
   noteRegistration: (
     runId: string, row: number, col: number, ts: number, wordIndex: number,
-    getExpectedChar: () => string | undefined, windowFocused: boolean,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => void
   noteCharContext: (
-    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+    runId: string, wordIndex: number,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => void
   /** Returns the just-finished log (whatever `RunLogRecorder.finish`
    *  produced), or null when there's no uid to save under or nothing was
@@ -98,27 +99,28 @@ export function useRunLogRecorder({
 
   const noteRegistration = useCallback((
     runId: string, row: number, col: number, ts: number, wordIndex: number,
-    getExpectedChar: () => string | undefined, windowFocused: boolean,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => {
     const typingTestLabel = typingTestLabelRef.current
     recorderRef.current.noteRegistration(
       { typingTestLabel, runId: typingTestLabel ? runId : null, consentAccepted: consentRef.current, windowFocused },
-      row, col, ts, wordIndex, getExpectedChar,
+      row, col, ts, wordIndex, getExpectedChar, getMistakeKey,
     )
   }, [typingTestLabelRef])
 
   const noteCharContext = useCallback((
-    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+    runId: string, wordIndex: number,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => {
     const typingTestLabel = typingTestLabelRef.current
     // Skip the (possibly expensive, for romaji) derivation whenever no
     // test label is active, same as noteRegistration's `runId` gate
-    // below — the recorder's own `noteCharContext` takes an
-    // already-resolved value rather than a thunk (see its doc comment),
-    // so this wrapper is what has to defer calling `getExpectedChar`.
+    // below — the recorder's own `noteCharContext` takes already-resolved
+    // values rather than thunks (see its doc comment), so this wrapper is
+    // what has to defer calling `getExpectedChar`/`getMistakeKey`.
     recorderRef.current.noteCharContext(
       { typingTestLabel, runId: typingTestLabel ? runId : null, consentAccepted: consentRef.current, windowFocused },
-      wordIndex, typingTestLabel ? getExpectedChar() : undefined,
+      wordIndex, typingTestLabel ? getExpectedChar() : undefined, typingTestLabel ? getMistakeKey() : undefined,
     )
   }, [typingTestLabelRef])
 

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.67",
+  "version": "0.1.72",
   "name": "English",
   "common": {
     "save": "Save",
@@ -538,7 +538,7 @@
           "partialBadge": "Partial",
           "stats": {
             "wordPace": "Word Pace",
-            "runWpm": "Run WPM",
+            "runWpm": "WPM",
             "accuracy": "Accuracy",
             "overlap": "Overlap",
             "duration": "Duration",
@@ -587,7 +587,11 @@
         "errorSubstitutions": "Substitution {{count}}",
         "errorOmissions": "Omission {{count}}",
         "errorInsertions": "Insertion {{count}}",
-        "timelineConsentHint": "Enable typing recording to see the keystroke timeline here."
+        "timelineConsentHint": "Enable typing recording to see the keystroke timeline here.",
+        "missedBarTypedLine": "Typed instead: {{chars}}",
+        "missedBarCorrectedLine": "Corrected with Backspace: {{count}}",
+        "missedBarMovedOnLine": "Moved on uncorrected: {{count}}",
+        "missedBarNoDetail": "No per-keystroke detail available for this run"
       }
     }
   },

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -150,6 +150,20 @@
   width: 100cqw;
 }
 
+/* MissedTable's own scroll container (mistake-summary.tsx) — same
+   `scrollbar-gutter: stable` lesson as `.keystroke-timeline-scrollport`
+   above, applied to a VERTICAL scrollbar this time: the table's
+   right-aligned "Moved on" column must land at the same x position
+   whether or not a real scrollbar is currently showing, so the gutter is
+   reserved unconditionally rather than only once content actually
+   overflows (which would otherwise shift/clip that column's edge the
+   moment the row count crosses the scroll threshold). No
+   `container-type` needed here — MissedTable has no cqw-based sticky
+   horizontal header the way the line timeline's `100cqw` header does. */
+.missed-table-scrollport {
+  scrollbar-gutter: stable;
+}
+
 /* Interactive elements use pointer cursor */
 button:not(:disabled),
 a,

--- a/src/renderer/typing-test/HistorySections.tsx
+++ b/src/renderer/typing-test/HistorySections.tsx
@@ -26,6 +26,11 @@ interface Props {
    *  reappearing through this new layer). */
   id: string
   ariaLabelledBy: string
+  /** Forwarded to `MistakeRankingSection` — see its own prop docs. The
+   *  same `uid`/`availableRunIds` `TypingTestHistory` already threads to
+   *  `HistoryResultsPanel` for the Results view's timeline column. */
+  uid?: string
+  availableRunIds?: ReadonlySet<string>
 }
 
 /** The History modal's "Analysis" view: accuracy trend, mistake ranking,
@@ -33,7 +38,7 @@ interface Props {
  *  a tall stack (e.g. many mistake-ranking rows) scrolls independently
  *  instead of pushing past the modal's bottom edge (flex children don't
  *  shrink below their content height otherwise). */
-export function HistorySections({ tabResults, selectedCondition, id, ariaLabelledBy }: Props) {
+export function HistorySections({ tabResults, selectedCondition, id, ariaLabelledBy, uid, availableRunIds }: Props) {
   return (
     <div
       role="tabpanel"
@@ -43,7 +48,7 @@ export function HistorySections({ tabResults, selectedCondition, id, ariaLabelle
       data-testid="history-sections"
     >
       <AccuracyTrendSection results={tabResults} selectedCondition={selectedCondition} />
-      <MistakeRankingSection results={tabResults} />
+      <MistakeRankingSection results={tabResults} uid={uid} availableRunIds={availableRunIds} />
       <ErrorMixSection results={tabResults} />
     </div>
   )

--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -27,7 +27,8 @@ import { LineTimelineRow, type LineHoverTarget } from './LineTimelineRow'
 import { TIMELINE_LEGEND, type TimelineFillKind } from './word-timeline-colors'
 import { useTimelineModel } from './use-timeline-model'
 import { buildTimelineStatItems } from './keystroke-timeline-stats'
-import { MissedCharsList } from './mistake-summary'
+import { MissedTable } from './mistake-summary'
+import { buildMissedDetails } from './missed-details'
 
 /** Floor for the "fit" zoom level's canvas width — a run with a very
  *  short `maxDisplayMs` (e.g. a single short word) would otherwise
@@ -241,6 +242,16 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
   // `summaryItems` (see keystroke-timeline-stats.ts), not as their own
   // line below — see the module's own doc comment for the fallback rule.
   const summaryItems = useMemo(() => buildTimelineStatItems(result, summary, log), [result, summary, log])
+  // Per-key detail for the Missed table below — derived from this run's
+  // own raw log (see buildMissedDetails's own doc comment for why this is
+  // computed at input time, not by replaying the log after the fact).
+  const missedDetails = useMemo(() => buildMissedDetails(log), [log])
+  // Gates the Missed section's own bordered wrapper below — `MissedTable`
+  // itself renders nothing when there are no mistakes (see its own doc
+  // comment), but a wrapper `div` around it would still paint an empty
+  // bordered box if left unconditional. Mirrors `MissedTable`'s own
+  // `entries.length === 0` check without duplicating its sort.
+  const hasMistakes = Object.keys(result?.mistakes ?? {}).length > 0
 
   // The legend's info icon tooltip content — both former standalone note
   // paragraphs (corrected-mistake markers, compressed-pause axis), joined
@@ -252,6 +263,18 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
+      {/* Correctness-markers-unreliable warning — sits at the VERY TOP of
+          the panel (above the stat-card grid, coordinator-requested layout
+          tweak from a real-device screenshot review), since it qualifies
+          EVERY figure below it (the stat cards' own correctness-derived
+          values, and the timeline's own mistake/overlap markers), not just
+          the timeline box specifically. */}
+      {activeCharCorrelationUnavailable && (
+        <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
+          {t('editor.typingTest.history.timeline.correlationUnreliable')}
+        </p>
+      )}
+
       {/* Deliberate exception to the Analyze chart-above-stats rule
           (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
           this grid is the panel's summary header, not a chart-adjacent
@@ -260,167 +283,191 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           reaching the scrollable, flex-grow canvas below. */}
       <AnalyzeStatGrid items={summaryItems} ariaLabelKey="editor.typingTest.history.timeline.modalTitle" />
 
-      {activeCharCorrelationUnavailable && (
-        <p className="text-2xs text-warning" data-testid="word-timeline-correlation-note">
-          {t('editor.typingTest.history.timeline.correlationUnreliable')}
-        </p>
-      )}
-
-      {/* Legend — color alone never carries meaning elsewhere in
-          this view (tooltips spell everything out too), but this
-          is the at-a-glance key. Line-mode overrides the blank/
-          lead-in wording to the line-view's own meaning (a 250ms
-          cut and "before this line", not the word view's 1000ms /
-          "before this word") — every other entry, and the word
-          view's own wording, stays unchanged. The two longer-form
-          notes (corrected-mistake markers, compressed-pause axis)
-          used to render as their own paragraph lines below the
-          legend — collapsed into this single info icon (`ml-auto`,
-          right end of the row) so the legend reads as one compact
-          line; both notes still live in the tooltip, joined with a
-          newline (BUBBLE_BASE's `whitespace-pre-line` renders it as
-          two lines), same idiom as ErrorMixSection's row-label
-          tooltip. */}
-      <div className="flex flex-wrap items-center gap-3 rounded-md border border-edge bg-surface px-3 py-1.5">
-        {LEGEND_ORDER.map((kind) => (
-          <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
-        ))}
-        <Tooltip content={legendNotes} className="max-w-xs">
-          <button
-            type="button"
-            data-testid="word-timeline-legend-info"
-            aria-label={t('editor.typingTest.history.timeline.legend.infoAriaLabel')}
-            className="ml-auto rounded p-1 text-content-muted hover:text-content transition-colors"
-          >
-            <Info size={ICON_SM} aria-hidden="true" />
-          </button>
-        </Tooltip>
-      </div>
-
-      {/* Zoom — same row shape as RGBConfigurator's brightness
-          slider (the only existing range-input precedent). The
-          slider only mounts once `fitPxPerMs` is known, so its
-          (uncontrolled) `defaultValue` is always correct at
-          first paint — no remount-on-resolve hack needed. The
-          WHOLE row (including its label) is gated on `fitPxPerMs`,
-          not just the input — a log with zero drawable content
-          (`maxDisplayMs <= 0`) never computes a fit level, and an
-          orphan "Zoom" label with no control under it read as
-          broken rather than as "nothing to zoom". */}
-      {fitPxPerMs !== null && (
-        <div className="flex items-center gap-3">
-          <label className="text-sm text-content-secondary">{t('editor.typingTest.history.timeline.zoom.label')}</label>
-          <input
-            type="range"
-            data-testid="word-timeline-zoom"
-            aria-label={t('editor.typingTest.history.timeline.zoom.aria')}
-            min={fitPxPerMs}
-            max={fitPxPerMs * ZOOM_MAX_FACTOR}
-            step={fitPxPerMs / 20}
-            defaultValue={fitPxPerMs}
-            onChange={handleZoomInput}
-            className="flex-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          />
-        </div>
-      )}
-
-      {/* `keystroke-timeline-scrollport` (style.css) opts this scroll
-          container into `container-type: inline-size` — the LINE view's
-          per-row header pins itself to this container's own visible
-          width via `100cqw` (see LineTimelineRow.tsx and
-          .line-timeline-header-sticky's own doc comment), independent of
-          how wide the zoomed canvas inside it grows. `overflow-auto`
-          already covers BOTH axes — a many-row run scrolls vertically
-          within this same element, not just horizontally on zoom; the
-          sticky header's `left: 0` pin is horizontal-axis only, so it is
-          unaffected by (and stays correctly positioned through) vertical
-          scrolling here.
-          `flex-1 min-h-0` is what makes that vertical scroll trigger AT
-          ALL — it relies entirely on an unbroken flex-height chain from
-          this element up to a real bounded ancestor (the editor's own
-          overflow-auto content pane). A fixed viewport-relative max-height
-          cap used to live here for the completion screen specifically
-          (which lacked that chain), but a fixed vh figure can't adapt to
-          how much OTHER chrome (Lines/Font sidebar controls, an
-          IME-composition warning, the Missed-chars line, ...) a given run
-          actually has above/below it — it either wastes space or (on a
-          shorter window, or a run with more of that chrome) still
-          overflows the pane. TypingTestView.tsx now instead extends this
-          same flex chain up through its own finished-state wrapper, so
-          this scrollport ends up correctly sized without any cap at all,
-          in both the modal and the completion-screen contexts alike —
-          see TypingTestView.tsx's own "Completion screen" comment for the
-          exact chain. */}
+      {/* Single bordered box: Title, Zoom, Legend, rows scrollport — the
+          box's own `rounded-md border border-edge bg-surface` is the
+          same styling the legend row and the rows scrollport used to
+          each carry independently (generalized up to this one wrapper so
+          the four pieces read as one card instead of two separately
+          bordered boxes stacked on top of each other). The box itself
+          participates in the flex-height chain (`flex-1 min-h-0
+          flex-col`) so the rows scrollport inside it can still absorb
+          all the remaining height — title/zoom/legend keep their natural
+          height, same as before. */}
       <div
-        ref={containerRef}
-        className="keystroke-timeline-scrollport relative min-h-0 flex-1 overflow-auto rounded-md border border-edge bg-surface p-2"
+        className="flex min-h-0 flex-1 flex-col gap-3 rounded-md border border-edge bg-surface p-3"
+        data-testid="typing-test-timeline-box"
       >
-        <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
-          {displayMode === 'line' && lineModel
-            ? lineModel.lines.map((line) => (
-              <LineTimelineRow
-                key={line.lineIndex}
-                line={line}
-                maxDisplayMs={lineModel.maxDisplayMs}
-                romajiInput={log.romajiInput === true}
-                onHover={handleLineHover}
-                onHoverEnd={handleHoverEnd}
-              />
-            ))
-            : wordModel?.words.map((word) => (
-              <WordTimelineRow
-                key={word.index}
-                word={word}
-                maxDisplayMs={wordModel.maxDisplayMs}
-                onHover={handleWordHover}
-                onHoverEnd={handleHoverEnd}
-              />
-            ))}
-        </div>
+        <h3 data-testid="typing-test-timeline-title" className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+          {t('editor.typingTest.history.timeline.modalTitle')}
+        </h3>
 
-        {hover && (
-          <div
-            ref={tooltipRef}
-            className="pointer-events-none fixed z-70"
-            style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 6 }}
-            data-testid="word-timeline-tooltip"
-          >
-            {hover.segment.kind === 'keystroke'
-              ? keystrokeTooltipBody(hover.kind === 'word' ? hover.word.display : hover.lineText, hover.segment, t)
-              : (
-                <TooltipShell>
-                  <Stat
-                    label={t(lineLegendLabelKey(hover.segment.kind === 'blank' ? 'blank' : 'leadIn', hover.kind === 'line' ? 'line' : 'word'))}
-                    value={t(
-                      hover.segment.kind === 'blank'
-                        ? 'editor.typingTest.history.timeline.tooltip.blankDuration'
-                        : (hover.kind === 'line'
-                          ? 'editor.typingTest.history.timeline.tooltip.leadInLineDuration'
-                          : 'editor.typingTest.history.timeline.tooltip.leadInDuration'),
-                      { ms: Math.round(hover.segment.trueDurationMs) },
-                    )}
-                  />
-                </TooltipShell>
-              )}
+        {/* Zoom — same row shape as RGBConfigurator's brightness
+            slider (the only existing range-input precedent). The
+            slider only mounts once `fitPxPerMs` is known, so its
+            (uncontrolled) `defaultValue` is always correct at
+            first paint — no remount-on-resolve hack needed. The
+            WHOLE row (including its label) is gated on `fitPxPerMs`,
+            not just the input — a log with zero drawable content
+            (`maxDisplayMs <= 0`) never computes a fit level, and an
+            orphan "Zoom" label with no control under it read as
+            broken rather than as "nothing to zoom". */}
+        {fitPxPerMs !== null && (
+          <div className="flex items-center gap-3" data-testid="word-timeline-zoom-row">
+            <label className="text-sm text-content-secondary">{t('editor.typingTest.history.timeline.zoom.label')}</label>
+            <input
+              type="range"
+              data-testid="word-timeline-zoom"
+              aria-label={t('editor.typingTest.history.timeline.zoom.aria')}
+              min={fitPxPerMs}
+              max={fitPxPerMs * ZOOM_MAX_FACTOR}
+              step={fitPxPerMs / 20}
+              defaultValue={fitPxPerMs}
+              onChange={handleZoomInput}
+              className="flex-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            />
           </div>
         )}
+
+        {/* Legend — color alone never carries meaning elsewhere in
+            this view (tooltips spell everything out too), but this
+            is the at-a-glance key. Line-mode overrides the blank/
+            lead-in wording to the line-view's own meaning (a 250ms
+            cut and "before this line", not the word view's 1000ms /
+            "before this word") — every other entry, and the word
+            view's own wording, stays unchanged. The two longer-form
+            notes (corrected-mistake markers, compressed-pause axis)
+            used to render as their own paragraph lines below the
+            legend — collapsed into this single info icon (`ml-auto`,
+            right end of the row) so the legend reads as one compact
+            line; both notes still live in the tooltip, joined with a
+            newline (BUBBLE_BASE's `whitespace-pre-line` renders it as
+            two lines), same idiom as ErrorMixSection's row-label
+            tooltip. */}
+        <div className="flex flex-wrap items-center gap-3" data-testid="word-timeline-legend">
+          {LEGEND_ORDER.map((kind) => (
+            <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
+          ))}
+          <Tooltip content={legendNotes} className="max-w-xs">
+            <button
+              type="button"
+              data-testid="word-timeline-legend-info"
+              aria-label={t('editor.typingTest.history.timeline.legend.infoAriaLabel')}
+              className="ml-auto rounded p-1 text-content-muted hover:text-content transition-colors"
+            >
+              <Info size={ICON_SM} aria-hidden="true" />
+            </button>
+          </Tooltip>
+        </div>
+
+        {/* `keystroke-timeline-scrollport` (style.css) opts this scroll
+            container into `container-type: inline-size` — the LINE view's
+            per-row header pins itself to this container's own visible
+            width via `100cqw` (see LineTimelineRow.tsx and
+            .line-timeline-header-sticky's own doc comment), independent of
+            how wide the zoomed canvas inside it grows. `overflow-auto`
+            already covers BOTH axes — a many-row run scrolls vertically
+            within this same element, not just horizontally on zoom; the
+            sticky header's `left: 0` pin is horizontal-axis only, so it is
+            unaffected by (and stays correctly positioned through) vertical
+            scrolling here.
+            `flex-1 min-h-0` is what makes that vertical scroll trigger AT
+            ALL — it relies entirely on an unbroken flex-height chain from
+            this element up through the box above to a real bounded
+            ancestor (the editor's own overflow-auto content pane). A fixed
+            viewport-relative max-height cap used to live here for the
+            completion screen specifically (which lacked that chain), but a
+            fixed vh figure can't adapt to how much OTHER chrome
+            (Lines/Font sidebar controls, an IME-composition warning, the
+            Missed table, ...) a given run actually has above/below it — it
+            either wastes space or (on a shorter window, or a run with more
+            of that chrome) still overflows the pane. TypingTestView.tsx
+            now instead extends this same flex chain up through its own
+            finished-state wrapper, so this scrollport ends up correctly
+            sized without any cap at all, in both the modal and the
+            completion-screen contexts alike — see TypingTestView.tsx's own
+            "Completion screen" comment for the exact chain. */}
+        <div
+          ref={containerRef}
+          className="keystroke-timeline-scrollport relative min-h-0 flex-1 overflow-auto p-2"
+        >
+          <div ref={setCanvasNode} data-testid="word-timeline-canvas" className="flex flex-col gap-2">
+            {displayMode === 'line' && lineModel
+              ? lineModel.lines.map((line) => (
+                <LineTimelineRow
+                  key={line.lineIndex}
+                  line={line}
+                  maxDisplayMs={lineModel.maxDisplayMs}
+                  romajiInput={log.romajiInput === true}
+                  onHover={handleLineHover}
+                  onHoverEnd={handleHoverEnd}
+                />
+              ))
+              : wordModel?.words.map((word) => (
+                <WordTimelineRow
+                  key={word.index}
+                  word={word}
+                  maxDisplayMs={wordModel.maxDisplayMs}
+                  onHover={handleWordHover}
+                  onHoverEnd={handleHoverEnd}
+                />
+              ))}
+          </div>
+
+          {hover && (
+            <div
+              ref={tooltipRef}
+              className="pointer-events-none fixed z-70"
+              style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 6 }}
+              data-testid="word-timeline-tooltip"
+            >
+              {hover.segment.kind === 'keystroke'
+                ? keystrokeTooltipBody(hover.kind === 'word' ? hover.word.display : hover.lineText, hover.segment, t)
+                : (
+                  <TooltipShell>
+                    <Stat
+                      label={t(lineLegendLabelKey(hover.segment.kind === 'blank' ? 'blank' : 'leadIn', hover.kind === 'line' ? 'line' : 'word'))}
+                      value={t(
+                        hover.segment.kind === 'blank'
+                          ? 'editor.typingTest.history.timeline.tooltip.blankDuration'
+                          : (hover.kind === 'line'
+                            ? 'editor.typingTest.history.timeline.tooltip.leadInLineDuration'
+                            : 'editor.typingTest.history.timeline.tooltip.leadInDuration'),
+                        { ms: Math.round(hover.segment.trueDurationMs) },
+                      )}
+                    />
+                  </TooltipShell>
+                )}
+            </div>
+          )}
+        </div>
       </div>
 
-      {/* Missed characters — result-only (see the module doc comment):
+      {/* Missed table — result-only (see the module doc comment):
           reconstructing it from the raw log would re-derive scoring rules
           run-state.ts already owns. Renders nothing when the result has
           no mistakes, same convention the completion screen
           (`TypingTestStatsRow`) already follows for its own copy of this
           list. Substitution/Omission/Insertion render above, as stat
-          cards in `summaryItems`, not here. Moved below the rows
-          scrollport (was between the stat-card grid and the legend) so
-          the timeline itself reads first; `shrink-0` keeps it from being
-          squeezed by the scrollport's own `flex-1`, which must keep
-          absorbing all the remaining height in the flex-height chain
-          (see the scrollport's own comment above). */}
-      <div className="shrink-0">
-        <MissedCharsList mistakes={result?.mistakes ?? {}} />
-      </div>
+          cards in `summaryItems`, not here. Stays in the same position it
+          held as a chip list (below the timeline box) so the timeline
+          itself reads first; `shrink-0` keeps it from being squeezed by
+          the box's own `flex-1`, which must keep absorbing all the
+          remaining height in the flex-height chain (see the scrollport's
+          own comment above).
+
+          Wrapped in the SAME bordered-box treatment as the timeline box
+          above (`rounded-md border border-edge bg-surface p-3`,
+          coordinator-requested layout tweak) — but only at THIS call
+          site. `MissedTable` itself stays unwrapped: it's also rendered
+          by `MistakeRankingSection` (History's Analysis tab "Most missed"
+          section, which sits among unboxed section-heading siblings —
+          ACCURACY TREND / ERROR MIX — and must stay that way), so the box
+          is added here around the render, not inside `MissedTable`. */}
+      {hasMistakes && (
+        <div className="shrink-0 rounded-md border border-edge bg-surface p-3" data-testid="typing-test-missed-box">
+          <MissedTable mistakes={result?.mistakes ?? {}} details={missedDetails} />
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/typing-test/MistakeRankingSection.tsx
+++ b/src/renderer/typing-test/MistakeRankingSection.tsx
@@ -3,6 +3,8 @@
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import { MissedTable } from './mistake-summary'
+import { useAggregatedMissedDetails } from './use-mistake-ranking-details'
 
 interface Props {
   /** The active tab's full result set (see `AccuracyTrendSection`'s prop
@@ -10,72 +12,77 @@ interface Props {
    *  since a mistake ranking is meaningful across every condition mixed
    *  together, unlike the accuracy trend line). */
   results: TypingTestResult[]
+  /** Active keyboard's uid — same value `TypingTestHistory`/
+   *  `HistoryResultsPanel` already thread for the timeline column.
+   *  Required to fetch any run log at all; undefined disables per-key
+   *  detail fetching outright (the rows still render, bars all-gray/
+   *  unknown-split — see `MissedTable`'s own `barFillSplit` doc comment). */
+  uid?: string
+  /** runIds known to have a saved keystroke log (`useRunLogAvailability`,
+   *  owned by `HistoryToggle`) — see `useAggregatedMissedDetails`'s own
+   *  doc comment for how this scopes which logs actually get fetched. */
+  availableRunIds?: ReadonlySet<string>
 }
-
-interface MistakeRankEntry {
-  key: string
-  count: number
-}
-
-const MAX_MISTAKE_RANKING_ENTRIES = 15
 
 /** Sums each result's `mistakes` tally (key = canonical romaji unit or
  *  verbatim target char, see `TypingTestResult.mistakes`) across the whole
- *  set, then sorts by count DESC / key ASC (matches the completion
- *  screen's `mistakeEntries` ordering in `TypingTestView.tsx` so the two
- *  views read the same way) and caps to the top N. */
-function aggregateMistakes(results: TypingTestResult[]): MistakeRankEntry[] {
-  const totals = new Map<string, number>()
+ *  set. Sorting happens inside `MissedTable` itself
+ *  (`allSortedMistakeEntries`) — every entry renders, reachable via the
+ *  row list's own internal scroll rather than a top-N cap — this only
+ *  builds the raw totals record `MissedTable` expects, the same shape a
+ *  single run's own `TypingTestResult.mistakes` already has. */
+function aggregateMistakeTotals(results: TypingTestResult[]): Record<string, number> {
+  const totals: Record<string, number> = {}
   for (const r of results) {
     if (!r.mistakes) continue
     for (const [key, count] of Object.entries(r.mistakes)) {
-      totals.set(key, (totals.get(key) ?? 0) + count)
+      totals[key] = (totals[key] ?? 0) + count
     }
   }
-  return Array.from(totals, ([key, count]) => ({ key, count }))
-    .sort((a, b) => b.count - a.count || a.key.localeCompare(b.key))
-    .slice(0, MAX_MISTAKE_RANKING_ENTRIES)
+  return totals
 }
 
 /** Most-missed-characters ranking — aggregates `mistakes` across every
  *  result in the active tab (condition filter doesn't apply here, unlike
  *  `AccuracyTrendSection`; a mistake tally is still meaningful mixed
- *  across conditions). Hidden entirely when the tab has no results at
- *  all; shows a subtle "no mistakes" line when there are results but
- *  none of them recorded any mistakes. */
-export function MistakeRankingSection({ results }: Props) {
+ *  across conditions) into the SAME per-key bar-graph row list
+ *  `KeystrokeTimelinePanel` uses for a single run (`MissedTable`) — see
+ *  `useAggregatedMissedDetails` for how each bar's red/gray split and
+ *  hover-tooltip figures are populated by merging `buildMissedDetails`
+ *  across every run log available for this tab's results. Hidden entirely when the
+ *  tab has no results at all; shows a subtle "no mistakes" line when
+ *  there are results but none of them recorded any mistakes (kept as
+ *  this component's own concern, not `MissedTable`'s — this section's
+ *  empty state is worded around "results in this tab", which only this
+ *  caller knows about). */
+export function MistakeRankingSection({ results, uid, availableRunIds }: Props) {
   const { t } = useTranslation()
 
-  const ranked = useMemo(() => aggregateMistakes(results), [results])
-  const maxCount = ranked[0]?.count ?? 0
+  const totals = useMemo(() => aggregateMistakeTotals(results), [results])
+  const hasAnyMistakes = Object.keys(totals).length > 0
+  const details = useAggregatedMissedDetails(uid, results, availableRunIds)
 
   if (results.length === 0) return null
 
-  return (
-    <div className="flex flex-col gap-2" data-testid="typing-test-mistake-ranking">
-      <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
-        {t('editor.typingTest.history.mistakeRankingTitle')}
-      </h3>
-      {ranked.length === 0 ? (
+  if (!hasAnyMistakes) {
+    return (
+      <div className="flex flex-col gap-2" data-testid="typing-test-mistake-ranking">
+        <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+          {t('editor.typingTest.history.mistakeRankingTitle')}
+        </h3>
         <p className="text-xs text-content-muted">
           {t('editor.typingTest.history.mistakeRankingEmpty')}
         </p>
-      ) : (
-        <div className="flex flex-col gap-1">
-          {ranked.map(({ key, count }) => (
-            <div key={key} className="flex items-center gap-2 text-xs" data-testid={`mistake-rank-${key}`}>
-              <span className="w-12 shrink-0 truncate font-mono text-content">{key}</span>
-              <div className="h-1.5 flex-1 overflow-hidden rounded bg-surface-dim">
-                <div
-                  className="h-full rounded bg-accent"
-                  style={{ width: maxCount > 0 ? `${(count / maxCount) * 100}%` : '0%' }}
-                />
-              </div>
-              <span className="w-6 shrink-0 text-right font-mono text-content-muted">{count}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+      </div>
+    )
+  }
+
+  return (
+    <MissedTable
+      mistakes={totals}
+      details={details}
+      titleKey="editor.typingTest.history.mistakeRankingTitle"
+      testId="typing-test-mistake-ranking"
+    />
   )
 }

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -404,6 +404,8 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
           ariaLabelledBy={viewTabId('analysis')}
           tabResults={tabResults}
           selectedCondition={effectiveConditionKey}
+          uid={uid}
+          availableRunIds={availableRunIds}
         />
       )}
     </div>

--- a/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
+++ b/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
@@ -72,7 +72,7 @@ describe('KeystrokeTimelinePanel', () => {
     })
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
 
-    expect(statCardText('Run WPM')).toContain('42.0')
+    expect(statCardText('WPM')).toContain('42.0')
     expect(statCardText('KPM')).toContain('300') // (50 correctChars * 60) / 10s
     expect(statCardText('Accuracy')).toContain('95.0%')
     expect(statCardText('KSPC')).toContain('1.20') // 12 keystrokes / 10 chars
@@ -107,7 +107,7 @@ describe('KeystrokeTimelinePanel', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
 
     expect(screen.getByText('Word Pace')).toBeTruthy()
-    expect(screen.queryByText('Run WPM')).toBeNull()
+    expect(screen.queryByText('WPM')).toBeNull()
     // Time falls back to the resolved log's own durationMs (5000ms -> 5s).
     expect(statCardText('Time')).toContain('0:05')
     expect(statCardText('KPM')).toContain('—')
@@ -179,10 +179,82 @@ describe('KeystrokeTimelinePanel', () => {
     expect(infoButton.tagName).toBe('BUTTON')
     expect(infoButton.getAttribute('title')).toBeNull()
     expect(infoButton).toHaveAccessibleName()
-    // Right end of the legend row (`ml-auto`), after every swatch.
+    // Right end of the legend row (`ml-auto`), after every swatch. The
+    // legend row itself no longer carries its own border/bg (that moved up
+    // to the timeline box — see the box-order test below).
     expect(infoButton.className).toContain('ml-auto')
-    const legendRow = infoButton.closest('.rounded-md.border.border-edge.bg-surface')
-    expect(legendRow?.lastElementChild).toBe(infoButton.parentElement)
+    const legendRow = screen.getByTestId('word-timeline-legend')
+    expect(legendRow.contains(infoButton)).toBe(true)
+    expect(legendRow.lastElementChild).toBe(infoButton.parentElement)
+  })
+
+  describe('the timeline box (title / zoom / legend / rows in one bordered container)', () => {
+    it('wraps title, zoom, legend, and the rows scrollport in a single bordered container, in that order', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const box = screen.getByTestId('typing-test-timeline-box')
+      expect(box.className).toContain('rounded-md')
+      expect(box.className).toContain('border')
+      expect(box.className).toContain('border-edge')
+      expect(box.className).toContain('bg-surface')
+
+      const title = within(box).getByTestId('typing-test-timeline-title')
+      const zoomRow = within(box).getByTestId('word-timeline-zoom-row')
+      const legendRow = within(box).getByTestId('word-timeline-legend')
+      const canvas = within(box).getByTestId('word-timeline-canvas')
+
+      // Everything the box wraps must actually be INSIDE it (not just
+      // rendered somewhere else in the tree)...
+      expect(box.contains(title)).toBe(true)
+      expect(box.contains(zoomRow)).toBe(true)
+      expect(box.contains(legendRow)).toBe(true)
+      expect(box.contains(canvas)).toBe(true)
+
+      // ...and in the sketch's own order: title, then zoom, then legend,
+      // then rows (swapped from the pre-existing legend-before-zoom order).
+      expect(title.compareDocumentPosition(zoomRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      expect(zoomRow.compareDocumentPosition(legendRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+      expect(legendRow.compareDocumentPosition(canvas) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('the box participates in the flex-height chain (flex-1 min-h-0 flex-col), so the rows scrollport inside it still absorbs the remaining height', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const box = screen.getByTestId('typing-test-timeline-box')
+      expect(box.className).toContain('flex-1')
+      expect(box.className).toContain('min-h-0')
+      expect(box.className).toContain('flex-col')
+      const scrollport = screen.getByTestId('word-timeline-canvas').parentElement!
+      expect(scrollport.className).toContain('flex-1')
+      expect(scrollport.className).toContain('min-h-0')
+    })
+
+    it('the stat cards stay OUTSIDE/above the box', () => {
+      const result = makeResult()
+      const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+      const box = screen.getByTestId('typing-test-timeline-box')
+      const statLabel = screen.getByText('WPM')
+      expect(box.contains(statLabel)).toBe(false)
+      expect(container.contains(statLabel)).toBe(true)
+      expect(statLabel.compareDocumentPosition(box) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+  })
+
+  // Coordinator-requested layout tweak (real-device screenshot review):
+  // the correlation-unreliable warning used to sit between the stat grid
+  // and the timeline box — moved to the very top of the panel, above the
+  // stat grid, since it qualifies every stat card's own correctness-
+  // derived figures too, not just the timeline box below it.
+  it('renders the correlation-unreliable warning ABOVE the stat-card grid, at the very top of the panel', () => {
+    const unreliableLog: RunKeystrokeLog = { ...SAMPLE_LOG, charCorrelationUnavailable: true }
+    const result = makeResult()
+    const { container } = renderWithI18n(<KeystrokeTimelinePanel log={unreliableLog} result={result} />)
+
+    const warning = screen.getByTestId('word-timeline-correlation-note')
+    const statLabel = screen.getByText('WPM')
+
+    // The warning is the panel root's first child...
+    expect(container.firstElementChild?.firstElementChild).toBe(warning)
+    // ...and precedes the stat grid in document order.
+    expect(warning.compareDocumentPosition(statLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
   it('shows both note texts, joined as two lines, in the legend info tooltip', () => {
@@ -195,7 +267,14 @@ describe('KeystrokeTimelinePanel', () => {
     )
   })
 
-  it('shows the Missed characters list when the result carries mistakes', () => {
+  // FLAG (coordinator-requested layout change): these four cases used to
+  // assert on `typing-test-mistakes` (MissedCharsList's chip+tooltip
+  // presentation). KeystrokeTimelinePanel now renders `MissedTable`
+  // instead (see mistake-summary.tsx) — updated in place to the table's
+  // own testids rather than being dropped; MissedTable's own detailed
+  // table-structure coverage (headers, EMPTY_STAT_VALUE placeholders,
+  // shared grid tracks) lives in mistake-summary.test.tsx.
+  it('shows the Missed table when the result carries mistakes', () => {
     const result = makeResult({
       mistakes: { a: 3, b: 1 },
       errorSubstitutions: 2,
@@ -205,30 +284,79 @@ describe('KeystrokeTimelinePanel', () => {
     })
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
 
-    expect(screen.getByTestId('typing-test-mistakes')).toBeTruthy()
-    expect(screen.getByTestId('typing-test-mistake-a').textContent).toBe('a:3')
+    expect(screen.getByTestId('typing-test-missed-table')).toBeTruthy()
+    const row = screen.getByTestId('missed-table-row-a')
+    expect(within(row).getByTestId('missed-table-row-a-word').textContent).toBe('a')
+    expect(within(row).getByTestId('missed-table-row-a-count').textContent).toBe('3')
   })
 
-  it('omits the Missed characters list entirely when the result has none (not a "-" placeholder)', () => {
+  // FLAG (coordinator-requested bar-graph rewrite): the "Typed instead"
+  // cell used to show "x: 1" (char + count together); the mockup moved
+  // counts into the bar's own hover tooltip, so the row's inline cell now
+  // reads "→ x" (chars only) instead.
+  it('wires buildMissedDetails(log) end to end: a keystroke\'s typedChar/mistakeKey surfaces in the row\'s typed cell and bar split', () => {
+    const logWithDetail: RunKeystrokeLog = {
+      ...SAMPLE_LOG,
+      words: [{
+        index: 0, display: 'hi', typed: 'xi', correct: false,
+        keystrokes: [
+          { pressMs: 0, keycode: 0, row: 0, col: 0, correct: false, expectedChar: 'h', typedChar: 'x', mistakeKey: 'h' },
+        ],
+      }],
+    }
+    const result = makeResult({ mistakes: { h: 1 } })
+    renderWithI18n(<KeystrokeTimelinePanel log={logWithDetail} result={result} />)
+
+    const row = screen.getByTestId('missed-table-row-h')
+    expect(within(row).getByTestId('missed-table-row-h-typed').textContent).toBe('→ x')
+  })
+
+  it('omits the Missed table entirely when the result has none (not a "-" placeholder)', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
-    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+    expect(screen.queryByTestId('typing-test-missed-table')).toBeNull()
   })
 
-  it('omits the Missed characters list when no result is supplied at all', () => {
+  it('omits the Missed table when no result is supplied at all', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
-    expect(screen.queryByTestId('typing-test-mistakes')).toBeNull()
+    expect(screen.queryByTestId('typing-test-missed-table')).toBeNull()
   })
 
-  it('renders the Missed characters list AFTER the legend and the rows scrollport, not between the stat grid and the legend', () => {
+  it('renders the Missed table AFTER the timeline box (below it, same position the old chip list held)', () => {
     const result = makeResult({ mistakes: { a: 3 } })
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
 
-    const legendInfo = screen.getByTestId('word-timeline-legend-info')
-    const canvas = screen.getByTestId('word-timeline-canvas')
-    const mistakes = screen.getByTestId('typing-test-mistakes')
+    const box = screen.getByTestId('typing-test-timeline-box')
+    const missedTable = screen.getByTestId('typing-test-missed-table')
 
-    expect(legendInfo.compareDocumentPosition(mistakes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    expect(canvas.compareDocumentPosition(mistakes) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(box.compareDocumentPosition(missedTable) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(box.contains(missedTable)).toBe(false)
+  })
+
+  // Coordinator-requested layout tweak (real-device screenshot review):
+  // the Missed section used to sit outside any container. Wrapped here
+  // (at THIS call site only — see the wrapper's own doc comment in
+  // KeystrokeTimelinePanel.tsx) in the exact same bordered-box treatment
+  // as the timeline box above. `MistakeRankingSection` (History's "Most
+  // missed") renders the same `MissedTable` unboxed — see
+  // MistakeRankingSection.test.tsx, unchanged by this tweak.
+  it('wraps the Missed table in its own bordered box matching the timeline box treatment, keeping shrink-0', () => {
+    const result = makeResult({ mistakes: { a: 3 } })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    const missedBox = screen.getByTestId('typing-test-missed-box')
+    const missedTable = screen.getByTestId('typing-test-missed-table')
+
+    expect(missedBox.contains(missedTable)).toBe(true)
+    expect(missedBox.className).toContain('rounded-md')
+    expect(missedBox.className).toContain('border')
+    expect(missedBox.className).toContain('border-edge')
+    expect(missedBox.className).toContain('bg-surface')
+    expect(missedBox.className).toContain('shrink-0')
+  })
+
+  it('omits the Missed box entirely (no empty bordered box) when the result has no mistakes', () => {
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
+    expect(screen.queryByTestId('typing-test-missed-box')).toBeNull()
   })
 
   it('shows Substitution/Omission/Insertion as stat cards, sourced from the result', () => {

--- a/src/renderer/typing-test/__tests__/MistakeRankingSection.test.tsx
+++ b/src/renderer/typing-test/__tests__/MistakeRankingSection.test.tsx
@@ -1,12 +1,36 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
+//
+// FLAG (coordinator-requested layout changes, cumulative history):
+//  1. This file originally tested a bar-ranking presentation
+//     (`mistake-rank-${key}` rows, a width%-based bar). Rewritten once to
+//     the intermediate column-table presentation (`missed-table-row-*`/
+//     `missed-table-header*` testids).
+//  2. Rewritten again for internal scroll + no top-N cap (the "caps the
+//     ranking at 15 entries" test became "renders EVERY entry").
+//  3. THIS REWRITE: the column-table gave way to the approved bar-graph
+//     mockup (MissedTable, mistake-summary.tsx) — every row/cell
+//     assertion below was updated to the bar-graph's own shape (a
+//     `-typed` cell with "→ chars" instead of "chars: count", a
+//     `-bar`/`-bar-movedon`/`-bar-corrected` triad instead of a separate
+//     `-movedon` cell). The aggregation (sum `mistakes` across results,
+//     sort DESC/key ASC) and empty-state behavior are unchanged, just
+//     re-asserted against the new DOM shape.
+//
+// New coverage below (not present before any rewrite): the row list
+// renders with per-key detail (bar split + typed chars) once
+// `typingRunLogGet` resolves, and a per-log fetch error is skipped
+// without breaking the rest of the list — see
+// use-mistake-ranking-details.test.ts for the merge logic's own unit
+// tests, independent of any component mount.
 
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { MistakeRankingSection } from '../MistakeRankingSection'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
 
 function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
   return {
@@ -27,6 +51,23 @@ function renderWithI18n(ui: React.ReactElement) {
   return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
 }
 
+/** `[data-testid^="missed-table-row-"]` also matches each row's own cell
+ *  spans/divs (`-word`/`-count`/`-typed`/`-bar`/`-bar-movedon`/
+ *  `-bar-corrected`), which share the same prefix — this keeps only the
+ *  row CONTAINERS, i.e. testids of the exact form
+ *  `missed-table-row-<key>` with no further dash-suffix (every key used
+ *  in this file is dash-free, so this is unambiguous). */
+function rowContainers(scope: HTMLElement): Element[] {
+  return Array.from(scope.querySelectorAll('[data-testid^="missed-table-row-"]'))
+    .filter((el) => /^missed-table-row-[^-]+$/.test(el.getAttribute('data-testid') ?? ''))
+}
+
+const originalVialAPI = window.vialAPI
+
+beforeEach(() => {
+  window.vialAPI = { ...originalVialAPI } as typeof window.vialAPI
+})
+
 describe('MistakeRankingSection', () => {
   it('renders nothing when there are no results at all', () => {
     const { container } = renderWithI18n(<MistakeRankingSection results={[]} />)
@@ -37,45 +78,149 @@ describe('MistakeRankingSection', () => {
     renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes: undefined })]} />)
     expect(screen.getByTestId('typing-test-mistake-ranking')).toBeTruthy()
     expect(screen.getByText(/no mistakes/i)).toBeTruthy()
-    expect(screen.queryByTestId(/^mistake-rank-/)).toBeNull()
+    expect(screen.queryByTestId(/^missed-table-row-/)).toBeNull()
   })
 
-  it('aggregates the same key across multiple results and sums the counts', () => {
+  it('aggregates the same key across multiple results and sums the counts, in the shared bar-graph shape', () => {
     const results = [
       makeResult({ mistakes: { shi: 2, a: 1 } }),
       makeResult({ mistakes: { shi: 3 } }),
     ]
     renderWithI18n(<MistakeRankingSection results={results} />)
-    const shiRow = screen.getByTestId('mistake-rank-shi')
-    expect(shiRow.textContent).toContain('5')
-    const aRow = screen.getByTestId('mistake-rank-a')
-    expect(aRow.textContent).toContain('1')
+    const shiRow = screen.getByTestId('missed-table-row-shi')
+    expect(within(shiRow).getByTestId('missed-table-row-shi-count').textContent).toBe('5')
+    const aRow = screen.getByTestId('missed-table-row-a')
+    expect(within(aRow).getByTestId('missed-table-row-a-count').textContent).toBe('1')
+    // No log/uid supplied — counts only, no per-key detail yet: typed
+    // cell empty, bar entirely gray (unknown split).
+    expect(within(shiRow).getByTestId('missed-table-row-shi-typed').textContent).toBe('—')
+    expect(within(shiRow).getByTestId('missed-table-row-shi-bar-movedon').style.width).toBe('0%')
+    expect(within(shiRow).getByTestId('missed-table-row-shi-bar-corrected').style.width).toBe('100%')
   })
 
   it('sorts by count DESC then key ASC', () => {
-    const results = [
-      makeResult({ mistakes: { b: 3, a: 3, c: 5 } }),
-    ]
+    const results = [makeResult({ mistakes: { b: 3, a: 3, c: 5 } })]
     renderWithI18n(<MistakeRankingSection results={results} />)
-    const rows = screen.getByTestId('typing-test-mistake-ranking').querySelectorAll('[data-testid^="mistake-rank-"]')
-    const keys = Array.from(rows).map((r) => r.getAttribute('data-testid'))
-    expect(keys).toEqual(['mistake-rank-c', 'mistake-rank-a', 'mistake-rank-b'])
+    const rows = rowContainers(screen.getByTestId('typing-test-mistake-ranking'))
+    const keys = rows.map((r) => r.getAttribute('data-testid'))
+    expect(keys).toEqual(['missed-table-row-c', 'missed-table-row-a', 'missed-table-row-b'])
   })
 
-  it('caps the ranking at the top 15 entries', () => {
+  it('normalizes bar width to the list\'s own max count', () => {
+    const results = [makeResult({ mistakes: { c: 5, a: 3, b: 3 } })]
+    renderWithI18n(<MistakeRankingSection results={results} />)
+    const barC = screen.getByTestId('missed-table-row-c-bar').firstElementChild as HTMLElement
+    const barA = screen.getByTestId('missed-table-row-a-bar').firstElementChild as HTMLElement
+    expect(barC.style.width).toBe('100%')
+    expect(barA.style.width).toBe('60%') // 3/5
+  })
+
+  it('renders EVERY entry — no top-N cap, reachable via the shared row list\'s own internal scroll', () => {
     const mistakes: Record<string, number> = {}
     for (let i = 0; i < 20; i++) mistakes[`k${String(i).padStart(2, '0')}`] = 20 - i
     renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes })]} />)
-    const rows = screen.getByTestId('typing-test-mistake-ranking').querySelectorAll('[data-testid^="mistake-rank-"]')
-    expect(rows.length).toBe(15)
-    // Highest counts (k00..k14) should be the ones kept.
-    expect(screen.getByTestId('mistake-rank-k00')).toBeTruthy()
-    expect(screen.queryByTestId('mistake-rank-k15')).toBeNull()
+    const rows = rowContainers(screen.getByTestId('typing-test-mistake-ranking'))
+    expect(rows.length).toBe(20)
+    expect(screen.getByTestId('missed-table-row-k00')).toBeTruthy()
+    expect(screen.getByTestId('missed-table-row-k19')).toBeTruthy()
   })
 
   it('handles a result with an empty mistakes object without crashing', () => {
     renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes: {} })]} />)
     expect(screen.getByTestId('typing-test-mistake-ranking')).toBeTruthy()
     expect(screen.getByText(/no mistakes/i)).toBeTruthy()
+  })
+
+  it('uses the "Most missed" heading, not the single-run "Missed" heading', () => {
+    renderWithI18n(<MistakeRankingSection results={[makeResult({ mistakes: { a: 1 } })]} />)
+    expect(screen.getByText('Most missed')).toBeInTheDocument()
+  })
+
+  describe('per-key detail from run logs (uid + availableRunIds)', () => {
+    function makeLog(overrides: Partial<RunKeystrokeLog> = {}): RunKeystrokeLog {
+      return {
+        runId: 'run-1', uid: 'kb-1', startedAt: '2026-01-01T00:00:00.000Z', durationMs: 5000,
+        mode: 'words', language: 'english', words: [], ...overrides,
+      }
+    }
+
+    it('fetches only runIds that are both referenced by a result AND present in availableRunIds, then populates the typed-chars cell and bar split', async () => {
+      const getLog = vi.fn().mockResolvedValue({
+        success: true,
+        data: makeLog({
+          runId: 'run-1',
+          words: [{
+            index: 0, display: 'hi', typed: 'xi', correct: false,
+            keystrokes: [{ pressMs: 0, keycode: 0, row: 0, col: 0, correct: false, expectedChar: 'h', typedChar: 'x', mistakeKey: 'h' }],
+          }],
+        }),
+      })
+      window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+      const results = [makeResult({ mistakes: { h: 1 }, runId: 'run-1' })]
+      renderWithI18n(
+        <MistakeRankingSection results={results} uid="kb-1" availableRunIds={new Set(['run-1', 'run-unrelated'])} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('missed-table-row-h-typed').textContent).toBe('→ x')
+      })
+      expect(getLog).toHaveBeenCalledTimes(1)
+      expect(getLog).toHaveBeenCalledWith('kb-1', 'run-1')
+    })
+
+    it('a result whose runId has no saved log (not in availableRunIds) contributes counts only — no fetch, no detail', async () => {
+      const getLog = vi.fn().mockResolvedValue({ success: true, data: makeLog() })
+      window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+      const results = [makeResult({ mistakes: { h: 1 }, runId: 'run-no-log' })]
+      renderWithI18n(<MistakeRankingSection results={results} uid="kb-1" availableRunIds={new Set()} />)
+
+      const row = screen.getByTestId('missed-table-row-h')
+      expect(within(row).getByTestId('missed-table-row-h-typed').textContent).toBe('—')
+      expect(getLog).not.toHaveBeenCalled()
+    })
+
+    it('skips a run whose log fetch rejects, without breaking the rest of the list', async () => {
+      const getLog = vi.fn()
+        .mockRejectedValueOnce(new Error('network error'))
+        .mockResolvedValueOnce({
+          success: true,
+          data: makeLog({
+            runId: 'run-2',
+            words: [{
+              index: 0, display: 'ab', typed: 'ab', correct: true,
+              keystrokes: [{ pressMs: 0, keycode: 0, row: 0, col: 0, correct: false, expectedChar: 'a', typedChar: 'z', mistakeKey: 'a' }],
+            }],
+          }),
+        })
+      window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+      const results = [
+        makeResult({ mistakes: { h: 1 }, runId: 'run-1' }),
+        makeResult({ mistakes: { a: 1 }, runId: 'run-2' }),
+      ]
+      renderWithI18n(
+        <MistakeRankingSection results={results} uid="kb-1" availableRunIds={new Set(['run-1', 'run-2'])} />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId('missed-table-row-a-typed').textContent).toBe('→ z')
+      })
+      // The rejected run's own row still renders (from `mistakes`), just
+      // with no detail — the failure never surfaced as a crash or a
+      // missing row.
+      expect(screen.getByTestId('missed-table-row-h-typed').textContent).toBe('—')
+    })
+
+    it('does nothing (no fetch at all) when uid is undefined', () => {
+      const getLog = vi.fn().mockResolvedValue({ success: true, data: makeLog() })
+      window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+      const results = [makeResult({ mistakes: { h: 1 }, runId: 'run-1' })]
+      renderWithI18n(<MistakeRankingSection results={results} availableRunIds={new Set(['run-1'])} />)
+
+      expect(getLog).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
@@ -139,17 +139,17 @@ describe('WordTimelineView', () => {
     expect(parseFloat(canvas.style.width)).toBeGreaterThan(parseFloat(widthBefore))
   })
 
-  it('labels the pace card "Run WPM" (not "Word Pace") when a History result is supplied, since it shows result.wpm — a different metric', async () => {
+  it('labels the pace card "WPM" (not "Word Pace") when a History result is supplied, since it shows result.wpm — a different metric', async () => {
     const result = { date: '2026-01-01', wpm: 42, accuracy: 95, wordCount: 10, correctChars: 50, incorrectChars: 2, durationSeconds: 10 }
     renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" result={result} onClose={() => {}} />)
-    await waitFor(() => expect(screen.getByText('Run WPM')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText('WPM')).toBeTruthy())
     expect(screen.queryByText('Word Pace')).toBeNull()
   })
 
   it('labels the pace card "Word Pace" (the model-derived fallback) when no result is supplied', async () => {
     renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
     await waitFor(() => expect(screen.getByText('Word Pace')).toBeTruthy())
-    expect(screen.queryByText('Run WPM')).toBeNull()
+    expect(screen.queryByText('WPM')).toBeNull()
   })
 
   it('hides the entire Zoom row (including its label) when the log has zero drawable content', async () => {

--- a/src/renderer/typing-test/__tests__/expected-char.test.ts
+++ b/src/renderer/typing-test/__tests__/expected-char.test.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { describe, it, expect } from 'vitest'
-import { deriveExpectedChar } from '../expected-char'
+import { deriveExpectedChar, deriveMistakeKey } from '../expected-char'
 import type { TypingTestState } from '../run-state'
 import { createInitialState } from '../run-state'
-import { DEFAULT_CONFIG, DEFAULT_LANGUAGE } from '../types'
+import { DEFAULT_CONFIG, DEFAULT_LANGUAGE, type TypingTestConfig } from '../types'
 
 describe('deriveExpectedChar', () => {
   it('returns the next unconfirmed character of the current word in verbatim mode', () => {
@@ -15,5 +15,64 @@ describe('deriveExpectedChar', () => {
   it('returns undefined once past the last word', () => {
     const state: TypingTestState = { ...createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE), words: ['hi'], currentWordIndex: 1 }
     expect(deriveExpectedChar(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBeUndefined()
+  })
+})
+
+// Real kana pack id (see ROMAJI_INPUT_LANGUAGES) — `romajiInput: true` alone
+// isn't enough for `isRomajiInputActive` without the language also being a
+// kana pack.
+const KANA_LANGUAGE = 'japanese_hiragana'
+const ROMAJI_CONFIG: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false, romajiInput: true }
+
+describe('deriveMistakeKey', () => {
+  it('returns undefined once past the last word', () => {
+    const state: TypingTestState = { ...createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE), words: ['hi'], currentWordIndex: 1 }
+    expect(deriveMistakeKey(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBeUndefined()
+  })
+
+  describe('verbatim mode', () => {
+    it('equals deriveExpectedChar — the position\'s own target char is its own mistake key', () => {
+      const state: TypingTestState = { ...createInitialState(DEFAULT_CONFIG, DEFAULT_LANGUAGE), words: ['hello'], currentInput: 'he' }
+      expect(deriveMistakeKey(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBe('l')
+      expect(deriveMistakeKey(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE)).toBe(deriveExpectedChar(state, DEFAULT_CONFIG, DEFAULT_LANGUAGE))
+    })
+  })
+
+  describe('romaji mode', () => {
+    it('returns the current kana segment\'s canonical spelling, not the single next romaji char', () => {
+      const state: TypingTestState = {
+        ...createInitialState(ROMAJI_CONFIG, KANA_LANGUAGE),
+        words: ['あい'],
+        romajiCapable: true,
+        romajiKeystrokes: '',
+      }
+      // deriveExpectedChar's romaji branch is the single next guide char
+      // ("a"); the mistake key is the whole segment's canonical spelling
+      // — identical here (single-kana "あ" segment spells "a" too), so
+      // this case alone wouldn't distinguish the two. See the digraph
+      // case below for where they actually diverge.
+      expect(deriveMistakeKey(state, ROMAJI_CONFIG, KANA_LANGUAGE)).toBe('a')
+    })
+
+    it('diverges from deriveExpectedChar mid-digraph: the segment key is the whole spelling, not the next char', () => {
+      const state: TypingTestState = {
+        ...createInitialState(ROMAJI_CONFIG, KANA_LANGUAGE),
+        words: ['でぃなーにいく'],
+        romajiCapable: true,
+        romajiKeystrokes: 'd',
+      }
+      expect(deriveExpectedChar(state, ROMAJI_CONFIG, KANA_LANGUAGE)).toBe('h')
+      expect(deriveMistakeKey(state, ROMAJI_CONFIG, KANA_LANGUAGE)).toBe('dhi')
+    })
+
+    it('returns undefined once the word is fully matched', () => {
+      const state: TypingTestState = {
+        ...createInitialState(ROMAJI_CONFIG, KANA_LANGUAGE),
+        words: ['あ'],
+        romajiCapable: true,
+        romajiKeystrokes: 'a',
+      }
+      expect(deriveMistakeKey(state, ROMAJI_CONFIG, KANA_LANGUAGE)).toBeUndefined()
+    })
   })
 })

--- a/src/renderer/typing-test/__tests__/missed-details.test.ts
+++ b/src/renderer/typing-test/__tests__/missed-details.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { buildMissedDetails } from '../missed-details'
+import type { RunKeystrokeLog, RunKeystroke, RunWord } from '../../../shared/types/typing-run-log'
+
+function makeKeystroke(overrides: Partial<RunKeystroke> = {}): RunKeystroke {
+  return { pressMs: 0, keycode: 1, row: 0, col: 0, ...overrides }
+}
+
+function makeWord(overrides: Partial<RunWord> = {}): RunWord {
+  return { index: 0, display: 'hello', typed: 'hello', correct: true, keystrokes: [], ...overrides }
+}
+
+function makeLog(overrides: Partial<RunKeystrokeLog> = {}): RunKeystrokeLog {
+  return {
+    runId: 'run-1',
+    uid: 'uid-1',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    durationMs: 5000,
+    mode: 'words',
+    language: 'english',
+    words: [],
+    ...overrides,
+  }
+}
+
+describe('buildMissedDetails', () => {
+  it('bails out to an empty map when charCorrelationUnavailable', () => {
+    const log = makeLog({
+      charCorrelationUnavailable: true,
+      words: [makeWord({
+        display: 'hi', typed: 'xi', correct: false,
+        keystrokes: [makeKeystroke({ correct: false, expectedChar: 'h', typedChar: 'x', mistakeKey: 'h' })],
+      })],
+    })
+    expect(buildMissedDetails(log).size).toBe(0)
+  })
+
+  it('groups typedChar of incorrect keystrokes by mistakeKey (typedCounts)', () => {
+    const log = makeLog({
+      words: [makeWord({
+        display: 'hello', typed: 'hello', correct: true,
+        keystrokes: [
+          makeKeystroke({ correct: false, expectedChar: 'h', typedChar: 'm', mistakeKey: 'h' }),
+          makeKeystroke({ correct: false, expectedChar: 'h', typedChar: 'm', mistakeKey: 'h' }),
+          makeKeystroke({ correct: false, expectedChar: 'h', typedChar: 'b', mistakeKey: 'h' }),
+          makeKeystroke({ correct: true, expectedChar: 'e' }),
+        ],
+      })],
+    })
+    const details = buildMissedDetails(log)
+    expect(details.get('h')?.typedCounts).toEqual({ m: 2, b: 1 })
+  })
+
+  it('includes incorrect keystrokes from an interrupted (partial) word in typedCounts', () => {
+    const log = makeLog({
+      words: [makeWord({
+        display: 'wo', typed: 'x', correct: false, partial: true,
+        keystrokes: [makeKeystroke({ correct: false, expectedChar: 'w', typedChar: 'x', mistakeKey: 'w' })],
+      })],
+    })
+    expect(buildMissedDetails(log).get('w')?.typedCounts).toEqual({ x: 1 })
+  })
+
+  it('ignores an incorrect keystroke missing typedChar/mistakeKey (legacy log), independent of movedOn', () => {
+    // display === typed (a corrected mistake, fixed via Backspace before
+    // submit) isolates this to ONLY the per-keystroke signal — no
+    // movedOn contribution to conflate with the assertion below.
+    const log = makeLog({
+      words: [makeWord({
+        display: 'hi', typed: 'hi', correct: true,
+        keystrokes: [makeKeystroke({ correct: false, expectedChar: 'h' })],
+      })],
+    })
+    expect(buildMissedDetails(log).size).toBe(0)
+  })
+
+  it('a fully legacy log (no keystroke ever carries typedChar/mistakeKey) still surfaces movedOnCount alone — typedCounts stays empty, not the whole entry', () => {
+    // Deliberate: movedOnCount is derived purely from RunWord.display/typed
+    // (always present, even pre-dating this feature), independent of the
+    // per-keystroke fields — see buildMissedDetails' own doc comment. A
+    // legacy log therefore still gets a partial detail (moved-on line
+    // only, no "typed instead" line), not full absence.
+    const log = makeLog({
+      words: [makeWord({
+        display: 'hi', typed: 'ho', correct: false,
+        keystrokes: [makeKeystroke({ correct: false, expectedChar: 'i' })],
+      })],
+    })
+    const entry = buildMissedDetails(log).get('i')
+    expect(entry?.typedCounts).toEqual({})
+    expect(entry?.movedOnCount).toBe(1)
+  })
+
+  describe('movedOnCount (verbatim mode)', () => {
+    it('counts a position whose final typed char differs from display, keyed by the expected char', () => {
+      const log = makeLog({
+        words: [makeWord({ display: 'hello', typed: 'hbllo', correct: false, keystrokes: [] })],
+      })
+      const details = buildMissedDetails(log)
+      expect(details.get('e')?.movedOnCount).toBe(1)
+    })
+
+    it('counts an absent trailing char (typed shorter than display) as moved-on', () => {
+      const log = makeLog({
+        words: [makeWord({ display: 'hi', typed: 'h', correct: false, keystrokes: [] })],
+      })
+      expect(buildMissedDetails(log).get('i')?.movedOnCount).toBe(1)
+    })
+
+    it('counts nothing for a word typed exactly correct', () => {
+      const log = makeLog({
+        words: [makeWord({ display: 'hi', typed: 'hi', correct: true, keystrokes: [] })],
+      })
+      expect(buildMissedDetails(log).size).toBe(0)
+    })
+
+    it('excludes an interrupted (partial) word from movedOnCount', () => {
+      const log = makeLog({
+        words: [makeWord({ display: 'hello', typed: 'x', correct: false, partial: true, keystrokes: [] })],
+      })
+      expect(buildMissedDetails(log).size).toBe(0)
+    })
+
+    it('combines with typedCounts under the same key when both signals apply', () => {
+      const log = makeLog({
+        words: [makeWord({
+          display: 'hi', typed: 'xi', correct: false,
+          keystrokes: [makeKeystroke({ correct: false, expectedChar: 'h', typedChar: 'x', mistakeKey: 'h' })],
+        })],
+      })
+      const entry = buildMissedDetails(log).get('h')
+      expect(entry?.typedCounts).toEqual({ x: 1 })
+      expect(entry?.movedOnCount).toBe(1)
+    })
+  })
+
+  describe('romaji mode', () => {
+    it('is always 0 — never derives movedOnCount even when display/typed differ positionally', () => {
+      const log = makeLog({
+        romajiInput: true,
+        words: [makeWord({ display: 'あい', typed: 'ab', correct: false, keystrokes: [] })],
+      })
+      expect(buildMissedDetails(log).size).toBe(0)
+    })
+
+    it('still groups typedCounts from incorrect keystrokes normally', () => {
+      const log = makeLog({
+        romajiInput: true,
+        words: [makeWord({
+          display: 'あい', typed: 'ai', correct: true,
+          keystrokes: [makeKeystroke({ correct: false, expectedChar: 'a', typedChar: 'z', mistakeKey: 'a' })],
+        })],
+      })
+      const details = buildMissedDetails(log)
+      expect(details.get('a')?.typedCounts).toEqual({ z: 1 })
+      expect(details.get('a')?.movedOnCount).toBe(0)
+    })
+  })
+})

--- a/src/renderer/typing-test/__tests__/mistake-summary.test.tsx
+++ b/src/renderer/typing-test/__tests__/mistake-summary.test.tsx
@@ -1,0 +1,272 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// FLAG (coordinator-requested layout changes, cumulative history):
+//  1. MissedCharsList's original chip+tooltip presentation was replaced
+//     by a column TABLE (MissedTable) for KeystrokeTimelinePanel's use.
+//     MissedCharsList itself was reverted to its original plain-chip
+//     shape (no `details` prop) since TypingTestStatsRow, its only
+//     remaining caller, never had detail data to show in the first
+//     place.
+//  2. The table gained internal scrolling + a sticky header (no more
+//     top-N truncation).
+//  3. THIS REWRITE: the column-table presentation (headers, a separate
+//     Moved-on column) was replaced by the approved bar-graph mockup —
+//     Word / "→ typed chars" / stacked red-gray bar / Cnt, no header row
+//     at all. Every table-era test below (header assertions, the
+//     separate `-movedon` cell, `formatTypedInstead`-with-counts in the
+//     row itself) was rewritten to the bar-graph's own shape; none were
+//     silently dropped.
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within, fireEvent } from '@testing-library/react'
+import { I18nextProvider } from 'react-i18next'
+import i18n from '../../i18n'
+import { MissedCharsList, MissedTable } from '../mistake-summary'
+import type { MissedCharDetail } from '../missed-details'
+
+function renderWithI18n(ui: React.ReactElement) {
+  return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
+}
+
+/** Hovers a row's bar and returns the tooltip element it opens —
+ *  `fireEvent.mouseEnter` (not `.hover()`, which is a user-event/
+ *  Playwright-only API) is enough to flip `Tooltip`'s own `open` state
+ *  synchronously in a jsdom render. */
+function hoverBar(key: string): HTMLElement {
+  const bar = screen.getByTestId(`missed-table-row-${key}-bar`)
+  fireEvent.mouseEnter(bar)
+  const describedBy = bar.getAttribute('aria-describedby')
+  expect(describedBy).toBeTruthy()
+  return document.getElementById(describedBy!)!
+}
+
+describe('MissedCharsList (plain chip line — TypingTestStatsRow\'s no-log fallback)', () => {
+  it('renders nothing when mistakes is empty', () => {
+    const { container } = renderWithI18n(<MissedCharsList mistakes={{}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders a chip per mistake key, sorted by count', () => {
+    renderWithI18n(<MissedCharsList mistakes={{ h: 2, e: 3 }} />)
+    const list = screen.getByTestId('typing-test-mistakes')
+    const chips = within(list).getAllByText(/^[a-z]:\d$/)
+    expect(chips.map((c) => c.textContent)).toEqual(['e:3', 'h:2'])
+  })
+})
+
+describe('MissedTable (bar-graph rows: Word / typed chars / stacked bar / Cnt)', () => {
+  it('renders nothing when mistakes is empty', () => {
+    const { container } = renderWithI18n(<MissedTable mistakes={{}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the "Missed" section heading', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1 }} />)
+    expect(screen.getByText('Missed')).toBeInTheDocument()
+  })
+
+  // FLAG: replaces the old "renders a 4-column header row" test — the
+  // mockup has no header row at all.
+  it('renders no header row', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1 }} />)
+    expect(screen.queryByTestId('missed-table-header')).toBeNull()
+  })
+
+  it('every row shares the same grid column tracks', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1, e: 2 }} />)
+    const rowH = screen.getByTestId('missed-table-row-h')
+    const rowE = screen.getByTestId('missed-table-row-e')
+    expect(rowH.style.gridTemplateColumns.length).toBeGreaterThan(0)
+    expect(rowE.style.gridTemplateColumns).toBe(rowH.style.gridTemplateColumns)
+  })
+
+  it('renders Word and Cnt from `mistakes`, and the typed-chars cell as "→ chars" (no counts inline)', () => {
+    const details = new Map<string, MissedCharDetail>([
+      ['e', { typedCounts: { n: 2, m: 1 }, movedOnCount: 0 }],
+    ])
+    renderWithI18n(<MissedTable mistakes={{ e: 3 }} details={details} />)
+    const row = screen.getByTestId('missed-table-row-e')
+    expect(within(row).getByTestId('missed-table-row-e-word').textContent).toBe('e')
+    expect(within(row).getByTestId('missed-table-row-e-count').textContent).toBe('3')
+    // Sorted DESC by count, chars only — counts live in the tooltip, not here.
+    expect(within(row).getByTestId('missed-table-row-e-typed').textContent).toBe('→ n, m')
+  })
+
+  it('renders EMPTY_STAT_VALUE ("—", no arrow) for the typed-chars cell when the key has no detail entry (legacy log)', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1 }} details={new Map()} />)
+    expect(screen.getByTestId('missed-table-row-h-typed').textContent).toBe('—')
+  })
+
+  it('renders EMPTY_STAT_VALUE ("—") for the typed-chars cell when `details` is omitted entirely', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1, e: 2 }} />)
+    expect(screen.getByTestId('missed-table-row-h-typed').textContent).toBe('—')
+    expect(screen.getByTestId('missed-table-row-e-typed').textContent).toBe('—')
+  })
+
+  it('renders one row per sorted mistake key', () => {
+    renderWithI18n(<MissedTable mistakes={{ h: 1, e: 3, a: 2 }} />)
+    for (const key of ['e', 'a', 'h']) {
+      expect(screen.getByTestId(`missed-table-row-${key}`)).toBeInTheDocument()
+    }
+  })
+
+  it('renders EVERY entry — no truncation, however many distinct mistake keys there are', () => {
+    const mistakes: Record<string, number> = {}
+    for (let i = 0; i < 30; i++) mistakes[`k${String(i).padStart(2, '0')}`] = 30 - i
+    renderWithI18n(<MissedTable mistakes={mistakes} />)
+    for (let i = 0; i < 30; i++) {
+      expect(screen.getByTestId(`missed-table-row-k${String(i).padStart(2, '0')}`)).toBeInTheDocument()
+    }
+  })
+
+  describe('bar width normalization (total fill vs the list\'s own max Cnt)', () => {
+    it('the highest-count row\'s bar fills 100% of its track', () => {
+      renderWithI18n(<MissedTable mistakes={{ e: 10, a: 5 }} />)
+      const barE = screen.getByTestId('missed-table-row-e-bar').firstElementChild as HTMLElement
+      expect(barE.style.width).toBe('100%')
+    })
+
+    it('a lower-count row\'s bar fill is proportional to count/maxCount', () => {
+      renderWithI18n(<MissedTable mistakes={{ e: 10, a: 5 }} />)
+      const barA = screen.getByTestId('missed-table-row-a-bar').firstElementChild as HTMLElement
+      expect(barA.style.width).toBe('50%')
+    })
+
+    it('a single-row list (count === maxCount) always fills 100%', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 3 }} />)
+      const bar = screen.getByTestId('missed-table-row-h-bar').firstElementChild as HTMLElement
+      expect(bar.style.width).toBe('100%')
+    })
+  })
+
+  describe('red (moved-on) / gray (corrected) segment split', () => {
+    it('splits the fill proportionally: red = movedOnCount/count, gray = the remainder', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { x: 4 }, movedOnCount: 1 }]])
+      renderWithI18n(<MissedTable mistakes={{ h: 4 }} details={details} />)
+      const movedOn = screen.getByTestId('missed-table-row-h-bar-movedon')
+      const corrected = screen.getByTestId('missed-table-row-h-bar-corrected')
+      expect(movedOn.style.width).toBe('25%')
+      expect(corrected.style.width).toBe('75%')
+      expect(movedOn.className).toContain('bg-danger')
+      expect(corrected.className).toContain('bg-content-muted')
+    })
+
+    it('movedOnCount === count -> the bar is entirely red', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { x: 2 }, movedOnCount: 2 }]])
+      renderWithI18n(<MissedTable mistakes={{ h: 2 }} details={details} />)
+      expect(screen.getByTestId('missed-table-row-h-bar-movedon').style.width).toBe('100%')
+      expect(screen.getByTestId('missed-table-row-h-bar-corrected').style.width).toBe('0%')
+    })
+
+    it('movedOnCount === 0 -> the bar is entirely gray (corrected)', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { x: 2 }, movedOnCount: 0 }]])
+      renderWithI18n(<MissedTable mistakes={{ h: 2 }} details={details} />)
+      expect(screen.getByTestId('missed-table-row-h-bar-movedon').style.width).toBe('0%')
+      expect(screen.getByTestId('missed-table-row-h-bar-corrected').style.width).toBe('100%')
+    })
+
+    it('clamps a movedOnCount that (via a different code path) exceeds count, rather than overflowing past 100%', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { x: 1 }, movedOnCount: 99 }]])
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} details={details} />)
+      expect(screen.getByTestId('missed-table-row-h-bar-movedon').style.width).toBe('100%')
+      expect(screen.getByTestId('missed-table-row-h-bar-corrected').style.width).toBe('0%')
+    })
+
+    // FLAGGED CHOICE (unknown-split rendering): a row with no detail data
+    // at all renders IDENTICALLY to a genuinely all-corrected row (100%
+    // gray) — there's no third "unknown" visual state. The tooltip is
+    // what actually distinguishes the two cases (see the tooltip
+    // describe block below).
+    it('a legacy/no-detail row renders its bar entirely gray — identical to a confirmed all-corrected row', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} details={new Map()} />)
+      expect(screen.getByTestId('missed-table-row-h-bar-movedon').style.width).toBe('0%')
+      expect(screen.getByTestId('missed-table-row-h-bar-corrected').style.width).toBe('100%')
+    })
+
+    it('a row with `details` omitted entirely also renders its bar entirely gray', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} />)
+      expect(screen.getByTestId('missed-table-row-h-bar-movedon').style.width).toBe('0%')
+      expect(screen.getByTestId('missed-table-row-h-bar-corrected').style.width).toBe('100%')
+    })
+  })
+
+  describe('bar hover tooltip', () => {
+    it('shows Typed instead (with counts) / Corrected with Backspace / Moved on uncorrected, no native title', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { m: 2, b: 1 }, movedOnCount: 1 }]])
+      renderWithI18n(<MissedTable mistakes={{ h: 3 }} details={details} />)
+      const bar = screen.getByTestId('missed-table-row-h-bar')
+      expect(bar.getAttribute('title')).toBeNull()
+      const tooltip = hoverBar('h')
+      expect(tooltip.textContent).toBe(
+        'Typed instead: m: 2, b: 1\n'
+        + 'Corrected with Backspace: 2\n'
+        + 'Moved on uncorrected: 1',
+      )
+    })
+
+    it('omits the "Typed instead" line when typedCounts is empty, but still shows Corrected/Moved on', () => {
+      const details = new Map<string, MissedCharDetail>([['i', { typedCounts: {}, movedOnCount: 3 }]])
+      renderWithI18n(<MissedTable mistakes={{ i: 3 }} details={details} />)
+      const tooltip = hoverBar('i')
+      expect(tooltip.textContent).not.toContain('Typed instead')
+      expect(tooltip.textContent).toContain('Corrected with Backspace: 0')
+      expect(tooltip.textContent).toContain('Moved on uncorrected: 3')
+    })
+
+    // FLAGGED CHOICE, continued: the tooltip is where a legacy/no-detail
+    // row's bar becomes distinguishable from a confirmed all-corrected
+    // one, even though the bar itself renders identically for both.
+    it('a legacy/no-detail row shows a single distinct sentence instead of the normal 3-line breakdown', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} details={new Map()} />)
+      const tooltip = hoverBar('h')
+      expect(tooltip.textContent).toBe('No per-keystroke detail available for this run')
+    })
+
+    it('no element in the table carries a native title attribute (lint forbids it)', () => {
+      const details = new Map<string, MissedCharDetail>([['h', { typedCounts: { m: 1 }, movedOnCount: 0 }]])
+      const { container } = renderWithI18n(<MissedTable mistakes={{ h: 1 }} details={details} />)
+      expect(container.querySelectorAll('[title]').length).toBe(0)
+    })
+  })
+
+  describe('internal scroll (bounded height, retained from the earlier table version)', () => {
+    it('the scroll container carries the bounded max-height, overflow-y-auto, and the scrollbar-gutter class', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} />)
+      const scrollport = screen.getByTestId('missed-table-scrollport')
+      expect(scrollport.className).toContain('max-h-56')
+      expect(scrollport.className).toContain('overflow-y-auto')
+      // `.missed-table-scrollport` (style.css) is what actually declares
+      // `scrollbar-gutter: stable` — jsdom doesn't compute real CSS, so
+      // this only proves the class is applied, same limitation the
+      // existing `.keystroke-timeline-scrollport` tests accept.
+      expect(scrollport.className).toContain('missed-table-scrollport')
+    })
+
+    it('every row lives inside the scroll container', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1, e: 2 }} />)
+      const scrollport = screen.getByTestId('missed-table-scrollport')
+      expect(within(scrollport).getByTestId('missed-table-row-h')).toBeInTheDocument()
+      expect(within(scrollport).getByTestId('missed-table-row-e')).toBeInTheDocument()
+    })
+  })
+
+  // Shared-component reuse (MistakeRankingSection, History's Analysis tab)
+  // — proves the same row list renders correctly under the cross-run
+  // caller's own titleKey/testId, not just the single-run defaults
+  // exercised above.
+  describe('parameterization (reused by MistakeRankingSection)', () => {
+    it('titleKey overrides the section heading', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} titleKey="editor.typingTest.history.mistakeRankingTitle" />)
+      expect(screen.getByText('Most missed')).toBeInTheDocument()
+      expect(screen.queryByText('Missed')).toBeNull()
+    })
+
+    it('testId overrides the root element testid, without changing the inner row testids', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} testId="typing-test-mistake-ranking" />)
+      expect(screen.getByTestId('typing-test-mistake-ranking')).toBeInTheDocument()
+      expect(screen.queryByTestId('typing-test-missed-table')).toBeNull()
+      expect(screen.getByTestId('missed-table-row-h')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/renderer/typing-test/__tests__/romaji-engine.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-engine.test.ts
@@ -336,6 +336,49 @@ describe('completedKanaCount', () => {
   })
 })
 
+describe('currentSegmentCanonicalKey', () => {
+  it('returns the first segment\'s canonical spelling before any keystroke', () => {
+    const matcher = createRomajiMatcher('あい')
+    expect(matcher.currentSegmentCanonicalKey()).toBe('a')
+  })
+
+  it('resolves to the digraph winner once the buffer commits to it (でぃ = "dhi", 2 kana)', () => {
+    const matcher = createRomajiMatcher('でぃなーにいく')
+    matcher.acceptChar('d')
+    matcher.acceptChar('h')
+    expect(matcher.currentSegmentCanonicalKey()).toBe('dhi')
+  })
+
+  it('advances to the next segment\'s key once the previous segment commits', () => {
+    const matcher = createRomajiMatcher('でぃなーにいく')
+    matcher.acceptChar('d')
+    matcher.acceptChar('h')
+    matcher.acceptChar('i') // commits でぃ
+    expect(matcher.currentSegmentCanonicalKey()).toBe('na')
+  })
+
+  it('reflects the decomposed single-kana path once the buffer has committed to it, not the digraph', () => {
+    const matcher = createRomajiMatcher('でぃなーにいく')
+    matcher.acceptChar('d')
+    matcher.acceptChar('e') // commits で alone (1 kana), decomposed path
+    expect(matcher.currentSegmentCanonicalKey()).toBe(canonicalRomaji('ぃ'))
+  })
+
+  it('stays unaffected by a reject (buffer/position untouched)', () => {
+    const matcher = createRomajiMatcher('あい')
+    expect(matcher.acceptChar('z')).toBe('reject')
+    expect(matcher.currentSegmentCanonicalKey()).toBe('a')
+  })
+
+  it('returns undefined once the whole word is matched', () => {
+    const matcher = createRomajiMatcher('あい')
+    matcher.acceptChar('a')
+    matcher.acceptChar('i')
+    expect(matcher.isComplete()).toBe(true)
+    expect(matcher.currentSegmentCanonicalKey()).toBeUndefined()
+  })
+})
+
 describe('あ行 alternate spellings (wu/whu for う)', () => {
   it('accepts wu and whu for う alongside the canonical u, inside a word', () => {
     const wu = type('あう', 'awu')

--- a/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
+++ b/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
@@ -21,7 +21,7 @@ const DEFAULT_LABEL = 'words (english)'
 function register(
   recorder: RunLogRecorder, runId: string, row: number, col: number, ts: number, wordIndex: number,
   expectedChar: string | undefined,
-  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean },
+  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean; mistakeKey?: string },
 ): void {
   recorder.noteRegistration(
     {
@@ -30,7 +30,7 @@ function register(
       consentAccepted: gate?.consentAccepted ?? true,
       windowFocused: gate?.windowFocused ?? true,
     },
-    row, col, ts, wordIndex, () => expectedChar,
+    row, col, ts, wordIndex, () => expectedChar, () => gate?.mistakeKey,
   )
 }
 
@@ -41,7 +41,7 @@ function register(
  *  `register`. */
 function noteChar(
   recorder: RunLogRecorder, runId: string, wordIndex: number, expectedChar: string | undefined,
-  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean },
+  gate?: { typingTestLabel?: string | null; consentAccepted?: boolean; windowFocused?: boolean; mistakeKey?: string },
 ): void {
   recorder.noteCharContext(
     {
@@ -50,7 +50,7 @@ function noteChar(
       consentAccepted: gate?.consentAccepted ?? true,
       windowFocused: gate?.windowFocused ?? true,
     },
-    wordIndex, expectedChar,
+    wordIndex, expectedChar, gate?.mistakeKey,
   )
 }
 
@@ -704,6 +704,93 @@ describe('RunLogRecorder', () => {
 
       const log = recorder.finish(oneWordResult(), finishMeta())
       expect(log?.lineBreaks).toBeUndefined()
+    })
+  })
+
+  describe('typedChar / mistakeKey (missed-details detail capture)', () => {
+    it('sets typedChar and mistakeKey only on an incorrect keystroke (matrix-then-char)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { mistakeKey: 'a' })
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), charEvent('z'))
+
+      const log = recorder.finish(oneWordResult('z', false), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBe(false)
+      expect(k.typedChar).toBe('z')
+      expect(k.mistakeKey).toBe('a')
+    })
+
+    it('leaves typedChar and mistakeKey undefined on a correct keystroke', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { mistakeKey: 'a' })
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), charEvent('a'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBe(true)
+      expect(k.typedChar).toBeUndefined()
+      expect(k.mistakeKey).toBeUndefined()
+    })
+
+    it('leaves typedChar and mistakeKey undefined on an unjudged keystroke (no expectedChar)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, undefined, { mistakeKey: 'a' })
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_LSFT }))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBeUndefined()
+      expect(k.typedChar).toBeUndefined()
+      expect(k.mistakeKey).toBeUndefined()
+    })
+
+    it('never sets typedChar/mistakeKey for a Backspace, even though it consumes the queue slot', () => {
+      const recorder = new RunLogRecorder()
+      const KC_BSPC = deserialize('KC_BSPC')
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { mistakeKey: 'a' })
+      recorder.record(ctx(), matrixPress({ ts: 1000, keycode: KC_BSPC }))
+      recorder.record(ctx(), charEvent('Backspace'))
+
+      const log = recorder.finish(oneWordResult(), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBeUndefined()
+      expect(k.typedChar).toBeUndefined()
+      expect(k.mistakeKey).toBeUndefined()
+    })
+
+    it('uses the char-first pre-advance mistakeKey annotation (noteCharContext), overriding the registration snapshot — romaji segment key case', () => {
+      const recorder = new RunLogRecorder()
+      // Registration snapshot carries a stale/absent mistakeKey; the
+      // char-context annotation (captured immediately before this same
+      // key's own state advance, same ordering as expectedChar) is the
+      // more accurate one and must win — mirrors expectedChar's own
+      // override precedent.
+      noteChar(recorder, 'run-1', 0, 'a', { mistakeKey: 'kya' })
+      recorder.record(ctx(), charEvent('z', 995))
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a', { mistakeKey: 'stale' })
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult('z', false), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBe(false)
+      expect(k.typedChar).toBe('z')
+      expect(k.mistakeKey).toBe('kya')
+    })
+
+    it('carries mistakeKey through the pendingChars queue when the char arrives before any registration exists', () => {
+      const recorder = new RunLogRecorder()
+      noteChar(recorder, 'run-1', 0, 'a', { mistakeKey: 'a' })
+      recorder.record(ctx(), charEvent('z', 995))
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+
+      const log = recorder.finish(oneWordResult('z', false), finishMeta())
+      const [k] = log!.words[0].keystrokes
+      expect(k.correct).toBe(false)
+      expect(k.typedChar).toBe('z')
+      expect(k.mistakeKey).toBe('a')
     })
   })
 

--- a/src/renderer/typing-test/__tests__/use-mistake-ranking-details.test.ts
+++ b/src/renderer/typing-test/__tests__/use-mistake-ranking-details.test.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { mergeMissedDetails, useAggregatedMissedDetails } from '../use-mistake-ranking-details'
+import type { MissedCharDetail } from '../missed-details'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../../shared/types/typing-run-log'
+
+function detail(typedCounts: Record<string, number>, movedOnCount = 0): MissedCharDetail {
+  return { typedCounts, movedOnCount }
+}
+
+describe('mergeMissedDetails', () => {
+  it('sums typedCounts and movedOnCount for a key present in every map', () => {
+    const a = new Map([['h', detail({ x: 2 }, 1)]])
+    const b = new Map([['h', detail({ x: 1, y: 3 }, 2)]])
+    const merged = mergeMissedDetails([a, b])
+    expect(merged.get('h')).toEqual({ typedCounts: { x: 3, y: 3 }, movedOnCount: 3 })
+  })
+
+  it('a key present in only ONE of the maps carries through unchanged (missing log contributes nothing, not zero-fill)', () => {
+    const a = new Map([['h', detail({ x: 2 }, 1)], ['e', detail({ z: 1 }, 0)]])
+    const b = new Map([['h', detail({ x: 1 }, 0)]])
+    const merged = mergeMissedDetails([a, b])
+    expect(merged.get('h')).toEqual({ typedCounts: { x: 3 }, movedOnCount: 1 })
+    expect(merged.get('e')).toEqual({ typedCounts: { z: 1 }, movedOnCount: 0 })
+  })
+
+  it('merges zero maps into an empty map', () => {
+    expect(mergeMissedDetails([]).size).toBe(0)
+  })
+
+  it('merges a single map unchanged', () => {
+    const a = new Map([['h', detail({ x: 1 }, 2)]])
+    const merged = mergeMissedDetails([a])
+    expect(merged.get('h')).toEqual({ typedCounts: { x: 1 }, movedOnCount: 2 })
+    // Independent object — mutating the merge result must not mutate the input.
+    merged.get('h')!.movedOnCount = 99
+    expect(a.get('h')!.movedOnCount).toBe(2)
+  })
+
+  it('an empty per-run map (e.g. charCorrelationUnavailable bailout) contributes nothing', () => {
+    const a = new Map([['h', detail({ x: 1 })]])
+    const empty = new Map<string, MissedCharDetail>()
+    const merged = mergeMissedDetails([a, empty])
+    expect(merged.size).toBe(1)
+    expect(merged.get('h')).toEqual({ typedCounts: { x: 1 }, movedOnCount: 0 })
+  })
+})
+
+describe('useAggregatedMissedDetails', () => {
+  const originalVialAPI = window.vialAPI
+
+  beforeEach(() => {
+    window.vialAPI = { ...originalVialAPI } as typeof window.vialAPI
+  })
+
+  function makeLog(overrides: Partial<RunKeystrokeLog> = {}): RunKeystrokeLog {
+    return {
+      runId: 'run-1', uid: 'kb-1', startedAt: '2026-01-01T00:00:00.000Z', durationMs: 5000,
+      mode: 'words', language: 'english', words: [], ...overrides,
+    }
+  }
+
+  function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+    return {
+      date: '2026-01-01T00:00:00.000Z', wpm: 60, accuracy: 95, wordCount: 10,
+      correctChars: 50, incorrectChars: 2, durationSeconds: 10, ...overrides,
+    }
+  }
+
+  it('returns an empty map (no fetch) when uid is undefined', () => {
+    const getLog = vi.fn()
+    window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+    const { result } = renderHook(() => useAggregatedMissedDetails(undefined, [], new Set()))
+    expect(result.current.size).toBe(0)
+    expect(getLog).not.toHaveBeenCalled()
+  })
+
+  it('merges two logs\' details once both fetches resolve', async () => {
+    const getLog = vi.fn((uid: string, runId: string) => {
+      if (runId === 'run-1') {
+        return Promise.resolve({
+          success: true,
+          data: makeLog({
+            runId: 'run-1',
+            words: [{
+              index: 0, display: 'hi', typed: 'xi', correct: false,
+              keystrokes: [{ pressMs: 0, keycode: 0, row: 0, col: 0, correct: false, expectedChar: 'h', typedChar: 'x', mistakeKey: 'h' }],
+            }],
+          }),
+        })
+      }
+      return Promise.resolve({
+        success: true,
+        data: makeLog({
+          runId: 'run-2',
+          words: [{
+            index: 0, display: 'hi', typed: 'yi', correct: false,
+            keystrokes: [{ pressMs: 0, keycode: 0, row: 0, col: 0, correct: false, expectedChar: 'h', typedChar: 'y', mistakeKey: 'h' }],
+          }],
+        }),
+      })
+    })
+    window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+    const results = [
+      makeResult({ runId: 'run-1' }),
+      makeResult({ runId: 'run-2' }),
+    ]
+    const { result } = renderHook(() => useAggregatedMissedDetails('kb-1', results, new Set(['run-1', 'run-2'])))
+
+    await waitFor(() => expect(result.current.get('h')?.typedCounts).toEqual({ x: 1, y: 1 }))
+  })
+
+  it('a result whose runId is missing from availableRunIds is simply skipped — counts-only, no fetch', () => {
+    const getLog = vi.fn()
+    window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+    const results = [makeResult({ runId: 'run-not-available' })]
+    const { result } = renderHook(() => useAggregatedMissedDetails('kb-1', results, new Set()))
+
+    expect(result.current.size).toBe(0)
+    expect(getLog).not.toHaveBeenCalled()
+  })
+
+  it('does not refetch a runId already in the cache on a re-render with the same results', async () => {
+    const getLog = vi.fn().mockResolvedValue({ success: true, data: makeLog({ runId: 'run-1' }) })
+    window.vialAPI = { ...window.vialAPI, typingRunLogGet: getLog } as typeof window.vialAPI
+
+    const results = [makeResult({ runId: 'run-1' })]
+    const { result, rerender } = renderHook(
+      ({ r }: { r: TypingTestResult[] }) => useAggregatedMissedDetails('kb-1', r, new Set(['run-1'])),
+      { initialProps: { r: results } },
+    )
+
+    await waitFor(() => expect(getLog).toHaveBeenCalledTimes(1))
+    rerender({ r: [...results] }) // a NEW array, same runId content
+    rerender({ r: [...results] })
+    expect(result.current).toBeDefined()
+    expect(getLog).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/typing-test/__tests__/useTypingTest.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.test.ts
@@ -1899,7 +1899,8 @@ describe('useTypingTest onNoteKeystrokeRegistration / window focus gate (P1)', (
     act(() => result.current.processMatrixFrame(pressKeys(['0,0']), keymap))
 
     expect(noteRegistration).toHaveBeenCalledTimes(1)
-    const windowFocusedArg = noteRegistration.mock.calls[0][6] as boolean
+    // Args: (runId, row, col, ts, wordIndex, getExpectedChar, getMistakeKey, windowFocused).
+    const windowFocusedArg = noteRegistration.mock.calls[0][7] as boolean
     expect(windowFocusedArg).toBe(true)
   })
 

--- a/src/renderer/typing-test/expected-char.ts
+++ b/src/renderer/typing-test/expected-char.ts
@@ -8,7 +8,7 @@
  *  run-keystroke-log feature module — see run-log-recorder.ts's own doc
  *  comment for the consumer this exists to serve. */
 
-import { isRomajiInputActive, romajiNextExpectedChar, romajiDetail } from './romaji-input'
+import { isRomajiInputActive, romajiNextExpectedChar, currentRomajiMistakeKey, romajiDetail } from './romaji-input'
 import type { TypingTestConfig } from './types'
 import type { TypingTestState } from './run-state'
 
@@ -20,6 +20,29 @@ export function deriveExpectedChar(state: TypingTestState, config: TypingTestCon
   if (word === undefined) return undefined
   if (isRomajiInputActive(config, language, state.romajiCapable)) {
     return romajiNextExpectedChar(word, state.romajiKeystrokes, romajiDetail(config))
+  }
+  return word[state.currentInput.length]
+}
+
+/** The key an INCORRECT keystroke made right now should be tallied under
+ *  in the run's own `mistakes` map (see run-state.ts's
+ *  `applyWordMistakes`/`handleBackspace` for verbatim mode,
+ *  `handleRomajiChar` for romaji) — threaded into `RunKeystroke.mistakeKey`
+ *  by run-log-recorder.ts alongside `expectedChar`, so a completion
+ *  screen's Missed chip can show which characters were actually typed for
+ *  it (see `buildMissedDetails`, missed-details.ts). Mirrors
+ *  `deriveExpectedChar`'s branch structure but is NOT the same value in
+ *  romaji mode: `deriveExpectedChar`'s romaji branch is a single next
+ *  romaji character, while a mistake tallies against the whole kana
+ *  SEGMENT (e.g. "kya") regardless of which of its keystrokes was
+ *  rejected — see `currentRomajiMistakeKey`'s own best-effort caveat.
+ *  Verbatim mode has no such distinction: the position's own target char
+ *  IS its own mistake key, identical to `deriveExpectedChar`. */
+export function deriveMistakeKey(state: TypingTestState, config: TypingTestConfig, language: string): string | undefined {
+  const word = state.words[state.currentWordIndex]
+  if (word === undefined) return undefined
+  if (isRomajiInputActive(config, language, state.romajiCapable)) {
+    return currentRomajiMistakeKey(word, state.romajiKeystrokes, romajiDetail(config))
   }
   return word[state.currentInput.length]
 }

--- a/src/renderer/typing-test/missed-details.ts
+++ b/src/renderer/typing-test/missed-details.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Per-mistake-key detail derived from a run's own raw keystroke log — what
+// characters were actually typed for a Missed chip, and (verbatim mode
+// only) how many times the user moved on to the next word without ever
+// correcting a wrong character. Built from data recorded AT INPUT TIME
+// (`RunKeystroke.typedChar`/`mistakeKey`, threaded by run-log-recorder.ts —
+// see that field's own doc comment), never by replaying the saved log
+// afterward: a romaji mistake key can depend on which of several live
+// alternate spellings the user goes on to complete, which only the live
+// reducer state at the moment of the keystroke can name reliably — a
+// codex-reviewed design decision, not an oversight. See
+// .claude/plans/Plan-completion-timeline-view.md and mistake-summary.tsx's
+// `MissedCharsList`, the sole consumer.
+
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+
+export interface MissedCharDetail {
+  /** Actual characters typed for incorrect keystrokes tallied under this
+   *  mistake key, keyed by the typed character, counting occurrences —
+   *  e.g. `{ m: 2, b: 1 }` for "typed m twice and b once instead of the
+   *  expected char". Empty when no incorrect keystroke carried
+   *  `typedChar` for this key (a legacy log predating that field, or a
+   *  stretch this run's char correlation otherwise missed). */
+  typedCounts: Record<string, number>
+  /** Verbatim mode only (always 0 for a romaji run — see the module doc
+   *  comment on `buildMissedDetails`'s own romaji branch): how many times
+   *  this key's expected character was still wrong in the word's FINAL
+   *  submitted state — the user moved on to the next word without ever
+   *  correcting it, as opposed to a mistake that was later fixed via
+   *  Backspace before submitting. */
+  movedOnCount: number
+}
+
+function getOrCreate(details: Map<string, MissedCharDetail>, key: string): MissedCharDetail {
+  let entry = details.get(key)
+  if (!entry) {
+    entry = { typedCounts: {}, movedOnCount: 0 }
+    details.set(key, entry)
+  }
+  return entry
+}
+
+/** Per-mistake-key detail for every key this run's own `mistakes` map
+ *  could plausibly contain — a chip with no entry in the returned map
+ *  simply has nothing more to say than the count already on it (legacy
+ *  log, or this specific key's keystrokes never got typedChar/mistakeKey
+ *  attribution); `MissedCharsList` renders that chip exactly as it does
+ *  today, without a tooltip. Returns an empty map outright (bail out, no
+ *  per-key attempt at all) when `log.charCorrelationUnavailable` — the
+ *  same condition that makes this run's keystroke-level correctness
+ *  unreliable in general (see that field's own doc comment).
+ *
+ *  Two independent signals feed each entry:
+ *   - `typedCounts`: every incorrect keystroke (`correct === false`)
+ *     carrying both `typedChar` and `mistakeKey` groups its `typedChar`
+ *     under `mistakeKey` — this is the ONLY source for this figure, so a
+ *     keystroke missing either field (legacy log) contributes nothing.
+ *     Includes keystrokes from an interrupted (`partial: true`) word too
+ *     — a real recorded keystroke regardless of whether its word was
+ *     ever submitted.
+ *   - `movedOnCount` (verbatim mode only — `log.romajiInput !== true`):
+ *     derived purely from `RunWord.display`/`typed`'s final positional
+ *     diff on every SUBMITTED (non-`partial`) word, independent of
+ *     per-keystroke typedChar/mistakeKey data — the same predicate
+ *     run-state.ts's `applyWordMistakes` uses to decide whether a
+ *     position counts as a mistake at all. Romaji mode is structurally
+ *     always 0: the matcher blocks a segment from advancing until it
+ *     resolves correctly (see romaji-input.ts's `handleRomajiChar`), so
+ *     there is no notion of "moved on with an uncorrected kana" the way
+ *     a verbatim position can be submitted wrong. */
+export function buildMissedDetails(log: RunKeystrokeLog): Map<string, MissedCharDetail> {
+  const details = new Map<string, MissedCharDetail>()
+  if (log.charCorrelationUnavailable) return details
+
+  for (const word of log.words) {
+    for (const k of word.keystrokes) {
+      if (k.correct !== false) continue
+      if (k.mistakeKey === undefined || k.typedChar === undefined) continue
+      const entry = getOrCreate(details, k.mistakeKey)
+      entry.typedCounts[k.typedChar] = (entry.typedCounts[k.typedChar] ?? 0) + 1
+    }
+  }
+
+  if (log.romajiInput !== true) {
+    for (const word of log.words) {
+      if (word.partial) continue
+      const { display, typed } = word
+      for (let i = 0; i < display.length; i++) {
+        if (typed[i] === display[i]) continue
+        getOrCreate(details, display[i]).movedOnCount++
+      }
+    }
+  }
+
+  return details
+}

--- a/src/renderer/typing-test/mistake-summary.tsx
+++ b/src/renderer/typing-test/mistake-summary.tsx
@@ -1,24 +1,63 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Shared "missed characters" list + error-class (Substitution/Omission/
-// Insertion) line — extracted out of `TypingTestStatsRow` (the
+// Shared "missed characters" presentations + error-class (Substitution/
+// Omission/Insertion) line — extracted out of `TypingTestStatsRow` (the
 // completion screen's finished-state summary) so `KeystrokeTimelinePanel`
-// can show the identical presentation for a `TypingTestResult` without a
+// can show a consistent presentation for a `TypingTestResult` without a
 // second, drifting implementation of the same sort/slice/testid logic.
 // See .claude/plans/Plan-completion-timeline-view.md PR-A spec point 2.
+//
+// Two presentations of the same sorted mistake list:
+//  - `MissedCharsList` — the original inline chip line, still used by
+//    TypingTestStatsRow's no-log fallback row (never has per-key detail
+//    to show, so a bare chip line is all that context needs). Still
+//    CAPPED (`MAX_MISTAKE_ENTRIES`) — a flex-wrap chip line has no scroll
+//    mechanism of its own, unlike the rows below, so truncation is still
+//    the right visibility strategy here.
+//  - `MissedTable` — a per-key BAR-GRAPH row list (Word / "→ typed chars"
+//    / stacked red-gray bar / Cnt), used by KeystrokeTimelinePanel
+//    (single run) AND MistakeRankingSection (History's Analysis tab,
+//    aggregated across every run in the active tab — see
+//    use-mistake-ranking-details.ts). Parameterized (`titleKey`/`testId`)
+//    rather than duplicated between the two callers, which differ only in
+//    heading text and (History's own pre-existing contract) root testid.
+//    UNCAPPED: every entry is reachable via the list's own internal
+//    vertical scroll (bounded max-height) instead of being truncated —
+//    see `allSortedMistakeEntries` and `MISSED_TABLE_MAX_HEIGHT`.
+//    Replaces an earlier column-table presentation (headers + a separate
+//    Moved-on column; see git history) with the approved bar-graph
+//    mockup: the bar's own red/gray split communicates the
+//    corrected-vs-moved-on-uncorrected breakdown at a glance, with exact
+//    figures in a hover tooltip instead of their own column.
 
 import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Tooltip } from '../components/ui/Tooltip'
+import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
+import type { MissedCharDetail } from './missed-details'
 
-// Caps how many distinct mistake keys are shown, so a run with many
-// small errors doesn't turn the list into an unbounded wall of text.
+// Caps how many distinct mistake keys `MissedCharsList` shows, so a run
+// with many small errors doesn't turn its chip line into an unbounded
+// wall of text — `MissedTable` does NOT use this cap (see
+// `allSortedMistakeEntries`): it scrolls instead of truncating.
 export const MAX_MISTAKE_ENTRIES = 12
 
+function compareMistakeEntries([keyA, countA]: [string, number], [keyB, countB]: [string, number]): number {
+  return countB - countA || keyA.localeCompare(keyB)
+}
+
 /** Sorted by count DESC then key ASC (ties break deterministically
- *  instead of on object insertion order), capped to `max` entries. */
+ *  instead of on object insertion order), capped to `max` entries. Used
+ *  by `MissedCharsList` only — see `allSortedMistakeEntries` for the
+ *  uncapped table equivalent. */
 export function sortedMistakeEntries(mistakes: Record<string, number>, max: number = MAX_MISTAKE_ENTRIES): [string, number][] {
-  return Object.entries(mistakes)
-    .sort(([keyA, countA], [keyB, countB]) => countB - countA || keyA.localeCompare(keyB))
-    .slice(0, max)
+  return Object.entries(mistakes).sort(compareMistakeEntries).slice(0, max)
+}
+
+/** Same sort as `sortedMistakeEntries`, without the cap — every entry is
+ *  reachable via `MissedTable`'s own internal scroll instead of being
+ *  truncated. */
+function allSortedMistakeEntries(mistakes: Record<string, number>): [string, number][] {
+  return Object.entries(mistakes).sort(compareMistakeEntries)
 }
 
 interface MissedCharsListProps {
@@ -41,6 +80,222 @@ export function MissedCharsList({ mistakes }: MissedCharsListProps) {
           {key}:{count}
         </span>
       ))}
+    </div>
+  )
+}
+
+/** Fixed column widths (not `max-content`) so every row — each its own
+ *  independent grid instance — lands on identical column boundaries
+ *  without needing a single shared grid parent, same pattern as
+ *  `ERROR_MIX_GRID` in ErrorMixSection.tsx. No header row anymore (the
+ *  approved bar-graph mockup has none — see `MissedTable`'s own doc
+ *  comment), so these widths only ever have to agree with each other, not
+ *  with a caption row above them. Word/Cnt are fixed-width (short,
+ *  bounded content); the typed-chars cell gets a bounded-but-flexible
+ *  width (long enough for a handful of comma-joined chars before
+ *  truncating); the bar takes the remaining space (`1fr`) since it's the
+ *  row's main visual element. */
+const MISSED_ROW_GRID = { gridTemplateColumns: '4.5rem 5rem 1fr 3rem' }
+
+/** "m: 1, n: 2" — sorted DESC by count, ties on `Object.entries`'
+ *  stable insertion order (this is a per-row detail breakdown, not the
+ *  much larger user-facing key list `sortedMistakeEntries` orders, so an
+ *  explicit tie-break isn't worth the extra complexity here). Used for
+ *  the hover tooltip's own "Typed instead" line (WITH counts) — see
+ *  `formatTypedCharsOnly` for the row's own inline cell (chars only, no
+ *  counts — the mockup keeps counts out of the row and moves them into
+ *  the tooltip). Returns `EMPTY_STAT_VALUE` when there's no detail at all
+ *  for this key (legacy log, correlation-unavailable bailout) or the
+ *  detail carries no typedCounts. */
+function formatTypedInstead(detail: MissedCharDetail | undefined): string {
+  if (!detail) return EMPTY_STAT_VALUE
+  const entries = Object.entries(detail.typedCounts).sort(([, a], [, b]) => b - a)
+  if (entries.length === 0) return EMPTY_STAT_VALUE
+  return entries.map(([typedChar, n]) => `${typedChar}: ${n}`).join(', ')
+}
+
+/** "b, e" — same sort as `formatTypedInstead`, chars only (no counts),
+ *  for the row's own inline "→ ..." cell. Returns `null` (not
+ *  `EMPTY_STAT_VALUE`) when there's nothing to show, so the caller can
+ *  render the em-dash WITHOUT a leading arrow (`"→ —"` would read as if
+ *  something specific were known and just happened to be a dash). */
+function formatTypedCharsOnly(detail: MissedCharDetail | undefined): string | null {
+  if (!detail) return null
+  const entries = Object.entries(detail.typedCounts).sort(([, a], [, b]) => b - a)
+  if (entries.length === 0) return null
+  return entries.map(([typedChar]) => typedChar).join(', ')
+}
+
+/** Red (moved-on-uncorrected) / gray (corrected-with-Backspace) split of
+ *  a row's own bar FILL, as percentages of the fill's own width (i.e. of
+ *  `count`, not of the track) — the fill's own total width (relative to
+ *  the track) is computed separately in `MissedTable` from `count` vs the
+ *  list's own max, matching the old `MistakeRankingSection` bar's
+ *  width-percent approach.
+ *
+ *  UNKNOWN-SPLIT ROWS (FLAGGED CHOICE): a row with no `detail` at all
+ *  (legacy log predating this feature, or every contributing run's log
+ *  hit the `charCorrelationUnavailable` bailout) has no way to know its
+ *  own corrected/moved-on split — rendered as 100% gray (i.e. IDENTICAL
+ *  to a row that genuinely had zero moved-on-uncorrected mistakes),
+ *  rather than inventing a third visual state (e.g. a hatched/striped
+ *  "unknown" fill) for what should be a rare case once recording consent
+ *  is on. The bar alone can't tell these two apart — but the row's own
+ *  hover tooltip does (`missedBarNoDetail`, a distinct sentence instead
+ *  of the normal breakdown), so the information isn't lost, just not
+ *  encoded in color. `movedOnCount` is defensively clamped to `count` in
+ *  case the two ever disagree (they're computed via genuinely different
+ *  code paths — `TypingTestResult.mistakes`'s real-time reducer tally vs
+ *  `buildMissedDetails`'s best-effort per-keystroke log reconstruction —
+ *  and aren't contractually guaranteed to match exactly). */
+function barFillSplit(count: number, detail: MissedCharDetail | undefined): { movedOnPct: number; correctedPct: number } {
+  if (!detail || count <= 0) return { movedOnPct: 0, correctedPct: 100 }
+  const movedOn = Math.min(Math.max(detail.movedOnCount, 0), count)
+  const movedOnPct = (movedOn / count) * 100
+  return { movedOnPct, correctedPct: 100 - movedOnPct }
+}
+
+/** Hover tooltip content for a row's bar — exact figures the bar's own
+ *  red/gray split only communicates visually. Reuses `formatTypedInstead`
+ *  (WITH counts) for its own "Typed instead" line, unlike the row's
+ *  inline cell. A legacy/no-detail row gets a single distinct sentence
+ *  instead of the normal 3-line breakdown — see `barFillSplit`'s own doc
+ *  comment for why the bar itself can't tell these two cases apart. */
+function barTooltipContent(count: number, detail: MissedCharDetail | undefined, t: (key: string, opts?: Record<string, unknown>) => string): string {
+  if (!detail) return t('editor.typingTest.results.missedBarNoDetail')
+  const lines: string[] = []
+  const typed = formatTypedInstead(detail)
+  if (typed !== EMPTY_STAT_VALUE) {
+    lines.push(t('editor.typingTest.results.missedBarTypedLine', { chars: typed }))
+  }
+  const movedOn = Math.min(Math.max(detail.movedOnCount, 0), count)
+  lines.push(t('editor.typingTest.results.missedBarCorrectedLine', { count: count - movedOn }))
+  lines.push(t('editor.typingTest.results.missedBarMovedOnLine', { count: movedOn }))
+  return lines.join('\n')
+}
+
+interface MissedTableProps {
+  mistakes: Record<string, number>
+  /** Per-key detail — for a single run, derived from that run's own raw
+   *  keystroke log (see `buildMissedDetails`, missed-details.ts); for the
+   *  cross-run History ranking, the MERGED map from every available run's
+   *  log (see `useAggregatedMissedDetails`, use-mistake-ranking-details.ts).
+   *  A key with no entry (or no `details` map at all) renders its bar as
+   *  fully "corrected" gray (unknown split — see `barFillSplit`) and its
+   *  typed-chars cell as `EMPTY_STAT_VALUE`. */
+  details?: Map<string, MissedCharDetail>
+  /** Section-heading i18n key. Defaults to the single-run "Missed"
+   *  heading (`mistakesLabel`); `MistakeRankingSection` passes its own
+   *  "Most missed" key (`history.mistakeRankingTitle`) to reuse this
+   *  exact row list for the cross-run ranking. */
+  titleKey?: string
+  /** Root element testid. Defaults to `'typing-test-missed-table'`;
+   *  `MistakeRankingSection` overrides it to keep its own pre-existing
+   *  `'typing-test-mistake-ranking'` contract (TypingTestHistory.tsx's
+   *  Results/Analysis tab switch depends on it structurally). */
+  testId?: string
+}
+
+/** Bounds the row list's own scroll container to roughly 8-10 rows'
+ *  height before it starts scrolling internally — a fixed rem value
+ *  (14rem, Tailwind's `max-h-56`, on the 4px grid) rather than a
+ *  `vh`-relative figure, matching `KeystrokeTimelinePanel`'s own
+ *  scrollport sizing philosophy of not depending on ambient viewport
+ *  size. FLAGGED PICK: N rows at ~1.375rem each (`text-xs` + `gap-1`)
+ *  fits comfortably within 14rem for 8-10 rows before scrolling engages —
+ *  picked as a reasonable middle of the spec's own "~8-10 rows" range,
+ *  not derived from a measured DOM constant. Unaffected by the header
+ *  row's removal — it was never load-bearing for this figure, just one
+ *  more row's worth of height inside the same budget. */
+const MISSED_TABLE_MAX_HEIGHT = 'max-h-56'
+
+/** Per-key mistake bar-graph row list: Word / "→ typed instead chars" /
+ *  stacked bar / Cnt — approved mockup replacing the earlier column-table
+ *  presentation (headers + a separate Moved-on column; see git history).
+ *  Renders nothing when `mistakes` has no entries, same convention as
+ *  `MissedCharsList`.
+ *
+ *  BAR: total fill width is `count` normalized to the list's own max
+ *  `count` (`(count / maxCount) * 100%` of the track) — the same
+ *  width-percent approach the earlier bar-based `MistakeRankingSection`
+ *  used before it became a table. WITHIN that fill, `barFillSplit` stacks
+ *  two color segments: `bg-danger` (red) for `movedOnCount` (uncorrected)
+ *  and `bg-content-muted` (gray) for the remainder (corrected with
+ *  Backspace) — see that function's own doc comment for the
+ *  unknown-split (no `detail`) case. FLAGGED COLOR CHOICE: the track
+ *  itself stays `bg-surface-dim` (this codebase's established "subdued
+ *  tint" track color, same as the old ranking bar and
+ *  `ConnectingOverlay`'s progress track); the corrected segment uses
+ *  `bg-content-muted` specifically so it reads as a distinct, visible
+ *  gray FILL against that dimmer track background — there's no existing
+ *  "neutral bar fill" token/precedent in this codebase to match exactly,
+ *  so this reuses a token whose DESIGN.md role ("muted/disabled") is at
+ *  least semantically adjacent, rather than introducing a new one.
+ *
+ *  UNCAPPED + internally scrollable (not truncated): every entry from
+ *  `allSortedMistakeEntries` renders as its own row inside the bounded-
+ *  height (`MISSED_TABLE_MAX_HEIGHT`) scroll container
+ *  (`missed-table-scrollport`, `overflow-y-auto`, `p-2` on the scrollport
+ *  itself — matching `.keystroke-timeline-scrollport`'s own precedent in
+ *  KeystrokeTimelinePanel.tsx). `scrollbar-gutter: stable` (the
+ *  `.missed-table-scrollport` class, style.css) reserves the vertical
+ *  scrollbar's gutter unconditionally, same fix as
+ *  `.keystroke-timeline-scrollport`, so the right-aligned Cnt column's
+ *  edge never shifts the moment a real scrollbar appears. No sticky
+ *  header anymore — the mockup has none, and the scroll container itself
+ *  is otherwise unchanged from the earlier table version. */
+export function MissedTable({
+  mistakes, details,
+  titleKey = 'editor.typingTest.results.mistakesLabel',
+  testId = 'typing-test-missed-table',
+}: MissedTableProps) {
+  const { t } = useTranslation()
+  const entries = useMemo(() => allSortedMistakeEntries(mistakes), [mistakes])
+  if (entries.length === 0) return null
+  const maxCount = entries[0][1]
+  return (
+    <div className="flex flex-col gap-2" data-testid={testId}>
+      <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
+        {t(titleKey)}
+      </h3>
+      <div
+        className={`missed-table-scrollport ${MISSED_TABLE_MAX_HEIGHT} overflow-y-auto rounded-md border border-edge bg-surface p-2`}
+        data-testid="missed-table-scrollport"
+      >
+        <div className="flex flex-col gap-1">
+          {entries.map(([key, count]) => {
+            const detail = details?.get(key)
+            const typedChars = formatTypedCharsOnly(detail)
+            const fillPct = maxCount > 0 ? (count / maxCount) * 100 : 0
+            const { movedOnPct, correctedPct } = barFillSplit(count, detail)
+            return (
+              <div
+                key={key}
+                className="grid items-center gap-x-2 text-xs"
+                style={MISSED_ROW_GRID}
+                data-testid={`missed-table-row-${key}`}
+              >
+                <span className="truncate font-mono text-content" data-testid={`missed-table-row-${key}-word`}>{key}</span>
+                <span className="truncate text-content-muted" data-testid={`missed-table-row-${key}-typed`}>
+                  {typedChars ? `→ ${typedChars}` : EMPTY_STAT_VALUE}
+                </span>
+                <Tooltip content={barTooltipContent(count, detail, t)} wrapperClassName="w-full">
+                  <div
+                    className="h-1.5 w-full overflow-hidden rounded bg-surface-dim"
+                    data-testid={`missed-table-row-${key}-bar`}
+                  >
+                    <div className="flex h-full" style={{ width: `${fillPct}%` }}>
+                      <div className="h-full bg-danger" style={{ width: `${movedOnPct}%` }} data-testid={`missed-table-row-${key}-bar-movedon`} />
+                      <div className="h-full bg-content-muted" style={{ width: `${correctedPct}%` }} data-testid={`missed-table-row-${key}-bar-corrected`} />
+                    </div>
+                  </div>
+                </Tooltip>
+                <span className="text-right tabular-nums text-content" data-testid={`missed-table-row-${key}-count`}>{count}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -974,6 +974,26 @@ export interface RomajiMatcher {
    *  can't be mapped back to a kana count; the UI uses this instead to
    *  color the word's kana characters up through what's actually locked in. */
   completedKanaCount(): number
+  /** Canonical romaji spelling of the kana segment currently being
+   *  attempted at this matcher's live position/buffer — the same
+   *  candidate `remainingGuide()`/`nextGuideChar()` read off, resolved to
+   *  its full kana span and re-canonicalized style-agnostically (see
+   *  `canonicalRomaji`) so it matches the spelling a real completed
+   *  segment would tally under in `TypingTestState.mistakes`
+   *  (`handleRomajiChar` in run-state.ts). Used by run-log-recorder.ts
+   *  (via `deriveMistakeKey`/`currentRomajiMistakeKey`) to attribute a
+   *  REJECTED keystroke to the eventual mistake-map key without waiting
+   *  for the segment to actually finish — this is exactly the
+   *  "recorded at input time" design this feature deliberately chose
+   *  over replaying the saved log afterward (non-deterministic for
+   *  romaji: which alternate spelling family a segment resolves under
+   *  depends on what the user goes on to type). Best-effort, not a
+   *  guarantee: if the user later abandons this candidate for an
+   *  entirely different spelling family, the segment that eventually
+   *  completes could resolve a different kana span than the one
+   *  snapshotted here. Returns undefined once the word is already fully
+   *  matched. */
+  currentSegmentCanonicalKey(): string | undefined
 }
 
 interface ConsumeResult {
@@ -1116,6 +1136,13 @@ export function createRomajiMatcher(word: string, opts?: RomajiMatcherOptions): 
 
     completedKanaCount(): number {
       return position
+    },
+
+    currentSegmentCanonicalKey(): string | undefined {
+      if (position >= kana.length) return undefined
+      const winner = representativeAt(kana, position, buffer, disabledStyles, guideStyles)
+      if (!winner) return undefined
+      return canonicalRomaji(word.slice(position, position + winner.length))
     },
   }
 }

--- a/src/renderer/typing-test/romaji-input.ts
+++ b/src/renderer/typing-test/romaji-input.ts
@@ -109,6 +109,15 @@ export function romajiNextExpectedChar(word: string, keystrokes: string, opts?: 
   return buildRomajiMatcher(word, keystrokes, opts).nextGuideChar()
 }
 
+/** The mistake-map key for a REJECTED keystroke at this exact point in
+ *  `word` (given what's been typed so far) —
+ *  `buildRomajiMatcher(...).currentSegmentCanonicalKey()`. Used by
+ *  expected-char.ts's `deriveMistakeKey` for the romaji branch; see that
+ *  matcher method's own doc comment for the best-effort caveat. */
+export function currentRomajiMistakeKey(word: string, keystrokes: string, opts?: RomajiMatcherOptions): string | undefined {
+  return buildRomajiMatcher(word, keystrokes, opts).currentSegmentCanonicalKey()
+}
+
 /** Romaji Settings modal detail fields (disabledStyles / guideStyles /
  *  caseStyle), read only while `romajiInput` is honored (see
  *  `isRomajiInputActive`) — the config shape guarantees `romaji` only

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -194,11 +194,30 @@ export interface RunLogFinishMeta {
  *  strips it before persisting. */
 interface BufferedKeystroke extends RunKeystroke {
   wordIndex: number
+  /** Candidate mistake-map key from registration/char-context — NOT part
+   *  of the persisted `RunKeystroke` shape (unlike `mistakeKey` itself,
+   *  which this field feeds). `applyCharVerdict` promotes this into the
+   *  real `mistakeKey` field ONLY when the verdict lands on `correct ===
+   *  false`; kept as a separate field (rather than writing straight onto
+   *  `mistakeKey` and clearing it back out on every other outcome) so a
+   *  keystroke that never reaches a verdict at all (e.g. a bare
+   *  modifier, never char-producing, so `applyCharVerdict` is never even
+   *  called for it) can never leak a stale `mistakeKey` onto the
+   *  persisted shape — see `RunKeystroke.mistakeKey`'s own doc comment
+   *  ("set ONLY on incorrect keystrokes"). */
+  mistakeKeyCandidate?: string
 }
 
 interface RegistrationAnnotation {
   wordIndex: number
   expectedChar: string | undefined
+  /** Candidate mistake-map key (see `RunKeystroke.mistakeKey`'s own doc
+   *  comment), threaded alongside `expectedChar` from the same
+   *  registration/char-context snapshot. Only ever SURVIVES onto the
+   *  persisted keystroke when `applyCharVerdict` later finds `correct ===
+   *  false` for it — kept here unconditionally (same as `expectedChar`)
+   *  since the verdict isn't known yet at snapshot time. */
+  mistakeKey: string | undefined
 }
 
 /** Bound on how many char-producing keystrokes may sit unconfirmed in
@@ -239,6 +258,10 @@ interface PendingChar {
   key: string
   wordIndex: number | null
   expectedChar: string | undefined
+  /** Mirrors `RegistrationAnnotation.mistakeKey` — see that field's own
+   *  doc comment. `wordIndex: null` (no annotation captured) implies this
+   *  is `undefined` too, same as `expectedChar`. */
+  mistakeKey: string | undefined
 }
 
 interface RunLogBuffer {
@@ -279,11 +302,20 @@ function pressKey(row: number, col: number, keycode: number): string {
 /** Rough per-keystroke byte estimate for the {@link MAX_RUN_LOG_BYTES}
  *  running total — doesn't need to be exact, only a cheap, monotonic
  *  proxy for the final serialized size. A flat constant (the fields
- *  other than `expectedChar` vary little in width) plus the one field
- *  whose length actually varies, rather than paying for a real
- *  `JSON.stringify` on every keystroke just to measure it. */
+ *  other than `expectedChar`/`typedChar`/`mistakeKey` vary little in
+ *  width) plus the fields whose length actually varies, rather than
+ *  paying for a real `JSON.stringify` on every keystroke just to measure
+ *  it. `typedChar`/`mistakeKey` are candidate values at push time (not
+ *  yet cleared by `applyCharVerdict` for a correct keystroke — see that
+ *  method's own doc comment), so this can transiently overcount before
+ *  the verdict lands; harmless for a monotonic cap estimate. */
 function approxByteSize(k: BufferedKeystroke): number {
-  return 110 + (k.expectedChar?.length ?? 0)
+  // `mistakeKeyCandidate` approximates BOTH `mistakeKey` and `typedChar`'s
+  // eventual contribution once `applyCharVerdict` promotes them —
+  // `typedChar` is virtually always a single character, so folding its
+  // width into this same term rather than tracking it separately stays a
+  // safe overestimate, not an undercount.
+  return 110 + (k.expectedChar?.length ?? 0) + (k.mistakeKeyCandidate?.length ?? 0)
 }
 
 export class RunLogRecorder {
@@ -344,6 +376,7 @@ export class RunLogRecorder {
   noteRegistration(
     context: RunLogRecordContext, row: number, col: number, ts: number, wordIndex: number,
     getExpectedChar: () => string | undefined,
+    getMistakeKey?: () => string | undefined,
   ): void {
     if (!context.typingTestLabel) return
     if (!context.consentAccepted) return
@@ -358,7 +391,10 @@ export class RunLogRecorder {
       // this field's own doc comment.
       this.pendingCharAnnotation = null
     }
-    this.buffer.registrations.set(registrationKey(row, col, ts), { wordIndex, expectedChar: getExpectedChar() })
+    this.buffer.registrations.set(
+      registrationKey(row, col, ts),
+      { wordIndex, expectedChar: getExpectedChar(), mistakeKey: getMistakeKey?.() },
+    )
   }
 
   /** Snapshot a char-producing keystroke's word attribution immediately
@@ -379,13 +415,16 @@ export class RunLogRecorder {
    *  between to observe or clobber it. Never mints/advances the buffer
    *  itself (that happens in `record`, see its own doc comment) — this
    *  method only ever writes the slot. */
-  noteCharContext(context: RunLogRecordContext, wordIndex: number, expectedChar: string | undefined): void {
+  noteCharContext(
+    context: RunLogRecordContext, wordIndex: number, expectedChar: string | undefined,
+    mistakeKey?: string | undefined,
+  ): void {
     if (!context.typingTestLabel) return
     if (!context.consentAccepted) return
     if (!context.windowFocused) return
     if (!context.runId) return
     if (context.runId === this.poisonedRunId) return
-    this.pendingCharAnnotation = { wordIndex, expectedChar }
+    this.pendingCharAnnotation = { wordIndex, expectedChar, mistakeKey }
   }
 
   /** Record one analytics event already destined for the per-minute
@@ -448,6 +487,7 @@ export class RunLogRecorder {
       col: payload.col,
       wordIndex: reg.wordIndex,
       expectedChar: reg.expectedChar,
+      mistakeKeyCandidate: reg.mistakeKey,
       overlapped: payload.overlap,
     }
     this.pushKeystroke(buf, keystroke)
@@ -496,6 +536,7 @@ export class RunLogRecorder {
         if (pendingChar.wordIndex !== null) {
           keystroke.wordIndex = pendingChar.wordIndex
           keystroke.expectedChar = pendingChar.expectedChar
+          keystroke.mistakeKeyCandidate = pendingChar.mistakeKey
         }
         this.applyCharVerdict(keystroke, pendingChar.key)
       } else {
@@ -537,6 +578,15 @@ export class RunLogRecorder {
    *  confirms nothing, in either direction — the keystroke it lands on is
    *  still consumed (to keep the surrounding queue aligned) just without
    *  a misleading correctness verdict. */
+  /** Also decides whether `typedChar`/`mistakeKey` land on this keystroke
+   *  at all — both start UNSET (see `mistakeKeyCandidate`'s own doc
+   *  comment: the candidate lives in a separate field until promoted
+   *  here), and are only ever written when the verdict actually lands on
+   *  `correct === false` (see `RunKeystroke.typedChar`/`mistakeKey`'s own
+   *  doc comments: set ONLY on an incorrect keystroke, never on a
+   *  correct OR unjudged one — a keystroke this method is never called
+   *  for at all, e.g. a bare modifier press, therefore correctly never
+   *  gets either field either). */
   private applyCharVerdict(keystroke: BufferedKeystroke, key: string): void {
     if (key === 'Backspace') return
     if (keystroke.expectedChar !== undefined) {
@@ -550,6 +600,13 @@ export class RunLogRecorder {
       // compare false here — a known, accepted limitation, not fixed by
       // this comparison.
       keystroke.correct = key === keystroke.expectedChar
+    }
+    if (keystroke.correct === false) {
+      // `key` here is the actual DOM char produced by this press — the
+      // same value just compared against expectedChar above, never a
+      // keycode reverse-mapping (see `typedChar`'s own doc comment).
+      keystroke.typedChar = key
+      keystroke.mistakeKey = keystroke.mistakeKeyCandidate
     }
   }
 
@@ -569,7 +626,10 @@ export class RunLogRecorder {
       // dropping it (which is what caused the permanent off-by-one this
       // queue exists to fix — pairing this char to whatever unrelated
       // press happens to come next).
-      buf.pendingChars.push({ key: payload.key, wordIndex: annotation?.wordIndex ?? null, expectedChar: annotation?.expectedChar })
+      buf.pendingChars.push({
+        key: payload.key, wordIndex: annotation?.wordIndex ?? null,
+        expectedChar: annotation?.expectedChar, mistakeKey: annotation?.mistakeKey,
+      })
       if (buf.pendingChars.length > MAX_PENDING_CHAR_CONFIRMATIONS) buf.pendingChars.shift()
       return
     }
@@ -579,6 +639,7 @@ export class RunLogRecorder {
     if (annotation) {
       keystroke.wordIndex = annotation.wordIndex
       keystroke.expectedChar = annotation.expectedChar
+      keystroke.mistakeKeyCandidate = annotation.mistakeKey
     }
     this.applyCharVerdict(keystroke, payload.key)
   }
@@ -636,6 +697,8 @@ export class RunLogRecorder {
         expectedChar: k.expectedChar,
         correct: k.correct,
         overlapped: k.overlapped,
+        typedChar: k.typedChar,
+        mistakeKey: k.mistakeKey,
       }))
   }
 

--- a/src/renderer/typing-test/use-mistake-ranking-details.ts
+++ b/src/renderer/typing-test/use-mistake-ranking-details.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Aggregates buildMissedDetails(log) ACROSS every run log available for
+// the History Analysis tab's mistake ranking — unlike
+// KeystrokeTimelinePanel's single-run table, MistakeRankingSection.tsx's
+// own data source spans every result in the active tab. Split out of
+// MistakeRankingSection.tsx so the merge logic (mergeMissedDetails) stays
+// unit-testable without mounting a component or mocking IPC.
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
+import { buildMissedDetails, type MissedCharDetail } from './missed-details'
+
+/** Sums `source` into `target` in place — `typedCounts` per typed char,
+ *  `movedOnCount` as a running total. */
+function mergeMissedDetailInto(target: MissedCharDetail, source: MissedCharDetail): void {
+  for (const [typedChar, n] of Object.entries(source.typedCounts)) {
+    target.typedCounts[typedChar] = (target.typedCounts[typedChar] ?? 0) + n
+  }
+  target.movedOnCount += source.movedOnCount
+}
+
+/** Merges N per-run detail maps (each `buildMissedDetails(log)`'s own
+ *  return value) into one, summing `typedCounts` per key and
+ *  `movedOnCount` across every map that has an entry for that key. A key
+ *  present in only SOME of the maps still merges correctly — the
+ *  contributing runs' own figures simply accumulate onto whatever the
+ *  other runs already contributed, with no special-casing needed for
+ *  "this run has nothing to say about this key". */
+export function mergeMissedDetails(perRunDetails: readonly Map<string, MissedCharDetail>[]): Map<string, MissedCharDetail> {
+  const merged = new Map<string, MissedCharDetail>()
+  for (const details of perRunDetails) {
+    for (const [key, detail] of details) {
+      let entry = merged.get(key)
+      if (!entry) {
+        entry = { typedCounts: {}, movedOnCount: 0 }
+        merged.set(key, entry)
+      }
+      mergeMissedDetailInto(entry, detail)
+    }
+  }
+  return merged
+}
+
+/** Fetches every run log referenced by `results` (via its own `runId`)
+ *  that `availableRunIds` confirms actually has a saved log, and returns
+ *  the MERGED `buildMissedDetails()` map across all of them.
+ *
+ *  LAZY: this hook does nothing at all until it's actually mounted with a
+ *  real `uid` — `MistakeRankingSection` (and therefore this hook) only
+ *  mounts once the History modal's Analysis view is switched to
+ *  (`HistorySections` is a ternary branch in `TypingTestHistory.tsx`, not
+ *  always-rendered), so no extra "is the view active" gate is needed here.
+ *
+ *  CACHED PER MOUNT: fetched logs are kept in a `useRef` Map (runId ->
+ *  log-or-null), which — being a ref — survives every re-render without
+ *  itself triggering one, and is never cleared while this hook stays
+ *  mounted. Each effect run only fetches runIds NOT already in the cache
+ *  (a tab switch, or new results being merged in, adds runIds
+ *  incrementally rather than re-fetching everything already known).
+ *
+ *  BATCH, not progressive (flagged design choice — the task spec allows
+ *  either; batch picked for simplicity): every missing log fetches in
+ *  parallel via `Promise.allSettled`, and the merged result updates ONCE
+ *  all of them settle, rather than committing a new merge after each
+ *  individual fetch resolves. Trade-off: a slow fetch among many delays
+ *  the whole update instead of only its own row — accepted since History's
+ *  Analysis tab is a one-shot view, not a live/streaming one, and a
+ *  typical tab has a bounded number of runs; the progressive alternative
+ *  would need incremental per-item state merging for a marginal UX gain
+ *  here.
+ *
+ *  A result with no `runId`, or a `runId` not in `availableRunIds` (the
+ *  run predates the log feature, was evicted by retention, or was saved
+ *  without recording consent), simply never enters `runIds` at all — it
+ *  contributes counts only via `MistakeRankingSection`'s own `mistakes`
+ *  aggregation, with no per-key detail (renders `EMPTY_STAT_VALUE` in
+ *  Typed instead / Moved on). A per-log fetch error (rejected promise, or
+ *  `{ success: false }`) is caught and treated the same as "no log" for
+ *  that one run — it's swallowed here, never thrown, and never blocks the
+ *  rest of the batch. Every successfully-fetched log is also
+ *  independently subject to `buildMissedDetails`'s own
+ *  `charCorrelationUnavailable` bailout (an empty per-run map, not an
+ *  error). */
+export function useAggregatedMissedDetails(
+  uid: string | undefined,
+  results: readonly TypingTestResult[],
+  availableRunIds: ReadonlySet<string> | undefined,
+): Map<string, MissedCharDetail> {
+  const cacheRef = useRef<Map<string, RunKeystrokeLog | null>>(new Map())
+  // Has no meaning of its own — bumped once a fetch batch settles, purely
+  // to retrigger the merge below (cacheRef.current is a ref, invisible to
+  // React's dependency comparison).
+  const [fetchVersion, setFetchVersion] = useState(0)
+
+  const runIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (!availableRunIds) return ids
+    for (const result of results) {
+      if (result.runId && availableRunIds.has(result.runId)) ids.add(result.runId)
+    }
+    return ids
+  }, [results, availableRunIds])
+
+  useEffect(() => {
+    if (!uid) return
+    const missing = Array.from(runIds).filter((runId) => !cacheRef.current.has(runId))
+    if (missing.length === 0) return
+    let cancelled = false
+    Promise.allSettled(
+      missing.map((runId) =>
+        window.vialAPI.typingRunLogGet(uid, runId)
+          .then((res) => ({ runId, log: res.success && res.data ? res.data : null }))
+          .catch(() => ({ runId, log: null as RunKeystrokeLog | null })),
+      ),
+    ).then((settled) => {
+      if (cancelled) return
+      for (const outcome of settled) {
+        // Only a bug in the .catch() above (which never throws) could
+        // reach 'rejected' here — defensive, not a real code path.
+        if (outcome.status === 'fulfilled') cacheRef.current.set(outcome.value.runId, outcome.value.log)
+      }
+      setFetchVersion((v) => v + 1)
+    })
+    return () => { cancelled = true }
+  }, [uid, runIds])
+
+  return useMemo(() => {
+    const perRunDetails: Map<string, MissedCharDetail>[] = []
+    for (const runId of runIds) {
+      const log = cacheRef.current.get(runId)
+      if (log) perRunDetails.push(buildMissedDetails(log))
+    }
+    return mergeMissedDetails(perRunDetails)
+    // `fetchVersion` deliberately participates in this dependency list —
+    // see its own doc comment above.
+  }, [runIds, fetchVersion])
+}

--- a/src/renderer/typing-test/use-typing-test-matrix.ts
+++ b/src/renderer/typing-test/use-typing-test-matrix.ts
@@ -24,7 +24,7 @@ import {
 import { MatrixAnalyticsQueue } from './matrix-analytics-queue'
 import { PressDurationTracker } from './matrix-press-duration'
 import { MatrixLayerLatch } from './matrix-layer-latch'
-import { deriveExpectedChar } from './expected-char'
+import { deriveExpectedChar, deriveMistakeKey } from './expected-char'
 import type { UseTypingTestOptions } from './use-typing-test-types'
 
 export interface TypingTestMatrixParams<TPreparedEvent> {
@@ -150,6 +150,7 @@ export function useTypingTestMatrix<TPreparedEvent>(
         noteKeystrokeRegistrationRef.current?.(
           stateRef.current.runId, edge.row, edge.col, ts, stateRef.current.currentWordIndex,
           () => deriveExpectedChar(stateRef.current, configRef.current, languageRef.current),
+          () => deriveMistakeKey(stateRef.current, configRef.current, languageRef.current),
           windowFocusedRef.current,
         )
       }

--- a/src/renderer/typing-test/use-typing-test-types.ts
+++ b/src/renderer/typing-test/use-typing-test-types.ts
@@ -38,19 +38,23 @@ export interface UseTypingTestOptions<TPreparedEvent = unknown> {
    * useInputModes) of a matrix press at REGISTRATION time, so a later
    * (possibly TAPPING_TERM-delayed) analytics event can still be joined
    * back to the word it was actually typed against. See
-   * run-log-recorder.ts's `noteRegistration`. `getExpectedChar` is a
-   * thunk (not an already-computed value) so its — possibly expensive,
-   * for romaji — derivation is free whenever the recorder is gated off;
-   * the recorder invokes it only once it has confirmed recording is
-   * actually active. Only ever called while `windowFocused` (this
-   * hook's own live focus state) is true — see the call site in
-   * `processMatrixFrame` — so `windowFocused` is always `true` here too;
-   * threaded through anyway so the recorder's own gate (defense in
-   * depth, see run-log-recorder.ts's PRIVACY note) doesn't have to
-   * assume the caller's discipline. */
+   * run-log-recorder.ts's `noteRegistration`. `getExpectedChar`/
+   * `getMistakeKey` are thunks (not already-computed values) so their —
+   * possibly expensive, for romaji — derivation is free whenever the
+   * recorder is gated off; the recorder invokes each only once it has
+   * confirmed recording is actually active. `getMistakeKey` mirrors
+   * `getExpectedChar`'s shape but derives a DIFFERENT value in romaji
+   * mode (the in-progress kana segment's canonical spelling, not the
+   * single next romaji char) — see expected-char.ts's `deriveMistakeKey`.
+   * Only ever called while `windowFocused` (this hook's own live focus
+   * state) is true — see the call site in `processMatrixFrame` — so
+   * `windowFocused` is always `true` here too; threaded through anyway
+   * so the recorder's own gate (defense in depth, see
+   * run-log-recorder.ts's PRIVACY note) doesn't have to assume the
+   * caller's discipline. */
   onNoteKeystrokeRegistration?: (
     runId: string, row: number, col: number, ts: number, wordIndex: number,
-    getExpectedChar: () => string | undefined, windowFocused: boolean,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => void
   /** Notifies the run-keystroke-log recorder of a char-producing
    * keystroke's word attribution, snapshotted immediately BEFORE this
@@ -61,9 +65,12 @@ export interface UseTypingTestOptions<TPreparedEvent = unknown> {
    * run first, not merely before the emit. See run-log-recorder.ts's
    * `noteCharContext`. `getExpectedChar` is a thunk for the same reason
    * as `onNoteKeystrokeRegistration`'s. Only ever called while
-   * `windowFocused` is true, same as `onNoteKeystrokeRegistration`. */
+   * `windowFocused` is true, same as `onNoteKeystrokeRegistration`.
+   * `getMistakeKey` mirrors `getExpectedChar`'s shape — see this
+   * interface's `onNoteKeystrokeRegistration` doc comment above. */
   onNoteCharContext?: (
-    runId: string, wordIndex: number, getExpectedChar: () => string | undefined, windowFocused: boolean,
+    runId: string, wordIndex: number,
+    getExpectedChar: () => string | undefined, getMistakeKey: () => string | undefined, windowFocused: boolean,
   ) => void
   /** TAPPING_TERM (ms) used to classify masked-key presses as tap vs
    * hold against a deadline fixed at press time (pressTs + this value,

--- a/src/renderer/typing-test/useTypingTest.ts
+++ b/src/renderer/typing-test/useTypingTest.ts
@@ -18,7 +18,7 @@ import {
   tryFinishLastWord,
 } from './run-state'
 import { isRomajiInputActive, processRomajiKeyEvent, buildRomajiWordsTable, buildRomajiGuideProgress, romajiDetail } from './romaji-input'
-import { deriveExpectedChar } from './expected-char'
+import { deriveExpectedChar, deriveMistakeKey } from './expected-char'
 import { useTypingTestMatrix } from './use-typing-test-matrix'
 import { useTypingTestMetrics } from './use-typing-test-metrics'
 import { buildMemorySnapshot, buildRestoredState } from './typing-test-memory'
@@ -216,6 +216,7 @@ export function useTypingTest<TPreparedEvent = unknown>(
           noteCharContextRef.current?.(
             stateRef.current.runId, stateRef.current.currentWordIndex,
             () => deriveExpectedChar(stateRef.current, configRef.current, languageRef.current),
+            () => deriveMistakeKey(stateRef.current, configRef.current, languageRef.current),
             windowFocusedRef.current,
           )
         }

--- a/src/shared/types/typing-run-log.ts
+++ b/src/shared/types/typing-run-log.ts
@@ -60,6 +60,35 @@ export interface RunKeystroke {
    *  when this one landed — mirrors
    *  `TypingAnalyticsEventPayload['overlap']`'s tri-state semantics. */
   overlapped?: boolean
+  /** The character this press actually produced, set ONLY when `correct
+   *  === false` (never on a correct or unjudged keystroke) — see
+   *  run-log-recorder.ts's `applyCharVerdict`. Sourced from the char
+   *  analytics pipeline's real DOM 'char' event (the same `key` compared
+   *  against `expectedChar` to decide `correct`), NEVER reverse-mapped
+   *  from `keycode` — a keycode alone can't recover what character a
+   *  layer/shift/dead-key combination actually produced. Optional:
+   *  absent on every log saved before this field existed (legacy), and
+   *  a consumer must treat that the same as "no per-key detail
+   *  available" rather than "typed nothing wrong" — see
+   *  `buildMissedDetails` (missed-details.ts). Never sent to Hub, same
+   *  privacy class as the rest of this payload (see the module doc
+   *  comment). */
+  typedChar?: string
+  /** The key this mistake aggregates under, set ONLY when `correct ===
+   *  false` — matches the run's own `TypingTestState.mistakes` map key
+   *  EXACTLY for the same input (verbatim mode: the expected char at
+   *  this position, i.e. the same value as `expectedChar`; romaji mode:
+   *  the canonical romaji spelling of the kana segment in progress at
+   *  this exact keystroke — see `romaji-engine.ts`'s
+   *  `currentSegmentCanonicalKey`/`canonicalRomaji`), computed AT INPUT
+   *  TIME from live reducer state, not derived later by replaying this
+   *  log (log replay was rejected as non-deterministic for romaji — a
+   *  segment's eventual canonical spelling can depend on which of
+   *  several live alternate spellings the user goes on to complete, so
+   *  only the reducer's own in-the-moment state can name it reliably).
+   *  Optional for the same legacy-log reason as `typedChar`; the two are
+   *  always set or omitted together. */
+  mistakeKey?: string
 }
 
 /** One finalized word's keystrokes, joined against its `WordResult`. */


### PR DESCRIPTION
## Summary
- Each incorrect keystroke now records `typedChar` (the actual character produced) and `mistakeKey` (the in-progress kana segment's canonical romaji in romaji mode, or the expected character verbatim) at input time — a render-time log replay was rejected as non-deterministic for romaji (matcher options aren't persisted and `correct` compares against the guide spelling). Candidates only promote onto the persisted keystroke when the verdict lands incorrect, and the main-process validator bounds both fields.
- The Missed section becomes bar rows in the approved mockup's style: expected char, the chars typed instead, a stacked bar splitting corrected-with-Backspace (muted) from moved-on-uncorrected (danger) out of the total count — MOVED ON ⊆ CNT holds by construction — with a hover tooltip carrying the per-char counts and both totals. All entries stay reachable via the section's own scroll (sticky-free, scrollbar-gutter: stable), legacy logs render count-only bars with an explicit no-detail tooltip.
- Layout: the timeline lives in one bordered box (title, zoom, legend, rows), the Missed box matches it beneath, the IME correlation warning tops the panel, and the run-WPM card label simplifies to "WPM". History's MOST MISSED renders the same bar rows, aggregating details across every run whose log survives (lazy per-run fetch, cached, per-log errors skipped).

## Verification
- 8,501 passed / 22 skipped (net +85 tests vs main across recorder/validator/model/UI suites, red-run evidence per change; one pre-existing hardcoded mock-arg index fixed).
- Virtual-device Playwright flows: deliberate-mistake runs in both modes asserting recorded details end-to-end (bar split ratio ±0.5%, tooltip contents, romaji moved-on structurally 0), scroll/clip/sticky invariants, warning placement, and the boxed layout.
- i18n across english + 4 packs with lockstep bumps (final 0.1.72); eslint (no native titles) and typecheck clean.