### PR TITLE
feat(ui): filter the History modal by period

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.79",
+  "version": "0.1.80",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -508,6 +508,12 @@
         "tabAnalysis": "分析",
         "viewTabsAriaLabel": "履歴の表示切替",
         "sourceFilterLabel": "ソースで絞り込み",
+        "periodFilterLabel": "期間で絞り込み",
+        "period1Week": "1週間",
+        "period1Month": "1ヶ月",
+        "period3Months": "3ヶ月",
+        "period1Year": "1年",
+        "periodAll": "全期間",
         "noResults": "結果がありません",
         "pb": "PB",
         "allModes": "すべて",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.79",
+  "version": "0.1.80",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -508,6 +508,12 @@
         "tabAnalysis": "分析☆",
         "viewTabsAriaLabel": "履歴の表示を切り替えるっしょ",
         "sourceFilterLabel": "ソースで絞り込むっしょ",
+        "periodFilterLabel": "期間で絞り込むっしょ",
+        "period1Week": "1週間☆",
+        "period1Month": "1ヶ月☆",
+        "period3Months": "3ヶ月☆",
+        "period1Year": "1年☆",
+        "periodAll": "全期間☆",
         "noResults": "結果ないじゃん",
         "pb": "PB☆",
         "allModes": "全部",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.79",
+  "version": "0.1.80",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -508,6 +508,12 @@
         "tabAnalysis": "分析",
         "viewTabsAriaLabel": "履歴の表示を切り替えますえ",
         "sourceFilterLabel": "ソースで絞り込みますえ",
+        "periodFilterLabel": "期間で絞り込みますえ",
+        "period1Week": "1週間どす",
+        "period1Month": "1ヶ月どす",
+        "period3Months": "3ヶ月どす",
+        "period1Year": "1年どす",
+        "periodAll": "全期間どす",
         "noResults": "結果がおへんなぁ",
         "pb": "PB",
         "allModes": "全部",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.79",
+  "version": "0.1.80",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -508,6 +508,12 @@
         "tabAnalysis": "分析",
         "viewTabsAriaLabel": "履歴の表示切替",
         "sourceFilterLabel": "ソースで絞り込む",
+        "periodFilterLabel": "期間による絞り込み",
+        "period1Week": "一週間",
+        "period1Month": "一ヶ月",
+        "period3Months": "三ヶ月",
+        "period1Year": "一年",
+        "periodAll": "全期間",
         "noResults": "記録はございません",
         "pb": "自己最高",
         "allModes": "すべて",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.79",
