### PR TITLE
chore: make code comments self-contained instead of citing internal docs

### DIFF
--- a/e2e/analyze.test.ts
+++ b/e2e/analyze.test.ts
@@ -3,8 +3,7 @@
 // Analyze page e2e tests. Runs without a physical keyboard: dummy
 // typing-analytics data + keymap snapshot are seeded into the userData
 // directory before the first window loads, so `ensureCacheIsFresh`
-// rebuilds the SQLite cache from our JSONL master. See
-// `.claude/docs/TESTING-POLICY.md` §7 for the strategy.
+// rebuilds the SQLite cache from our JSONL master.
 
 import { test, expect } from '@playwright/test'
 import type { ElectronApplication, Page } from '@playwright/test'

--- a/e2e/helpers/analyze-seed.ts
+++ b/e2e/helpers/analyze-seed.ts
@@ -8,8 +8,6 @@
 // SQLite cache on next launch. Cleanup deletes the cache + sync_state so
 // the next launch starts from empty — restoring them would race against
 // the Electron process's own shutdown writes.
-//
-// See `.claude/docs/TESTING-POLICY.md` §7 for the full rationale.
 
 import { mkdirSync, writeFileSync, readFileSync, rmSync, unlinkSync, existsSync } from 'node:fs'
 import { join } from 'node:path'

--- a/src/main/hub/hub-analytics.ts
+++ b/src/main/hub/hub-analytics.ts
@@ -2,9 +2,8 @@
 //
 // Hub Analytics export builder. Assembles the
 // `analytics-export-v1.json` payload that the desktop ships to
-// pipette-hub. The full wire contract lives in
-// `.claude/docs/HUB-ANALYTICS-API.md`; this module is the only
-// production producer of that shape.
+// pipette-hub, which treats this shape as its wire contract; this
+// module is the only production producer of that shape.
 //
 // The export is *all derived data*. We never include raw events:
 // minute-level (1 minute) is the smallest granularity, and bigram

--- a/src/main/hub/hub-ipc-analytics-prepare.ts
+++ b/src/main/hub/hub-ipc-analytics-prepare.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: shared analytics-export assembly path used by the upload,
 // update, preview and private-upload analytics handlers. Split out of
