### PR TITLE
fix(ui): align picker multi-select index domain with paste target

### DIFF
--- a/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 // @vitest-environment jsdom
 
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import type { Keycode } from '../../../../shared/keycodes/keycodes'
+import type { DeviceInfo } from '../../../../shared/types/protocol'
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -27,6 +29,12 @@ vi.mock('../../../hooks/useAppConfig', () => ({
 
 let capturedWidgetProps: Array<Record<string, unknown>> = []
 let capturedTabbedProps: Record<string, unknown> = {}
+// Opt-in switch for the Keyboard-tab source-domain tests below: mounting the
+// picker's own `<KeyboardPane>` (via `keyboardPickerContent`) pulls in real
+// `LayoutPickerContent` chrome (Tooltip, ScaleInput, lucide icons) that the
+// rest of this file's tests have no need for, so it stays off by default and
+// each test that needs it flips it on in its own `beforeEach`.
+let renderKeyboardPickerContent = false
 
 vi.mock('../../keyboard/KeyboardWidget', () => ({
   KeyboardWidget: (props: Record<string, unknown>) => {
@@ -38,7 +46,12 @@ vi.mock('../../keyboard/KeyboardWidget', () => ({
 vi.mock('../../keycodes/TabbedKeycodes', () => ({
   TabbedKeycodes: (props: Record<string, unknown>) => {
     capturedTabbedProps = props
-    return <div data-testid="tabbed-keycodes">TabbedKeycodes</div>
+    return (
+      <div data-testid="tabbed-keycodes">
+        TabbedKeycodes
+        {renderKeyboardPickerContent ? (props.keyboardPickerContent as ReactNode) : null}
+      </div>
+    )
   },
 }))
 
@@ -82,8 +95,11 @@ const KEY_DEFAULTS: KleKey = {
   textColor: [], textSize: [], nub: false, stepped: false, ghost: false,
 }
 
-function makeKey(x: number, col: number): KleKey {
-  return { ...KEY_DEFAULTS, x, col }
+// Encoder/decal keys keep `parseKle`'s `row: 0, col: 0` defaults (only a
+// normal key's `labels[0]` "row,col" pair overwrites them) — pass col 0 with
+// the encoder/decal fields in `extra` to mirror that.
+function makeKey(x: number, col: number, extra: Partial<KleKey> = {}): KleKey {
+  return { ...KEY_DEFAULTS, x, col, ...extra }
 }
 
 const makeLayout = () => ({
@@ -495,5 +511,165 @@ describe('KeymapEditor — picker paste', () => {
     expect(rangeSelected.has(3)).toBe(true)
     expect(rangeSelected.has(4)).toBe(true)
     expect(rangeSelected.size).toBe(3)
+  })
+})
+
+// Regression coverage for the Keyboard-tab picker's SOURCE index domain
+// (`useLayoutPicker`'s `handlePickerKeyClick`/`pickerTabKeycodeNumbers`) —
+// distinct from every test above, which exercises `onKeycodeMultiSelect`
+// directly and never touches that source-side index computation at all.
+// These render the picker's own `<KeyboardPane>` (via `keyboardPickerContent`,
+// opted in through `renderKeyboardPickerContent`) and drive its real
+// `onKeyClick` handler, transitioning past the device-browse screen onto the
+// live connected device exactly like a user would.
+describe('KeymapEditor — picker paste (Keyboard tab source index domain)', () => {
+  const onSetKey = vi.fn().mockResolvedValue(undefined)
+  const onSetKeysBulk = vi.fn().mockResolvedValue(undefined)
+
+  const PICKER_DEVICE: DeviceInfo = {
+    vendorId: 1, productId: 2, serialNumber: 'picker-dev', productName: 'Picker Device', type: 'vial',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    capturedWidgetProps = []
+    capturedTabbedProps = {}
+    renderKeyboardPickerContent = true
+  })
+
+  afterEach(() => {
+    renderKeyboardPickerContent = false
+  })
+
+  type OnKeyClick = (key: KleKey, maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => void
+
+  /** The most recent same-commit [primary pane, picker pane] `onKeyClick`
+   *  pair — both panes always define `onKeyClick` and always render as a
+   *  contiguous pair (primary declared before the picker in `KeymapEditor`'s
+   *  JSX), so the last two `onKeyClick`-bearing captures from any render are
+   *  exactly this pair. Only valid to call once the picker's Keyboard view
+   *  has actually mounted (see `transitionToKeyboardView` below). */
+  function latestPair(): { primary?: OnKeyClick; secondary?: OnKeyClick } {
+    const withClick = capturedWidgetProps.filter((p) => p.onKeyClick != null)
+    return {
+      primary: withClick[withClick.length - 2]?.onKeyClick as OnKeyClick | undefined,
+      secondary: withClick[withClick.length - 1]?.onKeyClick as OnKeyClick | undefined,
+    }
+  }
+
+  function transitionToKeyboardView(getByText: (text: string) => HTMLElement) {
+    act(() => { fireEvent.click(getByText(PICKER_DEVICE.productName)) })
+  }
+
+  it('Shift-range picker selection straddling an encoder pair + decal pastes onto the correct target positions', async () => {
+    // KLE declaration order: real key, encoder CW, encoder CCW, decal, then
+    // three more real keys — the encoder pair + decal sit strictly between
+    // the two keys the test selects.
+    const layout = {
+      keys: [
+        makeKey(0, 0),
+        makeKey(1, 0, { encoderIdx: 0, encoderDir: 0 }),
+        makeKey(1, 0, { encoderIdx: 0, encoderDir: 1 }),
+        makeKey(1, 0, { decal: true }),
+        makeKey(2, 1),
+        makeKey(3, 2),
+        makeKey(4, 3),
+      ],
+    }
+    const keymap = new Map([
+      ['0,0,0', 1],
+      ['0,0,1', 2],
+      ['0,0,2', 3],
+      ['0,0,3', 4],
+    ])
+
+    const { getByText } = render(
+      <KeymapEditor
+        layout={layout} layers={4} currentLayer={0} keymap={keymap}
+        encoderLayout={new Map<string, number>()} encoderCount={1}
+        layoutOptions={new Map<number, number>()}
+        onSetKey={onSetKey} onSetKeysBulk={onSetKeysBulk} onSetEncoder={vi.fn().mockResolvedValue(undefined)}
+        devices={[PICKER_DEVICE]} connectedDevice={PICKER_DEVICE}
+      />,
+    )
+
+    transitionToKeyboardView(getByText)
+    const pickerClick = latestPair().secondary!
+
+    // Ctrl+click col 0 (anchor), Shift+click col 1 — a plain 2-key range
+    // that straddles the encoder pair + decal in KLE order.
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 0 }, false, { ctrlKey: true, shiftKey: false }) })
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 1 }, false, { ctrlKey: false, shiftKey: true }) })
+
+    const targetClick = latestPair().primary!
+
+    // Paste starting at col 2 — two consecutive target slots, distinct from
+    // the source positions so a shift really would be visible.
+    await act(async () => {
+      targetClick({ ...KEY_DEFAULTS, row: 0, col: 2 }, false, { ctrlKey: false, shiftKey: false })
+    })
+
+    expect(onSetKeysBulk).toHaveBeenCalledTimes(1)
+    expect(onSetKeysBulk).toHaveBeenCalledWith([
+      { layer: 0, row: 0, col: 2, keycode: 1 }, // col 0's code
+      { layer: 0, row: 0, col: 3, keycode: 2 }, // col 1's code
+    ])
+  })
+
+  it('Shift-range picker selection straddling an unselected layout-option alternate does not consume an extra index', async () => {
+    // KLE declaration order: real key, an UNSELECTED layoutOption alternate
+    // sharing the selected variant's (row, col), the selected variant
+    // itself, then two more real keys.
+    const layout = {
+      keys: [
+        makeKey(0, 0),
+        makeKey(1, 1, { layoutIndex: 0, layoutOption: 1 }), // unselected alternate
+        makeKey(1, 1, { layoutIndex: 0, layoutOption: 0 }), // selected variant
+        makeKey(2, 2),
+        makeKey(3, 3),
+      ],
+    }
+    const keymap = new Map([
+      ['0,0,0', 1],
+      ['0,0,1', 2],
+      ['0,0,2', 3],
+      ['0,0,3', 4],
+    ])
+
+    const { getByText } = render(
+      <KeymapEditor
+        layout={layout} layers={4} currentLayer={0} keymap={keymap}
+        encoderLayout={new Map<string, number>()} encoderCount={0}
+        // Empty map: no explicit selection for layoutIndex 0 → option 0 is
+        // the default-selected variant (matches `filterSelectableKeys`).
+        layoutOptions={new Map<number, number>()}
+        onSetKey={onSetKey} onSetKeysBulk={onSetKeysBulk} onSetEncoder={vi.fn().mockResolvedValue(undefined)}
+        devices={[PICKER_DEVICE]} connectedDevice={PICKER_DEVICE}
+      />,
+    )
+
+    transitionToKeyboardView(getByText)
+    const pickerClick = latestPair().secondary!
+
+    // Ctrl+click col 0 (anchor), Shift+click col 2 — a 3-key range (col 0,
+    // the selected col 1 variant, col 2) that straddles the unselected
+    // col 1 alternate in KLE order.
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 0 }, false, { ctrlKey: true, shiftKey: false }) })
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 2 }, false, { ctrlKey: false, shiftKey: true }) })
+
+    const targetClick = latestPair().primary!
+
+    // Paste back onto col 0 — should round-trip exactly the 3 selected
+    // keys' own codes onto themselves, touching nothing past col 2.
+    await act(async () => {
+      targetClick({ ...KEY_DEFAULTS, row: 0, col: 0 }, false, { ctrlKey: false, shiftKey: false })
+    })
+
+    expect(onSetKeysBulk).toHaveBeenCalledTimes(1)
+    expect(onSetKeysBulk).toHaveBeenCalledWith([
+      { layer: 0, row: 0, col: 0, keycode: 1 },
+      { layer: 0, row: 0, col: 1, keycode: 2 },
+      { layer: 0, row: 0, col: 2, keycode: 3 },
+    ])
   })
 })