+  "version": "0.1.80",
   "name": "English",
   "common": {
     "save": "Save",
@@ -508,6 +508,12 @@
         "tabAnalysis": "Analysis",
         "viewTabsAriaLabel": "History view",
         "sourceFilterLabel": "Filter by source",
+        "periodFilterLabel": "Filter by period",
+        "period1Week": "1 Week",
+        "period1Month": "1 Month",
+        "period3Months": "3 Months",
+        "period1Year": "1 Year",
+        "periodAll": "All Time",
         "noResults": "No results yet",
         "pb": "PB",
         "allModes": "All",

--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -13,6 +13,8 @@ import { HistorySections } from './HistorySections'
 import { HistoryResultsPanel } from './HistoryResultsPanel'
 import type { ModeFilter, SortColumn, SortDirection, HistoryTab } from './HistoryResultsPanel'
 import { deriveDistinctConditions } from './AccuracyTrendSection'
+import { PERIOD_FILTERS, DEFAULT_PERIOD_FILTER, filterResultsByPeriod } from './history-period-filter'
+import type { PeriodFilter } from './history-period-filter'
 
 // Tab order for the source tablist — MonkeyType (words/time/quote), Tatoeba
 // (mode 'tatoeba'), Aozora (fileImport rows whose text meta was imported via
@@ -26,6 +28,14 @@ const HISTORY_TAB_LABEL_KEYS: Record<HistoryTab, string> = {
   tatoeba: 'editor.typingTest.history.tabTatoeba',
   aozora: 'editor.typingTest.history.tabAozora',
   text: 'editor.typingTest.history.tabFileImport',
+}
+
+const PERIOD_FILTER_LABEL_KEYS: Record<PeriodFilter, string> = {
+  '1w': 'editor.typingTest.history.period1Week',
+  '1m': 'editor.typingTest.history.period1Month',
+  '3m': 'editor.typingTest.history.period3Months',
+  '1y': 'editor.typingTest.history.period1Year',
+  all: 'editor.typingTest.history.periodAll',
 }
 
 /** Set on a `TypingTestTextMeta.source.provider` when the text was imported
@@ -168,6 +178,32 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
   // pick-with-fallback shape as `textFilter`/`effectiveTextFilter` above.
   const [conditionFilter, setConditionFilter] = useState<string>('')
 
+  // Period filter — rightmost select in the header's right-end group.
+  // Scopes EVERYTHING below the header row (WPM Trend chart, stats summary,
+  // Results table, CSV export, and the entire Analysis tab) to a rolling
+  // window, not just the Results table — see periodResults below, which
+  // every other derived value in this file is built from instead of the raw
+  // `results` prop. Defaults to '1m' (1 month) on every mount; since
+  // HistoryToggle only mounts this component while the modal is open (see
+  // its `{showHistory && (...)}` guard), that also means "1 month" is the
+  // starting point on every fresh History open, not a one-time default —
+  // matching the source select above, which is likewise local, non-
+  // persisted state.
+  const [periodFilter, setPeriodFilter] = useState<PeriodFilter>(DEFAULT_PERIOD_FILTER)
+
+  // Anchor timestamp for the period filter, computed once when this
+  // component mounts (i.e. once per History open, per the mount note
+  // above) rather than re-read on every render or ticked via an interval —
+  // the window's far edge doesn't need to advance while the modal stays
+  // open, and a stable anchor keeps the visible set from shifting under the
+  // user mid-session as they switch between periods.
+  const [now] = useState(() => Date.now())
+
+  const periodResults = useMemo(
+    () => filterResultsByPeriod(results, periodFilter, now),
+    [results, periodFilter, now],
+  )
+
   // Imported-text metas, used to tell an Aozora-catalog fileImport row apart
   // from a plain File Import one (see classifyResultTab above).
   const { metas: textMetas } = useTypingTestTexts()
@@ -225,21 +261,24 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
     }
   }, [focusAndSelectView])
 
-  // Active tab's rows, per classifyResultTab above.
+  // Active tab's rows, per classifyResultTab above. Built from
+  // periodResults (not the raw `results` prop) so the period filter applies
+  // before source-tab classification.
   const tabResults = useMemo(
-    () => results.filter((r) => classifyResultTab(r, textMetaById) === tab),
-    [results, tab, textMetaById],
+    () => periodResults.filter((r) => classifyResultTab(r, textMetaById) === tab),
+    [periodResults, tab, textMetaById],
   )
 
   // Distinct imported texts (fileImport rows), keyed by stable textId,
   // displayed by the snapshotted name — scoped to the active tab (Aozora
   // gets only source.provider 'aozora' texts, File Import gets the rest).
   // Drives that tab's filter dropdown; empty (and thus hidden) for
-  // MonkeyType/Tatoeba.
+  // MonkeyType/Tatoeba. Scoped to periodResults so a text with no results
+  // inside the current period drops out of the dropdown too.
   const fileImportTexts = useMemo(() => {
     if (tab !== 'aozora' && tab !== 'text') return []
     const seen = new Map<string, string>()
-    for (const r of results) {
+    for (const r of periodResults) {
       if (r.mode !== 'fileImport') continue
       const id = fileImportTextId(r)
       const isAozoraText = textMetaById.get(id)?.source?.provider === AOZORA_PROVIDER
@@ -247,7 +286,7 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
       if (!seen.has(id)) seen.set(id, r.fileImportTextName ?? id)
     }
     return Array.from(seen, ([id, name]) => ({ id, name }))
-  }, [results, tab, textMetaById])
+  }, [periodResults, tab, textMetaById])
 
   // Fall back to 'all' when the selected text no longer exists in this tab
   // (e.g. all its rows were deleted, or the tab was just switched to one
@@ -316,7 +355,10 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
           order matters here (source first, condition second) per the
           approved redesign sketch. The condition select carries no visible
           label (aria-label only); the "ACCURACY TREND" heading stays above
-          the chart in AccuracyTrendSection itself. */}
+          the chart in AccuracyTrendSection itself. The period select is
+          always last, in both Results and Analysis (see its own comment
+          below) — it's the one selector in this group that scopes every
+          view, not just Analysis. */}
       <div className="flex items-center gap-3 border-b border-edge/60">
         <div
           role="tablist"
