### PR TITLE
chore(build): bump version to 0.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
Bump the app version to 0.4.16 for the next release (REC unlock gate + ambient recording, #416).