### PR TITLE
fix(ui): rename the pack pull button from Cloud to Google Drive

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.77",
+  "version": "0.1.78",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -45,7 +45,7 @@
     "importBatchFailed_other": "{{count}} 件のファイルをインポートできませんでした：",
     "importSummary_one": "{{count}} 件インポートしました (成功 {{success}}, 失敗 {{failure}})",
     "importSummary_other": "{{count}} 件インポートしました (成功 {{success}}, 失敗 {{failure}})",
-    "pullFromCloud": "クラウドから取得",
+    "pullFromCloud": "Google Drive から取得",
     "pulling": "取得中..."
   },
   "app": {
@@ -839,10 +839,10 @@
     "retry": "再試行",
     "pullError": {
       "busy": "同期を実行中です。少し待ってからもう一度お試しください。",
-      "unauthenticated": "クラウドから取得するには Google にサインインしてください。",
-      "noPasswordFile": "クラウドから取得するには同期パスワードを設定してください。",
+      "unauthenticated": "Google Drive から取得するには Google にサインインしてください。",
+      "noPasswordFile": "Google Drive から取得するには同期パスワードを設定してください。",
       "decryptFailed": "保存された同期パスワードを読み取れませんでした。",
-      "keystoreUnavailable": "OSキーチェーンが利用できないため、ここではクラウド取得を行えません。",
+      "keystoreUnavailable": "OSキーチェーンが利用できないため、ここでは Google Drive からの取得を行えません。",
       "remoteCheckFailed": "Google Drive に接続できませんでした。しばらくしてから再試行してください。",
       "partial": "一部のパックの取得に失敗しました。もう一度お試しください。"
     }

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.77",
+  "version": "0.1.78",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -45,7 +45,7 @@
     "importBatchFailed_other": "{{count}}個、入れられんかったよ…",
     "importSummary_one": "{{count}}個入れたよん☆(成功{{success}}、失敗{{failure}})",
     "importSummary_other": "{{count}}個入れたよん☆(成功{{success}}、失敗{{failure}})",
-    "pullFromCloud": "クラウドから取ってくる☆",
+    "pullFromCloud": "Google Driveから取ってくる☆",
     "pulling": "取得中だよん..."
   },
   "app": {
@@ -829,10 +829,10 @@
     "retry": "もう一回！",
     "pullError": {
       "busy": "今ちょうど同期ちうだから、ちょい待ってもっかい押して☆",
-      "unauthenticated": "クラウドから取ってくるにはGoogle入ってから☆",
-      "noPasswordFile": "クラウドから取ってくるには同期パスワード決めてよｗ",
+      "unauthenticated": "Google Driveから取ってくるにはGoogle入ってから☆",
+      "noPasswordFile": "Google Driveから取ってくるには同期パスワード決めてよｗ",
       "decryptFailed": "保存したパスワード読めなかったんですけどｗ",
-      "keystoreUnavailable": "OSのキーチェーン使えなくて、ここじゃ取ってこれないっぽい…",
+      "keystoreUnavailable": "OSのキーチェーン使えなくて、ここじゃGoogle Driveから取ってこれないっぽい…",
       "remoteCheckFailed": "Google Driveにつながんない…また後でやってみて！",
       "partial": "一部のパック取得失敗…サゲ。。もっかい試して！"
     }

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.77",
+  "version": "0.1.78",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -45,7 +45,7 @@
     "importBatchFailed_other": "{{count}} 件、インポートできまへんでしたわ",
     "importSummary_one": "{{count}} 件インポートしましたえ (成功{{success}}、失敗{{failure}})",
     "importSummary_other": "{{count}} 件インポートしましたえ (成功{{success}}、失敗{{failure}})",
-    "pullFromCloud": "クラウドから取ってきますえ",
+    "pullFromCloud": "Google Driveから取ってきますえ",
     "pulling": "取ってきてますえ..."
   },
   "app": {
@@ -829,10 +829,10 @@
     "retry": "もういっぺんやりますえ",
     "pullError": {
       "busy": "いま同期してますさかい、ちょっと待っておくれやす。",
-      "unauthenticated": "クラウドから取ってくるにはGoogleにつないでおくれやす。",
-      "noPasswordFile": "クラウドから取ってくるには同期パスワードを設定しておくれやす。",
+      "unauthenticated": "Google Driveから取ってくるにはGoogleにつないでおくれやす。",
+      "noPasswordFile": "Google Driveから取ってくるには同期パスワードを設定しておくれやす。",
       "decryptFailed": "保存してあるパスワードが読めまへんでしたえ。",
-      "keystoreUnavailable": "OSのキーチェーンが使えへんさかい、ここではクラウドから取ってこれまへんなぁ。",
+      "keystoreUnavailable": "OSのキーチェーンが使えへんさかい、ここではGoogle Driveから取ってこれまへんなぁ。",
       "remoteCheckFailed": "Google Driveにつながりまへんでした。また後でやっておくれやす。",
       "partial": "一部のパックの取得があきまへんでしたえ。もういっぺん試しておくれやす。"
     }

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.77",
+  "version": "0.1.78",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -45,7 +45,7 @@
     "importBatchFailed_other": "誠に恐縮ながら、{{count}} 件のファイルをお受け取りできませんでした。",
     "importSummary_one": "{{count}} 件のファイルをお受け取りいたしました (成功 {{success}} 件、失敗 {{failure}} 件)。",
     "importSummary_other": "{{count}} 件のファイルをお受け取りいたしました (成功 {{success}} 件、失敗 {{failure}} 件)。",
-    "pullFromCloud": "クラウドより頂戴する",
+    "pullFromCloud": "Google Drive より頂戴する",
     "pulling": "頂戴中でございます..."
   },
   "app": {
@@ -829,10 +829,10 @@
     "retry": "再試行",
     "pullError": {
       "busy": "ただいま揃えている最中でございます。しばしお待ちを。",
-      "unauthenticated": "雲上より取り寄せるには、まず Google へ御挨拶を。",
-      "noPasswordFile": "雲上より取り寄せるには、合言葉を定めてくださいませ。",
+      "unauthenticated": "Google Drive より取り寄せるには、まず Google へ御挨拶を。",
+      "noPasswordFile": "Google Drive より取り寄せるには、合言葉を定めてくださいませ。",
       "decryptFailed": "保管された合言葉を読み取れませんでした。",
-      "keystoreUnavailable": "OSの錠前が使えぬため、ここでは雲上より取り寄せられませぬ。",
+      "keystoreUnavailable": "OSの錠前が使えぬため、ここでは Google Drive より取り寄せられませぬ。",
       "remoteCheckFailed": "あちらへ繋がりませんでした。しばし後にもう一度お試しを。",
       "partial": "一部の包みが取り寄せられませんでした。今一度お試しくださいませ。"
     }

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.77",
+  "version": "0.1.78",
   "name": "English",
   "common": {
     "save": "Save",
@@ -45,7 +45,7 @@
     "importBatchFailed_other": "{{count}} files could not be imported:",
     "importSummary_one": "Imported {{count}} file (success {{success}}, failure {{failure}})",
     "importSummary_other": "Imported {{count}} files (success {{success}}, failure {{failure}})",
-    "pullFromCloud": "Pull from Cloud",
+    "pullFromCloud": "Pull from Google Drive",
     "pulling": "Pulling..."
   },
   "app": {
@@ -839,10 +839,10 @@
     "retry": "Retry",
     "pullError": {
       "busy": "A sync is already running. Try again in a moment.",
-      "unauthenticated": "Sign in to Google to pull from cloud.",
-      "noPasswordFile": "Set a sync password to pull from cloud.",
+      "unauthenticated": "Sign in to Google to pull from Google Drive.",
+      "noPasswordFile": "Set a sync password to pull from Google Drive.",
       "decryptFailed": "Couldn't read the saved sync password.",
-      "keystoreUnavailable": "OS keychain is not available; cloud pull is disabled here.",
+      "keystoreUnavailable": "OS keychain is not available; Google Drive pull is disabled here.",
       "remoteCheckFailed": "Couldn't reach Google Drive. Try again later.",
       "partial": "Some packs failed to pull. Try again."
     }


### PR DESCRIPTION
## Summary
- The app has two clouds — the user's own Google Drive (Cloud Sync) and the community Hub — so the pack modals' "Pull from Cloud" button was ambiguous about which one it reads from. The button and its three error messages now name Google Drive explicitly, matching the wording the sync error path already used ("Couldn't reach Google Drive").
- All four sample packs updated in their own voice (the 紳士 pack's 雲上 metaphor becomes Google Drive too); versions bumped in lockstep to 0.1.78.

## Verification
- Each replacement asserted unique before applying; all five JSON files re-validated; no "from cloud" remnants by grep.
- Pack-modal test suites pass (163 tests); virtual-device screenshot confirms the Language Packs modal button reads "Pull from Google Drive".