### PR TITLE
feat(ui): make Enter at romaji line ends optional

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.72",
+  "version": "0.1.73",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -337,6 +337,8 @@
           "lower": "romaji"
         },
         "guideLinesLabel": "表示行数",
+        "lineEndEnterLabel": "行末でEnterを必須にする",
+        "lineEndEnterHint": "オンの場合、行末の単語はEnterで確定するまで保持されます。オフにすると他の単語と同様に自動で次へ進みます",
         "guideLabel": "表示パターン",
         "guideHint": "表示のみです。他の入力パターンでも正解になります",
         "inputLabel": "入力パターン",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.72",
+  "version": "0.1.73",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -337,6 +337,8 @@
           "lower": "romaji"
         },
         "guideLinesLabel": "表示行数っしょ",
+        "lineEndEnterLabel": "行末でEnter必須にするっしょ",
+        "lineEndEnterHint": "オンだと行末の単語はEnter押すまで確定しないよん☆ オフれば他の単語と同じで自動で次いくよ☆",
         "guideLabel": "表示パターンっしょ",
         "guideHint": "表示だけだから、他の入力パターンでも正解になるよん☆",
         "inputLabel": "入力パターンっしょ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.72",
+  "version": "0.1.73",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -337,6 +337,8 @@
           "lower": "romaji"
         },
         "guideLinesLabel": "表示行数どす",
+        "lineEndEnterLabel": "行末でEnterを必須にしますえ",
+        "lineEndEnterHint": "オンやと行末の単語はEnterで確定するまで待っとくれやす。オフにしたら他の単語と同じですぐ次へ進みますえ",
         "guideLabel": "表示パターン",
         "guideHint": "表示だけどすえ。他の入力パターンでも正解になりますえ",
         "inputLabel": "入力パターン",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.72",
+  "version": "0.1.73",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -337,6 +337,8 @@
           "lower": "romaji"
         },
         "guideLinesLabel": "表示行数",
+        "lineEndEnterLabel": "行末でEnterを必須とする",
+        "lineEndEnterHint": "オンの場合、行末の単語はEnterにて確定するまで保持されます。オフになさると他の単語同様、自動で次へ進みます",
         "guideLabel": "表示する綴りの型",
         "guideHint": "表示のみにございます。他の入力パターンでも正解となります",
         "inputLabel": "受理する入力の型",

--- a/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
+++ b/src/renderer/hooks/__tests__/useDevicePrefs.test.ts
@@ -1226,6 +1226,71 @@ describe('useDevicePrefs', () => {
       })
     })
 
