### PR TITLE
feat(ui): lower the minimum window size and default to 1440

### DIFF
--- a/src/main/app-config.ts
+++ b/src/main/app-config.ts
@@ -7,13 +7,19 @@ import { IpcChannels } from '../shared/ipc/channels'
 import { DEFAULT_APP_CONFIG, SETTABLE_APP_CONFIG_KEYS, type AppConfig, type WindowState } from '../shared/types/app-config'
 import { secureHandle } from './ipc-guard'
 
-export const MIN_WIDTH = 1360
+export const MIN_WIDTH = 1280
 export const MIN_HEIGHT = 1024
+
+/** Default window width for a fresh launch (no saved window state).
+ * Wider than the enforced {@link MIN_WIDTH} floor because keyboards are
+ * physically wide, and the extra room keeps the keymap editor comfortable
+ * out of the box. */
+const DEFAULT_WIDTH = 1440
 
 const DEFAULT_STATE: WindowState = {
   x: -1,
   y: -1,
-  width: MIN_WIDTH,
+  width: DEFAULT_WIDTH,
   height: MIN_HEIGHT,
 }
 

--- a/src/renderer/components/analyze/stat-card.tsx
+++ b/src/renderer/components/analyze/stat-card.tsx
@@ -93,7 +93,7 @@ interface GridProps {
  * and `context` — same API shape as {@link AnalyzeSummaryTable} so
  * callers can swap between the two without rewriting their item
  * generator. The grid is always 4 columns (Electron main window enforces
- * `minWidth: 1360` so the Tailwind `sm` breakpoint is always met). */
+ * `minWidth: 1280` so the Tailwind `sm` breakpoint is always met). */
 export function AnalyzeStatGrid({ items, ariaLabelKey, testId, tooltipSide }: GridProps) {
   const { t } = useTranslation()
   return (


### PR DESCRIPTION
## Summary
- The window's minimum size drops from 1360×1024 to **1280×1024**, while a new `DEFAULT_WIDTH` makes fresh installs open at **1440×1024** (saved window states are still clamped to the minimum, not the default). Keyboards are wide; the default gives them comfortable room while the lower floor accommodates smaller displays.
- A stale doc comment referencing the old 1360 floor is updated; no other code referenced it.

## Verification
- Fresh-launch bounds asserted programmatically at 1440×1024 on the virtual device.
- Footer single-line guarantee re-verified at the new 1280px floor with seeded long theme labels (0.0px height delta vs a 2000px-wide window) — the existing shrink/truncate floors already cover it, no changes needed.
- Full suite 8,575 passed / 22 skipped; eslint and typecheck clean.