### PR TITLE
feat(ui): aggregate the WPM trend per day with best, worst, and average lines

### DIFF
--- a/sample-packs/i18n/i18n-packs-Japanese.json
+++ b/sample-packs/i18n/i18n-packs-Japanese.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.81",
+  "version": "0.1.82",
   "name": "Japanese",
   "common": {
     "save": "保存",
@@ -524,6 +524,9 @@
         "delete": "削除",
         "accuracyTrendTitle": "正確性の推移",
         "wpmTrendTitle": "WPMの推移",
+        "trendBest": "最高",
+        "trendWorst": "最低",
+        "trendAvg": "平均",
         "conditionFilterLabel": "条件で絞り込み",
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_ギャル.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.81",
+  "version": "0.1.82",
   "name": "Japanese - ギャル",
   "common": {
     "save": "保存☆",
@@ -524,6 +524,9 @@
         "delete": "ポイっちょ☆",
         "accuracyTrendTitle": "正確性の推移☆",
         "wpmTrendTitle": "WPMの推移☆",
+        "trendBest": "最高☆",
+        "trendWorst": "イマイチ",
+        "trendAvg": "ふつー",
         "conditionFilterLabel": "条件で絞り込みっしょ",
         "conditionPunctuation": "+句読点☆",
         "conditionNumbers": "+数字っしょ",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_京言葉.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.81",
+  "version": "0.1.82",
   "name": "Japanese - 京言葉",
   "common": {
     "save": "保存しますえ",
@@ -524,6 +524,9 @@
         "delete": "消しますえ",
         "accuracyTrendTitle": "正確性の推移どすえ",
         "wpmTrendTitle": "WPMの推移どすえ",
+        "trendBest": "最高どすえ",
+        "trendWorst": "最低どすえ",
+        "trendAvg": "平均どすえ",
         "conditionFilterLabel": "条件で絞り込みますえ",
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",

--- a/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
+++ b/sample-packs/i18n/i18n-packs-Japanese_-_紳士.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.81",
+  "version": "0.1.82",
   "name": "Japanese - 紳士",
   "common": {
     "save": "保存を承る",
@@ -524,6 +524,9 @@
         "delete": "抹消",
         "accuracyTrendTitle": "正確性の推移",
         "wpmTrendTitle": "速度の推移",
+        "trendBest": "最速",
+        "trendWorst": "最遅",
+        "trendAvg": "平均",
         "conditionFilterLabel": "条件による絞り込み",
         "conditionPunctuation": "+句読点",
         "conditionNumbers": "+数字",

--- a/src/renderer/i18n/locales/english.json
+++ b/src/renderer/i18n/locales/english.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.81",
+  "version": "0.1.82",
   "name": "English",
   "common": {
     "save": "Save",
@@ -524,6 +524,9 @@
         "delete": "Delete",
         "accuracyTrendTitle": "Accuracy Trend",
         "wpmTrendTitle": "WPM Trend",
+        "trendBest": "Best",
+        "trendWorst": "Worst",
+        "trendAvg": "Avg",
         "conditionFilterLabel": "Filter by condition",
         "conditionPunctuation": "+punct",
         "conditionNumbers": "+nums",

--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -15,6 +15,7 @@ import { formatDuration, fmtMs } from '../components/analyze/analyze-format'
 import { HistoryTimelineCell } from './HistoryTimelineCell'
 import { EMPTY_RUN_ID_SET } from '../hooks/useRunLogAvailability'
 import { WpmTrendChart } from './WpmTrendChart'
+import { aggregateWpmByDay } from './wpm-daily-trend'
 
 type ModeFilter = 'all' | 'words' | 'time' | 'quote'
 type SortColumn = 'date' | 'wpm' | 'kpm' | 'accuracy' | 'avgHold' | 'mode' | 'duration'
@@ -30,7 +31,6 @@ type HistoryTab = 'monkeytype' | 'tatoeba' | 'aozora' | 'text'
 export type { SortColumn, SortDirection, HistoryTab }
 
 const MAX_TABLE_ROWS = 20
-const MAX_SPARKLINE_RESULTS = 50
 const MODE_FILTERS: ModeFilter[] = ['all', 'words', 'time', 'quote']
 
 const EXPORT_BTN_CLASS = 'inline-flex h-8 items-center rounded-md border border-edge px-2.5 text-xs text-content-secondary transition-colors hover:text-content'
@@ -159,10 +159,11 @@ export function HistoryResultsPanel({
   const showFilterRow = showModeFilter || (showTextFilter && fileImportTexts.length > 0)
 
   const stats = useMemo(() => computeStats(filtered), [filtered])
-  const sparklineResults = useMemo(
-    () => filtered.slice(0, MAX_SPARKLINE_RESULTS).reverse(),
-    [filtered],
-  )
+  // Computed once here (not inside WpmTrendChart) so the same per-day
+  // grouping drives both the "WPM Trend" heading's visibility gate and the
+  // chart's own data — a single pass over `filtered` instead of running
+  // the identical aggregation twice per render.
+  const dailyTrend = useMemo(() => aggregateWpmByDay(filtered), [filtered])
 
   const sorted = useMemo(() => {
     return [...filtered].sort((a, b) => {
@@ -256,13 +257,18 @@ export function HistoryResultsPanel({
       )}
 
       {/* WPM trend — chart-above-stats, matching every other Analyze section's
-          order (and the Accuracy Trend section's own heading + chart shape). */}
-      {sparklineResults.length >= 2 && (
+          order (and the Accuracy Trend section's own heading + chart shape).
+          `dailyTrend` is derived from the same `filtered` set the table/stats
+          row below uses (not a separately-capped slice), grouped into one
+          best/worst/avg point per local calendar day — a busy multi-test day
+          collapses to a single point instead of stacking a vertical cluster
+          of raw results. */}
+      {dailyTrend.length >= 2 && (
         <div className="flex flex-col gap-2" data-testid="history-sparkline">
           <h3 className="text-xs font-semibold uppercase tracking-widest text-content-muted">
             {t('editor.typingTest.history.wpmTrendTitle')}
           </h3>
-          <WpmTrendChart results={sparklineResults} />
+          <WpmTrendChart data={dailyTrend} />
         </div>
       )}
 

--- a/src/renderer/typing-test/WpmTrendChart.tsx
+++ b/src/renderer/typing-test/WpmTrendChart.tsx
@@ -1,35 +1,60 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { memo, useMemo } from 'react'
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CartesianGrid, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
-import type { TypingTestResult } from '../../shared/types/pipette-settings'
-import { formatDate, formatDateShort } from '../components/editors/store-modal-shared'
+import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { formatDateShort } from '../components/editors/store-modal-shared'
 import { ANALYZE_TOOLTIP_DEFAULTS, boldValue } from '../components/analyze/analyze-tooltip'
-import { CHART_TICK_FONT_SIZE } from '../utils/chart-palette'
+import { CHART_LEGEND_FONT_SIZE, CHART_TICK_FONT_SIZE, chartSeriesColor } from '../utils/chart-palette'
+import { useEffectiveTheme } from '../hooks/useEffectiveTheme'
+import type { DailyWpmPoint } from './wpm-daily-trend'
 
 interface Props {
-  /** Results in any order (sorted ascending by date here, mirroring
-   *  AccuracyTrendChart) so the trend reads oldest-to-newest left to right. */
-  results: TypingTestResult[]
+  /** Already grouped one point PER LOCAL CALENDAR DAY (see
+   *  aggregateWpmByDay) — the caller owns that aggregation (and the
+   *  "enough days to show a trend" decision that comes with it, e.g. the
+   *  "WPM Trend" heading's own visibility) since it's also the caller's
+   *  gate for whether to render this component at all; computing the same
+   *  grouping twice per render (once to decide, once to draw) would be
+   *  redundant work over the same input. */
+  data: DailyWpmPoint[]
 }
 
-interface WpmPoint {
-  timestampMs: number
-  wpm: number
-}
+// Series count/order is fixed (best/worst/avg), so each line's color is a
+// stable index into the shared wide-hue ramp rather than something picked
+// per-render — same convention DurationSection/WpmChart use for their own
+// chartSeriesColor calls. Best sits at the cool end, Worst at the warm end
+// (an arbitrary but fixed anchor — the ramp itself carries no "good/bad"
+// meaning), Avg in between.
+const SERIES_TOTAL = 3
+const BEST_SERIES_INDEX = 0
+const AVG_SERIES_INDEX = 1
+const WORST_SERIES_INDEX = 2
 
-function WpmTrendChartInner({ results }: Props) {
+function WpmTrendChartInner({ data }: Props) {
   const { t } = useTranslation()
+  const theme = useEffectiveTheme()
 
-  const data = useMemo<WpmPoint[]>(
-    () => results
-      .map((r) => ({ timestampMs: new Date(r.date).getTime(), wpm: r.wpm }))
-      .sort((a, b) => a.timestampMs - b.timestampMs),
-    [results],
-  )
+  const bestColor = chartSeriesColor(BEST_SERIES_INDEX, SERIES_TOTAL, theme)
+  const worstColor = chartSeriesColor(WORST_SERIES_INDEX, SERIES_TOTAL, theme)
+  const avgColor = chartSeriesColor(AVG_SERIES_INDEX, SERIES_TOTAL, theme)
 
-  // Mirrors AccuracyTrendChart: a trend line needs at least 2 points.
+  const bestLabel = t('editor.typingTest.history.trendBest')
+  const worstLabel = t('editor.typingTest.history.trendWorst')
+  const avgLabel = t('editor.typingTest.history.trendAvg')
+  const labelByKey: Record<'best' | 'worst' | 'avg', string> = {
+    best: bestLabel, worst: worstLabel, avg: avgLabel,
+  }
+
+  // Mirrors the prior per-result chart: a trend line needs at least 2
+  // points to read as a trend — here that's 2 distinct days with data, not
+  // 2 raw results (a single busy day now collapses to 1 point). Days with
+  // no results are simply absent from `data` (aggregateWpmByDay never
+  // inserts a null/gap entry for them), so — same as before this rework —
+  // the line draws straight through any gap between the two nearest days
+  // that DO have data, rather than breaking. That keeps sparse periods
+  // (e.g. a "1 Year" window with only a handful of active days) reading as
+  // one continuous trend instead of a field of disconnected segments.
   if (data.length < 2) return null
 
   return (
@@ -43,7 +68,7 @@ function WpmTrendChartInner({ results }: Props) {
         <LineChart data={data} margin={{ top: 10, right: 20, bottom: 0, left: 10 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="var(--color-edge)" />
           <XAxis
-            dataKey="timestampMs"
+            dataKey="dayStartMs"
             type="number"
             domain={['dataMin', 'dataMax']}
             tick={{ fontSize: CHART_TICK_FONT_SIZE, fill: 'var(--color-content-muted)' }}
@@ -57,14 +82,38 @@ function WpmTrendChartInner({ results }: Props) {
           />
           <Tooltip
             {...ANALYZE_TOOLTIP_DEFAULTS}
-            labelFormatter={(v) => formatDate(v as number)}
-            formatter={(value) => [boldValue(String(value)), t('editor.typingTest.wpm')]}
+            labelFormatter={(v) => formatDateShort(v as number)}
+            formatter={(value, _name, item) => [
+              boldValue(String(value)),
+              labelByKey[item?.dataKey as keyof typeof labelByKey] ?? '',
+            ]}
+          />
+          <Legend wrapperStyle={{ fontSize: CHART_LEGEND_FONT_SIZE }} />
+          <Line
+            type="monotone"
+            dataKey="best"
+            name={bestLabel}
+            stroke={bestColor}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+            isAnimationActive={false}
           />
           <Line
             type="monotone"
-            dataKey="wpm"
-            name={t('editor.typingTest.wpm')}
-            stroke="var(--color-accent)"
+            dataKey="worst"
+            name={worstLabel}
+            stroke={worstColor}
+            strokeWidth={2}
+            dot={{ r: 3 }}
+            activeDot={{ r: 5 }}
+            isAnimationActive={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="avg"
+            name={avgLabel}
+            stroke={avgColor}
             strokeWidth={2}
             dot={{ r: 3 }}
             activeDot={{ r: 5 }}

--- a/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
+++ b/src/renderer/typing-test/__tests__/TypingTestHistory.test.tsx
@@ -552,9 +552,13 @@ describe('TypingTestHistory', () => {
   // chart-above-stats convention (RolloverSection's order-lock test is the
   // original of this pattern).
   it('renders the sparkline above the stats row', () => {
+    // Two distinct local calendar days — the WPM Trend chart now groups
+    // results per day (see wpm-daily-trend.ts), so two same-day results
+    // would collapse into a single point and never clear the chart's own
+    // "at least 2 days" floor.
     const results = [
       makeResult({ wpm: 80 }),
-      makeResult({ wpm: 60 }),
+      makeResult({ wpm: 60, date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
     const sparkline = screen.getByTestId('history-sparkline')
@@ -568,10 +572,10 @@ describe('TypingTestHistory', () => {
   // the Accuracy Trend chart): the Results view now shows an uppercase
   // "WPM Trend" heading above a chart carrying the same tooltip machinery,
   // instead of a bare unlabeled SVG polyline.
-  it('shows the WPM Trend heading and a tooltip-bearing chart once 2+ results exist', () => {
+  it('shows the WPM Trend heading and a tooltip-bearing chart once 2+ days of results exist', () => {
     const results = [
       makeResult({ wpm: 80 }),
-      makeResult({ wpm: 60 }),
+      makeResult({ wpm: 60, date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() }),
     ]
     renderWithI18n(<TypingTestHistory results={results} />)
     const sparkline = screen.getByTestId('history-sparkline')
@@ -737,7 +741,7 @@ describe('TypingTestHistory', () => {
     it('defaults to the Results view: table + sparkline/stats visible, analysis sections absent', () => {
       const results = [
         makeResult({ wpm: 80 }),
-        makeResult({ wpm: 60 }),
+        makeResult({ wpm: 60, date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
       const history = screen.getByTestId('typing-test-history')
@@ -752,7 +756,7 @@ describe('TypingTestHistory', () => {
     it('switching to Analysis shows the three sections and hides the table/filter/sparkline/stats, then switching back restores Results', () => {
       const results = [
         makeResult({ wpm: 60, accuracy: 90, mistakes: { a: 3, b: 2 } }),
-        makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 } }),
+        makeResult({ wpm: 65, accuracy: 92, mistakes: { a: 1 }, date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString() }),
       ]
       renderWithI18n(<TypingTestHistory results={results} />)
 

--- a/src/renderer/typing-test/__tests__/WpmTrendChart.test.tsx
+++ b/src/renderer/typing-test/__tests__/WpmTrendChart.test.tsx
@@ -1,31 +1,50 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 //
-// NOTE (deviation from the old WpmSparkline.test.tsx): the component was
-// rewritten from a bare SVG polyline to a recharts LineChart (matching
-// AccuracyTrendChart's own pattern) so its Results-view chart gets the same
-// hover-tooltip parity as the Accuracy Trend chart. The `width`/`height`
-// props are gone — the chart is now full-width/responsive, like the
-// Accuracy Trend chart, instead of a fixed centered 400x50 box — so the old
-// assertions on those props and on the raw `<svg><polyline>` DOM no longer
-// apply and are replaced below.
+// NOTE (per-day rework): the chart used to take raw results and plot every
+// individual one — with many tests in a single day the line zigzagged into
+// an unreadable vertical cluster. It now takes pre-aggregated per-day
+// points (one best/worst/avg triple per LOCAL calendar day) as its `data`
+// prop — the caller (HistoryResultsPanel) owns the TypingTestResult[] ->
+// DailyWpmPoint[] aggregation via aggregateWpmByDay (see
+// wpm-daily-trend.test.ts for its own unit tests) since it needs that same
+// grouping to decide whether to show the "WPM Trend" heading at all; this
+// component just draws whatever `data` it's given.
+//
+// recharts renders zero-size SVGs under jsdom (ResponsiveContainer has no
+// real layout to measure), so — same "avoid dragging recharts into jsdom"
+// approach WpmChart.test.tsx already uses for its own reference-line
+// assertion — recharts is stubbed down to plain divs here too, with Line
+// re-rendered as an inspectable div carrying its dataKey/name/stroke.
 
-import { describe, it, expect } from 'vitest'
+import type { ReactNode } from 'react'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
 import i18n from '../../i18n'
 import { WpmTrendChart } from '../WpmTrendChart'
-import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+import type { DailyWpmPoint } from '../wpm-daily-trend'
 
-function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  LineChart: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Legend: () => <div data-testid="wpm-trend-legend-mock" />,
+  Line: (props: { dataKey?: string, name?: string, stroke?: string }) => (
+    <div data-testid={`wpm-trend-line-${String(props.dataKey)}`} data-name={props.name} data-stroke={props.stroke} />
+  ),
+}))
+
+function point(overrides: Partial<DailyWpmPoint> = {}): DailyWpmPoint {
   return {
-    date: '2026-06-20T00:00:00.000Z',
-    wpm: 60,
-    accuracy: 95,
-    wordCount: 30,
-    correctChars: 300,
-    incorrectChars: 5,
-    durationSeconds: 30,
+    dayStartMs: new Date(2026, 5, 20).getTime(),
+    best: 80,
+    worst: 60,
+    avg: 70,
+    count: 3,
     ...overrides,
   }
 }
@@ -35,41 +54,56 @@ function renderWithI18n(ui: React.ReactElement) {
 }
 
 describe('WpmTrendChart', () => {
-  it('renders nothing with fewer than 2 results', () => {
-    const { container } = renderWithI18n(<WpmTrendChart results={[makeResult()]} />)
+  it('renders nothing with fewer than 2 day-points', () => {
+    const { container } = renderWithI18n(<WpmTrendChart data={[point()]} />)
     expect(container.querySelector('[data-testid="wpm-trend-chart"]')).toBeNull()
   })
 
-  it('renders nothing with zero results', () => {
-    const { container } = renderWithI18n(<WpmTrendChart results={[]} />)
+  it('renders nothing with zero day-points', () => {
+    const { container } = renderWithI18n(<WpmTrendChart data={[]} />)
     expect(container.querySelector('[data-testid="wpm-trend-chart"]')).toBeNull()
   })
 
-  it('renders the chart container for 2+ results', () => {
-    const results = [
-      makeResult({ date: '2026-06-18T00:00:00.000Z', wpm: 60 }),
-      makeResult({ date: '2026-06-19T00:00:00.000Z', wpm: 80 }),
+  it('renders the chart container for 2+ day-points', () => {
+    const data = [
+      point({ dayStartMs: new Date(2026, 5, 18).getTime() }),
+      point({ dayStartMs: new Date(2026, 5, 19).getTime() }),
     ]
-    renderWithI18n(<WpmTrendChart results={results} />)
+    renderWithI18n(<WpmTrendChart data={data} />)
     expect(screen.getByTestId('wpm-trend-chart')).toBeTruthy()
   })
 
-  it('renders regardless of the input ordering (sorts internally by date)', () => {
-    const results = [
-      makeResult({ date: '2026-06-20T00:00:00.000Z', wpm: 70 }),
-      makeResult({ date: '2026-06-18T00:00:00.000Z', wpm: 60 }),
-      makeResult({ date: '2026-06-19T00:00:00.000Z', wpm: 65 }),
+  it('renders exactly 3 line series — best/worst/avg — each with a distinct color and localized name', () => {
+    const data = [
+      point({ dayStartMs: new Date(2026, 5, 18).getTime() }),
+      point({ dayStartMs: new Date(2026, 5, 19).getTime() }),
     ]
-    renderWithI18n(<WpmTrendChart results={results} />)
-    expect(screen.getByTestId('wpm-trend-chart')).toBeTruthy()
+    renderWithI18n(<WpmTrendChart data={data} />)
+    const best = screen.getByTestId('wpm-trend-line-best')
+    const worst = screen.getByTestId('wpm-trend-line-worst')
+    const avg = screen.getByTestId('wpm-trend-line-avg')
+    expect(best.dataset.name).toBe('Best')
+    expect(worst.dataset.name).toBe('Worst')
+    expect(avg.dataset.name).toBe('Avg')
+    const colors = new Set([best.dataset.stroke, worst.dataset.stroke, avg.dataset.stroke])
+    expect(colors.size).toBe(3)
+  })
+
+  it('renders a legend', () => {
+    const data = [
+      point({ dayStartMs: new Date(2026, 5, 18).getTime() }),
+      point({ dayStartMs: new Date(2026, 5, 19).getTime() }),
+    ]
+    renderWithI18n(<WpmTrendChart data={data} />)
+    expect(screen.getByTestId('wpm-trend-legend-mock')).toBeTruthy()
   })
 
   it('suppresses the focus-ring outline on the chart wrapper (recharts accessibilityLayer regression guard)', () => {
-    const results = [
-      makeResult({ date: '2026-06-18T00:00:00.000Z', wpm: 60 }),
-      makeResult({ date: '2026-06-19T00:00:00.000Z', wpm: 80 }),
+    const data = [
+      point({ dayStartMs: new Date(2026, 5, 18).getTime() }),
+      point({ dayStartMs: new Date(2026, 5, 19).getTime() }),
     ]
-    renderWithI18n(<WpmTrendChart results={results} />)
+    renderWithI18n(<WpmTrendChart data={data} />)
     const wrapper = screen.getByTestId('wpm-trend-chart')
     expect(wrapper.className).toContain('[&_*]:focus:outline-none')
     expect(wrapper.className).toContain('[&_*]:focus-visible:outline-none')

--- a/src/renderer/typing-test/__tests__/wpm-daily-trend.test.ts
+++ b/src/renderer/typing-test/__tests__/wpm-daily-trend.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { aggregateWpmByDay } from '../wpm-daily-trend'
+import type { TypingTestResult } from '../../../shared/types/pipette-settings'
+
+/** Builds an ISO timestamp string from LOCAL date/time components (as
+ *  opposed to a hand-written `...Z` UTC literal), so a test asserting
+ *  "these three times are the same/different local calendar day" holds
+ *  regardless of which timezone the test runner's machine is in — a
+ *  literal like `T23:00:00.000Z` reads as a different local day in any
+ *  timezone ahead of UTC by more than 1 hour (e.g. JST, UTC+9). */
+function localISO(y: number, m: number, d: number, h: number, mi = 0): string {
+  return new Date(y, m - 1, d, h, mi, 0).toISOString()
+}
+
+function makeResult(overrides: Partial<TypingTestResult> = {}): TypingTestResult {
+  return {
+    date: '2026-06-20T00:00:00.000Z',
+    wpm: 60,
+    accuracy: 95,
+    wordCount: 30,
+    correctChars: 300,
+    incorrectChars: 5,
+    durationSeconds: 30,
+    ...overrides,
+  }
+}
+
+describe('aggregateWpmByDay', () => {
+  it('returns an empty array for no results', () => {
+    expect(aggregateWpmByDay([])).toEqual([])
+  })
+
+  it('groups multiple results on the same local day into one point with best/worst/avg', () => {
+    const results = [
+      makeResult({ date: localISO(2026, 6, 20, 1), wpm: 50 }),
+      makeResult({ date: localISO(2026, 6, 20, 12), wpm: 90 }),
+      makeResult({ date: localISO(2026, 6, 20, 23), wpm: 70 }),
+    ]
+    const points = aggregateWpmByDay(results)
+    expect(points).toHaveLength(1)
+    expect(points[0].best).toBe(90)
+    expect(points[0].worst).toBe(50)
+    expect(points[0].avg).toBeCloseTo(70, 5)
+    expect(points[0].count).toBe(3)
+  })
+
+  it('a single-result day has best === worst === avg', () => {
+    const points = aggregateWpmByDay([makeResult({ date: '2026-06-20T10:00:00.000Z', wpm: 42 })])
+    expect(points).toHaveLength(1)
+    expect(points[0].best).toBe(42)
+    expect(points[0].worst).toBe(42)
+    expect(points[0].avg).toBe(42)
+    expect(points[0].count).toBe(1)
+  })
+
+  it('sorts distinct days ascending by day, regardless of input order', () => {
+    const results = [
+      makeResult({ date: '2026-06-22T00:00:00.000Z', wpm: 65 }),
+      makeResult({ date: '2026-06-20T00:00:00.000Z', wpm: 60 }),
+      makeResult({ date: '2026-06-21T00:00:00.000Z', wpm: 70 }),
+    ]
+    const points = aggregateWpmByDay(results)
+    expect(points.map((p) => p.best)).toEqual([60, 70, 65])
+    // Each dayStartMs must be strictly increasing in the output.
+    expect(points[0].dayStartMs).toBeLessThan(points[1].dayStartMs)
+    expect(points[1].dayStartMs).toBeLessThan(points[2].dayStartMs)
+  })
+
+  it('keeps days with no results absent — output length equals the number of distinct days with data', () => {
+    const results = [
+      makeResult({ date: '2026-06-20T00:00:00.000Z', wpm: 60 }),
+      // Gap: no results on 06-21.
+      makeResult({ date: '2026-06-22T00:00:00.000Z', wpm: 65 }),
+    ]
+    const points = aggregateWpmByDay(results)
+    expect(points).toHaveLength(2)
+  })
+
+  it('rounds the daily average to one decimal place', () => {
+    const results = [
+      makeResult({ date: '2026-06-20T01:00:00.000Z', wpm: 60 }),
+      makeResult({ date: '2026-06-20T02:00:00.000Z', wpm: 61 }),
+      makeResult({ date: '2026-06-20T03:00:00.000Z', wpm: 61 }),
+    ]
+    const points = aggregateWpmByDay(results)
+    // (60 + 61 + 61) / 3 = 60.666... -> 60.7
+    expect(points[0].avg).toBe(60.7)
+  })
+
+  it('drops results with an unparseable date rather than crashing', () => {
+    const results = [
+      makeResult({ date: 'not-a-date', wpm: 999 }),
+      makeResult({ date: '2026-06-20T00:00:00.000Z', wpm: 60 }),
+    ]
+    const points = aggregateWpmByDay(results)
+    expect(points).toHaveLength(1)
+    expect(points[0].best).toBe(60)
+  })
+})

--- a/src/renderer/typing-test/wpm-daily-trend.ts
+++ b/src/renderer/typing-test/wpm-daily-trend.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// Per-day WPM aggregation for WpmTrendChart. With many results in a single
+// day, plotting every individual result zigzags into unreadable vertical
+// clusters (one x-position per day, N stacked y-values) — this groups
+// results by LOCAL calendar date and reduces each day to three numbers
+// (best/worst/avg WPM), so the chart reads as a smooth day-over-day trend
+// instead of a dense per-run scatter.
+
+import type { TypingTestResult } from '../../shared/types/pipette-settings'
+import { DAY_MS, snapBucketStartLocal } from '../components/analyze/analyze-bucket'
+
+export interface DailyWpmPoint {
+  /** Local midnight timestamp (ms) for this calendar day — the chart's X
+   *  axis value (matches WpmTrendChart's prior `timestampMs` convention:
+   *  a plain numeric axis, not a category axis). */
+  dayStartMs: number
+  best: number
+  worst: number
+  /** Rounded to one decimal — enough precision to distinguish close days
+   *  without implying false accuracy (mirrors computeStats' avgWpm, which
+   *  rounds to a whole number for the coarser all-time stat card; a
+   *  per-day trend point benefits from the extra digit since many days
+   *  cluster near the same integer WPM). */
+  avg: number
+  /** Result count for the day — not plotted, but useful for a tooltip or
+   *  future refinement (e.g. dimming single-sample days). */
+  count: number
+}
+
+/** Groups `results` by local calendar day and reduces each day to
+ *  best/worst/avg WPM. Days with zero results are simply absent from the
+ *  output (not represented as a null/gap entry) — the chart's line
+ *  connects directly between the nearest two days that DO have data, the
+ *  same behavior the prior per-result chart already had for sparse
+ *  periods (it never inserted gap markers either). Output is sorted
+ *  ascending by day, matching the chart's oldest-to-newest left-to-right
+ *  convention. Results with an unparseable `date` are dropped, same
+ *  treatment `filterResultsByPeriod` gives them.
+ *
+ *  Local-midnight snapping reuses `snapBucketStartLocal` (Analyze's own
+ *  day-bucketing primitive, already imported into this file's sibling
+ *  chart components for tooltip/palette helpers) rather than a bespoke
+ *  string key — the numeric snap result is itself already a unique,
+ *  sortable per-day Map key, so no separate `YYYY-MM-DD` key is needed. */
+export function aggregateWpmByDay(results: TypingTestResult[]): DailyWpmPoint[] {
+  const byDay = new Map<number, number[]>()
+  for (const r of results) {
+    const ms = new Date(r.date).getTime()
+    if (Number.isNaN(ms)) continue
+    const dayStartMs = snapBucketStartLocal(ms, DAY_MS)
+    const wpms = byDay.get(dayStartMs)
+    if (wpms) wpms.push(r.wpm)
+    else byDay.set(dayStartMs, [r.wpm])
+  }
+
+  const points = Array.from(byDay, ([dayStartMs, wpms]): DailyWpmPoint => ({
+    dayStartMs,
+    best: Math.max(...wpms),
+    worst: Math.min(...wpms),
+    avg: Math.round((wpms.reduce((sum, w) => sum + w, 0) / wpms.length) * 10) / 10,
+    count: wpms.length,
+  }))
+  points.sort((a, b) => a.dayStartMs - b.dayStartMs)
+  return points
+}


### PR DESCRIPTION
## Summary
- The History modal's WPM Trend no longer plots every individual result (which collapsed into unreadable vertical clusters on days with many tests). Results now aggregate per local calendar day, and the chart draws three legend-labeled series — daily best, worst, and average — colored from the existing chart palette.
- The aggregation is a pure helper (local-midnight snap reused from the analyze bucketing code) computed once in the panel and shared by the heading's visibility gate and the chart; the old result-count cap on the sparkline is gone, so the chart sees the same period-filtered set as the table and stats. Days without results are simply absent (line connects across gaps, matching the prior sparse behavior).
- i18n: three legend keys in english.json and all four sample packs, versions bumped in lockstep to 0.1.82.

## Verification
- New unit tests for the day aggregation (grouping, single-result day, sort, gaps, rounding, malformed dates) plus rewritten chart tests asserting the three series and legend; full suite 8,748 passed / 22 skipped; eslint/typecheck clean.
- Virtual-device screenshot with 16 results seeded across 5 days shows a readable 3-line chart with the legend.