--- a/src/renderer/components/editors/__tests__/selectable-keys.test.ts
+++ b/src/renderer/components/editors/__tests__/selectable-keys.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { describe, it, expect } from 'vitest'
+import { filterSelectableKeys } from '../selectable-keys'
+import type { KleKey } from '../../../../shared/kle/types'
+
+const KEY_DEFAULTS: KleKey = {
+  x: 0, y: 0,
+  width: 1, height: 1,
+  x2: 0, y2: 0,
+  width2: 1, height2: 1,
+  rotation: 0, rotationX: 0, rotationY: 0,
+  color: '#cccccc',
+  labels: Array(12).fill(null),
+  textColor: Array(12).fill(null),
+  textSize: Array(12).fill(null),
+  row: 0, col: 0,
+  encoderIdx: -1, encoderDir: -1,
+  layoutIndex: -1, layoutOption: -1,
+  decal: false, nub: false, stepped: false, ghost: false,
+}
+
+function makeKey(col: number, extra: Partial<KleKey> = {}): KleKey {
+  return { ...KEY_DEFAULTS, col, ...extra }
+}
+
+describe('filterSelectableKeys', () => {
+  it('excludes encoder and decal keys, preserving order', () => {
+    const keys = [
+      makeKey(0),
+      makeKey(0, { encoderIdx: 0, encoderDir: 0 }),
+      makeKey(0, { encoderIdx: 0, encoderDir: 1 }),
+      makeKey(0, { decal: true }),
+      makeKey(1),
+    ]
+
+    const result = filterSelectableKeys(keys, new Map())
+
+    expect(result.map((k) => k.col)).toEqual([0, 1])
+  })
+
+  it('keeps only option-0 variants when layoutOptions is empty', () => {
+    const keys = [
+      makeKey(0),
+      makeKey(1, { layoutIndex: 0, layoutOption: 0 }),
+      makeKey(2, { layoutIndex: 0, layoutOption: 1 }),
+    ]
+
+    const result = filterSelectableKeys(keys, new Map())
+
+    expect(result.map((k) => k.col)).toEqual([0, 1])
+  })
+
+  it('keeps the explicitly selected layout-option variant', () => {
+    const keys = [
+      makeKey(1, { layoutIndex: 0, layoutOption: 0 }),
+      makeKey(2, { layoutIndex: 0, layoutOption: 1 }),
+    ]
+
+    const result = filterSelectableKeys(keys, new Map([[0, 1]]))
+
+    expect(result.map((k) => k.col)).toEqual([2])
+  })
+})

