### PR TITLE
chore(build): bump version to 0.4.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump the app version to 0.4.17 for the next release (typing test exit fix #420 and window work-area clamp #421).

## Test plan

- CI (lint → test → build)