+    // Task: lineEndEnter (romaji "Enter at line ends" toggle) — default
+    // true, prune-at-default (only an explicit false persists), same
+    // convention as guideLineCount's default of 1 above.
+    it('round-trips an explicit lineEndEnter: false', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: {
+          mode: 'words',
+          wordCount: 30,
+          punctuation: false,
+          numbers: false,
+          romaji: { lineEndEnter: false },
+        },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romaji: { lineEndEnter: false },
+      })
+    })
+
+    it('drops a non-boolean lineEndEnter but keeps the rest of romaji', async () => {
+      setupMocks()
+      mockPipetteSettingsGet.mockResolvedValue({
+        _rev: 1,
+        keyboardLayout: 'qwerty',
+        autoAdvance: true,
+        layerNames: [],
+        typingTestConfig: {
+          mode: 'words',
+          wordCount: 30,
+          punctuation: false,
+          numbers: false,
+          romaji: { caseStyle: 'capital', lineEndEnter: 'nope' },
+        },
+      } as never)
+
+      const { result } = renderHookWithConfig(() => useDevicePrefs())
+      await act(async () => {})
+      await act(async () => {
+        await result.current.applyDevicePrefs('0xAABB')
+      })
+
+      expect(result.current.typingTestConfig).toEqual({
+        mode: 'words',
+        wordCount: 30,
+        punctuation: false,
+        numbers: false,
+        romaji: { caseStyle: 'capital' },
+      })
+    })
+
     it('drops individually invalid romaji fields but keeps the ones that validate', async () => {
       setupMocks()
       mockPipetteSettingsGet.mockResolvedValue({

--- a/src/renderer/hooks/device-prefs-validate.ts
+++ b/src/renderer/hooks/device-prefs-validate.ts
@@ -93,6 +93,9 @@ function validateRomajiDetailSettings(raw: unknown): RomajiDetailSettings | unde
   ) {
     result.guideLineCount = obj.guideWordCount
   }
+  if (typeof obj.lineEndEnter === 'boolean') {
+    result.lineEndEnter = obj.lineEndEnter
+  }
   return Object.keys(result).length > 0 ? result : undefined
 }
 

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.72",
+  "version": "0.1.73",
   "name": "English",
   "common": {
     "save": "Save",
@@ -337,6 +337,8 @@
           "lower": "romaji"
         },
         "guideLinesLabel": "Lines shown",
+        "lineEndEnterLabel": "Require Enter at line ends",
+        "lineEndEnterHint": "When on, a line-end word holds until Enter commits it. Turn off to auto-advance like any other word.",
         "guideLabel": "Guide spelling pattern",
         "guideHint": "Display only — typing any accepted pattern is still correct",
         "inputLabel": "Accepted input patterns",

--- a/src/renderer/typing-test/RomajiSettingsModal.tsx
+++ b/src/renderer/typing-test/RomajiSettingsModal.tsx
@@ -67,6 +67,7 @@ function pruneRomaji(next: RomajiDetailSettings): RomajiDetailSettings | undefin
   if (next.guideStyles !== undefined && next.guideStyles.length > 0) pruned.guideStyles = next.guideStyles
   if (next.disabledStyles !== undefined && next.disabledStyles.length > 0) pruned.disabledStyles = next.disabledStyles
   if (next.guideLineCount !== undefined && next.guideLineCount !== 1) pruned.guideLineCount = next.guideLineCount
+  if (next.lineEndEnter !== undefined && next.lineEndEnter !== true) pruned.lineEndEnter = next.lineEndEnter
   return Object.keys(pruned).length > 0 ? pruned : undefined
 }
 
@@ -94,6 +95,9 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
   const enabled = isRomajiInputEnabled(config)
   const caseStyle = romaji.caseStyle ?? 'lower'
   const guideLineCount = romaji.guideLineCount ?? 1
+  // Default ON (Enter required at line ends) — mirrors `enabled` above:
+  // undefined counts as the default, only an explicit false flips it.
+  const lineEndEnter = romaji.lineEndEnter !== false
   const guideStyles = new Set(romaji.guideStyles ?? [])
   const disabledStyles = new Set(romaji.disabledStyles ?? [])
 
@@ -170,6 +174,19 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
             label={t('editor.typingTest.romaji.toggle')}
             on={enabled}
             onToggle={() => onConfigChange({ ...config, romajiInput: !enabled })}
+          />
+
+          {/* Line-end Enter — whether a line-end word (tatoeba/fileImport
+              real lines) holds until Enter commits it, or auto-advances
+              like every other word. Boolean, so same ToggleRow pattern as
+              the master enable above rather than the button-row pattern
+              used by Displayed case / Lines shown. */}
+          <ToggleRow
+            testid="romaji-line-end-enter"
+            label={t('editor.typingTest.romajiSettings.lineEndEnterLabel')}
+            title={t('editor.typingTest.romajiSettings.lineEndEnterHint')}
+            on={lineEndEnter}
+            onToggle={() => applyRomaji({ lineEndEnter: !lineEndEnter })}
           />
 
           {/* Display case — sample text itself is the label (ROMAJI / Romaji

--- a/src/renderer/typing-test/TypingTestView.tsx
+++ b/src/renderer/typing-test/TypingTestView.tsx
@@ -7,6 +7,7 @@ import type { TypingTestState } from './useTypingTest'
 import type { RomajiGuide, TypingTestConfig } from './types'
 import type { ComparisonStats } from './comparison'
 import { DEFAULT_DISPLAY_LINES, DEFAULT_FONT_SIZE } from './types'
+import { romajiDetail } from './romaji-input'
 import { WordDisplay } from './WordDisplay'
 import { TypingTestControlsRow } from './TypingTestControlsRow'
 import { TypingTestStatsRow } from './TypingTestStatsRow'
@@ -202,6 +203,16 @@ export function TypingTestView({
     () => (state.lineBreaks.size > 0 ? groupIntoLines(state.words, state.lineBreaks) : null),
     [state.words, state.lineBreaks],
   )
+  // The ⏎ glyph is only truthful while Enter is actually required at a real
+  // line end. Romaji input mode's "Enter at line ends" toggle (default on)
+  // can turn that requirement off (see isLineEndEnterRequired in
+  // romaji-input.ts) — a line-end word then auto-advances on completion
+  // like any other word, so showing ⏎ would be a lie. `romajiGuide != null`
+  // is the established 1:1 stand-in for "romaji input is active" (romaji
+  // guide selectors return null exactly when `isRomajiInputActive` is
+  // false — see buildRomajiGuideProgress); when romaji is off entirely the
+  // config's `romaji` field is irrelevant and the glyph renders as before.
+  const showLineEndGlyph = realLines !== null && (romajiGuide == null || romajiDetail(config)?.lineEndEnter !== false)
   // Monkeytype modes (words/time/quote — lineBreaks empty) render synthetic
   // line rows too, derived from a hidden-mirror measurement (see
   // useVisualLines) instead of the flat CSS word-flow, so the reading
@@ -464,13 +475,15 @@ export function TypingTestView({
               {lines ? (
                 // Real (fileImport/tatoeba) or synthetic (monkeytype, measured
                 // via useVisualLines) line rows. ⏎ marks a real line end
-                // (Enter, not Space, advances there) — gated on `realLines`
-                // rather than lineWordIdxs' last-word membership in
-                // state.lineBreaks, so it can never fire for the synthetic
-                // monkeytype rows even in the (real-lines-only) edge case
-                // where the very last word happens to be a recorded break.
-                // line-indent-* is fileImport-only for the same "no real
-                // lines" reason: state.lineIndents stays empty elsewhere.
+                // (Enter, not Space, advances there) — gated on
+                // `showLineEndGlyph` (real lines AND Enter actually required
+                // there — see that const's own doc comment) rather than
+                // lineWordIdxs' last-word membership in state.lineBreaks, so
+                // it can never fire for the synthetic monkeytype rows even
+                // in the (real-lines-only) edge case where the very last
+                // word happens to be a recorded break. line-indent-* is
+                // fileImport-only for the same "no real lines" reason:
+                // state.lineIndents stays empty elsewhere.
                 lines.map((lineWordIdxs, lineIdx) => (
                   <div key={lineIdx} data-line-row={lineIdx} className="flex flex-wrap gap-x-3">
                     {state.lineIndents[lineIdx] && (
@@ -479,7 +492,7 @@ export function TypingTestView({
                       <span data-testid={`line-indent-${lineIdx}`} className="-mr-3 select-none whitespace-pre text-content-muted/40" aria-hidden="true">{state.lineIndents[lineIdx]}</span>
                     )}
                     {lineWordIdxs.map(renderWord)}
-                    {Boolean(realLines) && lineIdx < lines.length - 1 && (
+                    {showLineEndGlyph && lineIdx < lines.length - 1 && (
                       <span className="select-none text-content-muted/40" aria-hidden="true">⏎</span>
                     )}
                   </div>

--- a/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
@@ -66,6 +66,21 @@ describe('RomajiSettingsModal defaults', () => {
     expect(screen.getByTestId('romaji-guide-lines-1').className).not.toContain('text-accent')
   })
 
+  it('shows the line-end Enter toggle on by default when lineEndEnter is not set', () => {
+    renderModal()
+    expect(screen.getByTestId('romaji-line-end-enter')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows the line-end Enter toggle on when lineEndEnter is explicitly true', () => {
+    renderModal({ config: { ...BASE_CONFIG, romaji: { lineEndEnter: true } } })
+    expect(screen.getByTestId('romaji-line-end-enter')).toHaveAttribute('aria-checked', 'true')
+  })
+
+  it('shows the line-end Enter toggle off when lineEndEnter is explicitly false', () => {
+    renderModal({ config: { ...BASE_CONFIG, romaji: { lineEndEnter: false } } })
+    expect(screen.getByTestId('romaji-line-end-enter')).toHaveAttribute('aria-checked', 'false')
+  })
+
   it('defaults the guide Base selector to Hepburn, with every Option off', () => {
     renderModal()
     expect(screen.getByTestId('romaji-guide-base-hepburn')).toHaveAttribute('aria-pressed', 'true')
@@ -159,6 +174,30 @@ describe('RomajiSettingsModal edits', () => {
     fireEvent.click(screen.getByTestId('romaji-guide-lines-1'))
     const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
     if (arg.mode === 'words') expect(arg.romaji).toBeUndefined()
+  })
+
+  it('toggles the line-end Enter setting off from the default-on state (writes an explicit false)', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-line-end-enter'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toEqual({ lineEndEnter: false })
+  })
+
+  it('toggling line-end Enter back on from an explicit false prunes the field back to unset', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ config: { ...BASE_CONFIG, romaji: { lineEndEnter: false } }, onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-line-end-enter'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toBeUndefined()
+  })
+
+  it('toggling line-end Enter off preserves an existing romaji field alongside it', () => {
+    const onConfigChange = vi.fn()
+    renderModal({ config: { ...BASE_CONFIG, romaji: { caseStyle: 'capital' } }, onConfigChange })
+    fireEvent.click(screen.getByTestId('romaji-line-end-enter'))
+    const arg = onConfigChange.mock.calls[0][0] as TypingTestConfig
+    if (arg.mode === 'words') expect(arg.romaji).toEqual({ caseStyle: 'capital', lineEndEnter: false })
   })
 
   it('selecting Kunrei as the guide Base adds kunrei to guideStyles', () => {

--- a/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestView.test.tsx
@@ -824,6 +824,51 @@ describe('TypingTestView — imported fileImport text (line breaks)', () => {
     expect(screen.getByTestId('typing-test-words').className).toContain('typing-multiline-window')
   })
 
+  // Task: the ⏎ glyph is only truthful while Enter is actually required at
+  // a real line end. Romaji input's "Enter at line ends" toggle
+  // (RomajiDetailSettings.lineEndEnter, default true) can turn that
+  // requirement off — `romajiGuide != null` stands in for "romaji input is
+  // active" (see showLineEndGlyph's own doc comment in TypingTestView.tsx).
+  const ROMAJI_GUIDE_STUB = {
+    typed: '', remaining: 'か', kanaCompleted: 0, words: ['か', 'か'], lineCount: 1, showRow: true,
+  }
+
+  it('still shows ⏎ when romaji is active and lineEndEnter is unset (default on)', () => {
+    const { container } = renderView({
+      config: { mode: 'fileImport', textId: 'x', romajiInput: true },
+      romajiGuide: ROMAJI_GUIDE_STUB,
+      state: makeState({ status: 'running', words: ['a', 'b', 'c', 'd'], lineBreaks: new Set([1]) }),
+    })
+    expect(container.textContent).toContain('⏎')
+  })
+
+  it('still shows ⏎ when romaji is active and lineEndEnter is explicitly true', () => {
+    const { container } = renderView({
+      config: { mode: 'fileImport', textId: 'x', romajiInput: true, romaji: { lineEndEnter: true } },
+      romajiGuide: ROMAJI_GUIDE_STUB,
+      state: makeState({ status: 'running', words: ['a', 'b', 'c', 'd'], lineBreaks: new Set([1]) }),
+    })
+    expect(container.textContent).toContain('⏎')
+  })
+
+  it('hides ⏎ when romaji is active and lineEndEnter is explicitly false', () => {
+    const { container } = renderView({
+      config: { mode: 'fileImport', textId: 'x', romajiInput: true, romaji: { lineEndEnter: false } },
+      romajiGuide: ROMAJI_GUIDE_STUB,
+      state: makeState({ status: 'running', words: ['a', 'b', 'c', 'd'], lineBreaks: new Set([1]) }),
+    })
+    expect(container.textContent).not.toContain('⏎')
+  })
+
+  it('still shows ⏎ when lineEndEnter is false but romaji input is NOT active (romajiGuide null)', () => {
+    const { container } = renderView({
+      config: { mode: 'fileImport', textId: 'x', romajiInput: true, romaji: { lineEndEnter: false } },
+      romajiGuide: null,
+      state: makeState({ status: 'running', words: ['a', 'b', 'c', 'd'], lineBreaks: new Set([1]) }),
+    })
+    expect(container.textContent).toContain('⏎')
+  })
+
   it('applies font size and line count as CSS vars on the fileImport window', () => {
     renderView({
       displayLines: 6,

--- a/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
+++ b/src/renderer/typing-test/__tests__/useTypingTest.romaji.test.ts
@@ -53,8 +53,10 @@ let fileImportRomajiCounter = 0
  *  text, possibly multi-line so `parseFileImportText` produces genuine
  *  `lineBreaks` (unlike the monkeytype words/time configs above, whose
  *  `lineBreaks` is always empty). This is the harness for the line-end
- *  Enter semantics tests below (Task-romaji-line-end-enter). */
-async function renderFileImportRomaji(text: string) {
+ *  Enter semantics tests below (Task-romaji-line-end-enter). `romaji` is an
+ *  optional detail-settings passthrough — used by the "Enter at line ends"
+ *  toggle tests to set `lineEndEnter: false`. */
+async function renderFileImportRomaji(text: string, romaji?: { lineEndEnter?: boolean }) {
   const textId = `line-end-${fileImportRomajiCounter++}`
   mockTypingTestTextStoreGet.mockResolvedValue({
     success: true,
@@ -62,7 +64,7 @@ async function renderFileImportRomaji(text: string) {
   })
   const { result } = renderHook(() => useTypingTest(undefined, 'english'))
   await act(async () => {
-    await result.current.setConfig({ mode: 'fileImport', textId, romajiInput: true })
+    await result.current.setConfig({ mode: 'fileImport', textId, romajiInput: true, ...(romaji ? { romaji } : {}) })
   })
   return result
 }
@@ -830,5 +832,52 @@ describe('useTypingTest — romaji input mode (line-end Enter semantics)', () =>
     expect(result.current.state.currentWordIndex).toBe(3)
     press(result, 'Enter')
     expect(result.current.state.currentWordIndex).toBe(4)
+  })
+})
+
+// Task: the Romaji Settings modal's "Enter at line ends" toggle
+// (`RomajiDetailSettings.lineEndEnter`) lets the user turn OFF the
+// Task-romaji-line-end-enter hold above — with the toggle off, a line-end
+// word auto-advances on completion just like any other word, and Enter goes
+// back to being a no-op everywhere. Default (undefined/true) behaviour is
+// covered exhaustively by the describe block above and stays unmodified.
+describe('useTypingTest — romaji input mode (lineEndEnter: false auto-advances)', () => {
+  it('auto-advances a line-end word once its romaji completes, without Enter', async () => {
+    const result = await renderFileImportRomaji('か\nか', { lineEndEnter: false })
+    expect([...result.current.state.lineBreaks]).toEqual([0])
+
+    type(result, 'ka')
+
+    expect(result.current.state.currentWordIndex).toBe(1)
+    expect(result.current.state.wordResults).toEqual([{ word: 'か', typed: 'ka', correct: true }])
+    expect(result.current.state.romajiKeystrokes).toBe('')
+  })
+
+  it('Enter is a no-op once the toggle is off', async () => {
+    const result = await renderFileImportRomaji('か\nか', { lineEndEnter: false })
+    type(result, 'ka') // word 0 already auto-advanced to word 1
+
+    press(result, 'Enter')
+
+    expect(result.current.state.currentWordIndex).toBe(1)
+    expect(result.current.state.wordResults).toEqual([{ word: 'か', typed: 'ka', correct: true }])
+  })
+
+  it('the run finishes without any Enter presses when every line-end word auto-advances', async () => {
+    const result = await renderFileImportRomaji('か き\nさ', { lineEndEnter: false })
+    expect([...result.current.state.lineBreaks]).toEqual([1])
+
+    type(result, 'ka')
+    expect(result.current.state.currentWordIndex).toBe(1)
+    type(result, 'ki') // word 1, line-end — auto-advances (toggle off)
+    expect(result.current.state.currentWordIndex).toBe(2)
+    type(result, 'sa')
+
+    expect(result.current.state.status).toBe('finished')
+    expect(result.current.state.wordResults).toEqual([
+      { word: 'か', typed: 'ka', correct: true },
+      { word: 'き', typed: 'ki', correct: true },
+      { word: 'さ', typed: 'sa', correct: true },
+    ])
   })
 })

--- a/src/renderer/typing-test/romaji-input.ts
+++ b/src/renderer/typing-test/romaji-input.ts
@@ -131,6 +131,18 @@ export function romajiDetail(config: TypingTestConfig): RomajiDetailSettings | u
   return config.mode === 'quote' ? undefined : config.romaji
 }
 
