### PR TITLE
fix(ui): order the Japanese input methods Romaji, Kana, Direct

### DIFF
--- a/src/renderer/typing-test/RomajiSettingsModal.tsx
+++ b/src/renderer/typing-test/RomajiSettingsModal.tsx
@@ -33,8 +33,9 @@ import { resolveJapaneseInputMethod, type JapaneseInputMethod } from './romaji-i
 const CASE_STYLES: readonly RomajiCaseStyle[] = ['upper', 'capital', 'lower']
 
 // Unified 3-way selector (resolveJapaneseInputMethod, romaji-input.ts) —
-// shown first, since it decides which section below even applies.
-const INPUT_METHODS: readonly JapaneseInputMethod[] = ['direct', 'romaji', 'kana']
+// shown first, since it decides which section below even applies. Ordered
+// by expected usage: Romaji (default), Kana, then Direct.
+const INPUT_METHODS: readonly JapaneseInputMethod[] = ['romaji', 'kana', 'direct']
 
 // Total line count offered by the guide row (the line the current word
 // sits on included), 0-3: 0 hides the row, 1 shows only the current line,

--- a/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
+++ b/src/renderer/typing-test/__tests__/RomajiSettingsModal.test.tsx
@@ -31,6 +31,15 @@ function renderModal(props: Partial<Parameters<typeof RomajiSettingsModal>[0]> =
 }
 
 describe('RomajiSettingsModal — unified 3-way input method selector', () => {
+  it('renders the methods in Romaji, Kana, Direct order', () => {
+    renderModal()
+    const romaji = screen.getByTestId('japanese-input-method-romaji')
+    const kana = screen.getByTestId('japanese-input-method-kana')
+    const direct = screen.getByTestId('japanese-input-method-direct')
+    expect(romaji.compareDocumentPosition(kana) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(kana.compareDocumentPosition(direct) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
   it('defaults to Romaji when romajiInput/inputMethod are both unset', () => {
     renderModal()
     expect(screen.getByTestId('japanese-input-method-romaji').className).toContain('text-accent')


### PR DESCRIPTION
## Summary
- The Japanese Input Settings modal's 3-way method selector now lists Romaji, Kana, Direct — most-used first — instead of Direct-first. Pure order change; a DOM-order test pins it.

## Verification
- Modal suite 44 passed (+1 order test); eslint/typecheck clean; virtual-device screenshot confirms the rendered order.