### PR TITLE
fix(ui): tidy the keystroke timeline panel

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.73",
+  "version": "0.1.74",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -550,11 +550,15 @@
           "legend": {
             "normal": "通常の打鍵",
             "mistake": "ミス",
-            "overlap": "重複打鍵（前のキーを離す前に押した）",
-            "unjudged": "未判定（正誤データなし）",
-            "blank": "ブランク（圧縮表示）",
+            "overlap": "重複打鍵",
+            "overlapTooltip": "前のキーを離す前に押した",
+            "unjudged": "未判定",
+            "unjudgedTooltip": "正誤データなし",
+            "blank": "ブランク",
+            "blankTooltip": "圧縮表示",
             "leadIn": "ワード前の間",
-            "blankLine": "ブランク（250ms超、圧縮表示）",
+            "blankLine": "ブランク",
+            "blankLineTooltip": "250ms超、圧縮表示",
             "leadInLine": "行前の間",
             "correctedNote": "ミスの印には提出前に修正された打鍵も含まれます。ミスの印があっても正確度100%になることがあります。",
             "infoAriaLabel": "凡例の補足情報"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.73",
+  "version": "0.1.74",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -550,11 +550,15 @@
           "legend": {
             "normal": "普通の打鍵",
             "mistake": "ミス☆",
-            "overlap": "重複打鍵（前のキー離す前に押しちゃったやつ）",
-            "unjudged": "未判定（正誤わかんないやつ）",
-            "blank": "ブランク（圧縮表示だよ）",
+            "overlap": "重複打鍵",
+            "overlapTooltip": "前のキー離す前に押しちゃったやつ",
+            "unjudged": "未判定",
+            "unjudgedTooltip": "正誤わかんないやつ",
+            "blank": "ブランク",
+            "blankTooltip": "圧縮表示だよ",
             "leadIn": "ワード前の間",
-            "blankLine": "ブランク（250ms超、圧縮表示だよ）",
+            "blankLine": "ブランク",
+            "blankLineTooltip": "250ms超、圧縮表示だよ",
             "leadInLine": "行前の間じゃん",
             "correctedNote": "ミスの印、提出前に直したのも入ってるから、印あっても正確度100%になることあるよ",
             "infoAriaLabel": "凡例の補足情報"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.73",
+  "version": "0.1.74",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -550,11 +550,15 @@
           "legend": {
             "normal": "通常の打鍵どすえ",
             "mistake": "ミスどすえ",
-            "overlap": "重複打鍵（前のキーを離さんうちに押さはったん）",
-            "unjudged": "未判定（正誤のデータがおへん）",
-            "blank": "ブランク（圧縮して表示どすえ）",
+            "overlap": "重複打鍵",
+            "overlapTooltip": "前のキーを離さんうちに押さはったん",
+            "unjudged": "未判定",
+            "unjudgedTooltip": "正誤のデータがおへん",
+            "blank": "ブランク",
+            "blankTooltip": "圧縮して表示どすえ",
             "leadIn": "ワード前の間どすえ",
-            "blankLine": "ブランク（250ms超、圧縮して表示どすえ）",
+            "blankLine": "ブランク",
+            "blankLineTooltip": "250ms超、圧縮して表示どすえ",
             "leadInLine": "行前の間どすえ",
             "correctedNote": "ミスの印には提出前に直さはった打鍵も入ってますよって、印があっても正確度100%になることがおすえ",
             "infoAriaLabel": "凡例の補足情報"

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.73",
+  "version": "0.1.74",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -550,11 +550,15 @@
           "legend": {
             "normal": "通常の打鍵",
             "mistake": "誤り",
-            "overlap": "重複打鍵（前のキーを離す前に押したもの）",
-            "unjudged": "未判定（正誤のデータなし）",
-            "blank": "間（圧縮して表示）",
+            "overlap": "重複打鍵",
+            "overlapTooltip": "前のキーを離す前に押したもの",
+            "unjudged": "未判定",
+            "unjudgedTooltip": "正誤のデータなし",
+            "blank": "間",
+            "blankTooltip": "圧縮して表示",
             "leadIn": "ワード前の間",
-            "blankLine": "間（250ms超、圧縮して表示）",
+            "blankLine": "間",
+            "blankLineTooltip": "250ms超、圧縮して表示",
             "leadInLine": "行前の間",
             "correctedNote": "誤りの印には提出前に訂正された打鍵も含まれております。印があっても正確度100%となることがございます。",
             "infoAriaLabel": "凡例の補足情報"

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.73",
+  "version": "0.1.74",
   "name": "English",
   "common": {
     "save": "Save",
@@ -550,11 +550,15 @@
           "legend": {
             "normal": "Normal keystroke",
             "mistake": "Mistake",
-            "overlap": "Overlapped (pressed before the previous key released)",
-            "unjudged": "Unjudged (no correctness data)",
-            "blank": "Pause (shown compressed)",
+            "overlap": "Overlapped",
+            "overlapTooltip": "Pressed before the previous key released",
+            "unjudged": "Unjudged",
+            "unjudgedTooltip": "No correctness data",
+            "blank": "Pause",
+            "blankTooltip": "Shown compressed",
             "leadIn": "Pause before this word",
-            "blankLine": "Pause (>250ms, shown compressed)",
+            "blankLine": "Pause",
+            "blankLineTooltip": "More than 250ms, shown compressed",
             "leadInLine": "Pause before this line",
             "correctedNote": "Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy.",
             "infoAriaLabel": "Legend notes"

--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -53,14 +53,30 @@ interface Props {
 interface LegendSwatchProps {
   colorClass: string
   labelKey: string
+  /** When set, the label's former parenthetical explanation — hidden
+   *  behind a hover/focus tooltip instead of always-visible inline text.
+   *  Rendered PLAIN, no visual affordance on the label itself (no
+   *  underline, no special cursor) — same idiom every other tooltip
+   *  trigger in this codebase uses (ErrorMixSection's type labels,
+   *  CoverageBadge, the Missed table's own bar rows below): the tooltip
+   *  showing up on hover/focus IS the affordance, nothing on the trigger
+   *  itself hints at it in advance. */
+  tooltipKey?: string
 }
 
-function LegendSwatch({ colorClass, labelKey }: LegendSwatchProps) {
+function LegendSwatch({ colorClass, labelKey, tooltipKey }: LegendSwatchProps) {
   const { t } = useTranslation()
+  const label = tooltipKey
+    ? (
+      <Tooltip content={t(tooltipKey)}>
+        <span>{t(labelKey)}</span>
+      </Tooltip>
+    )
+    : t(labelKey)
   return (
     <span className="flex items-center gap-1.5 text-2xs text-content-secondary">
       <span className={`inline-block h-2.5 w-2.5 rounded-sm ${colorClass}`} aria-hidden="true" />
-      {t(labelKey)}
+      {label}
     </span>
   )
 }
@@ -88,6 +104,16 @@ function lineLegendLabelKey(kind: TimelineFillKind, displayMode: 'line' | 'word'
   if (displayMode === 'line' && kind === 'blank') return 'editor.typingTest.history.timeline.legend.blankLine'
   if (displayMode === 'line' && kind === 'leadIn') return 'editor.typingTest.history.timeline.legend.leadInLine'
   return TIMELINE_LEGEND[kind].labelKey
+}
+
+/** Sibling of `lineLegendLabelKey` for the tooltip half of the split —
+ *  `blank`'s line-mode variant (`blankLine`) carries a different cutoff
+ *  (250ms vs the word view's 1000ms) in its own tooltip text, same as the
+ *  label swap above. `leadIn` has no tooltip in either mode (its label
+ *  never carried a parenthetical to begin with). */
+function lineLegendTooltipKey(kind: TimelineFillKind, displayMode: 'line' | 'word'): string | undefined {
+  if (displayMode === 'line' && kind === 'blank') return 'editor.typingTest.history.timeline.legend.blankLineTooltip'
+  return TIMELINE_LEGEND[kind].tooltipKey
 }
 
 function keystrokeTooltipBody(word: string, seg: KeystrokeSegment, t: (key: string, opts?: Record<string, unknown>) => string) {
@@ -292,7 +318,50 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           participates in the flex-height chain (`flex-1 min-h-0
           flex-col`) so the rows scrollport inside it can still absorb
           all the remaining height — title/zoom/legend keep their natural
-          height, same as before. */}
+          height, same as before.
+
+          HEIGHT PRIORITY (polish item: in a bounded ancestor — the
+          History modal's `h-modal-80vh` — this box and the Missed box
+          below both compete for the SAME leftover space, and the Missed
+          box used to win: it was `shrink-0` (flex-shrink: 0) with its own
+          internal scroll capped at ~8-10 rows (`MISSED_TABLE_MAX_HEIGHT`),
+          so its natural height was reserved OFF THE TOP, non-negotiably,
+          before this box's `flex-1` ever saw the remainder — a run with
+          many distinct mistake keys could squeeze this box down to a
+          single visible row.
+
+          FLAGGED DEAD END: a `min-h-64` floor on THIS box (an earlier
+          version of this fix) does guarantee dominance whenever both
+          boxes fit, but doesn't actually prevent overflow — a `min-height`
+          is a hard floor, not a suggestion, so on a short enough window
+          (verified via the panel-polish E2E script's 800px case) the
+          Missed box's own `shrink-0` rigidity plus this floor together
+          summed to MORE than the available space, and — since neither
+          box had anywhere left to give — their rendered content visually
+          OVERLAPPED the finished-state controls row below instead of
+          properly stacking. A hard floor can only ever win a fixed-sum
+          contest against an equally rigid sibling; it can't make the
+          sibling actually yield.
+
+          FIX: make the Missed box wrapper (below) properly shrinkable
+          instead — drop its `shrink-0` for `min-h-0` (default
+          `flex-shrink: 1` already applies; `min-h-0` is what lets it
+          shrink below its own natural content size instead of hard-
+          flooring there, same reason every OTHER link in this flex chain
+          already carries `min-h-0`). With both boxes now genuinely
+          shrinkable, a real space deficit gets distributed
+          PROPORTIONALLY between them (flexbox's default shrink algorithm,
+          weighted by each box's own content size) instead of one box
+          refusing to give at all — which naturally keeps this box (whose
+          content is usually taller — timeline rows vs a handful of Missed
+          rows) LARGER post-shrink too, without ever risking overflow: a
+          `min-h-0` box can always still compress toward 0 rather than
+          spill past its container. The Missed table's own scrollport cap
+          is ALSO tightened for this call site (`max-h-40` vs the
+          component's own `max-h-56` default, see the `MissedTable` call
+          below) so it claims less of the ROOMY-window case too, biasing
+          the split toward this box even when nothing is actually
+          squeezed. */}
       <div
         className="flex min-h-0 flex-1 flex-col gap-3 rounded-md border border-edge bg-surface p-3"
         data-testid="typing-test-timeline-box"
@@ -330,32 +399,60 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
 
         {/* Legend — color alone never carries meaning elsewhere in
             this view (tooltips spell everything out too), but this
-            is the at-a-glance key. Line-mode overrides the blank/
-            lead-in wording to the line-view's own meaning (a 250ms
-            cut and "before this line", not the word view's 1000ms /
-            "before this word") — every other entry, and the word
-            view's own wording, stays unchanged. The two longer-form
-            notes (corrected-mistake markers, compressed-pause axis)
-            used to render as their own paragraph lines below the
-            legend — collapsed into this single info icon (`ml-auto`,
+            is the at-a-glance key. Every item shows only its head
+            word ("Overlapped" / "Unjudged" / "Pause") — the former
+            parenthetical explanation moved into a per-item hover
+            tooltip (`LegendSwatch`'s own `tooltipKey`), rendered PLAIN
+            with no visual affordance on the label itself (matching every
+            other tooltip trigger in this codebase — ErrorMixSection's
+            row labels, CoverageBadge, the Missed table's own bar rows —
+            none of which carry an underline or a special cursor; the
+            tooltip appearing on hover/focus is the only signal) so the
+            row stays a compact single line instead of wrapping under
+            long inline text.
+            "Normal keystroke" / "Mistake" / "Pause before this
+            word(/line)" never carried a parenthetical, so those three
+            have no tooltip. Line-mode overrides the blank/lead-in
+            wording (both label AND tooltip) to the line-view's own
+            meaning (a 250ms cut and "before this line", not the word
+            view's 1000ms / "before this word") — every other entry, and
+            the word view's own wording, stays unchanged. The two
+            longer-form notes (corrected-mistake markers, compressed-
+            pause axis) used to render as their own paragraph lines below
+            the legend — collapsed into this single info glyph (`ml-auto`,
             right end of the row) so the legend reads as one compact
             line; both notes still live in the tooltip, joined with a
             newline (BUBBLE_BASE's `whitespace-pre-line` renders it as
             two lines), same idiom as ErrorMixSection's row-label
-            tooltip. */}
+            tooltip. Rendered as a plain, non-interactive `<span>` (not a
+            `<button>`) for the same reason the legend labels above are
+            plain — this codebase's `button:not(:disabled) { cursor:
+            pointer }` global rule (style.css) would otherwise put an
+            interactive-looking cursor on a glyph that does nothing on
+            click, same inconsistency CoverageBadge's plain-span trigger
+            already avoids. `aria-label` still supplies its accessible
+            name (the `Info` icon itself is `aria-hidden`); like
+            CoverageBadge/ErrorMixSection's own triggers, this means
+            hover discovers it but Tab does not — no `tabIndex` is added,
+            since none of this codebase's other non-button tooltip
+            triggers add one either. */}
         <div className="flex flex-wrap items-center gap-3" data-testid="word-timeline-legend">
           {LEGEND_ORDER.map((kind) => (
-            <LegendSwatch key={kind} colorClass={TIMELINE_LEGEND[kind].swatchClass} labelKey={lineLegendLabelKey(kind, displayMode)} />
+            <LegendSwatch
+              key={kind}
+              colorClass={TIMELINE_LEGEND[kind].swatchClass}
+              labelKey={lineLegendLabelKey(kind, displayMode)}
+              tooltipKey={lineLegendTooltipKey(kind, displayMode)}
+            />
           ))}
           <Tooltip content={legendNotes} className="max-w-xs">
-            <button
-              type="button"
+            <span
               data-testid="word-timeline-legend-info"
               aria-label={t('editor.typingTest.history.timeline.legend.infoAriaLabel')}
               className="ml-auto rounded p-1 text-content-muted hover:text-content transition-colors"
             >
               <Info size={ICON_SM} aria-hidden="true" />
-            </button>
+            </span>
           </Tooltip>
         </div>
 
@@ -450,10 +547,17 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           list. Substitution/Omission/Insertion render above, as stat
           cards in `summaryItems`, not here. Stays in the same position it
           held as a chip list (below the timeline box) so the timeline
-          itself reads first; `shrink-0` keeps it from being squeezed by
-          the box's own `flex-1`, which must keep absorbing all the
-          remaining height in the flex-height chain (see the scrollport's
-          own comment above).
+          itself reads first.
+
+          `min-h-0` (NOT `shrink-0` — see the timeline box's own
+          HEIGHT PRIORITY comment for why that flip matters) lets this box
+          shrink below its own natural content size in a bounded ancestor
+          instead of hard-flooring there; the DEFAULT `flex-shrink: 1`
+          (unset, so this is just the browser default) is what actually
+          does the shrinking once space runs short, proportional to this
+          box's own content size vs the timeline box's — which keeps the
+          timeline box bigger post-shrink too, without either box ever
+          overflowing its container.
 
           Wrapped in the SAME bordered-box treatment as the timeline box
           above (`rounded-md border border-edge bg-surface p-3`,
@@ -462,10 +566,27 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           by `MistakeRankingSection` (History's Analysis tab "Most missed"
           section, which sits among unboxed section-heading siblings —
           ACCURACY TREND / ERROR MIX — and must stay that way), so the box
-          is added here around the render, not inside `MissedTable`. */}
+          is added here around the render, not inside `MissedTable`.
+
+          `maxHeightClass="max-h-40"` (vs `MissedTable`'s own `max-h-56`
+          default) and `bordered={false}` are this call site's own polish
+          tweaks: a tighter cap biases the ROOMY-window case toward the
+          timeline box too (less reserved by Missed even when nothing is
+          actually squeezed), and `bordered={false}` drops the
+          scrollport's inner border since THIS wrapper already frames the
+          whole section — the two together used to double-stack a border
+          around the same content. Neither prop is passed at
+          `MistakeRankingSection`'s call site, which keeps `MissedTable`'s
+          unbounded defaults (`max-h-56`, its own border) since that
+          section has no competing sibling and no outer box of its own. */}
       {hasMistakes && (
-        <div className="shrink-0 rounded-md border border-edge bg-surface p-3" data-testid="typing-test-missed-box">
-          <MissedTable mistakes={result?.mistakes ?? {}} details={missedDetails} />
+        <div className="min-h-0 rounded-md border border-edge bg-surface p-3" data-testid="typing-test-missed-box">
+          <MissedTable
+            mistakes={result?.mistakes ?? {}}
+            details={missedDetails}
+            maxHeightClass="max-h-40"
+            bordered={false}
+          />
         </div>
       )}
     </div>

--- a/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
+++ b/src/renderer/typing-test/__tests__/KeystrokeTimelinePanel.test.tsx
@@ -2,7 +2,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { KeystrokeTimelinePanel } from '../KeystrokeTimelinePanel'
@@ -123,6 +123,79 @@ describe('KeystrokeTimelinePanel', () => {
     expect(screen.getAllByTestId('word-timeline-keystroke')).toHaveLength(2)
   })
 
+  // Polish item 1: legend items that used to carry a parenthetical
+  // explanation inline now show only their head word, with the
+  // explanation moved into a hover tooltip (aria-describedby, not
+  // always-visible text).
+  describe('legend labels (head word only, parenthetical text moved to a hover tooltip)', () => {
+    function hoverLegendLabel(text: string): HTMLElement {
+      const label = screen.getByText(text)
+      fireEvent.mouseEnter(label)
+      const describedBy = label.getAttribute('aria-describedby')
+      expect(describedBy).toBeTruthy()
+      return document.getElementById(describedBy!)!
+    }
+
+    it('shows bare head words for Overlapped/Unjudged/Pause, with no parenthetical text anywhere in the legend row', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const legendRow = screen.getByTestId('word-timeline-legend')
+      expect(within(legendRow).getByText('Overlapped')).toBeTruthy()
+      expect(within(legendRow).getByText('Unjudged')).toBeTruthy()
+      expect(within(legendRow).getByText('Pause')).toBeTruthy()
+      expect(legendRow.textContent).not.toContain('(')
+      expect(legendRow.textContent).not.toContain(')')
+    })
+
+    it('leaves Normal keystroke / Mistake / Pause before this word unwrapped (no tooltip, since they never carried a parenthetical)', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      expect(screen.getByText('Normal keystroke').getAttribute('aria-describedby')).toBeNull()
+      expect(screen.getByText('Mistake').getAttribute('aria-describedby')).toBeNull()
+      expect(screen.getByText('Pause before this word').getAttribute('aria-describedby')).toBeNull()
+    })
+
+    it('opens the Overlapped tooltip with the former parenthetical text on hover', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const tooltip = hoverLegendLabel('Overlapped')
+      expect(tooltip.textContent).toBe('Pressed before the previous key released')
+    })
+
+    it('opens the Unjudged tooltip with the former parenthetical text on hover', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const tooltip = hoverLegendLabel('Unjudged')
+      expect(tooltip.textContent).toBe('No correctness data')
+    })
+
+    it('opens the word-view Pause tooltip ("Shown compressed") when no lineBreaks field is present', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const tooltip = hoverLegendLabel('Pause')
+      expect(tooltip.textContent).toBe('Shown compressed')
+    })
+
+    it('opens the line-view Pause tooltip ("More than 250ms, shown compressed") when the log carries lineBreaks', () => {
+      const lineLog: RunKeystrokeLog = { ...SAMPLE_LOG, lineBreaks: [0] }
+      renderWithI18n(<KeystrokeTimelinePanel log={lineLog} />)
+      const tooltip = hoverLegendLabel('Pause')
+      expect(tooltip.textContent).toBe('More than 250ms, shown compressed')
+    })
+
+    // FLAG (consistency fix): the tooltip-bearing label used to carry a
+    // dotted-underline + `cursor-help` affordance — no other tooltip
+    // trigger in this codebase does that (ErrorMixSection's type labels,
+    // CoverageBadge, the Missed table's own bar rows are all plain), so
+    // it was removed. The tooltip itself (hover -> aria-describedby ->
+    // portaled bubble) still works identically; only the label's own
+    // visual styling changed.
+    it('renders the tooltip-bearing label plain, with no underline/cursor-help decoration, while the tooltip still opens on hover', () => {
+      renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
+      const label = screen.getByText('Overlapped')
+      expect(label.className).not.toContain('cursor-help')
+      expect(label.className).not.toContain('underline')
+      expect(label.className).not.toContain('decoration-dotted')
+      const tooltip = hoverLegendLabel('Overlapped')
+      expect(tooltip.textContent).toBe('Pressed before the previous key released')
+    })
+  })
+
   it('opts the scroll container into container-type: inline-size, so a LINE row\'s sticky header can pin to its visible width via cqw', () => {
     const { container } = renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
     const canvas = screen.getByTestId('word-timeline-canvas')
@@ -173,10 +246,16 @@ describe('KeystrokeTimelinePanel', () => {
     // inline text in the flow.
     expect(within(container).queryByText(/Mistake markers include keystrokes later corrected/)).toBeNull()
     expect(within(container).queryByText(/Pauses are shown compressed on this axis/)).toBeNull()
-    // The info icon button sits at the legend row's right end, with an
-    // accessible name (no native title attribute — lint forbids it).
+    // FLAG (consistency fix): the info glyph used to be a `<button>`,
+    // which this codebase's global `button:not(:disabled) { cursor:
+    // pointer }` rule (style.css) put a pointer cursor on — inconsistent
+    // with every other tooltip-only trigger (CoverageBadge,
+    // ErrorMixSection's row labels), none of which are buttons. Now a
+    // plain, non-interactive `<span>` — sits at the legend row's right
+    // end, with an accessible name via `aria-label` (no native title
+    // attribute — lint forbids it).
     const infoButton = screen.getByTestId('word-timeline-legend-info')
-    expect(infoButton.tagName).toBe('BUTTON')
+    expect(infoButton.tagName).toBe('SPAN')
     expect(infoButton.getAttribute('title')).toBeNull()
     expect(infoButton).toHaveAccessibleName()
     // Right end of the legend row (`ml-auto`), after every swatch. The
@@ -257,9 +336,21 @@ describe('KeystrokeTimelinePanel', () => {
     expect(warning.compareDocumentPosition(statLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
   })
 
+  // FLAG (polish item 1): `getByRole('tooltip')` used to be safe because
+  // the info icon was the panel's only `Tooltip` consumer. Now that the
+  // legend's own Overlapped/Unjudged/Pause labels each carry their own
+  // `Tooltip` too (portaled to `document.body` unconditionally once
+  // mounted, per Tooltip.tsx's own comment — `role="tooltip"` exists in
+  // the DOM before any hover), several `role="tooltip"` elements coexist
+  // and the single-role query throws. Scoped instead via the info
+  // button's own `aria-describedby`, same technique the legend-tooltip
+  // tests above use.
   it('shows both note texts, joined as two lines, in the legend info tooltip', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} />)
-    const tooltip = screen.getByRole('tooltip')
+    const infoButton = screen.getByTestId('word-timeline-legend-info')
+    const describedBy = infoButton.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    const tooltip = document.getElementById(describedBy!)!
     expect(tooltip.className).toContain('whitespace-pre-line')
     expect(tooltip.textContent).toBe(
       'Mistake markers include keystrokes later corrected before submit — a word can show markers and still be 100% accuracy.'
@@ -339,7 +430,14 @@ describe('KeystrokeTimelinePanel', () => {
   // as the timeline box above. `MistakeRankingSection` (History's "Most
   // missed") renders the same `MissedTable` unboxed — see
   // MistakeRankingSection.test.tsx, unchanged by this tweak.
-  it('wraps the Missed table in its own bordered box matching the timeline box treatment, keeping shrink-0', () => {
+  // FLAG (polish item 2, height-priority fix): `shrink-0` (flex-shrink: 0)
+  // became `min-h-0` — `shrink-0` refused to compress at all, which
+  // (verified via the E2E script's 800px-window case) could overflow past
+  // the finished-state controls row below in a bounded ancestor with a
+  // real content-heavy Missed table. `min-h-0` keeps the default
+  // `flex-shrink: 1` in effect, so this box can shrink proportionally
+  // instead of forcing an overflow — see the box's own doc comment.
+  it('wraps the Missed table in its own bordered box matching the timeline box treatment, with min-h-0 (not shrink-0)', () => {
     const result = makeResult({ mistakes: { a: 3 } })
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
 
@@ -351,12 +449,69 @@ describe('KeystrokeTimelinePanel', () => {
     expect(missedBox.className).toContain('border')
     expect(missedBox.className).toContain('border-edge')
     expect(missedBox.className).toContain('bg-surface')
-    expect(missedBox.className).toContain('shrink-0')
+    expect(missedBox.className).toContain('min-h-0')
+    expect(missedBox.className).not.toContain('shrink-0')
   })
 
   it('omits the Missed box entirely (no empty bordered box) when the result has no mistakes', () => {
     renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={makeResult()} />)
     expect(screen.queryByTestId('typing-test-missed-box')).toBeNull()
+  })
+
+  // Polish item 2: in a bounded ancestor (the History modal's
+  // `h-modal-80vh`), the timeline box and the Missed box compete for the
+  // same leftover flex space — the timeline box must win, WITHOUT ever
+  // overflowing the ancestor at a short window (see the timeline box's own
+  // doc comment for the flagged `min-h-64` dead end this replaced). Both
+  // boxes now carry `min-h-0` (genuinely shrinkable, default
+  // `flex-shrink: 1`, no `shrink-0` anywhere in this pair) so a real space
+  // deficit distributes proportionally instead of one box refusing to
+  // give at all; this call site also tightens the Missed table's own
+  // scrollport cap (`max-h-40`, vs its `max-h-56` default) so it claims
+  // less even in the roomy case. jsdom has no layout engine, so this only
+  // asserts the STRUCTURAL classes that implement the mechanism, not
+  // actual rendered pixel heights (that's the E2E script's job, run
+  // against the real, built app — see panel-polish-e2e.ts, which measured
+  // 268px timeline vs 182px Missed in the modal, and confirmed zero
+  // overflow/overlap at both a normal and an 800px-tall window on the
+  // completion screen).
+  it('keeps both the timeline box and the Missed box genuinely shrinkable (min-h-0, no shrink-0), with a tighter max-h-40 cap on the Missed table', () => {
+    const result = makeResult({ mistakes: { a: 3 } })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    const timelineBox = screen.getByTestId('typing-test-timeline-box')
+    expect(timelineBox.className).toContain('min-h-0')
+    expect(timelineBox.className).toContain('flex-1')
+
+    const missedBox = screen.getByTestId('typing-test-missed-box')
+    expect(missedBox.className).toContain('min-h-0')
+    expect(missedBox.className).not.toContain('shrink-0')
+
+    const missedScrollport = screen.getByTestId('missed-table-scrollport')
+    expect(missedScrollport.className).toContain('max-h-40')
+    expect(missedScrollport.className).not.toContain('max-h-56')
+  })
+
+  // Polish item 3: the Missed section used to show a border on its OWN
+  // outer box (`typing-test-missed-box`, asserted above) AND an inner
+  // border on the table's own scroll container — a visible double
+  // border around the same content. The scrollport keeps its scroll/
+  // padding but loses the border/rounded classes at THIS call site only
+  // (History's own unboxed "Most missed" instance keeps its border —
+  // see mistake-summary.test.tsx's `bordered` describe block).
+  it('removes the Missed table scrollport\'s own inner border (the outer Missed box is the only frame)', () => {
+    const result = makeResult({ mistakes: { a: 3 } })
+    renderWithI18n(<KeystrokeTimelinePanel log={SAMPLE_LOG} result={result} />)
+
+    const missedScrollport = screen.getByTestId('missed-table-scrollport')
+    expect(missedScrollport.className).not.toContain('border')
+    expect(missedScrollport.className).not.toContain('rounded-md')
+    // Still scrollable, still padded — only the border/rounded frame is gone.
+    expect(missedScrollport.className).toContain('overflow-y-auto')
+    expect(missedScrollport.className).toContain('p-2')
+
+    const missedBox = screen.getByTestId('typing-test-missed-box')
+    expect(missedBox.contains(missedScrollport)).toBe(true)
   })
 
   it('shows Substitution/Omission/Insertion as stat cards, sourced from the result', () => {

--- a/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
+++ b/src/renderer/typing-test/__tests__/WordTimelineView.test.tsx
@@ -163,13 +163,23 @@ describe('WordTimelineView', () => {
     expect(screen.queryByText('Zoom')).toBeNull()
   })
 
-  it('auto-selects line rows (never word rows) once the log has a lineBreaks field, and legend uses the line-view blank wording', async () => {
+  // FLAG (timeline-panel polish item 1): the legend's blank/blankLine
+  // entries used to carry their line-vs-word distinction (250ms vs
+  // 1000ms cutoff) directly in the always-visible label text — both now
+  // show the bare head word "Pause" (see LegendSwatch), so the
+  // distinction only surfaces in the item's own hover tooltip. Rewritten
+  // to hover the "Pause" label and assert on the opened tooltip's text
+  // instead of `getByText` on the label itself.
+  it('auto-selects line rows (never word rows) once the log has a lineBreaks field, and the legend\'s Pause tooltip uses the line-view wording', async () => {
     window.vialAPI.typingRunLogGet = vi.fn().mockResolvedValue({ success: true, data: SAMPLE_LOG_WITH_LINES })
     renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
     await waitFor(() => expect(screen.getByTestId('line-timeline-row-0')).toBeTruthy())
     expect(screen.queryByTestId('word-timeline-row-0')).toBeNull()
-    expect(screen.getByText('Pause (>250ms, shown compressed)')).toBeTruthy()
-    expect(screen.queryByText('Pause (shown compressed)')).toBeNull()
+    const pauseLabel = screen.getByText('Pause')
+    fireEvent.mouseEnter(pauseLabel)
+    const describedBy = pauseLabel.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)!.textContent).toBe('More than 250ms, shown compressed')
   })
 
   it('treats an empty lineBreaks array ([]) as a single-line log, still line mode (field PRESENCE, not emptiness, selects the mode)', async () => {
@@ -182,12 +192,17 @@ describe('WordTimelineView', () => {
     expect(screen.queryByTestId('word-timeline-row-0')).toBeNull()
   })
 
-  it('falls back to word rows (and the word-view legend wording) for a legacy log with no lineBreaks field at all', async () => {
+  // FLAG (timeline-panel polish item 1): see the line-view test above —
+  // same rewrite, word-view wording.
+  it('falls back to word rows (and the word-view legend tooltip wording) for a legacy log with no lineBreaks field at all', async () => {
     renderWithI18n(<WordTimelineView uid="uid-1" runId="run-1" onClose={() => {}} />)
     await waitFor(() => expect(screen.getByTestId('word-timeline-row-0')).toBeTruthy())
     expect(screen.queryByTestId('line-timeline-row-0')).toBeNull()
-    expect(screen.getByText('Pause (shown compressed)')).toBeTruthy()
-    expect(screen.queryByText('Pause (>250ms, shown compressed)')).toBeNull()
+    const pauseLabel = screen.getByText('Pause')
+    fireEvent.mouseEnter(pauseLabel)
+    const describedBy = pauseLabel.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+    expect(document.getElementById(describedBy!)!.textContent).toBe('Shown compressed')
   })
 
   it('renders a fractional line duration as seconds-with-one-decimal ("8.7s"), never mm:ss ("0:8...")', async () => {

--- a/src/renderer/typing-test/__tests__/mistake-summary.test.tsx
+++ b/src/renderer/typing-test/__tests__/mistake-summary.test.tsx
@@ -251,6 +251,39 @@ describe('MissedTable (bar-graph rows: Word / typed chars / stacked bar / Cnt)',
     })
   })
 
+  // `bordered`/`maxHeightClass` (timeline-panel polish items 2 & 3):
+  // KeystrokeTimelinePanel passes `maxHeightClass="max-h-40"
+  // bordered={false}` for its own bounded-modal instance (see
+  // KeystrokeTimelinePanel.test.tsx) — this describe block covers the
+  // props themselves, on `MissedTable` directly, independent of that
+  // caller.
+  describe('bordered / maxHeightClass (scrollport framing + height cap, caller-overridable)', () => {
+    it('defaults to bordered=true (rounded-md border border-edge) and max-h-56, matching History\'s unboxed "Most missed" usage', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} />)
+      const scrollport = screen.getByTestId('missed-table-scrollport')
+      expect(scrollport.className).toContain('rounded-md')
+      expect(scrollport.className).toContain('border')
+      expect(scrollport.className).toContain('border-edge')
+      expect(scrollport.className).toContain('max-h-56')
+    })
+
+    it('bordered={false} drops the rounded/border classes but keeps scroll/padding', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} bordered={false} />)
+      const scrollport = screen.getByTestId('missed-table-scrollport')
+      expect(scrollport.className).not.toContain('border')
+      expect(scrollport.className).not.toContain('rounded-md')
+      expect(scrollport.className).toContain('overflow-y-auto')
+      expect(scrollport.className).toContain('p-2')
+    })
+
+    it('maxHeightClass overrides the default max-h-56 cap', () => {
+      renderWithI18n(<MissedTable mistakes={{ h: 1 }} maxHeightClass="max-h-40" />)
+      const scrollport = screen.getByTestId('missed-table-scrollport')
+      expect(scrollport.className).toContain('max-h-40')
+      expect(scrollport.className).not.toContain('max-h-56')
+    })
+  })
+
   // Shared-component reuse (MistakeRankingSection, History's Analysis tab)
   // — proves the same row list renders correctly under the cross-run
   // caller's own titleKey/testId, not just the single-run defaults

--- a/src/renderer/typing-test/mistake-summary.tsx
+++ b/src/renderer/typing-test/mistake-summary.tsx
@@ -194,6 +194,24 @@ interface MissedTableProps {
    *  `'typing-test-mistake-ranking'` contract (TypingTestHistory.tsx's
    *  Results/Analysis tab switch depends on it structurally). */
   testId?: string
+  /** Scrollport's own max-height Tailwind class. Defaults to
+   *  `MISSED_TABLE_MAX_HEIGHT` (`max-h-56`, ~8-10 rows) — History's
+   *  "Most missed" Analysis-tab usage, which has no sibling competing for
+   *  the same bounded space. `KeystrokeTimelinePanel` passes a smaller
+   *  cap (`max-h-40`) for its own bounded-modal instance, so this table's
+   *  worst-case footprint stays comfortably under the sibling timeline
+   *  box's own `min-h-64` height floor — see that call site's own
+   *  height-priority comment for the full mechanism. */
+  maxHeightClass?: string
+  /** Whether the scrollport itself carries its own `rounded-md border
+   *  border-edge` frame. Defaults to `true` — History's "Most missed"
+   *  section has no outer box of its own (see `MistakeRankingSection`'s
+   *  doc comment: it sits among unboxed section-heading siblings), so
+   *  the scrollport's border is its ONLY framing. `KeystrokeTimelinePanel`
+   *  passes `false`: its own Missed section wrapper already frames the
+   *  whole thing (see that call site), so the scrollport's own border
+   *  was a redundant inner border double-stacked against the outer one. */
+  bordered?: boolean
 }
 
 /** Bounds the row list's own scroll container to roughly 8-10 rows'
@@ -248,18 +266,35 @@ export function MissedTable({
   mistakes, details,
   titleKey = 'editor.typingTest.results.mistakesLabel',
   testId = 'typing-test-missed-table',
+  maxHeightClass = MISSED_TABLE_MAX_HEIGHT,
+  bordered = true,
 }: MissedTableProps) {
   const { t } = useTranslation()
   const entries = useMemo(() => allSortedMistakeEntries(mistakes), [mistakes])
   if (entries.length === 0) return null
   const maxCount = entries[0][1]
+  const scrollportClass = [
+    'missed-table-scrollport',
+    'min-h-0',
+    maxHeightClass,
+    'overflow-y-auto',
+    bordered ? 'rounded-md border border-edge' : null,
+    'bg-surface p-2',
+  ].filter(Boolean).join(' ')
   return (
-    <div className="flex flex-col gap-2" data-testid={testId}>
+    // `min-h-0` (harmless when this root isn't nested inside a
+    // height-constrained flex ancestor, e.g. MistakeRankingSection's plain
+    // block placement in History) is what lets `KeystrokeTimelinePanel`'s
+    // own bounded-modal instance shrink this whole table below its natural
+    // content size instead of overflowing — see that call site's own
+    // height-priority comment (`typing-test-missed-box`'s `min-h-0`, not
+    // `shrink-0`) for the full mechanism this propagates.
+    <div className="flex min-h-0 flex-col gap-2" data-testid={testId}>
       <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
         {t(titleKey)}
       </h3>
       <div
-        className={`missed-table-scrollport ${MISSED_TABLE_MAX_HEIGHT} overflow-y-auto rounded-md border border-edge bg-surface p-2`}
+        className={scrollportClass}
         data-testid="missed-table-scrollport"
       >
         <div className="flex flex-col gap-1">

--- a/src/renderer/typing-test/word-timeline-colors.ts
+++ b/src/renderer/typing-test/word-timeline-colors.ts
@@ -33,6 +33,12 @@ export interface TimelineLegendEntry {
    *  needs an extra opacity modifier its swatch fill doesn't. */
   swatchClass: string
   labelKey: string
+  /** i18n key for this entry's former parenthetical explanation — now
+   *  shown via a hover tooltip on the label instead of inline text (see
+   *  `LegendSwatch` in KeystrokeTimelinePanel.tsx). Undefined for entries
+   *  whose head word alone was already the whole label (`normal`,
+   *  `mistake`, `leadIn`). */
+  tooltipKey?: string
 }
 
 /** Legend entries in on-screen order — `WordTimelineView` maps over this
@@ -40,9 +46,21 @@ export interface TimelineLegendEntry {
 export const TIMELINE_LEGEND: Record<TimelineFillKind, TimelineLegendEntry> = {
   normal: { swatchClass: 'bg-accent', labelKey: 'editor.typingTest.history.timeline.legend.normal' },
   mistake: { swatchClass: 'bg-danger', labelKey: 'editor.typingTest.history.timeline.legend.mistake' },
-  overlap: { swatchClass: 'bg-warning', labelKey: 'editor.typingTest.history.timeline.legend.overlap' },
-  unjudged: { swatchClass: 'bg-content-muted', labelKey: 'editor.typingTest.history.timeline.legend.unjudged' },
-  blank: { swatchClass: 'bg-content-muted opacity-40', labelKey: 'editor.typingTest.history.timeline.legend.blank' },
+  overlap: {
+    swatchClass: 'bg-warning',
+    labelKey: 'editor.typingTest.history.timeline.legend.overlap',
+    tooltipKey: 'editor.typingTest.history.timeline.legend.overlapTooltip',
+  },
+  unjudged: {
+    swatchClass: 'bg-content-muted',
+    labelKey: 'editor.typingTest.history.timeline.legend.unjudged',
+    tooltipKey: 'editor.typingTest.history.timeline.legend.unjudgedTooltip',
+  },
+  blank: {
+    swatchClass: 'bg-content-muted opacity-40',
+    labelKey: 'editor.typingTest.history.timeline.legend.blank',
+    tooltipKey: 'editor.typingTest.history.timeline.legend.blankTooltip',
+  },
   leadIn: { swatchClass: 'bg-edge-strong', labelKey: 'editor.typingTest.history.timeline.legend.leadIn' },
 }
 


### PR DESCRIPTION
## Summary
- Legend items shrink to head words ("Overlapped" / "Unjudged" / "Pause") with the former parenthetical explanations moved into hover tooltips — plain triggers with no underline/cursor decoration, matching the app's other tooltip triggers; the legend info glyph becomes a non-interactive span so it stops picking up the global button pointer cursor.
- The timeline box now genuinely outweighs the Missed box under height pressure: both participate in flex shrink (min-h-0 chain) with the Missed table capped tighter in the panel (max-h-40), so the modal shows a dominant timeline instead of a one-row sliver — measured 268px vs 182px — while the completion screen keeps zero outer overflow at normal and 800px windows (a hard min-height floor was tried first and rejected after E2E caught it overlapping the buttons).
- The Missed section loses its doubled inner border on the completion screen (bordered prop, History's unboxed MOST MISSED keeps its own scrollport border).

## Verification
- 8,528 passed / 22 skipped (+12 vs main); eslint / typecheck clean; i18n label+tooltip keys across english + 4 packs, lockstep 0.1.74.
- Virtual-device Playwright: modal height ratio, bare legend text + tooltip content on hover, computed cursor auto on the info glyph, border absence, and completion-screen overflow checks at two window heights.