### PR TITLE
fix(ui): export keymap.c in raw matrix order

### DIFF
--- a/src/renderer/components/data-modal/useSnapshotActions.ts
+++ b/src/renderer/components/data-modal/useSnapshotActions.ts
@@ -47,6 +47,8 @@ function loadVilData(uid: string, entryId: string): Promise<VilFile | null> {
   }).catch(() => null)
 }
 
+// Superset param object shared by the keymap.c / PDF / hub export paths;
+// keys and layoutOptions are consumed only by the PDF generator.
 function buildParams(vilData: VilFile) {
   const def = vilData.definition!
   const kleResult = parseKle(def.layouts.keymap as unknown[][])
@@ -60,6 +62,8 @@ function buildParams(vilData: VilFile) {
   return {
     layers: deriveLayerCount(vilData.keymap),
     keys: kleResult.keys,
+    matrixRows: def.matrix.rows,
+    matrixCols: def.matrix.cols,
     keymap: recordToMap(vilData.keymap),
     encoderLayout: recordToMap(vilData.encoderLayout),
     encoderCount,
@@ -84,13 +88,10 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
-      const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
       const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
-      const rows = def.matrix?.rows ?? 0
-      const cols = def.matrix?.cols ?? 0
-      const encoderCount = buildParams(vilData).encoderCount
+      const { matrixRows: rows, matrixCols: cols, encoderCount } = buildParams(vilData)
       const macroActions = splitMacroBuffer(vilData.macros, macroCount)
         .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
       const json = vilToVialGuiJson(vilData, {
@@ -144,13 +145,10 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
         findOuterKeycode,
         findInnerKeycode,
       })
-      const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
       const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
-      const rows = def.matrix?.rows ?? 0
-      const cols = def.matrix?.cols ?? 0
-      const encoderCount = params.encoderCount
+      const { matrixRows: rows, matrixCols: cols, encoderCount } = params
       const macroActions = splitMacroBuffer(vilData.macros, macroCount)
         .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
       const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)
@@ -183,13 +181,10 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
         findOuterKeycode,
         findInnerKeycode,
       })
-      const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
       const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
-      const rows = def.matrix?.rows ?? 0
-      const cols = def.matrix?.cols ?? 0
-      const encoderCount = params.encoderCount
+      const { matrixRows: rows, matrixCols: cols, encoderCount } = params
       const macroActions = splitMacroBuffer(vilData.macros, macroCount)
         .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
       const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)

--- a/src/renderer/hooks/use-file-generators.ts
+++ b/src/renderer/hooks/use-file-generators.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Keymap-C / PDF export generator callbacks fed into useFileIO. Split out
-// of App.tsx (Task-split-app-tsx) — pure move, same generators and
-// dependency arrays as before.
+// of App.tsx (Task-split-app-tsx).
 
 import { useCallback } from 'react'
 import type { useKeyboard } from './useKeyboard'