+/** True when a LINE-END word must hold until Enter commits it (the
+ *  Task-romaji-line-end-enter behaviour) rather than auto-advancing on
+ *  completion like every other word. Reads `RomajiDetailSettings.lineEndEnter`
+ *  via `romajiDetail` — default ON: undefined counts as required, and only
+ *  an explicit `false` (the Romaji Settings modal's new toggle) opts out.
+ *  The single gate both `handleRomajiChar`'s complete-branch hold and
+ *  `processRomajiKeyEvent`'s Enter-at-line-end branch check, so the two stay
+ *  in sync by construction rather than by convention. */
+function isLineEndEnterRequired(config: TypingTestConfig): boolean {
+  return romajiDetail(config)?.lineEndEnter !== false
+}
+
 /** Romaji-mode key semantics, dispatched once from `processKeyEvent`'s
  *  updater instead of checking `isRomajiInputActive` separately at each key
  *  kind. Space and Backspace are always no-ops in this mode — rejected
@@ -139,7 +151,14 @@ export function romajiDetail(config: TypingTestConfig): RomajiDetailSettings | u
  *  a no-op everywhere EXCEPT to commit a LINE-END word (`state.lineBreaks`)
  *  whose romaji has reached `isComplete()` — such a word holds instead of
  *  auto-advancing on completion (see `handleRomajiChar`), matching the
- *  non-romaji Enter-at-line-end convention (Task-romaji-line-end-enter). A
+ *  non-romaji Enter-at-line-end convention (Task-romaji-line-end-enter). Both
+ *  the hold and this commit are additionally gated on
+ *  `isLineEndEnterRequired` (the Romaji Settings modal's "Enter at line
+ *  ends" toggle, default on): when the user has turned it off, a line-end
+ *  word never holds in the first place (see `handleRomajiChar`), so
+ *  `currentWordIndex` has already moved past it by the time Enter is
+ *  pressed — the explicit check below is belt-and-suspenders documentation
+ *  of that invariant, not a second independent gate. A
  *  printable character starts the run from 'waiting' before being fed to
  *  the matcher; Enter never starts the run from 'waiting' (mirrors the
  *  pre-existing romaji policy of only a printable char doing so). Every
@@ -153,7 +172,7 @@ export function processRomajiKeyEvent(state: TypingTestState, key: string, confi
     if (state.currentWordIndex >= state.words.length) return state
     const word = state.words[state.currentWordIndex]
     const matcher = buildRomajiMatcher(word, state.romajiKeystrokes, romajiDetail(config))
-    if (matcher.isComplete() && state.lineBreaks.has(state.currentWordIndex)) {
+    if (matcher.isComplete() && state.lineBreaks.has(state.currentWordIndex) && isLineEndEnterRequired(config)) {
       return commitRomajiWord(state, matcher, config, language)
     }
     return state
@@ -197,14 +216,18 @@ function commitRomajiWord(state: TypingTestState, matcher: RomajiMatcher, config
  *  matcher's position untouched (nothing is appended to currentInput or
  *  the keystroke buffer). Completing the whole word auto-advances via
  *  `commitRomajiWord` — UNLESS the current word is a LINE-END word
- *  (`state.lineBreaks`, real lines from tatoeba/fileImport): that word
- *  instead holds (keystrokes still accumulate, so a printable char typed
- *  while held keeps flowing through the matcher normally — see below) until
- *  `processRomajiKeyEvent`'s Enter handler commits it, matching the
- *  non-romaji Enter-at-line-end convention (Task-romaji-line-end-enter).
- *  Space is blocked in this mode regardless (see `processRomajiKeyEvent`),
- *  so there is no separate Space-triggered finalize path to keep in sync
- *  for non-line-end words.
+ *  (`state.lineBreaks`, real lines from tatoeba/fileImport) AND
+ *  `isLineEndEnterRequired(config)` (the Romaji Settings modal's "Enter at
+ *  line ends" toggle, default on): such a word instead holds (keystrokes
+ *  still accumulate, so a printable char typed while held keeps flowing
+ *  through the matcher normally — see below) until `processRomajiKeyEvent`'s
+ *  Enter handler commits it, matching the non-romaji Enter-at-line-end
+ *  convention (Task-romaji-line-end-enter). With the toggle off, a line-end
+ *  word commits immediately on completion exactly like any other word, and
+ *  Enter goes back to being a no-op everywhere (see
+ *  `processRomajiKeyEvent`'s doc comment). Space is blocked in this mode
+ *  regardless (see `processRomajiKeyEvent`), so there is no separate
+ *  Space-triggered finalize path to keep in sync for non-line-end words.
  *
  *  Mistake tracking (romaji mode): a rejected keystroke marks
  *  `romajiSegmentErred` true for the kana segment currently in progress,
@@ -257,7 +280,7 @@ function handleRomajiChar(state: TypingTestState, char: string, config: TypingTe
   }
 
   if (result === 'complete' && matcher.isComplete()) {
-    if (state.lineBreaks.has(state.currentWordIndex)) return held
+    if (state.lineBreaks.has(state.currentWordIndex) && isLineEndEnterRequired(config)) return held
     return commitRomajiWord(held, matcher, config, language)
   }
 

--- a/src/renderer/typing-test/types.ts
+++ b/src/renderer/typing-test/types.ts
@@ -31,6 +31,15 @@ export interface RomajiDetailSettings {
    *  row anchors to the same line structure as the reading window — see
    *  `RomajiGuide`. */
   guideLineCount?: number
