### PR TITLE
refactor(ui): consolidate snapshot export builders

### DIFF
--- a/src/renderer/components/data-modal/useSnapshotActions.ts
+++ b/src/renderer/components/data-modal/useSnapshotActions.ts
@@ -2,28 +2,23 @@
 // Standalone snapshot export/hub actions for Data modal (works with v2 VilFiles only)
 
 import { useCallback } from 'react'
-import { decodeLayoutOptions } from '../../../shared/kle/layout-options'
 import { generateKeymapC } from '../../../shared/keymap-export'
 import { generateKeymapPdf } from '../../../shared/pdf-export'
-import { generatePdfThumbnail } from '../../utils/pdf-thumbnail'
-import { isVilFile, recordToMap, deriveLayerCount } from '../../../shared/vil-file'
+import { isVilFile } from '../../../shared/vil-file'
 import { vilToVialGuiJson } from '../../../shared/vil-compat'
 import { FALLBACK_VIAL_PROTOCOL } from '../../../shared/favorite-data'
 import {
-  splitMacroBuffer,
-  deserializeMacro,
-  macroActionsToJson,
-  jsonToMacroActions,
-} from '../../../preload/macro'
-import {
-  serialize as serializeKeycode,
   serializeForCExport,
   keycodeLabel,
   isMask,
   findOuterKeycode,
   findInnerKeycode,
 } from '../../../shared/keycodes/keycodes'
-import { parseDefinitionLayout } from '../../../shared/kle/definition-layout'
+import {
+  buildSnapshotExportParams,
+  buildVilExportContext,
+} from '../../export/snapshot-export-params'
+import { buildHubPostPayload } from '../../export/snapshot-hub-payload'
 import type { VilFile } from '../../../shared/types/protocol'
 
 interface Options {
@@ -37,6 +32,10 @@ interface Options {
 // common VIA/Vial default).
 const FALLBACK_MACRO_COUNT = 16
 
+// useKeyboardLoaders.ts falls back to 9 for the live-keyboard read path;
+// this is the snapshot-export fallback and intentionally differs.
+const FALLBACK_VIA_PROTOCOL = 12
+
 function loadVilData(uid: string, entryId: string): Promise<VilFile | null> {
   return window.vialAPI.snapshotStoreLoad(uid, entryId).then((result) => {
     if (!result.success || !result.data) return null
@@ -47,37 +46,31 @@ function loadVilData(uid: string, entryId: string): Promise<VilFile | null> {
   }).catch(() => null)
 }
 
-// Superset param object shared by the keymap.c / PDF / hub export paths;
-// keys and layoutOptions are consumed only by the PDF generator.
-function buildParams(vilData: VilFile) {
-  const def = vilData.definition!
-  const { layout, encoderCount } = parseDefinitionLayout(def)
-  const labels = def.layouts?.labels
-  const macroCount = FALLBACK_MACRO_COUNT
-  const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
-
+// Export protocol values a loaded snapshot resolves to: vial/via protocol are
+// read from the snapshot's own recorded values, falling back to the shared
+// default when a snapshot predates that field. Macro count has no
+// definition-level source (dynamic_keymap_macro_get_count is a live protocol
+// query, not part of the definition file) so it always falls back to 16 (the
+// common VIA/Vial default).
+function resolveExportProtocols(vilData: VilFile) {
   return {
-    layers: deriveLayerCount(vilData.keymap),
-    keys: layout?.keys ?? [],
-    matrixRows: def.matrix.rows,
-    matrixCols: def.matrix.cols,
-    keymap: recordToMap(vilData.keymap),
-    encoderLayout: recordToMap(vilData.encoderLayout),
-    encoderCount,
-    layoutOptions: labels
-      ? decodeLayoutOptions(vilData.layoutOptions, labels)
-      : new Map<number, number>(),
-    serializeKeycode,
-    customKeycodes: def.customKeycodes,
-    tapDance: vilData.tapDance,
-    combo: vilData.combo,
-    keyOverride: vilData.keyOverride,
-    altRepeatKey: vilData.altRepeatKey,
-    macros: vilData.macroJson
-      ? vilData.macroJson.map((m) => jsonToMacroActions(JSON.stringify(m)) ?? [])
-      : splitMacroBuffer(vilData.macros, macroCount)
-          .map((m) => deserializeMacro(m, vialProtocol)),
+    macroCount: FALLBACK_MACRO_COUNT,
+    vialProtocol: vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL,
+    viaProtocol: vilData.viaProtocol ?? FALLBACK_VIA_PROTOCOL,
   }
+}
+
+// `loadVilData` guarantees a v2 snapshot with its own embedded definition,
+// so there is no live-definition fallback here. Resolves protocols once so
+// every caller reuses the same params/protocols pair for the action.
+function buildExportBundle(vilData: VilFile) {
+  const protocols = resolveExportProtocols(vilData)
+  const params = buildSnapshotExportParams(vilData, {
+    fallbackDefinition: null,
+    macroCount: protocols.macroCount,
+    vialProtocol: protocols.vialProtocol,
+  })
+  return { params, protocols }
 }
 
 export function useSnapshotActions({ uid, deviceName }: Options) {
@@ -85,23 +78,8 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
-      const def = vilData.definition!
-      const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
-      const viaProtocol = vilData.viaProtocol ?? 12
-      const { rows, cols } = def.matrix
-      const { encoderCount } = parseDefinitionLayout(def)
-      const macroActions = splitMacroBuffer(vilData.macros, macroCount)
-        .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
-      const json = vilToVialGuiJson(vilData, {
-        rows,
-        cols,
-        layers: deriveLayerCount(vilData.keymap),
-        encoderCount,
-        vialProtocol,
-        viaProtocol,
-        macroActions,
-      })
+      const { params, protocols } = buildExportBundle(vilData)
+      const json = vilToVialGuiJson(vilData, buildVilExportContext(vilData, params, protocols))
       await window.vialAPI.saveLayout(json, deviceName)
     } catch { /* non-critical */ }
   }, [uid, deviceName])
@@ -110,7 +88,8 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
-      const content = generateKeymapC({ ...buildParams(vilData), serializeKeycode: serializeForCExport })
+      const { params } = buildExportBundle(vilData)
+      const content = generateKeymapC({ ...params, serializeKeycode: serializeForCExport })
       await window.vialAPI.exportKeymapC(content, deviceName)
     } catch { /* non-critical */ }
   }, [uid, deviceName])
