### PR TITLE
fix(ui): derive snapshot export encoder count from parsed layout

### DIFF
--- a/src/renderer/components/data-modal/useSnapshotActions.ts
+++ b/src/renderer/components/data-modal/useSnapshotActions.ts
@@ -23,7 +23,7 @@ import {
   findOuterKeycode,
   findInnerKeycode,
 } from '../../../shared/keycodes/keycodes'
-import { parseKle } from '../../../shared/kle/kle-parser'
+import { parseDefinitionLayout } from '../../hooks/keyboard-state-helpers'
 import type { VilFile } from '../../../shared/types/protocol'
 
 interface Options {
@@ -51,17 +51,14 @@ function loadVilData(uid: string, entryId: string): Promise<VilFile | null> {
 // keys and layoutOptions are consumed only by the PDF generator.
 function buildParams(vilData: VilFile) {
   const def = vilData.definition!
-  const kleResult = parseKle(def.layouts.keymap as unknown[][])
+  const { layout, encoderCount } = parseDefinitionLayout(def)
   const labels = def.layouts?.labels
-  const encoderCount = def.layouts?.keymap
-    ? (def.layouts.keymap as unknown[][]).flat().filter((k) => typeof k === 'string' && k.includes('\n\n\n\n\n\n\n\n\n\ne')).length
-    : 0
   const macroCount = FALLBACK_MACRO_COUNT
   const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
 
   return {
     layers: deriveLayerCount(vilData.keymap),
-    keys: kleResult.keys,
+    keys: layout?.keys ?? [],
     matrixRows: def.matrix.rows,
     matrixCols: def.matrix.cols,
     keymap: recordToMap(vilData.keymap),
@@ -88,10 +85,12 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
+      const def = vilData.definition!
       const macroCount = FALLBACK_MACRO_COUNT
       const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
       const viaProtocol = vilData.viaProtocol ?? 12
-      const { matrixRows: rows, matrixCols: cols, encoderCount } = buildParams(vilData)
+      const { rows, cols } = def.matrix
+      const { encoderCount } = parseDefinitionLayout(def)
       const macroActions = splitMacroBuffer(vilData.macros, macroCount)
         .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
       const json = vilToVialGuiJson(vilData, {
@@ -161,10 +160,6 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
         pdfBase64,
         thumbnailBase64,
       })
-      // Update hubPostId in snapshot after upload
-      const listResult = await window.vialAPI.snapshotStoreList(uid)
-      const _entry = listResult.entries?.find((e) => e.id === entryId)
-      // hubPostId is updated server-side via the upload response
     } catch { /* non-critical */ }
   }, [uid, deviceName])
 

--- a/src/renderer/hooks/__tests__/keyboard-state-helpers.test.ts
+++ b/src/renderer/hooks/__tests__/keyboard-state-helpers.test.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { parseDefinitionLayout } from '../keyboard-state-helpers'
+import type { KeyboardDefinition } from '../../../shared/types/protocol'
+
+function buildDefinition(keymap: unknown[][]): KeyboardDefinition {
+  return {
+    matrix: { rows: 2, cols: 2 },
+    layouts: { keymap },
+  }
+}
+
+describe('parseDefinitionLayout', () => {
+  it('counts one encoder from its CW/CCW label pair', () => {
+    const definition = buildDefinition([
+      ['0,0', '0,1'],
+      [`0,0${'\n'.repeat(9)}e`, `0,1${'\n'.repeat(9)}e`],
+    ])
+
+    const { layout, encoderCount } = parseDefinitionLayout(definition)
+
+    expect(layout!.keys).toHaveLength(4)
+    expect(encoderCount).toBe(1)
+  })
+
+  it('counts zero encoders for a keymap with only normal keys', () => {
+    const definition = buildDefinition([
+      ['0,0', '0,1'],
+      ['1,0', '1,1'],
+    ])
+
+    const { layout, encoderCount } = parseDefinitionLayout(definition)
+
+    expect(layout!.keys).toHaveLength(4)
+    expect(encoderCount).toBe(0)
+  })
+
+  it('counts distinct encoder indices, not raw CW/CCW entries', () => {
+    const definition = buildDefinition([
+      [
+        `0,0${'\n'.repeat(9)}e`,
+        `0,1${'\n'.repeat(9)}e`,
+        `1,0${'\n'.repeat(9)}e`,
+        `1,1${'\n'.repeat(9)}e`,
+      ],
+    ])
+
+    const { layout, encoderCount } = parseDefinitionLayout(definition)
+
+    expect(layout!.keys).toHaveLength(4)
+    expect(encoderCount).toBe(2)
+  })
+
+  it('returns a null layout and zero encoders when the keymap is missing', () => {
+    // The type marks `keymap` as required, but malformed/legacy definition
+    // files can still omit it, so the runtime guard is exercised here.
+    const definition = { matrix: { rows: 2, cols: 2 }, layouts: {} } as KeyboardDefinition
+
+    expect(parseDefinitionLayout(definition)).toEqual({ layout: null, encoderCount: 0 })
+  })
+})

--- a/src/renderer/hooks/useKeyboardPersistence.ts
+++ b/src/renderer/hooks/useKeyboardPersistence.ts
@@ -5,7 +5,7 @@ import type { KeyboardDefinition, VilFile } from '../../shared/types/protocol'
 import { mapToRecord, recordToMap, VILFILE_CURRENT_VERSION } from '../../shared/vil-file'
 import { vilToVialGuiJson } from '../../shared/vil-compat'
 import { splitMacroBuffer, deserializeMacro, macroActionsToJson, jsonToMacroActions } from '../../preload/macro'
-import { parseKle } from '../../shared/kle/kle-parser'
+import { parseDefinitionLayout } from './keyboard-state-helpers'
 import type { SetState, KeyboardRefs, BootGuardRef } from './keyboard-types'
 import { emptyState } from './keyboard-types'
 
@@ -65,13 +65,10 @@ export function useKeyboardPersistence(
       const newState = { ...s, definition: def }
       newState.rows = def.matrix.rows
       newState.cols = def.matrix.cols
-      if (def.layouts?.keymap) {
-        newState.layout = parseKle(def.layouts.keymap)
-        const indices = new Set<number>()
-        for (const key of newState.layout.keys) {
-          if (key.encoderIdx >= 0) indices.add(key.encoderIdx)
-        }
-        newState.encoderCount = indices.size
+      const { layout, encoderCount } = parseDefinitionLayout(def)
+      if (layout) {
+        newState.layout = layout
+        newState.encoderCount = encoderCount
       }
       return newState
     })


### PR DESCRIPTION
## Problem

The Data-modal export path (`useSnapshotActions.buildParams`) counted encoders by scanning raw KLE label text for `'\n\n\n\n\n\n\n\n\n\ne'` (ten newlines + `e`). Real encoder labels carry nine newlines before the trailing `e`, so the marker never matched and `encoderCount` was always 0 — encoder assignments were silently dropped from `.vil` exports, `keymap.c` exports (`encoder_map[]` omitted), and hub upload/update payloads. Even with the right marker the scan would have double-counted, since each encoder contributes a CW and a CCW entry.

## Fix

- `buildParams` and `handleExportVil` now use the existing canonical helper `parseDefinitionLayout` (distinct `encoderIdx` set over the parsed layout), which also removes a duplicate `parseKle` pass and an unsafe cast
- `useKeyboardPersistence.applyDefinition` carried a verbatim inline copy of the same derivation — folded into the helper (a definition without a keymap keeps the previous layout state, as before)
- Removed an unused `snapshotStoreList` IPC round-trip from the hub upload handler
- New unit tests for `parseDefinitionLayout`: CW/CCW pair → 1, distinct indices → 2, no encoders → 0, missing keymap → `{ layout: null, encoderCount: 0 }`

## Verification

- Full suite green: 401 files / 9052 tests, lint, typecheck

## Notes

Two same-class derivations remain wrong elsewhere (`preload/keyboard.ts` `countEncoders` counts a nonexistent `{e: n}` object convention; `main/hid-service.ts` probe checks `labels[4]` on the raw pre-reorder split). The live-device path is unaffected because the renderer recomputes the count independently; unifying those on the shared helper is tracked as follow-up work.