### PR TITLE
fix(ui): unify tooltip behavior across the app

### DIFF
--- a/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
+++ b/src/renderer/components/analyze/AnalyzeFilterStorePanel.tsx
@@ -275,13 +275,14 @@ export function AnalyzeFilterStorePanel({
                               />
                             ) : (
                               <Tooltip content={entry.label} disabled={!entry.label} wrapperClassName="block max-w-full">
-                                <div
-                                  className="cursor-pointer truncate text-sm font-semibold text-content"
+                                <button
+                                  type="button"
+                                  className="block w-full truncate text-left text-sm font-semibold text-content"
                                   onClick={() => rename.startRename(entry.id, entry.label)}
                                   data-testid={`analyze-filter-store-entry-label-${entry.id}`}
                                 >
                                   {entry.label || t('common.noLabel')}
-                                </div>
+                                </button>
                               </Tooltip>
                             )}
                           </div>

--- a/src/renderer/components/analyze/BigramsRankingTables.tsx
+++ b/src/renderer/components/analyze/BigramsRankingTables.tsx
@@ -72,7 +72,7 @@ function SortHeader({ label, indicator, align, active, onClick, title }: SortHea
         <button
           type="button"
           onClick={onClick}
-          className={`cursor-pointer ${active ? 'text-content' : 'text-content-muted hover:text-content'}`}
+          className={active ? 'text-content' : 'text-content-muted hover:text-content'}
         >
           {label}
           {indicator}

--- a/src/renderer/components/analyze/__tests__/AnalyzeFilterStorePanel-overwrite.test.tsx
+++ b/src/renderer/components/analyze/__tests__/AnalyzeFilterStorePanel-overwrite.test.tsx
@@ -128,3 +128,24 @@ describe('AnalyzeFilterStorePanel overwrite flow', () => {
     expect(props.onOverwriteSave).not.toHaveBeenCalled()
   })
 })
+
+describe('AnalyzeFilterStorePanel entry label rename trigger', () => {
+  // Coverage for the C1 tooltip-unification fix: the clickable label
+  // used to be a non-focusable `div` (mouse-only, cursor-pointer
+  // hardcoded on top of the Tooltip trigger) — now a real `button` so
+  // it picks up focusability and the pointer cursor from the global
+  // `button:not(:disabled) { cursor: pointer }` rule instead of an
+  // inline override.
+  it('renders the entry label as a focusable button, not a div', () => {
+    renderPanel()
+    const label = screen.getByTestId('analyze-filter-store-entry-label-entry-1')
+    expect(label.tagName).toBe('BUTTON')
+    expect(label).not.toHaveClass('cursor-pointer')
+  })
+
+  it('starts rename mode when the label button is clicked', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId('analyze-filter-store-entry-label-entry-1'))
+    expect(screen.getByTestId('analyze-filter-store-rename-input-entry-1')).toBeInTheDocument()
+  })
+})

