### PR TITLE
chore(build): bump version to 0.4.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pipette-desktop",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Pipette — Vial-compatible keyboard configurator built with Electron and TypeScript",
   "license": "GPL-3.0-or-later",
   "type": "module",


### PR DESCRIPTION
Version bump for the release containing #428-#435: matrix-order keymap.c export, encoder derivation/export fixes across probe/preload/picker, picker multi-select index-domain and view-matrix traversal unification, snapshot export definition-source unification and builder consolidation, and removal of the superseded preload Keyboard class.