### PR TITLE
fix(ui): dock the Analyze page's Split View and Back buttons in a footer bar

### DIFF
--- a/src/renderer/components/analyze/AnalyzePage.tsx
+++ b/src/renderer/components/analyze/AnalyzePage.tsx
@@ -3,8 +3,14 @@
 // the DeviceSelector shell (top of app) and the typing-view chrome so
 // the two entry points render identical content; callers just supply
 // an `onBack` target and (optionally) a keyboard to preselect. The
-// Back button itself lives in the sidebar of TypingAnalyticsView so
+// Back button itself lives in TypingAnalyticsView's own footer bar so
 // this page stays header-less.
+//
+// The padded `<main>` wrapper only surrounds the scrollable content —
+// TypingAnalyticsView's footer bar renders full-bleed below it (edge
+// to edge like the keymap editor's StatusBar) so it reads as a docked
+// bar instead of a pair of buttons floating at the end of the scroll
+// content.
 
 import { TypingAnalyticsView } from './TypingAnalyticsView'
 import type { ConnectedTappingTerm } from './analyze-types'
@@ -19,9 +25,7 @@ interface Props {
 export function AnalyzePage({ onBack, initialUid, connectedTappingTerm, onOpenRunTimeline }: Props) {
   return (
     <div className="flex h-screen flex-col bg-surface" data-testid="analyze-page">
-      <main className="flex-1 min-h-0 p-8">
-        <TypingAnalyticsView initialUid={initialUid} onBack={onBack} connectedTappingTerm={connectedTappingTerm} onOpenRunTimeline={onOpenRunTimeline} />
-      </main>
+      <TypingAnalyticsView initialUid={initialUid} onBack={onBack} connectedTappingTerm={connectedTappingTerm} onOpenRunTimeline={onOpenRunTimeline} />
     </div>
   )
 }

--- a/src/renderer/components/analyze/TypingAnalyticsView.tsx
+++ b/src/renderer/components/analyze/TypingAnalyticsView.tsx
@@ -143,7 +143,7 @@ export function TypingAnalyticsView({ initialUid, onBack, connectedTappingTerm, 
       className="flex h-full min-h-modal-70vh flex-col"
       data-testid="analyze-view"
     >
-      <div className="flex flex-1 min-h-0 min-w-0 gap-4">
+      <main className="flex flex-1 min-h-0 min-w-0 gap-4 p-8 pb-4">
         <AnalyzePane
           paneKey="A"
           keyboards={keyboards}
@@ -166,10 +166,16 @@ export function TypingAnalyticsView({ initialUid, onBack, connectedTappingTerm, 
             onOpenRunTimeline={onOpenRunTimeline}
           />
         )}
-      </div>
-      <footer className="flex shrink-0 items-center justify-between gap-2 border-t border-edge pt-2">
+      </main>
+      {/* Full-bleed footer bar (mirrors the keymap editor's StatusBar
+       * visual language) so Split View / Back read as a docked bar
+       * instead of buttons floating at the end of the scroll content. */}
+      <footer
+        className="flex shrink-0 items-center justify-between gap-2 border-t border-edge bg-surface-alt px-4 py-1.5 text-xs leading-none text-content-secondary"
+        data-testid="analyze-footer"
+      >
         <div
-          className="min-w-0 flex-1 truncate text-left text-xs text-content-muted"
+          className="min-w-0 flex-1 truncate text-left text-content-muted"
           data-testid="analyze-skip-warning"
         >
           {skipWarningMessage}

--- a/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
+++ b/src/renderer/components/analyze/__tests__/TypingAnalyticsView.test.tsx
@@ -261,6 +261,34 @@ describe('TypingAnalyticsView', () => {
     expect(screen.queryByTestId('analyze-keyheatmap-empty')).toBeNull()
   })
 
+  it('renders Split View / Back inside a docked footer bar, not the scrollable content', async () => {
+    mockListKeyboards.mockResolvedValue(SAMPLE)
+    const onBack = vi.fn()
+    const { TypingAnalyticsView } = await importView()
+    render(<TypingAnalyticsView onBack={onBack} />)
+    await waitFor(() => expect(screen.getByTestId('mock-summary')).toBeInTheDocument())
+
+    const footer = screen.getByTestId('analyze-footer')
+    expect(footer.tagName).toBe('FOOTER')
+    // Styled like the keymap editor's StatusBar (border-t + bg-surface-alt
+    // bar) rather than a bare border-t row floating in the scroll content.
+    expect(footer.className).toContain('border-t')
+    expect(footer.className).toContain('border-edge')
+    expect(footer.className).toContain('bg-surface-alt')
+
+    const splitToggle = screen.getByTestId('analyze-split-toggle')
+    const backButton = screen.getByTestId('analyze-back')
+    expect(footer.contains(splitToggle)).toBe(true)
+    expect(footer.contains(backButton)).toBe(true)
+
+    // Content (the panes) renders in a separate container, not inside footer.
+    const content = screen.getByTestId('mock-summary')
+    expect(footer.contains(content)).toBe(false)
+
+    fireEvent.click(backButton)
+    expect(onBack).toHaveBeenCalledTimes(1)
+  })
+
   it('renders the mocked KeyHeatmapChart after switching to the Heatmap tab when a snapshot is available', async () => {
     mockListKeyboards.mockResolvedValue(SAMPLE)
     mockGetSnapshot.mockResolvedValue(SNAPSHOT)


### PR DESCRIPTION
## Summary
- The Analyze page's Split View / Back buttons were plain rows at the end of the scrollable content, inset by the page's own padding — reading as floating buttons with a dead whitespace band under them and only 8px separating them from the last stat-card row. The page now has a real docked footer: the padded content area became its own scroll region and the footer renders full-bleed below it with the keymap editor status bar's visual language, fixed at the bottom in both normal and Split View layouts.
- Button labels, behavior, and testids are unchanged; the last card row keeps normal spacing above the footer border.

## Verification
- New component test pins the footer element, its bar styling, both buttons, and the Back callback; full suite 8,740 passed / 22 skipped; eslint/typecheck clean.
- Virtual-device screenshots (seeded analytics) confirm the docked footer in both normal and Split View.