@@ -373,6 +415,22 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
               ))}
             </select>
           )}
+          {/* Period filter — always the rightmost select, in both Results
+              and Analysis (unlike the condition select above, which only
+              applies to Analysis). Scopes periodResults, which every value
+              below this row is ultimately derived from — see the
+              periodResults doc comment above. */}
+          <select
+            data-testid="history-filter-period"
+            aria-label={t('editor.typingTest.history.periodFilterLabel')}
+            className={HEADER_SELECT_CLASS}
+            value={periodFilter}
+            onChange={(e) => setPeriodFilter(e.target.value as PeriodFilter)}
+          >
+            {PERIOD_FILTERS.map((p) => (
+              <option key={p} value={p}>{t(PERIOD_FILTER_LABEL_KEYS[p])}</option>
+            ))}
+          </select>
         </div>
       </div>
 

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -28,6 +28,20 @@ function renderWithI18n(ui: React.ReactElement) {
   return render(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>)
 }
 
+/** Same as renderWithI18n, but also switches the period filter to "All
+ *  Time". The period filter defaults to "1 month" (see
+ *  history-period-filter.ts), so any test using a fixture `date` more than
+ *  a month before the real wall-clock "now" — most of the ones below, which
+ *  pin specific ISO strings to assert sort order / CSV content rather than
+ *  to exercise the period feature itself — needs this to keep its rows
+ *  visible. Tests that specifically cover the period filter render with
+ *  plain renderWithI18n instead, so its default stays exercised. */
+function renderWithI18nAllTime(ui: React.ReactElement) {
+  const result = renderWithI18n(ui)
+  fireEvent.change(screen.getByTestId('history-filter-period'), { target: { value: 'all' } })
+  return result
+}
+
 /** Minimal TypingTestTextMeta builder for source-tab classification tests —
  *  only `source` (aozora-provider detection) and `id` matter here. */
 function textMeta(id: string, name: string, source?: { provider: string; workId: string }): TypingTestTextMeta {
@@ -146,7 +160,7 @@ describe('TypingTestHistory', () => {
       makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z' }),
       makeResult({ wpm: 75, date: '2025-01-01T00:00:00Z' }),
     ]
-    renderWithI18n(<TypingTestHistory results={results} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} />)
 
     const rows = () => {
       const history = screen.getByTestId('typing-test-history')
@@ -177,7 +191,7 @@ describe('TypingTestHistory', () => {
       makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z', holdSumMs: 800, holdSamples: 5 }), // 160 ms
       makeResult({ wpm: 75, date: '2025-01-01T00:00:00Z' }), // legacy, no raw fields
     ]
-    renderWithI18n(<TypingTestHistory results={results} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} />)
 
     const cellsFor = (idx: number) => {
       const history = screen.getByTestId('typing-test-history')
@@ -234,7 +248,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z', mode: 'words', mode2: 30 }),
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     const exportBtn = screen.getByTestId('history-export-csv')
     expect(exportBtn).toBeTruthy()
@@ -255,7 +269,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z', kspcKeystrokes: 6, kspcChars: 4 }),
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -268,7 +282,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z' }), // no kspcKeystrokes/kspcChars
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -283,7 +297,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z', holdSumMs: 241, holdSamples: 3 }), // 80.33... -> 80
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -298,7 +312,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z' }), // no holdSumMs/holdSamples
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -315,7 +329,7 @@ describe('TypingTestHistory', () => {
         errorSubstitutions: 2, errorOmissions: 1, errorInsertions: 0, errorTargetChars: 40,
       }),
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -337,7 +351,7 @@ describe('TypingTestHistory', () => {
     const results = [
       makeResult({ wpm: 80, date: '2025-01-01T00:00:00Z' }),
     ]
-    renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+    renderWithI18nAllTime(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
 
     fireEvent.click(screen.getByTestId('history-export-csv'))
     const csv = onExportCsv.mock.calls[0][0] as string
@@ -375,7 +389,7 @@ describe('TypingTestHistory', () => {
   it('renames a result via the naming modal and calls onRename', () => {
     const date = '2025-02-02T03:04:05.000Z'
     const onRename = vi.fn()
-    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onRename={onRename} />)
+    renderWithI18nAllTime(<TypingTestHistory results={[makeResult({ date })]} onRename={onRename} />)
     // The name cell opens the naming modal; type and Save commits.
     fireEvent.click(screen.getByTestId(`history-name-${date}`))
     const input = screen.getByTestId('result-name-modal-input')
@@ -423,7 +437,7 @@ describe('TypingTestHistory', () => {
   it('deletes a result only after confirmation', () => {
     const date = '2025-03-03T01:02:03.000Z'
     const onDelete = vi.fn()
-    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
+    renderWithI18nAllTime(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
     // First click asks for confirmation, does not delete yet.
     fireEvent.click(screen.getByTestId(`history-delete-${date}`))
     expect(onDelete).not.toHaveBeenCalled()
@@ -434,7 +448,7 @@ describe('TypingTestHistory', () => {
   it('cancels deletion when cancel is clicked', () => {
     const date = '2025-04-04T01:02:03.000Z'
     const onDelete = vi.fn()
-    renderWithI18n(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
+    renderWithI18nAllTime(<TypingTestHistory results={[makeResult({ date })]} onDelete={onDelete} />)
     fireEvent.click(screen.getByTestId(`history-delete-${date}`))
     fireEvent.click(screen.getByTestId(`history-delete-cancel-${date}`))
     expect(onDelete).not.toHaveBeenCalled()
@@ -480,7 +494,12 @@ describe('TypingTestHistory', () => {
   })
 
   it('renders the name read-only (no edit) when no onRename handler', () => {
-    renderWithI18n(<TypingTestHistory results={[makeResult({ date: 'x', name: 'kept' })]} />)
+    // date: 'x' here is a non-date identifier (drives the `history-name-x`
+    // testid below), not a real timestamp — renderWithI18nAllTime is
+    // required so the period filter's "unparseable date" drop (see
+    // history-period-filter.ts) doesn't exclude this row under the default
+    // 1-month window.
+    renderWithI18nAllTime(<TypingTestHistory results={[makeResult({ date: 'x', name: 'kept' })]} />)
     expect(screen.queryByTestId('history-name-x')).toBeNull()
     // The name shows in the cell (and again in its hover tooltip bubble).
     expect(screen.getAllByText('kept').length).toBeGreaterThan(0)
@@ -562,7 +581,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
       fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       const select = screen.getByTestId('history-condition-filter') as HTMLSelectElement
       expect(select.options.length).toBe(2)
@@ -577,7 +596,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
       fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.getByTestId('accuracy-trend-chart')).toBeTruthy()
     })
@@ -590,7 +609,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
       fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       // Default (latest = time|60) has only 1 run → no chart yet.
       expect(screen.queryByTestId('accuracy-trend-chart')).toBeNull()
@@ -607,7 +626,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
       fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
       expect(screen.getByTestId('accuracy-trend-chart')).toBeTruthy()
       // The mode filter dropdown lives in the Results view — switch there to
@@ -771,7 +790,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z' }),
         makeResult({ wpm: 75, date: '2025-01-01T00:00:00Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
 
       const rows = () => {
         const history = screen.getByTestId('typing-test-history')
@@ -1050,7 +1069,7 @@ describe('TypingTestHistory', () => {
         makeResult({ wpm: 65, accuracy: 92, mode: 'words', mode2: 30, language: 'english', date: '2026-01-02T00:00:00.000Z' }),
         makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: '2026-01-01T00:00:00.000Z' }),
       ]
-      renderWithI18n(<TypingTestHistory results={results} />)
+      renderWithI18nAllTime(<TypingTestHistory results={results} />)
       fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
 
       // Default (latest = time|60) has only 1 run → no chart yet.
@@ -1086,6 +1105,119 @@ describe('TypingTestHistory', () => {
       // The heading lives inside the Analysis tabpanel (history-sections),
       // not in the always-visible header row alongside the selects.
       expect(screen.getByTestId('history-sections').contains(heading)).toBe(true)
+    })
+  })
+
+  describe('period filter', () => {
+    const DAY_MS = 24 * 60 * 60 * 1000
+
+    it('renders the period select as the rightmost item in the header, with 5 options in order, defaulting to 1 Month', () => {
+      renderWithI18n(<TypingTestHistory results={[makeResult()]} />)
+      const select = screen.getByTestId('history-filter-period') as HTMLSelectElement
+      expect(Array.from(select.options).map((o) => o.value)).toEqual(['1w', '1m', '3m', '1y', 'all'])
+      expect(select.value).toBe('1m')
+
+      // Rightmost: it comes after the source select in document order, in
+      // both the Results view (no condition select) and the Analysis view
+      // (source, condition, period).
+      const sourceSelect = screen.getByTestId('history-filter-source')
+      expect(sourceSelect.compareDocumentPosition(select) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      const conditionSelect = screen.getByTestId('history-condition-filter')
+      const periodSelectInAnalysis = screen.getByTestId('history-filter-period')
+      expect(conditionSelect.compareDocumentPosition(periodSelectInAnalysis) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('excludes a result older than the default 1-month window from the table and stats, while a recent one stays', () => {
+      const results = [
+        makeResult({ wpm: 80, date: new Date(Date.now() - 2 * DAY_MS).toISOString() }), // 2 days ago — inside 1m
+        makeResult({ wpm: 55, date: new Date(Date.now() - 40 * DAY_MS).toISOString() }), // 40 days ago — outside 1m
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+
+      // Default period (1 Month, no interaction needed): only the recent row shows.
+      expect(screen.getAllByText('80').length).toBeGreaterThan(0)
+      expect(screen.queryByText('55')).toBeNull()
+      const stats = screen.getByTestId('history-stats')
+      expect(stats.textContent).toContain('Tests:1')
+    })
+
+    it('shows every result, regardless of age, once "All Time" is selected', () => {
+      const results = [
+        makeResult({ wpm: 80, date: new Date(Date.now() - 2 * DAY_MS).toISOString() }),
+        makeResult({ wpm: 55, date: new Date(Date.now() - 400 * DAY_MS).toISOString() }), // well past 1y too
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      expect(screen.queryByText('55')).toBeNull()
+
+      fireEvent.change(screen.getByTestId('history-filter-period'), { target: { value: 'all' } })
+      expect(screen.getAllByText('80').length).toBeGreaterThan(0)
+      expect(screen.getAllByText('55').length).toBeGreaterThan(0)
+      const stats = screen.getByTestId('history-stats')
+      expect(stats.textContent).toContain('Tests:2')
+    })
+
+    it('excludes a result from the WPM Trend chart once it falls outside the selected period', () => {
+      const results = [
+        makeResult({ wpm: 80, date: new Date(Date.now() - 1 * DAY_MS).toISOString() }),
+        makeResult({ wpm: 82, date: new Date(Date.now() - 2 * DAY_MS).toISOString() }),
+        makeResult({ wpm: 55, date: new Date(Date.now() - 40 * DAY_MS).toISOString() }), // outside 1m
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      // 2 in-window results → the chart renders (needs >= 2 points).
+      expect(screen.getByTestId('wpm-trend-chart')).toBeTruthy()
+
+      // Narrow to 1 Week: still 2 in-window results (1 and 2 days ago), so
+      // the chart keeps rendering — this only pins that the chart re-derives
+      // from the filtered set, not a specific point count.
+      fireEvent.change(screen.getByTestId('history-filter-period'), { target: { value: '1w' } })
+      expect(screen.getByTestId('wpm-trend-chart')).toBeTruthy()
+    })
+
+    it('feeds the Analysis tab from period-filtered results only — a condition outside the window drops out of the condition select', () => {
+      const results = [
+        makeResult({ wpm: 60, accuracy: 90, mode: 'words', mode2: 30, language: 'english', date: new Date(Date.now() - 1 * DAY_MS).toISOString() }),
+        // Only 'quote' result, dated outside the default 1-month window.
+        makeResult({ wpm: 50, accuracy: 85, mode: 'quote', mode2: 'short', language: 'english', date: new Date(Date.now() - 40 * DAY_MS).toISOString() }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} />)
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+
+      const select = screen.getByTestId('history-condition-filter') as HTMLSelectElement
+      const values = Array.from(select.options).map((o) => o.value)
+      expect(values.some((v) => v.startsWith('words|'))).toBe(true)
+      expect(values.some((v) => v.startsWith('quote|'))).toBe(false)
+
+      // Switching to All Time brings the older condition back into view.
+      fireEvent.click(screen.getByTestId('history-view-tab-results'))
+      fireEvent.change(screen.getByTestId('history-filter-period'), { target: { value: 'all' } })
+      fireEvent.click(screen.getByTestId('history-view-tab-analysis'))
+      const valuesAllTime = Array.from((screen.getByTestId('history-condition-filter') as HTMLSelectElement).options).map((o) => o.value)
+      expect(valuesAllTime.some((v) => v.startsWith('quote|'))).toBe(true)
+    })
+
+    it('exports only the results within the selected period as CSV', () => {
+      const onExportCsv = vi.fn()
+      const recentDate = new Date(Date.now() - 1 * DAY_MS).toISOString()
+      const oldDate = new Date(Date.now() - 40 * DAY_MS).toISOString()
+      const results = [
+        makeResult({ wpm: 80, date: recentDate }),
+        makeResult({ wpm: 55, date: oldDate }),
+      ]
+      renderWithI18n(<TypingTestHistory results={results} onExportCsv={onExportCsv} />)
+
+      fireEvent.click(screen.getByTestId('history-export-csv'))
+      const csv = onExportCsv.mock.calls[0][0] as string
+      expect(csv).toContain(recentDate)
+      expect(csv).not.toContain(oldDate)
+
+      // Widening to All Time brings the older row into the export too.
+      fireEvent.change(screen.getByTestId('history-filter-period'), { target: { value: 'all' } })
+      fireEvent.click(screen.getByTestId('history-export-csv'))
+      const csvAllTime = onExportCsv.mock.calls[1][0] as string
+      expect(csvAllTime).toContain(recentDate)
+      expect(csvAllTime).toContain(oldDate)
     })
   })
 })

--- a/src/renderer/typing-test/__tests__/history-period-filter.test.ts
+++ b/src/renderer/typing-test/__tests__/history-period-filter.test.ts
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { cutoffForPeriod, filterResultsByPeriod, PERIOD_FILTERS, DEFAULT_PERIOD_FILTER } from '../history-period-filter'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+
+function makeResult(date: string): TypingTestResult {
+  return {
+    date,
+    wpm: 60,
+    accuracy: 95,
+    wordCount: 30,
+    correctChars: 100,
+    incorrectChars: 5,
+    durationSeconds: 30,
+  }
+}
+
+const NOW = new Date('2026-08-04T12:00:00.000Z').getTime()
+
+describe('cutoffForPeriod', () => {
+  it('returns null for "all" (no lower bound)', () => {
+    expect(cutoffForPeriod('all', NOW)).toBeNull()
+  })
+
+  it('computes a 7-day cutoff for "1w"', () => {
+    expect(cutoffForPeriod('1w', NOW)).toBe(new Date('2026-07-28T12:00:00.000Z').getTime())
+  })
+
+  it('computes a calendar-month cutoff for "1m"', () => {
+    expect(cutoffForPeriod('1m', NOW)).toBe(new Date('2026-07-04T12:00:00.000Z').getTime())
+  })
+
+  it('computes a 3-calendar-month cutoff for "3m"', () => {
+    expect(cutoffForPeriod('3m', NOW)).toBe(new Date('2026-05-04T12:00:00.000Z').getTime())
+  })
+
+  it('computes a calendar-year cutoff for "1y"', () => {
+    expect(cutoffForPeriod('1y', NOW)).toBe(new Date('2025-08-04T12:00:00.000Z').getTime())
+  })
+})
+
+describe('filterResultsByPeriod', () => {
+  it('excludes results dated before the cutoff', () => {
+    const results = [
+      makeResult('2026-08-01T00:00:00.000Z'), // within 1w
+      makeResult('2026-06-01T00:00:00.000Z'), // outside 1w
+    ]
+    const filtered = filterResultsByPeriod(results, '1w', NOW)
+    expect(filtered.map((r) => r.date)).toEqual(['2026-08-01T00:00:00.000Z'])
+  })
+
+  it('includes every result for "all", regardless of age', () => {
+    const results = [makeResult('2020-01-01T00:00:00.000Z'), makeResult('2026-08-04T00:00:00.000Z')]
+    expect(filterResultsByPeriod(results, 'all', NOW)).toEqual(results)
+  })
+
+  // Boundary behavior: a result timestamped exactly at the cutoff counts as
+  // "within" the window (inclusive), matching the everyday reading of e.g.
+  // "the last 7 days" as including the day exactly 7 days ago.
+  it('includes a result dated exactly at the cutoff (inclusive boundary)', () => {
+    const cutoff = cutoffForPeriod('1w', NOW)!
+    const results = [makeResult(new Date(cutoff).toISOString())]
+    expect(filterResultsByPeriod(results, '1w', NOW)).toEqual(results)
+  })
+
+  it('excludes a result one millisecond before the cutoff', () => {
+    const cutoff = cutoffForPeriod('1w', NOW)!
+    const results = [makeResult(new Date(cutoff - 1).toISOString())]
+    expect(filterResultsByPeriod(results, '1w', NOW)).toEqual([])
+  })
+
+  it('drops a result with an unparseable date rather than keeping it', () => {
+    const results = [makeResult('not-a-date')]
+    expect(filterResultsByPeriod(results, '1w', NOW)).toEqual([])
+  })
+
+  it('exposes "1m" as the default period', () => {
+    expect(DEFAULT_PERIOD_FILTER).toBe('1m')
+  })
+
+  it('orders options oldest-window-first, ending with "all"', () => {
+    expect(PERIOD_FILTERS).toEqual(['1w', '1m', '3m', '1y', 'all'])
+  })
+})

--- a/src/renderer/typing-test/history-period-filter.ts
+++ b/src/renderer/typing-test/history-period-filter.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+
+/** History modal period filter — scopes every view below the tab row (WPM
+ *  Trend chart, stats summary, Results table, CSV export, and the entire
+ *  Analysis tab) to a rolling window ending at a caller-supplied `now`.
+ *  Ordered oldest-window-first, matching the rendered `<select>` option
+ *  order in TypingTestHistory's header. */
+export type PeriodFilter = '1w' | '1m' | '3m' | '1y' | 'all'
+export const PERIOD_FILTERS: PeriodFilter[] = ['1w', '1m', '3m', '1y', 'all']
+export const DEFAULT_PERIOD_FILTER: PeriodFilter = '1m'
+
+/** Rolling cutoff timestamp (ms) for `period`, anchored at `now` — `null`
+ *  for 'all' (no lower bound). Uses calendar month/year subtraction
+ *  (`setMonth`/`setFullYear`) rather than a fixed day count, so "1 month"
+ *  and "1 year" track actual calendar months/years instead of a 30/365-day
+ *  approximation. Note: `Date` normalizes day-of-month overflow (e.g. Mar
+ *  31 minus 1 month lands on Mar 3, not Feb 28) — an accepted quirk for a
+ *  coarse period filter, not a full calendar library. */
+export function cutoffForPeriod(period: PeriodFilter, now: number): number | null {
+  if (period === 'all') return null
+  const d = new Date(now)
+  switch (period) {
+    case '1w':
+      d.setDate(d.getDate() - 7)
+      break
+    case '1m':
+      d.setMonth(d.getMonth() - 1)
+      break
+    case '3m':
+      d.setMonth(d.getMonth() - 3)
+      break
+    case '1y':
+      d.setFullYear(d.getFullYear() - 1)
+      break
+  }
+  return d.getTime()
+}
+
+/** Filters `results` to those dated on/after the period's cutoff. Inclusive
+ *  boundary — a result timestamped exactly at the cutoff counts as "within"
+ *  the window (see cutoffForPeriod's doc for the calendar-math it's
+ *  measured against). A result with an unparseable `date` is dropped rather
+ *  than kept, so a malformed row can't silently bypass the filter. */
+export function filterResultsByPeriod(
+  results: TypingTestResult[],
+  period: PeriodFilter,
+  now: number,
+): TypingTestResult[] {
+  const cutoff = cutoffForPeriod(period, now)
+  if (cutoff === null) return results
+  return results.filter((r) => {
+    const t = new Date(r.date).getTime()
+    return !Number.isNaN(t) && t >= cutoff
+  })
+}


### PR DESCRIPTION
## Summary
- The History modal's tab row gains a period select at its right end (beside the source select): 1 Week / 1 Month (default) / 3 Months / 1 Year / All Time. Everything below the row respects the window — the WPM Trend chart, the Best/Avg/Last-10/Tests/Avg-Acc stats line, the results table, the Analysis tab's whole content (its condition select included), and the CSV export (which keeps exporting exactly what the table shows).
- Filtering is a pure helper (inclusive cutoff, calendar month/year arithmetic, unparseable dates dropped) with the "now" anchor fixed once per modal open; the selection is session state like the source select, resetting to 1 Month per open.
- i18n: option labels in english.json and all four sample packs, versions bumped in lockstep to 0.1.80.

## Verification
- 18 new tests (12 unit on the filter math incl. the inclusive boundary, 6 component covering default/table/stats/chart/Analysis/CSV scoping); pre-existing history tests pinned to old fixture dates now render under All Time so they keep testing what they tested. Full suite 8,734 passed / 22 skipped; eslint/typecheck clean.
- Virtual-device screenshot with results seeded 2/10/40/100/400 days back shows the 1-Month default narrowing every section to the two in-window runs.