--- a/src/renderer/components/editors/selectable-keys.ts
+++ b/src/renderer/components/editors/selectable-keys.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// Shared filter for the "keymap-selectable" key domain: real matrix keys a
+// user can click/select/paste onto. Both sides of a Layout Picker
+// multi-select count indices over this same ordered list.
+
+import type { KleKey } from '../../../shared/kle/types'
+
+/**
+ * Keeps non-encoder, non-decal keys and only the selected variant of each
+ * layout-option group; when a `layoutIndex` has no entry in `layoutOptions`,
+ * its option 0 variant is kept. Unlike `filterVisibleKeys`
+ * (`shared/kle/filter-keys.ts`), encoders are excluded and an empty
+ * `layoutOptions` map still applies the option-0 default, so the renderer
+ * can show alternate keys that sit outside this domain.
+ */
+export function filterSelectableKeys(keys: KleKey[], layoutOptions: Map<number, number>): KleKey[] {
+  return keys.filter((key) => {
+    if (key.encoderIdx >= 0 || key.decal) return false
+    if (key.layoutIndex >= 0) {
+      const sel = layoutOptions.get(key.layoutIndex)
+      return sel === undefined ? key.layoutOption === 0 : key.layoutOption === sel
+    }
+    return true
+  })
+}

--- a/src/renderer/components/editors/useLayoutOptionsPanel.ts
+++ b/src/renderer/components/editors/useLayoutOptionsPanel.ts
@@ -4,6 +4,7 @@ import { useState, useCallback, useMemo, useEffect, useRef } from 'react'
 import { useUploadConfirm } from '../../hooks/useUploadConfirm'
 import { parseLayoutLabels, unpackLayoutOptions, packLayoutOptions } from '../../../shared/layout-options'
 import { filterVisibleKeys, repositionLayoutKeys } from '../../../shared/kle/filter-keys'
