### PR TITLE
fix(ui): derive entry exports from a single definition source

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -137,13 +137,9 @@ export function App() {
   const entryOps = useEntryOperations({
     keyboardUid: keyboard.uid,
     definition: keyboard.definition,
-    layout: keyboard.layout,
-    encoderCount: keyboard.encoderCount,
     macroCount: keyboard.macroCount,
     vialProtocol: keyboard.vialProtocol,
     viaProtocol: keyboard.viaProtocol,
-    rows: keyboard.rows,
-    cols: keyboard.cols,
     qmkSettingsValues: keyboard.qmkSettingsValues,
     dynamicCountsFeatureFlags: keyboard.dynamicCounts.featureFlags,
     layoutStoreEntries: layoutStore.entries,

--- a/src/renderer/hooks/__tests__/useEntryOperations.test.ts
+++ b/src/renderer/hooks/__tests__/useEntryOperations.test.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+// @vitest-environment jsdom
+//
+// Entry exports must describe a v2 snapshot's own embedded definition;
+// the live keyboard's definition only backfills v1 snapshots.
+
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useEntryOperations } from '../useEntryOperations'
+import type { KeyboardDefinition, VilFile } from '../../../shared/types/protocol'
+
+// Live keyboard: 2x2 grid plus one encoder (CW/CCW pair), one layout-option
+// label, and its own custom keycode.
+const LIVE_DEFINITION: KeyboardDefinition = {
+  matrix: { rows: 2, cols: 2 },
+  layouts: {
+    keymap: [
+      ['0,0', '0,1'],
+      ['1,0', '1,1'],
+      [`0,0${'\n'.repeat(9)}e`, `0,1${'\n'.repeat(9)}e`],
+    ],
+    labels: ['Live Option'],
+  },
+  customKeycodes: [{ name: 'LIVE_KC', title: 'LIVE_KC', shortName: 'LIVE_KC' }],
+}
+
+// Snapshot's own embedded definition: 1x1 grid, no encoders, no labels, a
+// different custom keycode — simulates a firmware update that reshaped the
+// keyboard after this snapshot was saved.
+const SNAPSHOT_DEFINITION: KeyboardDefinition = {
+  matrix: { rows: 1, cols: 1 },
+  layouts: { keymap: [['0,0']] },
+  customKeycodes: [{ name: 'SNAP_KC', title: 'SNAP_KC', shortName: 'SNAP_KC' }],
+}
+
+function buildVilData(overrides: Partial<VilFile> = {}): VilFile {
+  return {
+    uid: 'test-uid',
+    keymap: {},
+    encoderLayout: {},
+    macros: [],
+    layoutOptions: 0,
+    tapDance: [],
+    combo: [],
+    keyOverride: [],
+    altRepeatKey: [],
+    qmkSettings: {},
+    ...overrides,
+  }
+}
+
+function useHarness() {
+  return useEntryOperations({
+    keyboardUid: 'test-uid',
+    definition: LIVE_DEFINITION,
+    macroCount: 16,
+    vialProtocol: 6,
+    viaProtocol: 12,
+    qmkSettingsValues: {},
+    dynamicCountsFeatureFlags: 0,
+    layoutStoreEntries: [],
+    deviceName: 'Test Keyboard',
+  })
+}
+
+describe('useEntryOperations — export definition source', () => {
+  it('v2 snapshot: buildEntryParams uses the snapshot own definition, not the live one', () => {
+    const { result } = renderHook(useHarness)
+    const vilData = buildVilData({ version: 2, definition: SNAPSHOT_DEFINITION })
+
+    const params = result.current.buildEntryParams(vilData)
+
+    expect(params.keys).toHaveLength(1)
+    expect(params.matrixRows).toBe(1)
+    expect(params.matrixCols).toBe(1)
+    expect(params.encoderCount).toBe(0)
+    expect(params.customKeycodes).toEqual(SNAPSHOT_DEFINITION.customKeycodes)
+  })
+
+  it('v2 snapshot without labels: does not decode layoutOptions with the live labels', () => {
+    const { result } = renderHook(useHarness)
+    const vilData = buildVilData({ version: 2, definition: SNAPSHOT_DEFINITION, layoutOptions: 1 })
+
+    const params = result.current.buildEntryParams(vilData)
+
+    expect(params.layoutOptions.size).toBe(0)
+  })
+
+  it('v1 snapshot (no embedded definition): falls back to the live definition', () => {
+    const { result } = renderHook(useHarness)
+    const vilData = buildVilData({ layoutOptions: 1 })
+
+    const params = result.current.buildEntryParams(vilData)
+
+    // 4 normal keys + the encoder pair (keys carries all parsed entries;
+    // the PDF generator partitions encoders itself)
+    expect(params.keys).toHaveLength(6)
+    expect(params.matrixRows).toBe(2)
+    expect(params.matrixCols).toBe(2)
+    expect(params.encoderCount).toBe(1)
+    expect(params.layoutOptions.size).toBe(1)
+    expect(params.customKeycodes).toEqual(LIVE_DEFINITION.customKeycodes)
+  })
+
+  it('buildVilExportContext follows the same definition source as buildEntryParams', () => {
+    const { result } = renderHook(useHarness)
+    const vilData = buildVilData({ version: 2, definition: SNAPSHOT_DEFINITION })
+
+    const context = result.current.buildVilExportContext(vilData)
+
+    expect(context.rows).toBe(1)
+    expect(context.cols).toBe(1)
+    expect(context.encoderCount).toBe(0)
+  })
+})

--- a/src/renderer/hooks/useEntryOperations.ts
+++ b/src/renderer/hooks/useEntryOperations.ts
@@ -13,6 +13,7 @@ import {
   deriveLayerCount,
 } from '../../shared/vil-file'
 import { vilToVialGuiJson } from '../../shared/vil-compat'
+import { parseDefinitionLayout } from './keyboard-state-helpers'
 import {
   splitMacroBuffer,
   deserializeMacro,
@@ -29,18 +30,13 @@ import {
 } from '../../shared/keycodes/keycodes'
 import type { VilFile, KeyboardDefinition } from '../../shared/types/protocol'
 import type { SnapshotMeta } from '../../shared/types/snapshot-store'
-import type { KeyboardLayout } from '../../shared/kle/types'
 
 interface Options {
   keyboardUid: string | undefined
   definition: KeyboardDefinition | null
-  layout: KeyboardLayout | null
-  encoderCount: number
   macroCount: number
   vialProtocol: number
   viaProtocol: number
-  rows: number
-  cols: number
   qmkSettingsValues: Record<string, number[]>
   dynamicCountsFeatureFlags: number
   layoutStoreEntries: SnapshotMeta[]
@@ -51,13 +47,9 @@ export function useEntryOperations(options: Options) {
   const {
     keyboardUid,
     definition,
-    layout,
-    encoderCount,
     macroCount,
     vialProtocol,
     viaProtocol,
-    rows,
-    cols,
     qmkSettingsValues,
     dynamicCountsFeatureFlags,
     layoutStoreEntries,
@@ -118,21 +110,28 @@ export function useEntryOperations(options: Options) {
 
   // Superset param object shared by the keymap.c / PDF / hub export paths;
   // keys and layoutOptions are consumed only by the PDF generator.
+  // The whole geometry (keys, matrix, labels, custom keycodes, encoders)
+  // comes from one definition: a v2 snapshot's own embedded one, with the
+  // live definition backfilling v1 snapshots only.
   const buildEntryParams = useCallback((vilData: VilFile) => {
-    const labels = definition?.layouts?.labels
+    const def = vilData.definition ?? definition
+    const { layout: defLayout, encoderCount: defEncoderCount } = def
+      ? parseDefinitionLayout(def)
+      : { layout: null, encoderCount: 0 }
+    const labels = def?.layouts?.labels
     return {
       layers: deriveLayerCount(vilData.keymap),
-      keys: layout?.keys ?? [],
-      matrixRows: vilData.definition?.matrix.rows ?? rows,
-      matrixCols: vilData.definition?.matrix.cols ?? cols,
+      keys: defLayout?.keys ?? [],
+      matrixRows: def?.matrix.rows ?? 0,
+      matrixCols: def?.matrix.cols ?? 0,
       keymap: recordToMap(vilData.keymap),
       encoderLayout: recordToMap(vilData.encoderLayout),
-      encoderCount,
+      encoderCount: defEncoderCount,
       layoutOptions: labels
         ? decodeLayoutOptions(vilData.layoutOptions, labels)
         : new Map<number, number>(),
       serializeKeycode,
-      customKeycodes: definition?.customKeycodes,
+      customKeycodes: def?.customKeycodes,
       tapDance: vilData.tapDance,
       combo: vilData.combo,
       keyOverride: vilData.keyOverride,
@@ -142,23 +141,25 @@ export function useEntryOperations(options: Options) {
         : splitMacroBuffer(vilData.macros, macroCount)
             .map((m) => deserializeMacro(m, vialProtocol)),
     }
-  }, [definition, layout, encoderCount, macroCount, vialProtocol, rows, cols])
+  }, [definition, macroCount, vialProtocol])
 
-  const buildVilExportContext = useCallback((vilData: VilFile) => {
+  const buildVilExportContext = useCallback((
+    vilData: VilFile,
+    params?: ReturnType<typeof buildEntryParams>,
+  ) => {
     const macroActions = splitMacroBuffer(vilData.macros, macroCount)
       .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
+    const p = params ?? buildEntryParams(vilData)
     return {
-      // Match buildEntryParams: prefer the snapshot's own matrix so the
-      // exported vil JSON and keymap.c describe the same dimensions.
-      rows: vilData.definition?.matrix.rows ?? rows,
-      cols: vilData.definition?.matrix.cols ?? cols,
-      layers: deriveLayerCount(vilData.keymap),
-      encoderCount,
+      rows: p.matrixRows,
+      cols: p.matrixCols,
+      layers: p.layers,
+      encoderCount: p.encoderCount,
       vialProtocol,
       viaProtocol,
       macroActions,
     }
-  }, [rows, cols, macroCount, encoderCount, vialProtocol, viaProtocol])
+  }, [macroCount, vialProtocol, viaProtocol, buildEntryParams])
 
   const handleExportEntryVil = useCallback(async (entryId: string) => {
     try {
@@ -215,7 +216,7 @@ export function useEntryOperations(options: Options) {
     return {
       title: entry.label || deviceName,
       keyboardName: deviceName,
-      vilJson: vilToVialGuiJson(vilData, buildVilExportContext(vilData)),
+      vilJson: vilToVialGuiJson(vilData, buildVilExportContext(vilData, params)),
       pipetteJson: JSON.stringify(vilData, null, 2),
       keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
       pdfBase64,


### PR DESCRIPTION
## Problem

Snapshot-entry exports (PDF, keymap.c, vil JSON, hub uploads) mixed definition sources: matrix dimensions came from the v2 snapshot's embedded definition while keys, layout-option labels, custom keycodes, and the encoder count came from the live keyboard. A snapshot saved before a firmware update could render its keycodes on the live keyboard's geometry, and a snapshot definition without labels decoded its layout-option bitfield against the live keyboard's label set (wrong option decoding in the PDF).

## Fix

- `buildEntryParams` picks **one definition** — `vilData.definition ?? definition` (v2 snapshot's own; live only backfills v1 snapshots) — and derives keys, matrix dimensions, encoder count, labels, and custom keycodes from it via `parseDefinitionLayout`
- `buildVilExportContext` reads the same values from the params object, with an optional pre-computed argument so the hub flow parses the KLE once
- The hook no longer takes the live `layout` / `encoderCount` / `rows` / `cols` options (they only fed these builders); `App.tsx` call site updated

## Verification

- Unit tests: v2-snapshot-wins, snapshot-without-labels (no live-label bleed), v1 fallback (incl. encoder pair), context/params source agreement
- Full suite green: 403 files / 9067 tests, lint, typecheck

## Notes

`buildEntryParams` has now converged with `useSnapshotActions.buildParams`; consolidating them into one shared builder is tracked as follow-up work (behavior-neutral refactor).