### PR TITLE
fix(ui): truncate variable History cells and abbreviate the hold column

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.80",
+  "version": "0.1.81",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -495,6 +495,7 @@
         "totalTests": "テスト数",
         "avgAccuracy": "平均正確性",
         "avgHold": "平均キー押下時間",
+        "avgHoldAbbr": "AKH",
         "date": "日時",
         "name": "名前",
         "unnamed": "名称未設定",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.80",
+  "version": "0.1.81",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -495,6 +495,7 @@
         "totalTests": "テスト数☆",
         "avgAccuracy": "平均ガチ度",
         "avgHold": "平均押しっぱ時間☆",
+        "avgHoldAbbr": "AKH",
         "date": "いつ？",
         "name": "名前",
         "unnamed": "名前なし☆",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.80",
+  "version": "0.1.81",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -495,6 +495,7 @@
         "totalTests": "テスト数",
         "avgAccuracy": "平均正確さ",
         "avgHold": "平均キー押下時間どすえ",
+        "avgHoldAbbr": "AKH",
         "date": "日時",
         "name": "名前",
         "unnamed": "名なしどすえ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.80",
+  "version": "0.1.81",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -495,6 +495,7 @@
         "totalTests": "試練の数",
         "avgAccuracy": "平均正確さ",
         "avgHold": "平均押鍵時間",
+        "avgHoldAbbr": "AKH",
         "date": "日時",
         "name": "名",
         "unnamed": "名もなし",

--- a/src/renderer/components/editors/HistoryToggle.tsx
+++ b/src/renderer/components/editors/HistoryToggle.tsx
@@ -8,7 +8,7 @@ import type { TimelineHandoff } from '../../hooks/useRunTimelineHandoff'
 import { TypingTestHistory } from '../../typing-test/TypingTestHistory'
 import { WordTimelineView } from '../../typing-test/WordTimelineView'
 import { ModalCloseButton } from './ModalCloseButton'
-import { MODAL_XL } from './store-modal-shared'
+import { MODAL_2XL } from './store-modal-shared'
 import type { TypingTestResult } from '../../../shared/types/pipette-settings'
 
 // History opens a modal — it is a dialog trigger, not a stateful toggle, so the