--- a/src/renderer/components/editors/KeycodeField.tsx
+++ b/src/renderer/components/editors/KeycodeField.tsx
@@ -112,7 +112,7 @@ export function KeycodeField({ value, selected, selectedMaskPart, onSelect, onMa
         aria-pressed={selected}
         data-testid="keycode-field"
         disabled={disabled}
-        className={`flex shrink-0 rounded ring-1 ${disabled ? 'cursor-default' : 'cursor-pointer'} ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
+        className={`flex shrink-0 rounded ring-1 disabled:cursor-not-allowed ${selected ? 'ring-accent' : `ring-picker-item-border ${disabled ? '' : 'hover:ring-accent'}`}`}
         onClick={handleClick}
         onDoubleClick={isMasked ? undefined : handleDoubleClick}
       >

--- a/src/renderer/components/editors/LayoutPickerContent.tsx
+++ b/src/renderer/components/editors/LayoutPickerContent.tsx
@@ -4,12 +4,13 @@
 // browse views plus the keyboard-as-keycode-picker itself. Pure props in,
 // JSX out; all state and handlers live in `useLayoutPicker`.
 
+import { useId, useLayoutEffect, useRef, useState } from 'react'
 import type { KleKey } from '../../../shared/kle/types'
 import type { DeviceInfo } from '../../../shared/types/protocol'
 import type { StoredKeyboardInfo } from '../../../shared/types/sync'
 import type { SnapshotMeta } from '../../../shared/types/snapshot-store'
 import { KeyboardPane } from './KeyboardPane'
-import { Tooltip } from '../ui/Tooltip'
+import { BUBBLE_BASE, computeBubblePosition, Tooltip } from '../ui/Tooltip'
 import { ScaleInput, ghostZoomButtonClass } from './keymap-editor-toolbar'
 import { MIN_SCALE, MAX_SCALE } from './keymap-editor-types'
 import { ZoomIn, ZoomOut } from 'lucide-react'
@@ -53,7 +54,7 @@ export interface LayoutPickerContentProps {
   handlePickerKeyClick: (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
   handlePickerHover: (key: KleKey, keycode: string, rect: DOMRect) => void
   handlePickerHoverEnd: () => void
-  pickerTooltip: { keycode: string; top: number; left: number } | null
+  pickerTooltip: { keycode: string; rect: DOMRect } | null
   setPickerSource: (source: 'file' | 'device') => void
   setPickerLayer: (layer: number) => void
   setPickerFileData: (data: PickerFileData) => void
@@ -75,6 +76,27 @@ export function LayoutPickerContent({
   pickerBrowseMode, onScaleChange, clearPickerSelection,
 }: LayoutPickerContentProps) {
   const { t } = useTranslation()
+
+  // Canonicalized shared bubble (see .claude/DESIGN.md "Tooltip" section):
+  // same `computeBubblePosition` viewport clamping every canonical
+  // `Tooltip` uses, kept as a hand-rolled single bubble (not a per-key
+  // `Tooltip` wrap) since `KeyboardPane` reports hover via one callback
+  // across the whole rendered layout rather than per-key trigger elements.
+  const pickerTooltipRef = useRef<HTMLDivElement>(null)
+  const pickerTooltipId = useId()
+  const [pickerTooltipPos, setPickerTooltipPos] = useState<{ top: number; left: number } | null>(null)
+  useLayoutEffect(() => {
+    const el = pickerTooltipRef.current
+    if (!el || !pickerTooltip) { setPickerTooltipPos(null); return }
+    setPickerTooltipPos(computeBubblePosition(
+      pickerTooltip.rect,
+      el.getBoundingClientRect(),
+      'top',
+      'center',
+      8,
+      { width: window.innerWidth, height: window.innerHeight },
+    ))
+  }, [pickerTooltip])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -165,8 +187,14 @@ export function LayoutPickerContent({
             />
             {pickerTooltip && (
               <div
-                className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
-                style={{ top: pickerTooltip.top - 4, left: pickerTooltip.left, transform: 'translate(-50%, -100%)' }}
+                ref={pickerTooltipRef}
+                role="tooltip"
+                id={pickerTooltipId}
+                className={BUBBLE_BASE}
+                style={{
+                  top: pickerTooltipPos?.top ?? pickerTooltip.rect.top,
+                  left: pickerTooltipPos?.left ?? pickerTooltip.rect.left,
+                }}
               >
                 <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">{pickerTooltip.keycode}</div>
               </div>

--- a/src/renderer/components/editors/MacroActionItem.tsx
+++ b/src/renderer/components/editors/MacroActionItem.tsx
@@ -116,7 +116,7 @@ export function MacroActionItem({
               />
             ))}
             {onEditClick && (
-              <Tooltip content={t('editor.macro.addKeycode')} side="bottom" openDelay={0}>
+              <Tooltip content={t('editor.macro.addKeycode')} side="bottom">
                 <button
                   type="button"
                   data-testid="macro-edit-action"
@@ -176,7 +176,7 @@ export function MacroActionItem({
               />
             )
           })}
-          <Tooltip content={t('editor.macro.addKeycode')} side="bottom" openDelay={0}>
+          <Tooltip content={t('editor.macro.addKeycode')} side="bottom">
             <button
               type="button"
               data-testid="macro-add-keycode"

--- a/src/renderer/components/editors/useLayoutPicker.tsx
+++ b/src/renderer/components/editors/useLayoutPicker.tsx
@@ -7,6 +7,7 @@
 // to thread it into `TabbedKeycodes`' `keyboardPickerContent` prop.
 
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { useSharedHoverBubble } from '../../hooks/use-shared-hover-bubble'
 import { useTranslation } from 'react-i18next'
 import { serialize, findKeycode } from '../../../shared/keycodes/keycodes'
 import type { Keycode } from '../../../shared/keycodes/keycodes'
@@ -79,21 +80,17 @@ export function useLayoutPicker({
   const [probeStatus, setProbeStatus] = useState<'idle' | 'probing' | 'error'>('idle')
   const [deviceBrowsing, setDeviceBrowsing] = useState(true)
   const [pickerScale, setPickerScale] = useState<number | undefined>(undefined)
-  const [pickerTooltip, setPickerTooltip] = useState<{ keycode: string; top: number; left: number } | null>(null)
+  // Canonicalized shared bubble (see .claude/DESIGN.md "Tooltip" section)
+  // rather than a per-key `Tooltip` wrap — the picker keyboard renders
+  // every key of the layout at once purely for hover, so one shared
+  // bubble covers it the same way TabbedKeycodes/PopoverTabKey do.
+  const { target: pickerTooltip, show: showPickerTooltip, hide: handlePickerHoverEnd } = useSharedHoverBubble<{ keycode: string; rect: DOMRect }>()
   // pickerClickedPositions removed — now tracked via pickerSelectedIndices in useKeymapMultiSelect
   const pickerContainerRef = useRef<HTMLDivElement>(null)
 
   const handlePickerHover = useCallback((_key: KleKey, keycode: string, rect: DOMRect) => {
-    const containerRect = pickerContainerRef.current?.getBoundingClientRect()
-    if (!containerRect) return
-    setPickerTooltip({
-      keycode,
-      top: rect.top - containerRect.top,
-      left: rect.left - containerRect.left + rect.width / 2,
-    })
-  }, [])
-
-  const handlePickerHoverEnd = useCallback(() => { setPickerTooltip(null) }, [])
+    showPickerTooltip({ keycode, rect })
+  }, [showPickerTooltip])
 
   // --- Notify parent when device list browsing state changes ---
   useEffect(() => {

--- a/src/renderer/components/keycodes/PopoverTabKey.tsx
+++ b/src/renderer/components/keycodes/PopoverTabKey.tsx
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useState, useRef, useCallback, useLayoutEffect, useMemo } from 'react'
+import { useState, useRef, useCallback, useId, useLayoutEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type Keycode, getKeycodeRevision, serialize, isMask, findInnerKeycode, isBasic, isLMKeycode, getAvailableLMMods, extractBasicKey } from '../../../shared/keycodes/keycodes'
 import { KEYCODE_CATEGORIES } from './categories'
 import { getRemapDisplayLabel } from './KeycodeGrid'
+import { BUBBLE_BASE, computeBubblePosition } from '../ui/Tooltip'
+import { useSharedHoverBubble } from '../../hooks/use-shared-hover-bubble'
 
 interface SearchEntry {
   keycode: Keycode
@@ -29,14 +31,16 @@ function flattenLabel(label: string): string {
   return label.split('\n').map((line) => line.trim()).filter(Boolean).join(' ')
 }
 
+// Shared bubble contract (see .claude/DESIGN.md "Tooltip" section): a
+// canonicalized shared bubble, not a per-row `Tooltip` wrap — up to
+// MAX_RESULTS (50) rows can be mounted at once, each with its own
+// truncated-detail hover target, so a per-row `Tooltip` would mount that
+// many portals + effects for a hover affordance only ever one row shows
+// at a time.
 interface DetailTooltipState {
   text: string
-  top: number
-  left: number
-  containerWidth: number
+  rect: DOMRect
 }
-
-const TOOLTIP_VERTICAL_GAP = 4
 
 /**
  * Strip text before and including the first underscore.
@@ -179,37 +183,37 @@ export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask 
   }, [query, searchIndex, suppressResults])
 
   // Tooltip for truncated detail text (styled like key picker tooltip in TabbedKeycodes)
-  const [tooltip, setTooltip] = useState<DetailTooltipState | null>(null)
+  const { target: tooltip, show: showTooltip, hide: hideTooltip } = useSharedHoverBubble<DetailTooltipState>()
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null)
+  const tooltipId = useId()
   const tooltipRef = useRef<HTMLDivElement>(null)
-  const containerRef = useRef<HTMLDivElement>(null)
 
-  // Clamp tooltip horizontally after render so it never overflows the container
+  // Position the bubble left-aligned above the truncated span, clamped to
+  // the VIEWPORT (not just this container) so it never clips at the
+  // screen's left/right edge.
   useLayoutEffect(() => {
     const el = tooltipRef.current
-    if (!el || !tooltip) return
-    const w = el.offsetWidth
-    const clampedLeft = Math.max(0, Math.min(tooltip.left, tooltip.containerWidth - w))
-    el.style.left = `${clampedLeft}px`
+    if (!el || !tooltip) { setTooltipPos(null); return }
+    setTooltipPos(computeBubblePosition(
+      tooltip.rect,
+      el.getBoundingClientRect(),
+      'top',
+      'start',
+      8,
+      { width: window.innerWidth, height: window.innerHeight },
+    ))
   }, [tooltip])
 
   const handleDetailMouseEnter = useCallback((e: React.MouseEvent<HTMLSpanElement>) => {
     const span = e.currentTarget
     if (span.scrollWidth <= span.clientWidth) return
-    const containerRect = containerRef.current?.getBoundingClientRect()
-    if (!containerRect) return
-    const spanRect = span.getBoundingClientRect()
-    setTooltip({
-      text: span.textContent ?? '',
-      top: spanRect.top - containerRect.top,
-      left: spanRect.left - containerRect.left,
-      containerWidth: containerRect.width,
-    })
-  }, [])
+    showTooltip({ text: span.textContent ?? '', rect: span.getBoundingClientRect() })
+  }, [showTooltip])
 
-  const handleDetailMouseLeave = useCallback(() => setTooltip(null), [])
+  const handleDetailMouseLeave = useCallback(() => hideTooltip(), [hideTooltip])
 
   return (
-    <div ref={containerRef} className="relative flex min-h-0 flex-1 flex-col gap-2">
+    <div className="flex min-h-0 flex-1 flex-col gap-2">
       <input
         type="text"
         value={query}
@@ -251,7 +255,7 @@ export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask 
               key={`${entry.categoryId}-${entry.keycode.qmkId}`}
               type="button"
               className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-surface-dim"
-              onClick={() => { setTooltip(null); onKeycodeSelect(entry.keycode); setSuppressResults(true); setQuery(entry.keycode.label || stripPrefix(entry.keycode.qmkId)) }}
+              onClick={() => { hideTooltip(); onKeycodeSelect(entry.keycode); setSuppressResults(true); setQuery(entry.keycode.label || stripPrefix(entry.keycode.qmkId)) }}
               data-testid={`popover-result-${entry.keycode.qmkId}`}
             >
               <span className={`min-w-keycode font-mono text-xs font-medium ${entry.displayLabel != null ? 'text-key-label-remap' : ''}`}>
@@ -271,8 +275,13 @@ export function PopoverTabKey({ currentKeycode, emptyInitial, maskOnly, modMask 
       {tooltip && (
         <div
           ref={tooltipRef}
-          className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
-          style={{ top: tooltip.top - TOOLTIP_VERTICAL_GAP, transform: 'translateY(-100%)' }}
+          role="tooltip"
+          id={tooltipId}
+          className={BUBBLE_BASE}
+          style={{
+            top: tooltipPos?.top ?? tooltip.rect.top,
+            left: tooltipPos?.left ?? tooltip.rect.left,
+          }}
         >
           <div className="text-xs font-medium text-content whitespace-nowrap">
             {tooltip.text}

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { findKeycode, type Keycode, getKeycodeRevision, isBasic, getAvailableLMMods, deserialize } from '../../../shared/keycodes/keycodes'
 import { parseKle } from '../../../shared/kle/kle-parser'
@@ -14,6 +14,8 @@ import { UpwardSelect } from '../UpwardSelect'
 import { KeycodeGrid } from './KeycodeGrid'
 import { BasicKeyboardView } from './BasicKeyboardView'
 import { isShiftedKeycode, getShiftedKeycode } from './SplitKey'
+import { BUBBLE_BASE, computeBubblePosition } from '../ui/Tooltip'
+import { useSharedHoverBubble } from '../../hooks/use-shared-hover-bubble'
 
 export interface KeycodeIndexEntry { baseIdx: number; shiftedIdx?: number }
 
@@ -93,13 +95,17 @@ const LM_CATEGORY: KeycodeCategory = {
   getKeycodes: getAvailableLMMods,
 }
 
-const TOOLTIP_VERTICAL_GAP = 4
-
+// Shared bubble contract (see .claude/DESIGN.md "Tooltip" section): 8px
+// offset, `computeBubblePosition` viewport clamping, `BUBBLE_BASE` skin,
+// 300ms open delay via `useSharedHoverBubble`. A canonicalized shared
+// bubble rather than per-key `Tooltip` wraps — every category's key grid
+// mounts simultaneously (inactive tabs stay in the DOM, just visually
+// hidden, to keep tab-switch instant and preserve scroll position), so a
+// per-key `Tooltip` would multiply its portal + effects across hundreds
+// of tiles that are never all visible at once.
 interface TooltipState {
   keycode: Keycode
-  top: number
-  left: number
-  containerWidth: number
+  rect: DOMRect
 }
 
 interface Props {
@@ -162,7 +168,9 @@ export function TabbedKeycodes({
     { id: 'list', name: t('settings.basicViewTypeList') },
   ], [t])
   const [activeTab, setActiveTab] = useState('basic')
-  const [tooltip, setTooltip] = useState<TooltipState | null>(null)
+  const { target: tooltip, show: showTooltip, hide: hideTooltip } = useSharedHoverBubble<TooltipState>()
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number } | null>(null)
+  const tooltipId = useId()
   const containerRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
   // Guard against spurious double-clicks right after mount (layout shift can
@@ -177,13 +185,20 @@ export function TabbedKeycodes({
     }
   }, [onKeycodeDoubleClick])
 
-  // Clamp tooltip horizontally after render so it never overflows the container
+  // Position the bubble centered above the hovered key, clamped to the
+  // VIEWPORT (not just this container) so it never clips at the screen's
+  // left/right edge — same contract every canonical `Tooltip` follows.
   useLayoutEffect(() => {
     const el = tooltipRef.current
-    if (!el || !tooltip) return
-    const w = el.offsetWidth
-    const clampedLeft = Math.max(0, Math.min(tooltip.left - w / 2, tooltip.containerWidth - w))
-    el.style.left = `${clampedLeft}px`
+    if (!el || !tooltip) { setTooltipPos(null); return }
+    setTooltipPos(computeBubblePosition(
+      tooltip.rect,
+      el.getBoundingClientRect(),
+      'top',
+      'center',
+      8,
+      { width: window.innerWidth, height: window.innerHeight },
+    ))
   }, [tooltip])
 
   // Enter key confirms current selection and closes the picker.
@@ -331,35 +346,28 @@ export function TabbedKeycodes({
   // Clear any open tooltip whenever the rendered tab changes, whether from a
   // user click or an automatic fallback/restore driven by effectiveTab.
   useEffect(() => {
-    setTooltip(null)
-  }, [effectiveTab])
+    hideTooltip()
+  }, [effectiveTab, hideTooltip])
 
   const selectTab = useCallback(
     (id: string) => {
       onTabChange?.()
       setActiveTab(id)
-      setTooltip(null)
+      hideTooltip()
     },
-    [onTabChange],
+    [onTabChange, hideTooltip],
   )
 
   const handleKeycodeHover = useCallback(
     (kc: Keycode, rect: DOMRect) => {
-      const containerRect = containerRef.current?.getBoundingClientRect()
-      if (!containerRect) return
-      setTooltip({
-        keycode: kc,
-        top: rect.top - containerRect.top,
-        left: rect.left - containerRect.left + rect.width / 2,
-        containerWidth: containerRect.width,
-      })
+      showTooltip({ keycode: kc, rect })
     },
-    [],
+    [showTooltip],
   )
 
   const handleKeycodeHoverEnd = useCallback(() => {
-    setTooltip(null)
-  }, [])
+    hideTooltip()
+  }, [hideTooltip])
 
   const activeTabKeycodeNumbers = useMemo(
     () => activeTabKeycodes.map((kc) => deserialize(kc.qmkId)),
@@ -575,15 +583,20 @@ export function TabbedKeycodes({
         {panelOverlay}
       </div>
 
-      {/* Tooltip — rendered outside the scroll container to avoid clipping */}
+      {/* Tooltip — rendered outside the scroll container to avoid clipping.
+          `BUBBLE_BASE` already positions `fixed`, so this needs no
+          container-relative math (unlike the old absolute-positioned
+          version) — `tooltipPos` is computed straight from the hovered
+          key's own viewport rect via `computeBubblePosition`. */}
       {tooltip && (
         <div
           ref={tooltipRef}
-          className="pointer-events-none absolute z-50 rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg"
+          role="tooltip"
+          id={tooltipId}
+          className={BUBBLE_BASE}
           style={{
-            top: tooltip.top - TOOLTIP_VERTICAL_GAP,
-            left: tooltip.left,
-            transform: 'translateY(-100%)',
+            top: tooltipPos?.top ?? tooltip.rect.top,
+            left: tooltipPos?.left ?? tooltip.rect.left,
           }}
         >
           <div className="text-2xs leading-snug text-content-muted whitespace-nowrap">

--- a/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/KeyPopover.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 
 vi.mock('react-i18next', () => ({
@@ -856,6 +856,58 @@ describe('KeyPopover — remount on Auto Move advance (key prop change)', () => 
 // re-derive wrapper mode / selected layer / any buffered pick for the new
 // layer's keycode, via `usePopoverKeycodeWorkflow`'s own `currentLayer` effect.
 // ---------------------------------------------------------------------------
+
+describe('PopoverTabKey — truncated detail hover tooltip (canonicalized shared bubble)', () => {
+  // jsdom never computes real layout, so `scrollWidth`/`clientWidth` both
+  // default to 0 — force a "truncated" reading (scrollWidth > clientWidth)
+  // on the hovered detail span so `handleDetailMouseEnter`'s early-return
+  // guard doesn't skip the tooltip.
+  function markTruncated(el: Element): void {
+    Object.defineProperty(el, 'scrollWidth', { configurable: true, value: 200 })
+    Object.defineProperty(el, 'clientWidth', { configurable: true, value: 100 })
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not show a tooltip for a non-truncated detail span', () => {
+    render(<PopoverTabKey currentKeycode={4} onKeycodeSelect={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'enter' } })
+    const detail = screen.getByTestId('popover-result-KC_ENTER').querySelector('span:last-child')!
+    fireEvent.mouseEnter(detail)
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows a role="tooltip" bubble with the full detail text after the 300ms open delay', () => {
+    render(<PopoverTabKey currentKeycode={4} onKeycodeSelect={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'enter' } })
+    const detail = screen.getByTestId('popover-result-KC_ENTER').querySelector('span:last-child')!
+    markTruncated(detail)
+    fireEvent.mouseEnter(detail)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+    act(() => { vi.advanceTimersByTime(300) })
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble).toHaveTextContent('Return')
+  })
+
+  it('closes instantly on mouse leave, even mid-delay', () => {
+    render(<PopoverTabKey currentKeycode={4} onKeycodeSelect={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('popover-search-input'), { target: { value: 'enter' } })
+    const detail = screen.getByTestId('popover-result-KC_ENTER').querySelector('span:last-child')!
+    markTruncated(detail)
+    fireEvent.mouseEnter(detail)
+    act(() => { vi.advanceTimersByTime(150) })
+    fireEvent.mouseLeave(detail)
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+})
 
 describe('KeyPopover — layer sidebar change (currentLayer prop, same instance)', () => {
   it('keeps the active tab on Code across a layer change', () => {

--- a/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
+++ b/src/renderer/components/keycodes/__tests__/TabbedKeycodes.test.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 
 const mockBasicKeycodes = [
   { qmkId: 'KC_A', label: 'A', hidden: false },
@@ -230,5 +230,39 @@ describe('TabbedKeycodes', () => {
         allKeycodes.forEach((kc) => { kc.hidden = false })
       }
     })
+  })
+})
+
+describe('TabbedKeycodes hover tooltip (canonicalized shared bubble)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not show the tooltip immediately on hover', () => {
+    render(<TabbedKeycodes />)
+    fireEvent.mouseEnter(screen.getByText('A').closest('button')!)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows a role="tooltip" bubble with the qmkId after the 300ms open delay', () => {
+    render(<TabbedKeycodes />)
+    fireEvent.mouseEnter(screen.getByText('A').closest('button')!)
+    act(() => { vi.advanceTimersByTime(300) })
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble).toHaveTextContent('KC_A')
+  })
+
+  it('closes instantly on mouse leave, even mid-delay', () => {
+    render(<TabbedKeycodes />)
+    const button = screen.getByText('A').closest('button')!
+    fireEvent.mouseEnter(button)
+    act(() => { vi.advanceTimersByTime(150) })
+    fireEvent.mouseLeave(button)
+    act(() => { vi.advanceTimersByTime(300) })
+    expect(screen.queryByRole('tooltip')).toBeNull()
   })
 })

--- a/src/renderer/components/ui/Tooltip.tsx
+++ b/src/renderer/components/ui/Tooltip.tsx
@@ -43,8 +43,16 @@ export interface TooltipProps {
   describedByOn?: 'trigger' | 'wrapper'
 }
 
-const BUBBLE_BASE =
-  'pointer-events-none fixed z-50 w-max rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg text-xs font-medium text-content whitespace-pre-line transition-opacity'
+// Exported so the handful of hand-rolled shared-bubble tooltips (perf-
+// sensitive surfaces that render one bubble over many hover targets
+// instead of wrapping each target in its own `Tooltip`, e.g. the keycode
+// picker) can match this exact skin instead of drifting into their own
+// ad-hoc styling. `max-w-sm` is the default cap for dynamic/long content
+// (filter summaries, snapshot labels, …); callers needing a narrower
+// bubble still pass their own `max-w-xs` via `className`, which wins
+// because it's appended after this base string.
+export const BUBBLE_BASE =
+  'pointer-events-none fixed z-50 w-max max-w-sm rounded-md border border-edge bg-surface-alt px-2.5 py-1.5 shadow-lg text-xs font-medium text-content whitespace-pre-line transition-opacity'
 
 const WRAPPER_BASE = 'relative inline-block'
 

--- a/src/renderer/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/renderer/components/ui/__tests__/Tooltip.test.tsx
@@ -129,6 +129,26 @@ describe('Tooltip', () => {
     expect(bubble.className).toContain('opacity-0')
   })
 
+  it('defaults the bubble to max-w-sm so long dynamic content wraps instead of overflowing', () => {
+    render(
+      <Tooltip content="Help">
+        <button type="button">Trigger</button>
+      </Tooltip>,
+    )
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.className).toContain('max-w-sm')
+  })
+
+  it('lets an explicit max-w-xs className win over the default max-w-sm', () => {
+    render(
+      <Tooltip content="Help" className="max-w-xs">
+        <button type="button">Trigger</button>
+      </Tooltip>,
+    )
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.className).toContain('max-w-xs')
+  })
+
   it('merges additional className into bubble', () => {
     render(
       <Tooltip content="Help" className="custom-bubble">

--- a/src/renderer/hooks/__tests__/use-shared-hover-bubble.test.ts
+++ b/src/renderer/hooks/__tests__/use-shared-hover-bubble.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSharedHoverBubble, SHARED_BUBBLE_OPEN_DELAY_MS } from '../use-shared-hover-bubble'
+
+describe('useSharedHoverBubble', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts with no target shown', () => {
+    const { result } = renderHook(() => useSharedHoverBubble<string>())
+    expect(result.current.target).toBeNull()
+  })
+
+  it('delays showing the target by SHARED_BUBBLE_OPEN_DELAY_MS', () => {
+    const { result } = renderHook(() => useSharedHoverBubble<string>())
+    act(() => result.current.show('a'))
+    expect(result.current.target).toBeNull()
+    act(() => vi.advanceTimersByTime(SHARED_BUBBLE_OPEN_DELAY_MS - 1))
+    expect(result.current.target).toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current.target).toBe('a')
+  })
+
+  it('hides instantly, with no delay', () => {
+    const { result } = renderHook(() => useSharedHoverBubble<string>())
+    act(() => result.current.show('a'))
+    act(() => vi.advanceTimersByTime(SHARED_BUBBLE_OPEN_DELAY_MS))
+    expect(result.current.target).toBe('a')
+    act(() => result.current.hide())
+    expect(result.current.target).toBeNull()
+  })
+
+  it('restarts the timer when show is called again before it fires (moving between adjacent targets)', () => {
+    const { result } = renderHook(() => useSharedHoverBubble<string>())
+    act(() => result.current.show('a'))
+    act(() => vi.advanceTimersByTime(SHARED_BUBBLE_OPEN_DELAY_MS - 1))
+    act(() => result.current.show('b'))
+    act(() => vi.advanceTimersByTime(SHARED_BUBBLE_OPEN_DELAY_MS - 1))
+    expect(result.current.target).toBeNull()
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current.target).toBe('b')
+  })
+
+  it('cancels a pending show when hide is called first', () => {
+    const { result } = renderHook(() => useSharedHoverBubble<string>())
+    act(() => result.current.show('a'))
+    act(() => result.current.hide())
+    act(() => vi.advanceTimersByTime(SHARED_BUBBLE_OPEN_DELAY_MS))
+    expect(result.current.target).toBeNull()
+  })
+})

--- a/src/renderer/hooks/use-shared-hover-bubble.ts
+++ b/src/renderer/hooks/use-shared-hover-bubble.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// State + timer management for a SINGLE shared hover bubble reused across
+// many hover targets — the keycode picker's key grid, its search result
+// rows, the keyboard-layout picker's key tiles. Wrapping every one of
+// those targets in its own `Tooltip` (portal + a few effects + a ref each)
+// is fine for a handful of triggers but too costly when a screen can
+// render hundreds of them at once (see TabbedKeycodes/PopoverTabKey/
+// LayoutPickerContent's own perf-sensitive doc comments — this is the
+// "canonicalized shared bubble" half of the tooltip-unification pass,
+// as opposed to wrapping each target in `Tooltip` directly).
+//
+// Behavior mirrors `Tooltip.tsx`'s own contract even though the mechanism
+// differs: `Tooltip` delays the CSS opacity transition so a fast hover
+// never shows anything (mount stays, paint doesn't); this hook instead
+// delays the STATE update itself (nothing mounts until the timer fires),
+// which is the natural fit here since these call sites build their own
+// bubble content function-by-function rather than rendering a fixed
+// child. Either mechanism produces the same "no flash on a quick hover
+// pass, close is instant" behavior from the user's perspective.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/** Same default as `Tooltip.tsx`'s `openDelay` prop. Kept as its own
+ *  constant (not imported from Tooltip.tsx) since these call sites don't
+ *  render a `Tooltip` at all — this is a parallel, deliberately-matched
+ *  value, not a shared prop default. */
+export const SHARED_BUBBLE_OPEN_DELAY_MS = 300
+
+export interface SharedHoverBubble<T> {
+  /** The currently-shown hover target, or null while closed/pending. */
+  target: T | null
+  /** Call from the hovered element's mouse-enter handler. Schedules
+   *  `target` to be set after `SHARED_BUBBLE_OPEN_DELAY_MS` — repeated
+   *  calls (moving between adjacent targets) restart the timer, so only
+   *  a genuine dwell opens the bubble. */
+  show: (value: T) => void
+  /** Call from the mouse-leave handler. Cancels any pending open and
+   *  clears the bubble immediately — closing is never delayed. */
+  hide: () => void
+}
+
+export function useSharedHoverBubble<T>(): SharedHoverBubble<T> {
+  const [target, setTarget] = useState<T | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+  }, [])
+
+  const show = useCallback((value: T) => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null
+      setTarget(value)
+    }, SHARED_BUBBLE_OPEN_DELAY_MS)
+  }, [])
+
+  const hide = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+      timerRef.current = null
+    }
+    setTarget(null)
+  }, [])
+
+  return { target, show, hide }
+}

--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -259,7 +259,7 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
       tooltipRef.current.getBoundingClientRect(),
       'bottom',
       'start',
-      6,
+      8,
       { width: window.innerWidth, height: window.innerHeight },
     ))
   }, [hover])
@@ -513,8 +513,8 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
           {hover && (
             <div
               ref={tooltipRef}
-              className="pointer-events-none fixed z-70"
-              style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 6 }}
+              className="pointer-events-none fixed z-50"
+              style={{ left: tooltipPos?.left ?? hover.rect.left, top: tooltipPos?.top ?? hover.rect.bottom + 8 }}
               data-testid="word-timeline-tooltip"
             >
               {hover.segment.kind === 'keystroke'

--- a/src/renderer/typing-test/RomajiSettingsModal.tsx
+++ b/src/renderer/typing-test/RomajiSettingsModal.tsx
@@ -243,7 +243,7 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
                 separates the two groups (per design feedback). */}
             <div className={STYLE_GRID_CLASS}>
               {BASE_STYLES.map((style) => (
-                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full" className="max-w-sm">
+                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full">
                   <button
                     type="button"
                     data-testid={`romaji-guide-base-${style}`}
@@ -259,7 +259,7 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
 
             <div className={`${STYLE_GRID_CLASS} mt-3`}>
               {OPTION_STYLES.map((style) => (
-                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full" className="max-w-sm">
+                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full">
                   <button
                     type="button"
                     data-testid={`romaji-guide-${style}`}
@@ -288,7 +288,7 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
               {BASE_STYLES.map((style) => {
                 const baseEnabled = !disabledStyles.has(style)
                 return (
-                  <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full" className="max-w-sm">
+                  <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full">
                     <button
                       type="button"
                       data-testid={`romaji-base-${style}`}
@@ -305,7 +305,7 @@ export function RomajiSettingsModal({ config, onConfigChange, onClose }: Props) 
 
             <div className={`${STYLE_GRID_CLASS} mt-3`}>
               {OPTION_STYLES.map((style) => (
-                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full" className="max-w-sm">
+                <Tooltip key={style} content={t(`editor.typingTest.romajiSettings.styleTip.${style}`)} side="top" wrapperClassName="w-full">
                   <button
                     type="button"
                     data-testid={`romaji-input-${style}`}


### PR DESCRIPTION
## Summary
- Trigger-anchored tooltips unify on the canonical component's contract: 300ms open delay (the two openDelay=0 stragglers removed), a default `max-w-sm` bubble width (unbounded dynamic content now wraps; explicit narrower overrides still win), and no cursor overrides from the tooltip itself — buttons keep their global pointer, informational triggers keep the default arrow, disabled buttons unify on `disabled:cursor-not-allowed`.
- The three hand-rolled hover bubbles (keycode picker tiles, popover search details, layout-picker keys) adopt the canonical contract — bubble skin, 300ms delay, offset-8 viewport clamping, `role=tooltip` — via a new shared `useSharedHoverBubble` hook, keeping their perf-friendly single-bubble structure (hundreds of simultaneously mounted triggers).
- The keystroke timeline's bar bubble drops its stray `z-70`/offset-6 for the standard `z-50`/8; the saved-filter rename label becomes a real focusable button; redundant cursor declarations removed. Same-control side placements were audited and left contextually correct.

## Verification
- 8,543 passed / 22 skipped (+15: hook suite, delay/role tests for both migrated bubbles, Tooltip default-width tests, rename-button tests); eslint / typecheck clean; no i18n changes.
- Virtual-device edge check: bubbles measured within [8, viewport-8] on six surfaces incl. the picker's leftmost/rightmost keys; the clamp branch itself is covered by computeBubblePosition's unit tests.