### PR TITLE
fix(ui): unify keymap traversal on the view-matrix order

### DIFF
--- a/src/renderer/components/editors/KeymapEditor.tsx
+++ b/src/renderer/components/editors/KeymapEditor.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-import { useCallback, useEffect, useRef, useImperativeHandle, forwardRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useImperativeHandle, forwardRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useTileContentOverride } from '../../hooks/useTileContentOverride'
 import { ViewMatrixPanel } from './ViewMatrixPanel'
@@ -29,6 +29,7 @@ import { useKeymapRewrite } from './use-keymap-rewrite'
 import { useKeymapPackTabs } from './use-keymap-pack-tabs'
 import { KeymapPickerRegion } from './KeymapPickerRegion'
 import { KeymapPrimaryPane } from './KeymapPrimaryPane'
+import { sortKeysByViewMatrix } from './view-matrix'
 import type { LineSnapshot } from '../../typing-test/TypingTestView'
 
 export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEditorHandle, Props>(function KeymapEditor(props, ref) {
@@ -114,6 +115,11 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     layoutPanelOpen, setLayoutPanelOpen, layoutPanelRef, layoutButtonRef,
   } = useLayoutOptionsPanel({ layout, layoutLabels, packedLayoutOptions, onSetLayoutOptions, layoutOptions, scale: scaleProp })
 
+  // This editor's single ordered key domain: auto-advance, popover
+  // follow-along, Shift-range, paste targets, and the picker's live source
+  // all index against this one array.
+  const advancableKeys = useMemo(() => sortKeysByViewMatrix(selectableKeys, viewMatrix), [selectableKeys, viewMatrix])
+
   // --- Multi-selection ---
   const hasActiveSingleSelectionRef = useRef(false)
   const multiSelect = useKeymapMultiSelect({ hasActiveSingleSelectionRef })
@@ -140,7 +146,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
     tdModalIndex, macroModalIndex, handleTdModalSave, handleTdModalClose, handleMacroModalClose,
   } = useKeymapSelectionHandlers({
     keymap, encoderLayout, currentLayer,
-    selectableKeys, autoAdvance, viewMatrix,
+    advancableKeys, autoAdvance,
     onSetKey, onSetKeysBulk, onSetEncoder, keyboardContentRef, unlocked, onUnlock,
     multiSelect, history,
     onHistoryApplied: triggerFlash,
@@ -264,7 +270,7 @@ export const KeymapEditor = forwardRef<import('./keymap-editor-types').KeymapEdi
   // holds, or start a picker multi-select, regardless of what's selected
   // on THIS surface). Same `packTabReadOnly` gate as every other edit path.
   const { layoutPickerContent } = useLayoutPicker({
-    layout, layers, layerNames, keymap, effectiveLayoutOptions, remapLabel,
+    layout, layers, layerNames, keymap, effectiveLayoutOptions, advancableKeys, remapLabel,
     scale: scaleProp, onScaleChange,
     devices, connectedDevice, onDeviceListActiveChange,
     selectedKey, selectedEncoder,

--- a/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
+++ b/src/renderer/components/editors/__tests__/KeymapEditor-pickerPaste.test.tsx
@@ -106,6 +106,17 @@ const makeLayout = () => ({
   keys: [makeKey(0, 0), makeKey(1, 1), makeKey(2, 2), makeKey(3, 3)],
 })
 
+// Declared col order (1,2,0,3) disagrees with matrix order (ascending col:
+// 0,1,2,3) on which key follows col 0 — shared by the tests below that
+// assert paste targets / Shift-range walk matrix order, not KLE declaration
+// order.
+const makeScrambledLayout = () => ({
+  keys: [makeKey(0, 1), makeKey(1, 2), makeKey(2, 0), makeKey(3, 3)],
+})
+const SCRAMBLED_KEYMAP = new Map([
+  ['0,0,0', 0], ['0,0,1', 0], ['0,0,2', 0], ['0,0,3', 0],
+])
+
 // Structural stand-in for the Keycode class instances the picker consumes.
 function makeKeycode(qmkId: string, label?: string): Keycode {
   return {
@@ -512,6 +523,115 @@ describe('KeymapEditor — picker paste', () => {
     expect(rangeSelected.has(4)).toBe(true)
     expect(rangeSelected.size).toBe(3)
   })
+
+  it('paste target order follows matrix (view) order, not KLE declaration order, when they differ', async () => {
+    render(<KeymapEditor {...defaultProps} layout={makeScrambledLayout()} keymap={SCRAMBLED_KEYMAP} />)
+    const multiSelect = getOnKeycodeMultiSelect()!
+
+    act(() => {
+      multiSelect(0, TAB_KEYCODE_NUMBERS[0], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+    act(() => {
+      multiSelect(1, TAB_KEYCODE_NUMBERS[1], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+
+    // Paste starting at col 0 — declaration order's next key is col 3
+    // (index 3 follows col 0 at index 2), but matrix order's next key is
+    // col 1. Only the latter is correct.
+    const onKeyClick = getLatestOnKeyClick()!
+    await act(async () => {
+      onKeyClick({ row: 0, col: 0 } as KleKey, false, { ctrlKey: false, shiftKey: false })
+    })
+
+    expect(onSetKeysBulk).toHaveBeenCalledTimes(1)
+    expect(onSetKeysBulk).toHaveBeenCalledWith([
+      { layer: 0, row: 0, col: 0, keycode: 10 }, // KC_10 -> col 0
+      { layer: 0, row: 0, col: 1, keycode: 11 }, // KC_11 -> col 1 (matrix-adjacent), not col 3
+    ])
+  })
+
+  it('paste target order follows a viewMatrix override over physical matrix order', async () => {
+    // The layout's declaration order already equals physical matrix order
+    // (col 0..3), but an override moves col 3's effective position to tie
+    // with col 0 — Auto Move order becomes col 0, col 3, col 1, col 2 (ties
+    // break on physical position, keeping col 0 ahead of col 3).
+    const viewMatrix = { '0,3': { row: 0, col: 0 } }
+    render(<KeymapEditor {...defaultProps} viewMatrix={viewMatrix} />)
+    const multiSelect = getOnKeycodeMultiSelect()!
+
+    act(() => {
+      multiSelect(0, TAB_KEYCODE_NUMBERS[0], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+    act(() => {
+      multiSelect(1, TAB_KEYCODE_NUMBERS[1], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+
+    const onKeyClick = getLatestOnKeyClick()!
+    await act(async () => {
+      onKeyClick({ row: 0, col: 0 } as KleKey, false, { ctrlKey: false, shiftKey: false })
+    })
+
+    expect(onSetKeysBulk).toHaveBeenCalledTimes(1)
+    expect(onSetKeysBulk).toHaveBeenCalledWith([
+      { layer: 0, row: 0, col: 0, keycode: 10 },
+      { layer: 0, row: 0, col: 3, keycode: 11 }, // col 3 sorts right after col 0 under the override
+    ])
+  })
+
+  it('primary-pane Shift-range multi-select spans matrix order, not KLE declaration order', () => {
+    render(<KeymapEditor {...defaultProps} layout={makeScrambledLayout()} keymap={SCRAMBLED_KEYMAP} />)
+
+    // Ctrl+click col 0 sets the anchor and starts a multi-selection.
+    const firstClick = getActiveOnKeyClick()!
+    act(() => {
+      firstClick({ ...KEY_DEFAULTS, row: 0, col: 0 }, false, { ctrlKey: true, shiftKey: false })
+    })
+
+    // Shift+click col 2 — matrix order between col 0 and col 2 is col 1.
+    const secondClick = getLatestOnKeyClick()!
+    act(() => {
+      secondClick({ ...KEY_DEFAULTS, row: 0, col: 2 }, false, { ctrlKey: false, shiftKey: true })
+    })
+
+    const widgetWithSelection = capturedWidgetProps.filter((p) => p.onKeyClick != null).pop()
+    const ms = widgetWithSelection?.multiSelectedKeys as Set<string> | undefined
+    expect(ms?.has('0,0')).toBe(true)
+    expect(ms?.has('0,1')).toBe(true)
+    expect(ms?.has('0,2')).toBe(true)
+    expect(ms?.size).toBe(3)
+  })
+
+  it('clears a stale picker selection when the key domain changes', () => {
+    const { rerender } = render(<KeymapEditor {...defaultProps} />)
+    const multiSelect = getOnKeycodeMultiSelect()!
+
+    act(() => {
+      multiSelect(0, TAB_KEYCODE_NUMBERS[0], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+    expect(getPickerSelectedSet()!.size).toBe(1)
+
+    // A view-matrix override changes `pickerSourceKeys`' sort identity even
+    // though the underlying key set is unchanged.
+    rerender(<KeymapEditor {...defaultProps} viewMatrix={{ '0,3': { row: 0, col: 0 } }} />)
+
+    expect(getPickerSelectedSet()!.size).toBe(0)
+  })
+
+  it('does not clear the picker selection on a rerender with unchanged props', () => {
+    const { rerender } = render(<KeymapEditor {...defaultProps} />)
+    const multiSelect = getOnKeycodeMultiSelect()!
+
+    act(() => {
+      multiSelect(0, TAB_KEYCODE_NUMBERS[0], { ctrlKey: true, shiftKey: false }, TAB_KEYCODE_NUMBERS)
+    })
+    expect(getPickerSelectedSet()!.size).toBe(1)
+
+    // Same props, same object references — `pickerSourceKeys` keeps its
+    // identity, so the clear effect must not fire (pins its dep array).
+    rerender(<KeymapEditor {...defaultProps} />)
+
+    expect(getPickerSelectedSet()!.size).toBe(1)
+  })
 })
 
 // Regression coverage for the Keyboard-tab picker's SOURCE index domain
@@ -670,6 +790,49 @@ describe('KeymapEditor — picker paste (Keyboard tab source index domain)', () 
       { layer: 0, row: 0, col: 0, keycode: 1 },
       { layer: 0, row: 0, col: 1, keycode: 2 },
       { layer: 0, row: 0, col: 2, keycode: 3 },
+    ])
+  })
+
+  it('picker source domain follows a viewMatrix override end-to-end (source click index pairing -> paste result)', async () => {
+    // Same override as the primary-pane viewMatrix paste test above: ties
+    // col 3's effective position with col 0, so Auto Move order becomes
+    // col 0, col 3, col 1, col 2.
+    const viewMatrix = { '0,3': { row: 0, col: 0 } }
+    const keymap = new Map([
+      ['0,0,0', 1], ['0,0,1', 2], ['0,0,2', 3], ['0,0,3', 4],
+    ])
+
+    const { getByText } = render(
+      <KeymapEditor
+        layout={makeLayout()} layers={4} currentLayer={0} keymap={keymap}
+        encoderLayout={new Map<string, number>()} encoderCount={0}
+        layoutOptions={new Map<number, number>()}
+        onSetKey={onSetKey} onSetKeysBulk={onSetKeysBulk} onSetEncoder={vi.fn().mockResolvedValue(undefined)}
+        devices={[PICKER_DEVICE]} connectedDevice={PICKER_DEVICE}
+        viewMatrix={viewMatrix}
+      />,
+    )
+
+    transitionToKeyboardView(getByText)
+    const pickerClick = latestPair().secondary!
+
+    // Ctrl+click col 0 (view index 0), then col 3 (view index 1 under the
+    // override) — the source selection's indices come entirely from the
+    // picker's own `pickerSourceKeys`, which now equals `advancableKeys`.
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 0 }, false, { ctrlKey: true, shiftKey: false }) })
+    act(() => { pickerClick({ ...KEY_DEFAULTS, row: 0, col: 3 }, false, { ctrlKey: true, shiftKey: false }) })
+
+    const targetClick = latestPair().primary!
+
+    // Paste starting at col 1 — view order after col 1 is col 2.
+    await act(async () => {
+      targetClick({ ...KEY_DEFAULTS, row: 0, col: 1 }, false, { ctrlKey: false, shiftKey: false })
+    })
+
+    expect(onSetKeysBulk).toHaveBeenCalledTimes(1)
+    expect(onSetKeysBulk).toHaveBeenCalledWith([
+      { layer: 0, row: 0, col: 1, keycode: 1 }, // col 0's code, view index 0
+      { layer: 0, row: 0, col: 2, keycode: 4 }, // col 3's code, view index 1 (tied w/ col 0)
     ])
   })
 })

--- a/src/renderer/components/editors/__tests__/useKeymapSelectionHandlers.popoverAdvance.test.ts
+++ b/src/renderer/components/editors/__tests__/useKeymapSelectionHandlers.popoverAdvance.test.ts
@@ -109,7 +109,7 @@ function useHarness(overrides: HarnessOverrides) {
     keymap: new Map(),
     encoderLayout: new Map(),
     currentLayer: 0,
-    selectableKeys: SELECTABLE_KEYS,
+    advancableKeys: SELECTABLE_KEYS,
     autoAdvance: true,
     onSetKey: vi.fn().mockResolvedValue(undefined),
     onSetKeysBulk: vi.fn().mockResolvedValue(undefined),

--- a/src/renderer/components/editors/__tests__/useLayoutPicker.readOnly.test.tsx
+++ b/src/renderer/components/editors/__tests__/useLayoutPicker.readOnly.test.tsx
@@ -41,6 +41,7 @@ function Host(props: Partial<UseLayoutPickerOptions>) {
     layerNames: [],
     keymap: new Map([['0,0,0', 4]]),
     effectiveLayoutOptions: new Map(),
+    advancableKeys: [KEY],
     scale: 1,
     devices: [CONNECTED_DEVICE],
     connectedDevice: CONNECTED_DEVICE,

--- a/src/renderer/components/editors/useKeymapSelectionHandlers.ts
+++ b/src/renderer/components/editors/useKeymapSelectionHandlers.ts
@@ -8,13 +8,11 @@ import type { Keycode } from '../../../shared/keycodes/keycodes'
 import type { BulkKeyEntry } from '../../hooks/useKeyboard'
 import { useUnlockGate } from '../../hooks/useUnlockGate'
 import type { TapDanceEntry } from '../../../shared/types/protocol'
-import type { ViewMatrixCell } from '../../../shared/types/pipette-settings'
 import type { MacroAction } from '../../../preload/macro'
 import { hasModifierKey } from './KeyboardPane'
 import type { PopoverState } from './keymap-editor-types'
 import type { UseKeymapMultiSelectReturn } from './useKeymapMultiSelect'
 import type { UseKeymapHistoryReturn, SingleHistoryEntry } from './useKeymapHistory'
-import { sortKeysByViewMatrix } from './view-matrix'
 import { nextAdvanceKey, getKeyAnchorRect } from './keymap-auto-advance'
 import { useKeymapHistoryActions } from './use-keymap-history-actions'
 
@@ -35,13 +33,12 @@ export interface UseKeymapSelectionOptions {
   keymap: Map<string, number>
   encoderLayout: Map<string, number>
   currentLayer: number
-  selectableKeys: KleKey[]
   // Key operations
   autoAdvance: boolean
-  /** Auto Move order override — see `PipetteSettings.viewMatrix`. Sorts
-   *  `advancableKeys` by each key's effective (override ?? physical)
-   *  position instead of raw definition order. */
-  viewMatrix?: Record<string, ViewMatrixCell>
+  /** The editor's single ordered key domain (`KeymapEditor`'s hoisted
+   *  `sortKeysByViewMatrix(selectableKeys, viewMatrix)`) — backs
+   *  auto-advance, popover follow-along, Shift-range, and paste targets. */
+  advancableKeys: KleKey[]
   onSetKey: (layer: number, row: number, col: number, keycode: number) => Promise<void>
   onSetKeysBulk: (entries: BulkKeyEntry[]) => Promise<void>
   onSetEncoder: (layer: number, idx: number, dir: number, keycode: number) => Promise<void>
@@ -75,9 +72,8 @@ export function useKeymapSelectionHandlers({
   keymap,
   encoderLayout,
   currentLayer,
-  selectableKeys,
   autoAdvance,
-  viewMatrix,
+  advancableKeys,
   onSetKey,
   onSetKeysBulk,
   onSetEncoder,
@@ -220,16 +216,8 @@ export function useKeymapSelectionHandlers({
     return newCode
   }
 
-  // --- Auto-advance ---
-  // Walk `selectableKeys` (already layout-option/decal/encoder filtered),
-  // not raw `layout.keys` — otherwise Auto Move can land on a key hidden by
-  // the current layout option (e.g. the unselected ISO/ANSI or split
-  // spacebar variant), leaving the selection highlight invisible.
-  const advancableKeys = useMemo(
-    () => sortKeysByViewMatrix(selectableKeys, viewMatrix),
-    [selectableKeys, viewMatrix],
-  )
-
+  // --- Auto-advance, popover follow-along, Shift-range, and paste targets
+  // (all share `advancableKeys`) ---
   const advanceToNextKey = useCallback(() => {
     if (!autoAdvance || !selectedKey) return
     const next = nextAdvanceKey(advancableKeys, selectedKey)
@@ -304,10 +292,14 @@ export function useKeymapSelectionHandlers({
   }, [])
 
   const handlePickerPaste = useCallback(async (targetKey: KleKey) => {
-    const targetIdx = selectableKeys.findIndex((k) => k.row === targetKey.row && k.col === targetKey.col)
+    // Target positions walk `advancableKeys` — the same domain the picker's
+    // own source list is built from, so a source key and its eventual
+    // target key share one traversal order.
+    const targetIdx = advancableKeys.findIndex((k) => k.row === targetKey.row && k.col === targetKey.col)
     if (targetIdx < 0) return
     const sortedEntries = [...pickerSelected.entries()].sort((a, b) => a[0] - b[0])
-    const targetPositions = selectableKeys.slice(targetIdx, targetIdx + sortedEntries.length)
+    // Over-long selections truncate at the end of the list (intended).
+    const targetPositions = advancableKeys.slice(targetIdx, targetIdx + sortedEntries.length)
     await runCopy(async () => {
       const entries: BulkKeyEntry[] = []
       const histEntries: SingleHistoryEntry[] = []
@@ -323,7 +315,7 @@ export function useKeymapSelectionHandlers({
     })
     clearPickerSelection()
     setSelectedKey(null); setSelectedMaskPart(false); setSelectedEncoder(null)
-  }, [pickerSelected, selectableKeys, currentLayer, keymap, onSetKeysBulk, runCopy, clearPickerSelection, history])
+  }, [pickerSelected, advancableKeys, currentLayer, keymap, onSetKeysBulk, runCopy, clearPickerSelection, history])
 
   // --- Click handlers ---
   const handleKeyClick = useCallback(
@@ -337,12 +329,13 @@ export function useKeymapSelectionHandlers({
       }
       if (event?.shiftKey && !selectedKey && selectionAnchor) {
         clearPickerSelection()
-        const anchorIdx = selectableKeys.findIndex((k) => k.row === selectionAnchor.row && k.col === selectionAnchor.col)
-        const currentIdx = selectableKeys.findIndex((k) => k.row === key.row && k.col === key.col)
+        // Range walks `advancableKeys`, same order Auto Move traverses.
+        const anchorIdx = advancableKeys.findIndex((k) => k.row === selectionAnchor.row && k.col === selectionAnchor.col)
+        const currentIdx = advancableKeys.findIndex((k) => k.row === key.row && k.col === key.col)
         if (anchorIdx >= 0 && currentIdx >= 0) {
           const start = Math.min(anchorIdx, currentIdx); const end = Math.max(anchorIdx, currentIdx)
           const next = new Set(multiSelectedKeys)
-          for (let i = start; i <= end; i++) next.add(`${selectableKeys[i].row},${selectableKeys[i].col}`)
+          for (let i = start; i <= end; i++) next.add(posKey(advancableKeys[i].row, advancableKeys[i].col))
           setMultiSelectedKeys(next)
         }
         setSelectionSourcePane('primary'); setSelectionMode('shift'); return
@@ -359,7 +352,7 @@ export function useKeymapSelectionHandlers({
         selectedEncoder: null,
       })
     },
-    [selectedKey, selectionAnchor, selectableKeys, multiSelectedKeys, pickerSelected, handlePickerPaste, clearPickerSelection, setMultiSelectedKeys, setSelectionAnchor, setSelectionSourcePane, setSelectionMode, applySelectionChange],
+    [selectedKey, selectionAnchor, advancableKeys, multiSelectedKeys, pickerSelected, handlePickerPaste, clearPickerSelection, setMultiSelectedKeys, setSelectionAnchor, setSelectionSourcePane, setSelectionMode, applySelectionChange],
   )
 
   const handleEncoderClick = useCallback((_key: KleKey, dir: number, maskClicked: boolean) => {

--- a/src/renderer/components/editors/useLayoutPicker.tsx
+++ b/src/renderer/components/editors/useLayoutPicker.tsx
@@ -15,6 +15,7 @@ import { parseKle } from '../../../shared/kle/kle-parser'
 import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
 import { posKey } from '../../../shared/kle/pos-key'
 import { filterSelectableKeys } from './selectable-keys'
+import { sortKeysByViewMatrix } from './view-matrix'
 import { isVilFile, isVilFileV1, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
 import type { KleKey, KeyboardLayout } from '../../../shared/kle/types'
 import type { DeviceInfo } from '../../../shared/types/protocol'
@@ -29,6 +30,11 @@ export interface UseLayoutPickerOptions {
   layerNames?: string[]
   keymap: Map<string, number>
   effectiveLayoutOptions: Map<number, number>
+  /** The editor's single ordered key domain (`KeymapEditor`'s hoisted
+   *  `sortKeysByViewMatrix(selectableKeys, viewMatrix)`) — the live-device
+   *  source falls back to this by construction, sharing identity with the
+   *  paste target's domain. */
+  advancableKeys: KleKey[]
   remapLabel?: (qmkId: string) => string
   scale: number
   onScaleChange?: (delta: number) => void
@@ -62,7 +68,7 @@ export interface UseLayoutPickerReturn {
 }
 
 export function useLayoutPicker({
-  layout, layers, layerNames, keymap, effectiveLayoutOptions, remapLabel, scale, onScaleChange,
+  layout, layers, layerNames, keymap, effectiveLayoutOptions, advancableKeys, remapLabel, scale, onScaleChange,
   devices, connectedDevice, onDeviceListActiveChange,
   selectedKey, selectedEncoder, handleKeycodeSelect, handlePickerMultiSelect,
   pickerSelectedIndices, clearPickerSelection,
@@ -255,14 +261,18 @@ export function useLayoutPicker({
     () => buildEncoderKeycodesForLayer(pickerLayer), [buildEncoderKeycodesForLayer, pickerLayer])
 
   // Single ordered list every picker multi-select index is counted against.
-  // Built with the same `filterSelectableKeys` predicate as the paste
-  // target's `selectableKeys` (`useLayoutOptionsPanel`), so a source key and
-  // its eventual target key always share one index domain. A loaded
-  // file/probed device uses its own layout + decoded layout options.
-  const pickerSourceKeys = useMemo(() => (pickerFileData
-    ? filterSelectableKeys(pickerFileData.layout.keys, pickerFileData.layoutOptions)
-    : filterSelectableKeys(layout?.keys ?? [], effectiveLayoutOptions)
-  ), [pickerFileData, layout, effectiveLayoutOptions])
+  // Shares identity with the paste target's domain by construction (the
+  // live-device branch IS `advancableKeys`); a loaded file/probed device has
+  // no per-file view matrix, so that branch sorts in physical matrix order.
+  const pickerSourceKeys = useMemo(() => (
+    pickerFileData
+      ? sortKeysByViewMatrix(filterSelectableKeys(pickerFileData.layout.keys, pickerFileData.layoutOptions), undefined)
+      : advancableKeys
+  ), [pickerFileData, advancableKeys])
+
+  // Indices from an old source domain would point at different keys after a
+  // layout / layout-option / view-matrix / picker-source swap.
+  useEffect(() => { clearPickerSelection() }, [pickerSourceKeys, clearPickerSelection])
 
   // Build ordered keycode numbers for picker multi-select (Shift+click range).
   // Unmapped positions emit 0 (KC_NO) so indices stay aligned with the list.

--- a/src/renderer/components/editors/useViewMatrixEditing.ts
+++ b/src/renderer/components/editors/useViewMatrixEditing.ts
@@ -74,8 +74,12 @@ export function useViewMatrixEditing({
     _maskClicked: boolean,
     event?: { ctrlKey: boolean; shiftKey: boolean },
   ) => {
+    // Hidden layout-option alternates never reach this handler —
+    // KeyboardWidget only wires rendered keys.
     if (key.decal || key.encoderIdx >= 0) return
     if (event?.ctrlKey) { viewMatrixMode.toggleKeySelection(key.row, key.col); return }
+    // Declaration-order on purpose — ranging by the view order being edited
+    // would shift the range domain mid-edit.
     if (event?.shiftKey) { viewMatrixMode.extendSelection(key.row, key.col, selectableKeys); return }
     viewMatrixMode.selectKey(key.row, key.col)
     // The hook's setters are useCallback-stable; depending on the wrapper
@@ -134,6 +138,8 @@ export function useViewMatrixEditing({
     // Effective position -> physical "row,col" keys resolving to it, used
     // below to find every key involved in a collision (group size > 1).
     const groups = new Map<string, string[]>()
+    // Deliberately wider than `filterSelectableKeys` — covers unselected
+    // layout-option alternates too, so the legend stays correct for those.
     for (const key of layout.keys) {
       if (key.decal || key.encoderIdx >= 0) continue
       const physPos = posKey(key.row, key.col)


### PR DESCRIPTION
## Problem

Shift-range selection and multi-key paste targets walked keys in raw KLE declaration order, while Auto Move walks the view-matrix order (`sortKeysByViewMatrix`: effective override ?? physical matrix position — equal to physical row-major order with no overrides). On keyboards whose declaration order differs from matrix order (rotated blocks, split halves), the three features traversed different key sequences, and a picker paste could land on a sequence the user never saw highlighted.

## Fix

- `KeymapEditor` derives **one ordered key domain** (`advancableKeys`) and passes it to both `useKeymapSelectionHandlers` and `useLayoutPicker` — Shift-range, paste targets, Auto Move, and the picker's live source all index against the same array, so their agreement holds by construction
- Loaded files / probed devices have no per-file view matrix and sort in physical matrix order
- Stale picker selections are cleared when the source domain changes (layout / layout-option / view-matrix / picker-source swap) — old indices would point at different keys
- View Matrix mode's own range selection deliberately keeps declaration order (ranging by the ordering being edited would shift the range domain mid-edit); its wider key predicates are documented against `filterSelectableKeys`

## Verification

- Regression tests: declaration-vs-matrix-order fixtures (verified failing pre-fix), view-matrix override tracking on target and source sides, domain-change selection clear, negative no-clear-on-rerender case
- Full suite green: 403 files / 9067 tests, lint, typecheck