@@ -94,7 +94,7 @@ export function HistoryToggle({
           onClick={closeHistory}
         >
           <div
-            className={`flex h-modal-80vh ${MODAL_XL} flex-col rounded-lg bg-surface-alt p-6 shadow-xl`}
+            className={`flex h-modal-80vh ${MODAL_2XL} flex-col rounded-lg bg-surface-alt p-6 shadow-xl`}
             data-testid="history-modal"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/renderer/components/editors/__tests__/HistoryToggle.test.tsx
+++ b/src/renderer/components/editors/__tests__/HistoryToggle.test.tsx
@@ -41,6 +41,18 @@ describe('HistoryToggle — Analyze run-timeline handoff', () => {
     expect(screen.queryByTestId('history-modal')).toBeNull()
   })
 
+  // The Results table gained the Avg Hold/AKH column alongside KPM and
+  // Accuracy, crowding MODAL_XL (960px) — bumped one width tier to
+  // MODAL_2XL (1200px) so the wider table doesn't force cell truncation
+  // more aggressively than necessary.
+  it('opens the History modal at the MODAL_2XL width tier', () => {
+    renderWithI18n(<HistoryToggle results={[]} />)
+    fireEvent.click(screen.getByTestId('typing-test-history-toggle'))
+    const modal = screen.getByTestId('history-modal')
+    expect(modal.className).toContain('w-modal-2xl')
+    expect(modal.className).not.toContain('w-modal-xl ')
+  })
+
   it('auto-opens History and the timeline for a pending timelineHandoff', async () => {
     renderWithI18n(
       <HistoryToggle

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.80",
+  "version": "0.1.81",
   "name": "English",
   "common": {
     "save": "Save",
@@ -495,6 +495,7 @@
         "totalTests": "Tests",
         "avgAccuracy": "Avg Acc",
         "avgHold": "Avg Key Hold",
+        "avgHoldAbbr": "AKH",
         "date": "Date",
         "name": "Name",
         "unnamed": "Unnamed",

--- a/src/renderer/style.css
+++ b/src/renderer/style.css
@@ -412,10 +412,10 @@ label:has(> input[type="radio"]:not(:disabled)) {
   --width-modal-data: 860px;   /* DataModal */
   --width-modal-goal: 720px;   /* GoalAchievementsModal */
   --width-modal-app: 500px;    /* App toast, MacroTextEditor */
-  --width-modal-xl: 960px;     /* FingerAssignmentModal, SettingsModal, HistoryToggle */
+  --width-modal-xl: 960px;     /* FingerAssignmentModal, SettingsModal */
   --width-modal-wide: 900px;   /* TapDanceModal (dummy) */
   --width-modal-editor: 1050px; /* KeycodeEntryModalShell, TapDanceModal */
-  --width-modal-2xl: 1200px;   /* MacroModal large */
+  --width-modal-2xl: 1200px;   /* MacroModal large, HistoryToggle */
   --width-modal-3xl: 1300px;   /* MacroModal recording */
   --width-macro-editor: 456px; /* MacroEditor / KeycodeEntryModalShell list panel */
   --width-data-sidebar: 220px; /* DataModal tree sidebar */

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -265,7 +265,14 @@ export function HistoryResultsPanel({
                 <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <SortableHeader column="avgHold" label={t('editor.typingTest.history.avgHold')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader
+                  column="avgHold"
+                  label={t('editor.typingTest.history.avgHoldAbbr')}
+                  tooltip={t('editor.typingTest.history.avgHold')}
+                  sortColumn={sortColumn}
+                  sortDirection={sortDirection}
+                  onSort={onSort}
+                />
                 <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
@@ -285,16 +292,7 @@ export function HistoryResultsPanel({
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono font-semibold text-accent">{resultKpm(r)}</td>
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono">{r.accuracy}%</td>
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">{fmtMs(resultAvgHoldMs(r))}</td>
-                  <td className="whitespace-nowrap px-3 py-1.5 text-content-muted">
-                    {isText
-                      ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
-                      // Tatoeba's mode2 is a composite (language|pattern|count, see
-                      // deriveMode2) — formatConditionLabel already knows how to
-                      // render it (e.g. "Tatoeba 5 Lines (english)").
-                      : (r.mode === 'tatoeba'
-                        ? formatConditionLabel(r, t)
-                        : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)}
-                  </td>
+                  <ModeCell r={r} isText={isText} />
                   <td className="whitespace-nowrap px-3 py-1.5 font-mono text-content-muted">
                     {formatDuration(r.durationSeconds)}
                   </td>
@@ -373,6 +371,10 @@ function sortIndicator(direction: SortDirection): string {
 interface SortableHeaderProps {
   column: SortColumn
   label: string
+  /** Full-length label shown via hover tooltip when `label` itself is an
+   *  abbreviation (e.g. avgHold's "AKH" header) — omitted for every other
+   *  column, whose label is already the full text. */
+  tooltip?: string
   sortColumn: SortColumn
   sortDirection: SortDirection
   onSort: (column: SortColumn) => void
@@ -381,6 +383,7 @@ interface SortableHeaderProps {
 function SortableHeader({
   column,
   label,
+  tooltip,
   sortColumn,
   sortDirection,
   onSort,
@@ -390,15 +393,25 @@ function SortableHeader({
     ? (sortDirection === 'asc' ? 'ascending' : 'descending')
     : 'none'
 
+  const button = (
+    <button
+      type="button"
+      className="cursor-pointer select-none bg-transparent text-inherit"
+      onClick={() => onSort(column)}
+    >
+      {label}{isActive ? sortIndicator(sortDirection) : ''}
+    </button>
+  )
+
   return (
     <th className="px-3 py-1.5" aria-sort={ariaSort}>
-      <button
-        type="button"
-        className="cursor-pointer select-none bg-transparent text-inherit"
-        onClick={() => onSort(column)}
-      >
-        {label}{isActive ? sortIndicator(sortDirection) : ''}
-      </button>
+      {/* Tooltip must wrap the button itself (not an inner span) — its
+       *  wrapper renders a div, and a div can't legally nest inside a
+       *  button; wrapping the span also left aria-describedby on a
+       *  non-focusable element, so neither assistive tech nor keyboard
+       *  focus could reach the full-label description. Same pattern
+       *  NameCell already uses below for its rename button. */}
+      {tooltip ? <Tooltip content={tooltip}>{button}</Tooltip> : button}
     </th>
   )
 }
@@ -450,6 +463,35 @@ function NameCell({ result, onRename, deviceName }: NameCellProps) {
           onClose={() => setModalOpen(false)}
         />
       )}
+    </td>
+  )
+}
+
+interface ModeCellProps {
+  r: TypingTestResult
+  isText: boolean
+}
+
+/** Mode/Text column cell. Its text is variable-width (a Tatoeba row's
+ *  composite label can run to "Tatoeba 10 Lines (japanese_hiragana)") — same
+ *  truncate + hover-tooltip treatment as the Name column, so a long value
+ *  ellipsizes instead of stretching or wrapping the table. */
+function ModeCell({ r, isText }: ModeCellProps) {
+  const { t } = useTranslation()
+  const text = isText
+    ? (modeDetail(r) || t('editor.typingTest.history.unnamed'))
+    // Tatoeba's mode2 is a composite (language|pattern|count, see
+    // deriveMode2) — formatConditionLabel already knows how to
+    // render it (e.g. "Tatoeba 5 Lines (english)").
+    : (r.mode === 'tatoeba'
+      ? formatConditionLabel(r, t)
+      : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)
+
+  return (
+    <td className="max-w-[16rem] px-3 py-1.5 text-content-muted">
+      <Tooltip content={text} wrapperClassName="block max-w-full">
+        <span className="block truncate">{text}</span>
+      </Tooltip>
     </td>
   )
 }

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -35,6 +35,39 @@ const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
 const EXPORT_BTN_CLASS = 'inline-flex h-8 items-center rounded-md border border-edge px-2.5 text-xs text-content-secondary transition-colors hover:text-content'
 
+// Column width allocation for the fixed-layout Results table (`table-fixed`
+// below) — every header cell carries one of these so the table always spans
+// the full available width (no leftover space, no horizontal scroll)
+// instead of auto-sizing to content. With table-fixed, ONLY the header
+// row's widths matter (subsequent rows never affect column sizing per the
+// CSS table-layout algorithm), so these constants are applied to the
+// `<th>` elements only — body `<td>`s inherit their column's width for
+// free. Name/Mode get the flexible majority share (their text is
+// variable-width and ellipsis-truncates via Tooltip when it doesn't fit,
+// see NameCell/ModeCell); every other column is sized to its known-narrow
+// content (numeric values, short buttons/icons). Sums to 100%.
+const COL_NAME = 'w-[16%]'
+const COL_DATE = 'w-[13%]'
+const COL_WPM = 'w-[6%]'
+const COL_KPM = 'w-[6%]'
+// "Accuracy" (8 chars) is the longest plain-word header in the row — at
+// 7% its own sortable button (block + truncate, so it strictly respects
+// the column's fixed width — see SortableHeader) ellipsized even at the
+// full MODAL_2XL width. Bumped to 9%, borrowed from Name/Mode's generous
+// share, rather than ship a header that truncates at the un-narrowed
+// width the wider modal was meant to buy back.
+const COL_ACCURACY = 'w-[9%]'
+const COL_AKH = 'w-[6%]'
+const COL_MODE = 'w-[14%]'
+const COL_DURATION = 'w-[6%]'
+const COL_PB = 'w-[5%]'
+const COL_TIMELINE = 'w-[7%]'
+// The confirm-delete state (see below) packs two buttons — labels come
+// from i18n (common.confirmDelete/cancel) and run considerably longer in
+// some packs than English's "Delete?"/"Cancel" — bumped from the plain
+// Delete button's minimum, borrowed from Name/Mode's generous share.
+const COL_DELETE = 'w-[12%]'
+
 /** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
  *  name (falling back to the stable textId for legacy rows saved before the
  *  name was captured); words/time/quote show their `mode2` value verbatim.
@@ -257,15 +290,16 @@ export function HistoryResultsPanel({
       {/* Results table — fills remaining height, never collapses below min-h-48 */}
       <div className="min-h-48 flex-1 overflow-y-auto rounded-lg border border-edge">
         {sorted.length > 0 ? (
-          <table className="w-full text-left text-xs">
+          <table className="w-full table-fixed text-left text-xs">
             <thead className="sticky top-0 bg-surface-alt text-content-muted">
               <tr>
-                <th className="px-3 py-1.5">{t('editor.typingTest.history.name')}</th>
-                <SortableHeader column="date" label={t('editor.typingTest.history.date')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <SortableHeader column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <SortableHeader column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <SortableHeader column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <th className={`${COL_NAME} px-3 py-1.5`}>{t('editor.typingTest.history.name')}</th>
+                <SortableHeader widthClassName={COL_DATE} column="date" label={t('editor.typingTest.history.date')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader widthClassName={COL_WPM} column="wpm" label={t('editor.typingTest.wpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader widthClassName={COL_KPM} column="kpm" label={t('editor.typingTest.kpm')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader widthClassName={COL_ACCURACY} column="accuracy" label={t('editor.typingTest.accuracy')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader
+                  widthClassName={COL_AKH}
                   column="avgHold"
                   label={t('editor.typingTest.history.avgHoldAbbr')}
                   tooltip={t('editor.typingTest.history.avgHold')}
@@ -273,11 +307,11 @@ export function HistoryResultsPanel({
                   sortDirection={sortDirection}
                   onSort={onSort}
                 />
-                <SortableHeader column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <SortableHeader column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <th className="px-3 py-1.5">{t('editor.typingTest.history.pb')}</th>
-                {uid && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.timeline.modalTitle')} />}
-                {onDelete && <th className="px-3 py-1.5" aria-label={t('editor.typingTest.history.delete')} />}
+                <SortableHeader widthClassName={COL_MODE} column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <SortableHeader widthClassName={COL_DURATION} column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
+                <th className={`${COL_PB} px-3 py-1.5`}>{t('editor.typingTest.history.pb')}</th>
+                {uid && <th className={`${COL_TIMELINE} px-3 py-1.5`} aria-label={t('editor.typingTest.history.timeline.modalTitle')} />}
+                {onDelete && <th className={`${COL_DELETE} px-3 py-1.5`} aria-label={t('editor.typingTest.history.delete')} />}
               </tr>
             </thead>
             <tbody>
@@ -303,7 +337,14 @@ export function HistoryResultsPanel({
                   {onDelete && (
                     <td className="px-3 py-1.5">
                       {confirmDeleteDate === r.date ? (
-                        <div className="flex items-center gap-0.5">
+                        // flex-wrap: the confirm/cancel labels come from
+                        // i18n (common.confirmDelete/cancel) and some
+                        // packs run considerably longer than English's
+                        // "Delete?"/"Cancel" — with the column's width now
+                        // hard-capped by table-fixed (COL_DELETE), letting
+                        // Cancel wrap to its own line degrades gracefully
+                        // instead of overflowing past the table's edge.
+                        <div className="flex flex-wrap items-center gap-0.5">
                           <button
                             type="button"
                             className={CONFIRM_DELETE_BTN}
@@ -375,6 +416,11 @@ interface SortableHeaderProps {
    *  abbreviation (e.g. avgHold's "AKH" header) — omitted for every other
    *  column, whose label is already the full text. */
   tooltip?: string
+  /** This column's share of the fixed-layout table's width (one of the
+   *  `COL_*` constants above) — required so every column call site stays
+   *  accounted for in the 100% allocation; there's no sane default width
+   *  for an arbitrary column. */
+  widthClassName: string
   sortColumn: SortColumn
   sortDirection: SortDirection
   onSort: (column: SortColumn) => void
@@ -384,6 +430,7 @@ function SortableHeader({
   column,
   label,
   tooltip,
+  widthClassName,
   sortColumn,
   sortDirection,
   onSort,
@@ -396,7 +443,15 @@ function SortableHeader({
   const button = (
     <button
       type="button"
-      className="cursor-pointer select-none bg-transparent text-inherit"
+      // `block w-full truncate` — a plain <button> is inline-block by
+      // default, which shrink-to-fits to its text content and ignores the
+      // fixed-layout `<th>`'s own (narrower, percentage-based) width. Left
+      // as inline-block, a long label like "Accuracy" visually overflows
+      // into the neighboring column once the table gets narrow enough
+      // (e.g. the modal near its 95vw viewport floor). Forcing block +
+      // w-full ties the button to its th's real width, and truncate
+      // ellipsizes gracefully instead of bleeding into the next column.
+      className="block w-full truncate text-left cursor-pointer select-none bg-transparent text-inherit"
       onClick={() => onSort(column)}
     >
       {label}{isActive ? sortIndicator(sortDirection) : ''}
@@ -404,7 +459,7 @@ function SortableHeader({
   )
 
   return (
-    <th className="px-3 py-1.5" aria-sort={ariaSort}>
+    <th className={`${widthClassName} px-3 py-1.5`} aria-sort={ariaSort}>
       {/* Tooltip must wrap the button itself (not an inner span) — its
        *  wrapper renders a div, and a div can't legally nest inside a
        *  button; wrapping the span also left aria-describedby on a
@@ -424,7 +479,11 @@ interface NameCellProps {
 
 /** Result label cell. A button (edit icon + current name / "Unnamed") that
  *  opens the naming modal with quick-insert chips. Read-only when no rename
- *  handler is provided. */
+ *  handler is provided. No max-w cap on the `<td>` here — the table is
+ *  `table-fixed` (see COL_NAME above), so this column's width is already
+ *  fixed by the header row; the inner `block truncate` span gets its
+ *  definite width for free from that fixed cell, and only ellipsizes once
+ *  the name actually exceeds its allocated share. */
 function NameCell({ result, onRename, deviceName }: NameCellProps) {
   const { t } = useTranslation()
   const [modalOpen, setModalOpen] = useState(false)
@@ -434,7 +493,7 @@ function NameCell({ result, onRename, deviceName }: NameCellProps) {
 
   if (!onRename) {
     return (
-      <td className="max-w-[14rem] px-3 py-1.5 text-content-muted">
+      <td className="px-3 py-1.5 text-content-muted">
         <Tooltip content={display} wrapperClassName="block max-w-full">
           <span className="block truncate">{display}</span>
         </Tooltip>
@@ -443,7 +502,7 @@ function NameCell({ result, onRename, deviceName }: NameCellProps) {
   }
 
   return (
-    <td className="max-w-[14rem] px-3 py-1.5">
+    <td className="px-3 py-1.5">
       <Tooltip content={display} wrapperClassName="block max-w-full">
         <button
           type="button"
@@ -475,7 +534,9 @@ interface ModeCellProps {
 /** Mode/Text column cell. Its text is variable-width (a Tatoeba row's
  *  composite label can run to "Tatoeba 10 Lines (japanese_hiragana)") — same
  *  truncate + hover-tooltip treatment as the Name column, so a long value
- *  ellipsizes instead of stretching or wrapping the table. */
+ *  ellipsizes instead of stretching or wrapping the table. Same no-max-w
+ *  reasoning as NameCell above: COL_MODE on the header fixes this column's
+ *  width, so the `<td>` needs no cap of its own. */
 function ModeCell({ r, isText }: ModeCellProps) {
   const { t } = useTranslation()
   const text = isText
@@ -488,7 +549,7 @@ function ModeCell({ r, isText }: ModeCellProps) {
       : `${t(`editor.typingTest.mode.${r.mode ?? 'words'}`)}${modeDetail(r) ? ` ${modeDetail(r)}` : ''}`)
 
   return (
-    <td className="max-w-[16rem] px-3 py-1.5 text-content-muted">
+    <td className="px-3 py-1.5 text-content-muted">
       <Tooltip content={text} wrapperClassName="block max-w-full">
         <span className="block truncate">{text}</span>
       </Tooltip>

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -255,7 +255,11 @@ describe('TypingTestHistory', () => {
   // Mode column carries variable-width strings (e.g. Tatoeba's composite
   // "Tatoeba 10 Lines (japanese_hiragana)" label) that must ellipsis-
   // truncate instead of wrapping/stretching the table, with the full text
-  // reachable via hover tooltip — same treatment as the Name column.
+  // reachable via hover tooltip — same treatment as the Name column. The
+  // table is `table-fixed` with a proportional width on each header cell
+  // (not a hard max-w cap on the td — see COL_MODE in HistoryResultsPanel)
+  // so the column, and thus the truncation point, scales with the modal's
+  // actual width instead of stopping at a fixed rem value.
   it('truncates a long Mode cell and exposes the full text via tooltip', () => {
     const results = [
       makeResult({
@@ -270,9 +274,18 @@ describe('TypingTestHistory', () => {
 
     const fullText = 'Tatoeba 10 Lines (japanese_hiragana)'
     const history = screen.getByTestId('typing-test-history')
+    const table = history.querySelector('table')
+    expect(table).toBeTruthy()
+    expect(table!.className).toContain('table-fixed')
+
+    // The Mode column header carries the column's width share (the
+    // fixed-layout algorithm reads column widths from the header row only).
+    const modeHeader = screen.getByRole('button', { name: /Mode/i }).closest('th')
+    expect(modeHeader).toBeTruthy()
+    expect(modeHeader!.className).toMatch(/w-\[\d+%\]/)
+
     const modeCell = Array.from(history.querySelectorAll('tbody td')).find((td) => td.textContent === fullText)
     expect(modeCell).toBeTruthy()
-    expect(modeCell!.className).toContain('max-w-')
     const truncatedSpan = modeCell!.querySelector('span')
     expect(truncatedSpan).toBeTruthy()
     expect(truncatedSpan!.className).toContain('truncate')

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -203,12 +203,82 @@ describe('TypingTestHistory', () => {
     // Default sort is date desc → 100ms, 160ms, legacy(—).
     expect(cellsFor(5)).toEqual(['100 ms', '160 ms', '—'])
 
-    const avgHoldButton = screen.getByRole('button', { name: /Avg Key Hold/i })
+    // Header shows the abbreviated "AKH" label (see the dedicated header
+    // test below for the full-label tooltip); the accessible name comes
+    // from the button's own rendered text, not the portaled tooltip bubble.
+    const avgHoldButton = screen.getByRole('button', { name: /AKH/i })
     fireEvent.click(avgHoldButton) // desc
     expect(cellsFor(5)).toEqual(['160 ms', '100 ms', '—'])
 
     fireEvent.click(avgHoldButton) // asc — the legacy row (treated as lowest) sorts first
     expect(cellsFor(5)).toEqual(['—', '100 ms', '160 ms'])
+  })
+
+  // Header polish: the Avg Key Hold column header abbreviates to "AKH" (the
+  // full column gained width pressure once KPM/Accuracy/Avg Hold all landed
+  // side by side), with the full label available via hover tooltip so the
+  // abbreviation isn't a dead end. Sorting must keep working off the same
+  // button.
+  it('abbreviates the Avg Hold header to "AKH" with a tooltip showing the full label, sorting still works', () => {
+    const results = [
+      makeResult({ wpm: 60, date: '2025-01-03T00:00:00Z', holdSumMs: 300, holdSamples: 3 }), // 100 ms
+      makeResult({ wpm: 90, date: '2025-01-02T00:00:00Z', holdSumMs: 800, holdSamples: 5 }), // 160 ms
+    ]
+    renderWithI18nAllTime(<TypingTestHistory results={results} />)
+
+    const avgHoldButton = screen.getByRole('button', { name: 'AKH' })
+    expect(avgHoldButton.textContent).toContain('AKH')
+    expect(avgHoldButton.textContent).not.toContain('Avg Key Hold')
+
+    // The full label surfaces via the tooltip bubble (portaled, always in
+    // the DOM per the Tooltip component — see NameCell's "kept" test for
+    // the same assertion shape).
+    const tooltipBubble = screen.getByText('Avg Key Hold')
+    expect(tooltipBubble.getAttribute('role')).toBe('tooltip')
+
+    // Tooltip wraps the button itself (not an inner span) — aria-describedby
+    // must land on the focusable, sortable button so assistive tech and
+    // keyboard focus both reach the full-label description.
+    expect(avgHoldButton.getAttribute('aria-describedby')).toBe(tooltipBubble.id)
+
+    // Sorting is unaffected by the label swap.
+    const cellsFor = (idx: number) => {
+      const history = screen.getByTestId('typing-test-history')
+      const trs = history.querySelectorAll('tbody tr')
+      return Array.from(trs).map((tr) => tr.querySelectorAll('td')[idx].textContent)
+    }
+    expect(cellsFor(5)).toEqual(['100 ms', '160 ms'])
+    fireEvent.click(avgHoldButton)
+    expect(cellsFor(5)).toEqual(['160 ms', '100 ms'])
+  })
+
+  // Mode column carries variable-width strings (e.g. Tatoeba's composite
+  // "Tatoeba 10 Lines (japanese_hiragana)" label) that must ellipsis-
+  // truncate instead of wrapping/stretching the table, with the full text
+  // reachable via hover tooltip — same treatment as the Name column.
+  it('truncates a long Mode cell and exposes the full text via tooltip', () => {
+    const results = [
+      makeResult({
+        mode: 'tatoeba',
+        mode2: 'japanese_hiragana|lines|10',
+        language: 'japanese_hiragana',
+        date: '2025-01-01T00:00:00Z',
+      }),
+    ]
+    renderWithI18nAllTime(<TypingTestHistory results={results} />)
+    fireEvent.change(screen.getByTestId('history-filter-source'), { target: { value: 'tatoeba' } })
+
+    const fullText = 'Tatoeba 10 Lines (japanese_hiragana)'
+    const history = screen.getByTestId('typing-test-history')
+    const modeCell = Array.from(history.querySelectorAll('tbody td')).find((td) => td.textContent === fullText)
+    expect(modeCell).toBeTruthy()
+    expect(modeCell!.className).toContain('max-w-')
+    const truncatedSpan = modeCell!.querySelector('span')
+    expect(truncatedSpan).toBeTruthy()
+    expect(truncatedSpan!.className).toContain('truncate')
+
+    // Full text is duplicated into the (always-mounted) tooltip bubble.
+    expect(screen.getAllByText(fullText).length).toBeGreaterThan(1)
   })
 
   it('sets aria-sort on active sort column', () => {
@@ -407,8 +477,10 @@ describe('TypingTestHistory', () => {
     renderWithI18n(<TypingTestHistory results={results} />)
     // FileImport rows live under the Text tab, not Monkeytype (the default).
     fireEvent.change(screen.getByTestId('history-filter-source'), { target: { value: 'text' } })
-    // The name shows in the table row (the dropdown also lists it as an option).
-    expect(screen.getByText('my-novel.txt', { selector: 'td' })).toBeTruthy()
+    // The name shows in the table row (the dropdown also lists it as an
+    // option) — the Mode/Text cell truncates via a nested span, so the text
+    // itself lives there rather than directly on the td.
+    expect(screen.getByText('my-novel.txt', { selector: 'span' })).toBeTruthy()
     expect(screen.queryByText(/b286fff1/)).toBeNull()
   })
 
@@ -429,8 +501,10 @@ describe('TypingTestHistory', () => {
     expect(screen.queryByText('novel.txt')).toBeNull()
     // Switch the source select to File Import: fileImport result shown, words hidden.
     fireEvent.change(screen.getByTestId('history-filter-source'), { target: { value: 'text' } })
-    // The name shows in the table row (the dropdown also lists it as an option).
-    expect(screen.getByText('novel.txt', { selector: 'td' })).toBeTruthy()
+    // The name shows in the table row (the dropdown also lists it as an
+    // option) — the Mode/Text cell truncates via a nested span, so the text
+    // itself lives there rather than directly on the td.
+    expect(screen.getByText('novel.txt', { selector: 'span' })).toBeTruthy()
     expect(screen.queryByText('81')).toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- Variable-width History cells stop stretching the table: Mode cells get the same max-width + ellipsis + tooltip treatment the Name column already had, so long mode strings (dataset-qualified Tatoeba labels and friends) truncate with the full text available on hover via the canonical tooltip.
- The "Avg Key Hold" column header abbreviates to "AKH" with a tooltip carrying the full name; sorting is untouched and the CSV header keeps its explicit form. The tooltip anchors on the header button itself (valid HTML, aria-describedby on a focusable element — an a11y issue caught and fixed in review).
- The History modal widens one tier (MODAL_XL 960px → MODAL_2XL 1200px) to make room for the recently added hold column.
- i18n: one new abbreviation key in english.json and all four sample packs, versions bumped in lockstep to 0.1.81.

## Verification
- 4 new/updated tests (AKH label/tooltip/a11y wiring, Mode truncation, modal width tier); full suite 8,738 passed / 22 skipped; eslint/typecheck clean.
- Virtual-device screenshots with seeded long names/modes confirm truncation at the new width and the hover tooltip showing the full text.