### PR TITLE
fix(ui): keep History action labels on one line across language packs

### DIFF
--- a/src/renderer/typing-test/HistoryResultsPanel.tsx
+++ b/src/renderer/typing-test/HistoryResultsPanel.tsx
@@ -46,7 +46,12 @@ const EXPORT_BTN_CLASS = 'inline-flex h-8 items-center rounded-md border border-
 // variable-width and ellipsis-truncates via Tooltip when it doesn't fit,
 // see NameCell/ModeCell); every other column is sized to its known-narrow
 // content (numeric values, short buttons/icons). Sums to 100%.
-const COL_NAME = 'w-[16%]'
+// NAME/MODE keep the flexible majority share but give up some of it below
+// to TIMELINE/PB/DELETE, whose action labels must render on one line (see
+// the whitespace-nowrap cells below) — Name/Mode already ellipsis-truncate
+// via Tooltip when their content doesn't fit, so narrowing them just means
+// truncation kicks in a little sooner, not a broken layout.
+const COL_NAME = 'w-[12%]'
 const COL_DATE = 'w-[13%]'
 const COL_WPM = 'w-[6%]'
 const COL_KPM = 'w-[6%]'
@@ -58,15 +63,27 @@ const COL_KPM = 'w-[6%]'
 // width the wider modal was meant to buy back.
 const COL_ACCURACY = 'w-[9%]'
 const COL_AKH = 'w-[6%]'
-const COL_MODE = 'w-[14%]'
+const COL_MODE = 'w-[11%]'
 const COL_DURATION = 'w-[6%]'
-const COL_PB = 'w-[5%]'
-const COL_TIMELINE = 'w-[7%]'
+// The header label (t('editor.typingTest.history.pb'), whitespace-nowrap
+// below) is "PB" in most packs but 4 kanji in 紳士's "自己最高" — 5% left it
+// wrapping onto two lines at this table's font size. Bumped to 7%.
+const COL_PB = 'w-[7%]'
+// The Timeline link's label (whitespace-nowrap in HistoryTimelineCell) is
+// the longest action string across the built-in packs: 京言葉's
+// "タイムラインどすえ" (9 chars) needs more room than English's "Timeline"
+// (8 chars) suggests. Bumped from 7% to fit that string plus button/cell
+// padding on one line, funded by shrinking Name/Mode's share above.
+const COL_TIMELINE = 'w-[14%]'
 // The confirm-delete state (see below) packs two buttons — labels come
 // from i18n (common.confirmDelete/cancel) and run considerably longer in
-// some packs than English's "Delete?"/"Cancel" — bumped from the plain
-// Delete button's minimum, borrowed from Name/Mode's generous share.
-const COL_DELETE = 'w-[12%]'
+// some packs than English's "Delete?"/"Cancel" (up to 紳士's 19-character
+// confirm string) — but that row keeps its existing flex-wrap tolerance
+// (Cancel drops to its own line rather than forcing the column wider), so
+// this column only needs to comfortably fit the plain, single-line Delete
+// button (longest: ギャル's "ポイっちょ☆", 6 chars) on one line. Trimmed
+// from 12% to 10%, the saved 2% going to TIMELINE above.
+const COL_DELETE = 'w-[10%]'
 
 /** Mode-column detail. FileImport (imported-text) runs show the snapshotted text
  *  name (falling back to the stable textId for legacy rows saved before the
@@ -315,7 +332,7 @@ export function HistoryResultsPanel({
                 />
                 <SortableHeader widthClassName={COL_MODE} column="mode" label={isText ? t('editor.typingTest.history.tabText') : t('editor.typingTest.history.mode')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
                 <SortableHeader widthClassName={COL_DURATION} column="duration" label={t('editor.typingTest.time')} sortColumn={sortColumn} sortDirection={sortDirection} onSort={onSort} />
-                <th className={`${COL_PB} px-3 py-1.5`}>{t('editor.typingTest.history.pb')}</th>
+                <th className={`${COL_PB} px-3 py-1.5 whitespace-nowrap`}>{t('editor.typingTest.history.pb')}</th>
                 {uid && <th className={`${COL_TIMELINE} px-3 py-1.5`} aria-label={t('editor.typingTest.history.timeline.modalTitle')} />}
                 {onDelete && <th className={`${COL_DELETE} px-3 py-1.5`} aria-label={t('editor.typingTest.history.delete')} />}
               </tr>
@@ -369,9 +386,15 @@ export function HistoryResultsPanel({
                           </button>
                         </div>
                       ) : (
+                        // whitespace-nowrap: the plain (non-confirm) Delete
+                        // link must never wrap mid-word — COL_DELETE is
+                        // sized to fit every built-in pack's common.delete
+                        // label on one line (see the constant above). The
+                        // confirm-state buttons below intentionally keep
+                        // their default wrap tolerance instead.
                         <button
                           type="button"
-                          className={DELETE_BTN}
+                          className={`${DELETE_BTN} whitespace-nowrap`}
                           onClick={() => setConfirmDeleteDate(r.date)}
                           data-testid={`history-delete-${r.date}`}
                         >

--- a/src/renderer/typing-test/HistoryTimelineCell.tsx
+++ b/src/renderer/typing-test/HistoryTimelineCell.tsx
@@ -38,10 +38,16 @@ export function HistoryTimelineCell({ result, uid, availableRunIds }: Props) {
        *  short "Timeline" label. No aria-label on the button itself — the
        *  visible text already supplies its accessible name. */}
       <Tooltip content={t('editor.typingTest.history.timeline.openButton')}>
+        {/* whitespace-nowrap: with the fixed-layout table's narrow COL_TIMELINE
+         *  share, some i18n packs' Timeline label (e.g. 京言葉's
+         *  "タイムラインどすえ") is long enough that the default wrap would break
+         *  it mid-word onto two lines. COL_TIMELINE is sized to fit the
+         *  longest built-in pack string on one line (see HistoryResultsPanel),
+         *  so this never needs to clip. */}
         <button
           type="button"
           onClick={() => setOpen(true)}
-          className={LOAD_BTN}
+          className={`${LOAD_BTN} whitespace-nowrap`}
           data-testid={`history-timeline-open-${result.date}`}
         >
           {t('editor.typingTest.history.timeline.linkLabel')}


### PR DESCRIPTION
## Summary
- The History table's Timeline link wrapped mid-word (「タイム/ライン」) under the Japanese pack because the fixed-layout column gave Timeline only 7% — sized for the English label. Columns rebalance from a survey of every built-in pack's actual strings: Timeline 7→14%, PB 5→7%, Delete 12→10%, funded by Name 16→12% and Mode 14→11% (both already ellipsis-truncate with tooltips); still sums to 100%.
- The Timeline link, Delete button, and PB header get whitespace-nowrap so action labels never break mid-word; the delete-confirm row keeps its deliberate flex-wrap tolerance for the longest pack's 19-char confirm string.

## Verification
- Measured live with the Japanese pack active on the virtual device: Timeline/Delete/PB cells single-line, table edge gap 0.8px; off-screen text measurement confirms the widest pack strings fit their budgets (京言葉 Timeline 107px/121px, ギャル Delete 72px/75px, 紳士 PB 48px/56px). English UI re-shot with no regression.
- Full suite 8,748 passed / 22 skipped; eslint/typecheck clean.