-// hub-ipc.ts (Task-split-hub-ipc) — see .claude/rules/file-splitting.md.
+// hub-ipc.ts to keep it under the project's 800-line Service/Util size
+// ceiling.
 
 import type {
   HubUploadAnalyticsPostParams, HubPreviewAnalyticsPostParams,

--- a/src/main/hub/hub-ipc-analytics.ts
+++ b/src/main/hub/hub-ipc-analytics.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: analytics post upload/update/preview handlers. Split out of
-// hub-ipc.ts (Task-split-hub-ipc) — see .claude/rules/file-splitting.md.
+// hub-ipc.ts to keep it under the project's 800-line Service/Util size
+// ceiling.
 //
 // Pattern mirrors the favorite-post upload: validate inputs → assemble
 // payload → withTokenRetry → save the postId on success. Distinct

--- a/src/main/hub/hub-ipc-favorite.ts
+++ b/src/main/hub/hub-ipc-favorite.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: favorite (feature) post upload/update, plus the shared
 // `prepareFavoritePost` assembly step reused by the private-upload
-// handler. Split out of hub-ipc.ts (Task-split-hub-ipc) — see
-// .claude/rules/file-splitting.md.
+// handler. Split out of hub-ipc.ts to keep it under the project's
+// 800-line Service/Util size ceiling.
 
 import { secureHandle } from '../ipc-guard'
 import { IpcChannels } from '../../shared/ipc/channels'

--- a/src/main/hub/hub-ipc-key-labels.ts
+++ b/src/main/hub/hub-ipc-key-labels.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: Key Label Hub handlers (list/detail/timestamps/download/
-// upload/update/sync/delete). Split out of hub-ipc.ts
-// (Task-split-hub-ipc) — see .claude/rules/file-splitting.md.
+// upload/update/sync/delete). Split out of hub-ipc.ts to keep it under
+// the project's 800-line Service/Util size ceiling.
 
 import { secureHandle } from '../ipc-guard'
 import { IpcChannels } from '../../shared/ipc/channels'

--- a/src/main/hub/hub-ipc-packs.ts
+++ b/src/main/hub/hub-ipc-packs.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: i18n language pack + theme pack handlers. Split out of
-// hub-ipc.ts (Task-split-hub-ipc) — see .claude/rules/file-splitting.md.
+// hub-ipc.ts to keep it under the project's 800-line Service/Util size
+// ceiling.
 //
 // Targets the standalone /api/i18n-packs and /api/theme-packs
 // endpoints. The pack body (HubI18nPackBody / HubThemePackBody) carries

--- a/src/main/hub/hub-ipc-posts.ts
+++ b/src/main/hub/hub-ipc-posts.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: public keymap post CRUD, auth-me, and the auth-display-name
-// handler. Split out of hub-ipc.ts (Task-split-hub-ipc) — see
-// .claude/rules/file-splitting.md.
+// handler. Split out of hub-ipc.ts to keep it under the project's
+// 800-line Service/Util size ceiling.
 
 import { secureHandle } from '../ipc-guard'
 import { IpcChannels } from '../../shared/ipc/channels'

--- a/src/main/hub/hub-ipc-private.ts
+++ b/src/main/hub/hub-ipc-private.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: private (unlisted) upload handlers. Split out of hub-ipc.ts
-// (Task-split-hub-ipc) — see .claude/rules/file-splitting.md.
+// to keep it under the project's 800-line Service/Util size ceiling.
 //
 // Each uploads to `/api/private/*` and returns the relative share URL
 // + expiry. Persisting the link onto the local entry is the renderer's

--- a/src/main/hub/hub-ipc-shared.ts
+++ b/src/main/hub/hub-ipc-shared.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: input validators + small pure helpers shared across every
-// hub-ipc-*.ts sibling. Split out of hub-ipc.ts (Task-split-hub-ipc) —
-// see .claude/rules/file-splitting.md.
+// hub-ipc-*.ts sibling. Split out of hub-ipc.ts to keep it under the
+// project's 800-line Service/Util size ceiling.
 
 import type { HubUploadPostParams } from '../../shared/types/hub'
 import type { HubUploadFiles } from './hub-client'

--- a/src/main/hub/hub-ipc-token.ts
+++ b/src/main/hub/hub-ipc-token.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Hub IPC: JWT cache + auth-retry wrapper shared across every
-// hub-ipc-*.ts sibling. Split out of hub-ipc.ts (Task-split-hub-ipc) —
-// see .claude/rules/file-splitting.md.
+// hub-ipc-*.ts sibling. Split out of hub-ipc.ts to keep it under the
+// project's 800-line Service/Util size ceiling.
 //
 // Module state lives on the exported `hubAuthState` object (mirrors
 // sync-runtime-state.ts's `syncRuntime` convention) since a plain

--- a/src/main/hub/hub-ipc.ts
+++ b/src/main/hub/hub-ipc.ts
@@ -17,9 +17,9 @@
 // New Hub IPC logic belongs in the sibling module whose responsibility
 // it extends — not here. External consumers (sync-ipc.ts, main/index.ts,
 // and every test file's mock of this facade path) must keep importing
-// this facade path, never a submodule directly. See
-// .claude/tasks/backlog/Task-split-hub-ipc.md and
-// .claude/rules/file-splitting.md for the split rationale.
+// this facade path, never a submodule directly — this facade/sibling
+// split keeps every file under the project's 800-line Service/Util size
+// ceiling while preserving one stable import path for consumers.
 
 import { registerHubPostHandlers } from './hub-ipc-posts'
 import { registerHubFavoriteHandlers } from './hub-ipc-favorite'

--- a/src/main/i18n-pack-store.ts
+++ b/src/main/i18n-pack-store.ts
@@ -24,9 +24,10 @@
 // extends — not here. External consumers (i18n-pack-ipc.ts,
 // pack-bundle-merge.ts, pack-gc.ts, i18n-startup-sync.ts, hub-ipc-packs.ts,
 // and every test file's partial mock of this facade path) must keep
-// importing this facade path, never a submodule directly. See
-// .claude/tasks/backlog/Task-split-i18n-pack-store.md and
-// .claude/rules/file-splitting.md for the split rationale.
+// importing this facade path, never a submodule directly — this
+// facade/sibling split keeps every file under the project's 800-line
+// Service/Util size ceiling while preserving one stable import path for
+// consumers.
 
 export type { I18nPackRecord } from '../shared/types/i18n-store'
 

--- a/src/main/sync/__tests__/sync-bundle.run-log.test.ts
+++ b/src/main/sync/__tests__/sync-bundle.run-log.test.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 //
-// Focused coverage for the run-log sync unit (keyboards/{uid}/runs) —
-// see .claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md. Mirrors
-// sync-bundle.test.ts's scoping/mocking approach.
+// Focused coverage for the run-log sync unit (keyboards/{uid}/runs).
+// Mirrors sync-bundle.test.ts's scoping/mocking approach.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { join } from 'node:path'

--- a/src/main/sync/pack-bundle-merge.ts
+++ b/src/main/sync/pack-bundle-merge.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Merge strategies for the i18n/theme index + pack-body bundle shapes.
-// Split out of sync-service.ts (Task-sync-unit-filename-gap) so these
-// bundle-variant merge branches don't push an already-oversized file
-// further past its budget — see .claude/rules/file-splitting.md.
+// Split out of sync-service.ts so these bundle-variant merge branches
+// don't push it past the project's 800-line Service/Util size ceiling.
 //
 // This module owns only the merge/LWW decision and the post-write
 // broadcast — every path/mkdir/writeFile concern lives in

--- a/src/main/sync/pack-gc.ts
+++ b/src/main/sync/pack-gc.ts
@@ -27,8 +27,8 @@
 // (no pack-body filesystem scan), so it stays safe and idempotent even
 // when a sibling unit failed this pass.
 //
-// Pulled into its own module (rather than growing sync-service.ts
-// further) per .claude/rules/file-splitting.md.
+// Pulled into its own module rather than growing sync-service.ts past
+// the project's 800-line Service/Util size ceiling.
 
 import { log } from '../logger'
 import { runGcUnderLock as runI18nGc } from '../i18n-pack-store'

--- a/src/main/sync/sync-analytics.ts
+++ b/src/main/sync/sync-analytics.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Analyze-panel-triggered typing-analytics sync: pulls + pushes one
 // keyboard's analytics bundles on its own per-uid mutex, independent
-// from the global sync lock. Split out of sync-service.ts
-// (Task-split-sync-service) — see .claude/rules/file-splitting.md.
+// from the global sync lock. Split out of sync-service.ts to keep it
+// under the project's 800-line Service/Util size ceiling.
 
 import { listFiles, driveFilenamePrefix, syncUnitFromFileName } from './google-drive'
 import { pLimit } from '../../shared/concurrency'

--- a/src/main/sync/sync-bundle.ts
+++ b/src/main/sync/sync-bundle.ts
@@ -211,19 +211,16 @@ export async function bundleSyncUnit(syncUnit: string): Promise<SyncBundle | nul
  * parser so the shape (including `utcDay` validation) is single-sourced
  * and drifts with the parser, not with a separate regex. Connect-time
  * initial sync and 3-minute polling skip these; the Analyze panel pulls
- * them on demand via `executeAnalyticsSync`. See
- * `.claude/rules/settings-persistence.md`. */
+ * them on demand via `executeAnalyticsSync`. */
 export function isAnalyticsSyncUnit(syncUnit: string): boolean {
   return parseTypingAnalyticsDeviceDaySyncUnit(syncUnit) !== null
 }
 
 /** Per-run raw keystroke log units (`keyboards/{uid}/runs`). Excluded
  * from connect-time initial sync and 3-minute polling for the same
- * reason as `isAnalyticsSyncUnit` — see
- * `.claude/rules/settings-persistence.md`'s trigger matrix. Unlike
- * typing-analytics units, this data has no dedicated on-demand sync
- * entry point yet (Row F: "no dedicated sync") — it only syncs via the
- * generic before-quit flush and manual "sync now". */
+ * reason as `isAnalyticsSyncUnit`. Unlike typing-analytics units, this
+ * data has no dedicated on-demand sync entry point — it only syncs via
+ * the generic before-quit flush and manual "sync now". */
 export function isRunLogSyncUnit(syncUnit: string): boolean {
   return /^keyboards\/[^/]+\/runs$/.test(syncUnit)
 }

--- a/src/main/sync/sync-execute.ts
+++ b/src/main/sync/sync-execute.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Full-pass sync execution: the manual/initial download and upload
 // sync passes driven by executeSync (IPC-facing entry point). Split
-// out of sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// out of sync-service.ts to keep it under the project's 800-line
+// Service/Util size ceiling.
 
 import { app } from 'electron'
 import { listFiles, syncUnitFromFileName, type DriveFile } from './google-drive'

--- a/src/main/sync/sync-flush.ts
+++ b/src/main/sync/sync-flush.ts
@@ -2,8 +2,8 @@
 // Debounced auto-sync upload (notifyChange → flushPendingChanges) and
 // the before-quit handler that flushes pending changes and runs
 // registered finalizers before the app is allowed to exit. Split out
-// of sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// of sync-service.ts to keep it under the project's 800-line
+// Service/Util size ceiling.
 
 import { app } from 'electron'
 import { listFiles } from './google-drive'

--- a/src/main/sync/sync-merge-dispatch.ts
+++ b/src/main/sync/sync-merge-dispatch.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Per-sync-unit upload/merge/dispatch: uploading a bundle, merging a
 // downloaded remote bundle into local state by sync-unit shape, and the
-// upload-or-merge-with-remote decision. Split out of sync-service.ts
-// (Task-split-sync-service) — see .claude/rules/file-splitting.md.
+// upload-or-merge-with-remote decision. Split out of sync-service.ts to
+// keep it under the project's 800-line Service/Util size ceiling.
 
 import { app } from 'electron'
 import { join } from 'node:path'

--- a/src/main/sync/sync-password.ts
+++ b/src/main/sync/sync-password.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sync credentials and the password-check sentinel file: verifying the
 // stored password against the remote password-check unit, and the
-// non-destructive change-password flow. Split out of sync-service.ts
-// (Task-split-sync-service) — see .claude/rules/file-splitting.md.
+// non-destructive change-password flow. Split out of sync-service.ts to
+// keep it under the project's 800-line Service/Util size ceiling.
 
 import { encrypt, decrypt, retrievePasswordResult, storePassword, clearPassword } from './sync-crypto'
 import { getAuthStatus } from './google-auth'

--- a/src/main/sync/sync-polling.ts
+++ b/src/main/sync/sync-polling.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // 3-minute background polling for remote changes. Split out of
-// sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// sync-service.ts to keep it under the project's 800-line Service/Util
+// size ceiling.
 
 import { listFiles, syncUnitFromFileName } from './google-drive'
 import { pLimit } from '../../shared/concurrency'

--- a/src/main/sync/sync-runtime-state.ts
+++ b/src/main/sync/sync-runtime-state.ts
@@ -5,8 +5,8 @@
 // outside its declaring module (an imported binding is read-only), so
 // every module-scoped flag that's read/written across the split lives
 // on `syncRuntime` instead of as a bare top-level `let`. Split out of
-// sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// sync-service.ts to keep it under the project's 800-line Service/Util
+// size ceiling.
 
 import { IpcChannels } from '../../shared/ipc/channels'
 import { broadcastToAllWindows } from '../utils/broadcast'

--- a/src/main/sync/sync-scan.ts
+++ b/src/main/sync/sync-scan.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Remote data inspection: listing/categorizing what's on Drive without
 // merging it into local state (used by the sync settings scan UI and
-// the undecryptable-files diagnostic). Split out of sync-service.ts
-// (Task-split-sync-service) — see .claude/rules/file-splitting.md.
+// the undecryptable-files diagnostic). Split out of sync-service.ts to
+// keep it under the project's 800-line Service/Util size ceiling.
 
 import { decrypt } from './sync-crypto'
 import {

--- a/src/main/sync/sync-scope.ts
+++ b/src/main/sync/sync-scope.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Sync-unit scope matching: which sync units a given SyncScope covers,
 // and which remote units are worth downloading given what's stored
-// locally. Split out of sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// locally. Split out of sync-service.ts to keep it under the project's
+// 800-line Service/Util size ceiling.
 
 import { app } from 'electron'
 import { join } from 'node:path'
@@ -24,8 +24,6 @@ export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean
   // checks don't otherwise care what scope was asked for. Returning here
   // also means 'packs' never falls through to the i18n/themes rejection
   // further down, and never matches anything else (favorites/keyboards).
-  // See .claude/docs/DATA-INVENTORY.md §3.7's packs-scope definition for
-  // the full discovery-route writeup this ordering exists to support.
   if (scope === 'packs') {
     return syncUnit.startsWith(I18N_SYNC_UNIT_PREFIX) || syncUnit.startsWith(THEME_SYNC_UNIT_PREFIX)
   }
@@ -37,9 +35,11 @@ export function matchesScope(syncUnit: string | null, scope: SyncScope): boolean
   // by the 3-minute poll alone despite it using 'all': polling only merges
   // a CHANGED modifiedTime since its own last snapshot, so a pack already
   // on Drive before this machine's first poll is invisible to it forever.
-  // See matchesScope's doc in .claude/docs/DATA-INVENTORY.md §3.7 (and
-  // .claude/rules/settings-persistence.md) for the full writeup and the
-  // 'packs'-scope discovery routes that actually close this gap.
+  // What actually closes the gap is the 'packs' scope above: an
+  // automatic pull on first device connection (AppConfig.packsPulledOnce)
+  // and the Language/Theme Packs modal's "Pull from Cloud" button both
+  // use it to fetch i18n/theme packs directly, without depending on
+  // poll-detected diffs.
   if (syncUnit.startsWith(I18N_SYNC_UNIT_PREFIX) || syncUnit.startsWith(THEME_SYNC_UNIT_PREFIX)) return false
   if (scope === 'favorites') return syncUnit.startsWith('favorites/')
   if (typeof scope === 'object' && 'favorites' in scope) {
@@ -73,7 +73,7 @@ export function shouldDownloadSyncUnit(
   // separately when the Analyze panel opens — skip it here so the
   // connect progress bar stays short. Run logs are excluded the same
   // way (no per-uid keystroke count to show on the connect progress
-  // bar either) — see .claude/rules/settings-persistence.md Row E.
+  // bar either).
   if (typeof scope === 'object' && 'favorites' in scope && (isAnalyticsSyncUnit(syncUnit) || isRunLogSyncUnit(syncUnit))) {
     return false
   }

--- a/src/main/sync/sync-service.ts
+++ b/src/main/sync/sync-service.ts
@@ -22,9 +22,9 @@
 // extends — not here. External consumers (sync-ipc.ts, main/index.ts,
 // the 9+ store files that call `notifyChange`, and every test file's
 // whole-module mock of this facade path) must keep importing this
-// facade path, never a submodule directly. See
-// .claude/tasks/backlog/Task-split-sync-service.md and
-// .claude/rules/file-splitting.md for the split rationale.
+// facade path, never a submodule directly — this facade/sibling split
+// keeps every file under the project's 800-line Service/Util size
+// ceiling while preserving one stable import path for consumers.
 //
 // New module-private mutable state must either live on `syncRuntime`
 // (sync-runtime-state.ts) or ship its own `*ForTests` reset seam called

--- a/src/main/sync/sync-typing-remote.ts
+++ b/src/main/sync/sync-typing-remote.ts
@@ -3,8 +3,8 @@
 // cloud state against local + `uploaded` state before an upload pass,
 // and the Sync > Typing lazy-expand UI's on-demand cloud reads (list
 // remote hashes/days, delete a remote day, fetch a single remote day).
-// Split out of sync-service.ts (Task-split-sync-service) — see
-// .claude/rules/file-splitting.md.
+// Split out of sync-service.ts to keep it under the project's 800-line
+// Service/Util size ceiling.
 
 import { app } from 'electron'
 import { join } from 'node:path'

--- a/src/main/typing-analytics/bigram-aggregate.ts
+++ b/src/main/typing-analytics/bigram-aggregate.ts
@@ -3,7 +3,6 @@
 // functions over NgramMinuteCellRow arrays — no DB / IPC concerns.
 // Histogram boundaries are imported from bigram-bucket so the merge,
 // emit, and aggregation layers all share the same bucket layout.
-// See .claude/plans/Plan-analyze-bigram.md for the metric design.
 
 import {
   BIGRAM_BUCKET_CENTERS_MS,

--- a/src/main/typing-analytics/bigram-bucket.ts
+++ b/src/main/typing-analytics/bigram-bucket.ts
@@ -2,8 +2,7 @@
 // Bigram inter-key interval (IKI) bucketing. Raw IKIs are accumulated by
 // MinuteBuffer and bucketized here at flush time before being persisted
 // as a fixed-size histogram. The boundary set is log-scale so the slow
-// tail (300ms+) is preserved without inflating storage. See
-// .claude/plans/Plan-analyze-bigram.md for the bucket rationale.
+// tail (300ms+) is preserved without inflating storage.
 
 import { BIGRAM_HIST_BUCKETS } from './jsonl/jsonl-row'
 // The duration grid itself lives in shared/duration-buckets.ts (the

--- a/src/main/typing-analytics/cache-rebuild.ts
+++ b/src/main/typing-analytics/cache-rebuild.ts
@@ -3,7 +3,7 @@
 // cache is always derivable from the JSONL files, so a missing /
 // stale / machine-migrated cache is never fatal: this module drops the
 // user rows, re-reads every master file, and re-applies every row via
-// the LWW merge path. See .claude/plans/typing-analytics.md.
+// the LWW merge path.
 
 import { applyRowsToCache } from './jsonl/apply-to-cache'
 import { readRows } from './jsonl/jsonl-reader'

--- a/src/main/typing-analytics/db/schema.ts
+++ b/src/main/typing-analytics/db/schema.ts
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// SQLite schema for the typing analytics database. See
-// .claude/plans/typing-analytics.md for the design rationale.
+// SQLite schema for the typing analytics database — a rebuildable
+// cache over the per-day JSONL master files
+// (sync/keyboards/{uid}/devices/{hash}/{date}.jsonl); every table here
+// can be safely truncated and repopulated from those files via LWW merge.
 
 export const SCHEMA_VERSION = 8
 

--- a/src/main/typing-analytics/db/typing-analytics-db-base.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db-base.ts
@@ -2,8 +2,7 @@
 // Base of the TypingAnalyticsDB class chain: owns the SQLite connection,
 // the 3-phase migration-aware constructor, and the prepared-statement
 // bundle every derived class reads from `this.stmts`. Split out of what
-// used to be one 3,255-line file/class — see
-// .claude/tasks/done/Task-split-typing-analytics-db.md.
+// used to be one 3,255-line file/class.
 //
 // typing-analytics-db-writes.ts extends this with the ingest/tombstone/
 // export/merge write methods, typing-analytics-db-reads.ts extends that

--- a/src/main/typing-analytics/db/typing-analytics-db-reads.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db-reads.ts
@@ -5,8 +5,7 @@
 // n-gram range queries, sessions, peak records, remote device info) plus
 // the sync-facing scope/live-row listers. Extends TypingAnalyticsDbWrites
 // so it inherits the write methods without duplicating `this.stmts`.
-// Split out of what used to be one 3,255-line file/class — see
-// .claude/tasks/done/Task-split-typing-analytics-db.md.
+// Split out of what used to be one 3,255-line file/class.
 
 import type {
   TypingKeyboardSummary,

--- a/src/main/typing-analytics/db/typing-analytics-db-writes.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db-writes.ts
@@ -4,8 +4,7 @@
 // export selects, and authoritative LWW sync-merge writes. Extends
 // TypingAnalyticsDbBase so it can reach `this.db` (for db.transaction)
 // and `this.stmts` (every prepared statement group). Split out of what
-// used to be one 3,255-line file/class — see
-// .claude/tasks/done/Task-split-typing-analytics-db.md.
+// used to be one 3,255-line file/class.
 
 import { emptyTombstoneResult } from '../../../shared/types/typing-analytics'
 import type { TypingTombstoneResult } from '../../../shared/types/typing-analytics'

--- a/src/main/typing-analytics/db/typing-analytics-db.ts
+++ b/src/main/typing-analytics/db/typing-analytics-db.ts
@@ -7,9 +7,10 @@
 // prepared-statement bundle) -> TypingAnalyticsDbWrites (ingest / tombstone
 // / sync export / merge) -> TypingAnalyticsDbReads (every Analyze-facing
 // query). It exists so importers keep the single `TypingAnalyticsDB` name,
-// constructor signature, and full method surface they always have — see
-// .claude/tasks/done/Task-split-typing-analytics-db.md for why the
-// 3,255-line original was split this way. External code must import this
+// constructor signature, and full method surface they always have. The
+// 3,255-line original was split into this abstract-class chain to keep
+// each file under the project's 800-line Service/Util size ceiling.
+// External code must import this
 // facade path, never a db/ sibling directly; new DB logic belongs in the
 // appropriate sibling (a statement group under sql/, or the base/writes/
 // reads class it operates on), not here.

--- a/src/main/typing-analytics/jsonl/jsonl-row.ts
+++ b/src/main/typing-analytics/jsonl/jsonl-row.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // JSONL row format for the per-device typing-analytics master files. Each
 // line is a single self-contained row with a composite id, a kind tag, the
-// payload, and an updated_at timestamp. See .claude/plans/typing-analytics.md
-// for the design rationale (JSONL master + SQLite cache).
+// payload, and an updated_at timestamp, so the file itself is a fully
+// self-describing source of truth — the SQLite cache is a disposable
+// index that can always be rebuilt by replaying rows in order.
 
 export const JSONL_SCHEMA_VERSION = 1
 

--- a/src/main/typing-analytics/minute-buffer.ts
+++ b/src/main/typing-analytics/minute-buffer.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Per-minute in-memory aggregator: accumulates char/matrix events and raw
 // keystroke intervals, then flushes a compact snapshot to the SQLite store
-// when a minute rolls over or the service is closed. See
-// .claude/plans/typing-analytics.md for the retention/aggregation design.
+// when a minute rolls over or the service is closed. Aggregation stops at
+// 1-minute granularity — no raw per-keystroke timing survives past this
+// buffer's own lifetime — so the exported/synced data is always derived,
+// never a raw event log.
 
 import type {
   TypingAnalyticsEvent,

--- a/src/main/typing-analytics/sync-state.ts
+++ b/src/main/typing-analytics/sync-state.ts
@@ -2,8 +2,7 @@
 // Persistent bookkeeping for the typing-analytics sync pipeline.
 // Tracks per-keyboard own-hash upload state so the sync pass can tell
 // "never uploaded" apart from "uploaded then remotely deleted", plus a
-// reconcile-pending timestamp per own hash. See
-// .claude/plans/typing-analytics.md.
+// reconcile-pending timestamp per own hash.
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'

--- a/src/main/typing-analytics/sync.ts
+++ b/src/main/typing-analytics/sync.ts
@@ -4,7 +4,9 @@
 // Shape: keyboards/{uid}/devices/{machineHash}/days/{YYYY-MM-DD}
 //   (one unit per (uid, hash, day), bundles a single per-day file)
 //
-// See .claude/plans/typing-analytics.md.
+// Per-day units (not per-device) keep sync granular: a remote device's
+// typing history is fetched and merged one day-file at a time instead
+// of as a single, ever-growing blob.
 
 import type { UtcDay } from './jsonl/utc-day'
 import { isUtcDay } from './jsonl/utc-day'

--- a/src/main/typing-analytics/typing-analytics-pipeline.ts
+++ b/src/main/typing-analytics/typing-analytics-pipeline.ts
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Ingest validation, event ingestion, and the debounced flush pipeline that
 // drains the in-memory MinuteBuffer + session queue to the per-device JSONL
-// master file and the local SQLite cache. See
-// .claude/plans/typing-analytics.md for the design rationale.
+// master file and the local SQLite cache.
 
 import { app } from 'electron'
 import type {

--- a/src/main/typing-analytics/typing-analytics-service.ts
+++ b/src/main/typing-analytics/typing-analytics-service.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Typing analytics service — orchestrates the per-minute in-memory buffer,
-// session detector, and SQLite persistence. See
-// .claude/plans/typing-analytics.md for the design rationale.
+// session detector, and SQLite persistence.
 //
 // This file is the facade: it owns async bootstrap (`setupTypingAnalytics`),
 // the top-level IPC registration entry point (`setupTypingAnalyticsIpc`,

--- a/src/main/typing-analytics/typing-analytics-state.ts
+++ b/src/main/typing-analytics/typing-analytics-state.ts
@@ -7,8 +7,7 @@
 // of a reassigned local either) — `minuteBuffer` below is reassigned
 // wholesale (see resetTypingAnalyticsForTests), so every other field is
 // folded into the same object rather than mixing two different state-
-// sharing conventions across the split. See
-// .claude/plans/typing-analytics.md for the design rationale.
+// sharing conventions across the split.
 
 import type { TypingAnalyticsFingerprint } from '../../shared/types/typing-analytics'
 import { MinuteBuffer } from './minute-buffer'

--- a/src/renderer/components/analyze/DurationSection.tsx
+++ b/src/renderer/components/analyze/DurationSection.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Analyze > Interval > Keypress duration — Pipette-only metric derived
 // from matrix-release duration capture (see
-// .claude/plans/Plan-typing-metrics-chi2018.md Phase 2 and
 // bigram-bucket.ts's DURATION_BUCKET_* grid, now shared via
 // shared/duration-buckets.ts). One of the three panes AnalyzePane's
 // "Section" filter-row select picks between (see `DistributionSection`

--- a/src/renderer/components/analyze/RolloverSection.tsx
+++ b/src/renderer/components/analyze/RolloverSection.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Analyze > Interval > Observed rollover rate — Pipette-only metric
 // derived from bigram physical-overlap sampling (see
-// .claude/plans/Plan-typing-metrics-chi2018.md Phase 2 and
 // bigram-aggregate.ts's `observedRolloverRatio` for the "observed, not
 // true" framing this section must never drop). Mounted below
 // IntervalChart, only in timeSeries mode — the same gate AnalyzePane

--- a/src/renderer/components/analyze/TappingTermCard.tsx
+++ b/src/renderer/components/analyze/TappingTermCard.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Analyze > Interval > TAPPING_TERM advisor — Pipette-only diagnosis
 // checking a keyboard's configured TAPPING_TERM against the user's own
-// measured keypress durations on its tap-hold keys. See
-// .claude/plans/Plan-typing-metrics-chi2018.md Phase 2 and the pure
+// measured keypress durations on its tap-hold keys. See the pure
 // logic in analyze-tapping-term.ts, which owns every statistical
 // decision made here — this component only fetches, filters to
 // tap-hold cells, and renders.

--- a/src/renderer/components/analyze/__tests__/DurationSection.test.tsx
+++ b/src/renderer/components/analyze/__tests__/DurationSection.test.tsx
@@ -216,7 +216,8 @@ describe('DurationSection', () => {
   })
 
   // Regression guard: pins chart-then-stat order, same as RolloverSection's
-  // equivalent test (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md).
+  // equivalent test, per the Analyze convention that a chart always
+  // renders above its stat numbers.
   it('renders the chart above the stat card, matching every other section\'s chart-then-numbers order', async () => {
     durationFetchSpy.mockResolvedValue([
       cell({ hist: [1, 0, 0, 0, 0, 0, 0, 0], durationSamples: 1, sum: 80, sumSq: 6_400 }),

--- a/src/renderer/components/analyze/__tests__/IntervalChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/IntervalChart.test.tsx
@@ -176,9 +176,9 @@ describe('IntervalChart distribution mode layout', () => {
     expect(screen.getByText('analyze.interval.timeSeries.sectionTitle')).toBeTruthy()
   })
 
-  // Regression guard, same pattern as RolloverSection's order-lock test
-  // (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
-  // pins chart-then-stat order in both viewModes.
+  // Regression guard, same pattern as RolloverSection's order-lock test:
+  // pins chart-then-stat order in both viewModes, per the Analyze
+  // convention that a chart always renders above its stat numbers.
   it('renders the chart above the stat card in timeSeries mode', async () => {
     renderChart({ viewMode: 'timeSeries' })
     await waitFor(() => {

--- a/src/renderer/components/analyze/__tests__/WpmChart.test.tsx
+++ b/src/renderer/components/analyze/__tests__/WpmChart.test.tsx
@@ -127,9 +127,9 @@ describe('WpmChart section order', () => {
     setVialAPI()
   })
 
-  // Regression guard, same pattern as RolloverSection's order-lock test
-  // (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
-  // pins chart-then-stat order in timeSeries mode.
+  // Regression guard, same pattern as RolloverSection's order-lock test:
+  // pins chart-then-stat order in timeSeries mode, per the Analyze
+  // convention that a chart always renders above its stat numbers.
   it('renders the chart above the stat card in timeSeries mode', async () => {
     renderChart({ viewMode: 'timeSeries' })
     await waitFor(() => {

--- a/src/renderer/components/analyze/analyze-snapshot-codes.ts
+++ b/src/renderer/components/analyze/analyze-snapshot-codes.ts
@@ -2,8 +2,10 @@
 // Resolves Speed-ranking / bigram-pair labels straight from a
 // snapshot's OWN recorded qmk strings, instead of round-tripping a
 // numeric code back through the CURRENT session's `RAWCODES_MAP`
-// (option B from .claude/tasks/backlog/Task-speed-ranking-snapshot-labels.md,
-// the keyboard-shape follow-up to #359's protocol-version fix).
+// (the keyboard-shape follow-up to #359's protocol-version fix, chosen
+// over patching the round-trip because the snapshot already carries
+// everything needed to resolve its own labels without depending on the
+// live session's keyboard context).
 //
 // The round-trip breaks whenever the snapshot's keyboard had more
 // layers/macros/tap-dances than the currently connected session:

--- a/src/renderer/components/analyze/analyze-tapping-term.ts
+++ b/src/renderer/components/analyze/analyze-tapping-term.ts
@@ -2,9 +2,7 @@
 // Analyze > Interval > TAPPING_TERM advisor — Pipette-only diagnosis
 // that checks whether a keyboard's configured TAPPING_TERM (the QMK
 // tap/hold decision window) fits the user's own measured keypress
-// durations on its tap-hold keys (LT / MT / SH_T). See
-// .claude/plans/Plan-typing-metrics-chi2018.md Phase 2 and
-// .claude/tasks/backlog/Task-tm-phase2-tapping-term-advisor.md.
+// durations on its tap-hold keys (LT / MT / SH_T).
 //
 // Observation-structure facts that drive every decision below:
 //

--- a/src/renderer/components/analyze/use-analyze-pane-sync.ts
+++ b/src/renderer/components/analyze/use-analyze-pane-sync.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Analytics-only sync trigger for the Analyze pane's selected keyboard.
-// Runs on mount / keyboard switch (see .claude/rules/settings-persistence.md)
-// and exposes the uid-scoped sync progress subscription so the pane's
-// ConnectingOverlay can show `syncing` accurately. Split out of
-// AnalyzePane.tsx (Task-split-analyze-pane).
+// Runs on mount / keyboard switch — typing-analytics sync units are
+// excluded from the 3-minute background poll and the keyboard-connect
+// initial sync (so the connect progress bar stays short), so this is
+// the only place that actually pulls/pushes them. Also exposes the
+// uid-scoped sync progress subscription so the pane's ConnectingOverlay
+// can show `syncing` accurately. Split out of AnalyzePane.tsx.
 
 import { useEffect, useState } from 'react'
 import type { SyncProgress } from '../../../shared/types/sync'
@@ -46,9 +48,10 @@ export function useAnalyzePaneSync(selectedUid: string | null): UseAnalyzePaneSy
     })
   }, [selectedUid])
 
-  // Analytics-only sync runs on Analyze mount (see
-  // .claude/rules/settings-persistence.md). The per-uid rate-limit map
-  // lives at module scope so split-view panes that share a uid don't
+  // Analytics-only sync runs on Analyze mount, the dedicated trigger
+  // that pulls typing-analytics data the 3-minute poll and connect-time
+  // sync both skip. The per-uid rate-limit map lives at module scope so
+  // split-view panes that share a uid don't
   // both fire the IPC. `syncingAnalytics` gates this pane's filter row
   // the same way `filtersReady` does.
   const [syncingAnalytics, setSyncingAnalytics] = useState(false)

--- a/src/renderer/components/editors/LayoutPickerContent.tsx
+++ b/src/renderer/components/editors/LayoutPickerContent.tsx
@@ -77,7 +77,7 @@ export function LayoutPickerContent({
 }: LayoutPickerContentProps) {
   const { t } = useTranslation()
 
-  // Canonicalized shared bubble (see .claude/DESIGN.md "Tooltip" section):
+  // Canonicalized shared bubble:
   // same `computeBubblePosition` viewport clamping every canonical
   // `Tooltip` uses, kept as a hand-rolled single bubble (not a per-key
   // `Tooltip` wrap) since `KeyboardPane` reports hover via one callback

--- a/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
+++ b/src/renderer/components/editors/__tests__/use-typing-test-result-save.test.ts
@@ -2,11 +2,9 @@
 // @vitest-environment jsdom
 //
 // Focused unit coverage for useTypingTestResultSave's `lineBreaks`
-// derivation at finish time (Plan-line-keystroke-timeline PR1) — see
-// .claude/tasks/backlog/Task-line-timeline-pr1-persist-linebreaks.md and
-// the P2 codex-review fixes: the source is chosen by `config.mode` (never
-// by `state.lineBreaks.size`, which can't tell "real single-line text"
-// apart from "no real line source"), and every clamp is STRICT
+// derivation at finish time — codex-review fixes: the source is chosen
+// by `config.mode` (never by `state.lineBreaks.size`, which can't tell
+// "real single-line text" apart from "no real line source"), and every clamp is STRICT
 // (`< persistedWordCount - 1`, not `< persistedWordCount`) since a line
 // break can never legitimately land on the run's own last persisted word.
 // Every other existing behavior of this hook (result build/save,

--- a/src/renderer/components/editors/useLayoutPicker.tsx
+++ b/src/renderer/components/editors/useLayoutPicker.tsx
@@ -80,7 +80,8 @@ export function useLayoutPicker({
   const [probeStatus, setProbeStatus] = useState<'idle' | 'probing' | 'error'>('idle')
   const [deviceBrowsing, setDeviceBrowsing] = useState(true)
   const [pickerScale, setPickerScale] = useState<number | undefined>(undefined)
-  // Canonicalized shared bubble (see .claude/DESIGN.md "Tooltip" section)
+  // Canonicalized shared bubble (same BUBBLE_BASE skin, computeBubblePosition
+  // viewport clamping, and 300ms open delay as the canonical `Tooltip`)
   // rather than a per-key `Tooltip` wrap — the picker keyboard renders
   // every key of the layout at once purely for hover, so one shared
   // bubble covers it the same way TabbedKeycodes/PopoverTabKey do.

--- a/src/renderer/components/keyboard/fill-luminance.ts
+++ b/src/renderer/components/keyboard/fill-luminance.ts
@@ -5,9 +5,11 @@
 // plus a single dynamic branch for heatmap HSL values: unknown fills are
 // returned as `false` so callers keep the default label color. This
 // matches the rule that new key colours must register themselves here
-// explicitly rather than relying on a generic luminance formula.
-//
-// See `.claude/rules/coding-ui.md` (Key fill palette) for the rule.
+// explicitly rather than relying on a generic luminance formula: every
+// new fill color must get an explicit `{ light, dark }` legibility
+// decision added to `FILL_INVERT_TABLE` below, decided per theme rather
+// than derived, so an untested fill silently keeps the default label
+// instead of guessing.
 
 import type { EffectiveTheme } from '../../hooks/useEffectiveTheme'
 

--- a/src/renderer/components/keycodes/PopoverTabKey.tsx
+++ b/src/renderer/components/keycodes/PopoverTabKey.tsx
@@ -31,8 +31,9 @@ function flattenLabel(label: string): string {
   return label.split('\n').map((line) => line.trim()).filter(Boolean).join(' ')
 }
 
-// Shared bubble contract (see .claude/DESIGN.md "Tooltip" section): a
-// canonicalized shared bubble, not a per-row `Tooltip` wrap — up to
+// Shared bubble contract: a canonicalized shared bubble (same
+// BUBBLE_BASE skin, computeBubblePosition viewport clamping, 300ms open
+// delay as the canonical `Tooltip`), not a per-row `Tooltip` wrap — up to
 // MAX_RESULTS (50) rows can be mounted at once, each with its own
 // truncated-detail hover target, so a per-row `Tooltip` would mount that
 // many portals + effects for a hover affordance only ever one row shows

--- a/src/renderer/components/keycodes/TabbedKeycodes.tsx
+++ b/src/renderer/components/keycodes/TabbedKeycodes.tsx
@@ -95,7 +95,7 @@ const LM_CATEGORY: KeycodeCategory = {
   getKeycodes: getAvailableLMMods,
 }
 
-// Shared bubble contract (see .claude/DESIGN.md "Tooltip" section): 8px
+// Shared bubble contract: 8px
 // offset, `computeBubblePosition` viewport clamping, `BUBBLE_BASE` skin,
 // 300ms open delay via `useSharedHoverBubble`. A canonicalized shared
 // bubble rather than per-key `Tooltip` wraps — every category's key grid

--- a/src/renderer/components/pack-modal/pack-modal-types.ts
+++ b/src/renderer/components/pack-modal/pack-modal-types.ts
@@ -5,8 +5,7 @@
 // extracts the common shell (PackManagerModal / PackListRow /
 // PackHubTab) while keeping every existing per-feature asymmetry
 // (delete cascade, hub search ordering, installed-detection, columns,
-// drag) exactly as it behaves today. See
-// `.claude/plans/Plan-pack-modal-unification.md`.
+// drag) exactly as it behaves today.
 
 /** Inline per-row success/error feedback shown under the Hub action line. */
 export interface PackActionResult {

--- a/src/renderer/hooks/useTroubleshooting.ts
+++ b/src/renderer/hooks/useTroubleshooting.ts
@@ -7,8 +7,7 @@
 // per-keyboard and remote reset affordances live in KeyboardSavesContent
 // ("Delete All") and CloudDataContent respectively, and Local >
 // Application's own reset is the single-target AppSettingsReset below.
-// That dead half is pruned here; see
-// .claude/tasks/backlog/Task-sync-remote-reset-and-discovery-gaps.md.
+// That dead half is pruned here.
 
 import { useState, useCallback } from 'react'
 

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -90,8 +90,7 @@ interface Props {
 /** Results view of the History modal: sub-filter row (mode/text dropdown +
  *  Export CSV), sparkline, stats summary, results table. Split out of
  *  `TypingTestHistory` so that file (which also owns the Analysis view
- *  switch) stays under the 500-line component cap
- *  (`.claude/rules/file-splitting.md`). */
+ *  switch) stays under the project's 500-line UI-component size cap. */
 export function HistoryResultsPanel({
   tab,
   modeFilter,

--- a/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
+++ b/src/renderer/typing-test/KeystrokeTimelinePanel.tsx
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Content of the per-run keystroke timeline — unified stat block, legend,
 // zoom slider, and the line/word rows with their hover tooltip. Extracted
-// out of `WordTimelineView` (see .claude/plans/Plan-completion-timeline-view.md
-// PR-A spec point 1) so a later PR can render the identical content
-// inline on the typing-test completion screen, not only inside the
+// out of `WordTimelineView` so this content can also render inline on
+// the typing-test completion screen, not only inside the
 // History modal. Deliberately has NO modal-specific assumptions: the
 // zoom's DOM-width-write invariant and the horizontal-scroll `overflow-auto`
 // wrapper both key off this component's own container width via
@@ -301,9 +300,9 @@ export function KeystrokeTimelinePanel({ log, result }: Props) {
         </p>
       )}
 
-      {/* Deliberate exception to the Analyze chart-above-stats rule
-          (.claude/tasks/backlog/Task-analyze-section-layout-consistency.md):
-          this grid is the panel's summary header, not a chart-adjacent
+      {/* Deliberate exception to the Analyze chart-above-stats convention
+          (a chart renders above its stat numbers everywhere else in
+          Analyze): this grid is the panel's summary header, not a chart-adjacent
           stat row — it must sit above the legend/zoom controls and the
           canvas, all of which the user reads top-to-bottom before ever
           reaching the scrollable, flex-grow canvas below. */}

--- a/src/renderer/typing-test/WordTimelineView.tsx
+++ b/src/renderer/typing-test/WordTimelineView.tsx
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Row-opened detail view for a single run's per-word keystroke timeline
-// (see .claude/tasks/backlog/Task-tm-phase5-word-timeline-ui.md). Nests
-// inside the History modal (opened from `HistoryTimelineCell`), so its
+// Row-opened detail view for a single run's per-word keystroke timeline.
+// Nests inside the History modal (opened from `HistoryTimelineCell`), so its
 // own Escape handling must consume the keydown before it can bubble up
 // to the History modal's own bubble-phase `useEscapeClose` — this
 // mirrors `JsonEditorModal`'s capture-phase + `stopPropagation` handler,
@@ -13,9 +12,8 @@
 // This component owns only the modal shell (backdrop, title, close
 // button) and the log fetch/loading/error states — the actual timeline
 // content (stat block, legend, zoom, rows) lives in
-// `KeystrokeTimelinePanel`, extracted out so a later PR can render the
-// identical content inline on the completion screen (see
-// .claude/plans/Plan-completion-timeline-view.md).
+// `KeystrokeTimelinePanel`, extracted out so the identical content can
+// also render inline on the completion screen.
 
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -449,8 +449,7 @@ describe('TypingTestHistory', () => {
 
   // Regression guard: pins sparkline-then-stats order, matching the Analyze
   // chart-above-stats convention (RolloverSection's order-lock test is the
-  // original of this pattern; see
-  // .claude/tasks/backlog/Task-analyze-section-layout-consistency.md).
+  // original of this pattern).
   it('renders the sparkline above the stats row', () => {
     const results = [
       makeResult({ wpm: 80 }),

--- a/src/renderer/typing-test/__tests__/romaji-engine-mozc.test.ts
+++ b/src/renderer/typing-test/__tests__/romaji-engine-mozc.test.ts
@@ -7,7 +7,10 @@
 // BSD-3-Clause; redistribution with attribution permitted). When mozc
 // updates its table, re-copy the file and re-run this suite — any drift
 // between the fixture and KANA_TABLE / sokuon / ん handling fails here.
-// Policy and scope details: .claude/docs/ROMAJI-ENGINE.md.
+// Policy: mozc's own table is the single source of truth for accepted
+// spellings — a spelling that's orthographically correct romanization
+// but that mozc's IME can't actually type (e.g. ぢ's "ji", which mozc
+// resolves to じ) is excluded even though it's valid on paper.
 //
 // TSV format: `input \t output \t pending?`. Three row classes matter:
 // - plain kana rows (2 columns, kana output) → KANA_TABLE entries

--- a/src/renderer/typing-test/keystroke-timeline-stats.ts
+++ b/src/renderer/typing-test/keystroke-timeline-stats.ts
@@ -3,8 +3,7 @@
 // same ten figures (WPM, KPM, Accuracy, KSPC, Time, Words, Overlap,
 // Substitution, Omission, Insertion) in both the History timeline modal
 // and the inline completion screen, so a run reads identically in either
-// place. See .claude/plans/Plan-completion-timeline-view.md PR-A spec
-// point 2.
+// place.
 //
 // Fallback scope is deliberately narrow: only WPM, Accuracy, Time, and
 // Overlap have a value when `result` is absent —

--- a/src/renderer/typing-test/line-timeline.ts
+++ b/src/renderer/typing-test/line-timeline.ts
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Pure log → display model for the per-LINE keystroke timeline (see
-// .claude/tasks/backlog/Task-line-timeline-pr2-line-view.md and
-// .claude/plans/Plan-line-keystroke-timeline.md). Sibling of
+// Pure log → display model for the per-LINE keystroke timeline. Sibling of
 // `word-timeline.ts`: a "line" groups one or more `RunWord`s onto ONE
 // shared display-ms axis (built once via `buildKeystrokeStream`, never
 // per-word — see that function's own doc comment), rather than resetting

--- a/src/renderer/typing-test/matrix-press-duration.ts
+++ b/src/renderer/typing-test/matrix-press-duration.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 /** Per-key press-duration + physical-overlap tracking for matrix analytics.
- *  Split out of useTypingTest.ts (see .claude/rules/file-splitting.md) —
- *  this owns state the queue-based tap/hold classifier
+ *  Split out of useTypingTest.ts to keep it under the project's 600-line
+ *  custom-hook size ceiling — this owns state the queue-based tap/hold classifier
  *  (matrix-analytics-queue.ts) doesn't need: how long every physical
  *  press (masked or not) stays down, and whether consecutive presses
  *  physically overlapped. Both are read straight off the `pressed` set

--- a/src/renderer/typing-test/missed-details.ts
+++ b/src/renderer/typing-test/missed-details.ts
@@ -9,8 +9,7 @@
 // alternate spellings the user goes on to complete, which only the live
 // reducer state at the moment of the keystroke can name reliably — a
 // codex-reviewed design decision, not an oversight. See
-// .claude/plans/Plan-completion-timeline-view.md and mistake-summary.tsx's
-// `MissedCharsList`, the sole consumer.
+// mistake-summary.tsx's `MissedCharsList`, the sole consumer.
 
 import type { RunKeystrokeLog } from '../../shared/types/typing-run-log'
 

--- a/src/renderer/typing-test/mistake-summary.tsx
+++ b/src/renderer/typing-test/mistake-summary.tsx
@@ -4,7 +4,6 @@
 // completion screen's finished-state summary) so `KeystrokeTimelinePanel`
 // can show a consistent presentation for a `TypingTestResult` without a
 // second, drifting implementation of the same sort/slice/testid logic.
-// See .claude/plans/Plan-completion-timeline-view.md PR-A spec point 2.
 //
 // Two presentations of the same sorted mistake list:
 //  - `MissedCharsList` — the original inline chip line, still used by

--- a/src/renderer/typing-test/romaji-engine.ts
+++ b/src/renderer/typing-test/romaji-engine.ts
@@ -33,9 +33,13 @@
 // (mozc/src/data/preedit/romanji-hiragana.tsv) — IME keystroke input, not
 // romanization orthography — so every accepted spelling here is something
 // a real IME actually accepts, not merely a valid way to transliterate the
-// finished word. See `.claude/docs/ROMAJI-ENGINE.md` for the mapping
-// rationale and `__tests__/romaji-engine-mozc.test.ts` for the compliance
-// sweep against that table.
+// finished word: mozc's table (not orthography guides) is the single
+// source of truth for what counts as an accepted spelling, so a
+// spelling that's correct romanization but not IME-typable (e.g. ぢ's
+// orthographic "ji", which mozc's IME resolves to じ instead) is
+// deliberately excluded even though it looks valid on paper. See
+// `__tests__/romaji-engine-mozc.test.ts` for the compliance sweep
+// against that table.
 
 import { toHiragana } from './kana-script'
 import { ROMAJI_PUNCTUATION, isRomajiPunctuation } from '../../shared/kana-purity'
@@ -351,7 +355,7 @@ export const KANA_TABLE: Record<string, readonly string[]> = {
 // KANA_TABLE gains a non-kana key). mozc's own romaji table maps "."/","
 // to 。/、; ？/！ aren't part of that kana table, but "?"/"!" are their
 // natural direct-keystroke spelling. One canonical ASCII spelling each, no
-// style variants — see .claude/docs/ROMAJI-ENGINE.md. Keys are type-locked
+// style variants — the settings modal has nothing to toggle here. Keys are type-locked
 // to ROMAJI_PUNCTUATION (shared with isKanaOnlyText in shared/kana-purity)
 // so the two lists can't drift apart.
 export const PUNCTUATION_TABLE: Record<(typeof ROMAJI_PUNCTUATION)[number], readonly string[]> = {

--- a/src/renderer/typing-test/run-log-recorder.ts
+++ b/src/renderer/typing-test/run-log-recorder.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-/** In-memory buffer + join logic for the per-run raw keystroke log (see
- *  `.claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md`). Owned by
+/** In-memory buffer + join logic for the per-run raw keystroke log. Owned by
  *  `useInputModes` (one instance per editor session) and fed from three
  *  seams already wired for the existing per-minute analytics pipeline:
  *

--- a/src/renderer/typing-test/use-timeline-model.ts
+++ b/src/renderer/typing-test/use-timeline-model.ts
@@ -4,8 +4,8 @@
 // PRESENCE (see that field's own doc comment in typing-run-log.ts: `[]`
 // means "one line", still line-mode; absent means a legacy log, always
 // word-mode). Extracted out of the view component itself to keep
-// WordTimelineView.tsx under its file-splitting cap (see
-// .claude/rules/file-splitting.md) — this hook owns every `useMemo` that
+// WordTimelineView.tsx under the project's 500-line UI-component size
+// cap — this hook owns every `useMemo` that
 // derives from `log`, the view owns only rendering + zoom/hover DOM
 // wiring.
 

--- a/src/renderer/typing-test/word-timeline-colors.ts
+++ b/src/renderer/typing-test/word-timeline-colors.ts
@@ -69,8 +69,7 @@ export const TIMELINE_LEGEND: Record<TimelineFillKind, TimelineLegendEntry> = {
  *  keystrokes end and the next begins on the line's shared axis), not a
  *  semantic "kind" like the ones above, so it has no `TIMELINE_LEGEND`
  *  entry of its own. Uses the same subtle hairline-divider token
- *  `style.css` reserves for this purpose elsewhere (`--color-edge-subtle`
- *  — see `.claude/DESIGN.md`'s Elevation & Depth table). */
+ *  `style.css` reserves for this purpose elsewhere (`--color-edge-subtle`). */
 export const WORD_SEPARATOR_FILL = 'var(--color-edge-subtle)'
 
 /** Priority order for a keystroke's fill when more than one condition
@@ -88,7 +87,7 @@ export function fillForKeystroke(seg: KeystrokeSegment): string {
 
 /** Per-fill-kind label TEXT color for the LINE view's on-bar keystroke
  *  labels (`LineTimelineRow.tsx`) — same philosophy as `KeyWidget`'s
- *  `FILL_INVERT_TABLE` (`.claude/rules/coding-ui.md`): every fill a
+ *  `FILL_INVERT_TABLE`: every fill a
  *  keystroke can render as gets an explicit, theme-aware class instead of
  *  one default that quietly breaks on fills bright enough to need dark
  *  text. `normal`/`mistake` are safe with the plain inverse token in both

--- a/src/renderer/typing-test/word-timeline.ts
+++ b/src/renderer/typing-test/word-timeline.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Pure log → display model for the per-word keystroke timeline (see
-// .claude/tasks/backlog/Task-tm-phase5-word-timeline-ui.md). Every
+// Pure log → display model for the per-word keystroke timeline. Every
 // coordinate this module produces is in "display-ms" space: a single
 // shared, zoom-independent horizontal axis that the view scales by a
 // pixel-per-ms factor without ever recomputing bar positions (see

--- a/src/renderer/utils/chart-palette.ts
+++ b/src/renderer/utils/chart-palette.ts
@@ -9,7 +9,8 @@
 // lightness so the ramp reads against both light and dark surfaces.
 // The saturation/lightness constants come from the project palette
 // spec — if you tweak them, keep `fill-luminance.ts`'s HSL thresholds
-// in sync (see `.claude/rules/coding-ui.md`).
+// in sync (it inverts label text below l=60% in light mode and above
+// l=42% in dark mode).
 
 import type { EffectiveTheme } from '../hooks/useEffectiveTheme'
 

--- a/src/shared/keymap/__tests__/keymap-apply.test.ts
+++ b/src/shared/keymap/__tests__/keymap-apply.test.ts
@@ -28,9 +28,8 @@ const COLEMAK: Record<string, string> = {
 // Real Dvorak entry from pipette-hub's data/key-labels-seed.json (the
 // "Dvorak" pack, `keymap_applicable: true`) — 33 entries. NOT closed:
 // `KC_RBRACKET -> "="` and `KC_QUOTE -> "-"` resolve to targets KC_EQUAL /
-// KC_MINUS, but neither has a source entry of its own (see
-// pipette-hub's .claude/plan/key-label-dvorak-closure-fix.md, the real
-// bug this fixture reproduces). Applying this map as-is would duplicate
+// KC_MINUS, but neither has a source entry of its own — the real closure
+// bug this fixture reproduces. Applying this map as-is would duplicate
 // `-`/`=` on two keys each while no key sends `[`/`]` anymore. KC_A/KC_M
 // are present as harmless identity entries in the real pack (not part of
 // the defect).

--- a/src/shared/types/hub.ts
+++ b/src/shared/types/hub.ts
@@ -241,10 +241,9 @@ export interface HubUpdateFavoritePostParams extends HubUploadFavoritePostParams
 
 // --- Analytics post types ---
 //
-// Wire format for "Analyze 集計データ" uploads. The full contract lives in
-// `.claude/docs/HUB-ANALYTICS-API.md` (Hub agent's source of truth). The
-// types below mirror that contract; the validators in
-// `src/main/hub/hub-analytics.ts` enforce the runtime invariants.
+// Wire format for "Analyze 集計データ" uploads, the payload shape shared
+// with pipette-hub. The types below mirror that contract; the validators
+// in `src/main/hub/hub-analytics.ts` enforce the runtime invariants.
 
 /** Hub-side `analytics-export-v1.json` payload. */
 export interface HubAnalyticsExportV1 {

--- a/src/shared/types/pipette-settings.ts
+++ b/src/shared/types/pipette-settings.ts
@@ -321,8 +321,7 @@ export interface PipetteSettings {
    * survives reloads and follows the keyboard across machines. Actual
    * recording is gated additionally on typingTestViewOnly at the
    * analyticsSink layer — leaving the typing view stops recording
-   * without touching this value. See the "Record lifecycle" section
-   * in .claude/plans/typing-analytics.md. */
+   * without touching this value. */
   typingRecordEnabled?: boolean
   typingSyncSpanDays?: TypingSyncSpanDays
   layerPanelOpen?: boolean

--- a/src/shared/types/typing-analytics.ts
+++ b/src/shared/types/typing-analytics.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-// Typing analytics shared types — see .claude/plans/typing-analytics.md.
+// Typing analytics shared types, used by both the renderer (Analyze view)
+// and main (ingestion, SQLite cache, sync).
 
 import type { FingerType, RowCategory } from '../kle/kle-ergonomics'
 

--- a/src/shared/types/typing-run-log.ts
+++ b/src/shared/types/typing-run-log.ts
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Per-run raw keystroke log for a Typing Test run — the timeline data a
 // per-minute aggregate cannot reconstruct (order and inter-keystroke
-// gaps are lost once folded into a minute bucket). See
-// .claude/tasks/backlog/Task-tm-phase5-run-keystroke-log.md and
-// .claude/plans/Plan-typing-metrics-chi2018.md Phase 5.
+// gaps are lost once folded into a minute bucket).
 //
 // PRIVACY (read before touching this file): this is the highest
 // input-content-recovery-risk data in the app — higher than trigrams.

--- a/src/shared/typing-benchmarks.ts
+++ b/src/shared/typing-benchmarks.ts
@@ -133,8 +133,9 @@ export type TypistClusterId = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8
  * The paper's own cluster label (e.g. "SLOW CARELESS HAND ALTERNATORS")
  * and participant count `N` are NOT fields on this interface — they're
  * transcription provenance too, but evaluative label strings like that
- * are exactly the vocabulary `.claude/rules/coding-ui.md` bars from
- * reaching a renderer bundle or any future render path. Keeping them as
+ * are exactly the kind of hardcoded, non-i18n user-facing text the
+ * project's i18n rule already bars from reaching a renderer bundle (all
+ * UI text must go through `t()`) or any future render path. Keeping them as
  * a `//` comment on each `TYPIST_CLUSTER_CENTROIDS` row preserves the
  * same provenance without shipping the string or giving any future code
  * path something to read and render. */


### PR DESCRIPTION
## Summary
- 99 comment references to `.claude/...` paths (internal, gitignored, invisible to readers of the public repo) across 83 shipped files are eliminated. Each referenced internal doc was read first; comments that leaned on the citation now carry the actual constraint inline (fill-legibility table rule with its HSL thresholds, the mozc single-source-of-truth spelling policy, concrete file-size ceilings, the pack-discovery routes), while provenance-only citations are simply dropped.
- Comments/strings only — zero behavior changes.

## Verification
- `grep -rn ".claude" src/ e2e/ scripts/ docs/` → zero matches.
- eslint clean on all touched files; typecheck clean; full suite 8,716 passed / 22 skipped (exact baseline).