### PR TITLE
fix(ui): stop the History results table from leaving a right-side gap

### DIFF
--- a/src/renderer/typing-test/TypingTestHistory.tsx
+++ b/src/renderer/typing-test/TypingTestHistory.tsx
@@ -342,8 +342,17 @@ export function TypingTestHistory({ results, onExportCsv, onRename, onDelete, de
   // modal's bottom edge regardless of content or window size. flex-1
   // (flex-basis:0 + grow) makes it consume exactly the space left over
   // after the title row instead.
+  //
+  // No max-w cap here on purpose: this root is a flex-col child of
+  // HistoryToggle's modal box (default align-items:stretch already sizes
+  // it to the modal's full content width), so any max-w narrower than that
+  // content width leaves dead space to the right of the Results table
+  // instead of a benign safety cap. A leftover `max-w-5xl` (1024px) did
+  // exactly that once the modal widened to MODAL_2XL (#401, 1200px width /
+  // ~1152px content box) without this div being widened to match — a
+  // ~128px gap between the table's right edge and the modal's inner edge.
   return (
-    <div data-testid="typing-test-history" className="flex min-h-0 flex-1 max-w-5xl flex-col gap-3">
+    <div data-testid="typing-test-history" className="flex min-h-0 flex-1 flex-col gap-3">
       {/* Single header row: Results/Analysis tabs on the left, selects at
           the right end (ml-auto group). The source tabs (MonkeyType /
           Tatoeba / Aozora / File Import) that used to be their own row


### PR DESCRIPTION
## Summary
- The History modal's content root still carried a leftover `max-w-5xl` (1024px) cap from before the modal widened to 1200px (#401), so the table — which correctly fills 100% of its ancestor — stopped ~128px short of the modal's real content edge. The cap is removed; the root now stretches to the modal's content width like any flex child, with a comment explaining why no cap belongs there.

## Verification
- Measured before/after against the modal title row's right edge (an element outside the bug): gap 128.8px → **0.8px**, and the last header cell's right edge matches the table edge exactly. The measuring script's first draft compared against the buggy element itself (circular, trivially green) — caught and re-anchored before trusting it.
- Full suite unchanged at 8,739 passed / 22 skipped (no test asserts the removed cap); eslint/typecheck clean; before/after screenshots captured with seeded long names, dataset-qualified modes, and a Timeline-linked row.