### PR TITLE
feat(ui): show average key press duration in the typing test

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.76",
+  "version": "0.1.77",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -485,6 +485,7 @@
         "last10Avg": "直近10回",
         "totalTests": "テスト数",
         "avgAccuracy": "平均正確性",
+        "avgHold": "平均キー押下時間",
         "date": "日時",
         "name": "名前",
         "unnamed": "名称未設定",
@@ -542,7 +543,9 @@
             "overlap": "重複率",
             "duration": "所要時間",
             "kpm": "1分あたりの打鍵数",
-            "durationSeconds": "{{s}}秒"
+            "durationSeconds": "{{s}}秒",
+            "avgHold": "平均キー押下時間",
+            "avgHoldTooltip": "キーを押してから離すまでの平均時間（ミリ秒）。"
           },
           "legend": {
             "normal": "通常の打鍵",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.76",
+  "version": "0.1.77",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -485,6 +485,7 @@
         "last10Avg": "最近の10回",
         "totalTests": "テスト数☆",
         "avgAccuracy": "平均ガチ度",
+        "avgHold": "平均押しっぱ時間☆",
         "date": "いつ？",
         "name": "名前",
         "unnamed": "名前なし☆",
@@ -542,7 +543,9 @@
             "overlap": "重複率☆",
             "duration": "所要時間☆",
             "kpm": "1分の打鍵数☆",
-            "durationSeconds": "{{s}}秒"
+            "durationSeconds": "{{s}}秒",
+            "avgHold": "平均押しっぱ時間☆",
+            "avgHoldTooltip": "キー押してから離すまでの平均時間（ミリ秒）だよ☆"
           },
           "legend": {
             "normal": "普通の打鍵",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.76",
+  "version": "0.1.77",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -485,6 +485,7 @@
         "last10Avg": "直近10回",
         "totalTests": "テスト数",
         "avgAccuracy": "平均正確さ",
+        "avgHold": "平均キー押下時間どすえ",
         "date": "日時",
         "name": "名前",
         "unnamed": "名なしどすえ",
@@ -542,7 +543,9 @@
             "overlap": "重複率どすえ",
             "duration": "所要時間どすえ",
             "kpm": "1分あたりの打鍵数どすえ",
-            "durationSeconds": "{{s}}秒"
+            "durationSeconds": "{{s}}秒",
+            "avgHold": "平均キー押下時間どすえ",
+            "avgHoldTooltip": "キーを押してから離すまでの平均の時間（ミリ秒）どすえ。"
           },
           "legend": {
             "normal": "通常の打鍵どすえ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.76",
+  "version": "0.1.77",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -485,6 +485,7 @@
         "last10Avg": "直近十回",
         "totalTests": "試練の数",
         "avgAccuracy": "平均正確さ",
+        "avgHold": "平均押鍵時間",
         "date": "日時",
         "name": "名",
         "unnamed": "名もなし",
@@ -542,7 +543,9 @@
             "overlap": "重複率",
             "duration": "所要時間",
             "kpm": "1分あたりの打鍵数",
-            "durationSeconds": "{{s}}秒"
+            "durationSeconds": "{{s}}秒",
+            "avgHold": "平均押鍵時間",
+            "avgHoldTooltip": "キーを押してから離すまでの平均時間（ミリ秒）でございます。"
           },
           "legend": {
             "normal": "通常の打鍵",

--- a/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
+++ b/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
@@ -115,18 +115,18 @@ describe('useRunLogRecorder — currentRunHoldStats passthrough', () => {
       kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1080, durationMs: 80,
     })
 
-    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 80, holdSamples: 1 })
+    expect(result.current.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 80, holdSamples: 1 })
 
     result.current.finishAndSave('kb-1', wordResults, {
       runId: 'run-1', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
       charCorrelationUnavailable: false, romajiInput: false,
     })
     // finishAndSave cleared the buffer — the same runId now reads zeroed.
-    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    expect(result.current.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
   })
 
   it('returns a zeroed pair for a runId with nothing buffered', () => {
     const { result } = renderRecorder(true)
-    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    expect(result.current.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
   })
 })

--- a/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
+++ b/src/renderer/components/editors/__tests__/use-run-log-recorder.test.ts
@@ -106,3 +106,27 @@ describe('useRunLogRecorder — finishAndSave return value', () => {
     expect(mockTypingRunLogSave).not.toHaveBeenCalled()
   })
 })
+
+describe('useRunLogRecorder — currentRunHoldStats passthrough', () => {
+  it('reads the buffered hold sums for the active run, before finishAndSave clears it', () => {
+    const { result } = renderRecorder(true)
+    driveOneKeystroke(result, 'run-1', 0)
+    result.current.record({ typingTestLabel: 'words (english)', runId: 'run-1', windowFocused: true }, {
+      kind: 'matrix-release', row: 0, col: 0, layer: 0, keycode: KC_A, ts: 1080, durationMs: 80,
+    })
+
+    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 80, holdSamples: 1 })
+
+    result.current.finishAndSave('kb-1', wordResults, {
+      runId: 'run-1', startedAtMs: 1000, durationMs: 500, mode: 'words', language: 'english',
+      charCorrelationUnavailable: false, romajiInput: false,
+    })
+    // finishAndSave cleared the buffer — the same runId now reads zeroed.
+    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+  })
+
+  it('returns a zeroed pair for a runId with nothing buffered', () => {
+    const { result } = renderRecorder(true)
+    expect(result.current.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+  })
+})

--- a/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
+++ b/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
@@ -372,15 +372,26 @@ describe('useTypingTestResultSave — lastFinishedLog (completion timeline PR-B)
   })
 })
 