@@ -119,8 +98,9 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
+      const { params } = buildExportBundle(vilData)
       const base64 = generateKeymapPdf({
-        ...buildParams(vilData),
+        ...params,
         deviceName,
         keycodeLabel,
         isMask,
@@ -135,31 +115,9 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
-      const params = buildParams(vilData)
-      const pdfBase64 = generateKeymapPdf({
-        ...params,
-        deviceName,
-        keycodeLabel,
-        isMask,
-        findOuterKeycode,
-        findInnerKeycode,
-      })
-      const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
-      const viaProtocol = vilData.viaProtocol ?? 12
-      const { matrixRows: rows, matrixCols: cols, encoderCount } = params
-      const macroActions = splitMacroBuffer(vilData.macros, macroCount)
-        .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
-      const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)
-      await window.vialAPI.hubUploadPost({
-        title: label || deviceName,
-        keyboardName: deviceName,
-        vilJson: vilToVialGuiJson(vilData, { rows, cols, layers: deriveLayerCount(vilData.keymap), encoderCount, vialProtocol, viaProtocol, macroActions }),
-        pipetteJson: JSON.stringify(vilData, null, 2),
-        keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
-        pdfBase64,
-        thumbnailBase64,
-      })
+      const { params, protocols } = buildExportBundle(vilData)
+      const payload = await buildHubPostPayload(vilData, params, protocols, { label, deviceName })
+      await window.vialAPI.hubUploadPost(payload)
     } catch { /* non-critical */ }
   }, [uid, deviceName])
 
