### PR TITLE
chore(build): bump version to 0.4.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary
- Version bump 0.4.13 → 0.4.14 for the next release; v0.4.14 will be tagged on the merge commit.