### PR TITLE
fix(ui): order the timeline stat cards by related metrics

### DIFF
--- a/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
+++ b/src/renderer/typing-test/__tests__/keystroke-timeline-stats.test.ts
@@ -35,12 +35,32 @@ function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult
   }
 }
 
-/** The 7th (Words/Lines) card is always index 5 in buildTimelineStatItems'
- *  own fixed ordering (WPM, KPM, Accuracy, KSPC, Time, Words/Lines,
- *  Overlap, Substitution, Omission, Insertion). */
+/** The Words/Lines card is always LAST (index 10) in
+ *  buildTimelineStatItems' own fixed ordering (WPM, KPM, Accuracy, KSPC,
+ *  Substitution, Omission, Insertion, Overlap, Avg Key Hold, Time,
+ *  Words/Lines). */
 function wordsOrLinesItem(result: TypingTestResult | undefined, log: RunKeystrokeLog) {
-  return buildTimelineStatItems(result, SUMMARY, log)[5]
+  return buildTimelineStatItems(result, SUMMARY, log)[10]
 }
+
+describe('buildTimelineStatItems — card order', () => {
+  it('renders the fixed related-metric order ending in Time and Words/Lines', () => {
+    const items = buildTimelineStatItems(makeResult({}), SUMMARY, makeLog({}))
+    expect(items.map((i) => i.labelKey)).toEqual([
+      'editor.typingTest.history.timeline.stats.runWpm',
+      'editor.typingTest.kpm',
+      'editor.typingTest.history.timeline.stats.accuracy',
+      'editor.typingTest.kspc',
+      'editor.typingTest.history.errorMixLabelSubstitution',
+      'editor.typingTest.history.errorMixLabelOmission',
+      'editor.typingTest.history.errorMixLabelInsertion',
+      'editor.typingTest.history.timeline.stats.overlap',
+      'editor.typingTest.history.timeline.stats.avgHold',
+      'editor.typingTest.time',
+      'editor.typingTest.words',
+    ])
+  })
+})
 
 describe('buildTimelineStatItems — Words/Lines card branch table', () => {
   it('branch 1: log.lineBreaks present -> Lines, value = lineBreaks.length + 1, REGARDLESS of result.mode', () => {
@@ -104,10 +124,10 @@ describe('buildTimelineStatItems — Words/Lines card branch table', () => {
   })
 })
 
-/** The 11th (Avg Key Hold) card is always the last entry in
- *  buildTimelineStatItems' fixed ordering. */
+/** The Avg Key Hold card sits at index 8 in buildTimelineStatItems'
+ *  fixed ordering (between Overlap and Time). */
 function avgHoldItem(result: TypingTestResult | undefined, summary: WordTimelineSummary, log: RunKeystrokeLog) {
-  return buildTimelineStatItems(result, summary, log)[10]
+  return buildTimelineStatItems(result, summary, log)[8]
 }
 
 describe('buildTimelineStatItems — Avg Key Hold card', () => {

--- a/src/renderer/typing-test/keystroke-timeline-stats.ts
+++ b/src/renderer/typing-test/keystroke-timeline-stats.ts
@@ -141,15 +141,6 @@ export function buildTimelineStatItems(
       labelKey: 'editor.typingTest.kspc',
       value: kspc !== null ? formatKspc(kspc) : EMPTY_STAT_VALUE,
     },
-    {
-      labelKey: 'editor.typingTest.time',
-      value: formatDuration(durationSeconds),
-    },
-    wordsOrLinesCard(result, log),
-    {
-      labelKey: 'editor.typingTest.history.timeline.stats.overlap',
-      value: formatPercentLabel(summary.avgOverlap),
-    },
     // Reuses ErrorMixSection's own per-class caption keys (#332) rather
     // than the `results.errorSubstitutions` et al. keys — those are
     // "Substitution {{count}}"-style interpolated sentences meant for the
@@ -167,9 +158,18 @@ export function buildTimelineStatItems(
       value: result?.errorInsertions ?? EMPTY_STAT_VALUE,
     },
     {
+      labelKey: 'editor.typingTest.history.timeline.stats.overlap',
+      value: formatPercentLabel(summary.avgOverlap),
+    },
+    {
       labelKey: 'editor.typingTest.history.timeline.stats.avgHold',
       value: fmtMs(avgHoldMsFor(result, summary)),
       descriptionKey: 'editor.typingTest.history.timeline.stats.avgHoldTooltip',
     },
+    {
+      labelKey: 'editor.typingTest.time',
+      value: formatDuration(durationSeconds),
+    },
+    wordsOrLinesCard(result, log),
   ]
 }


### PR DESCRIPTION
## Summary
- The completion/timeline stat cards reorder into related groups: WPM, KPM, Accuracy, KSPC, Substitution, Omission, Insertion, Overlap, Avg Key Hold, Time, Words/Lines — a pure order change with no card, grid, or styling modifications.
- A new test pins the full label order; the positional card helpers in the test file track the moved indices.

## Verification
- Stats suite 13 passed (incl. the new order test), typing-test directory 2,575 passed, eslint/typecheck clean; virtual-device completion screen confirms the rendered order.