@@ -167,32 +125,9 @@ export function useSnapshotActions({ uid, deviceName }: Options) {
     try {
       const vilData = await loadVilData(uid, entryId)
       if (!vilData) return
-      const params = buildParams(vilData)
-      const pdfBase64 = generateKeymapPdf({
-        ...params,
-        deviceName,
-        keycodeLabel,
-        isMask,
-        findOuterKeycode,
-        findInnerKeycode,
-      })
-      const macroCount = FALLBACK_MACRO_COUNT
-      const vialProtocol = vilData.vialProtocol ?? FALLBACK_VIAL_PROTOCOL
-      const viaProtocol = vilData.viaProtocol ?? 12
-      const { matrixRows: rows, matrixCols: cols, encoderCount } = params
-      const macroActions = splitMacroBuffer(vilData.macros, macroCount)
-        .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
-      const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)
-      await window.vialAPI.hubUpdatePost({
-        postId: hubPostId,
-        title: label || deviceName,
-        keyboardName: deviceName,
-        vilJson: vilToVialGuiJson(vilData, { rows, cols, layers: deriveLayerCount(vilData.keymap), encoderCount, vialProtocol, viaProtocol, macroActions }),
-        pipetteJson: JSON.stringify(vilData, null, 2),
-        keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
-        pdfBase64,
-        thumbnailBase64,
-      })
+      const { params, protocols } = buildExportBundle(vilData)
+      const payload = await buildHubPostPayload(vilData, params, protocols, { label, deviceName })
+      await window.vialAPI.hubUpdatePost({ postId: hubPostId, ...payload })
     } catch { /* non-critical */ }
   }, [uid, deviceName])
 

--- a/src/renderer/export/__tests__/snapshot-export-params.test.ts
+++ b/src/renderer/export/__tests__/snapshot-export-params.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// buildSnapshotExportParams/buildVilExportContext are the single shared
+// implementation behind useEntryOperations.buildEntryParams and
+// useSnapshotActions.buildExportBundle — this pins their field-by-field
+// contract directly so both call sites can stay thin wrappers. Definition
+// precedence (snapshot's own definition vs. the fallback definition) is
+// pinned end-to-end by useEntryOperations.test.ts instead of being
+// duplicated here.
+
+import { describe, it, expect } from 'vitest'
+import { buildSnapshotExportParams, buildVilExportContext } from '../snapshot-export-params'
+import type { KeyboardDefinition, VilFile } from '../../../shared/types/protocol'
+
+const SNAPSHOT_DEFINITION: KeyboardDefinition = {
+  matrix: { rows: 1, cols: 1 },
+  layouts: { keymap: [['0,0']] },
+  customKeycodes: [{ name: 'SNAP_KC', title: 'SNAP_KC', shortName: 'SNAP_KC' }],
+}
+
+function buildVilData(overrides: Partial<VilFile> = {}): VilFile {
+  return {
+    uid: 'test-uid',
+    keymap: {},
+    encoderLayout: {},
+    macros: [],
+    layoutOptions: 0,
+    tapDance: [],
+    combo: [],
+    keyOverride: [],
+    altRepeatKey: [],
+    qmkSettings: {},
+    ...overrides,
+  }
+}
+
+describe('buildSnapshotExportParams', () => {
+  it('with no definition at all (fallbackDefinition null, snapshot has none), degrades to empty geometry', () => {
+    const vilData = buildVilData()
+
+    const params = buildSnapshotExportParams(vilData, {
+      fallbackDefinition: null,
+      macroCount: 16,
+      vialProtocol: 6,
+    })
+
+    expect(params.keys).toEqual([])
+    expect(params.matrixRows).toBe(0)
+    expect(params.matrixCols).toBe(0)
+    expect(params.encoderCount).toBe(0)
+    expect(params.layoutOptions.size).toBe(0)
+    expect(params.customKeycodes).toBeUndefined()
+  })
+
+  it('prefers macroJson over the raw macro buffer when both are present', () => {
+    const vilData = buildVilData({
+      definition: SNAPSHOT_DEFINITION,
+      macros: [104, 105, 0], // would decode to text "hi" if the buffer were used
+      macroJson: [[['text', 'from-json']]],
+    })
+
+    const params = buildSnapshotExportParams(vilData, {
+      fallbackDefinition: null,
+      macroCount: 16,
+      vialProtocol: 1,
+    })
+
+    expect(params.macros).toEqual([[{ type: 'text', text: 'from-json' }]])
+  })
+
+  it('falls back to splitMacroBuffer + deserializeMacro when macroJson is absent', () => {
+    const vilData = buildVilData({
+      definition: SNAPSHOT_DEFINITION,
+      macros: [104, 105, 0], // 'h', 'i', NUL terminator
+    })
+
+    const params = buildSnapshotExportParams(vilData, {
+      fallbackDefinition: null,
+      macroCount: 16,
+      vialProtocol: 1, // pre-advanced-macros: plain ASCII decodes to text
+    })
+
+    expect(params.macros).toEqual([[{ type: 'text', text: 'hi' }]])
+  })
+})
+
+describe('buildVilExportContext', () => {
+  it('derives rows/cols/layers/encoderCount from the passed-in params, and re-decodes macroActions', () => {
+    const vilData = buildVilData({
+      definition: SNAPSHOT_DEFINITION,
+      keymap: { '0,0': 4, '1,0': 5 },
+      macros: [104, 105, 0],
+    })
+    const params = buildSnapshotExportParams(vilData, {
+      fallbackDefinition: null,
+      macroCount: 16,
+      vialProtocol: 1,
+    })
+
+    const context = buildVilExportContext(vilData, params, {
+      vialProtocol: 1,
+      viaProtocol: 12,
+      macroCount: 16,
+    })
+
+    expect(context.rows).toBe(1)
+    expect(context.cols).toBe(1)
+    expect(context.layers).toBe(2)
+    expect(context.encoderCount).toBe(0)
+    expect(context.vialProtocol).toBe(1)
+    expect(context.viaProtocol).toBe(12)
+    expect(context.macroActions).toEqual([[['text', 'hi']]])
+  })
+})

