### PR TITLE
chore(build): bump version to 0.4.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump app version 0.4.14 → 0.4.15 for release (Weak Spot Training Mode, operation-guide catch-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AvgjrMSesjxw1VH5ZMYQx