-// Average key-hold duration: `currentRunHoldStats` is snapshotted BEFORE
-// `finishAndSave` (see run-log-recorder.ts's own ordering note) so the
-// still-buffered raw pair makes it onto the saved TypingTestResult.
+// Average key-hold duration: `resetMatrixPressTracking` drains the matrix
+// ordering queue, THEN `currentRunHoldStats` is snapshotted, THEN
+// `finishAndSave` runs — in that exact order (see
+// use-typing-test-result-save.ts's own ordering comment above the
+// `drained`/`startedAtMs` consts) — so a keystroke the drain synchronously
+// appends to the recorder's buffer still makes it onto the saved
+// TypingTestResult, the same as it makes it into the saved run log.
 describe('useTypingTestResultSave — average key-hold duration wiring', () => {
   function renderWithHoldStats(holdStats: { holdSumMs: number; holdSamples: number }) {
     const callOrder: string[] = []
-    const currentRunHoldStats = vi.fn((runId: string) => {
+    const resetMatrixPressTracking = vi.fn(() => {
+      callOrder.push('resetMatrixPressTracking')
+      return Promise.resolve()
+    })
+    const currentRunHoldStats = vi.fn((runId: string, startedAtMs: number) => {
       callOrder.push('currentRunHoldStats')
       expect(runId).toBe('run-1')
+      // 1000 is `makeState`'s default `startTime` — the value
+      // `useTypingTestResultSave` must forward verbatim as `startedAtMs`.
+      expect(startedAtMs).toBe(1000)
       return holdStats
     })
     const finishAndSave = vi.fn(() => {
@@ -392,8 +403,9 @@ describe('useTypingTestResultSave — average key-hold duration wiring', () => {
       record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(),
       finishAndSave, currentRunHoldStats, discardRun: vi.fn(),
     }
+    const typingTest = { ...makeTypingTest({}, DEFAULT_CONFIG), resetMatrixPressTracking }
     const options: UseTypingTestResultSaveOptions = {
-      typingTest: makeTypingTest({}, DEFAULT_CONFIG),
+      typingTest,
       onSaveTypingTestResult,
       saveUnnamed: true,
       savedMemoryRef: { current: undefined } as RefObject<undefined>,
@@ -403,13 +415,13 @@ describe('useTypingTestResultSave — average key-hold duration wiring', () => {
       runLog,
     }
     renderHook(() => useTypingTestResultSave(options))
-    return { onSaveTypingTestResult, currentRunHoldStats, callOrder }
+    return { onSaveTypingTestResult, currentRunHoldStats, resetMatrixPressTracking, callOrder }
   }
 
-  it('reads the recorder\'s current-run hold stats before finishAndSave, and stores the pair on the saved result', () => {
+  it('drains the matrix queue, THEN reads the recorder\'s current-run hold stats, THEN finishAndSave — and stores the pair on the saved result', () => {
     const { onSaveTypingTestResult, currentRunHoldStats, callOrder } = renderWithHoldStats({ holdSumMs: 240, holdSamples: 3 })
-    expect(currentRunHoldStats).toHaveBeenCalledWith('run-1')
-    expect(callOrder).toEqual(['currentRunHoldStats', 'finishAndSave'])
+    expect(currentRunHoldStats).toHaveBeenCalledWith('run-1', 1000)
+    expect(callOrder).toEqual(['resetMatrixPressTracking', 'currentRunHoldStats', 'finishAndSave'])
     expect(onSaveTypingTestResult).toHaveBeenCalledTimes(1)
     const saved = onSaveTypingTestResult.mock.calls[0][0]
     expect(saved.holdSumMs).toBe(240)
@@ -421,5 +433,52 @@ describe('useTypingTestResultSave — average key-hold duration wiring', () => {
     const saved = onSaveTypingTestResult.mock.calls[0][0]
     expect(saved.holdSumMs).toBeUndefined()
     expect(saved.holdSamples).toBeUndefined()
+  })
+
+  it('includes a hold sample the drain synchronously appends to the buffer — reading currentRunHoldStats before the drain would miss it', () => {
+    // Simulates resetMatrixPressTracking's real synchronous side effect: a
+    // queued tap-hold press settles and reaches runLog.record synchronously
+    // (MatrixAnalyticsQueue.drainAll's for-loop calls emit(), and
+    // emitAnalyticsEvent calls runLog.record as its very first statement,
+    // before any IPC await — see use-typing-analytics-sink.ts), appending
+    // a new sample to the recorder's buffer before resetMatrixPressTracking
+    // returns. currentRunHoldStats must see the buffer AFTER that append.
+    const callOrder: string[] = []
+    let holdStatsAfterDrain = { holdSumMs: 0, holdSamples: 0 }
+    const resetMatrixPressTracking = vi.fn(() => {
+      callOrder.push('resetMatrixPressTracking')
+      holdStatsAfterDrain = { holdSumMs: 90, holdSamples: 1 }
+      return Promise.resolve()
+    })
+    const currentRunHoldStats = vi.fn((runId: string, startedAtMs: number) => {
+      callOrder.push('currentRunHoldStats')
+      expect(runId).toBe('run-1')
+      expect(startedAtMs).toBe(1000)
+      return holdStatsAfterDrain
+    })
+    const finishAndSave = vi.fn(() => null)
+    const onSaveTypingTestResult = vi.fn()
+    const runLog: UseRunLogRecorderReturn = {
+      record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(),
+      finishAndSave, currentRunHoldStats, discardRun: vi.fn(),
+    }
+    const typingTest = { ...makeTypingTest({}, DEFAULT_CONFIG), resetMatrixPressTracking }
+    const options: UseTypingTestResultSaveOptions = {
+      typingTest,
+      onSaveTypingTestResult,
+      saveUnnamed: true,
+      savedMemoryRef: { current: undefined } as RefObject<undefined>,
+      onMemoryChangeRef: { current: undefined } as RefObject<undefined>,
+      keyboardRef: { current: { uid: 'kb-1', vendorId: 1, productId: 1, productName: 'x' } } as UseTypingTestResultSaveOptions['keyboardRef'],
+      flushAfterPendingEmits: vi.fn(),
+      runLog,
+    }
+    renderHook(() => useTypingTestResultSave(options))
+
+    expect(callOrder).toEqual(['resetMatrixPressTracking', 'currentRunHoldStats'])
+    expect(onSaveTypingTestResult).toHaveBeenCalledTimes(1)
+    const saved = onSaveTypingTestResult.mock.calls[0][0]
+    expect(saved.holdSumMs).toBe(90)
+    expect(saved.holdSamples).toBe(1)
   })
 })

--- a/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
+++ b/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
@@ -113,6 +113,7 @@ function run(
     noteRegistration: vi.fn(),
     noteCharContext: vi.fn(),
     finishAndSave,
+    currentRunHoldStats: vi.fn().mockReturnValue({ holdSumMs: 0, holdSamples: 0 }),
     discardRun: vi.fn(),
   }
   const options: UseTypingTestResultSaveOptions = {
@@ -327,7 +328,8 @@ describe('useTypingTestResultSave — lastFinishedLog (completion timeline PR-B)
   function renderWithFinishAndSave(status: TypingTestState['status'], finishAndSaveReturn: RunKeystrokeLog | null) {
     const finishAndSave = vi.fn().mockReturnValue(finishAndSaveReturn)
     const runLog: UseRunLogRecorderReturn = {
-      record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(), finishAndSave, discardRun: vi.fn(),
+      record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(), finishAndSave,
+      currentRunHoldStats: vi.fn().mockReturnValue({ holdSumMs: 0, holdSamples: 0 }), discardRun: vi.fn(),
     }
     const buildOptions = (s: TypingTestState['status']): UseTypingTestResultSaveOptions => ({
       typingTest: makeTypingTest({ status: s }, DEFAULT_CONFIG),
@@ -367,5 +369,57 @@ describe('useTypingTestResultSave — lastFinishedLog (completion timeline PR-B)
   it('starts null before any run has ever finished', () => {
     const { result } = renderWithFinishAndSave('waiting', FAKE_LOG)
     expect(result.current.lastFinishedLog).toBeNull()
+  })
+})
+
+// Average key-hold duration: `currentRunHoldStats` is snapshotted BEFORE
+// `finishAndSave` (see run-log-recorder.ts's own ordering note) so the
+// still-buffered raw pair makes it onto the saved TypingTestResult.
+describe('useTypingTestResultSave — average key-hold duration wiring', () => {
+  function renderWithHoldStats(holdStats: { holdSumMs: number; holdSamples: number }) {
+    const callOrder: string[] = []
+    const currentRunHoldStats = vi.fn((runId: string) => {
+      callOrder.push('currentRunHoldStats')
+      expect(runId).toBe('run-1')
+      return holdStats
+    })
+    const finishAndSave = vi.fn(() => {
+      callOrder.push('finishAndSave')
+      return null
+    })
+    const onSaveTypingTestResult = vi.fn()
+    const runLog: UseRunLogRecorderReturn = {
+      record: vi.fn(), noteRegistration: vi.fn(), noteCharContext: vi.fn(),
+      finishAndSave, currentRunHoldStats, discardRun: vi.fn(),
+    }
+    const options: UseTypingTestResultSaveOptions = {
+      typingTest: makeTypingTest({}, DEFAULT_CONFIG),
+      onSaveTypingTestResult,
+      saveUnnamed: true,
+      savedMemoryRef: { current: undefined } as RefObject<undefined>,
+      onMemoryChangeRef: { current: undefined } as RefObject<undefined>,
+      keyboardRef: { current: { uid: 'kb-1', vendorId: 1, productId: 1, productName: 'x' } } as UseTypingTestResultSaveOptions['keyboardRef'],
+      flushAfterPendingEmits: vi.fn(),
+      runLog,
+    }
+    renderHook(() => useTypingTestResultSave(options))
+    return { onSaveTypingTestResult, currentRunHoldStats, callOrder }
+  }
+
+  it('reads the recorder\'s current-run hold stats before finishAndSave, and stores the pair on the saved result', () => {
+    const { onSaveTypingTestResult, currentRunHoldStats, callOrder } = renderWithHoldStats({ holdSumMs: 240, holdSamples: 3 })
+    expect(currentRunHoldStats).toHaveBeenCalledWith('run-1')
+    expect(callOrder).toEqual(['currentRunHoldStats', 'finishAndSave'])
+    expect(onSaveTypingTestResult).toHaveBeenCalledTimes(1)
+    const saved = onSaveTypingTestResult.mock.calls[0][0]
+    expect(saved.holdSumMs).toBe(240)
+    expect(saved.holdSamples).toBe(3)
+  })
+
+  it('stores neither field when nothing was observed this run (zero samples)', () => {
+    const { onSaveTypingTestResult } = renderWithHoldStats({ holdSumMs: 0, holdSamples: 0 })
+    const saved = onSaveTypingTestResult.mock.calls[0][0]
+    expect(saved.holdSumMs).toBeUndefined()
+    expect(saved.holdSamples).toBeUndefined()
   })
 })

--- a/src/renderer/components/editors/use-run-log-recorder.ts
+++ b/src/renderer/components/editors/use-run-log-recorder.ts
@@ -71,8 +71,10 @@ export interface UseRunLogRecorderReturn {
    *  read-only snapshot of the average-key-hold raw pair for `runId`'s
    *  still-buffered keystrokes, callable BEFORE `finishAndSave` (see that
    *  method's own doc comment for why `useTypingTestResultSave` needs the
-   *  ordering). */
-  currentRunHoldStats: (runId: string) => { holdSumMs: number; holdSamples: number }
+   *  ordering). `startedAtMs` must be the exact same value the caller is
+   *  about to pass as `finishAndSave`'s own `meta.startedAtMs` — see
+   *  `currentRunHoldStats`'s own doc comment for why the two must agree. */
+  currentRunHoldStats: (runId: string, startedAtMs: number) => { holdSumMs: number; holdSamples: number }
   /** Discard `runId`'s buffer and block it from being re-buffered later
    *  under the same id — see the module doc comment's `discardRun`
    *  bullet and run-log-recorder.ts's `discardRun()`. */
@@ -146,8 +148,8 @@ export function useRunLogRecorder({
     recorderRef.current.discardRun(runId)
   }, [])
 
-  const currentRunHoldStats = useCallback((runId: string) => {
-    return recorderRef.current.currentRunHoldStats(runId)
+  const currentRunHoldStats = useCallback((runId: string, startedAtMs: number) => {
+    return recorderRef.current.currentRunHoldStats(runId, startedAtMs)
   }, [])
 
   return { record, noteRegistration, noteCharContext, finishAndSave, currentRunHoldStats, discardRun }

--- a/src/renderer/components/editors/use-run-log-recorder.ts
+++ b/src/renderer/components/editors/use-run-log-recorder.ts
@@ -67,6 +67,12 @@ export interface UseRunLogRecorderReturn {
    *  (Plan-completion-timeline-view PR-B), no IPC round-trip needed since
    *  this is the exact object already handed to `typingRunLogSave`. */
   finishAndSave: (uid: string | undefined, wordResults: readonly WordResult[], meta: Omit<RunLogFinishMeta, 'uid'>) => RunKeystrokeLog | null
+  /** Direct passthrough to `RunLogRecorder.currentRunHoldStats` — a
+   *  read-only snapshot of the average-key-hold raw pair for `runId`'s
+   *  still-buffered keystrokes, callable BEFORE `finishAndSave` (see that
+   *  method's own doc comment for why `useTypingTestResultSave` needs the
+   *  ordering). */
+  currentRunHoldStats: (runId: string) => { holdSumMs: number; holdSamples: number }
   /** Discard `runId`'s buffer and block it from being re-buffered later
    *  under the same id — see the module doc comment's `discardRun`
    *  bullet and run-log-recorder.ts's `discardRun()`. */
@@ -140,5 +146,9 @@ export function useRunLogRecorder({
     recorderRef.current.discardRun(runId)
   }, [])
 
-  return { record, noteRegistration, noteCharContext, finishAndSave, discardRun }
+  const currentRunHoldStats = useCallback((runId: string) => {
+    return recorderRef.current.currentRunHoldStats(runId)
+  }, [])
+
+  return { record, noteRegistration, noteCharContext, finishAndSave, currentRunHoldStats, discardRun }
 }

--- a/src/renderer/components/editors/use-typing-test-result-save.ts
+++ b/src/renderer/components/editors/use-typing-test-result-save.ts
@@ -174,6 +174,31 @@ export function useTypingTestResultSave({
       const elapsed = typingTest.state.startTime && typingTest.state.endTime
         ? typingTest.state.endTime - typingTest.state.startTime
         : 0
+      // The same instant `finishAndSave`'s own `meta.startedAtMs` gets
+      // below — computed ONCE and reused for both, rather than calling
+      // `Date.now()` twice (which could disagree by a few ms and make the
+      // hold-stats snapshot's pre-start filter and `convertKeystrokes`'
+      // own filter draw the boundary in two slightly different places).
+      const startedAtMs = typingTest.state.startTime ?? Date.now()
+
+      // Drain any matrix event still sitting in the tap-hold ordering
+      // queue BEFORE snapshotting the recorder's hold stats below —
+      // `resetMatrixPressTracking`'s drain (see its own doc comment /
+      // MatrixAnalyticsQueue.drainAll) settles every queued item
+      // SYNCHRONOUSLY, and each settled item reaches `runLog.record`
+      // (appending it to the very buffer `currentRunHoldStats` is about
+      // to read) before emitAnalyticsEvent's own async IPC send — see
+      // use-typing-analytics-sink.ts's `emitAnalyticsEvent`, which calls
+      // `runLog.record` as its very first statement. Reading the hold
+      // stats before this drain could miss a keystroke that the SAVED
+      // log (via `finishAndSave` below, itself downstream of this same
+      // drained buffer) still includes — the History value and the
+      // timeline it links to must agree. Only drained when there's an
+      // active keyboard uid to flush for below, matching the original
+      // (pre-hold-stats) gating exactly.
+      const uid = keyboardRef.current?.uid
+      const drained = uid ? resetMatrixPressTracking() : undefined
+
       const result = buildTypingTestResult({
         correctChars: typingTest.state.correctChars,
         incorrectChars: typingTest.state.incorrectChars,
@@ -192,12 +217,13 @@ export function useTypingTestResultSave({
         confirmedChars: typingTest.state.confirmedChars,
         kspcUncomputable: typingTest.state.kspcUncomputable,
         wordResults: typingTest.state.wordResults,
-        // Snapshotted from the recorder's still-buffered keystrokes BEFORE
-        // `runLog.finishAndSave` runs below — the run log is only
-        // finalized (and its buffer cleared) AFTER this result is built,
-        // so this is the one chance to read it (see
-        // `RunLogRecorder.currentRunHoldStats`'s own doc comment).
-        holdStats: runLog.currentRunHoldStats(typingTest.state.runId),
+        // Snapshotted AFTER the drain above, still BEFORE
+        // `runLog.finishAndSave` runs below clears the buffer — the run
+        // log is only finalized afterward, so this is the one chance to
+        // read it (see `RunLogRecorder.currentRunHoldStats`'s own doc
+        // comment). `startedAtMs` matches `finishAndSave`'s own meta
+        // field exactly (see that const's own comment above).
+        holdStats: runLog.currentRunHoldStats(typingTest.state.runId, startedAtMs),
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       if (saveUnnamed) {
@@ -211,8 +237,7 @@ export function useTypingTestResultSave({
       // regardless of whether the result row is saved. See
       // flushAfterPendingEmits for why the drain and the chain tail must
       // both settle first.
-      const uid = keyboardRef.current?.uid
-      if (uid) flushAfterPendingEmits(resetMatrixPressTracking(), uid)
+      if (uid && drained) flushAfterPendingEmits(drained, uid)
       // The word the run ended on without submitting (e.g. a timed run
       // expiring mid-word) — undefined when the run ended cleanly on a
       // word boundary (currentWordIndex === words.length, every
@@ -240,7 +265,11 @@ export function useTypingTestResultSave({
       // truncated-and-saved: finish() refuses instead.
       const finishedLog = runLog.finishAndSave(uid, typingTest.state.wordResults, {
         runId: typingTest.state.runId,
-        startedAtMs: typingTest.state.startTime ?? Date.now(),
+        // Reuses the exact same value already passed to
+        // `currentRunHoldStats` above — see that const's own comment for
+        // why a second, separately-evaluated `Date.now()` here would risk
+        // disagreeing with it by a few ms.
+        startedAtMs,
         durationMs: elapsed,
         mode: typingTest.config.mode,
         language: typingTest.language,

--- a/src/renderer/components/editors/use-typing-test-result-save.ts
+++ b/src/renderer/components/editors/use-typing-test-result-save.ts
@@ -192,6 +192,12 @@ export function useTypingTestResultSave({
         confirmedChars: typingTest.state.confirmedChars,
         kspcUncomputable: typingTest.state.kspcUncomputable,
         wordResults: typingTest.state.wordResults,
+        // Snapshotted from the recorder's still-buffered keystrokes BEFORE
+        // `runLog.finishAndSave` runs below — the run log is only
+        // finalized (and its buffer cleared) AFTER this result is built,
+        // so this is the one chance to read it (see
+        // `RunLogRecorder.currentRunHoldStats`'s own doc comment).
+        holdStats: runLog.currentRunHoldStats(typingTest.state.runId),
       })
       result.isPb = isPbForConfig(result, typingTestHistory ?? [])
       if (saveUnnamed) {
@@ -269,7 +275,7 @@ export function useTypingTestResultSave({
     typingTest.wpm, typingTest.accuracy,
     typingTest.config, typingTest.language,
     typingTestHistory, onSaveTypingTestResult, saveUnnamed, pendingUnnamedResult, lastFinishedLog,
-    resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave])
+    resetMatrixPressTracking, flushAfterPendingEmits, runLog.finishAndSave, runLog.currentRunHoldStats])
 
   // The just-finished result, exposed so the pane can build name chips: the
   // held unsaved one (save-unnamed off) until named, else the saved latest.

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.76",
+  "version": "0.1.77",
   "name": "English",
   "common": {
     "save": "Save",
@@ -485,6 +485,7 @@
         "last10Avg": "Last 10",
         "totalTests": "Tests",
         "avgAccuracy": "Avg Acc",
+        "avgHold": "Avg Key Hold",
         "date": "Date",
         "name": "Name",
         "unnamed": "Unnamed",
@@ -542,7 +543,9 @@
             "overlap": "Overlap",
             "duration": "Duration",
             "kpm": "Keystrokes/min",
-            "durationSeconds": "{{s}}s"
+            "durationSeconds": "{{s}}s",
+            "avgHold": "Avg Key Hold",
+            "avgHoldTooltip": "Average time a key is held down (press to release), in milliseconds."
           },
           "legend": {
             "normal": "Normal keystroke",

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -7,17 +7,17 @@ import { ICON_SM } from '../constants/ui-tokens'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import { computeStats } from './history-stats'
 import { formatDate, ACTION_BTN, DELETE_BTN, CONFIRM_DELETE_BTN, FILTER_SELECT_CLASS } from '../components/editors/store-modal-shared'
-import { resultKpm, buildResultNameChips } from './result-builder'
+import { resultKpm, resultAvgHoldMs, buildResultNameChips } from './result-builder'
 import { formatConditionLabel } from './condition-label'
 import { ResultNameModal } from './ResultNameModal'
 import { Tooltip } from '../components/ui/Tooltip'
-import { formatDuration } from '../components/analyze/analyze-format'
+import { formatDuration, fmtMs } from '../components/analyze/analyze-format'
 import { HistoryTimelineCell } from './HistoryTimelineCell'
 import { EMPTY_RUN_ID_SET } from '../hooks/useRunLogAvailability'
 import { WpmTrendChart } from './WpmTrendChart'
 
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
-type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'mode' | 'duration'
+type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'avgHold' | 'mode' | 'duration'
 type SortDirection = 'asc' | 'desc'
 /** Source-tab split: MonkeyType (words/time/quote) keeps the mode dropdown;
  *  Tatoeba has no sub-filter (the Analysis condition selector already
@@ -148,6 +148,15 @@ export function HistoryResultsPanel({
         case 'accuracy':
           cmp = a.accuracy - b.accuracy
           break
+        case 'avgHold': {
+          // A legacy row with no raw holdSumMs/holdSamples pair sorts as
+          // the lowest possible value (-1, below any real non-negative
+          // ms mean) rather than being excluded from sort order entirely.
+          const a1 = resultAvgHoldMs(a) ?? -1
+          const b1 = resultAvgHoldMs(b) ?? -1
+          cmp = a1 - b1
+          break
+        }
         case 'mode': {
           // Sort by what the Mode column actually shows (text name for fileImport),
           // so fileImport rows order by name rather than an opaque textId.
@@ -257,6 +266,7 @@ export function HistoryResultsPanel({
                 <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader column="avgHold" label={t('editor.typingTest.history.avgHold')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
@@ -275,6 +285,7 @@ export function HistoryResultsPanel({
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{r.wpm}</td>
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono">{r.accuracy}%</td>
+                  <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">{fmtMs(resultAvgHoldMs(r))}</td>
                   <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
                     {isText
                       ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { TypingTestTextMeta } from '../../shared/types/typing-test-text-store'
 import { buildCsv } from '../../shared/csv-export'
-import { resultKpm, resultKspc } from './result-builder'
+import { resultKpm, resultKspc, resultAvgHoldMs } from './result-builder'
 import { formatKspc } from '../../shared/kspc'
 import { useTypingTestTexts } from '../hooks/useTypingTestTexts'
 import { HistorySections } from './HistorySections'
@@ -113,7 +113,7 @@ function exportFilterSlug(
 // shared denominator let a spreadsheet compute the same char-weighted
 // Σ/Σ rate this app itself uses. Empty (not 0) for a result missing the
 // group, same treatment as `kspc`.
-const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'kspc', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'fileImportTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb', 'errorSubstitutions', 'errorOmissions', 'errorInsertions', 'errorTargetChars'] as const
+const CSV_HEADERS = ['date', 'name', 'wpm', 'kpm', 'accuracy', 'kspc', 'avgHoldMs', 'wordCount', 'correctChars', 'incorrectChars', 'durationSeconds', 'rawWpm', 'mode', 'mode2', 'fileImportTextName', 'language', 'punctuation', 'numbers', 'consistency', 'isPb', 'errorSubstitutions', 'errorOmissions', 'errorInsertions', 'errorTargetChars'] as const
 
 function buildResultsCsv(results: TypingTestResult[]): string {
   return buildCsv(
@@ -125,6 +125,13 @@ function buildResultsCsv(results: TypingTestResult[]): string {
       if (key === 'kspc') {
         const kspc = resultKspc(r)
         return kspc === null ? '' : formatKspc(kspc)
+      }
+      // Derived mean, rounded to the nearest ms — empty (not 0) for a
+      // legacy result with no raw holdSumMs/holdSamples pair, same
+      // both-or-neither treatment as kspc above.
+      if (key === 'avgHoldMs') {
+        const avgHold = resultAvgHoldMs(r)
+        return avgHold === null ? '' : Math.round(avgHold)
       }
       return r[key as keyof TypingTestResult]
     })),

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -171,6 +171,32 @@ describe('TypingTestHistory', () => {
     expect(rows()).toEqual([60, 75, 90])
   })
 
+  it('renders and sorts the Avg Hold column, formatted "N ms", with a legacy (no raw fields) row sorting to the low end', () => {
+    const results = [
+      makeResult({ wpm: 60, date: '2025-01-03T00:00:00Z', holdSumMs: 300, holdSamples: 3 }), // 100 ms
+      makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z', holdSumMs: 800, holdSamples: 5 }), // 160 ms
+      makeResult({ wpm: 75, date: '2025-01-01T00:00:00Z' }), // legacy, no raw fields
+    ]
+    renderWithI18n(<TypingTestHistory results={results} />)
+
+    const cellsFor = (idx: number) => {
+      const history = screen.getByTestId('typing-test-history')
+      const trs = history.querySelectorAll('tbody tr')
+      return Array.from(trs).map((tr) => tr.querySelectorAll('td')[idx].textContent)
+    }
+
+    // Column order: Name, Date, WPM, KPM, Accuracy, Avg Hold, Mode, Duration, PB.
+    // Default sort is date desc → 100ms, 160ms, legacy(—).
+    expect(cellsFor(5)).toEqual(['100 ms', '160 ms', '—'])
+
+    const avgHoldButton = screen.getByRole('button', { name: /Avg Key Hold/i })
+    fireEvent.click(avgHoldButton) // desc
+    expect(cellsFor(5)).toEqual(['160 ms', '100 ms', '—'])
+
+    fireEvent.click(avgHoldButton) // asc — the legacy row (treated as lowest) sorts first
+    expect(cellsFor(5)).toEqual(['—', '100 ms', '160 ms'])
+  })
+
   it('sets aria-sort on active sort column', () => {
     const results = [makeResult({ wpm: 60 })]
     renderWithI18n(<TypingTestHistory results={results} />)
@@ -184,7 +210,7 @@ describe('TypingTestHistory', () => {
 
     // Other sortable headers should be 'none'
     const noneHeaders = Array.from(headers).filter((h) => h.getAttribute('aria-sort') === 'none')
-    expect(noneHeaders.length).toBe(5) // wpm, kpm, accuracy, mode, duration
+    expect(noneHeaders.length).toBe(6) // wpm, kpm, accuracy, avgHold, mode, duration
   })
 
   it('computes stats from filtered data', () => {
@@ -250,6 +276,35 @@ describe('TypingTestHistory', () => {
     const headers = csv.split('\n')[0].split(',')
     const kspcIndex = headers.indexOf('kspc')
     expect(dataLine.split(',')[kspcIndex]).toBe('')
+  })
+
+  it('includes an avgHoldMs CSV column, rounded to the nearest ms, for a result carrying the raw fields', () => {
+    const onExportCsv = vi.fn()
+    const results = [
+      makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z', holdSumMs: 241, holdSamples: 3 }), // 80.33... -> 80
+    ]
+    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+
+    fireEvent.click(screen.getByTestId('history-export-csv'))
+    const csv = onExportCsv.mock.calls[0][0] as string
+    const [headerLine, dataLine] = csv.split('\n')
+    const headers = headerLine.split(',')
+    expect(headers).toContain('avgHoldMs')
+    expect(dataLine.split(',')[headers.indexOf('avgHoldMs')]).toBe('80')
+  })
+
+  it('leaves the avgHoldMs CSV cell empty for a legacy result with no raw fields', () => {
+    const onExportCsv = vi.fn()
+    const results = [
+      makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z' }), // no holdSumMs/holdSamples
+    ]
+    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+
+    fireEvent.click(screen.getByTestId('history-export-csv'))
+    const csv = onExportCsv.mock.calls[0][0] as string
+    const [headerLine, dataLine] = csv.split('\n')
+    const headers = headerLine.split(',')
+    expect(dataLine.split(',')[headers.indexOf('avgHoldMs')]).toBe('')
   })
 
   it('includes raw error-class CSV columns for a result carrying the 4-field group', () => {

--- a/src/renderer/typing-test/__tests__/keystroke-hold.test.ts
+++ b/src/renderer/typing-test/__tests__/keystroke-hold.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { qualifyingHoldMs } from '../keystroke-hold'
+
+describe('qualifyingHoldMs', () => {
+  it('returns the press-to-release span when releaseMs is observed and the span is positive', () => {
+    expect(qualifyingHoldMs(1000, 1080)).toBe(80)
+  })
+
+  it('returns undefined when releaseMs was never observed', () => {
+    expect(qualifyingHoldMs(1000, undefined)).toBeUndefined()
+  })
+
+  it('returns undefined for a zero-duration span', () => {
+    expect(qualifyingHoldMs(1000, 1000)).toBeUndefined()
+  })
+
+  it('returns undefined for a negative span (defensive — release before press)', () => {
+    expect(qualifyingHoldMs(1000, 900)).toBeUndefined()
+  })
+})

--- a/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
+++ b/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
@@ -103,3 +103,38 @@ describe('buildTimelineStatItems — Words/Lines card branch table', () => {
     expect(item.value).toBe(4)
   })
 })
+
+/** The 11th (Avg Key Hold) card is always the last entry in
+ *  buildTimelineStatItems' fixed ordering. */
+function avgHoldItem(result: TypingTestResult | undefined, summary: WordTimelineSummary, log: RunKeystrokeLog) {
+  return buildTimelineStatItems(result, summary, log)[10]
+}
+
+describe('buildTimelineStatItems — Avg Key Hold card', () => {
+  it('prefers the persisted result raw pair over the model summary when both are present', () => {
+    const result = makeResult({ holdSumMs: 240, holdSamples: 3 }) // mean 80
+    const summary: WordTimelineSummary = { avgHoldMs: 999 }
+    const item = avgHoldItem(result, summary, makeLog())
+    expect(item.labelKey).toBe('editor.typingTest.history.timeline.stats.avgHold')
+    expect(item.value).toBe('80 ms')
+    expect(item.descriptionKey).toBe('editor.typingTest.history.timeline.stats.avgHoldTooltip')
+  })
+
+  it('falls back to the model summary when no result is available', () => {
+    const summary: WordTimelineSummary = { avgHoldMs: 142 }
+    const item = avgHoldItem(undefined, summary, makeLog())
+    expect(item.value).toBe('142 ms')
+  })
+
+  it('falls back to the model summary when a result is present but predates this field (legacy row)', () => {
+    const result = makeResult()
+    const summary: WordTimelineSummary = { avgHoldMs: 55 }
+    const item = avgHoldItem(result, summary, makeLog())
+    expect(item.value).toBe('55 ms')
+  })
+
+  it('shows the empty placeholder when neither the result nor the model summary has a sample', () => {
+    const item = avgHoldItem(makeResult(), SUMMARY, makeLog())
+    expect(item.value).toBe(EMPTY_STAT_VALUE)
+  })
+})

--- a/src/renderer/typing-test/__tests__/result-builder.test.ts
+++ b/src/renderer/typing-test/__tests__/result-builder.test.ts
@@ -11,6 +11,7 @@ import {
   resultKpm,
   buildResultNameChips,
   resultKspc,
+  resultAvgHoldMs,
 } from '../result-builder'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 import type { TypingTestConfig } from '../types'
@@ -436,6 +437,54 @@ describe('buildTypingTestResult — KSPC raw fields', () => {
     })
     expect(result.kspcKeystrokes).toBeUndefined()
     expect(result.kspcChars).toBeUndefined()
+  })
+})
+
+describe('resultAvgHoldMs', () => {
+  const base: TypingTestResult = {
+    date: '2026-01-01T00:00:00.000Z', wpm: 50, accuracy: 95, wordCount: 10,
+    correctChars: 50, incorrectChars: 2, durationSeconds: 30,
+  }
+  it('derives the mean from the stored raw pair', () => {
+    expect(resultAvgHoldMs({ ...base, holdSumMs: 300, holdSamples: 4 })).toBe(75)
+  })
+
+  it('returns null when either raw field is missing (legacy result)', () => {
+    expect(resultAvgHoldMs(base)).toBeNull()
+    expect(resultAvgHoldMs({ ...base, holdSumMs: 300 })).toBeNull()
+    expect(resultAvgHoldMs({ ...base, holdSamples: 4 })).toBeNull()
+  })
+
+  it('returns null when holdSamples is zero (no division by zero)', () => {
+    expect(resultAvgHoldMs({ ...base, holdSumMs: 0, holdSamples: 0 })).toBeNull()
+  })
+})
+
+describe('buildTypingTestResult — average key-hold raw fields', () => {
+  const wordsConfig: TypingTestConfig = { mode: 'words', wordCount: 30, punctuation: false, numbers: false }
+  const baseInput = {
+    wordCount: 5, wpm: 40, accuracy: 90, elapsedMs: 20000,
+    config: wordsConfig, language: 'english', wpmHistory: [], mistakes: {},
+    correctChars: 4, incorrectChars: 0, confirmedChars: 4, totalKeystrokes: 6, kspcUncomputable: false,
+  }
+
+  it('stores the raw pair verbatim when holdStats carries at least one sample', () => {
+    const result = buildTypingTestResult({ ...baseInput, romajiActive: false, holdStats: { holdSumMs: 240, holdSamples: 3 } })
+    expect(result.holdSumMs).toBe(240)
+    expect(result.holdSamples).toBe(3)
+    expect(resultAvgHoldMs(result)).toBe(80)
+  })
+
+  it('omits both fields when holdStats has zero samples (nothing observed this run)', () => {
+    const result = buildTypingTestResult({ ...baseInput, romajiActive: false, holdStats: { holdSumMs: 0, holdSamples: 0 } })
+    expect(result.holdSumMs).toBeUndefined()
+    expect(result.holdSamples).toBeUndefined()
+  })
+
+  it('omits both fields when holdStats is not provided (caller opted out)', () => {
+    const result = buildTypingTestResult({ ...baseInput, romajiActive: false })
+    expect(result.holdSumMs).toBeUndefined()
+    expect(result.holdSamples).toBeUndefined()
   })
 })
 

--- a/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
+++ b/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
@@ -803,4 +803,86 @@ describe('RunLogRecorder', () => {
       expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
     })
   })
+
+  describe('currentRunHoldStats()', () => {
+    it('sums press-to-release durations for the currently-buffered run, read-only (does not clear the buffer)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
+
+      register(recorder, 'run-1', 0, 1, 1100, 1, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1100, keycode: KC_B }))
+      recorder.record(ctx(), matrixRelease({ row: 0, col: 1, ts: 1200, durationMs: 100, keycode: KC_B }))
+
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 150, holdSamples: 2 })
+      // Read-only: a second call sees the exact same buffer, and finish()
+      // afterward still has everything (proves the accessor never cleared
+      // it — this is what lets useTypingTestResultSave call it BEFORE
+      // finish() runs).
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 150, holdSamples: 2 })
+      const log = recorder.finish(
+        [{ word: 'a', typed: 'a', correct: true }, { word: 'b', typed: 'b', correct: true }],
+        finishMeta({ startedAtMs: 1000 }),
+      )
+      expect(log?.words[0].keystrokes).toHaveLength(1)
+      expect(log?.words[1].keystrokes).toHaveLength(1)
+    })
+
+    it('skips a still-open press with no observed release', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      // No matrix-release event — the key is still held.
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('returns a zeroed pair for an unknown/absent buffer (no recording happened this run)', () => {
+      const recorder = new RunLogRecorder()
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('resets once the buffer is discarded (pause / consent revoked / keyboard switch)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 50, holdSamples: 1 })
+
+      recorder.discard()
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('resets once a NEW run starts under a different runId (never leaks the previous run\'s sums)', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 50, holdSamples: 1 })
+
+      // A fresh noteRegistration under a new runId replaces the buffer
+      // outright (see the module doc comment) — the old run's id must now
+      // read as "no buffer for it".
+      register(recorder, 'run-2', 0, 0, 2000, 0, 'x')
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-2')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('resets after finish() clears the buffer', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
+      recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000 }))
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('does not count a zero or negative duration as a sample', () => {
+      const recorder = new RunLogRecorder()
+      register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 1000 }))
+      recorder.record(ctx(), matrixRelease({ ts: 1000, durationMs: 0 }))
+      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+  })
 })

--- a/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
+++ b/src/renderer/typing-test/__tests__/run-log-recorder.test.ts
@@ -815,12 +815,12 @@ describe('RunLogRecorder', () => {
       recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1100, keycode: KC_B }))
       recorder.record(ctx(), matrixRelease({ row: 0, col: 1, ts: 1200, durationMs: 100, keycode: KC_B }))
 
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 150, holdSamples: 2 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 150, holdSamples: 2 })
       // Read-only: a second call sees the exact same buffer, and finish()
       // afterward still has everything (proves the accessor never cleared
       // it — this is what lets useTypingTestResultSave call it BEFORE
       // finish() runs).
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 150, holdSamples: 2 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 150, holdSamples: 2 })
       const log = recorder.finish(
         [{ word: 'a', typed: 'a', correct: true }, { word: 'b', typed: 'b', correct: true }],
         finishMeta({ startedAtMs: 1000 }),
@@ -834,12 +834,12 @@ describe('RunLogRecorder', () => {
       register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
       recorder.record(ctx(), matrixPress({ ts: 1000 }))
       // No matrix-release event — the key is still held.
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
     })
 
     it('returns a zeroed pair for an unknown/absent buffer (no recording happened this run)', () => {
       const recorder = new RunLogRecorder()
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
     })
 
     it('resets once the buffer is discarded (pause / consent revoked / keyboard switch)', () => {
@@ -847,10 +847,10 @@ describe('RunLogRecorder', () => {
       register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
       recorder.record(ctx(), matrixPress({ ts: 1000 }))
       recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 50, holdSamples: 1 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 50, holdSamples: 1 })
 
       recorder.discard()
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
     })
 
     it('resets once a NEW run starts under a different runId (never leaks the previous run\'s sums)', () => {
@@ -858,14 +858,14 @@ describe('RunLogRecorder', () => {
       register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
       recorder.record(ctx(), matrixPress({ ts: 1000 }))
       recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 50, holdSamples: 1 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 50, holdSamples: 1 })
 
       // A fresh noteRegistration under a new runId replaces the buffer
       // outright (see the module doc comment) — the old run's id must now
       // read as "no buffer for it".
       register(recorder, 'run-2', 0, 0, 2000, 0, 'x')
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
-      expect(recorder.currentRunHoldStats('run-2')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-2', 2000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
     })
 
     it('resets after finish() clears the buffer', () => {
@@ -874,7 +874,7 @@ describe('RunLogRecorder', () => {
       recorder.record(ctx(), matrixPress({ ts: 1000 }))
       recorder.record(ctx(), matrixRelease({ ts: 1050, durationMs: 50 }))
       recorder.finish(oneWordResult(), finishMeta({ startedAtMs: 1000 }))
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
     })
 
     it('does not count a zero or negative duration as a sample', () => {
@@ -882,7 +882,43 @@ describe('RunLogRecorder', () => {
       register(recorder, 'run-1', 0, 0, 1000, 0, 'a')
       recorder.record(ctx(), matrixPress({ ts: 1000 }))
       recorder.record(ctx(), matrixRelease({ ts: 1000, durationMs: 0 }))
-      expect(recorder.currentRunHoldStats('run-1')).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
+    })
+
+    it('excludes a keystroke pressed before the run\'s own start time — mirrors convertKeystrokes\' pre-start drop, so the History value and the saved timeline agree', () => {
+      const recorder = new RunLogRecorder()
+      // Pressed at absolute ts=900, but the run's own startedAtMs is
+      // 1000 (e.g. a key held during armed-waiting, before the run
+      // actually began) — finish()'s convertKeystrokes drops this
+      // keystroke entirely (`k.pressMs - startedAtMs >= 0`), so the
+      // accessor must agree rather than reading it back into the mean.
+      register(recorder, 'run-1', 0, 0, 900, 0, 'a')
+      recorder.record(ctx(), matrixPress({ ts: 900 }))
+      recorder.record(ctx(), matrixRelease({ ts: 950, durationMs: 50 }))
+
+      // A second, qualifying keystroke pressed AFTER start.
+      register(recorder, 'run-1', 0, 1, 1100, 0, 'b')
+      recorder.record(ctx(), matrixPress({ row: 0, col: 1, ts: 1100, keycode: KC_B }))
+      recorder.record(ctx(), matrixRelease({ row: 0, col: 1, ts: 1170, durationMs: 70, keycode: KC_B }))
+
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 70, holdSamples: 1 })
+    })
+
+    it('returns a zeroed pair (not partial data) once the buffer has exceeded its cap — mirrors finish()\'s own rejection', () => {
+      const recorder = new RunLogRecorder()
+      for (let i = 0; i <= MAX_RUN_LOG_EVENTS; i++) {
+        register(recorder, 'run-1', 0, 0, 1000 + i * 100, 0, 'a')
+        recorder.record(ctx(), matrixPress({ ts: 1000 + i * 100 }))
+        recorder.record(ctx(), matrixRelease({ ts: 1000 + i * 100 + 50, durationMs: 50 }))
+      }
+      // The buffer still holds many real, positive-duration holds
+      // recorded before the cap tripped — without the exceeded guard
+      // this would return a large non-zero pair instead of zero.
+      expect(recorder.currentRunHoldStats('run-1', 1000)).toEqual({ holdSumMs: 0, holdSamples: 0 })
+      // Confirm this really is the same overflow finish() itself refuses
+      // (a silently-truncated log is never saved — see finish()'s own
+      // doc comment) — the accessor's rejection mirrors it exactly.
+      expect(recorder.finish(oneWordResult(), finishMeta())).toBeNull()
     })
   })
 })

--- a/src/renderer/typing-test/__tests__/typing-test-result-sanitize.test.ts
+++ b/src/renderer/typing-test/__tests__/typing-test-result-sanitize.test.ts
@@ -58,6 +58,41 @@ describe('sanitizeTypingTestResult KSPC fields', () => {
   })
 })
 
+describe('sanitizeTypingTestResult average key-hold fields', () => {
+  it('keeps a valid holdSumMs/holdSamples pair', () => {
+    const result = sanitizeTypingTestResult(baseResult({ holdSumMs: 240, holdSamples: 3 }))
+    expect(result.holdSumMs).toBe(240)
+    expect(result.holdSamples).toBe(3)
+  })
+
+  it('leaves both fields undefined when neither is present', () => {
+    const result = sanitizeTypingTestResult(baseResult())
+    expect(result.holdSumMs).toBeUndefined()
+    expect(result.holdSamples).toBeUndefined()
+  })
+
+  it('drops the pair when only one of the two fields is present', () => {
+    expect(sanitizeTypingTestResult(baseResult({ holdSumMs: 240 })).holdSumMs).toBeUndefined()
+    expect(sanitizeTypingTestResult(baseResult({ holdSamples: 3 })).holdSamples).toBeUndefined()
+  })
+
+  it('drops the pair when holdSamples is 0 (division-by-zero guard)', () => {
+    const result = sanitizeTypingTestResult(baseResult({ holdSumMs: 0, holdSamples: 0 }))
+    expect(result.holdSumMs).toBeUndefined()
+    expect(result.holdSamples).toBeUndefined()
+  })
+
+  it('drops the pair when holdSamples is fractional or negative', () => {
+    expect(sanitizeTypingTestResult(baseResult({ holdSumMs: 240, holdSamples: 3.5 })).holdSamples).toBeUndefined()
+    expect(sanitizeTypingTestResult(baseResult({ holdSumMs: 240, holdSamples: -1 })).holdSamples).toBeUndefined()
+  })
+
+  it('drops the pair when holdSumMs is negative or non-finite', () => {
+    expect(sanitizeTypingTestResult(baseResult({ holdSumMs: -10, holdSamples: 3 })).holdSumMs).toBeUndefined()
+    expect(sanitizeTypingTestResult(baseResult({ holdSumMs: Number.NaN, holdSamples: 3 })).holdSumMs).toBeUndefined()
+  })
+})
+
 describe('sanitizeTypingTestResult error-class fields', () => {
   it('keeps a valid all-four error-class group', () => {
     const result = sanitizeTypingTestResult(baseResult({

--- a/src/renderer/typing-test/__tests__/word-timeline.test.ts
+++ b/src/renderer/typing-test/__tests__/word-timeline.test.ts
@@ -535,4 +535,68 @@ describe('buildWordTimelineSummary', () => {
     expect(summary.avgAccuracy).toBeUndefined()
     expect(summary.avgOverlap).toBe(1)
   })
+
+  it('pools average key-hold duration (Σ hold / Σ samples) across all words, skipping keystrokes with no observed release', () => {
+    const model = buildWordTimeline(log([
+      // Word 0: two qualifying holds (50ms, 100ms) plus one open-ended
+      // keystroke (no releaseMs) that must not contribute a sample.
+      word({
+        index: 0,
+        keystrokes: [
+          keystroke({ pressMs: 0, releaseMs: 50 }),
+          keystroke({ pressMs: 60, releaseMs: 160 }),
+          keystroke({ pressMs: 200 }),
+        ],
+      }),
+      // Word 1: one more qualifying hold (30ms).
+      word({ index: 1, keystrokes: [keystroke({ pressMs: 1000, releaseMs: 1030 })] }),
+    ]))
+    expect(model.words[0].stats.holdSumMs).toBe(150)
+    expect(model.words[0].stats.holdSamples).toBe(2)
+    expect(model.words[1].stats.holdSumMs).toBe(30)
+    expect(model.words[1].stats.holdSamples).toBe(1)
+    // Pooled by sample count, not a mean of each word's own mean: (150 + 30) / (2 + 1) = 60.
+    expect(buildWordTimelineSummary(model).avgHoldMs).toBeCloseTo(60, 5)
+  })
+
+  it('skips a non-positive hold duration (a release observed at or before its own press) as a sample', () => {
+    const model = buildWordTimeline(log([
+      word({
+        index: 0,
+        keystrokes: [
+          // Zero-duration and (defensively) negative-duration releases
+          // never contribute a hold sample — only a strictly positive
+          // press-to-release span counts.
+          keystroke({ pressMs: 0, releaseMs: 0 }),
+          keystroke({ pressMs: 100, releaseMs: 90 }),
+        ],
+      }),
+    ]))
+    expect(model.words[0].stats.holdSumMs).toBeUndefined()
+    expect(model.words[0].stats.holdSamples).toBeUndefined()
+  })
+
+  it('leaves holdSumMs/holdSamples undefined (not zero) for a word with no qualifying release, and avgHoldMs undefined when no word in the run has one', () => {
+    const model = buildWordTimeline(log([
+      word({ index: 0, keystrokes: [keystroke({ pressMs: 0 })] }),
+    ]))
+    expect(model.words[0].stats.holdSumMs).toBeUndefined()
+    expect(model.words[0].stats.holdSamples).toBeUndefined()
+    expect(buildWordTimelineSummary(model).avgHoldMs).toBeUndefined()
+  })
+
+  it('pools hold duration across a partial word too — orthogonal to scoring, same as overlap', () => {
+    const model = buildWordTimeline(log([
+      word({
+        index: 0,
+        partial: true,
+        display: 'wor',
+        typed: 'wo',
+        keystrokes: [keystroke({ pressMs: 0, releaseMs: 40 })],
+      }),
+    ]))
+    expect(model.words[0].stats.holdSumMs).toBe(40)
+    expect(model.words[0].stats.holdSamples).toBe(1)
+    expect(buildWordTimelineSummary(model).avgHoldMs).toBe(40)
+  })
 })

--- a/src/renderer/typing-test/keystroke-hold.ts
+++ b/src/renderer/typing-test/keystroke-hold.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Single source of truth for the "qualifying hold duration" rule behind
+// average-key-hold pooling — shared by two independent accumulation sites
+// that must never drift apart: word-timeline.ts's `buildKeystrokeStream`
+// (pools into `WordTimelineStats.holdSumMs`/`holdSamples`, itself pooled
+// into `WordTimelineSummary.avgHoldMs`) and run-log-recorder.ts's
+// `RunLogRecorder.currentRunHoldStats` (the still-live recorder buffer
+// snapshot `useTypingTestResultSave` reads before `finish()` clears it).
+
+/** The TRUE press-to-release span for one keystroke, when it qualifies as
+ *  an average-key-hold sample: `releaseMs` must be observed AND the
+ *  resulting span must be strictly positive — a release at or before its
+ *  own press (same-instant, or negative — defensive only) never counts.
+ *  Returns `undefined` when the keystroke doesn't qualify. */
+export function qualifyingHoldMs(pressMs: number, releaseMs: number | undefined): number | undefined {
+  if (releaseMs === undefined) return undefined
+  const holdMs = releaseMs - pressMs
+  return holdMs > 0 ? holdMs : undefined
+}

--- a/src/renderer/typing-test/keystroke-timeline-stats.ts
+++ b/src/renderer/typing-test/keystroke-timeline-stats.ts
@@ -33,16 +33,26 @@
 // `wordsOrLinesCard`'s own doc comment), unconditionally — a line-based
 // run's line count is knowable even without a `result` at all, unlike
 // KPM/KSPC/error-class, which have no raw-log equivalent to fall back to.
+// The 11th card (Avg Key Hold) is a THIRD fallback shape, distinct from
+// both of the above: unlike KPM/KSPC/error-class (result-only, no model
+// equivalent exists) it DOES have an always-available model equivalent
+// (`summary.avgHoldMs`, pooled straight from the log already loaded here);
+// unlike WPM/Accuracy (fall back only when `result` itself is entirely
+// absent, since those fields are never optional on an existing result) its
+// own result field (`holdSumMs`/`holdSamples`) can be legacy-absent even
+// when `result` exists. So it falls back per-VALUE: prefer the result's
+// own derived mean when present, else the model summary, regardless of
+// whether `result` exists at all — see `avgHoldMsFor` below.
 
 import type { TypingTestResult } from '../../shared/types/pipette-settings'
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
 import type { WordTimelineSummary } from './word-timeline'
 import type { AnalyzeSummaryItem } from '../components/analyze/analyze-summary-table'
-import { formatDuration, formatPercentLabel } from '../components/analyze/analyze-format'
+import { formatDuration, formatPercentLabel, fmtMs } from '../components/analyze/analyze-format'
 import { formatWpm } from '../components/analyze/analyze-wpm'
 import { formatKspc } from '../../shared/kspc'
 import { EMPTY_STAT_VALUE } from '../components/analyze/analyze-constants'
-import { resultKpm, resultKspc } from './result-builder'
+import { resultKpm, resultKspc, resultAvgHoldMs } from './result-builder'
 
 /** The 7th card's caption + value — "Words" for a normal (Monkeytype-style)
  *  run, "Lines" for a line-based one (fileImport with real line structure,
@@ -79,6 +89,14 @@ function wordsOrLinesCard(result: TypingTestResult | undefined, log: RunKeystrok
     return { labelKey: 'editor.typingTest.lines', value: result.wordCount }
   }
   return { labelKey: 'editor.typingTest.words', value: result ? result.wordCount : EMPTY_STAT_VALUE }
+}
+
+/** `TypingTestResult`-preferred, `WordTimelineSummary`-fallback mean hold
+ *  duration for the 11th card — see the module doc comment's paragraph on
+ *  this card's distinct fallback shape. */
+function avgHoldMsFor(result: TypingTestResult | undefined, summary: WordTimelineSummary): number | null {
+  const fromResult = result ? resultAvgHoldMs(result) : null
+  return fromResult ?? summary.avgHoldMs ?? null
 }
 
 /** Ordered stat cards for `AnalyzeStatGrid` — see the module doc comment
@@ -148,6 +166,11 @@ export function buildTimelineStatItems(
     {
       labelKey: 'editor.typingTest.history.errorMixLabelInsertion',
       value: result?.errorInsertions ?? EMPTY_STAT_VALUE,
+    },
+    {
+      labelKey: 'editor.typingTest.history.timeline.stats.avgHold',
+      value: fmtMs(avgHoldMsFor(result, summary)),
+      descriptionKey: 'editor.typingTest.history.timeline.stats.avgHoldTooltip',
     },
   ]
 }

--- a/src/renderer/typing-test/result-builder.ts
+++ b/src/renderer/typing-test/result-builder.ts
@@ -57,6 +57,16 @@ export function resultKspc(r: TypingTestResult): number | null {
   return computeKspc(r.kspcKeystrokes, r.kspcChars)
 }
 
+/** Derives a saved result's average key-hold duration (ms) from its raw
+ *  `holdSumMs`/`holdSamples` pair — same derived-field precedent as
+ *  `resultKpm`/`resultKspc`. `null` when either is absent (legacy row, or
+ *  the run had no qualifying keystroke) or `holdSamples` is not positive
+ *  (division-by-zero guard). */
+export function resultAvgHoldMs(r: TypingTestResult): number | null {
+  if (r.holdSumMs === undefined || r.holdSamples === undefined || r.holdSamples <= 0) return null
+  return r.holdSumMs / r.holdSamples
+}
+
 /** Compact `YYYYMMDDHHmmss` timestamp from a result's ISO date. */
 function compactTimestamp(iso: string): string {
   const d = new Date(iso)
@@ -164,6 +174,15 @@ export interface BuildTypingTestResultInput {
    *  thread it through; an empty (or omitted) list stores nothing, same
    *  as a romaji run (see `buildTypingTestResult`). */
   wordResults?: readonly WordResult[]
+  /** Raw average-key-hold-duration pair, pooled from the run's raw
+   *  keystroke log (see `RunLogRecorder.currentRunHoldStats` — the log is
+   *  finalized AFTER this function runs, so the caller snapshots the
+   *  still-buffered sums first). Optional and defaulted to "store
+   *  nothing" so existing callers/tests that don't care about hold
+   *  duration don't have to thread it through, same precedent as
+   *  `wordResults`. A zero-sample pair (nothing observed this run, e.g.
+   *  recording was off) stores neither field — see `buildTypingTestResult`. */
+  holdStats?: { holdSumMs: number; holdSamples: number }
 }
 
 /** Narrows to the 'words' / 'time' config variants — the only ones carrying
@@ -229,6 +248,8 @@ export function buildTypingTestResult(input: BuildTypingTestResultInput): Typing
     mistakes: Object.keys(input.mistakes).length > 0 ? input.mistakes : undefined,
     kspcKeystrokes: kspc !== null ? input.totalKeystrokes : undefined,
     kspcChars: kspc !== null ? input.confirmedChars : undefined,
+    holdSumMs: input.holdStats && input.holdStats.holdSamples > 0 ? input.holdStats.holdSumMs : undefined,
+    holdSamples: input.holdStats && input.holdStats.holdSamples > 0 ? input.holdStats.holdSamples : undefined,
     errorSubstitutions: errorClasses?.substitutions,
     errorOmissions: errorClasses?.omissions,
     errorInsertions: errorClasses?.insertions,

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -716,12 +716,29 @@ export class RunLogRecorder {
    *  was recorded" case (no buffer yet, consent off, view-only, or a
    *  fresh run already replaced the buffer), the same both-or-neither-
    *  friendly shape `buildTypingTestResult` already expects (zero
-   *  `holdSamples` drops the pair, see its own doc comment). */
-  currentRunHoldStats(runId: string): { holdSumMs: number; holdSamples: number } {
+   *  `holdSamples` drops the pair, see its own doc comment).
+   *
+   *  Two rules mirror `finish()`/`convertKeystrokes` exactly, so this
+   *  snapshot never disagrees with the log `finish()` goes on to save
+   *  (the History value and the timeline it links to must agree):
+   *   - `startedAtMs` (the same value the caller is about to pass as
+   *     `RunLogFinishMeta.startedAtMs`) drops any keystroke pressed
+   *     before the run's own start (e.g. a key held during armed-
+   *     waiting) — same `pressMs - startedAtMs >= 0` bound
+   *     `convertKeystrokes` applies.
+   *   - A buffer already past {@link MAX_RUN_LOG_EVENTS}/{@link
+   *     MAX_RUN_LOG_BYTES} (`exceeded`) returns a zeroed pair rather
+   *     than partial pre-cap data — `finish()` refuses to save a
+   *     silently-truncated log outright (see its own doc comment); a
+   *     hold mean derived from that same truncated prefix must be
+   *     refused the same way, not leak into the persisted result. */
+  currentRunHoldStats(runId: string, startedAtMs: number): { holdSumMs: number; holdSamples: number } {
     if (!this.buffer || this.buffer.runId !== runId) return { holdSumMs: 0, holdSamples: 0 }
+    if (this.buffer.exceeded) return { holdSumMs: 0, holdSamples: 0 }
     let holdSumMs = 0
     let holdSamples = 0
     for (const k of this.buffer.keystrokes) {
+      if (k.pressMs - startedAtMs < 0) continue
       const holdMs = qualifyingHoldMs(k.pressMs, k.releaseMs)
       if (holdMs !== undefined) {
         holdSumMs += holdMs

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -101,6 +101,7 @@ import type { RunKeystroke, RunKeystrokeLog, RunWord } from '../../shared/types/
 import { MAX_RUN_LOG_BYTES, MAX_RUN_LOG_EVENTS } from '../../shared/types/typing-run-log'
 import { producesChar } from './keycode-char-map'
 import type { WordResult } from './run-state'
+import { qualifyingHoldMs } from './keystroke-hold'
 
 /** Context carried into every `record` call — mirrors the gate/tag
  *  decision `useInputModes.emitAnalyticsEvent` already makes for the
@@ -700,6 +701,34 @@ export class RunLogRecorder {
         typedChar: k.typedChar,
         mistakeKey: k.mistakeKey,
       }))
+  }
+
+  /** Read-only snapshot of `runId`'s currently-buffered average-key-hold
+   *  raw pair — sums `releaseMs - pressMs` (still in absolute-epoch `Date.now()`
+   *  form at this point; the difference is unaffected by the eventual
+   *  run-relative conversion `finish()` performs) over every buffered
+   *  keystroke with an observed, positive-duration release. Unlike
+   *  `finish()`, does NOT clear the buffer: `useTypingTestResultSave`
+   *  calls this BEFORE `finish()` because `buildTypingTestResult` (which
+   *  needs this pair) runs first, and the run log is only finalized
+   *  afterward — see that hook's own ordering note. Returns a zeroed pair
+   *  (never null) for an unknown/mismatched runId — the natural "nothing
+   *  was recorded" case (no buffer yet, consent off, view-only, or a
+   *  fresh run already replaced the buffer), the same both-or-neither-
+   *  friendly shape `buildTypingTestResult` already expects (zero
+   *  `holdSamples` drops the pair, see its own doc comment). */
+  currentRunHoldStats(runId: string): { holdSumMs: number; holdSamples: number } {
+    if (!this.buffer || this.buffer.runId !== runId) return { holdSumMs: 0, holdSamples: 0 }
+    let holdSumMs = 0
+    let holdSamples = 0
+    for (const k of this.buffer.keystrokes) {
+      const holdMs = qualifyingHoldMs(k.pressMs, k.releaseMs)
+      if (holdMs !== undefined) {
+        holdSumMs += holdMs
+        holdSamples++
+      }
+    }
+    return { holdSumMs, holdSamples }
   }
 
   /** Finalize the current run's buffer into a saveable log, joining each

--- a/src/renderer/typing-test/typing-test-result-sanitize.ts
+++ b/src/renderer/typing-test/typing-test-result-sanitize.ts
@@ -63,6 +63,25 @@ function sanitizeKspcFields(result: TypingTestResult): { kspcKeystrokes?: number
   return {}
 }
 
+/** Validates a result's optional `holdSumMs`/`holdSamples` pair:
+ *  both-or-neither, `holdSumMs` a non-negative finite number (a
+ *  millisecond sum, not necessarily an integer boundary in practice but
+ *  never required to be one here), `holdSamples` a non-negative integer
+ *  > 0 (matches `computeKspc`'s zero-division guard precedent). Returns
+ *  `{}` for anything else so a malformed pair degrades to "not set",
+ *  same treatment as `sanitizeKspcFields` above. */
+function sanitizeHoldFields(result: TypingTestResult): { holdSumMs?: number; holdSamples?: number } {
+  const { holdSumMs, holdSamples } = result
+  if (holdSumMs === undefined && holdSamples === undefined) return {}
+  if (
+    typeof holdSumMs === 'number' && Number.isFinite(holdSumMs) && holdSumMs >= 0
+    && isNonNegInt(holdSamples) && holdSamples > 0
+  ) {
+    return { holdSumMs, holdSamples }
+  }
+  return {}
+}
+
 /** Validates a result's optional 4-field error-class raw group
  *  (`errorSubstitutions`/`errorOmissions`/`errorInsertions`/
  *  `errorTargetChars` — see `TypingTestResult`'s doc comment): all-or-
@@ -104,12 +123,15 @@ function sanitizeErrorClassFields(result: TypingTestResult): {
  *  entirely. */
 export function sanitizeTypingTestResult(result: TypingTestResult): TypingTestResult {
   const { kspcKeystrokes, kspcChars } = sanitizeKspcFields(result)
+  const { holdSumMs, holdSamples } = sanitizeHoldFields(result)
   const { errorSubstitutions, errorOmissions, errorInsertions, errorTargetChars } = sanitizeErrorClassFields(result)
   return {
     ...result,
     mistakes: sanitizeMistakes(result.mistakes),
     kspcKeystrokes,
     kspcChars,
+    holdSumMs,
+    holdSamples,
     errorSubstitutions,
     errorOmissions,
     errorInsertions,

--- a/src/renderer/typing-test/word-timeline.ts
+++ b/src/renderer/typing-test/word-timeline.ts
@@ -12,6 +12,7 @@
 import type { RunKeystroke, RunKeystrokeLog, RunWord } from '../../shared/types/typing-run-log'
 import { computeWordCharCounts } from './run-state'
 import { resolveCharFromKeycode } from './keycode-char-map'
+import { qualifyingHoldMs } from './keystroke-hold'
 
 /** A press with no observed release renders as a fixed-width sliver so it
  *  has SOMETHING to show — never treat this width as a real duration (see
@@ -142,6 +143,17 @@ export interface WordTimelineStats {
    *  keystroke the same as one with 20. */
   overlapObserved?: number
   overlapTrue?: number
+  /** Sum of `releaseMs - pressMs` over every keystroke in this word whose
+   *  release was actually observed AND whose duration is positive — the
+   *  raw pair (with `holdSamples`) backing `WordTimelineSummary.avgHoldMs`,
+   *  pooled the same Σ/Σ way as `overlapObserved`/`overlapTrue` (a mean of
+   *  each word's own average would weight a 1-keystroke word the same as
+   *  a 20-keystroke one). Undefined — not zero — when the word has no
+   *  qualifying sample, the same tri-state convention `overlapObserved`
+   *  uses. Orthogonal to a word being `partial`/scored: a hold duration is
+   *  measurable regardless of whether the word was ever judged. */
+  holdSumMs?: number
+  holdSamples?: number
   /** Raw char counts backing `accuracy` (post separator-credit
    *  adjustment — see the run-last-word rule in `buildStats`) — undefined
    *  exactly when `accuracy` is. Lets `buildWordTimelineSummary` pool
@@ -191,6 +203,12 @@ export interface WordTimelineSummary {
    *  doc comment for the bug this pooling fixes). Undefined when no word
    *  has one. */
   avgOverlap?: number
+  /** Keystroke-weighted average key-hold duration (ms) across ALL words
+   *  (not just scored ones) with a qualifying sample — Σ holdSumMs / Σ
+   *  holdSamples, same pooling shape and same "orthogonal to scoring" rule
+   *  as `avgOverlap`. Undefined when no word has one (e.g. every keystroke
+   *  in the run is still open-ended). */
+  avgHoldMs?: number
 }
 
 export interface WordTimelineModel {
@@ -252,6 +270,9 @@ interface WordBuildResult {
   overlapRate?: number
   overlapObserved?: number
   overlapTrue?: number
+  /** See `WordTimelineStats.holdSumMs`/`holdSamples`. */
+  holdSumMs?: number
+  holdSamples?: number
   /** True ms of this word's own last observed boundary — carried forward
    *  as the next word's lead-in comparison point. Undefined when the
    *  word had no keystrokes at all (an empty word never updates the
@@ -291,6 +312,10 @@ export interface KeystrokeStreamResult {
   lastObservedTrueMs: number
   overlapObserved?: number
   overlapTrue?: number
+  /** See `WordTimelineStats.holdSumMs`/`holdSamples` — same Σ/Σ pooling,
+   *  computed over this stream's own keystrokes. */
+  holdSumMs?: number
+  holdSamples?: number
 }
 
 /** Builds one continuous run of keystroke + blank segments over an
@@ -315,6 +340,8 @@ export function buildKeystrokeStream(
   let displayCursor = startCursor
   let observedOverlapCount = 0
   let overlappedTrueCount = 0
+  let holdSumMs = 0
+  let holdSamples = 0
 
   keystrokes.forEach((k, i) => {
     if (i > 0) {
@@ -361,6 +388,19 @@ export function buildKeystrokeStream(
       if (k.overlapped) overlappedTrueCount++
     }
 
+    // Hold duration is always the TRUE press-to-release span — never the
+    // display-compressed `startMs`/`endMs` this loop also computes above
+    // (those can shrink an `openEnded` bar to MIN_BAR_MS, which must never
+    // be mistaken for a real duration — see KeystrokeSegment.openEnded).
+    // Qualification rule lives in keystroke-hold.ts, shared with
+    // run-log-recorder.ts's `currentRunHoldStats` so the two independent
+    // accumulation sites can't drift apart.
+    const trueHoldMs = qualifyingHoldMs(k.pressMs, k.releaseMs)
+    if (trueHoldMs !== undefined) {
+      holdSumMs += trueHoldMs
+      holdSamples++
+    }
+
     keystrokeSegments.push({
       kind: 'keystroke',
       startMs,
@@ -386,6 +426,8 @@ export function buildKeystrokeStream(
     lastObservedTrueMs,
     overlapObserved: observedOverlapCount > 0 ? observedOverlapCount : undefined,
     overlapTrue: observedOverlapCount > 0 ? overlappedTrueCount : undefined,
+    holdSumMs: holdSamples > 0 ? holdSumMs : undefined,
+    holdSamples: holdSamples > 0 ? holdSamples : undefined,
   }
 }
 
@@ -428,6 +470,8 @@ function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordB
     overlapRate: stream.overlapObserved !== undefined ? stream.overlapTrue! / stream.overlapObserved : undefined,
     overlapObserved: stream.overlapObserved,
     overlapTrue: stream.overlapTrue,
+    holdSumMs: stream.holdSumMs,
+    holdSamples: stream.holdSamples,
     lastObservedTrueMs: stream.lastObservedTrueMs,
   }
 }
@@ -435,6 +479,9 @@ function buildWord(word: RunWord, crossWordLastObservedMs: number | null): WordB
 interface BuildStatsExtras {
   overlapObserved?: number
   overlapTrue?: number
+  /** See `WordTimelineStats.holdSumMs`/`holdSamples`. */
+  holdSumMs?: number
+  holdSamples?: number
   /** True for the log's own last `RunWord` entry — the ONLY word
    *  `computeWordCharCounts`'s +1 separator credit must be withheld from,
    *  mirroring `run-state.ts`'s own two submit paths exactly: every word
@@ -478,7 +525,7 @@ export function computeScoredWordCharCounts(word: RunWord, isRunLastWord: boolea
 }
 
 function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras): WordTimelineStats {
-  const { overlapObserved, overlapTrue } = extras
+  const { overlapObserved, overlapTrue, holdSumMs, holdSamples } = extras
   const overlapRate = overlapObserved !== undefined ? overlapTrue! / overlapObserved : undefined
   // A partial (unsubmitted, interrupted) word is never scored — see
   // RunWord.partial's doc comment. Its keystrokes/segments still render;
@@ -490,7 +537,7 @@ function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras)
   // `BuildStatsExtras.romajiInput`'s doc comment.
   const scored = computeScoredWordCharCounts(word, extras.isRunLastWord, extras.romajiInput)
   if (!scored) {
-    return { durationMs, overlapRate, overlapObserved, overlapTrue }
+    return { durationMs, overlapRate, overlapObserved, overlapTrue, holdSumMs, holdSamples }
   }
 
   const { correct, incorrect } = scored
@@ -505,6 +552,8 @@ function buildStats(word: RunWord, durationMs: number, extras: BuildStatsExtras)
     overlapRate,
     overlapObserved,
     overlapTrue,
+    holdSumMs,
+    holdSamples,
     correctChars: totalChars > 0 ? correct : undefined,
     incorrectChars: totalChars > 0 ? incorrect : undefined,
     durationMs,
@@ -534,6 +583,8 @@ export function buildWordTimeline(log: RunKeystrokeLog): WordTimelineModel {
       stats: buildStats(word, built.durationMs, {
         overlapObserved: built.overlapObserved,
         overlapTrue: built.overlapTrue,
+        holdSumMs: built.holdSumMs,
+        holdSamples: built.holdSamples,
         isRunLastWord: i === log.words.length - 1,
         romajiInput: log.romajiInput === true,
       }),
@@ -590,5 +641,10 @@ export function buildWordTimelineSummary(model: WordTimelineModel): WordTimeline
   const overlapTrueSum = sum(overlapWords.map((w) => w.stats.overlapTrue!))
   const avgOverlap = overlapObservedSum > 0 ? overlapTrueSum / overlapObservedSum : undefined
 
-  return { avgPace, avgAccuracy, avgOverlap }
+  const holdWords = model.words.filter((w) => w.stats.holdSamples !== undefined)
+  const holdSumMsTotal = sum(holdWords.map((w) => w.stats.holdSumMs!))
+  const holdSamplesTotal = sum(holdWords.map((w) => w.stats.holdSamples!))
+  const avgHoldMs = holdSamplesTotal > 0 ? holdSumMsTotal / holdSamplesTotal : undefined
+
+  return { avgPace, avgAccuracy, avgOverlap, avgHoldMs }
 }

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -58,6 +58,19 @@ export interface TypingTestResult {
    *  run-state.ts/romaji-input.ts as each mode confirms a character). See
    *  `kspcKeystrokes` for the both-or-neither contract. */
   kspcChars?: number
+  /** Average key-hold-duration raw pair (press→release ms), both-or-neither
+   *  same shape as `kspcKeystrokes`/`kspcChars`: `holdSumMs` sums every
+   *  keystroke's `releaseMs - pressMs` this run where a release was
+   *  actually observed and the duration was positive (see
+   *  `word-timeline.ts`'s `WordTimelineStats.holdSumMs`/`holdSamples` for
+   *  the per-word raw counters this pools from), `holdSamples` is the
+   *  qualifying keystroke count. The displayed mean is derived via
+   *  `resultAvgHoldMs` rather than precomputed, mirroring the KPM
+   *  (`resultKpm`)/KSPC (`resultKspc`) precedent. Omitted for a run with
+   *  no qualifying keystroke (e.g. every key still held at run end) or one
+   *  saved before this field existed. */
+  holdSumMs?: number
+  holdSamples?: number
   /** Error-class breakdown (see `error-classify.ts`'s `classifyWordResults`),
    *  a 4-field all-or-nothing raw group (same both-or-neither shape as
    *  `kspcKeystrokes`/`kspcChars`, just with four fields instead of two):


### PR DESCRIPTION
## Summary
- Each typing-test run now reports the average time a key is held down (press to release, in ms), computed from the run log's existing press/release timestamps — no new capture code. The qualifying rule (release observed, positive span) lives in a single shared helper used by both the timeline model and the recorder.
- Surfaces: an "Avg Key Hold" card on the completion/timeline stats grid (with an explanatory tooltip), a sortable History Results column, and a CSV export column. Results persist the raw pair (holdSumMs/holdSamples, both-or-neither, sanitized) with the mean derived at read time, mirroring the KSPC pattern; legacy results simply show no value.
- The recorder gains a read-only current-run snapshot accessor taken after the matrix-event drain and before the log finalizes. Three review-found data races are closed with regression tests: drain-added samples are included, a cap-exceeded buffer yields no partial stats (matching the log's own rejection), and pre-start keystrokes are filtered exactly like the saved log.
- i18n: new labels in english.json and all four sample packs, versions bumped in lockstep to 0.1.77.

## Verification
- Full suite 8,619 passed / 22 skipped (+41 new tests, TDD red→green including race regressions proven red against the pre-fix code); eslint and typecheck clean.
- Virtual-device run with real matrix taps (80–150 ms holds) shows a plausible "114 ms" on the completion card and the History column.