--- a/src/renderer/export/snapshot-export-params.ts
+++ b/src/renderer/export/snapshot-export-params.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { decodeLayoutOptions } from '../../shared/kle/layout-options'
+import { parseDefinitionLayout } from '../../shared/kle/definition-layout'
+import { recordToMap, deriveLayerCount } from '../../shared/vil-file'
+import {
+  splitMacroBuffer,
+  deserializeMacro,
+  macroActionsToJson,
+  jsonToMacroActions,
+} from '../../preload/macro'
+import { serialize as serializeKeycode } from '../../shared/keycodes/keycodes'
+import type { VilFile, KeyboardDefinition } from '../../shared/types/protocol'
+import type { VilExportContext } from '../../shared/vil-compat'
+
+export interface SnapshotExportParamOpts {
+  /** Definition to use when the snapshot itself carries none (v1 snapshots). */
+  fallbackDefinition: KeyboardDefinition | null
+  macroCount: number
+  vialProtocol: number
+}
+
+// Superset param object shared by the keymap.c / PDF / hub export paths;
+// keys and layoutOptions are consumed only by the PDF generator.
+// The whole geometry (keys, matrix, labels, custom keycodes, encoders)
+// comes from one definition: a v2 snapshot's own embedded one, with the
+// fallback definition backfilling v1 snapshots only.
+export function buildSnapshotExportParams(vilData: VilFile, opts: SnapshotExportParamOpts) {
+  const def = vilData.definition ?? opts.fallbackDefinition
+  const { layout: defLayout, encoderCount: defEncoderCount } = def
+    ? parseDefinitionLayout(def)
+    : { layout: null, encoderCount: 0 }
+  const labels = def?.layouts?.labels
+  return {
+    layers: deriveLayerCount(vilData.keymap),
+    keys: defLayout?.keys ?? [],
+    matrixRows: def?.matrix.rows ?? 0,
+    matrixCols: def?.matrix.cols ?? 0,
+    keymap: recordToMap(vilData.keymap),
+    encoderLayout: recordToMap(vilData.encoderLayout),
+    encoderCount: defEncoderCount,
+    layoutOptions: labels
+      ? decodeLayoutOptions(vilData.layoutOptions, labels)
+      : new Map<number, number>(),
+    serializeKeycode,
+    customKeycodes: def?.customKeycodes,
+    tapDance: vilData.tapDance,
+    combo: vilData.combo,
+    keyOverride: vilData.keyOverride,
+    altRepeatKey: vilData.altRepeatKey,
+    macros: vilData.macroJson
+      ? vilData.macroJson.map((m) => jsonToMacroActions(JSON.stringify(m)) ?? [])
+      : splitMacroBuffer(vilData.macros, opts.macroCount)
+          .map((m) => deserializeMacro(m, opts.vialProtocol)),
+  }
+}
+
+export type SnapshotExportParams = ReturnType<typeof buildSnapshotExportParams>
+
+// Mirrors the subset of SnapshotExportParamOpts that must match whatever
+// opts built `params` (macroCount, vialProtocol), plus viaProtocol which
+// buildSnapshotExportParams never needs.
+export type VilExportContextOpts =
+  Pick<SnapshotExportParamOpts, 'macroCount' | 'vialProtocol'> & { viaProtocol: number }
+
+// Derives the vial-gui export context (rows/cols/layers/encoderCount) from
+// an already-built params object, plus a freshly re-decoded macroActions
+// list (vilToVialGuiJson needs the vial-gui JSON macro shape, not the
+// MacroAction[] shape params.macros carries — unlike params.macros, this
+// always re-decodes the raw macro buffer and ignores macroJson).
+export function buildVilExportContext(
+  vilData: VilFile,
+  params: Pick<SnapshotExportParams, 'matrixRows' | 'matrixCols' | 'layers' | 'encoderCount'>,
+  opts: VilExportContextOpts,
+): VilExportContext {
+  const macroActions = splitMacroBuffer(vilData.macros, opts.macroCount)
+    .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, opts.vialProtocol))) as unknown[])
+  return {
+    rows: params.matrixRows,
+    cols: params.matrixCols,
+    layers: params.layers,
+    encoderCount: params.encoderCount,
+    vialProtocol: opts.vialProtocol,
+    viaProtocol: opts.viaProtocol,
+    macroActions,
+  }
+}

