### PR TITLE
fix(app): reveal the window when relaunching a tray-resident instance

### DIFF
--- a/e2e/tray-start-unlock.test.ts
+++ b/e2e/tray-start-unlock.test.ts
@@ -21,10 +21,10 @@
 
 import { test, expect } from '@playwright/test'
 import type { ElectronApplication } from '@playwright/test'
-import { join } from 'node:path'
+import { join, resolve } from 'node:path'
 import { homedir } from 'node:os'
 import { readFileSync, writeFileSync, existsSync } from 'node:fs'
-import { execSync } from 'node:child_process'
+import { execSync, spawnSync } from 'node:child_process'
 import { launchApp } from './helpers/electron'
 import {
   connectToDevice,
@@ -39,6 +39,7 @@ import {
   type FileBackup,
 } from './helpers/doc-capture-common'
 
+const PROJECT_ROOT = resolve(import.meta.dirname, '..')
 const USER_DATA = join(homedir(), '.config', 'Electron')
 const CONFIG_PATH = join(USER_DATA, 'config.json')
 const SETTINGS_PATH = join(USER_DATA, 'sync', 'keyboards', VIRTUAL_DEVICE_UID, 'pipette_settings.json')
@@ -97,7 +98,7 @@ let app: ElectronApplication | null = null
 let configBackup: FileBackup
 let settingsBackup: FileBackup
 
-test.describe.serial('tray start-in-tray unlock reveal', () => {
+test.describe.serial('tray start-in-tray unlock reveal', { tag: '@virtual' }, () => {
   test.setTimeout(180_000)
 
   test.beforeAll(() => {
@@ -264,6 +265,47 @@ test.describe.serial('tray start-in-tray unlock reveal', () => {
       expect(dialogUp, `Unlock dialog appeared on sample ${sample}`).toBe(false)
       await page.waitForTimeout(1000)
     }
+
+    await quitApp(app)
+    app = null
+  })
+
+  test('second-instance reveal: relaunching a tray-resident hidden app reveals the running instance\'s window', async () => {
+    // Persisted viewMode is still 'editor' from the previous test, so the
+    // primary instance boots hidden with no Unlock dialog in play — the
+    // only thing that can make its window visible here is the
+    // 'second-instance' handler reacting to the relaunch attempt below.
+    const launched = await launchApp({ env: { PIPETTE_VIRTUAL_DEVICE: 'only' } })
+    app = launched.app
+    const page = launched.page
+
+    await page.locator('[data-testid="editor-content"]').waitFor({ state: 'visible', timeout: 25_000 })
+
+    const bootVisible = await app!.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((w) => w.isVisible()))
+    expect(bootVisible, 'expected the primary instance to boot hidden').toBe(false)
+
+    // Spawn a second instance as a raw child process rather than through
+    // launchApp — Playwright's electron.launch would try to attach to this
+    // process, but the single-instance lock makes it exit immediately
+    // (before creating any window) once it loses the lock race.
+    const electronBin = resolve(PROJECT_ROOT, 'node_modules', '.bin', 'electron')
+    const second = spawnSync(electronBin, ['out/main/index.js', '--no-sandbox', '--disable-gpu-sandbox'], {
+      cwd: PROJECT_ROOT,
+      env: { ...process.env, PIPETTE_VIRTUAL_DEVICE: 'only' },
+      stdio: 'ignore',
+      // The loser of the single-instance lock race exits within ~a second;
+      // the timeout only bounds a pathological hang so it cannot block the
+      // whole (synchronous) spawn past the suite budget.
+      timeout: 30_000,
+    })
+    expect(second.status).toBe(0)
+
+    await expect.poll(async () => {
+      const winVisible = await app!.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().map((w) => w.isVisible()))
+      return winVisible.some(Boolean)
+    }, { message: 'expected the primary instance\'s window to become visible after a second launch attempt', timeout: 15_000, intervals: [1000] }).toBe(true)
 
     await quitApp(app)
     app = null

--- a/src/main/__tests__/app-behavior.test.ts
+++ b/src/main/__tests__/app-behavior.test.ts
@@ -179,6 +179,24 @@ describe('applyAutoLaunch', () => {
   })
 })
 
+// Minimal BrowserWindow stub for the reveal-path tests. Defaults model a
+// hidden, non-minimized window; override per test. Adding a method here
+// (instead of at each call site) keeps a new showWindow predicate a
+// one-line change.
+function makeWin(state: { visible?: boolean; minimized?: boolean } = {}): Record<'show' | 'focus' | 'restore' | 'isVisible' | 'isMinimized', ReturnType<typeof vi.fn>> {
+  return {
+    show: vi.fn(),
+    focus: vi.fn(),
+    restore: vi.fn(),
+    isVisible: vi.fn().mockReturnValue(state.visible ?? false),
+    isMinimized: vi.fn().mockReturnValue(state.minimized ?? false),
+  }
+}
+
+function asWin(win: ReturnType<typeof makeWin>): Electron.BrowserWindow {
+  return win as unknown as Electron.BrowserWindow
+}
+
 describe('tray', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -218,8 +236,8 @@ describe('tray', () => {
   })
 
   it('Show menu item shows and focuses the window', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
-    setupTray(() => win as unknown as Electron.BrowserWindow)
+    const win = makeWin()
+    setupTray(() => asWin(win))
 
     const template = mockBuildFromTemplate.mock.calls[0][0]
     const showItem = template.find((item) => item.label === 'Show')
@@ -247,8 +265,8 @@ describe('tray', () => {
   })
 
   it('tray click event shows and focuses the window, same as Show', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
-    setupTray(() => win as unknown as Electron.BrowserWindow)
+    const win = makeWin()
+    setupTray(() => asWin(win))
 
     const clickHandler = trayInstances[0].handlers.get('click')
     expect(clickHandler).toBeDefined()
@@ -332,8 +350,8 @@ describe('updateTrayStatus', () => {
   })
 
   it('the rebuilt Show item still shows and focuses the window', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
-    const getWindow = () => win as unknown as Electron.BrowserWindow
+    const win = makeWin()
+    const getWindow = (): Electron.BrowserWindow => asWin(win)
     setupTray(getWindow)
     updateTrayStatus({ keyboardName: 'GPK-63R', recording: true, count: 1, kpm: 1 }, getWindow)
 
@@ -347,11 +365,19 @@ describe('updateTrayStatus', () => {
 })
 
 describe('showWindow', () => {
-  it('shows and focuses the window when one exists', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
-    showWindow(() => win as unknown as Electron.BrowserWindow)
+  it('shows and focuses the window when one exists, without restoring a non-minimized one', () => {
+    const win = makeWin()
+    showWindow(() => asWin(win))
     expect(win.show).toHaveBeenCalled()
     expect(win.focus).toHaveBeenCalled()
+    expect(win.restore).not.toHaveBeenCalled()
+  })
+
+  it('restores a minimized window before showing it', () => {
+    const win = makeWin({ minimized: true })
+    showWindow(() => asWin(win))
+    expect(win.restore).toHaveBeenCalled()
+    expect(win.show).toHaveBeenCalled()
   })
 
   it('is a no-op when there is no window', () => {
@@ -363,13 +389,11 @@ describe('showWindow', () => {
   })
 
   it('returns true when the window transitions from hidden to shown', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(false) }
-    expect(showWindow(() => win as unknown as Electron.BrowserWindow)).toBe(true)
+    expect(showWindow(() => asWin(makeWin()))).toBe(true)
   })
 
   it('returns false when the window was already visible', () => {
-    const win = { show: vi.fn(), focus: vi.fn(), isVisible: vi.fn().mockReturnValue(true) }
-    expect(showWindow(() => win as unknown as Electron.BrowserWindow)).toBe(false)
+    expect(showWindow(() => asWin(makeWin({ visible: true })))).toBe(false)
   })
 })
 

--- a/src/main/app-behavior.ts
+++ b/src/main/app-behavior.ts
@@ -83,16 +83,19 @@ export function appIconPath(): string {
 
 let trayInstance: Tray | null = null
 
-/** Show and focus the given window. Shared by the tray menu/click
- * handlers and the WINDOW_SHOW IPC handler so a hidden (start-in-tray)
- * window and the tray icon reveal it the same way. Returns whether the
- * window actually transitioned from hidden to shown, so callers that only
- * want to act on a genuine hidden→visible edge (e.g. the boot-hidden Unlock
- * dialog flow) can tell that apart from a window that was already visible. */
+/** Show and focus the given window. Shared by every reveal path (tray,
+ * WINDOW_SHOW IPC, app relaunch) so a hidden (start-in-tray) window is
+ * revealed the same way regardless of trigger. Restores a minimized
+ * window first — `show()` alone does not un-minimize on every platform.
+ * Returns whether the window actually transitioned from hidden to shown,
+ * so callers that only want to act on a genuine hidden→visible edge
+ * (e.g. the boot-hidden Unlock dialog flow) can tell that apart from a
+ * window that was already visible. */
 export function showWindow(getWindow: () => BrowserWindow | null): boolean {
   const win = getWindow()
   if (!win) return false
   const wasVisible = win.isVisible()
+  if (win.isMinimized()) win.restore()
   win.show()
   win.focus()
   return !wasVisible

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,9 +55,13 @@ app.setDesktopName('pipette')
 
 // Single-instance guard: a second launch exits immediately and silently
 // (app.exit skips before-quit/will-quit — nothing is set up yet at this
-// point); the running instance is left untouched.
+// point); the surviving instance reveals its window instead. Electron only
+// emits 'second-instance' on the lock holder and never before 'ready', so
+// registering at module top level is safe.
 if (!app.requestSingleInstanceLock()) {
   app.exit(0)
+} else {
+  app.on('second-instance', revealApp)
 }
 
 // Distinguishes a user-initiated quit from a plain window close so the
@@ -196,6 +200,25 @@ function createWindow(): void {
   if (isDev) win.webContents.openDevTools()
 
   win.webContents.setZoomFactor(clampZoomFactor(cfg.zoomFactor) / 100)
+}
+
+// Bring the app to the user's attention: reveal the existing window
+// (hidden tray-resident, or minimized) or create one when none exists.
+// Shared by both relaunch paths — 'second-instance' (Windows/Linux spawn
+// a second process that loses the lock) and macOS 'activate' (a Dock/
+// Finder relaunch re-activates the running process instead) — so every
+// platform gives the same visible feedback when the user launches the
+// app while it is already running.
+function revealApp(): void {
+  // A relaunch attempt racing this instance's own startup can arrive
+  // before 'ready'; creating a BrowserWindow then would throw, and the
+  // startup sequence is about to produce the window anyway.
+  if (!app.isReady()) return
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow()
+  } else {
+    showWindow(getFirstWindow)
+  }
 }
 
 interface WindowSize { width: number; height: number }
@@ -477,11 +500,7 @@ app.whenReady().then(() => {
   // checks the Hub version when its tab is shown and surfaces a manual
   // "Update" button (see TYPING_DATASET_CHECK / TYPING_DATASET_UPDATE).
 
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      createWindow()
-    }
-  })
+  app.on('activate', revealApp)
 })
 
 app.on('window-all-closed', () => {


### PR DESCRIPTION
## Problem

With **Tray Residency** and **Start in Tray** enabled, launching the app while it is already running appeared to do nothing: the second process exited silently through the single-instance lock, and the running instance had no `second-instance` handler to reveal its hidden window. On macOS the equivalent Dock relaunch (`activate`) only created a window when none existed and never revealed a hidden one.

## Fix

- Register a shared `revealApp()` for both `second-instance` and `activate`: reveal the existing window, or create one when none exists. Guarded with `app.isReady()` against a relaunch racing startup.
- `showWindow` now restores a minimized window before showing it, covering every reveal path (tray Show, WINDOW_SHOW IPC, relaunch).

## Tests

- New serial e2e: with the app tray-resident and hidden, a raw second Electron process exits with the lock and the primary window becomes visible.
- The whole tray e2e suite is now tagged `@virtual` so CI actually runs it (it previously matched no `--grep @virtual` run).
- Unit tests: minimized-restore coverage via a shared window-stub factory.

Verified locally: lint, typecheck, 8991 unit tests, tray e2e 5/5.