@@ -29,15 +28,15 @@ export function useFileGenerators({ keyboard, deviceName, decodedLayoutOptions, 
   const keymapCGenerator = useCallback(
     () => generateKeymapC({
       layers: keyboard.layers,
-      keys: keyboard.layout?.keys ?? [],
+      matrixRows: keyboard.rows,
+      matrixCols: keyboard.cols,
       keymap: keyboard.keymap,
       encoderLayout: keyboard.encoderLayout,
       encoderCount: keyboard.encoderCount,
-      layoutOptions: decodedLayoutOptions,
       serializeKeycode: serializeForCExport,
       customKeycodes: keyboard.definition?.customKeycodes,
     }),
-    [keyboard.layers, keyboard.layout, keyboard.keymap, keyboard.encoderLayout, keyboard.encoderCount, decodedLayoutOptions, keyboard.definition?.customKeycodes],
+    [keyboard.layers, keyboard.rows, keyboard.cols, keyboard.keymap, keyboard.encoderLayout, keyboard.encoderCount, keyboard.definition?.customKeycodes],
   )
 
   const pdfGenerator = useCallback(

--- a/src/renderer/hooks/useEntryOperations.ts
+++ b/src/renderer/hooks/useEntryOperations.ts
@@ -116,11 +116,15 @@ export function useEntryOperations(options: Options) {
     return `${deviceName}_${suffix}`
   }, [deviceName, layoutStoreEntries])
 
+  // Superset param object shared by the keymap.c / PDF / hub export paths;
+  // keys and layoutOptions are consumed only by the PDF generator.
   const buildEntryParams = useCallback((vilData: VilFile) => {
     const labels = definition?.layouts?.labels
     return {
       layers: deriveLayerCount(vilData.keymap),
       keys: layout?.keys ?? [],
+      matrixRows: vilData.definition?.matrix.rows ?? rows,
+      matrixCols: vilData.definition?.matrix.cols ?? cols,
       keymap: recordToMap(vilData.keymap),
       encoderLayout: recordToMap(vilData.encoderLayout),
       encoderCount,
@@ -138,14 +142,16 @@ export function useEntryOperations(options: Options) {
         : splitMacroBuffer(vilData.macros, macroCount)
             .map((m) => deserializeMacro(m, vialProtocol)),
     }
-  }, [definition, layout, encoderCount, macroCount, vialProtocol])
+  }, [definition, layout, encoderCount, macroCount, vialProtocol, rows, cols])
 
   const buildVilExportContext = useCallback((vilData: VilFile) => {
     const macroActions = splitMacroBuffer(vilData.macros, macroCount)
       .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
     return {
-      rows,
-      cols,
+      // Match buildEntryParams: prefer the snapshot's own matrix so the
+      // exported vil JSON and keymap.c describe the same dimensions.
+      rows: vilData.definition?.matrix.rows ?? rows,
+      cols: vilData.definition?.matrix.cols ?? cols,
       layers: deriveLayerCount(vilData.keymap),
       encoderCount,
       vialProtocol,

--- a/src/shared/__tests__/keymap-export.test.ts
+++ b/src/shared/__tests__/keymap-export.test.ts
@@ -2,26 +2,6 @@
 
 import { describe, it, expect } from 'vitest'
 import { generateKeymapC, type KeymapExportInput } from '../keymap-export'
-import type { KleKey } from '../kle/types'
-
-function makeKey(overrides: Partial<KleKey> = {}): KleKey {
-  return {
-    x: 0, y: 0,
-    width: 1, height: 1,
-    x2: 0, y2: 0,
-    width2: 1, height2: 1,
-    rotation: 0, rotationX: 0, rotationY: 0,
-    color: '#cccccc',
-    labels: Array(12).fill(null),
-    textColor: Array(12).fill(null),
-    textSize: Array(12).fill(null),
-    row: 0, col: 0,
-    encoderIdx: -1, encoderDir: -1,
-    layoutIndex: -1, layoutOption: -1,
-    decal: false, nub: false, stepped: false, ghost: false,
-    ...overrides,
-  }
-}
 
 function mockSerialize(code: number): string {
   const names: Record<number, string> = {
@@ -45,16 +25,7 @@ function mockSerialize(code: number): string {
 }
 
 function createBasicInput(overrides: Partial<KeymapExportInput> = {}): KeymapExportInput {
-  // 2x3 grid: row0=(0,0)(0,1)(0,2), row1=(1,0)(1,1)(1,2)
-  const keys: KleKey[] = [
-    makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-    makeKey({ x: 1, y: 0, row: 0, col: 1 }),
-    makeKey({ x: 2, y: 0, row: 0, col: 2 }),
-    makeKey({ x: 0, y: 1, row: 1, col: 0 }),
-    makeKey({ x: 1, y: 1, row: 1, col: 1 }),
-    makeKey({ x: 2, y: 1, row: 1, col: 2 }),
-  ]
-
+  // 2x3 matrix: row0=(0,0)(0,1)(0,2), row1=(1,0)(1,1)(1,2)
   const keymap = new Map<string, number>([
     ['0,0,0', 0x29], ['0,0,1', 0x04], ['0,0,2', 0x05],
     ['0,1,0', 0x2B], ['0,1,1', 0x06], ['0,1,2', 0x07],
@@ -62,11 +33,11 @@ function createBasicInput(overrides: Partial<KeymapExportInput> = {}): KeymapExp
 
   return {
     layers: 1,
-    keys,
+    matrixRows: 2,
+    matrixCols: 3,
     keymap,
     encoderLayout: new Map(),
     encoderCount: 0,
-    layoutOptions: new Map(),
     serializeKeycode: mockSerialize,
     ...overrides,
   }
@@ -78,9 +49,9 @@ describe('generateKeymapC', () => {
 
     expect(result).toContain('#include QMK_KEYBOARD_H')
     expect(result).toContain('PROGMEM')
-    expect(result).toContain('[0] = LAYOUT(')
-    expect(result).toContain('KC_ESC, KC_A, KC_B')
-    expect(result).toContain('KC_TAB, KC_C, KC_D')
+    expect(result).toContain('[0] = {')
+    expect(result).toContain('{ KC_ESC, KC_A, KC_B }')
+    expect(result).toContain('{ KC_TAB, KC_C, KC_D }')
   })
 
   it('generates header with SPDX and include', () => {
@@ -101,52 +72,45 @@ describe('generateKeymapC', () => {
 
     const result = generateKeymapC(createBasicInput({ layers: 2, keymap }))
 
-    expect(result).toContain('[0] = LAYOUT(')
-    expect(result).toContain('[1] = LAYOUT(')
-    expect(result).toContain('KC_GRV, KC_1, KC_2')
-    expect(result).toContain('KC_TRNS, KC_E, KC_F')
+    expect(result).toContain('[0] = {')
+    expect(result).toContain('[1] = {')
+    expect(result).toContain('{ KC_GRV, KC_1, KC_2 }')
+    expect(result).toContain('{ KC_TRNS, KC_E, KC_F }')
   })
 
-  it('filters keys by layout options', () => {
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0, row: 0, col: 1, layoutIndex: 0, layoutOption: 0 }),
-      makeKey({ x: 1, y: 0, row: 0, col: 2, layoutIndex: 0, layoutOption: 1 }),
-    ]
+  it('emits a full grid in row-then-col order using designated initializers', () => {
+    const result = generateKeymapC(createBasicInput())
 
-    const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,0,2', 0x05],
-    ])
-
-    // Select layoutOption 1 for layoutIndex 0
-    const layoutOptions = new Map<number, number>([[0, 1]])
-
-    const result = generateKeymapC(createBasicInput({ keys, keymap, layoutOptions }))
-
-    // col 2 (option 1) should be included, col 1 (option 0) should not
-    expect(result).toContain('KC_ESC, KC_B')
-    expect(result).not.toContain('KC_A')
+    expect(result).toContain(
+      '[0] = {\n        { KC_ESC, KC_A, KC_B },\n        { KC_TAB, KC_C, KC_D }\n    }',
+    )
   })
 
-  it('excludes decal keys', () => {
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0, row: 0, col: 1, decal: true }),
-      makeKey({ x: 2, y: 0, row: 0, col: 2 }),
-    ]
-
+  it('defaults missing Map entries to KC_NO at their coordinates', () => {
     const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,0,2', 0x05],
+      ['0,0,0', 0x29], ['0,0,1', 0x04],
+      // 0,0,2 intentionally missing
+      ['0,1,0', 0x2B], ['0,1,1', 0x06], ['0,1,2', 0x07],
     ])
 
-    const result = generateKeymapC(createBasicInput({ keys, keymap }))
+    const result = generateKeymapC(createBasicInput({ keymap }))
 
-    expect(result).toContain('KC_ESC, KC_B')
-    expect(result).not.toContain('KC_A')
+    expect(result).toContain('{ KC_ESC, KC_A, KC_NO }')
+  })
+
+  it('emits a full KC_NO grid for a layer whose entries are all missing', () => {
+    const result = generateKeymapC(createBasicInput({ layers: 2, keymap: new Map() }))
+
+    expect(result).toContain('[0] = {')
+    expect(result).toContain('[1] = {')
+    expect(result).toContain('{ KC_NO, KC_NO, KC_NO }')
+  })
+
+  it('throws when matrix dimensions are unavailable or invalid', () => {
+    expect(() => generateKeymapC(createBasicInput({ matrixRows: 0 }))).toThrow()
+    expect(() => generateKeymapC(createBasicInput({ matrixCols: 0 }))).toThrow()
+    expect(() => generateKeymapC(createBasicInput({ matrixRows: Number.NaN }))).toThrow()
+    expect(() => generateKeymapC(createBasicInput({ matrixCols: 1.5 }))).toThrow()
   })
 
   it('generates encoder_map when encoders exist', () => {
@@ -198,117 +162,6 @@ describe('generateKeymapC', () => {
 
     expect(result).toContain('[0] = { ENCODER_CCW_CW(KC_VOLD, KC_VOLU) }')
     expect(result).toContain('[1] = { ENCODER_CCW_CW(KC_TRNS, KC_TRNS) }')
-  })
-
-  it('groups keys by y coordinate (visual rows)', () => {
-    // Keys on same visual row (y difference <= 0.3)
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0.1, row: 0, col: 1 }), // close y => same row
-      makeKey({ x: 0, y: 1.5, row: 1, col: 0 }),   // far y => new row
-    ]
-
-    const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,1,0', 0x05],
-    ])
-
-    const result = generateKeymapC(createBasicInput({ keys, keymap }))
-
-    // Row 1: ESC, A (same visual row)
-    // Row 2: B (new visual row)
-    const lines = result.split('\n')
-    const layoutLine1 = lines.find(l => l.includes('KC_ESC'))!
-    expect(layoutLine1).toContain('KC_A')
-    const layoutLine2 = lines.find(l => l.includes('KC_B') && !l.includes('KC_ESC'))!
-    expect(layoutLine2).toBeDefined()
-  })
-
-  it('separates normal keys from encoder keys', () => {
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0, row: 0, col: 1 }),
-      makeKey({ x: 2, y: 0, row: 0, col: 2, encoderIdx: 0, encoderDir: 0 }),
-      makeKey({ x: 3, y: 0, row: 0, col: 3, encoderIdx: 0, encoderDir: 1 }),
-    ]
-
-    const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,0,2', 0x80],
-      ['0,0,3', 0x81],
-    ])
-
-    const result = generateKeymapC(createBasicInput({ keys, keymap }))
-
-    // LAYOUT should only contain normal keys
-    const layoutSection = result.split('};')[0]
-    expect(layoutSection).toContain('KC_ESC, KC_A')
-    // Encoder keys should not appear in LAYOUT
-    expect(layoutSection).not.toContain('KC_VOLD')
-  })
-
-  it('defaults keycode to 0 (KC_NO) for missing keys', () => {
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-    ]
-
-    const result = generateKeymapC(createBasicInput({
-      keys,
-      keymap: new Map(), // empty keymap
-    }))
-
-    expect(result).toContain('KC_NO')
-  })
-
-  it('includes all keys when layoutOptions is empty (matches KeyboardWidget)', () => {
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0, row: 0, col: 1, layoutIndex: 0, layoutOption: 0 }),
-      makeKey({ x: 2, y: 0, row: 0, col: 2, layoutIndex: 0, layoutOption: 1 }),
-    ]
-
-    const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,0,2', 0x05],
-    ])
-
-    // Empty layoutOptions → include all keys regardless of layoutOption
-    const result = generateKeymapC(createBasicInput({ keys, keymap, layoutOptions: new Map() }))
-
-    expect(result).toContain('KC_ESC, KC_A, KC_B')
-  })
-
-  it('does not chain-merge rows with gradual y offsets', () => {
-    // Keys at y=0.0, 0.2, 0.4 — should split into rows based on distance from row start
-    const keys: KleKey[] = [
-      makeKey({ x: 0, y: 0.0, row: 0, col: 0 }),
-      makeKey({ x: 1, y: 0.2, row: 0, col: 1 }),
-      makeKey({ x: 2, y: 0.4, row: 0, col: 2 }), // > 0.3 from row start (0.0)
-    ]
-
-    const keymap = new Map<string, number>([
-      ['0,0,0', 0x29],
-      ['0,0,1', 0x04],
-      ['0,0,2', 0x05],
-    ])
-
-    const result = generateKeymapC(createBasicInput({ keys, keymap }))
-
-    // First two keys in same row, third in new row
-    const lines = result.split('\n')
-    const escLine = lines.find(l => l.includes('KC_ESC'))!
-    expect(escLine).toContain('KC_A')
-    expect(escLine).not.toContain('KC_B')
-  })
-
-  it('handles empty keys array', () => {
-    const result = generateKeymapC(createBasicInput({ keys: [], keymap: new Map() }))
-
-    expect(result).toContain('LAYOUT(')
-    expect(result).toContain('#include QMK_KEYBOARD_H')
   })
 
   it('ends output with newline', () => {

--- a/src/shared/keymap-export.ts
+++ b/src/shared/keymap-export.ts
@@ -1,62 +1,34 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // Generate QMK-compatible keymap.c from current keymap state
 
-import type { KleKey } from './kle/types'
 import type { CustomKeycodeDefinition } from './keycodes/keycodes'
-import { filterVisibleKeys } from './kle/filter-keys'
 
 export interface KeymapExportInput {
   layers: number
-  keys: KleKey[]
+  matrixRows: number
+  matrixCols: number
   keymap: Map<string, number>
   encoderLayout: Map<string, number>
   encoderCount: number
-  layoutOptions: Map<number, number>
   serializeKeycode: (code: number) => string
   customKeycodes?: CustomKeycodeDefinition[]
 }
 
-function groupKeysByRow(keys: KleKey[]): KleKey[][] {
-  if (keys.length === 0) return []
-
-  const sorted = [...keys].sort((a, b) => {
-    if (a.y !== b.y) return a.y - b.y
-    return a.x - b.x
-  })
-
-  const rows: KleKey[][] = [[sorted[0]]]
-  for (let i = 1; i < sorted.length; i++) {
-    const rowStart = rows[rows.length - 1][0]
-    const curr = sorted[i]
-    if (Math.abs(curr.y - rowStart.y) > 0.3) {
-      rows.push([curr])
-    } else {
-      rows[rows.length - 1].push(curr)
-    }
-  }
-
-  return rows
-}
-
-function generateLayerLayout(
+function generateLayerMatrix(
   layer: number,
-  normalKeys: KleKey[],
+  matrixRows: number,
+  matrixCols: number,
   keymap: Map<string, number>,
   serializeKeycode: (code: number) => string,
 ): string {
-  const rows = groupKeysByRow(normalKeys)
-  const lines: string[] = []
+  const rowLines = Array.from({ length: matrixRows }, (_, r) => {
+    const codes = Array.from({ length: matrixCols }, (_, c) =>
+      serializeKeycode(keymap.get(`${layer},${r},${c}`) ?? 0),
+    )
+    return `        { ${codes.join(', ')} }`
+  })
 
-  for (let r = 0; r < rows.length; r++) {
-    const codes = rows[r].map((key) => {
-      const code = keymap.get(`${layer},${key.row},${key.col}`) ?? 0
-      return serializeKeycode(code)
-    })
-    const suffix = r < rows.length - 1 ? ',' : ''
-    lines.push(`        ${codes.join(', ')}${suffix}`)
-  }
-
-  return `    [${layer}] = LAYOUT(\n${lines.join('\n')}\n    )`
+  return `    [${layer}] = {\n${rowLines.join(',\n')}\n    }`
 }
 
 function generateEncoderLayer(
@@ -89,20 +61,21 @@ function generateCustomKeycodeEnum(customKeycodes: CustomKeycodeDefinition[]): s
 export function generateKeymapC(input: KeymapExportInput): string {
   const {
     layers,
-    keys,
+    matrixRows,
+    matrixCols,
     keymap,
     encoderLayout,
     encoderCount,
-    layoutOptions,
     serializeKeycode,
     customKeycodes,
   } = input
 
-  const visibleKeys = filterVisibleKeys(keys, layoutOptions)
-  const normalKeys = visibleKeys.filter((k) => k.encoderIdx === -1)
+  if (!Number.isInteger(matrixRows) || !Number.isInteger(matrixCols) || matrixRows <= 0 || matrixCols <= 0) {
+    throw new Error('matrix dimensions unavailable')
+  }
 
   const layerBlocks = Array.from({ length: layers }, (_, l) =>
-    generateLayerLayout(l, normalKeys, keymap, serializeKeycode),
+    generateLayerMatrix(l, matrixRows, matrixCols, keymap, serializeKeycode),
   )
 
   const sections = [
@@ -117,6 +90,8 @@ export function generateKeymapC(input: KeymapExportInput): string {
   }
 
   sections.push(
+    `/* Keymap is written in raw matrix order, keymaps[layer][row][col]; unwired`,
+    ` * matrix positions are KC_NO. This is what the LAYOUT() macro expands to. */`,
     `const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {`,
     `${layerBlocks.join(',\n')},`,
     `};`,


### PR DESCRIPTION
## Problem

Exporting keymap.c from a keyboard whose definition uses rotated KLE blocks (e.g. GPK60-46SGR V3) produced keys in the wrong order. The exporter sorted keys by visual KLE coordinates before emitting `LAYOUT()` arguments, but rotated blocks carry pre-rotation coordinates, so the visual sort order does not match the firmware's `LAYOUT()` macro argument order.

## Fix

Emit the `keymaps[][MATRIX_ROWS][MATRIX_COLS]` initializer directly in matrix row/col order instead of a `LAYOUT()` call. QMK firmware only reads `keymaps[layer][row][col]` (`quantum/keymap_introspection.c`), and the generated `LAYOUT()` macro is just a rearrangement of its arguments into that `[row][col]` initializer with `KC_NO` fill — so the raw matrix form is equivalent to a correct `LAYOUT()` call on every keyboard and requires no key-order guessing.

- `generateKeymapC` takes `matrixRows`/`matrixCols` instead of `keys`/`layoutOptions`; invalid dimensions (0/NaN/fractional) throw and surface as an export error
- Callers pass matrix dimensions from the live device state or the snapshot's embedded definition; the vil JSON export now uses the same dimension source as keymap.c so both artifacts agree
- Tests rewritten for the matrix format (full-grid ordering, KC_NO fill, invalid-dimension guard)

## Verification

- Full suite green: 400 files / 9048 tests, lint, typecheck
- Exported output verified row-identical to the GPK60-46SGR V3 firmware `LAYOUT()` expansion (all 4 layers × 4 matrix rows)