--- a/src/renderer/export/snapshot-hub-payload.ts
+++ b/src/renderer/export/snapshot-hub-payload.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+import { generateKeymapC } from '../../shared/keymap-export'
+import { generateKeymapPdf } from '../../shared/pdf-export'
+import { generatePdfThumbnail } from '../utils/pdf-thumbnail'
+import { vilToVialGuiJson } from '../../shared/vil-compat'
+import {
+  serializeForCExport,
+  keycodeLabel,
+  isMask,
+  findOuterKeycode,
+  findInnerKeycode,
+} from '../../shared/keycodes/keycodes'
+import { buildVilExportContext, type SnapshotExportParams, type VilExportContextOpts } from './snapshot-export-params'
+import type { HubUploadPostParams } from '../../shared/types/hub'
+import type { VilFile } from '../../shared/types/protocol'
+
+// Shared by useSnapshotActions (Data modal, standalone snapshots) and
+// useEntryOperations (Layout Store entries) — both assembled a field-for-field
+// identical 7-key Hub upload payload from the same params/context, so it
+// lives here once. `params` and `protocols` must come from the same
+// buildSnapshotExportParams call (same fallbackDefinition/macroCount/vialProtocol).
+export async function buildHubPostPayload(
+  vilData: VilFile,
+  params: SnapshotExportParams,
+  protocols: VilExportContextOpts,
+  { label, deviceName }: { label: string; deviceName: string },
+): Promise<HubUploadPostParams> {
+  const pdfBase64 = generateKeymapPdf({
+    ...params,
+    deviceName,
+    keycodeLabel,
+    isMask,
+    findOuterKeycode,
+    findInnerKeycode,
+  })
+  const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)
+  return {
+    title: label || deviceName,
+    keyboardName: deviceName,
+    vilJson: vilToVialGuiJson(vilData, buildVilExportContext(vilData, params, protocols)),
+    pipetteJson: JSON.stringify(vilData, null, 2),
+    keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
+    pdfBase64,
+    thumbnailBase64,
+  }
+}