+  /** Whether a LINE-END word (real lines from tatoeba/fileImport, tracked
+   *  via `state.lineBreaks`) holds once its romaji completes until Enter
+   *  commits it, instead of auto-advancing like every other word (see
+   *  `processRomajiKeyEvent`/`handleRomajiChar` in romaji-input.ts, and
+   *  Task-romaji-line-end-enter). Default: true (Enter required) — this is
+   *  the behaviour that existed before the setting did, so an absent value
+   *  changes nothing for existing configs. Only an explicit `false` opts
+   *  out and auto-advances at line ends too. */
+  lineEndEnter?: boolean
 }
 
 export type TypingTestConfig =


### PR DESCRIPTION
## Summary
- New Romaji setting `lineEndEnter` (default on — the current hold-for-Enter behavior from #375; prune-at-default so only `false` persists). Turning it off restores auto-advance at line ends: the completed line-end word commits immediately and Enter goes back to a no-op.
- The reading window's ⏎ marks stay truthful: they hide when romaji input is active with the option off (Enter isn't expected), and render as today otherwise.
- The toggle sits directly under the master Romaji switch, above Displayed case.

## Verification
- 8,516 passed / 22 skipped (+15: prefs round-trip/validation, modal toggle, engine both-modes, glyph gating); the existing line-end-Enter suite passes unmodified (default path byte-identical). eslint / typecheck clean; i18n keys in english + 4 packs, lockstep 0.1.73.
- Virtual-device Playwright: default holds at the line end until Enter with ⏎ visible; toggling off auto-advances to the next line with zero Enter presses and no ⏎ marks (10/10 assertions, config isolated per scenario).