+import { filterSelectableKeys } from './selectable-keys'
 import { KEY_UNIT, KEY_SPACING, KEYBOARD_PADDING } from '../keyboard/constants'
 import type { KeyboardLayout } from '../../../shared/kle/types'
 
@@ -119,15 +120,7 @@ export function useLayoutOptionsPanel({
   // Visible non-encoder, non-decal keys for selection
   const selectableKeys = useMemo(() => {
     if (!layout) return []
-    const opts = effectiveLayoutOptions
-    return layout.keys.filter((key) => {
-      if (key.encoderIdx >= 0 || key.decal) return false
-      if (key.layoutIndex >= 0) {
-        const sel = opts.get(key.layoutIndex)
-        return sel === undefined ? key.layoutOption === 0 : key.layoutOption === sel
-      }
-      return true
-    })
+    return filterSelectableKeys(layout.keys, effectiveLayoutOptions)
   }, [layout, effectiveLayoutOptions])
 
   // Layout overlay panel state

--- a/src/renderer/components/editors/useLayoutPicker.tsx
+++ b/src/renderer/components/editors/useLayoutPicker.tsx
@@ -14,6 +14,7 @@ import type { Keycode } from '../../../shared/keycodes/keycodes'
 import { parseKle } from '../../../shared/kle/kle-parser'
 import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
 import { posKey } from '../../../shared/kle/pos-key'
+import { filterSelectableKeys } from './selectable-keys'
 import { isVilFile, isVilFileV1, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
 import type { KleKey, KeyboardLayout } from '../../../shared/kle/types'
 import type { DeviceInfo } from '../../../shared/types/protocol'
@@ -253,51 +254,43 @@ export function useLayoutPicker({
   const pickerEncoderKeycodes = useMemo(
     () => buildEncoderKeycodesForLayer(pickerLayer), [buildEncoderKeycodesForLayer, pickerLayer])
 
-  // Build ordered keycode numbers for picker multi-select (Shift+click range)
+  // Single ordered list every picker multi-select index is counted against.
+  // Built with the same `filterSelectableKeys` predicate as the paste
+  // target's `selectableKeys` (`useLayoutOptionsPanel`), so a source key and
+  // its eventual target key always share one index domain. A loaded
+  // file/probed device uses its own layout + decoded layout options.
+  const pickerSourceKeys = useMemo(() => (pickerFileData
+    ? filterSelectableKeys(pickerFileData.layout.keys, pickerFileData.layoutOptions)
+    : filterSelectableKeys(layout?.keys ?? [], effectiveLayoutOptions)
+  ), [pickerFileData, layout, effectiveLayoutOptions])
+
+  // Build ordered keycode numbers for picker multi-select (Shift+click range).
+  // Unmapped positions emit 0 (KC_NO) so indices stay aligned with the list.
   const pickerTabKeycodeNumbers = useMemo(() => {
     const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
-    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-    const numbers: number[] = []
-    for (const key of keys) {
-      if (key.row == null || key.col == null) continue
-      const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
-      if (code != null) numbers.push(code)
-    }
-    return numbers
-  }, [pickerFileData, keymap, pickerLayer, layout])
+    return pickerSourceKeys.map((key) => sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`) ?? 0)
+  }, [pickerFileData, keymap, pickerLayer, pickerSourceKeys])
 
   const handlePickerKeyClick = useCallback((key: KleKey, _maskClicked: boolean, event?: { ctrlKey: boolean; shiftKey: boolean }) => {
     const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
     const code = sourceKeymap.get(`${pickerLayer},${key.row},${key.col}`)
     if (code == null) return
+    const isModified = event && (event.ctrlKey || event.shiftKey)
+    if (handlePickerMultiSelect && (isModified || (!selectedKey && !selectedEncoder))) {
+      const index = pickerSourceKeys.findIndex((k) => k.row === key.row && k.col === key.col)
+      if (index >= 0) {
+        handlePickerMultiSelect(index, code, { ctrlKey: !!event?.ctrlKey, shiftKey: !!event?.shiftKey }, pickerTabKeycodeNumbers)
+        return
+      }
+      // A rendered key outside the selectable domain (e.g. an unselected
+      // layout-option variant) cannot join a multi-select range
+      if (isModified) return
+    }
     // Always assign the full composite keycode (e.g. LT1(KC_SPC) as-is)
     const qmkId = serialize(code)
     const kc = findKeycode(qmkId) ?? { qmkId, label: qmkId, keycode: code }
-    const isModified = event && (event.ctrlKey || event.shiftKey)
-    if (isModified && handlePickerMultiSelect) {
-      // Find the index of this key in the picker's ordered list
-      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-      let index = 0
-      for (const k of keys) {
-        if (k.row == null || k.col == null) continue
-        if (k.row === key.row && k.col === key.col) break
-        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
-      }
-      handlePickerMultiSelect(index, code, { ctrlKey: !!event.ctrlKey, shiftKey: !!event.shiftKey }, pickerTabKeycodeNumbers)
-    } else if (handlePickerMultiSelect && !selectedKey && !selectedEncoder) {
-      // Normal click (no key selected): select single key and set anchor
-      const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-      let index = 0
-      for (const k of keys) {
-        if (k.row == null || k.col == null) continue
-        if (k.row === key.row && k.col === key.col) break
-        if (sourceKeymap.has(`${pickerLayer},${k.row},${k.col}`)) index++
-      }
-      handlePickerMultiSelect(index, code, { ctrlKey: false, shiftKey: false }, pickerTabKeycodeNumbers)
-    } else {
-      handleKeycodeSelect?.(kc)
-    }
-  }, [keymap, pickerLayer, pickerFileData, layout, handleKeycodeSelect, handlePickerMultiSelect, pickerTabKeycodeNumbers])
+    handleKeycodeSelect?.(kc)
+  }, [keymap, pickerLayer, pickerFileData, pickerSourceKeys, handleKeycodeSelect, handlePickerMultiSelect, pickerTabKeycodeNumbers, selectedKey, selectedEncoder])
 
   // For file/device mode, build keycodes per-layer on the fly
   const filePickerKeycodes = useMemo(() => {
@@ -311,21 +304,17 @@ export function useLayoutPicker({
     return keycodes
   }, [pickerFileData, pickerLayer, remapLabel, pickerKeycodes])
 
-  // Convert picker selected indices to position strings for keyboard widget highlight
+  // Convert picker selected indices to position strings for keyboard widget
+  // highlight — same `pickerSourceKeys` domain the index came from.
   const pickerHighlightPositions = useMemo(() => {
     if (pickerSelectedIndices.size === 0) return undefined
-    const keys = pickerFileData ? pickerFileData.layout.keys : layout?.keys ?? []
-    const sourceKeymap = pickerFileData ? pickerFileData.keymap : keymap
     const positions = new Set<string>()
-    let idx = 0
-    for (const key of keys) {
-      if (key.row == null || key.col == null) continue
-      if (!sourceKeymap.has(`${pickerLayer},${key.row},${key.col}`)) continue
-      if (pickerSelectedIndices.has(idx)) positions.add(`${key.row},${key.col}`)
-      idx++
+    for (const idx of pickerSelectedIndices) {
+      const k = pickerSourceKeys[idx]
+      if (k) positions.add(`${k.row},${k.col}`)
     }
     return positions.size > 0 ? positions : undefined
-  }, [pickerSelectedIndices, pickerFileData, layout, keymap, pickerLayer])
+  }, [pickerSelectedIndices, pickerSourceKeys])
 
   // Layout picker: keyboard-as-keycode-picker shown inside the picker panel
   const pickerData: PickerData = pickerFileData


### PR DESCRIPTION
## Problem

Multi-key copy/paste from the Layout Picker paired source and target keys through incompatible index domains:

- **Source** (`useLayoutPicker`): walked the raw KLE key list and counted every key with a keymap entry. Encoder keys (left at the parser's default `0,0` matrix position) falsely matched, and decals / unselected layout-option alternates were not excluded.
- **Target** (`handlePickerPaste`): slices `selectableKeys`, which excludes encoders, decals, and unselected layout-option alternates.

On layouts containing any of those, an n-key paste landed on keys shifted relative to the highlighted source keys.

## Fix

- Extract the target-side filter into a shared `filterSelectableKeys()` predicate (`selectable-keys.ts`), documented against `filterVisibleKeys`' intentionally different semantics
- `useLayoutPicker` derives one `pickerSourceKeys` memo — the live layout, or a loaded file/probed device with its own decoded layout options — and index assignment, the multi-select keycode sequence (unmapped positions emit `KC_NO` to keep indices aligned), and highlight positions all read from that single list
- The two identical multi-select branches in `handlePickerKeyClick` were unified; clicking a rendered key outside the domain now falls back to plain keycode selection instead of dead-clicking, and the handler no longer captures stale selection state (missing deps fixed)

## Verification

- Regression tests drive the real picker pane click handlers across an encoder pair + decal and an unselected layout-option alternate (verified to fail against the pre-fix code), plus direct unit tests for the shared predicate
- Full suite green: 402 files / 9057 tests, lint, typecheck