--- a/src/renderer/hooks/useEntryOperations.ts
+++ b/src/renderer/hooks/useEntryOperations.ts
@@ -1,33 +1,27 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 import { useCallback } from 'react'
-import { decodeLayoutOptions } from '../../shared/kle/layout-options'
 import { generateKeymapC } from '../../shared/keymap-export'
 import { generateKeymapPdf } from '../../shared/pdf-export'
-import { generatePdfThumbnail } from '../utils/pdf-thumbnail'
 import {
   isVilFile,
   isVilFileV1,
   migrateVilFileToV2,
-  recordToMap,
-  deriveLayerCount,
 } from '../../shared/vil-file'
 import { vilToVialGuiJson } from '../../shared/vil-compat'
-import { parseDefinitionLayout } from '../../shared/kle/definition-layout'
 import {
-  splitMacroBuffer,
-  deserializeMacro,
-  macroActionsToJson,
-  jsonToMacroActions,
-} from '../../preload/macro'
-import {
-  serialize as serializeKeycode,
   serializeForCExport,
   keycodeLabel,
   isMask,
   findOuterKeycode,
   findInnerKeycode,
 } from '../../shared/keycodes/keycodes'
+import {
+  buildSnapshotExportParams,
+  buildVilExportContext as buildVilExportContextShared,
+  type SnapshotExportParams,
+} from '../export/snapshot-export-params'
+import { buildHubPostPayload } from '../export/snapshot-hub-payload'
 import type { VilFile, KeyboardDefinition } from '../../shared/types/protocol'
 import type { SnapshotMeta } from '../../shared/types/snapshot-store'
 
@@ -108,58 +102,20 @@ export function useEntryOperations(options: Options) {
     return `${deviceName}_${suffix}`
   }, [deviceName, layoutStoreEntries])
 
-  // Superset param object shared by the keymap.c / PDF / hub export paths;
-  // keys and layoutOptions are consumed only by the PDF generator.
-  // The whole geometry (keys, matrix, labels, custom keycodes, encoders)
-  // comes from one definition: a v2 snapshot's own embedded one, with the
-  // live definition backfilling v1 snapshots only.
-  const buildEntryParams = useCallback((vilData: VilFile) => {
-    const def = vilData.definition ?? definition
-    const { layout: defLayout, encoderCount: defEncoderCount } = def
-      ? parseDefinitionLayout(def)
-      : { layout: null, encoderCount: 0 }
-    const labels = def?.layouts?.labels
-    return {
-      layers: deriveLayerCount(vilData.keymap),
-      keys: defLayout?.keys ?? [],
-      matrixRows: def?.matrix.rows ?? 0,
-      matrixCols: def?.matrix.cols ?? 0,
-      keymap: recordToMap(vilData.keymap),
-      encoderLayout: recordToMap(vilData.encoderLayout),
-      encoderCount: defEncoderCount,
-      layoutOptions: labels
-        ? decodeLayoutOptions(vilData.layoutOptions, labels)
-        : new Map<number, number>(),
-      serializeKeycode,
-      customKeycodes: def?.customKeycodes,
-      tapDance: vilData.tapDance,
-      combo: vilData.combo,
-      keyOverride: vilData.keyOverride,
-      altRepeatKey: vilData.altRepeatKey,
-      macros: vilData.macroJson
-        ? vilData.macroJson.map((m) => jsonToMacroActions(JSON.stringify(m)) ?? [])
-        : splitMacroBuffer(vilData.macros, macroCount)
-            .map((m) => deserializeMacro(m, vialProtocol)),
-    }
-  }, [definition, macroCount, vialProtocol])
+  const buildEntryParams = useCallback((vilData: VilFile) => (
+    buildSnapshotExportParams(vilData, { fallbackDefinition: definition, macroCount, vialProtocol })
+  ), [definition, macroCount, vialProtocol])
 
   const buildVilExportContext = useCallback((
     vilData: VilFile,
-    params?: ReturnType<typeof buildEntryParams>,
-  ) => {
-    const macroActions = splitMacroBuffer(vilData.macros, macroCount)
-      .map((m) => JSON.parse(macroActionsToJson(deserializeMacro(m, vialProtocol))) as unknown[])
-    const p = params ?? buildEntryParams(vilData)
-    return {
-      rows: p.matrixRows,
-      cols: p.matrixCols,
-      layers: p.layers,
-      encoderCount: p.encoderCount,
+    params?: SnapshotExportParams,
+  ) => (
+    buildVilExportContextShared(vilData, params ?? buildEntryParams(vilData), {
       vialProtocol,
       viaProtocol,
-      macroActions,
-    }
-  }, [macroCount, vialProtocol, viaProtocol, buildEntryParams])
+      macroCount,
+    })
+  ), [macroCount, vialProtocol, viaProtocol, buildEntryParams])
 
   const handleExportEntryVil = useCallback(async (entryId: string) => {
     try {
@@ -204,25 +160,11 @@ export function useEntryOperations(options: Options) {
 
   const buildHubPostParams = useCallback(async (entry: { label: string }, vilData: VilFile) => {
     const params = buildEntryParams(vilData)
-    const pdfBase64 = generateKeymapPdf({
-      ...params,
+    return buildHubPostPayload(vilData, params, { vialProtocol, viaProtocol, macroCount }, {
+      label: entry.label,
       deviceName,
-      keycodeLabel,
-      isMask,
-      findOuterKeycode,
-      findInnerKeycode,
     })
-    const thumbnailBase64 = await generatePdfThumbnail(pdfBase64)
-    return {
-      title: entry.label || deviceName,
-      keyboardName: deviceName,
-      vilJson: vilToVialGuiJson(vilData, buildVilExportContext(vilData, params)),
-      pipetteJson: JSON.stringify(vilData, null, 2),
-      keymapC: generateKeymapC({ ...params, serializeKeycode: serializeForCExport }),
-      pdfBase64,
-      thumbnailBase64,
-    }
-  }, [buildEntryParams, buildVilExportContext, deviceName])
+  }, [buildEntryParams, vialProtocol, viaProtocol, macroCount, deviceName])
 
   return {
     backfillQmkSettings,


### PR DESCRIPTION
## Background

`useEntryOperations` and `useSnapshotActions` built near-identical snapshot-export param objects, vil-export contexts, and 7-field hub upload payloads — three copies of the same precedence rules, kept in sync by hand (and recently a source of drift-class bugs).

## Change

- New `src/renderer/export/snapshot-export-params.ts`: `buildSnapshotExportParams(vilData, { fallbackDefinition, macroCount, vialProtocol })` (single definition pick; v2 snapshot's own embedded definition, fallback for v1) and `buildVilExportContext` (parameter narrowed to the geometry subset it reads; opts type `Pick`-coupled to the params opts so the two cannot drift)
- New `src/renderer/export/snapshot-hub-payload.ts`: the previously duplicated hub payload assembly, once
- Both hooks become thin wrappers; `useSnapshotActions` resolves its protocol fallbacks once per action (`FALLBACK_VIA_PROTOCOL = 12`, distinct from the live-path `?? 9` in `useKeyboardLoaders`, deliberately untouched)
- Net −123 lines across the two hooks

## Behavior neutrality

No existing test file was edited; full suite green (404 files / 9074 tests), lint, typecheck. New unit tests cover module-level behaviors the hook tests cannot reach (missing-definition degradation, `macroJson` vs raw-buffer macro branch, context derivation).

Known pre-existing inconsistency, documented in-code and deliberately preserved: the vil-export context's `macroActions` always re-decodes the raw macro buffer and ignores `macroJson`.